### PR TITLE
fix(nix): expand sail-lean v4.28 compat patch to Sail.lean

### DIFF
--- a/nix/sail-lean-tree.nix
+++ b/nix/sail-lean-tree.nix
@@ -1,4 +1,4 @@
-{ sail-riscv, sail-riscv-src, lib }:
+{ sail-riscv, sail-riscv-src, lib, patch }:
 
 # Override nixpkgs's sail-riscv derivation: swap in our pinned source
 # and build the `generated_lean_rv64d` cmake target instead of the
@@ -23,22 +23,33 @@ sail-riscv.overrideAttrs (old: {
   # The default cmake install phase builds the emulator. We want only
   # the Lean tree.
   #
-  # Patch the sail-emitted `Sail/IntRange.lean` to add `[Monad m]` to
-  # its `ForIn'` / `ForM` instance heads. The handwritten prelude in
-  # upstream sail targets a Lean nightly (`nightly-2025-11-18`) whose
-  # instance elaboration propagates the Monad constraint implicitly;
-  # stable Lean v4.28 does not, so the instances fail to synthesize
-  # `Monad m` without this annotation. The same fix lives on
-  # codygunton/sail @ lean-backend/v4.28 (commit 46acc966), ready to
-  # upstream to rems-project/sail.
+  # Apply the v4.28-stable compat patch to the sail-emitted prelude.
+  # Upstream sail's handwritten Lean prelude (`Sail/IntRange.lean`,
+  # `Sail/Sail.lean`) targets a Lean nightly (`nightly-2025-11-18`)
+  # whose elaboration handles some signatures that stable Lean v4.28
+  # does not. The patch fixes:
+  #
+  #   - `IntRange.lean`: `[Monad m]` on `ForIn'` / `ForM` instance heads
+  #     (the nightly propagates the constraint implicitly; stable does
+  #     not, so `Monad m` fails to synthesize).
+  #
+  #   - `Sail.lean`: a `Coe String.Slice String` instance + explicit
+  #     `: String` ascriptions to handle `String.take`/`drop` now
+  #     returning `String.Slice` under v4.28's stdlib; replacement of
+  #     `String.Pos.Raw.get!` (nightly-only) with `str.toList[i]!`;
+  #     and `str.all` → `str.toList.all` to dodge the same
+  #     `String.Slice`-overload disambiguation issue.
+  #
+  # The same fix lives on codygunton/sail @ lean-backend/v4.28
+  # (commit e4ba7849), ready to upstream to rems-project/sail. The
+  # patch file is the literal `git diff 277470b2..e4ba7849` with the
+  # in-source path prefix `src/sail_lean_backend/Sail/` rewritten to
+  # the install-phase output prefix `LeanRV64D/Sail/`.
   installPhase = ''
     runHook preInstall
     mkdir -p $out
     cp -r model/Lean_RV64D/. $out/
-    sed -i \
-      -e 's|^instance : ForIn'"'"' m IntRange Int|instance [Monad m] : ForIn'"'"' m IntRange Int|' \
-      -e 's|^instance : ForM m IntRange Int|instance [Monad m] : ForM m IntRange Int|' \
-      $out/LeanRV64D/Sail/IntRange.lean
+    ${patch}/bin/patch -p1 -d $out < ${./sail-lean-v4.28-compat.patch}
     runHook postInstall
   '';
 

--- a/nix/sail-lean-v4.28-compat.patch
+++ b/nix/sail-lean-v4.28-compat.patch
@@ -1,0 +1,76 @@
+diff --git a/LeanRV64D/Sail/IntRange.lean b/LeanRV64D/Sail/IntRange.lean
+index ac463027..3b7b1773 100644
+--- a/LeanRV64D/Sail/IntRange.lean
++++ b/LeanRV64D/Sail/IntRange.lean
+@@ -51,7 +51,7 @@ theorem toNat_lt_toNat {a b : Int} (hb : 0 < b) : Int.toNat a < Int.toNat b ↔
+   have := range.step_pos
+   loop init range.start (by simp)
+ 
+-instance : ForIn' m IntRange Int inferInstance where
++instance [Monad m] : ForIn' m IntRange Int inferInstance where
+   forIn' := IntRange.forIn'
+ 
+ -- No separate `ForIn` instance is required because it can be derived from `ForIn'`.
+@@ -77,7 +77,7 @@ instance : ForIn' m IntRange Int inferInstance where
+   have := range.step_pos
+   loop range.start
+ 
+-instance : ForM m IntRange Int where
++instance [Monad m] : ForM m IntRange Int where
+   forM := IntRange.forM
+ 
+ syntax:max "[" withoutPosition(":" term) "]i" : term
+diff --git a/LeanRV64D/Sail/Sail.lean b/LeanRV64D/Sail/Sail.lean
+index 7ed5b57d..20a3da09 100644
+--- a/LeanRV64D/Sail/Sail.lean
++++ b/LeanRV64D/Sail/Sail.lean
+@@ -123,11 +123,17 @@ def charToHex (c : Char) : BitVec 4 :=
+ 
+ def round4 (n : Nat) := ((n - 1) / 4) * 4 + 4
+ 
++-- Coerce String.Slice → String for v4.28+ stdlib, where `String.take`/`drop`
++-- return `String.Slice`. Sail-emitted callers (e.g. HexBitsSigned.lean) pass
++-- `String.drop str 1` directly to functions expecting `String`; this Coe
++-- lets that compile without changing the codegen.
++instance : Coe String.Slice String where coe s := s.toString
++
+ def parse_hex_bits_digits (n : Nat) (str : String) : BitVec n :=
+   let len := str.length
+   if h : n < 4 || len = 0 then BitVec.zero n else
+     let bv := parse_hex_bits_digits (n-4) (str.take (len-1))
+-    let c := String.Pos.Raw.get! str ⟨len-1⟩ |> charToHex
++    let c := str.toList[len-1]! |> charToHex
+     BitVec.append bv c |>.cast (by simp_all)
+ decreasing_by simp_all <;> omega
+ 
+@@ -137,8 +143,8 @@ where
+   -- TODO: when there are lemmas about `String.take`, replace with WF induction
+   go (fuel : Nat) (str : String) :=
+     if fuel = 0 then 0 else
+-      let lsd := String.Pos.Raw.get! str ⟨str.length - 1⟩
+-      let rest := str.take (str.length - 1)
++      let lsd := str.toList[str.length - 1]!
++      let rest : String := str.take (str.length - 1)
+       (charToHex lsd).setWidth n + 10#n * go (fuel-1) rest
+ 
+ def parse_hex_bits (n : Nat) (str : String) : BitVec n :=
+@@ -147,14 +153,14 @@ def parse_hex_bits (n : Nat) (str : String) : BitVec n :=
+ 
+ def valid_hex_bits (n : Nat) (str : String) : Bool :=
+   if str.length < 2 then false else
+-  let str := str.drop 2
+-  str.all fun x => x.toLower ∈
+-    ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'] &&
++  let str : String := str.drop 2
++  str.toList.all (fun x => x.toLower ∈
++    ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f']) &&
+   2 ^ n > (parse_hex_bits_digits (round4 n) str).toNat
+ 
+ def valid_dec_bits (_ : Nat) (str : String) : Bool :=
+-  str.all fun x => x.toLower ∈
+-    ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
++  str.toList.all (fun (x : Char) => x.toLower ∈
++    ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])
+ 
+ @[simp_sail]
+ def shift_bits_left (bv : BitVec n) (sh : BitVec m) : BitVec n :=


### PR DESCRIPTION
## Summary

Follow-up to #31 fixing the CI failure on `main` ([run 25895957354](https://github.com/eth-act/zisk-fv/actions/runs/25895957354)). The post-merge CI failed with the same `LeanRV64D/Sail/Sail.lean` errors I thought I'd fixed pre-merge.

**What slipped through #31:** my local Sail.lean fixes lived only in `build/sail-lean/` (gitignored output), so `lake build` was green locally. The flake's `installPhase` only patched `IntRange.lean`. On a clean machine, `nix run .#populate` overwrites `build/sail-lean/` from the nix store path, which contains the unpatched upstream Sail.lean → the six v4.28 errors resurface.

## Fix

- New file: `nix/sail-lean-v4.28-compat.patch` — the literal `git diff 277470b2..e4ba7849` from [codygunton/sail@lean-backend/v4.28](https://github.com/codygunton/sail/tree/lean-backend/v4.28), with the in-source path prefix `src/sail_lean_backend/Sail/` rewritten to the cmake install-phase output prefix `LeanRV64D/Sail/`.
- `nix/sail-lean-tree.nix`: `installPhase` switched from a 2-line inline `sed` (IntRange.lean only) to `patch -p1 < ./sail-lean-v4.28-compat.patch` covering both files.

The patch fixes:
- `IntRange.lean`: `[Monad m]` on `ForIn'` / `ForM` instance heads (was the pre-merge patch).
- `Sail.lean`: `Coe String.Slice String` instance + explicit `: String` ascriptions for the `String.take`/`drop` → `String.Slice` change in v4.28's stdlib; `String.Pos.Raw.get!` → `str.toList[i]!`; `str.all` → `str.toList.all` on rebound `let str` to dodge `String.Slice` overload disambiguation.

The corresponding upstream-ready patches live on `codygunton/sail` branch `lean-backend/v4.28`, demo at codygunton/sail#1.

## Verification

- [x] `lake build` — 8491 / 8491 jobs green locally
- [x] `nix run .#test` — green end-to-end locally
- [x] Trust gates V1 + V2 pass
- [x] New `sail-lean-tree` store hash `cs2iziahz...` pushed to `zisk-fv.cachix.org` (cache hit ready for CI)
- [ ] Apply `run-ci` label to fire proofs.yml on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)