### PR TITLE
Upgrade pilout to ZisK v0.17.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,16 +54,16 @@
     "pil2-proofman-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1773934051,
-        "narHash": "sha256-M4sf0WLF3d8DmtiWArarfZS78OLqj6geSI43J5jWfBA=",
+        "lastModified": 1777581721,
+        "narHash": "sha256-d96RLAolTCoP2zs6R+Q6Zi/JpmvyJApgijZ5eoVVVNU=",
         "owner": "0xPolygonHermez",
         "repo": "pil2-proofman",
-        "rev": "971209423e8fa53fa32dc747744d68c65aafa6c7",
+        "rev": "ff0e33a9b40f2467b35ef26aa2aabb4a624dfed3",
         "type": "github"
       },
       "original": {
         "owner": "0xPolygonHermez",
-        "ref": "v0.16.1",
+        "ref": "v0.17.0",
         "repo": "pil2-proofman",
         "type": "github"
       }
@@ -131,17 +131,17 @@
     "zisk-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1774024716,
-        "narHash": "sha256-4LG9R9CpsP4kLJ6Cvk8Afu7wGYjxTl1ZLIrgFPdTdAM=",
+        "lastModified": 1777619881,
+        "narHash": "sha256-ZVlMF3EUzk1kajzXwnW7+Tj1Ms9p6bFGGZPKx7v1nZo=",
         "owner": "0xPolygonHermez",
         "repo": "zisk",
-        "rev": "48cf7ccefb5ed62261abf6bfb007b5be8a23c547",
+        "rev": "b63274507a040bf9e09d22214df43066e8f80cb7",
         "type": "github"
       },
       "original": {
         "owner": "0xPolygonHermez",
+        "ref": "v0.17.0",
         "repo": "zisk",
-        "rev": "48cf7ccefb5ed62261abf6bfb007b5be8a23c547",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
       flake = false;
     };
     zisk-src = {
-      url = "github:0xPolygonHermez/zisk/48cf7ccefb5ed62261abf6bfb007b5be8a23c547";
+      url = "github:0xPolygonHermez/zisk/v0.17.0";
       flake = false;
     };
     pil2-compiler-src = {
@@ -26,7 +26,7 @@
       flake = false;
     };
     pil2-proofman-src = {
-      url = "github:0xPolygonHermez/pil2-proofman/v0.16.1";
+      url = "github:0xPolygonHermez/pil2-proofman/v0.17.0";
       flake = false;
     };
   };


### PR DESCRIPTION
## Summary

Bumps the Nix-pinned ZisK sources from v0.16.1 (current `main`, after #6) to v0.17.0:

| input | old | new |
| --- | --- | --- |
| `zisk-src` | `48cf7ccef` (v0.16.1) | `v0.17.0` tag (resolves to `b6327450`) |
| `pil2-proofman-src` | `v0.16.1` | `v0.17.0` |
| `pil2-compiler-src` | `v0.9.0` | unchanged (paired with both v0.16.1 and v0.17.0 of proofman) |

Also switches `zisk-src` from a raw commit hash to the release tag form, matching how the other two Polygon inputs are pinned. `flake.lock` still records the resolved commit + narHash, so reproducibility is unchanged.

## Why so small?

`state-machines/main/pil/main.pil` and `state-machines/arith/pil/arith.pil` are byte-identical between v0.16.1 and v0.17.0. The only `pil/` diff is in top-level `pil/zisk.pil`: a Keccakf signature change (precompile, out-of-scope per `CLAUDE.md`) and removal of stale `#pragma arg` build-config comments. So no constraint we verify against actually changed, and no Lean edits are needed.

## Test plan

- [x] `nix run .#populate` regenerates `ZiskFv/Extraction/*.lean` from the v0.17.0 pilout
- [x] `lake build` — 8132/8132 jobs green, 0 errors, 0 sorries
- [x] `trust/scripts/check-all.sh` — ALL CHECKS PASSED (locality, baseline, tier1 params, floors, sorry, 63-opcode uniformity)
- [x] `zisk-pilout` for v0.17.0 already pushed to `zisk-fv.cachix.org` from a prior local build, so CI lands on the cached path

🤖 Generated with [Claude Code](https://claude.com/claude-code)