### PR TITLE
Upgrade pilout to ZisK v0.16.1

### DIFF
--- a/.github/workflows/proofs.yml
+++ b/.github/workflows/proofs.yml
@@ -10,16 +10,29 @@ name: proofs
 # nixpkgs rev) by content hash, so the same build runs across machines.
 
 on:
-  # Run only on push to main (post-merge), not on PRs. The full
-  # pipeline is ~50 min cold / ~10 min warm; running it on every PR
-  # commit dominates self-hosted runner time. Trade-off: PR breakage
-  # is caught post-merge instead of pre-merge. Mitigation: the cheap
-  # trust-gate.yml workflow still runs on every PR, catching the
-  # axiom/baseline/sorry/uniformity regressions that account for
-  # most accidental breakage.
-  #
-  # Path filter restricts even pushes to main to changes that can
-  # alter the proof outcome (skipping pure-doc commits).
+  # On PRs the workflow is opt-in: it only runs when the `run-ci` label
+  # is present. Labels require Triage role or higher to apply, so an
+  # external contributor cannot self-trigger a ~30–50 min CI run from a
+  # fork. The job-level `if:` enforces the gate; `types: [labeled,
+  # synchronize]` re-triggers on label apply and on subsequent pushes
+  # to an already-labeled PR. Path filters still apply as a secondary
+  # gate so pure-doc commits on a labeled PR don't burn runner time.
+  # Push to main and manual `workflow_dispatch` are unaffected.
+  pull_request:
+    types: [labeled, synchronize]
+    branches: [main]
+    paths:
+      - 'ZiskFv/**'
+      - 'tools/pil-extract/**'
+      - 'lake-manifest.json'
+      - 'lakefile.toml'
+      - 'lean-toolchain'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
+      - 'bin/test.sh'
+      - 'trust/**'
+      - '.github/workflows/proofs.yml'
   push:
     branches: [main]
     paths:
@@ -51,6 +64,9 @@ jobs:
     # 25371352799), which fits comfortably on the 16 GiB L runner.
     # Net effect: warm PRs (~99% of them) pay the cheaper L runner.
     name: pick runner based on cachix state
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: ubuntu-latest
     outputs:
       runner: ${{ steps.pick.outputs.runner }}

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ docs/site/*.png
 ZiskFv/Extraction/*.lean
 !ZiskFv/Extraction/ArithTable.lean
 !ZiskFv/Extraction/MemoryBuses.lean
+!ZiskFv/Extraction/OperationBuses.lean
 
 # Nix flake build outputs (symlinks)
 /result

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ build/sail-lean/, build/zisk.pilout, ZiskFv/Extraction/*.lean
         │
         │ tools/pil-extract (run inside the flake)
         ▼
-ZiskFv/Extraction/<AIR>.lean  ← auto-generated; gitignored except 2 hand-written files
+ZiskFv/Extraction/<AIR>.lean  ← auto-generated; gitignored except 3 hand-written files
         │
         │ named-column wrappers
         ▼
@@ -199,10 +199,15 @@ Recover via `git show`:
   pinned commit of upstream zisk).
 - `ZiskFv/Extraction/` is mixed: most files are gitignored
   auto-generated build outputs (`nix run .#populate`
-  regenerates them); 2 stay tracked because they're hand-written:
+  regenerates them); 3 stay tracked because they're hand-written:
   - `ArithTable.lean` — hand-transcribed from
     `zisk/state-machines/arith/src/arith_table_data.rs`.
   - `MemoryBuses.lean` — hand-curated subset of memory-bus emissions
     with documentation.
+  - `OperationBuses.lean` — hand-written operation-bus emission for
+    Main. The auto-extracted `Buses.lean::bus_emission_Main_0` became
+    a multiplicity-0 stub starting v0.16.0 (the new `proves_operation`
+    macro emits ExtF-typed challenge cells the V1 extractor can't
+    render). The hand-written replacement lives here.
 - `native_decide` on Goldilocks primality takes ~6 min cold. Mathlib's
   Azure cache via `lake exe cache get` handles the rest.

--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -13,6 +13,7 @@ import ZiskFv.Airs.Binary.BinaryAdd
 import ZiskFv.Airs.Main
 import ZiskFv.Airs.OperationBus
 import ZiskFv.Extraction.Buses
+import ZiskFv.Extraction.OperationBuses
 import ZiskFv.Airs.BusShape
 import ZiskFv.Airs.OpBusEffect
 import ZiskFv.Airs.OpBusHypotheses

--- a/ZiskFv/Airs/BusShape.lean
+++ b/ZiskFv/Airs/BusShape.lean
@@ -3,6 +3,7 @@ import Mathlib
 import LeanZKCircuit.OpenVM.Circuit
 import ZiskFv.Fundamentals.Goldilocks
 import ZiskFv.Extraction.Buses
+import ZiskFv.Extraction.OperationBuses
 import ZiskFv.Airs.Main
 import ZiskFv.Airs.OperationBus
 
@@ -64,7 +65,7 @@ def slotValue (spec : @BusEmissionSpec C F ExtF _ _ _) (i : ℕ)
     equalities and the multiplicity equality here. -/
 theorem bus_emission_main_slots_match_opBus_row_Main
     (m : Valid_Main C F ExtF) (row : ℕ) :
-    let spec := @bus_emission_Main_0 C F ExtF _ _ _
+    let spec := @ZiskFv.Extraction.OperationBuses.bus_emission_Main_op_0 C F ExtF _ _ _
     let entry := opBus_row_Main m row
     spec.multiplicity m.circuit row = entry.multiplicity ∧
     slotValue spec 0 m.circuit row = entry.op ∧
@@ -91,7 +92,7 @@ theorem bus_emission_main_slots_match_opBus_row_Main
   -- (which also handles `... + 0 = ...` from the extractor's `Add(x, 0)`
   -- representation of unary expressions).
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
-    · simp only [bus_emission_Main_0, slotValue, opBus_row_Main,
+    · simp only [ZiskFv.Extraction.OperationBuses.bus_emission_Main_op_0, slotValue, opBus_row_Main,
                  List.getElem?_cons_zero, List.getElem?_cons_succ]
       try simp only [m.is_external_op_def, m.op_def, m.a_0_def, m.a_1_def,
                      m.b_0_def, m.b_1_def, m.c_0_def, m.c_1_def, m.flag_def,
@@ -115,7 +116,7 @@ theorem bus_shape_for_ADD
     (h_op : m.op row = 10)
     (h_ext : m.is_external_op row = 1)
     (h_m32 : m.m32 row = 0) :
-    let spec := @bus_emission_Main_0 C F ExtF _ _ _
+    let spec := @ZiskFv.Extraction.OperationBuses.bus_emission_Main_op_0 C F ExtF _ _ _
     let entry := opBus_row_Main m row
     spec.multiplicity m.circuit row = 1
     ∧ slotValue spec 0 m.circuit row = 10
@@ -167,7 +168,7 @@ theorem bus_shape_for_main_at_m32_zero
     (h_op : m.op row = op_lit)
     (h_ext : m.is_external_op row = 1)
     (h_m32 : m.m32 row = 0) :
-    let spec := @bus_emission_Main_0 C F ExtF _ _ _
+    let spec := @ZiskFv.Extraction.OperationBuses.bus_emission_Main_op_0 C F ExtF _ _ _
     let entry := opBus_row_Main m row
     spec.multiplicity m.circuit row = 1
     ∧ slotValue spec 0 m.circuit row = op_lit
@@ -201,7 +202,7 @@ theorem bus_shape_for_main_at_m32_one
     (h_op : m.op row = op_lit)
     (h_ext : m.is_external_op row = 1)
     (h_m32 : m.m32 row = 1) :
-    let spec := @bus_emission_Main_0 C F ExtF _ _ _
+    let spec := @ZiskFv.Extraction.OperationBuses.bus_emission_Main_op_0 C F ExtF _ _ _
     let entry := opBus_row_Main m row
     spec.multiplicity m.circuit row = 1
     ∧ slotValue spec 0 m.circuit row = op_lit
@@ -233,7 +234,7 @@ theorem bus_shape_for_main_at_m32_one
 @[simp]
 def bus_shape_main_at_m32_zero_conclusion
     (m : Valid_Main C F ExtF) (row : ℕ) (op_lit : F) : Prop :=
-  let spec := @bus_emission_Main_0 C F ExtF _ _ _
+  let spec := @ZiskFv.Extraction.OperationBuses.bus_emission_Main_op_0 C F ExtF _ _ _
   let entry := opBus_row_Main m row
   spec.multiplicity m.circuit row = 1
   ∧ slotValue spec 0 m.circuit row = op_lit
@@ -250,7 +251,7 @@ def bus_shape_main_at_m32_zero_conclusion
 @[simp]
 def bus_shape_main_at_m32_one_conclusion
     (m : Valid_Main C F ExtF) (row : ℕ) (op_lit : F) : Prop :=
-  let spec := @bus_emission_Main_0 C F ExtF _ _ _
+  let spec := @ZiskFv.Extraction.OperationBuses.bus_emission_Main_op_0 C F ExtF _ _ _
   let entry := opBus_row_Main m row
   spec.multiplicity m.circuit row = 1
   ∧ slotValue spec 0 m.circuit row = op_lit
@@ -790,8 +791,8 @@ end PerOpcode
 -- Dependency / axiom audit. The output messages confirm both lemmas
 -- depend only on the standard built-in axioms `propext`,
 -- `Classical.choice`, `Quot.sound` (Mathlib base) — no ZisK trust-base
--- axioms. The extracted `bus_emission_Main_0` is a pure `def`, and
--- `bus_shape_for_ADD` is closed by `ring` over field laws and the
+-- axioms. The hand-written `bus_emission_Main_op_0` is a pure `def`,
+-- and `bus_shape_for_ADD` is closed by `ring` over field laws and the
 -- named-column `_def` equalities (also `def`-defined by the
 -- `Valid_Main` structure).
 #print axioms bus_shape_for_ADD

--- a/ZiskFv/Airs/Main.lean
+++ b/ZiskFv/Airs/Main.lean
@@ -39,7 +39,7 @@ structure Valid_Main (C : Type → Type → Type) (F ExtF : Type)
   op : ℕ → F
   m32 : ℕ → F
   /-- `set_pc` selector (column 25). Constrained to be disjoint from `flag`
-      via `constraint_19_every_row`. -/
+      via `constraint_17_every_row`. -/
   set_pc : ℕ → F
   /-- `jmp_offset1` (column 26). Branch-taken offset (per
       `main.pil:151` and `create_branch_op` in
@@ -179,7 +179,7 @@ def add_subset_holds (v : Valid_Main C F ExtF) (row : ℕ) : Prop :=
     `ℕ`, so at row 0 the `row - 1` subterm saturates to 0 — but the
     `(1 - SEGMENT_L1)` gate evaluates to `0` at row 0 (`SEGMENT_L1 = 1`
     there by definition), so the misaligned subterm is multiplied out.
-    See `Extraction/Main.hand.lean`'s `constraint_20_every_row` and the
+    See `Extraction/Main.lean`'s `constraint_18_every_row` and the
     extractor-notes for the full argument.
 
     Callers who need the classical "next_pc" formulation (at some row
@@ -338,56 +338,56 @@ def jump_subset_holds (v : Valid_Main C F ExtF) (row : ℕ) (next_pc : F) : Prop
 section extraction_bridge
 
 @[simp]
-lemma constraint_8_of_extraction
+lemma constraint_7_of_extraction
     (v : Valid_Main C F ExtF) (row : ℕ) :
-    constraint_8_every_row v.circuit row ↔ internal_op0_zeroes_c0 v row := by
-  unfold constraint_8_every_row internal_op0_zeroes_c0
+    constraint_7_every_row v.circuit row ↔ internal_op0_zeroes_c0 v row := by
+  unfold constraint_7_every_row internal_op0_zeroes_c0
   rw [v.is_external_op_def, v.op_def, v.c_0_def]
 
 @[simp]
-lemma constraint_9_of_extraction
+lemma constraint_8_of_extraction
     (v : Valid_Main C F ExtF) (row : ℕ) :
-    constraint_9_every_row v.circuit row ↔ internal_op1_copies_b0 v row := by
-  unfold constraint_9_every_row internal_op1_copies_b0
+    constraint_8_every_row v.circuit row ↔ internal_op1_copies_b0 v row := by
+  unfold constraint_8_every_row internal_op1_copies_b0
   rw [v.is_external_op_def, v.op_def, v.b_0_def, v.c_0_def]
+
+@[simp]
+lemma constraint_13_of_extraction
+    (v : Valid_Main C F ExtF) (row : ℕ) :
+    constraint_13_every_row v.circuit row ↔ internal_op0_zeroes_c1 v row := by
+  unfold constraint_13_every_row internal_op0_zeroes_c1
+  rw [v.is_external_op_def, v.op_def, v.c_1_def]
+
+@[simp]
+lemma constraint_14_of_extraction
+    (v : Valid_Main C F ExtF) (row : ℕ) :
+    constraint_14_every_row v.circuit row ↔ internal_op1_copies_b1 v row := by
+  unfold constraint_14_every_row internal_op1_copies_b1
+  rw [v.is_external_op_def, v.op_def, v.b_1_def, v.c_1_def]
 
 @[simp]
 lemma constraint_15_of_extraction
     (v : Valid_Main C F ExtF) (row : ℕ) :
-    constraint_15_every_row v.circuit row ↔ internal_op0_zeroes_c1 v row := by
-  unfold constraint_15_every_row internal_op0_zeroes_c1
-  rw [v.is_external_op_def, v.op_def, v.c_1_def]
+    constraint_15_every_row v.circuit row ↔ internal_op0_sets_flag v row := by
+  unfold constraint_15_every_row internal_op0_sets_flag
+  rw [v.is_external_op_def, v.op_def, v.flag_def]
 
 @[simp]
 lemma constraint_16_of_extraction
     (v : Valid_Main C F ExtF) (row : ℕ) :
-    constraint_16_every_row v.circuit row ↔ internal_op1_copies_b1 v row := by
-  unfold constraint_16_every_row internal_op1_copies_b1
-  rw [v.is_external_op_def, v.op_def, v.b_1_def, v.c_1_def]
+    constraint_16_every_row v.circuit row ↔ internal_op1_clears_flag v row := by
+  unfold constraint_16_every_row internal_op1_clears_flag
+  rw [v.is_external_op_def, v.op_def, v.flag_def]
 
 @[simp]
 lemma constraint_17_of_extraction
     (v : Valid_Main C F ExtF) (row : ℕ) :
-    constraint_17_every_row v.circuit row ↔ internal_op0_sets_flag v row := by
-  unfold constraint_17_every_row internal_op0_sets_flag
-  rw [v.is_external_op_def, v.op_def, v.flag_def]
-
-@[simp]
-lemma constraint_18_of_extraction
-    (v : Valid_Main C F ExtF) (row : ℕ) :
-    constraint_18_every_row v.circuit row ↔ internal_op1_clears_flag v row := by
-  unfold constraint_18_every_row internal_op1_clears_flag
-  rw [v.is_external_op_def, v.op_def, v.flag_def]
-
-@[simp]
-lemma constraint_19_of_extraction
-    (v : Valid_Main C F ExtF) (row : ℕ) :
-    constraint_19_every_row v.circuit row ↔ flag_set_pc_disjoint v row := by
-  unfold constraint_19_every_row flag_set_pc_disjoint
+    constraint_17_every_row v.circuit row ↔ flag_set_pc_disjoint v row := by
+  unfold constraint_17_every_row flag_set_pc_disjoint
   rw [v.flag_def, v.set_pc_def]
 
-/-- **Constraint 20 (PC handshake) bridge.** The raw extracted
-    `constraint_20_every_row` — `(1 - SEGMENT_L1) * (pc - expected) = 0`
+/-- **Constraint 18 (PC handshake) bridge.** The raw extracted
+    `constraint_18_every_row` — `(1 - SEGMENT_L1) * (pc - expected) = 0`
     with all primed cells rendered at `(row := row - 1) (rotation := 0)`
     by the extractor — is definitionally the named closed-form
     `pc_handshake`. Bridge via `unfold` + the per-column
@@ -397,25 +397,25 @@ lemma constraint_19_of_extraction
     the `(1 - SEGMENT_L1)` gate makes the `row = 0` case vacuous, so
     the bridge is sound. -/
 @[simp]
-lemma constraint_20_of_extraction
+lemma constraint_18_of_extraction
     (v : Valid_Main C F ExtF) (row : ℕ) :
-    constraint_20_every_row v.circuit row ↔ pc_handshake v row := by
-  unfold constraint_20_every_row pc_handshake
+    constraint_18_every_row v.circuit row ↔ pc_handshake v row := by
+  unfold constraint_18_every_row pc_handshake
   simp only [v.segment_l1_def, v.pc_def, v.set_pc_def, v.c_0_def,
              v.jmp_offset1_def, v.jmp_offset2_def, v.flag_def]
 
 @[simp]
-lemma constraint_24_of_extraction
+lemma constraint_22_of_extraction
     (v : Valid_Main C F ExtF) (row : ℕ) :
-    constraint_24_every_row v.circuit row ↔ flag_boolean v row := by
-  unfold constraint_24_every_row flag_boolean
+    constraint_22_every_row v.circuit row ↔ flag_boolean v row := by
+  unfold constraint_22_every_row flag_boolean
   rw [v.flag_def]
 
 @[simp]
-lemma constraint_30_of_extraction
+lemma constraint_28_of_extraction
     (v : Valid_Main C F ExtF) (row : ℕ) :
-    constraint_30_every_row v.circuit row ↔ is_external_op_boolean v row := by
-  unfold constraint_30_every_row is_external_op_boolean
+    constraint_28_every_row v.circuit row ↔ is_external_op_boolean v row := by
+  unfold constraint_28_every_row is_external_op_boolean
   rw [v.is_external_op_def]
 
 end extraction_bridge

--- a/ZiskFv/Airs/Mem.lean
+++ b/ZiskFv/Airs/Mem.lean
@@ -36,8 +36,8 @@ Column layout taken from the witness-column header in
 * 7: `value[1]`
 * 8: `wr`
 * 9: `previous_step`
-* 10: `increment[0]`
-* 11: `increment[1]`
+* 10: `l_increment` (named `increment[0]` pre-v0.16.0, when bit-width was 18+18 → 22+16)
+* 11: `h_increment` (named `increment[1]` pre-v0.16.0)
 * 12: `read_same_addr`
 Stage-2 columns:
 * 0: `gsum`

--- a/ZiskFv/Extraction/OperationBuses.lean
+++ b/ZiskFv/Extraction/OperationBuses.lean
@@ -1,0 +1,79 @@
+import Mathlib
+
+import LeanZKCircuit.OpenVM.Circuit
+import ZiskFv.Extraction.Buses
+
+set_option linter.all false
+
+namespace ZiskFv.Extraction.OperationBuses
+
+open ZiskFv.Extraction.Buses
+
+/-! Hand-written bus-emission spec for the operation bus emitted by
+AIR `Main`. Filter: bus_id = 5000 (`OPERATION_BUS_ID`,
+`zisk/pil/opids.pil:2`).
+
+Why hand-written: ZisK v0.16.0 rewrote Main's operation-bus emission
+from
+```
+lookup_assumes(operation_bus_id, [op, a[0], (1 - m32) * a[1], b[0],
+                                   (1 - m32) * b[1], c[0], c[1], flag],
+               sel: is_external_op)
+```
+to a `proves_operation(...)` macro that expands into a permutation
+argument involving challenge cells. The new form mixes `F` (witness)
+with `ExtF` (challenges), which `tools/pil-extract`'s V1 renderer
+cannot emit without a coercion — so the auto-extracted
+`ZiskFv.Extraction.Buses.bus_emission_Main_0` is now a multiplicity-0
+placeholder stub.
+
+The operation-bus *tuple* itself is unchanged across the v0.15.0 →
+v0.16.1 refactor: the slot ordering, the column references, and the
+gating selector (`is_external_op`, column 19) are identical. Only the
+PIL macro form differs. The hand-written spec below is byte-equivalent
+to the v0.15.0 auto-extracted one.
+
+Naming: `bus_emission_Main_op_N` (with `_op_` infix) parallels
+`MemoryBuses.lean`'s `bus_emission_Main_mem_N` and disambiguates from
+the auto-extracted `bus_emission_Main_N` namespace in
+`Extraction.Buses`.
+
+Trust delta: this file lives in the
+`trust/allowed-axiom-files.txt`-adjacent zone — any change to slot
+ordering, column indices, or gating selector must be reviewed against
+`zisk/state-machines/main/pil/main.pil` to confirm the bus tuple still
+matches. The `MemoryBuses.lean` precedent uses the same convention. -/
+
+-- ----------------------------------------------------------------
+-- AIR `Main` (group 0, air idx 12 in v0.16.1) — operation bus (id 5000)
+-- ----------------------------------------------------------------
+
+-- Gating selector: `is_external_op` (column 19). PIL `assumes`-side.
+--   slot 0: op                                  -- column 20
+--   slot 1: a[0]                                -- column 0
+--   slot 2: (1 - m32) * a[1]                    -- (1 - col 28) * col 1
+--   slot 3: b[0]                                -- column 2
+--   slot 4: (1 - m32) * b[1]                    -- (1 - col 28) * col 3
+--   slot 5: c[0]                                -- column 4
+--   slot 6: c[1]                                -- column 5
+--   slot 7: flag                                -- column 6
+@[simp]
+def bus_emission_Main_op_0 {C : Type → Type → Type} {F ExtF : Type}
+    [Field F] [Field ExtF] [Circuit F ExtF C]
+: @BusEmissionSpec C F ExtF _ _ _ :=
+  { bus_id := 5000
+    is_proves := false
+    piop := "Lookup"
+    multiplicity := fun c row => ((Circuit.main c (id := 1) (column := 19) (row := row) (rotation := 0)) + 0)
+    slots := [
+      { name := "op", value := fun c row => ((Circuit.main c (id := 1) (column := 20) (row := row) (rotation := 0)) + 0) },
+      { name := "a[0]", value := fun c row => ((Circuit.main c (id := 1) (column := 0) (row := row) (rotation := 0)) + 0) },
+      { name := "(1 - m32) * a[1]", value := fun c row => ((1 - (Circuit.main c (id := 1) (column := 28) (row := row) (rotation := 0))) * (Circuit.main c (id := 1) (column := 1) (row := row) (rotation := 0))) },
+      { name := "b[0]", value := fun c row => ((Circuit.main c (id := 1) (column := 2) (row := row) (rotation := 0)) + 0) },
+      { name := "(1 - m32) * b[1]", value := fun c row => ((1 - (Circuit.main c (id := 1) (column := 28) (row := row) (rotation := 0))) * (Circuit.main c (id := 1) (column := 3) (row := row) (rotation := 0))) },
+      { name := "c[0]", value := fun c row => ((Circuit.main c (id := 1) (column := 4) (row := row) (rotation := 0)) + 0) },
+      { name := "c[1]", value := fun c row => ((Circuit.main c (id := 1) (column := 5) (row := row) (rotation := 0)) + 0) },
+      { name := "flag", value := fun c row => ((Circuit.main c (id := 1) (column := 6) (row := row) (rotation := 0)) + 0) }
+    ] }
+
+end ZiskFv.Extraction.OperationBuses


### PR DESCRIPTION
## Summary

Tracks upstream: `pilout-zisk-commit b3ca745b... → 48cf7ccef...` (v0.15.0 → v0.16.1). Toolchain bumps required: `pil2-compiler v0.8.0 → v0.9.0`, `pil2-proofman v0.15.0 → v0.16.1`. The zisk-fv submodule pin happens to already be at `48cf7ccef` (it's the v0.16.1 release SHA), so the `transpile_*` axiom citations and the pilout source now agree without further work.

`bin/test.sh` is green end-to-end against v0.16.1 — 8132 lake jobs, trust gate 6/6, fingerprint check passes (`504c8583... → d1a2932d...`).

## Extraction-layer diff

The Lean extraction tree (`ZiskFv/Extraction/`, regenerated from the new pilout) compared to v0.15.0:

| AIR                | old → new lines | diff lines | character of change                                                  |
| ------------------ | --------------- | ---------- | -------------------------------------------------------------------- |
| Mem                | 126 → 126       | 18         | AIR-id metadata; one `previous_step` source-line shift; column-name comments `increment[0]/[1]` → `l_increment / h_increment` |
| MemAlign           | 205 → 205       | 50         | AIR-id metadata + per-constraint PIL-line shifts (mostly ±1)         |
| MemAlignByte       | 94  → 94        | 18         | same shape                                                           |
| MemAlignReadByte   | 60  → 60        | 8          | AIR-id metadata + a few PIL-line shifts                              |
| MemAlignWriteByte  | 84  → 84        | 14         | same shape                                                           |
| Binary             | 108 → 108       | 14         | AIR-id metadata + PIL-line shifts                                    |
| BinaryAdd          | 58  → 58        | 8          | AIR-id metadata + PIL-line shifts                                    |
| BinaryExtension    | 66  → 66        | 2          | AIR-id metadata only (`id 12 → 24`)                                  |
| Main               | 111 → 111       | 40         | AIR-id metadata + column 12 rename `a_src_step → is_precompiled` + column 21 rename `store_ra → store_pc` + reshuffled constraint indices in the `--only` filter |
| Arith              | 169 → 169       | 38         | AIR-id metadata + per-constraint PIL-line shifts                     |
| Buses              | 274 → 293       | 34         | `bus_emission_Main_0` becomes a multiplicity-0 stub (see below); `bus_emission_Arith_0` gains 3 trailing zero slots |

Across every AIR, **line counts are identical** between v0.15.0 and v0.16.1. The diffs are dominated by:

- AIR-id metadata (`-- airgroup: Zisk (id 0)  air: Main (id 0)` → `(id 12)`) — bumped because new precompile AIRs (Add256, Blake2br, DMA, Poseidon2) were inserted before the AIRs we depend on.
- PIL source-line citations shifting by ±1 (`-- main/pil/main.pil:384` → `:387`) from a single-line PIL header change.
- Two column renames in Main: `a_src_step → is_precompiled` (col 12), `store_ra → store_pc` (col 21). Column **positions** are unchanged; only the metadata names shift.
- Two column renames in Mem: `increment[0] / increment[1]` → `l_increment / h_increment` (cols 10, 11). Bit-decomposition changed from 18+18 to 22+16 bits underneath, but the data semantics (a step-delta range check) and column positions are stable.

### The big structural change: bus emissions

ZisK v0.16.0 rewrote operation-bus emissions across Main / Arith / BinaryExtension from
```
lookup_assumes(operation_bus_id, [op, a[0], (1 - m32) * a[1], b[0], (1 - m32) * b[1], c[0], c[1], flag], sel: is_external_op)
```
to a `proves_operation(op:, a: [...], b: [...], c: [...])` macro. The new macro expands into a permutation argument involving challenge cells — i.e., it mixes `F` (witness) with `ExtF` (challenge), which `tools/pil-extract`'s V1 renderer can't emit without a coercion.

Concrete impact in `Extraction/Buses.lean`:

```diff
- -- gsum_debug_data #46 (Lookup assumes; bus_id 5000)
- --   slot: op
- --   slot: a[0]
- --   slot: (1 - m32) * a[1]
- --   slot: b[0]
- --   slot: (1 - m32) * b[1]
- --   slot: c[0]
- --   slot: c[1]
- --   slot: flag
+ -- gsum_debug_data #637 (Lookup assumes; bus_id 5000)
+ -- SKIPPED: bus_emission_Main_0 references ExtF-typed challenges /
+ -- exposed values [...]; the body has multiplicity 0 and an empty
+ -- slot list, which is sound because this emission is irrelevant
+ -- to opcode-level bus-shape proofs.
  @[simp]
  def bus_emission_Main_0 ... :=
    { bus_id := 5000
      ...
-     multiplicity := fun c row => Circuit.main c 1 19 row 0
-     slots := [ {op}, {a_lo}, {a_hi=(1-m32)*a_1}, ..., {flag} ] }
+     multiplicity := fun _ _ => 0
+     slots := [] }
```

The auto-extracted `bus_emission_Main_0` becomes a placeholder. **The bus tuple itself — slot ordering, column references, gating selector — is unchanged across the v0.15.0 → v0.16.1 refactor**; only the PIL macro form differs.

The only direct hand-written-proof dependency on auto-extracted bus emissions is `Airs/BusShape.lean`'s six references to `bus_emission_Main_0`. Resolution: hand-write the operation-bus spec in `ZiskFv/Extraction/OperationBuses.lean`, modeled on the existing `MemoryBuses.lean` (also hand-tracked). The new file is byte-equivalent to the v0.15.0 auto-extracted version.

### Constraint-index reshuffle (Main only)

The PIL macro change inserts a couple of intermediate witness-side constraints into Main, shifting the indices the Lean named-accessor layer addresses:

| Lean predicate              | v0.15.0 idx | v0.16.1 idx |
| --------------------------- | ----------- | ----------- |
| `internal_op0_zeroes_c0`    | 8           | 7           |
| `internal_op1_copies_b0`    | 9           | 8           |
| `internal_op0_zeroes_c1`    | 15          | 13          |
| `internal_op1_copies_b1`    | 16          | 14          |
| `internal_op0_sets_flag`    | 17          | 15          |
| `internal_op1_clears_flag`  | 18          | 16          |
| `flag_set_pc_disjoint`      | 19          | 17          |
| `pc_handshake`              | 20          | 18          |
| `flag_boolean`              | 24          | 22          |
| `is_external_op_boolean`    | 30          | 28          |

PIL bodies are byte-equal; only the index moves. Mapping derived by matching PIL-line citations between the two extractions.

Arith constraint indices are unchanged (Arith's own bus emission also moved to `proves_operation`, but the constraint pool around it preserved its order — confirmed for constraint_46, the only Arith index referenced from `Spec/{MulField,DivFieldSigned}.lean`).

## Proof-side changes

| File                                        | LoC | What                                                                         |
| ------------------------------------------- | --- | ---------------------------------------------------------------------------- |
| `ZiskFv/Extraction/OperationBuses.lean`     | +51 | New tracked file; hand-written bus emission spec, modeled on `MemoryBuses.lean` |
| `ZiskFv/Airs/Main.lean`                     |  ~5 | 10 bridge lemmas re-indexed (constraint_<old> → constraint_<new>), 2 doc-comment cross-refs updated |
| `ZiskFv/Airs/BusShape.lean`                 |  ~7 | 7 references rebound from `bus_emission_Main_0` → `OperationBuses.bus_emission_Main_op_0` |
| `docker/build-zisk-lean.sh`                 |  ~2 | Main `--only` filter: `8,9,15,16,17,18,19,20,24,30` → `7,8,13,14,15,16,17,18,22,28` |
| `docker/Dockerfile.pilout`                  |  ~3 | ARG defaults bump + `touch libziskfloat.a` (v0.16.0+ ships the static lib and `lib-float/build.rs` is stricter about mtime ordering) |
| `docker/versions.txt`                       |  ~3 | new commits, new fingerprint pin                                             |
| `docker/README.md` / `CLAUDE.md`            | ~10 | provenance prose + mixed-tracking section gains the third entry              |
| `.gitignore`                                |  +1 | exception for the new `OperationBuses.lean`                                  |
| `ZiskFv/Airs/Mem.lean`                      |  ~3 | doc-comment column-name refresh (cosmetic; column indices unchanged)         |

**Net: ~95 LoC across 9 files. No new axioms, no sorries.** Trust gate's `baseline-axioms.txt` hash is unchanged.

## Why the footprint stayed small

The named-accessor layer (`Valid_Main`'s 17 named columns + `_def` lemmas, similar for the other AIRs) already isolates the 56 finishing-series proofs from extraction churn. `Spec/`, `Equivalence/`, `RV64D/`, `Tactics/` all go through stable accessors only — confirmed by exhaustive grep, with the single exception of `Spec/{MulField,DivFieldSigned}.lean`'s reference to `Arith.constraint_46_every_row`, which is byte-identical between v0.15.0 and v0.16.1.

The bus-emission refactor is the only reason any meaningful work was needed; without it, the upgrade would have been a one-line pin bump.

## Test plan

- [x] `lake build` — 8132 jobs (one extra over v0.15.0 because of the new `OperationBuses.lean`)
- [x] `bin/test.sh` — 4/4 steps green (cargo + lake + trust gate + repro hashes)
- [x] Fingerprint pin (`expected-zisk-pilout-fingerprint`) updated and re-verified
- [x] Trust gate's `baseline-axioms.txt` hash unchanged (no new axioms introduced)
- [x] `#print axioms` audit on `bus_shape_for_ADD` and `bus_emission_main_slots_match_opBus_row_Main` — still no ZisK trust-base axioms beyond Mathlib's standard built-ins

🤖 Generated with [Claude Code](https://claude.com/claude-code)