### PR TITLE
Fix v0.16.1 upgrade: bump flake pins to match the proof-side changes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,16 +37,16 @@
     "pil2-compiler-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1761656030,
-        "narHash": "sha256-ExwQkVkrYM2JmQQnuTa7SaKEePjsbpgj6cC4kzBMLF4=",
+        "lastModified": 1772012391,
+        "narHash": "sha256-NTSsdiyHs8DEoFSRgVwuhQgQSui5gtFkvzmi97tR0bc=",
         "owner": "0xPolygonHermez",
         "repo": "pil2-compiler",
-        "rev": "bb07cb415b11002a5e754776f570c88e6e08c56e",
+        "rev": "a036e9fb0c1a9442cf9b90248a74a0a03291dad7",
         "type": "github"
       },
       "original": {
         "owner": "0xPolygonHermez",
-        "ref": "v0.8.0",
+        "ref": "v0.9.0",
         "repo": "pil2-compiler",
         "type": "github"
       }
@@ -54,16 +54,16 @@
     "pil2-proofman-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1766157330,
-        "narHash": "sha256-rmx/j9vFvEMMDA3S8C/pHRaCjBI1/H+D41/FWn93oFI=",
+        "lastModified": 1773934051,
+        "narHash": "sha256-M4sf0WLF3d8DmtiWArarfZS78OLqj6geSI43J5jWfBA=",
         "owner": "0xPolygonHermez",
         "repo": "pil2-proofman",
-        "rev": "78497c5a05ea316df2188f98c1df66bffb80192f",
+        "rev": "971209423e8fa53fa32dc747744d68c65aafa6c7",
         "type": "github"
       },
       "original": {
         "owner": "0xPolygonHermez",
-        "ref": "v0.15.0",
+        "ref": "v0.16.1",
         "repo": "pil2-proofman",
         "type": "github"
       }
@@ -131,17 +131,17 @@
     "zisk-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1766163698,
-        "narHash": "sha256-hzV4NedLnKV1JN497S7iiUq91NQltyx3M1W33SKWkeE=",
+        "lastModified": 1774024716,
+        "narHash": "sha256-4LG9R9CpsP4kLJ6Cvk8Afu7wGYjxTl1ZLIrgFPdTdAM=",
         "owner": "0xPolygonHermez",
         "repo": "zisk",
-        "rev": "b3ca745b80423c8123dc24f19039865a5bc8b074",
+        "rev": "48cf7ccefb5ed62261abf6bfb007b5be8a23c547",
         "type": "github"
       },
       "original": {
         "owner": "0xPolygonHermez",
         "repo": "zisk",
-        "rev": "b3ca745b80423c8123dc24f19039865a5bc8b074",
+        "rev": "48cf7ccefb5ed62261abf6bfb007b5be8a23c547",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -18,15 +18,15 @@
       flake = false;
     };
     zisk-src = {
-      url = "github:0xPolygonHermez/zisk/b3ca745b80423c8123dc24f19039865a5bc8b074";
+      url = "github:0xPolygonHermez/zisk/48cf7ccefb5ed62261abf6bfb007b5be8a23c547";
       flake = false;
     };
     pil2-compiler-src = {
-      url = "github:0xPolygonHermez/pil2-compiler/v0.8.0";
+      url = "github:0xPolygonHermez/pil2-compiler/v0.9.0";
       flake = false;
     };
     pil2-proofman-src = {
-      url = "github:0xPolygonHermez/pil2-proofman/v0.15.0";
+      url = "github:0xPolygonHermez/pil2-proofman/v0.16.1";
       flake = false;
     };
   };

--- a/nix/extracted-lean.nix
+++ b/nix/extracted-lean.nix
@@ -31,11 +31,12 @@ stdenv.mkDerivation {
         --output "$out/$air.lean"
     done
 
-    # Subset extractions for Main and Arith. Constraint indices were
-    # picked when the proofs were written against v0.15.0; they're
-    # what Airs/Main.lean::extraction_bridge addresses.
+    # Subset extractions for Main and Arith. Indices match
+    # `Airs/Main.lean::extraction_bridge`; they shifted from the
+    # v0.15.0 set (8,9,15,16,17,18,19,20,24,30) when ZisK reorganised
+    # operation-bus emissions in v0.16.0+.
     ${pil-extract}/bin/pil-extract --pilout ${zisk-pilout} --air Main \
-      --only 8,9,15,16,17,18,19,20,24,30 \
+      --only 7,8,13,14,15,16,17,18,22,28 \
       --output $out/Main.lean
 
     ${pil-extract}/bin/pil-extract --pilout ${zisk-pilout} --air Arith \

--- a/nix/pil2-compiler.nix
+++ b/nix/pil2-compiler.nix
@@ -9,13 +9,13 @@
 # skips that.
 buildNpmPackage {
   pname = "pil2-compiler";
-  version = "0.8.0";  # tag we pin (package.json's internal version is 0.7.0)
+  version = "0.9.0";  # tag we pin
 
   src = pil2-compiler-src;
 
   # First build will fail with a hash mismatch error; nix will print
   # the correct value to paste back in here.
-  npmDepsHash = "sha256-3gLeKYDIh95ugrPxlIi4pw0eCDburdZZctdMSRc5qsE=";
+  npmDepsHash = "sha256-Ugdu3E/USOPR7gBtj6MClx80PfShSR6Yqsj96BsFFHk=";
 
   dontNpmBuild = true;
   dontFixup = true;

--- a/nix/zisk-pilout.nix
+++ b/nix/zisk-pilout.nix
@@ -139,7 +139,7 @@ rustPlatform.buildRustPackage {
     # -i $PWD sets inputDir to the absolute source root so extern_fixed_file
     # paths (e.g. state-machines/arith/src/arith_frops_fixed.bin) are resolved
     # relative to the directory where the fixed_gen bins wrote them.
-    node --max-old-space-size=12288 \
+    node --max-old-space-size=16384 \
       ${pil2-compiler}/src/pil.js pil/zisk.pil \
       -I pil,${pil2-proofman-src}/pil2-components/lib/std/pil,state-machines,precompiles \
       -i "$PWD" \


### PR DESCRIPTION
## Summary

PR #1 ("Upgrade pilout to ZisK v0.16.1 + gate PR CI on `run-ci` label") shipped the Lean-side adjustments for v0.16.1's column layout but left `flake.nix` / `flake.lock` pinning the v0.15.x sources. After it merged, `lake build` on `main` fails: pil-extract pulls constraints `8,9,…,30` out of the v0.15.0 pilout, but the proofs in `ZiskFv/Airs/Main.lean::extraction_bridge` target the v0.16.1 indices `7,8,13,…,28`.

This PR finishes the upgrade by bumping the build-input pins to match:

| input | old | new |
| --- | --- | --- |
| `zisk-src` | `b3ca745b` (v0.15.0) | `48cf7ccef` (v0.16.1) |
| `pil2-proofman-src` | `v0.15.0` | `v0.16.1` |
| `pil2-compiler-src` | `v0.8.0` | `v0.9.0` (paired with proofman v0.16.1) |
| `nix/pil2-compiler.nix` | npm hash for `0.8.0` | refreshed for `0.9.0` |
| `nix/extracted-lean.nix` | `--only 8,9,15,16,17,18,19,20,24,30` | `--only 7,8,13,14,15,16,17,18,22,28` |
| `nix/zisk-pilout.nix` | `node --max-old-space-size=12288` | `16384` |

The Node heap bump is required: a cold rebuild of the v0.16.1 pilout under the prior 12 GiB limit aborts with v8's `OOMErrorHandler` in the GC slow path. v0.17.0 + pil2-compiler v0.9.0 happens to fit under 12 GiB, but v0.16.1 + same compiler does not — most likely a difference in the PIL surface, not the compiler.

## Test plan

- [x] `nix run .#populate` regenerates `ZiskFv/Extraction/*.lean` from the v0.16.1 pilout
- [x] `lake build` — 8132/8132 jobs, 0 errors, 0 sorries
- [x] `trust/scripts/check-all.sh` — ALL CHECKS PASSED (locality, baseline, tier1 params, floors, sorry, 63-opcode uniformity)
- [x] Cachix warmed: new `zisk-pilout` (5.64 MiB) and `extracted-lean` (124 KiB) pushed to `zisk-fv.cachix.org` so CI hits the cached path

## Followups

- PR #5 (`try-zisk-v0.17.0`) overlaps this fix entirely; once this merges I'll rebase #5 onto the new `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)