### PR TITLE
refactor(Compliance): thread *Promises bundles through wrappers + OpEnvelope

### DIFF
--- a/ZiskFv/Compliance.lean
+++ b/ZiskFv/Compliance.lean
@@ -268,127 +268,73 @@ inductive OpEnvelope
     (beq_input : PureSpec.BeqInput) (imm : BitVec 13) (r1 r2 : regidx)
     (misa_val : RegisterType Register.misa)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
-    (h_input_imm : beq_input.imm = imm)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok beq_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok beq_input.r2_val state)
-    (h_input_pc : state.regs.get? Register.PC = .some beq_input.PC)
-    (h_input_misa : state.regs.get? Register.misa = .some misa_val)
-    (h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1)
-    (h_target_aligned :
-      (beq_input.PC + BitVec.signExtend 64 beq_input.imm).toNat % 4 = 0)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_BEQ_pure beq_input).nextPC) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.BranchPromises
+        state beq_input.imm beq_input.r1_val beq_input.r2_val beq_input.PC
+        misa_val
+        (PureSpec.execute_BEQ_pure beq_input).nextPC
+        (PureSpec.execute_BEQ_pure beq_input).throws
+        (PureSpec.execute_BEQ_pure beq_input).success
+        imm r1 r2 exec_row) : OpEnvelope state m r_main
   -- ============================ BNE (branch, no mem) ====================
   | bne
     (bne_input : PureSpec.BneInput) (imm : BitVec 13) (r1 r2 : regidx)
     (misa_val : RegisterType Register.misa)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
-    (h_input_imm : bne_input.imm = imm)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok bne_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok bne_input.r2_val state)
-    (h_input_pc : state.regs.get? Register.PC = .some bne_input.PC)
-    (h_input_misa : state.regs.get? Register.misa = .some misa_val)
-    (h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1)
-    (h_target_aligned :
-      (bne_input.PC + BitVec.signExtend 64 bne_input.imm).toNat % 4 = 0)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_BNE_pure bne_input).nextPC) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.BranchPromises
+        state bne_input.imm bne_input.r1_val bne_input.r2_val bne_input.PC
+        misa_val
+        (PureSpec.execute_BNE_pure bne_input).nextPC
+        (PureSpec.execute_BNE_pure bne_input).throws
+        (PureSpec.execute_BNE_pure bne_input).success
+        imm r1 r2 exec_row) : OpEnvelope state m r_main
   -- ============================ BLT (branch, no mem) ====================
   | blt
     (blt_input : PureSpec.BltInput) (imm : BitVec 13) (r1 r2 : regidx)
     (misa_val : RegisterType Register.misa)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
-    (h_input_imm : blt_input.imm = imm)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok blt_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok blt_input.r2_val state)
-    (h_input_pc : state.regs.get? Register.PC = .some blt_input.PC)
-    (h_input_misa : state.regs.get? Register.misa = .some misa_val)
-    (h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1)
-    (h_target_aligned :
-      (blt_input.PC + BitVec.signExtend 64 blt_input.imm).toNat % 4 = 0)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_BLT_pure blt_input).nextPC) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.BranchPromises
+        state blt_input.imm blt_input.r1_val blt_input.r2_val blt_input.PC
+        misa_val
+        (PureSpec.execute_BLT_pure blt_input).nextPC
+        (PureSpec.execute_BLT_pure blt_input).throws
+        (PureSpec.execute_BLT_pure blt_input).success
+        imm r1 r2 exec_row) : OpEnvelope state m r_main
   -- ============================ BGE (branch, no mem) ====================
   | bge
     (bge_input : PureSpec.BgeInput) (imm : BitVec 13) (r1 r2 : regidx)
     (misa_val : RegisterType Register.misa)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
-    (h_input_imm : bge_input.imm = imm)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok bge_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok bge_input.r2_val state)
-    (h_input_pc : state.regs.get? Register.PC = .some bge_input.PC)
-    (h_input_misa : state.regs.get? Register.misa = .some misa_val)
-    (h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1)
-    (h_target_aligned :
-      (bge_input.PC + BitVec.signExtend 64 bge_input.imm).toNat % 4 = 0)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_BGE_pure bge_input).nextPC) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.BranchPromises
+        state bge_input.imm bge_input.r1_val bge_input.r2_val bge_input.PC
+        misa_val
+        (PureSpec.execute_BGE_pure bge_input).nextPC
+        (PureSpec.execute_BGE_pure bge_input).throws
+        (PureSpec.execute_BGE_pure bge_input).success
+        imm r1 r2 exec_row) : OpEnvelope state m r_main
   -- ============================ BLTU (branch, no mem) ===================
   | bltu
     (bltu_input : PureSpec.BltuInput) (imm : BitVec 13) (r1 r2 : regidx)
     (misa_val : RegisterType Register.misa)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
-    (h_input_imm : bltu_input.imm = imm)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok bltu_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok bltu_input.r2_val state)
-    (h_input_pc : state.regs.get? Register.PC = .some bltu_input.PC)
-    (h_input_misa : state.regs.get? Register.misa = .some misa_val)
-    (h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1)
-    (h_target_aligned :
-      (bltu_input.PC + BitVec.signExtend 64 bltu_input.imm).toNat % 4 = 0)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_BLTU_pure bltu_input).nextPC) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.BranchPromises
+        state bltu_input.imm bltu_input.r1_val bltu_input.r2_val bltu_input.PC
+        misa_val
+        (PureSpec.execute_BLTU_pure bltu_input).nextPC
+        (PureSpec.execute_BLTU_pure bltu_input).throws
+        (PureSpec.execute_BLTU_pure bltu_input).success
+        imm r1 r2 exec_row) : OpEnvelope state m r_main
   -- ============================ BGEU (branch, no mem) ===================
   | bgeu
     (bgeu_input : PureSpec.BgeuInput) (imm : BitVec 13) (r1 r2 : regidx)
     (misa_val : RegisterType Register.misa)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
-    (h_input_imm : bgeu_input.imm = imm)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok bgeu_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok bgeu_input.r2_val state)
-    (h_input_pc : state.regs.get? Register.PC = .some bgeu_input.PC)
-    (h_input_misa : state.regs.get? Register.misa = .some misa_val)
-    (h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1)
-    (h_target_aligned :
-      (bgeu_input.PC + BitVec.signExtend 64 bgeu_input.imm).toNat % 4 = 0)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_BGEU_pure bgeu_input).nextPC) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.BranchPromises
+        state bgeu_input.imm bgeu_input.r1_val bgeu_input.r2_val bgeu_input.PC
+        misa_val
+        (PureSpec.execute_BGEU_pure bgeu_input).nextPC
+        (PureSpec.execute_BGEU_pure bgeu_input).throws
+        (PureSpec.execute_BGEU_pure bgeu_input).success
+        imm r1 r2 exec_row) : OpEnvelope state m r_main
   -- ============================ FENCE (no mem) ==========================
   | fence
     (fence_input : PureSpec.FenceInput)
@@ -396,15 +342,10 @@ inductive OpEnvelope
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (h_main_active : m.is_external_op r_main = 0)
     (h_main_op_fence : m.op r_main = OP_FLAG)
-    (h_input_pc : state.regs.get? Register.PC = .some fence_input.PC)
-    (h_input_priv :
-      state.regs.get? Register.cur_privilege = .some Privilege.Machine)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_FENCE_pure fence_input).nextPC) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.FencePromises
+        state fence_input.PC
+        (PureSpec.execute_FENCE_pure fence_input).nextPC
+        exec_row) : OpEnvelope state m r_main
   -- ============================ LUI (1 mem entry) =======================
   | lui
     (lui_input : PureSpec.LuiInput)
@@ -414,17 +355,10 @@ inductive OpEnvelope
     (h_main_active : m.is_external_op r_main = 0)
     (h_main_op_lui : m.op r_main = OP_COPYB)
     (h_lui_subset : lui_subset_holds m r_main next_pc)
-    (h_input_imm : lui_input.imm = imm)
-    (h_input_rd : lui_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some lui_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = lui_input.PC + 4#64)
-    (h_rd_mult : e_rd.multiplicity = 1) (h_rd_as : e_rd.as.val = 1)
-    (h_rd_idx : lui_input.rd = Transpiler.wrap_to_regidx e_rd.ptr) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.UTypePromises
+        state lui_input.imm lui_input.rd lui_input.PC
+        (PureSpec.execute_LUI_pure lui_input).nextPC
+        imm rd exec_row e_rd (lui_input.PC + 4#64)) : OpEnvelope state m r_main
   -- ============================ AUIPC (1 mem entry) =====================
   | auipc
     (auipc_input : PureSpec.AuipcInput)
@@ -435,19 +369,10 @@ inductive OpEnvelope
     (h_main_active : m.is_external_op r_main = 0)
     (h_main_op_auipc : m.op r_main = OP_FLAG)
     (h_auipc_subset : auipc_subset_holds m r_main next_pc)
-    (h_input_imm : auipc_input.imm = imm)
-    (h_input_rd : auipc_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some auipc_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = nextPC_val)
-    (h_rd_mult : e_rd.multiplicity = 1) (h_rd_as : e_rd.as.val = 1)
-    (h_nextPC_eq :
-      (PureSpec.execute_AUIPC_pure auipc_input).nextPC = nextPC_val)
-    (h_rd_idx : auipc_input.rd = Transpiler.wrap_to_regidx e_rd.ptr)
+    (promises : ZiskFv.Equivalence.Promises.UTypePromises
+        state auipc_input.imm auipc_input.rd auipc_input.PC
+        (PureSpec.execute_AUIPC_pure auipc_input).nextPC
+        imm rd exec_row e_rd nextPC_val)
     (h_no_wrap : auipc_input.PC.toNat
       + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
         < GL_prime)
@@ -465,24 +390,15 @@ inductive OpEnvelope
     (e_rd : Interaction.MemoryBusEntry FGL) (nextPC_val : BitVec 64)
     (h_main_active : m.is_external_op r_main = 0)
     (h_main_op_jal : m.op r_main = OP_FLAG)
-    (h_jal_subset : ZiskFv.Airs.Main.jump_subset_holds m r_main next_pc)
+    (h_jal_subset :
+      ZiskFv.Airs.Main.jump_subset_holds m r_main next_pc)
+    (promises : ZiskFv.Equivalence.Promises.JumpPromises
+        state jal_input.PC jal_input.rd misa_val
+        (PureSpec.execute_JAL_pure jal_input).success
+        (PureSpec.execute_JAL_pure jal_input).nextPC
+        rd exec_row e_rd nextPC_val)
     (h_input_imm : jal_input.imm = imm)
-    (h_input_rd : jal_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some jal_input.PC)
-    (h_input_misa : state.regs.get? Register.misa = .some misa_val)
-    (h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = nextPC_val)
-    (h_rd_mult : e_rd.multiplicity = 1) (h_rd_as : e_rd.as.val = 1)
     (h_not_throws : (PureSpec.execute_JAL_pure jal_input).throws = false)
-    (h_success : (PureSpec.execute_JAL_pure jal_input).success = true)
-    (h_nextPC_option :
-      (PureSpec.execute_JAL_pure jal_input).nextPC = .some nextPC_val)
-    (h_rd_idx : jal_input.rd = Transpiler.wrap_to_regidx e_rd.ptr)
     (h_pc_bound : jal_input.PC.toNat < GL_prime - 4)
     (h_lo_bound : (m.pc r_main + 4 : FGL).val < 4294967296)
     (h_pc_offset_lt_2_32 : (jal_input.PC + 4#64).toNat < 4294967296) : OpEnvelope state m r_main
@@ -499,28 +415,18 @@ inductive OpEnvelope
     (h_main_op_jalr : m.op r_main = OP_COPYB)
     (h_jalr_subset :
       ZiskFv.Tactics.JumpArchetype.jalr_subset_holds m r_main next_pc)
+    (promises : ZiskFv.Equivalence.Promises.JumpPromises
+        state jalr_input.PC jalr_input.rd misa_val
+        (PureSpec.execute_JALR_pure jalr_input).success
+        (PureSpec.execute_JALR_pure jalr_input).nextPC
+        rd exec_row e_rd nextPC_val)
     (h_input_imm : jalr_input.imm = imm)
-    (h_input_rd : jalr_input.rd = regidx_to_fin rd)
     (h_input_rs1 : read_xreg (regidx_to_fin rs1) state
       = EStateM.Result.ok jalr_input.rs1_val state)
-    (h_input_pc : state.regs.get? Register.PC = .some jalr_input.PC)
-    (h_input_misa : state.regs.get? Register.misa = .some misa_val)
-    (h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1)
     (h_cur_privilege : Sail.readReg Register.cur_privilege state
       = EStateM.Result.ok Privilege.Machine state)
     (h_mseccfg : Sail.readReg Register.mseccfg state
       = EStateM.Result.ok mseccfg state)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = nextPC_val)
-    (h_rd_mult : e_rd.multiplicity = 1) (h_rd_as : e_rd.as.val = 1)
-    (h_success : (PureSpec.execute_JALR_pure jalr_input).success = true)
-    (h_nextPC_option :
-      (PureSpec.execute_JALR_pure jalr_input).nextPC = .some nextPC_val)
-    (h_rd_idx : jalr_input.rd = Transpiler.wrap_to_regidx e_rd.ptr)
     (h_pc_bound : jalr_input.PC.toNat < GL_prime - 4)
     (h_lo_bound : (m.pc r_main + 4 : FGL).val < 4294967296)
     (h_pc_offset_lt_2_32 : (jalr_input.PC + 4#64).toNat < 4294967296) : OpEnvelope state m r_main
@@ -535,22 +441,10 @@ inductive OpEnvelope
     (h_main_subset : add_subset_holds m r_main)
     (h_b_core : ∀ r, ZiskFv.Airs.BinaryAdd.core_every_row b r)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1_sail : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok add_input.r1_val state)
-    (h_input_r2_sail : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok add_input.r2_val state)
-    (h_input_rd : add_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some add_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_add_pure add_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : add_input.rd = Transpiler.wrap_to_regidx e2.ptr) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state add_input.r1_val add_input.r2_val add_input.rd add_input.PC
+        (PureSpec.execute_RTYPE_add_pure add_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ ADDI (do-block LHS, BinaryAdd) ==========
   | addi
     (addi_input : PureSpec.AddiInput) (r1 rd : regidx) (imm : BitVec 12)
@@ -563,21 +457,10 @@ inductive OpEnvelope
     (h_b_core : ∀ r, ZiskFv.Airs.BinaryAdd.core_every_row b r)
     (h_addi_subset : itype_imm_subset_holds_main m r_main addi_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok addi_input.r1_val state)
-    (h_input_imm : addi_input.imm = imm)
-    (h_input_rd : addi_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some addi_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_ITYPE_addi_pure addi_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : addi_input.rd = Transpiler.wrap_to_regidx e2.ptr) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.ITypePromises
+        state addi_input.r1_val addi_input.imm addi_input.rd addi_input.PC
+        (PureSpec.execute_ITYPE_addi_pure addi_input).nextPC
+        r1 rd imm exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ ADDW (Binary, do-block) =================
   | addw
     (addw_input : PureSpec.AddwInput) (r1 r2 rd : regidx)
@@ -587,22 +470,10 @@ inductive OpEnvelope
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op_addw : m.op r_main = OP_ADD_W)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok addw_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok addw_input.r2_val state)
-    (h_input_rd : addw_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some addw_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_addw_pure addw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : addw_input.rd = Transpiler.wrap_to_regidx e2.ptr) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state addw_input.r1_val addw_input.r2_val addw_input.rd addw_input.PC
+        (PureSpec.execute_RTYPE_addw_pure addw_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ SUBW (Binary, do-block) =================
   | subw
     (subw_input : PureSpec.SubwInput) (r1 r2 rd : regidx)
@@ -612,22 +483,10 @@ inductive OpEnvelope
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op_subw : m.op r_main = OP_SUB_W)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok subw_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok subw_input.r2_val state)
-    (h_input_rd : subw_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some subw_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_subw_pure subw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : subw_input.rd = Transpiler.wrap_to_regidx e2.ptr) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state subw_input.r1_val subw_input.r2_val subw_input.rd subw_input.PC
+        (PureSpec.execute_RTYPE_subw_pure subw_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ ADDIW (Binary, do-block, I-type) ========
   | addiw
     (addiw_input : PureSpec.AddiwInput) (r1 rd : regidx) (imm : BitVec 12)
@@ -638,21 +497,10 @@ inductive OpEnvelope
     (h_main_op_addiw : m.op r_main = OP_ADD_W)
     (h_addiw_subset : itype_imm_subset_holds_main m r_main addiw_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok addiw_input.r1_val state)
-    (h_input_imm : addiw_input.imm = imm)
-    (h_input_rd : addiw_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some addiw_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_ITYPE_addiw_pure addiw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : addiw_input.rd = Transpiler.wrap_to_regidx e2.ptr) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.ITypePromises
+        state addiw_input.r1_val addiw_input.imm addiw_input.rd addiw_input.PC
+        (PureSpec.execute_ITYPE_addiw_pure addiw_input).nextPC
+        r1 rd imm exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ SUB (Binary, R-type) ====================
   | sub
     (sub_input : PureSpec.SubInput) (r1 r2 rd : regidx)
@@ -662,22 +510,10 @@ inductive OpEnvelope
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op_sub : m.op r_main = OP_SUB)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok sub_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok sub_input.r2_val state)
-    (h_input_rd : sub_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some sub_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_sub_pure sub_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : sub_input.rd = Transpiler.wrap_to_regidx e2.ptr) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state sub_input.r1_val sub_input.r2_val sub_input.rd sub_input.PC
+        (PureSpec.execute_RTYPE_sub_pure sub_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ AND (Binary, R-type) ====================
   | and_op
     (and_input : PureSpec.AndInput) (r1 r2 rd : regidx)
@@ -687,22 +523,10 @@ inductive OpEnvelope
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op_and : m.op r_main = OP_AND)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok and_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok and_input.r2_val state)
-    (h_input_rd : and_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some and_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_and_pure and_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : and_input.rd = Transpiler.wrap_to_regidx e2.ptr) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state and_input.r1_val and_input.r2_val and_input.rd and_input.PC
+        (PureSpec.execute_RTYPE_and_pure and_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ OR (Binary, R-type) =====================
   | or_op
     (or_input : PureSpec.OrInput) (r1 r2 rd : regidx)
@@ -712,22 +536,10 @@ inductive OpEnvelope
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op_or : m.op r_main = OP_OR)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok or_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok or_input.r2_val state)
-    (h_input_rd : or_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some or_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_or_pure or_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : or_input.rd = Transpiler.wrap_to_regidx e2.ptr) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state or_input.r1_val or_input.r2_val or_input.rd or_input.PC
+        (PureSpec.execute_RTYPE_or_pure or_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ XOR (Binary, R-type) ====================
   | xor_op
     (xor_input : PureSpec.XorInput) (r1 r2 rd : regidx)
@@ -737,22 +549,10 @@ inductive OpEnvelope
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op_xor : m.op r_main = OP_XOR)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok xor_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok xor_input.r2_val state)
-    (h_input_rd : xor_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some xor_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_xor_pure xor_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : xor_input.rd = Transpiler.wrap_to_regidx e2.ptr) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state xor_input.r1_val xor_input.r2_val xor_input.rd xor_input.PC
+        (PureSpec.execute_RTYPE_xor_pure xor_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ SLT (Binary, R-type) ====================
   | slt
     (slt_input : PureSpec.SltInput) (r1 r2 rd : regidx)
@@ -762,22 +562,10 @@ inductive OpEnvelope
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op_slt : m.op r_main = OP_LT)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok slt_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok slt_input.r2_val state)
-    (h_input_rd : slt_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some slt_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_slt_pure slt_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : slt_input.rd = Transpiler.wrap_to_regidx e2.ptr) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state slt_input.r1_val slt_input.r2_val slt_input.rd slt_input.PC
+        (PureSpec.execute_RTYPE_slt_pure slt_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ SLTU (Binary, R-type) ===================
   | sltu
     (sltu_input : PureSpec.SltuInput) (r1 r2 rd : regidx)
@@ -787,22 +575,10 @@ inductive OpEnvelope
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op_sltu : m.op r_main = OP_LTU)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok sltu_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok sltu_input.r2_val state)
-    (h_input_rd : sltu_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some sltu_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_sltu_pure sltu_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : sltu_input.rd = Transpiler.wrap_to_regidx e2.ptr) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state sltu_input.r1_val sltu_input.r2_val sltu_input.rd sltu_input.PC
+        (PureSpec.execute_RTYPE_sltu_pure sltu_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ ANDI (Binary, I-type) ===================
   | andi
     (andi_input : PureSpec.AndiInput) (r1 rd : regidx) (imm : BitVec 12)
@@ -813,21 +589,10 @@ inductive OpEnvelope
     (h_main_op_andi : m.op r_main = OP_AND)
     (h_andi_subset : itype_imm_subset_holds_main m r_main andi_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok andi_input.r1_val state)
-    (h_input_imm : andi_input.imm = imm)
-    (h_input_rd : andi_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some andi_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_ITYPE_andi_pure andi_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : andi_input.rd = Transpiler.wrap_to_regidx e2.ptr) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.ITypePromises
+        state andi_input.r1_val andi_input.imm andi_input.rd andi_input.PC
+        (PureSpec.execute_ITYPE_andi_pure andi_input).nextPC
+        r1 rd imm exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ ORI (Binary, I-type) ====================
   | ori
     (ori_input : PureSpec.OriInput) (r1 rd : regidx) (imm : BitVec 12)
@@ -838,21 +603,10 @@ inductive OpEnvelope
     (h_main_op_ori : m.op r_main = OP_OR)
     (h_ori_subset : itype_imm_subset_holds_main m r_main ori_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok ori_input.r1_val state)
-    (h_input_imm : ori_input.imm = imm)
-    (h_input_rd : ori_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some ori_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_ITYPE_ori_pure ori_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : ori_input.rd = Transpiler.wrap_to_regidx e2.ptr) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.ITypePromises
+        state ori_input.r1_val ori_input.imm ori_input.rd ori_input.PC
+        (PureSpec.execute_ITYPE_ori_pure ori_input).nextPC
+        r1 rd imm exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ XORI (Binary, I-type) ===================
   | xori
     (xori_input : PureSpec.XoriInput) (r1 rd : regidx) (imm : BitVec 12)
@@ -863,21 +617,10 @@ inductive OpEnvelope
     (h_main_op_xori : m.op r_main = OP_XOR)
     (h_xori_subset : itype_imm_subset_holds_main m r_main xori_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok xori_input.r1_val state)
-    (h_input_imm : xori_input.imm = imm)
-    (h_input_rd : xori_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some xori_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_ITYPE_xori_pure xori_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : xori_input.rd = Transpiler.wrap_to_regidx e2.ptr) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.ITypePromises
+        state xori_input.r1_val xori_input.imm xori_input.rd xori_input.PC
+        (PureSpec.execute_ITYPE_xori_pure xori_input).nextPC
+        r1 rd imm exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ SLTI (Binary, I-type) ===================
   | slti
     (slti_input : PureSpec.SltiInput) (r1 rd : regidx) (imm : BitVec 12)
@@ -888,21 +631,10 @@ inductive OpEnvelope
     (h_main_op_slti : m.op r_main = OP_LT)
     (h_slti_subset : itype_imm_subset_holds_main m r_main slti_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok slti_input.r1_val state)
-    (h_input_imm : slti_input.imm = imm)
-    (h_input_rd : slti_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some slti_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_ITYPE_slti_pure slti_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : slti_input.rd = Transpiler.wrap_to_regidx e2.ptr) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.ITypePromises
+        state slti_input.r1_val slti_input.imm slti_input.rd slti_input.PC
+        (PureSpec.execute_ITYPE_slti_pure slti_input).nextPC
+        r1 rd imm exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ SLTIU (Binary, I-type) ==================
   | sltiu
     (sltiu_input : PureSpec.SltiuInput) (r1 rd : regidx) (imm : BitVec 12)
@@ -913,43 +645,20 @@ inductive OpEnvelope
     (h_main_op_sltiu : m.op r_main = OP_LTU)
     (h_sltiu_subset : itype_imm_subset_holds_main m r_main sltiu_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok sltiu_input.r1_val state)
-    (h_input_imm : sltiu_input.imm = imm)
-    (h_input_rd : sltiu_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some sltiu_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_ITYPE_sltiu_pure sltiu_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : sltiu_input.rd = Transpiler.wrap_to_regidx e2.ptr) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.ITypePromises
+        state sltiu_input.r1_val sltiu_input.imm sltiu_input.rd sltiu_input.PC
+        (PureSpec.execute_ITYPE_sltiu_pure sltiu_input).nextPC
+        r1 rd imm exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ SLL (BinaryExtension, R-type) ===========
   | sll
     (sll_input : PureSpec.SllInput) (r1 r2 rd : regidx)
     (v : Valid_BinaryExtension C FGL FGL)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
-    (h_input_r1_sail : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok sll_input.r1_val state)
-    (h_input_r2_sail : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok sll_input.r2_val state)
-    (h_input_rd : sll_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some sll_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_sll_pure sll_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : sll_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state sll_input.r1_val sll_input.r2_val sll_input.rd sll_input.PC
+        (PureSpec.execute_RTYPE_sll_pure sll_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op : m.op r_main = ZiskFv.Trusted.OP_SLL)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2) :
@@ -960,22 +669,10 @@ inductive OpEnvelope
     (v : Valid_BinaryExtension C FGL FGL)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok srl_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok srl_input.r2_val state)
-    (h_input_rd : srl_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some srl_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_srl_pure srl_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : srl_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state srl_input.r1_val srl_input.r2_val srl_input.rd srl_input.PC
+        (PureSpec.execute_RTYPE_srl_pure srl_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op : m.op r_main = ZiskFv.Trusted.OP_SRL)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2) :
@@ -986,22 +683,10 @@ inductive OpEnvelope
     (v : Valid_BinaryExtension C FGL FGL)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
-    (h_input_r1_sail : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok sra_input.r1_val state)
-    (h_input_r2_sail : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok sra_input.r2_val state)
-    (h_input_rd : sra_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some sra_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_sra_pure sra_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : sra_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state sra_input.r1_val sra_input.r2_val sra_input.rd sra_input.PC
+        (PureSpec.execute_RTYPE_sra_pure sra_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op : m.op r_main = ZiskFv.Trusted.OP_SRA)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2) :
@@ -1012,21 +697,10 @@ inductive OpEnvelope
     (v : Valid_BinaryExtension C FGL FGL)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
-    (h_input_r1_sail : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok slli_input.r1_val state)
-    (h_input_shamt : slli_input.shamt = shamt)
-    (h_input_rd : slli_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some slli_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_SHIFTIOP_slli_pure slli_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : slli_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.ShiftImmPromises
+        state slli_input.r1_val slli_input.shamt slli_input.rd slli_input.PC
+        (PureSpec.execute_SHIFTIOP_slli_pure slli_input).nextPC
+        r1 rd shamt exec_row e0 e1 e2)
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op : m.op r_main = ZiskFv.Trusted.OP_SLL)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2) :
@@ -1037,21 +711,10 @@ inductive OpEnvelope
     (v : Valid_BinaryExtension C FGL FGL)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok srli_input.r1_val state)
-    (h_input_shamt : srli_input.shamt = shamt)
-    (h_input_rd : srli_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some srli_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_SHIFTIOP_srli_pure srli_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : srli_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.ShiftImmPromises
+        state srli_input.r1_val srli_input.shamt srli_input.rd srli_input.PC
+        (PureSpec.execute_SHIFTIOP_srli_pure srli_input).nextPC
+        r1 rd shamt exec_row e0 e1 e2)
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op : m.op r_main = ZiskFv.Trusted.OP_SRL)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2) :
@@ -1062,21 +725,10 @@ inductive OpEnvelope
     (v : Valid_BinaryExtension C FGL FGL)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok srai_input.r1_val state)
-    (h_input_shamt : srai_input.shamt = shamt)
-    (h_input_rd : srai_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some srai_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_SHIFTIOP_srai_pure srai_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : srai_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.ShiftImmPromises
+        state srai_input.r1_val srai_input.shamt srai_input.rd srai_input.PC
+        (PureSpec.execute_SHIFTIOP_srai_pure srai_input).nextPC
+        r1 rd shamt exec_row e0 e1 e2)
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op : m.op r_main = ZiskFv.Trusted.OP_SRA)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2) :
@@ -1165,20 +817,10 @@ inductive OpEnvelope
     (v : Valid_BinaryExtension C FGL FGL)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
-    (h_input_r1_sail : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok slliw_input.r1_val state)
-    (h_input_rd : slliw_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some slliw_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_SHIFTIWOP_slliw_pure slliw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : slliw_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.ShiftWImmPromises
+        state slliw_input.r1_val slliw_input.rd slliw_input.PC
+        (PureSpec.execute_SHIFTIWOP_slliw_pure slliw_input).nextPC
+        r1 rd exec_row e0 e1 e2)
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op : m.op r_main = ZiskFv.Trusted.OP_SLL_W)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2) :
@@ -1189,20 +831,10 @@ inductive OpEnvelope
     (v : Valid_BinaryExtension C FGL FGL)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
-    (h_input_r1_sail : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok srliw_input.r1_val state)
-    (h_input_rd : srliw_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some srliw_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_SHIFTIWOP_srliw_pure srliw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : srliw_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.ShiftWImmPromises
+        state srliw_input.r1_val srliw_input.rd srliw_input.PC
+        (PureSpec.execute_SHIFTIWOP_srliw_pure srliw_input).nextPC
+        r1 rd exec_row e0 e1 e2)
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op : m.op r_main = ZiskFv.Trusted.OP_SRL_W)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2) :
@@ -1213,20 +845,10 @@ inductive OpEnvelope
     (v : Valid_BinaryExtension C FGL FGL)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
-    (h_input_r1_sail : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok sraiw_input.r1_val state)
-    (h_input_rd : sraiw_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some sraiw_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_SHIFTIWOP_sraiw_pure sraiw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : sraiw_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.ShiftWImmPromises
+        state sraiw_input.r1_val sraiw_input.rd sraiw_input.PC
+        (PureSpec.execute_SHIFTIWOP_sraiw_pure sraiw_input).nextPC
+        r1 rd exec_row e0 e1 e2)
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op : m.op r_main = ZiskFv.Trusted.OP_SRA_W)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2) :
@@ -1243,19 +865,12 @@ inductive OpEnvelope
     (h_main_active : m.is_external_op r_main = 0)
     (h_main_op : m.op r_main = OP_COPYB)
     (h_main_ind_width : m.ind_width r_main = 1)
-    (risc_v_assumptions :
-      RISC_V_assumptions state mstatus pmaRegion misa mseccfg)
-    (h_opcode_assumptions :
-      PureSpec.sb_state_assumptions sb_input state)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_STOREB_pure sb_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 2) : OpEnvelope state m r_main
+    (h_opcode_assumptions : PureSpec.sb_state_assumptions sb_input state)
+    (promises : ZiskFv.Equivalence.Promises.StorePromises
+        state mstatus pmaRegion misa mseccfg
+        (PureSpec.sb_state_assumptions sb_input state)
+        (PureSpec.execute_STOREB_pure sb_input).nextPC
+        exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ SH (store, Main-only) ===================
   | sh
     (sh_input : PureSpec.ShInput)
@@ -1268,19 +883,12 @@ inductive OpEnvelope
     (h_main_active : m.is_external_op r_main = 0)
     (h_main_op : m.op r_main = OP_COPYB)
     (h_main_ind_width : m.ind_width r_main = 2)
-    (risc_v_assumptions :
-      RISC_V_assumptions state mstatus pmaRegion misa mseccfg)
-    (h_opcode_assumptions :
-      PureSpec.sh_state_assumptions sh_input state)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_STOREH_pure sh_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 2) : OpEnvelope state m r_main
+    (h_opcode_assumptions : PureSpec.sh_state_assumptions sh_input state)
+    (promises : ZiskFv.Equivalence.Promises.StorePromises
+        state mstatus pmaRegion misa mseccfg
+        (PureSpec.sh_state_assumptions sh_input state)
+        (PureSpec.execute_STOREH_pure sh_input).nextPC
+        exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ SW (store, Main-only) ===================
   | sw
     (sw_input : PureSpec.SwInput)
@@ -1293,19 +901,12 @@ inductive OpEnvelope
     (h_main_active : m.is_external_op r_main = 0)
     (h_main_op : m.op r_main = OP_COPYB)
     (h_main_ind_width : m.ind_width r_main = 4)
-    (risc_v_assumptions :
-      RISC_V_assumptions state mstatus pmaRegion misa mseccfg)
-    (h_opcode_assumptions :
-      PureSpec.sw_state_assumptions sw_input state)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_STOREW_pure sw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 2) : OpEnvelope state m r_main
+    (h_opcode_assumptions : PureSpec.sw_state_assumptions sw_input state)
+    (promises : ZiskFv.Equivalence.Promises.StorePromises
+        state mstatus pmaRegion misa mseccfg
+        (PureSpec.sw_state_assumptions sw_input state)
+        (PureSpec.execute_STOREW_pure sw_input).nextPC
+        exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ SD (store, Main-only) ===================
   | sd
     (sd_input : PureSpec.SdInput)
@@ -1317,19 +918,12 @@ inductive OpEnvelope
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
     (h_main_active : m.is_external_op r_main = 0)
     (h_main_op : m.op r_main = OP_COPYB)
-    (risc_v_assumptions :
-      RISC_V_assumptions state mstatus pmaRegion misa mseccfg)
-    (h_opcode_assumptions :
-      PureSpec.sd_state_assumptions sd_input state)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_STORED_pure sd_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 2) : OpEnvelope state m r_main
+    (h_opcode_assumptions : PureSpec.sd_state_assumptions sd_input state)
+    (promises : ZiskFv.Equivalence.Promises.StorePromises
+        state mstatus pmaRegion misa mseccfg
+        (PureSpec.sd_state_assumptions sd_input state)
+        (PureSpec.execute_STORED_pure sd_input).nextPC
+        exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ LD (load doubleword) ====================
   | ld
     (ld_input : PureSpec.LdInput)
@@ -1342,19 +936,11 @@ inductive OpEnvelope
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
     (h_main_active : m.is_external_op r_main = 0)
     (h_main_op_ld : m.op r_main = OP_COPYB)
-    (risc_v_assumptions :
-      RISC_V_assumptions state mstatus pmaRegion misa mseccfg)
-    (h_opcode_assumptions :
-      PureSpec.ld_state_assumptions ld_input state)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_LOADD_pure ld_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 2)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.LoadPromises
+        state mstatus pmaRegion misa mseccfg
+        (PureSpec.ld_state_assumptions ld_input state)
+        (PureSpec.execute_LOADD_pure ld_input).nextPC
+        exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ LBU =====================================
   | lbu
     (lbu_input : PureSpec.LbuInput)
@@ -1373,19 +959,11 @@ inductive OpEnvelope
     (h_main_active : m.is_external_op r_main = 0)
     (h_main_op_lbu : m.op r_main = OP_COPYB)
     (h_width : m.ind_width r_main = (1 : FGL))
-    (risc_v_assumptions :
-      RISC_V_assumptions state mstatus pmaRegion misa mseccfg)
-    (h_opcode_assumptions :
-      PureSpec.lbu_state_assumptions lbu_input state)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_LOADBU_pure lbu_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 2)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.LoadPromises
+        state mstatus pmaRegion misa mseccfg
+        (PureSpec.lbu_state_assumptions lbu_input state)
+        (PureSpec.execute_LOADBU_pure lbu_input).nextPC
+        exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ LHU =====================================
   | lhu
     (lhu_input : PureSpec.LhuInput)
@@ -1404,19 +982,11 @@ inductive OpEnvelope
     (h_main_active : m.is_external_op r_main = 0)
     (h_main_op_lhu : m.op r_main = OP_COPYB)
     (h_width : m.ind_width r_main = (2 : FGL))
-    (risc_v_assumptions :
-      RISC_V_assumptions state mstatus pmaRegion misa mseccfg)
-    (h_opcode_assumptions :
-      PureSpec.lhu_state_assumptions lhu_input state)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_LOADHU_pure lhu_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 2)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.LoadPromises
+        state mstatus pmaRegion misa mseccfg
+        (PureSpec.lhu_state_assumptions lhu_input state)
+        (PureSpec.execute_LOADHU_pure lhu_input).nextPC
+        exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ LWU =====================================
   | lwu
     (lwu_input : PureSpec.LwuInput)
@@ -1435,19 +1005,11 @@ inductive OpEnvelope
     (h_main_active : m.is_external_op r_main = 0)
     (h_main_op_lwu : m.op r_main = OP_COPYB)
     (h_width : m.ind_width r_main = (4 : FGL))
-    (risc_v_assumptions :
-      RISC_V_assumptions state mstatus pmaRegion misa mseccfg)
-    (h_opcode_assumptions :
-      PureSpec.lwu_state_assumptions lwu_input state)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_LOADWU_pure lwu_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 2)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.LoadPromises
+        state mstatus pmaRegion misa mseccfg
+        (PureSpec.lwu_state_assumptions lwu_input state)
+        (PureSpec.execute_LOADWU_pure lwu_input).nextPC
+        exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ LB (signed-byte load) ===================
   | lb
     (lb_input : PureSpec.LbInput)
@@ -1461,19 +1023,11 @@ inductive OpEnvelope
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op : m.op r_main = ZiskFv.Trusted.OP_SIGNEXTEND_B)
-    (risc_v_assumptions :
-      RISC_V_assumptions state mstatus pmaRegion misa mseccfg)
-    (h_opcode_assumptions :
-      PureSpec.lb_state_assumptions lb_input state)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_LOADB_pure lb_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 2)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.LoadPromises
+        state mstatus pmaRegion misa mseccfg
+        (PureSpec.lb_state_assumptions lb_input state)
+        (PureSpec.execute_LOADB_pure lb_input).nextPC
+        exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ LH ======================================
   | lh
     (lh_input : PureSpec.LhInput)
@@ -1487,19 +1041,11 @@ inductive OpEnvelope
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op : m.op r_main = ZiskFv.Trusted.OP_SIGNEXTEND_H)
-    (risc_v_assumptions :
-      RISC_V_assumptions state mstatus pmaRegion misa mseccfg)
-    (h_opcode_assumptions :
-      PureSpec.lh_state_assumptions lh_input state)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_LOADH_pure lh_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 2)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.LoadPromises
+        state mstatus pmaRegion misa mseccfg
+        (PureSpec.lh_state_assumptions lh_input state)
+        (PureSpec.execute_LOADH_pure lh_input).nextPC
+        exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ LW ======================================
   | lw
     (lw_input : PureSpec.LwInput)
@@ -1513,19 +1059,11 @@ inductive OpEnvelope
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op : m.op r_main = ZiskFv.Trusted.OP_SIGNEXTEND_W)
-    (risc_v_assumptions :
-      RISC_V_assumptions state mstatus pmaRegion misa mseccfg)
-    (h_opcode_assumptions :
-      PureSpec.lw_state_assumptions lw_input state)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_LOADW_pure lw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 2)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1) : OpEnvelope state m r_main
+    (promises : ZiskFv.Equivalence.Promises.LoadPromises
+        state mstatus pmaRegion misa mseccfg
+        (PureSpec.lw_state_assumptions lw_input state)
+        (PureSpec.execute_LOADW_pure lw_input).nextPC
+        exec_row e0 e1 e2) : OpEnvelope state m r_main
   -- ============================ MUL =====================================
   | mul
     (mul_input : PureSpec.MulInput) (r1 r2 rd : regidx)
@@ -1538,22 +1076,10 @@ inductive OpEnvelope
     (h_match_primary :
       matches_entry (opBus_row_Main m r_main)
                     (opBus_row_Arith v r_a))
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok mul_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok mul_input.r2_val state)
-    (h_input_rd : mul_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some mul_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_MULH_mul_pure mul_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : mul_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state mul_input.r1_val mul_input.r2_val mul_input.rd mul_input.PC
+        (PureSpec.execute_MULH_mul_pure mul_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h0 : e2.x0.val < 256) (h1 : e2.x1.val < 256)
     (h2 : e2.x2.val < 256) (h3 : e2.x3.val < 256)
     (h4 : e2.x4.val < 256) (h5 : e2.x5.val < 256)
@@ -1572,22 +1098,10 @@ inductive OpEnvelope
     (h_match_secondary :
       matches_entry (opBus_row_Main m r_main)
                     (opBus_row_ArithMulSecondary v r_a))
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok mulh_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok mulh_input.r2_val state)
-    (h_input_rd : mulh_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some mulh_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_MULH_mulh_pure mulh_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : mulh_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state mulh_input.r1_val mulh_input.r2_val mulh_input.rd mulh_input.PC
+        (PureSpec.execute_MULH_mulh_pure mulh_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_row_constraints :
       ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a) :
     OpEnvelope state m r_main
@@ -1602,22 +1116,10 @@ inductive OpEnvelope
     (h_match_secondary :
       matches_entry (opBus_row_Main m r_main)
                     (opBus_row_ArithMulSecondary v r_a))
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok mulhu_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok mulhu_input.r2_val state)
-    (h_input_rd : mulhu_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some mulhu_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_MULH_mulhu_pure mulhu_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : mulhu_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state mulhu_input.r1_val mulhu_input.r2_val mulhu_input.rd mulhu_input.PC
+        (PureSpec.execute_MULH_mulhu_pure mulhu_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h0 : e2.x0.val < 256) (h1 : e2.x1.val < 256)
     (h2 : e2.x2.val < 256) (h3 : e2.x3.val < 256)
     (h4 : e2.x4.val < 256) (h5 : e2.x5.val < 256)
@@ -1636,22 +1138,10 @@ inductive OpEnvelope
     (h_match_secondary :
       matches_entry (opBus_row_Main m r_main)
                     (opBus_row_ArithMulSecondary v r_a))
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok mulhsu_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok mulhsu_input.r2_val state)
-    (h_input_rd : mulhsu_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some mulhsu_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_MULH_mulhsu_pure mulhsu_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : mulhsu_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state mulhsu_input.r1_val mulhsu_input.r2_val mulhsu_input.rd mulhsu_input.PC
+        (PureSpec.execute_MULH_mulhsu_pure mulhsu_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_row_constraints :
       ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a) :
     OpEnvelope state m r_main
@@ -1666,22 +1156,10 @@ inductive OpEnvelope
     (h_match_primary :
       matches_entry (opBus_row_Main m r_main)
                     (opBus_row_Arith v r_a))
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok mulw_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok mulw_input.r2_val state)
-    (h_input_rd : mulw_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some mulw_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_MULW_pure mulw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : mulw_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state mulw_input.r1_val mulw_input.r2_val mulw_input.rd mulw_input.PC
+        (PureSpec.execute_MULW_pure mulw_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_row_constraints :
       ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a)
     (h_sext_choice :
@@ -1709,22 +1187,10 @@ inductive OpEnvelope
     (h_match_primary :
       matches_entry (opBus_row_Main m r_main)
                     (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv v r_a))
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_DIVREM_div_pure div_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : div_input.rd = Transpiler.wrap_to_regidx e2.ptr)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok div_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok div_input.r2_val state)
-    (h_input_rd : div_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some div_input.PC)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state div_input.r1_val div_input.r2_val div_input.rd div_input.PC
+        (PureSpec.execute_DIVREM_div_pure div_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_op2_ne : div_input.r2_val.toInt ≠ 0)
     (h_no_overflow :
       ¬ (div_input.r1_val.toInt = -(2:ℤ)^63 ∧ div_input.r2_val.toInt = -1))
@@ -1749,22 +1215,10 @@ inductive OpEnvelope
     (h_match_primary :
       matches_entry (opBus_row_Main m r_main)
                     (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv v r_a))
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok divu_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok divu_input.r2_val state)
-    (h_input_rd : divu_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some divu_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_DIVREM_divu_pure divu_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : divu_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state divu_input.r1_val divu_input.r2_val divu_input.rd divu_input.PC
+        (PureSpec.execute_DIVREM_divu_pure divu_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h0 : e2.x0.val < 256) (h1 : e2.x1.val < 256)
     (h2 : e2.x2.val < 256) (h3 : e2.x3.val < 256)
     (h4 : e2.x4.val < 256) (h5 : e2.x5.val < 256)
@@ -1784,22 +1238,10 @@ inductive OpEnvelope
     (h_match_primary :
       matches_entry (opBus_row_Main m r_main)
                     (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv v r_a))
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok divw_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok divw_input.r2_val state)
-    (h_input_rd : divw_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some divw_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_DIVREM_divw_pure divw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : divw_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state divw_input.r1_val divw_input.r2_val divw_input.rd divw_input.PC
+        (PureSpec.execute_DIVREM_divw_pure divw_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_row_constraints :
       ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     (h_na_bool : v.na r_a = 0 ∨ v.na r_a = 1)
@@ -1838,22 +1280,10 @@ inductive OpEnvelope
     (h_match_primary :
       matches_entry (opBus_row_Main m r_main)
                     (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv v r_a))
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok divuw_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok divuw_input.r2_val state)
-    (h_input_rd : divuw_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some divuw_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_DIVREM_divuw_pure divuw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : divuw_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state divuw_input.r1_val divuw_input.r2_val divuw_input.rd divuw_input.PC
+        (PureSpec.execute_DIVREM_divuw_pure divuw_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_row_constraints :
       ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     (h_sext_choice :
@@ -1878,22 +1308,10 @@ inductive OpEnvelope
     (h_match_secondary :
       matches_entry (opBus_row_Main m r_main)
                     (ZiskFv.Airs.ArithDiv.opBus_row_ArithDivSecondary v r_a))
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_DIVREM_rem_pure rem_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : rem_input.rd = Transpiler.wrap_to_regidx e2.ptr)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok rem_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok rem_input.r2_val state)
-    (h_input_rd : rem_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some rem_input.PC)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state rem_input.r1_val rem_input.r2_val rem_input.rd rem_input.PC
+        (PureSpec.execute_DIVREM_rem_pure rem_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_op2_ne : rem_input.r2_val.toInt ≠ 0)
     (h_no_overflow :
       ¬ (rem_input.r1_val.toInt = -(2:ℤ)^63 ∧ rem_input.r2_val.toInt = -1))
@@ -1918,22 +1336,10 @@ inductive OpEnvelope
     (h_match_secondary :
       matches_entry (opBus_row_Main m r_main)
                     (ZiskFv.Airs.ArithDiv.opBus_row_ArithDivSecondary v r_a))
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok remu_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok remu_input.r2_val state)
-    (h_input_rd : remu_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some remu_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_DIVREM_remu_pure remu_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : remu_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state remu_input.r1_val remu_input.r2_val remu_input.rd remu_input.PC
+        (PureSpec.execute_DIVREM_remu_pure remu_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h0 : e2.x0.val < 256) (h1 : e2.x1.val < 256)
     (h2 : e2.x2.val < 256) (h3 : e2.x3.val < 256)
     (h4 : e2.x4.val < 256) (h5 : e2.x5.val < 256)
@@ -1953,22 +1359,10 @@ inductive OpEnvelope
     (h_match_secondary :
       matches_entry (opBus_row_Main m r_main)
                     (ZiskFv.Airs.ArithDiv.opBus_row_ArithDivSecondary v r_a))
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok remw_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok remw_input.r2_val state)
-    (h_input_rd : remw_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some remw_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_DIVREM_remw_pure remw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : remw_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state remw_input.r1_val remw_input.r2_val remw_input.rd remw_input.PC
+        (PureSpec.execute_DIVREM_remw_pure remw_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_row_constraints :
       ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     (h_na_bool : v.na r_a = 0 ∨ v.na r_a = 1)
@@ -2007,22 +1401,10 @@ inductive OpEnvelope
     (h_match_secondary :
       matches_entry (opBus_row_Main m r_main)
                     (ZiskFv.Airs.ArithDiv.opBus_row_ArithDivSecondary v r_a))
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok remuw_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok remuw_input.r2_val state)
-    (h_input_rd : remuw_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some remuw_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_DIVREM_remuw_pure remuw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : remuw_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state remuw_input.r1_val remuw_input.r2_val remuw_input.rd remuw_input.PC
+        (PureSpec.execute_DIVREM_remuw_pure remuw_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_row_constraints :
       ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     (h_sext_choice :
@@ -2521,349 +1903,201 @@ theorem zisk_riscv_compliant_program_bus
     (env : OpEnvelope (C := C) state m r_main) :
     env.exec_eq := by
   cases env with
-  | beq beq_input imm r1 r2 misa_val exec_row
-        h_input_imm h_input_r1 h_input_r2 h_input_pc h_input_misa h_misa_c
-        h_target_aligned h_exec_len h_e0_mult h_e1_mult h_nextPC_matches =>
+  | beq beq_input imm r1 r2 misa_val exec_row promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_BEQ_from_trust state beq_input imm r1 r2 misa_val exec_row
-      h_input_imm h_input_r1 h_input_r2 h_input_pc h_input_misa h_misa_c
-      h_target_aligned h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-  | bne bne_input imm r1 r2 misa_val exec_row
-        h_input_imm h_input_r1 h_input_r2 h_input_pc h_input_misa h_misa_c
-        h_target_aligned h_exec_len h_e0_mult h_e1_mult h_nextPC_matches =>
+      promises
+  | bne bne_input imm r1 r2 misa_val exec_row promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_BNE_from_trust state bne_input imm r1 r2 misa_val exec_row
-      h_input_imm h_input_r1 h_input_r2 h_input_pc h_input_misa h_misa_c
-      h_target_aligned h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-  | blt blt_input imm r1 r2 misa_val exec_row
-        h_input_imm h_input_r1 h_input_r2 h_input_pc h_input_misa h_misa_c
-        h_target_aligned h_exec_len h_e0_mult h_e1_mult h_nextPC_matches =>
+      promises
+  | blt blt_input imm r1 r2 misa_val exec_row promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_BLT_from_trust state blt_input imm r1 r2 misa_val exec_row
-      h_input_imm h_input_r1 h_input_r2 h_input_pc h_input_misa h_misa_c
-      h_target_aligned h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-  | bge bge_input imm r1 r2 misa_val exec_row
-        h_input_imm h_input_r1 h_input_r2 h_input_pc h_input_misa h_misa_c
-        h_target_aligned h_exec_len h_e0_mult h_e1_mult h_nextPC_matches =>
+      promises
+  | bge bge_input imm r1 r2 misa_val exec_row promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_BGE_from_trust state bge_input imm r1 r2 misa_val exec_row
-      h_input_imm h_input_r1 h_input_r2 h_input_pc h_input_misa h_misa_c
-      h_target_aligned h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-  | bltu bltu_input imm r1 r2 misa_val exec_row
-         h_input_imm h_input_r1 h_input_r2 h_input_pc h_input_misa h_misa_c
-         h_target_aligned h_exec_len h_e0_mult h_e1_mult h_nextPC_matches =>
+      promises
+  | bltu bltu_input imm r1 r2 misa_val exec_row promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_BLTU_from_trust state bltu_input imm r1 r2 misa_val exec_row
-      h_input_imm h_input_r1 h_input_r2 h_input_pc h_input_misa h_misa_c
-      h_target_aligned h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-  | bgeu bgeu_input imm r1 r2 misa_val exec_row
-         h_input_imm h_input_r1 h_input_r2 h_input_pc h_input_misa h_misa_c
-         h_target_aligned h_exec_len h_e0_mult h_e1_mult h_nextPC_matches =>
+      promises
+  | bgeu bgeu_input imm r1 r2 misa_val exec_row promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_BGEU_from_trust state bgeu_input imm r1 r2 misa_val exec_row
-      h_input_imm h_input_r1 h_input_r2 h_input_pc h_input_misa h_misa_c
-      h_target_aligned h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
+      promises
   | fence fence_input fm pred succ rs rd exec_row
-          h_main_active h_main_op_fence h_input_pc h_input_priv
-          h_exec_len h_e0_mult h_e1_mult h_nextPC_matches =>
+          h_main_active h_main_op_fence promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_FENCE_from_trust state fence_input fm pred succ rs rd m r_main
-      exec_row h_main_active h_main_op_fence h_input_pc h_input_priv
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
+      exec_row h_main_active h_main_op_fence promises
   | lui lui_input imm rd next_pc exec_row e_rd
-        h_main_active h_main_op_lui h_lui_subset
-        h_input_imm h_input_rd h_input_pc
-        h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-        h_rd_mult h_rd_as h_rd_idx =>
+        h_main_active h_main_op_lui h_lui_subset promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_LUI_from_trust state lui_input imm rd m r_main next_pc
-      exec_row e_rd h_main_active h_main_op_lui h_lui_subset
-      h_input_imm h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_rd_mult h_rd_as h_rd_idx
+      exec_row e_rd h_main_active h_main_op_lui h_lui_subset promises
   | auipc auipc_input imm rd exec_row e_rd nextPC_val next_pc
           h_main_active h_main_op_auipc h_auipc_subset
-          h_input_imm h_input_rd h_input_pc
-          h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-          h_rd_mult h_rd_as h_nextPC_eq h_rd_idx
-          h_no_wrap h_lo_bound h_pc_offset_lt_2_32 =>
+          promises h_no_wrap h_lo_bound h_pc_offset_lt_2_32 =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_AUIPC_from_trust state auipc_input imm rd exec_row e_rd nextPC_val
       m r_main next_pc h_main_active h_main_op_auipc h_auipc_subset
-      h_input_imm h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_rd_mult h_rd_as h_nextPC_eq h_rd_idx
-      h_no_wrap h_lo_bound h_pc_offset_lt_2_32
+      promises h_no_wrap h_lo_bound h_pc_offset_lt_2_32
   | jal jal_input imm rd misa_val next_pc exec_row e_rd nextPC_val
         h_main_active h_main_op_jal h_jal_subset
-        h_input_imm h_input_rd h_input_pc h_input_misa h_misa_c
-        h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-        h_rd_mult h_rd_as h_not_throws h_success h_nextPC_option h_rd_idx
+        promises h_input_imm h_not_throws
         h_pc_bound h_lo_bound h_pc_offset_lt_2_32 =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_JAL_from_trust state jal_input imm rd misa_val m r_main next_pc
       exec_row e_rd nextPC_val h_main_active h_main_op_jal h_jal_subset
-      h_input_imm h_input_rd h_input_pc h_input_misa h_misa_c
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_rd_mult h_rd_as h_not_throws h_success h_nextPC_option h_rd_idx
+      promises h_input_imm h_not_throws
       h_pc_bound h_lo_bound h_pc_offset_lt_2_32
   | jalr jalr_input imm rs1 rd misa_val mseccfg exec_row e_rd nextPC_val next_pc
          h_main_active h_main_op_jalr h_jalr_subset
-         h_input_imm h_input_rd h_input_rs1 h_input_pc h_input_misa h_misa_c
-         h_cur_privilege h_mseccfg
-         h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-         h_rd_mult h_rd_as h_success h_nextPC_option h_rd_idx
+         promises h_input_imm h_input_rs1 h_cur_privilege h_mseccfg
          h_pc_bound h_lo_bound h_pc_offset_lt_2_32 =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_JALR_from_trust state jalr_input imm rs1 rd misa_val mseccfg
       exec_row e_rd nextPC_val m r_main next_pc
       h_main_active h_main_op_jalr h_jalr_subset
-      h_input_imm h_input_rd h_input_rs1 h_input_pc h_input_misa h_misa_c
-      h_cur_privilege h_mseccfg
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_rd_mult h_rd_as h_success h_nextPC_option h_rd_idx
+      promises h_input_imm h_input_rs1 h_cur_privilege h_mseccfg
       h_pc_bound h_lo_bound h_pc_offset_lt_2_32
   | add add_input r1 r2 rd b exec_row e0 e1 e2
-        h_main_active h_main_op_add h_main_subset h_b_core h_lane_rd
-        h_input_r1_sail h_input_r2_sail h_input_rd h_input_pc
-        h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-        h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx =>
+        h_main_active h_main_op_add h_main_subset h_b_core h_lane_rd promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_ADD_from_trust state add_input r1 r2 rd m b r_main exec_row e0 e1 e2
-      h_main_active h_main_op_add h_main_subset h_b_core h_lane_rd
-      h_input_r1_sail h_input_r2_sail h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      h_main_active h_main_op_add h_main_subset h_b_core h_lane_rd promises
   | addi addi_input r1 rd imm b exec_row e0 e1 e2
          h_main_active h_main_op_addi h_main_subset h_b_core h_addi_subset h_lane_rd
-         h_input_r1 h_input_imm h_input_rd h_input_pc
-         h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-         h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx =>
+         promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_ADDI_from_trust state addi_input r1 rd imm m b r_main exec_row e0 e1 e2
       h_main_active h_main_op_addi h_main_subset h_b_core h_addi_subset h_lane_rd
-      h_input_r1 h_input_imm h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
   | addw addw_input r1 r2 rd v exec_row e0 e1 e2
-         h_main_active h_main_op_addw h_lane_rd
-         h_input_r1 h_input_r2 h_input_rd h_input_pc
-         h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-         h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx =>
+         h_main_active h_main_op_addw h_lane_rd promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_ADDW_from_trust state addw_input r1 r2 rd m v r_main exec_row e0 e1 e2
-      h_main_active h_main_op_addw h_lane_rd
-      h_input_r1 h_input_r2 h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      h_main_active h_main_op_addw h_lane_rd promises
   | subw subw_input r1 r2 rd v exec_row e0 e1 e2
-         h_main_active h_main_op_subw h_lane_rd
-         h_input_r1 h_input_r2 h_input_rd h_input_pc
-         h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-         h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx =>
+         h_main_active h_main_op_subw h_lane_rd promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_SUBW_from_trust state subw_input r1 r2 rd m v r_main exec_row e0 e1 e2
-      h_main_active h_main_op_subw h_lane_rd
-      h_input_r1 h_input_r2 h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      h_main_active h_main_op_subw h_lane_rd promises
   | addiw addiw_input r1 rd imm v exec_row e0 e1 e2
           h_main_active h_main_op_addiw h_addiw_subset h_lane_rd
-          h_input_r1 h_input_imm h_input_rd h_input_pc
-          h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-          h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx =>
+          promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_ADDIW_from_trust state addiw_input r1 rd imm m v r_main exec_row e0 e1 e2
       h_main_active h_main_op_addiw h_addiw_subset h_lane_rd
-      h_input_r1 h_input_imm h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
   | sub sub_input r1 r2 rd v exec_row e0 e1 e2
-        h_main_active h_main_op_sub h_lane_rd
-        h_input_r1 h_input_r2 h_input_rd h_input_pc
-        h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-        h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx =>
+        h_main_active h_main_op_sub h_lane_rd promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_SUB_from_trust state sub_input r1 r2 rd m v r_main exec_row e0 e1 e2
-      h_main_active h_main_op_sub h_lane_rd
-      h_input_r1 h_input_r2 h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      h_main_active h_main_op_sub h_lane_rd promises
   | and_op and_input r1 r2 rd v exec_row e0 e1 e2
-           h_main_active h_main_op_and h_lane_rd
-           h_input_r1 h_input_r2 h_input_rd h_input_pc
-           h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-           h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx =>
+           h_main_active h_main_op_and h_lane_rd promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_AND_from_trust state and_input r1 r2 rd m v r_main exec_row e0 e1 e2
-      h_main_active h_main_op_and h_lane_rd
-      h_input_r1 h_input_r2 h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      h_main_active h_main_op_and h_lane_rd promises
   | or_op or_input r1 r2 rd v exec_row e0 e1 e2
-          h_main_active h_main_op_or h_lane_rd
-          h_input_r1 h_input_r2 h_input_rd h_input_pc
-          h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-          h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx =>
+          h_main_active h_main_op_or h_lane_rd promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_OR_from_trust state or_input r1 r2 rd m v r_main exec_row e0 e1 e2
-      h_main_active h_main_op_or h_lane_rd
-      h_input_r1 h_input_r2 h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      h_main_active h_main_op_or h_lane_rd promises
   | xor_op xor_input r1 r2 rd v exec_row e0 e1 e2
-           h_main_active h_main_op_xor h_lane_rd
-           h_input_r1 h_input_r2 h_input_rd h_input_pc
-           h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-           h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx =>
+           h_main_active h_main_op_xor h_lane_rd promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_XOR_from_trust state xor_input r1 r2 rd m v r_main exec_row e0 e1 e2
-      h_main_active h_main_op_xor h_lane_rd
-      h_input_r1 h_input_r2 h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      h_main_active h_main_op_xor h_lane_rd promises
   | slt slt_input r1 r2 rd v exec_row e0 e1 e2
-        h_main_active h_main_op_slt h_lane_rd
-        h_input_r1 h_input_r2 h_input_rd h_input_pc
-        h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-        h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx =>
+        h_main_active h_main_op_slt h_lane_rd promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_SLT_from_trust state slt_input r1 r2 rd m v r_main exec_row e0 e1 e2
-      h_main_active h_main_op_slt h_lane_rd
-      h_input_r1 h_input_r2 h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      h_main_active h_main_op_slt h_lane_rd promises
   | sltu sltu_input r1 r2 rd v exec_row e0 e1 e2
-         h_main_active h_main_op_sltu h_lane_rd
-         h_input_r1 h_input_r2 h_input_rd h_input_pc
-         h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-         h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx =>
+         h_main_active h_main_op_sltu h_lane_rd promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_SLTU_from_trust state sltu_input r1 r2 rd m v r_main exec_row e0 e1 e2
-      h_main_active h_main_op_sltu h_lane_rd
-      h_input_r1 h_input_r2 h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      h_main_active h_main_op_sltu h_lane_rd promises
   | andi andi_input r1 rd imm v exec_row e0 e1 e2
          h_main_active h_main_op_andi h_andi_subset h_lane_rd
-         h_input_r1 h_input_imm h_input_rd h_input_pc
-         h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-         h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx =>
+         promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_ANDI_from_trust state andi_input r1 rd imm m v r_main exec_row e0 e1 e2
       h_main_active h_main_op_andi h_andi_subset h_lane_rd
-      h_input_r1 h_input_imm h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
   | ori ori_input r1 rd imm v exec_row e0 e1 e2
         h_main_active h_main_op_ori h_ori_subset h_lane_rd
-        h_input_r1 h_input_imm h_input_rd h_input_pc
-        h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-        h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx =>
+        promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_ORI_from_trust state ori_input r1 rd imm m v r_main exec_row e0 e1 e2
       h_main_active h_main_op_ori h_ori_subset h_lane_rd
-      h_input_r1 h_input_imm h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
   | xori xori_input r1 rd imm v exec_row e0 e1 e2
          h_main_active h_main_op_xori h_xori_subset h_lane_rd
-         h_input_r1 h_input_imm h_input_rd h_input_pc
-         h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-         h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx =>
+         promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_XORI_from_trust state xori_input r1 rd imm m v r_main exec_row e0 e1 e2
       h_main_active h_main_op_xori h_xori_subset h_lane_rd
-      h_input_r1 h_input_imm h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
   | slti slti_input r1 rd imm v exec_row e0 e1 e2
          h_main_active h_main_op_slti h_slti_subset h_lane_rd
-         h_input_r1 h_input_imm h_input_rd h_input_pc
-         h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-         h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx =>
+         promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_SLTI_from_trust state slti_input r1 rd imm m v r_main exec_row e0 e1 e2
       h_main_active h_main_op_slti h_slti_subset h_lane_rd
-      h_input_r1 h_input_imm h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
   | sltiu sltiu_input r1 rd imm v exec_row e0 e1 e2
           h_main_active h_main_op_sltiu h_sltiu_subset h_lane_rd
-          h_input_r1 h_input_imm h_input_rd h_input_pc
-          h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-          h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx =>
+          promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_SLTIU_from_trust state sltiu_input r1 rd imm m v r_main exec_row e0 e1 e2
       h_main_active h_main_op_sltiu h_sltiu_subset h_lane_rd
-      h_input_r1 h_input_imm h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
   | sll sll_input r1 r2 rd v exec_row e0 e1 e2
-        h_input_r1_sail h_input_r2_sail h_input_rd h_input_pc
-        h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-        h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+        promises
         h_main_active h_main_op h_lane_rd =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_SLL_from_trust state sll_input r1 r2 rd m v r_main exec_row e0 e1 e2
-      h_input_r1_sail h_input_r2_sail h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
       h_main_active h_main_op h_lane_rd
   | srl srl_input r1 r2 rd v exec_row e0 e1 e2
-        h_input_r1 h_input_r2 h_input_rd h_input_pc
-        h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-        h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+        promises
         h_main_active h_main_op h_lane_rd =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_SRL_from_trust state srl_input r1 r2 rd m v r_main exec_row e0 e1 e2
-      h_input_r1 h_input_r2 h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
       h_main_active h_main_op h_lane_rd
   | sra sra_input r1 r2 rd v exec_row e0 e1 e2
-        h_input_r1_sail h_input_r2_sail h_input_rd h_input_pc
-        h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-        h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+        promises
         h_main_active h_main_op h_lane_rd =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_SRA_from_trust state sra_input r1 r2 rd m v r_main exec_row e0 e1 e2
-      h_input_r1_sail h_input_r2_sail h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
       h_main_active h_main_op h_lane_rd
   | slli slli_input r1 rd shamt v exec_row e0 e1 e2
-         h_input_r1_sail h_input_shamt h_input_rd h_input_pc
-         h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-         h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+         promises
          h_main_active h_main_op h_lane_rd =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_SLLI_from_trust state slli_input r1 rd shamt m v r_main exec_row e0 e1 e2
-      h_input_r1_sail h_input_shamt h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
       h_main_active h_main_op h_lane_rd
   | srli srli_input r1 rd shamt v exec_row e0 e1 e2
-         h_input_r1 h_input_shamt h_input_rd h_input_pc
-         h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-         h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+         promises
          h_main_active h_main_op h_lane_rd =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_SRLI_from_trust state srli_input r1 rd shamt m v r_main exec_row e0 e1 e2
-      h_input_r1 h_input_shamt h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
       h_main_active h_main_op h_lane_rd
   | srai srai_input r1 rd shamt v exec_row e0 e1 e2
-         h_input_r1 h_input_shamt h_input_rd h_input_pc
-         h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-         h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+         promises
          h_main_active h_main_op h_lane_rd =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_SRAI_from_trust state srai_input r1 rd shamt m v r_main exec_row e0 e1 e2
-      h_input_r1 h_input_shamt h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
       h_main_active h_main_op h_lane_rd
   | sllw sllw_input r1 r2 rd v exec_row e0 e1 e2
          h_input_r1_sail h_input_r2_sail h_input_rd h_input_pc
@@ -2899,347 +2133,221 @@ theorem zisk_riscv_compliant_program_bus
       h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
       h_main_active h_main_op h_lane_rd
   | slliw slliw_input r1 rd v exec_row e0 e1 e2
-          h_input_r1_sail h_input_rd h_input_pc
-          h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-          h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+          promises
           h_main_active h_main_op h_lane_rd =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_SLLIW_from_trust state slliw_input r1 rd m v r_main exec_row e0 e1 e2
-      h_input_r1_sail h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
       h_main_active h_main_op h_lane_rd
   | srliw srliw_input r1 rd v exec_row e0 e1 e2
-          h_input_r1_sail h_input_rd h_input_pc
-          h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-          h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+          promises
           h_main_active h_main_op h_lane_rd =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_SRLIW_from_trust state srliw_input r1 rd m v r_main exec_row e0 e1 e2
-      h_input_r1_sail h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
       h_main_active h_main_op h_lane_rd
   | sraiw sraiw_input r1 rd v exec_row e0 e1 e2
-          h_input_r1_sail h_input_rd h_input_pc
-          h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-          h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+          promises
           h_main_active h_main_op h_lane_rd =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_SRAIW_from_trust state sraiw_input r1 rd m v r_main exec_row e0 e1 e2
-      h_input_r1_sail h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
       h_main_active h_main_op h_lane_rd
   | sb sb_input mstatus pmaRegion misa mseccfg exec_row e0 e1 e2
-       h_main_active h_main_op h_main_ind_width
-       risc_v_assumptions h_opcode_assumptions
-       h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-       h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as =>
+       h_main_active h_main_op h_main_ind_width h_opcode_assumptions promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_SB_from_trust state sb_input mstatus pmaRegion misa mseccfg
       m r_main exec_row e0 e1 e2
-      h_main_active h_main_op h_main_ind_width
-      risc_v_assumptions h_opcode_assumptions
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as
+      h_main_active h_main_op h_main_ind_width h_opcode_assumptions promises
   | sh sh_input mstatus pmaRegion misa mseccfg exec_row e0 e1 e2
-       h_main_active h_main_op h_main_ind_width
-       risc_v_assumptions h_opcode_assumptions
-       h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-       h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as =>
+       h_main_active h_main_op h_main_ind_width h_opcode_assumptions promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_SH_from_trust state sh_input mstatus pmaRegion misa mseccfg
       m r_main exec_row e0 e1 e2
-      h_main_active h_main_op h_main_ind_width
-      risc_v_assumptions h_opcode_assumptions
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as
+      h_main_active h_main_op h_main_ind_width h_opcode_assumptions promises
   | sw sw_input mstatus pmaRegion misa mseccfg exec_row e0 e1 e2
-       h_main_active h_main_op h_main_ind_width
-       risc_v_assumptions h_opcode_assumptions
-       h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-       h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as =>
+       h_main_active h_main_op h_main_ind_width h_opcode_assumptions promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_SW_from_trust state sw_input mstatus pmaRegion misa mseccfg
       m r_main exec_row e0 e1 e2
-      h_main_active h_main_op h_main_ind_width
-      risc_v_assumptions h_opcode_assumptions
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as
+      h_main_active h_main_op h_main_ind_width h_opcode_assumptions promises
   | sd sd_input mstatus pmaRegion misa mseccfg exec_row e0 e1 e2
-       h_main_active h_main_op
-       risc_v_assumptions h_opcode_assumptions
-       h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-       h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as =>
+       h_main_active h_main_op h_opcode_assumptions promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_SD_from_trust state sd_input mstatus pmaRegion misa mseccfg
       m r_main exec_row e0 e1 e2
-      h_main_active h_main_op
-      risc_v_assumptions h_opcode_assumptions
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as
+      h_main_active h_main_op h_opcode_assumptions promises
   | ld ld_input mstatus pmaRegion misa mseccfg mem exec_row e0 e1 e2
-       h_main_active h_main_op_ld
-       risc_v_assumptions h_opcode_assumptions
-       h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-       h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as =>
+       h_main_active h_main_op_ld promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_LD_from_trust state ld_input mstatus pmaRegion misa mseccfg
       m mem r_main exec_row e0 e1 e2
-      h_main_active h_main_op_ld
-      risc_v_assumptions h_opcode_assumptions
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as
+      h_main_active h_main_op_ld promises
   | lbu lbu_input mstatus pmaRegion misa mseccfg mem mab marb ma h_low exec_row e0 e1 e2
-        h_main_active h_main_op_lbu h_width
-        risc_v_assumptions h_opcode_assumptions
-        h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-        h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as =>
+        h_main_active h_main_op_lbu h_width promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_LBU_from_trust state lbu_input mstatus pmaRegion misa mseccfg
       m mem r_main mab marb ma h_low exec_row e0 e1 e2
-      h_main_active h_main_op_lbu h_width
-      risc_v_assumptions h_opcode_assumptions
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as
+      h_main_active h_main_op_lbu h_width promises
   | lhu lhu_input mstatus pmaRegion misa mseccfg mem mab marb ma h_low exec_row e0 e1 e2
-        h_main_active h_main_op_lhu h_width
-        risc_v_assumptions h_opcode_assumptions
-        h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-        h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as =>
+        h_main_active h_main_op_lhu h_width promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_LHU_from_trust state lhu_input mstatus pmaRegion misa mseccfg
       m mem r_main mab marb ma h_low exec_row e0 e1 e2
-      h_main_active h_main_op_lhu h_width
-      risc_v_assumptions h_opcode_assumptions
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as
+      h_main_active h_main_op_lhu h_width promises
   | lwu lwu_input mstatus pmaRegion misa mseccfg mem mab marb ma h_low exec_row e0 e1 e2
-        h_main_active h_main_op_lwu h_width
-        risc_v_assumptions h_opcode_assumptions
-        h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-        h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as =>
+        h_main_active h_main_op_lwu h_width promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_LWU_from_trust state lwu_input mstatus pmaRegion misa mseccfg
       m mem r_main mab marb ma h_low exec_row e0 e1 e2
-      h_main_active h_main_op_lwu h_width
-      risc_v_assumptions h_opcode_assumptions
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as
+      h_main_active h_main_op_lwu h_width promises
   | lb lb_input mstatus pmaRegion misa mseccfg mem v exec_row e0 e1 e2
-       h_main_active h_main_op
-       risc_v_assumptions h_opcode_assumptions
-       h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-       h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as =>
+       h_main_active h_main_op promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_LB_from_trust state lb_input mstatus pmaRegion misa mseccfg
       m mem r_main v exec_row e0 e1 e2
-      h_main_active h_main_op
-      risc_v_assumptions h_opcode_assumptions
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as
+      h_main_active h_main_op promises
   | lh lh_input mstatus pmaRegion misa mseccfg mem v exec_row e0 e1 e2
-       h_main_active h_main_op
-       risc_v_assumptions h_opcode_assumptions
-       h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-       h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as =>
+       h_main_active h_main_op promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_LH_from_trust state lh_input mstatus pmaRegion misa mseccfg
       m mem r_main v exec_row e0 e1 e2
-      h_main_active h_main_op
-      risc_v_assumptions h_opcode_assumptions
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as
+      h_main_active h_main_op promises
   | lw lw_input mstatus pmaRegion misa mseccfg mem v exec_row e0 e1 e2
-       h_main_active h_main_op
-       risc_v_assumptions h_opcode_assumptions
-       h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-       h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as =>
+       h_main_active h_main_op promises =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_LW_from_trust state lw_input mstatus pmaRegion misa mseccfg
       m mem r_main v exec_row e0 e1 e2
-      h_main_active h_main_op
-      risc_v_assumptions h_opcode_assumptions
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as
+      h_main_active h_main_op promises
   | mul mul_input r1 r2 rd srs1 srs2 exec_row e0 e1 e2 v r_a
         h_main_active h_main_op_mul h_match_primary
-        h_input_r1 h_input_r2 h_input_rd h_input_pc
-        h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-        h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+        promises
         h0 h1 h2 h3 h4 h5 h6 h7 h_row_constraints =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_MUL_from_trust state mul_input r1 r2 rd srs1 srs2
       exec_row e0 e1 e2 m r_main v r_a
       h_main_active h_main_op_mul h_match_primary
-      h_input_r1 h_input_r2 h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
       h0 h1 h2 h3 h4 h5 h6 h7 h_row_constraints
   | mulh mulh_input r1 r2 rd exec_row e0 e1 e2 v r_a
          h_main_active h_main_op_mulh h_match_secondary
-         h_input_r1 h_input_r2 h_input_rd h_input_pc
-         h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-         h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+         promises
          h_row_constraints =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_MULH_from_trust state mulh_input r1 r2 rd
       exec_row e0 e1 e2 m r_main v r_a
       h_main_active h_main_op_mulh h_match_secondary
-      h_input_r1 h_input_r2 h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
       h_row_constraints
   | mulhu mulhu_input r1 r2 rd exec_row e0 e1 e2 v r_a
           h_main_active h_main_op_mulhu h_match_secondary
-          h_input_r1 h_input_r2 h_input_rd h_input_pc
-          h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-          h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+          promises
           h0 h1 h2 h3 h4 h5 h6 h7 h_row_constraints =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_MULHU_from_trust state mulhu_input r1 r2 rd
       exec_row e0 e1 e2 m r_main v r_a
       h_main_active h_main_op_mulhu h_match_secondary
-      h_input_r1 h_input_r2 h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
       h0 h1 h2 h3 h4 h5 h6 h7 h_row_constraints
   | mulhsu mulhsu_input r1 r2 rd exec_row e0 e1 e2 v r_a
            h_main_active h_main_op_mulhsu h_match_secondary
-           h_input_r1 h_input_r2 h_input_rd h_input_pc
-           h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-           h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+           promises
            h_row_constraints =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_MULHSU_from_trust state mulhsu_input r1 r2 rd
       exec_row e0 e1 e2 m r_main v r_a
       h_main_active h_main_op_mulhsu h_match_secondary
-      h_input_r1 h_input_r2 h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
       h_row_constraints
   | mulw mulw_input r1 r2 rd exec_row e0 e1 e2 v r_a
          h_main_active h_main_op_mulw h_match_primary
-         h_input_r1 h_input_r2 h_input_rd h_input_pc
-         h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-         h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+         promises
          h_row_constraints h_sext_choice h_rs1_value h_rs2_value =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_MULW_from_trust state mulw_input r1 r2 rd
       exec_row e0 e1 e2 m r_main v r_a
       h_main_active h_main_op_mulw h_match_primary
-      h_input_r1 h_input_r2 h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
       h_row_constraints h_sext_choice h_rs1_value h_rs2_value
   | div div_input r1 r2 rd exec_row e0 e1 e2 v r_a
         h_main_active h_main_op_div h_match_primary
-        h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-        h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
-        h_input_r1 h_input_r2 h_input_rd h_input_pc h_op2_ne h_no_overflow
+        promises
+        h_op2_ne h_no_overflow
         h_row_constraints h_na_bool h_nb_bool h_nr_bool h_np_xor =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_DIV_from_trust state div_input r1 r2 rd exec_row e0 e1 e2
       m r_main v r_a h_main_active h_main_op_div h_match_primary
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
-      h_input_r1 h_input_r2 h_input_rd h_input_pc h_op2_ne h_no_overflow
+      promises
+      h_op2_ne h_no_overflow
       h_row_constraints h_na_bool h_nb_bool h_nr_bool h_np_xor
   | divu divu_input r1 r2 rd exec_row e0 e1 e2 v r_a
          h_main_active h_main_op_divu h_match_primary
-         h_input_r1 h_input_r2 h_input_rd h_input_pc
-         h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-         h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+         promises
          h0 h1 h2 h3 h4 h5 h6 h7 h_row_constraints h_op2_ne =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_DIVU_from_trust state divu_input r1 r2 rd exec_row e0 e1 e2
       m r_main v r_a h_main_active h_main_op_divu h_match_primary
-      h_input_r1 h_input_r2 h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
       h0 h1 h2 h3 h4 h5 h6 h7 h_row_constraints h_op2_ne
   | divw divw_input r1 r2 rd exec_row e0 e1 e2 v r_a
          h_main_active h_main_op_divw h_match_primary
-         h_input_r1 h_input_r2 h_input_rd h_input_pc
-         h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-         h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+         promises
          h_row_constraints h_na_bool h_nb_bool h_nr_bool h_np_xor
          h_sext_choice h_rs1_value h_rs2_value h_op2_ne h_no_overflow =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_DIVW_from_trust state divw_input r1 r2 rd exec_row e0 e1 e2
       m r_main v r_a h_main_active h_main_op_divw h_match_primary
-      h_input_r1 h_input_r2 h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
       h_row_constraints h_na_bool h_nb_bool h_nr_bool h_np_xor
       h_sext_choice h_rs1_value h_rs2_value h_op2_ne h_no_overflow
   | divuw divuw_input r1 r2 rd exec_row e0 e1 e2 v r_a
           h_main_active h_main_op_divuw h_match_primary
-          h_input_r1 h_input_r2 h_input_rd h_input_pc
-          h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-          h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+          promises
           h_row_constraints h_sext_choice h_rs1_value h_rs2_value h_op2_ne =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_DIVUW_from_trust state divuw_input r1 r2 rd exec_row e0 e1 e2
       m r_main v r_a h_main_active h_main_op_divuw h_match_primary
-      h_input_r1 h_input_r2 h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
       h_row_constraints h_sext_choice h_rs1_value h_rs2_value h_op2_ne
   | rem rem_input r1 r2 rd exec_row e0 e1 e2 v r_a
         h_main_active h_main_op_rem h_match_secondary
-        h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-        h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
-        h_input_r1 h_input_r2 h_input_rd h_input_pc h_op2_ne h_no_overflow
+        promises
+        h_op2_ne h_no_overflow
         h_row_constraints h_na_bool h_nb_bool h_nr_bool h_np_xor =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_REM_from_trust state rem_input r1 r2 rd exec_row e0 e1 e2
       m r_main v r_a h_main_active h_main_op_rem h_match_secondary
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
-      h_input_r1 h_input_r2 h_input_rd h_input_pc h_op2_ne h_no_overflow
+      promises
+      h_op2_ne h_no_overflow
       h_row_constraints h_na_bool h_nb_bool h_nr_bool h_np_xor
   | remu remu_input r1 r2 rd exec_row e0 e1 e2 v r_a
          h_main_active h_main_op_remu h_match_secondary
-         h_input_r1 h_input_r2 h_input_rd h_input_pc
-         h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-         h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+         promises
          h0 h1 h2 h3 h4 h5 h6 h7 h_row_constraints h_op2_ne =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_REMU_from_trust state remu_input r1 r2 rd exec_row e0 e1 e2
       m r_main v r_a h_main_active h_main_op_remu h_match_secondary
-      h_input_r1 h_input_r2 h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
       h0 h1 h2 h3 h4 h5 h6 h7 h_row_constraints h_op2_ne
   | remw remw_input r1 r2 rd exec_row e0 e1 e2 v r_a
          h_main_active h_main_op_remw h_match_secondary
-         h_input_r1 h_input_r2 h_input_rd h_input_pc
-         h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-         h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+         promises
          h_row_constraints h_na_bool h_nb_bool h_nr_bool h_np_xor
          h_sext_choice h_rs1_value h_rs2_value h_op2_ne h_no_overflow_w =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_REMW_from_trust state remw_input r1 r2 rd exec_row e0 e1 e2
       m r_main v r_a h_main_active h_main_op_remw h_match_secondary
-      h_input_r1 h_input_r2 h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
       h_row_constraints h_na_bool h_nb_bool h_nr_bool h_np_xor
       h_sext_choice h_rs1_value h_rs2_value h_op2_ne h_no_overflow_w
   | remuw remuw_input r1 r2 rd exec_row e0 e1 e2 v r_a
           h_main_active h_main_op_remuw h_match_secondary
-          h_input_r1 h_input_r2 h_input_rd h_input_pc
-          h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-          h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+          promises
           h_row_constraints h_sext_choice h_rs1_value h_rs2_value h_op2_ne =>
     simp only [OpEnvelope.exec_eq]
     exact equiv_REMUW_from_trust state remuw_input r1 r2 rd exec_row e0 e1 e2
       m r_main v r_a h_main_active h_main_op_remuw h_match_secondary
-      h_input_r1 h_input_r2 h_input_rd h_input_pc
-      h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
-      h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as h_rd_idx
+      promises
       h_row_constraints h_sext_choice h_rs1_value h_rs2_value h_op2_ne
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Add.lean
+++ b/ZiskFv/Compliance/FromTrust/Add.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Add
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -221,24 +222,15 @@ theorem equiv_ADD_from_trust
     -- Lane-match for the rd-write entry — caller-supplied; discharged
     -- downstream from `memory_bus_register_write_perm_sound`.
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    -- Sail-side state predicates (SPEC-PRE).
-    (h_input_r1_sail : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok add_input.r1_val state)
-    (h_input_r2_sail : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok add_input.r2_val state)
-    (h_input_rd : add_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some add_input.PC)
-    -- Bus-protocol structural hypotheses — pass-through from `equiv_ADD`.
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_add_pure add_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : add_input.rd = Transpiler.wrap_to_regidx e2.ptr) :
+    -- Structural promise bundle (15 fields). Subsumes the prior inline
+    -- `h_input_r1_sail`, `h_input_r2_sail`, `h_input_rd`, `h_input_pc`,
+    -- `h_exec_len`, `h_e0_mult`, `h_e1_mult`, `h_nextPC_matches`,
+    -- `h_m0_mult`, `h_m0_as`, `h_m1_mult`, `h_m1_as`, `h_m2_mult`,
+    -- `h_m2_as`, `h_rd_idx` binders.
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state add_input.r1_val add_input.r2_val add_input.rd add_input.PC
+        (PureSpec.execute_RTYPE_add_pure add_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2) :
     execute_instruction (instruction.RTYPE (r2, r1, rd, rop.ADD)) state
       = (bus_effect exec_row [e0, e1, e2] state).2 := by
   -- ============ Derive `m.m32 r_main = 0` via `transpile_ADD` ============
@@ -274,22 +266,7 @@ theorem equiv_ADD_from_trust
   -- ============ Delegate to canonical `equiv_ADD` ============
   exact ZiskFv.Equivalence.Add.equiv_ADD
     state add_input r1 r2 rd m b r_main exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1_sail
-      input_r2_eq := h_input_r2_sail
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
-    h_main_subset h_main_mode h_b_core h_lane_rd
+    promises h_main_subset h_main_mode h_b_core h_lane_rd
     h_e2_0 h_e2_1 h_e2_2 h_e2_3 h_e2_4 h_e2_5 h_e2_6 h_e2_7
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Addi.lean
+++ b/ZiskFv/Compliance/FromTrust/Addi.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Addi
+import ZiskFv.Equivalence.Promises.IType
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -141,23 +142,11 @@ theorem equiv_ADDI_from_trust
     (h_addi_subset : itype_imm_subset_holds_main m r_main addi_input.imm)
     -- Lane-match for rd-write entry (deferred to Mem pilot).
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    -- Sail-side state predicates.
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok addi_input.r1_val state)
-    (h_input_imm : addi_input.imm = imm)
-    (h_input_rd : addi_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some addi_input.PC)
-    -- Bus-protocol structural hypotheses — pass-through.
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_ITYPE_addi_pure addi_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : addi_input.rd = Transpiler.wrap_to_regidx e2.ptr) :
+    -- Structural promise bundle (14 fields, see Promises/IType.lean).
+    (promises : ZiskFv.Equivalence.Promises.ITypePromises
+        state addi_input.r1_val addi_input.imm addi_input.rd addi_input.PC
+        (PureSpec.execute_ITYPE_addi_pure addi_input).nextPC
+        r1 rd imm exec_row e0 e1 e2) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -183,21 +172,7 @@ theorem equiv_ADDI_from_trust
   -- ============ Delegate to canonical `equiv_ADDI` ============
   exact ZiskFv.Equivalence.Addi.equiv_ADDI
     state addi_input r1 rd imm m b r_main exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_imm_eq := h_input_imm
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_main_subset h_main_mode h_b_core h_addi_subset h_lane_rd
     h_e2_0 h_e2_1 h_e2_2 h_e2_3 h_e2_4 h_e2_5 h_e2_6 h_e2_7
 

--- a/ZiskFv/Compliance/FromTrust/Addiw.lean
+++ b/ZiskFv/Compliance/FromTrust/Addiw.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Addiw
+import ZiskFv.Equivalence.Promises.IType
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -90,27 +91,19 @@ theorem equiv_ADDIW_from_trust
     (h_main_op_addiw : m.op r_main = OP_ADD_W)
     (h_addiw_subset : itype_imm_subset_holds_main m r_main addiw_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok addiw_input.r1_val state)
-    (h_input_imm : addiw_input.imm = imm)
-    (h_input_rd : addiw_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some addiw_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_ITYPE_addiw_pure addiw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : addiw_input.rd = Transpiler.wrap_to_regidx e2.ptr) :
+    (promises : ZiskFv.Equivalence.Promises.ITypePromises
+        state addiw_input.r1_val addiw_input.imm addiw_input.rd addiw_input.PC
+        (PureSpec.execute_ITYPE_addiw_pure addiw_input).nextPC
+        r1 rd imm exec_row e0 e1 e2) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute
         (instruction.ADDIW (imm, r1, rd))) state
       = (bus_effect exec_row [e0, e1, e2] state).2 := by
+  -- Bundle field used later in the proof body (do NOT consume `promises`
+  -- with `obtain` since it is passed through to `equiv_ADDIW`).
+  have h_input_imm := promises.input_imm_eq
   -- ============ op-bus permutation handshake ============
   have h_op_disj :
       m.op r_main = 0x02 ∨ m.op r_main = 0x03 ∨ m.op r_main = 0x04
@@ -283,21 +276,7 @@ theorem equiv_ADDIW_from_trust
   -- ============ Delegate to canonical equiv_ADDIW ============
   exact ZiskFv.Equivalence.Addiw.equiv_ADDIW
     state addiw_input r1 rd imm m r_main exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_imm_eq := h_input_imm
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     v r_binary h_main_active h_main_op_addiw h_match
     (v.free_in_c_0 r_binary) (v.free_in_c_1 r_binary) (v.free_in_c_2 r_binary)
     (v.free_in_c_3 r_binary) (v.free_in_c_4 r_binary) (v.free_in_c_5 r_binary)

--- a/ZiskFv/Compliance/FromTrust/Addw.lean
+++ b/ZiskFv/Compliance/FromTrust/Addw.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Addw
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -45,22 +46,10 @@ theorem equiv_ADDW_from_trust
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op_addw : m.op r_main = OP_ADD_W)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok addw_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok addw_input.r2_val state)
-    (h_input_rd : addw_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some addw_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_addw_pure addw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : addw_input.rd = Transpiler.wrap_to_regidx e2.ptr) :
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state addw_input.r1_val addw_input.r2_val addw_input.rd addw_input.PC
+        (PureSpec.execute_RTYPE_addw_pure addw_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -180,21 +169,7 @@ theorem equiv_ADDW_from_trust
   -- ============ Delegate to canonical equiv_ADDW ============
   exact ZiskFv.Equivalence.Addw.equiv_ADDW
     state addw_input r1 r2 rd m r_main exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     v r_binary h_main_active h_main_op_addw h_match
     (v.free_in_c_0 r_binary) (v.free_in_c_1 r_binary) (v.free_in_c_2 r_binary)
     (v.free_in_c_3 r_binary) (v.free_in_c_4 r_binary) (v.free_in_c_5 r_binary)

--- a/ZiskFv/Compliance/FromTrust/And.lean
+++ b/ZiskFv/Compliance/FromTrust/And.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.And
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -39,22 +40,10 @@ theorem equiv_AND_from_trust
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op_and : m.op r_main = OP_AND)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok and_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok and_input.r2_val state)
-    (h_input_rd : and_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some and_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_and_pure and_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : and_input.rd = Transpiler.wrap_to_regidx e2.ptr) :
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state and_input.r1_val and_input.r2_val and_input.rd and_input.PC
+        (PureSpec.execute_RTYPE_and_pure and_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -88,21 +77,7 @@ theorem equiv_AND_from_trust
     binary_b_op_or_sext_eq_OP_AND v r_binary h_emit_op
   exact ZiskFv.Equivalence.And.equiv_AND
     state and_input r1 r2 rd m v r_main r_binary exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_main_active h_main_op_and h_match h_bop_or_sext h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Andi.lean
+++ b/ZiskFv/Compliance/FromTrust/Andi.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Andi
+import ZiskFv.Equivalence.Promises.IType
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -100,21 +101,10 @@ theorem equiv_ANDI_from_trust
     (h_main_op_andi : m.op r_main = OP_AND)
     (h_andi_subset : itype_imm_subset_holds_main m r_main andi_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok andi_input.r1_val state)
-    (h_input_imm : andi_input.imm = imm)
-    (h_input_rd : andi_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some andi_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_ITYPE_andi_pure andi_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : andi_input.rd = Transpiler.wrap_to_regidx e2.ptr) :
+    (promises : ZiskFv.Equivalence.Promises.ITypePromises
+        state andi_input.r1_val andi_input.imm andi_input.rd andi_input.PC
+        (PureSpec.execute_ITYPE_andi_pure andi_input).nextPC
+        r1 rd imm exec_row e0 e1 e2) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -151,21 +141,7 @@ theorem equiv_ANDI_from_trust
   -- ============ Delegate to canonical `equiv_ANDI` ============
   exact ZiskFv.Equivalence.Andi.equiv_ANDI
     state andi_input r1 rd imm m v r_main r_binary exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_imm_eq := h_input_imm
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_main_active h_main_op_andi h_match h_bop_or_sext h_lane_rd h_andi_subset
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Auipc.lean
+++ b/ZiskFv/Compliance/FromTrust/Auipc.lean
@@ -1,6 +1,8 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Auipc
+import ZiskFv.Equivalence.Promises.UType
+import ZiskFv.Equivalence.Promises.UTypeHelpers
 import ZiskFv.Tactics.UTypeArchetype
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
@@ -8,28 +10,10 @@ import ZiskFv.Airs.Main.Main
 /-!
 # `equiv_AUIPC` Compliance wrapper — ControlFlow non-branch
 
-> **Status:** within-shape wrapper, derived mechanically from
-> `FromTrust/Lui.lean`. Lives outside the canonical
-> surface so V1 anti-laundering metrics on the canonical theorem
-> are unaffected.
-
-## 5-category discharge applied
-
-* **Lane-match.** Internalized by `equiv_AUIPC` via
-  `auipc_discharge_lanes` (consumes `main_store_pc_emission_bundle`,
-  trust class #4). Pre-discharged on the canonical surface.
-* **Mode pins.** N/A on the provider side (no provider AIR). The
-  Main-side mode pins come from `transpile_AUIPC` (class #1).
-* **Sign-witness pins.** N/A.
-* **Range/bound.** Internalized by `equiv_AUIPC`.
-* **Operand bridges.** N/A (no register read; PC is a state value).
-
-## Anti-laundering report
-
-* **Zero new axioms** — consumes `transpile_AUIPC` (class #1) plus
-  `equiv_AUIPC`'s existing closure. Matches per-AIR axiom map's
-  0-new-axioms prediction.
-* **Caller-burden** mirrors LUI's structural-unpacking pattern.
+The wrapper takes the structural `UTypePromises` bundle along with the
+upstream activation/opcode pins and the per-row AUIPC subset
+constraint, and internally calls `auipc_h_circuit_of_main_constraints`
+(which transitively consumes `transpile_AUIPC`) to derive `h_circuit`.
 -/
 
 namespace ZiskFv.Compliance
@@ -41,10 +25,9 @@ open ZiskFv.Tactics.UTypeArchetype
 
 variable {C : Type → Type → Type} [Circuit FGL FGL C]
 
-/-- **Compliance wrapper for `equiv_AUIPC`.** Mirrors
-    `equiv_LUI_from_trust`'s structure with `transpile_AUIPC`
-    substituted for `transpile_LUI` and AUIPC's mode/subset
-    definitions in place of LUI's. -/
+/-- **Compliance wrapper for `equiv_AUIPC`.** Derives `h_circuit` from
+    `auipc_h_circuit_of_main_constraints` (consuming `transpile_AUIPC`)
+    and delegates to canonical `equiv_AUIPC`. -/
 theorem equiv_AUIPC_from_trust
     (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
     (auipc_input : PureSpec.AuipcInput)
@@ -53,29 +36,16 @@ theorem equiv_AUIPC_from_trust
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e_rd : Interaction.MemoryBusEntry FGL)
     (nextPC_val : BitVec 64)
-    -- AIR validator + row index.
     (m : Valid_Main C FGL FGL) (r_main : ℕ) (next_pc : FGL)
-    -- Activation + opcode pins (Compliance ROM handshake).
+    -- Activation / opcode pins on Main + per-row subset constraint.
     (h_main_active : m.is_external_op r_main = 0)
     (h_main_op_auipc : m.op r_main = OP_FLAG)
-    -- Per-row Main constraint bundle.
     (h_auipc_subset : auipc_subset_holds m r_main next_pc)
-    -- Sail-side state predicates (SPEC-PRE).
-    (h_input_imm : auipc_input.imm = imm)
-    (h_input_rd : auipc_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some auipc_input.PC)
-    -- Bus-shape structural hypotheses — pass-through from `equiv_AUIPC`.
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = nextPC_val)
-    (h_rd_mult : e_rd.multiplicity = 1) (h_rd_as : e_rd.as.val = 1)
-    (h_nextPC_eq :
-      (PureSpec.execute_AUIPC_pure auipc_input).nextPC = nextPC_val)
-    (h_rd_idx : auipc_input.rd = Transpiler.wrap_to_regidx e_rd.ptr)
-    -- Range/no-wrap obligations.
+    -- Structural `UTypePromises` bundle.
+    (promises : ZiskFv.Equivalence.Promises.UTypePromises
+        state auipc_input.imm auipc_input.rd auipc_input.PC
+        (PureSpec.execute_AUIPC_pure auipc_input).nextPC
+        imm rd exec_row e_rd nextPC_val)
     (h_no_wrap : auipc_input.PC.toNat
       + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
         < GL_prime)
@@ -84,33 +54,12 @@ theorem equiv_AUIPC_from_trust
       (auipc_input.PC + BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
         < 4294967296) :
     execute_instruction (instruction.UTYPE (imm, rd, uop.AUIPC)) state
-      = (bus_effect exec_row [e_rd] state).2 := by
-  -- ============ Derive routing mode pins via `transpile_AUIPC` ============
-  have h_tr := ZiskFv.Trusted.transpile_AUIPC m r_main (0 : Fin 32)
-    (0 : FGL) { xreg := fun _ => 0#64, pc := 0#64 }
-    h_main_active h_main_op_auipc
-  obtain ⟨h_m32, h_set_pc, h_store_pc, _, _, _, _, _, _⟩ := h_tr
-  -- ============ Assemble `main_row_in_auipc_mode` ============
-  have h_auipc_mode : main_row_in_auipc_mode m r_main := by
-    refine ⟨h_main_active, ?_, h_m32, h_set_pc, h_store_pc⟩
-    rw [h_main_op_auipc]; rfl
-  -- ============ Assemble `auipc_archetype_circuit_holds` ============
-  have h_circuit : auipc_archetype_circuit_holds m r_main next_pc :=
-    ⟨h_auipc_subset, h_auipc_mode⟩
-  -- ============ Delegate to canonical `equiv_AUIPC` ============
-  exact ZiskFv.Equivalence.Auipc.equiv_AUIPC state auipc_input imm rd
+      = (bus_effect exec_row [e_rd] state).2 :=
+  have h_circuit :=
+    ZiskFv.Equivalence.Promises.auipc_h_circuit_of_main_constraints
+      m r_main next_pc h_main_active h_main_op_auipc h_auipc_subset
+  ZiskFv.Equivalence.Auipc.equiv_AUIPC state auipc_input imm rd
     exec_row e_rd nextPC_val m r_main next_pc
-    { input_imm_eq := h_input_imm
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      rd_mult := h_rd_mult
-      rd_as := h_rd_as
-      nextPC_eq := h_nextPC_eq
-      rd_idx := h_rd_idx }
-    h_circuit h_no_wrap h_lo_bound h_pc_offset_lt_2_32
+    promises h_circuit h_no_wrap h_lo_bound h_pc_offset_lt_2_32
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Beq.lean
+++ b/ZiskFv/Compliance/FromTrust/Beq.lean
@@ -1,153 +1,21 @@
 import Mathlib
 
 import ZiskFv.Equivalence.BranchEqual
+import ZiskFv.Equivalence.Promises.BranchHelpers
 import ZiskFv.SailSpec.beq
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 
 /-!
 # `equiv_BEQ` trust-discharge wrapper — ControlFlow branches shape exemplar
-## Why BEQ
 
-BEQ is the cheapest branch in RV64IM:
-
-* **Symmetric** in `rs1` / `rs2` (vs. BLT/BGE which are signed and
-  need MSB sign-witness pins; vs. BLTU/BGEU which use an unsigned
-  comparison flag but no sign witness).
-* No `rd` write (no memory-bus rd-write entry — vs. LUI/AUIPC/JAL/JALR
-  which write `pc + 4` or an immediate).
-* No signed-vs-unsigned distinction at the comparison layer
-  (equality is sign-agnostic).
-* Sign-witness pins (category 3) are N/A — BLT / BGE would add them
-  in their within-shape authoring.
-
-The remaining wrapper-level discharge targets on `equiv_BEQ` are the
-*pure-spec misalignment promises* `h_not_throws` and `h_success`,
-plus the *Sail aux* `h_misa_c`. The misalignment promises are
-discharged from a single SPEC-PRE `h_target_aligned` describing the
-branch target's 4-byte alignment — a ZisK runtime invariant. `h_misa_c`
-passes through (Compliance.lean owns the ZisK-misa configuration).
-
-## 5-category discharge applied to BEQ
-
-* **Lane-match (category 1).** N/A on the provider side. The
-  flag-correctness fact (`m.flag = 1 ↔ r1_val = r2_val`) lives on
-  the Binary AIR via the operation-bus hop with `OP_EQ`; on the
-  canonical surface, the Sail-pure-spec form
-  `(execute_BEQ_pure beq_input).nextPC` already incorporates the
-  branch decision, and the **structural pin** `h_nextPC_matches`
-  ties the bus's exec_row[1].pc to that pure-spec output. The
-  wrapper does NOT discharge `h_nextPC_matches`; that work
-  belongs to a separate Binary-flag-correctness bridge consumed
-  by Compliance.lean's PC handshake.
-* **Mode pins (category 2).** N/A on the provider AIR side
-  (branches don't flow through a provider AIR with mode columns).
-  The Main-side mode pins (`m32 = 0`, `set_pc = 0`,
-  `is_external_op = 1`, `op = OP_EQ`) come from `transpile_BEQ`
-  (class #1) applied to `h_main_active` + `h_main_op_beq` — but
-  the canonical `equiv_BEQ` does not consume them directly; it
-  pivots on the Sail-side pure-spec equivalence. They are tracked
-  in `Bridge/ControlFlow.lean::branch_input_bridges_of_read_xreg`
-  for the Binary-flag-correctness path (not exercised here).
-* **Sign-witness pins (category 3).** N/A — equality is
-  sign-agnostic. BLT/BGE within-shape authoring will additionally
-  need `binary_b_op_or_sext_eq_OP_LT` or similar sign pins; BEQ
-  does not.
-* **Range/bound (category 4).** N/A — BEQ writes no register and
-  consumes no byte-level Mem entries.
-* **Operand bridges (category 5).** N/A at the wrapper level —
-  `equiv_BEQ` already consumes the unstructured Sail `read_xreg`
-  facts (`h_input_r1`, `h_input_r2`) directly; no
-  `packed_lane_eq_of_read_xreg` step is needed because the
-  comparison is performed inside `execute_BEQ_pure` via raw
-  `BitVec` equality, not via lane chunks.
-
-## The actual discharge: alignment promises
-
-The two promise hypotheses `h_not_throws` and `h_success` on
-`equiv_BEQ` say that the BEQ pure-spec output reports no exception.
-Reading `PureSpec.execute_BEQ_pure`:
-
-```
-skip   := !(input.r1_val == input.r2_val)
-throws := !skip && BitVec.ofBool (input.PC + signExt 64 input.imm)[0] == 1#1
-fails  := throws || (!skip && BitVec.ofBool (input.PC + signExt 64 input.imm)[1] == 1#1)
-success := !fails
-```
-
-So both `throws` and `!success` depend on bits 0 and 1 of
-`input.PC + signExt 64 input.imm` being zero. When the branch target
-is 4-byte-aligned (its low 2 bits are zero), both bit checks fail,
-giving `throws = false` and `success = true` uniformly — **regardless
-of whether the branch is taken**.
-
-The wrapper therefore discharges both promise hypotheses from a
-single caller-supplied alignment fact
-`h_target_aligned : (input.PC + signExt 64 input.imm).toNat % 4 = 0`.
-This is a SPEC-PRE caller obligation in the same trust class as
-`h_misa_c` (a ZisK-runtime configuration invariant). RV64I requires
-all branch targets to be 4-byte-aligned (RISC-V ISA Manual, §2.5),
-and ZisK's assembler/transpiler emits only well-formed branch
-instructions, so this hypothesis is unconditionally true in any
-real trace.
-
-## Anti-laundering report
-
-Per the discharge-recipe.md wrapper-specific checks:
-
-* **No new axioms.** This wrapper consumes only `equiv_BEQ` itself
-  plus pure Lean composition. Trust ledger unchanged — matches the
-  per-AIR axiom map's 0-new-axioms prediction for ControlFlow.
-* **Caller-burden shrinks.** −2 promises (`h_not_throws`,
-  `h_success`) discharged from +1 SPEC-PRE (`h_target_aligned`).
-  Net −1 binder / −1 hypothesis at the per-opcode level.
-* **Bridges cross-shape if possible.** N/A — no new helper added;
-  the alignment derivation is a 5-line BitVec computation local to
-  this file.
-
-## Caller-burden
-
-`equiv_BEQ` (canonical): 19 binders / 11 hypotheses (state, beq_input,
-imm, r1, r2, misa_val, exec_row, h_input_imm, h_input_r1, h_input_r2,
-h_input_pc, h_input_misa, h_misa_c, h_exec_len, h_e0_mult, h_e1_mult,
-h_nextPC_matches, h_not_throws, h_success).
-
-`equiv_BEQ_from_trust` (this file): 18 binders / 10 hypotheses
-(state, beq_input, imm, r1, r2, misa_val, exec_row, h_input_imm,
-h_input_r1, h_input_r2, h_input_pc, h_input_misa, h_misa_c,
-h_target_aligned, h_exec_len, h_e0_mult, h_e1_mult, h_nextPC_matches).
-
-**Net: −1 binder / −1 hypothesis.** Beats the +1 hypothesis growth
-observed on LUI's structural-unpacking pattern; the BEQ exemplar is a
-clean promise discharge with no compensating bundle unpack required
-(branches are simpler than UTYPE because no rd-write entries are
-involved).
-
-## Cross-shape lessons
-
-* **No new bridge added** to `Equivalence/Bridge/ControlFlow.lean`
-  or `Equivalence/Bridge/SailStateBridge.lean`. The misalignment
-  derivation is a local BitVec.toNat-vs-bit-extract argument.
-* **Generalizes mechanically to BNE / BLT / BGE / BLTU / BGEU** —
-  every branch's pure spec has the same `throws`/`success` shape
-  parameterized on the comparison output. The within-shape wrappers
-  swap `execute_BEQ_pure` for the per-branch pure spec; the
-  alignment lemma is opcode-agnostic. **Signed branches (BLT/BGE)
-  additionally need sign-witness pins** to discharge their flag-
-  correctness path through the Binary AIR's `OP_LT` lookup — but
-  those pins are independent of the alignment discharge done here.
-* **Flag-correctness discharge is deferred.** Discharging
-  `h_nextPC_matches` from circuit witnesses requires composing
-  `branch_eq_compositional` (`Circuit/BranchEqual.lean`) with a
-  Binary-AIR flag-correctness axiom (`OP_EQ` lookup-bus pin) plus
-  `transpile_BEQ`'s `jmp_offset1 = imm`, `jmp_offset2 = 4` pins.
-  That work belongs to a future ControlFlow flag-correctness
-  bridge and is not in scope for this exemplar. The branches'
-  per-AIR axiom map entry for category 1 is "bridge-only" — the
-  needed `OP_EQ` flag-correctness bridge lives in
-  `Bridge/ControlFlow.lean` (not added by this PR) consuming
-  `op_bus_perm_sound_Binary` (class #4) + `bin_table_consumer_wf`
-  (class #6) on the `wf_EQ` clause.
+This wrapper is now a pure pass-through. The previous internal derivation of
+`(not_throws, success)` from `h_target_aligned` (via the private theorem
+`beq_pure_no_exception_of_aligned`) has been hoisted into
+`Equivalence/Promises/BranchHelpers.lean` as
+`BranchPromises.of_aligned_BEQ`. Callers that previously supplied
+`h_target_aligned` should now use that helper to construct a full
+`BranchPromises` bundle and pass it here.
 -/
 
 namespace ZiskFv.Compliance
@@ -158,74 +26,8 @@ open ZiskFv.Airs.Main
 
 variable {C : Type → Type → Type} [Circuit FGL FGL C]
 
-/-- **Alignment-implies-no-exception lemma for BEQ.** Given a
-    4-byte-aligned branch target, both `throws` and `!success`
-    evaluate to `false` uniformly (regardless of taken/not-taken).
-
-    Pure BitVec computation: bits 0 and 1 of an address ≡ 0 mod 4
-    are both zero, so both `BitVec.ofBool x[i] == 1#1` checks fail. -/
-private theorem beq_pure_no_exception_of_aligned
-    (input : PureSpec.BeqInput)
-    (h_aligned : (input.PC + BitVec.signExtend 64 input.imm).toNat % 4 = 0) :
-    (PureSpec.execute_BEQ_pure input).throws = false
-    ∧ (PureSpec.execute_BEQ_pure input).success = true := by
-  -- Set up an abbreviation for the target address.
-  set t : BitVec 64 := input.PC + BitVec.signExtend 64 input.imm with h_t
-  -- Bits 0 and 1 of an address ≡ 0 mod 4 are both zero.
-  have h_bit0 : t[0] = false := by
-    -- t[0] = (t.toNat / 2^0) % 2 == 1 ; equivalently testBit 0.
-    rw [BitVec.getElem_eq_testBit_toNat]
-    rw [Nat.testBit_zero]
-    -- Now goal: (t.toNat % 2 == 1) = false, i.e. t.toNat % 2 ≠ 1.
-    -- From t.toNat % 4 = 0 we have t.toNat % 2 = 0.
-    have h_mod2 : t.toNat % 2 = 0 := by omega
-    simp [h_mod2]
-  have h_bit1 : t[1] = false := by
-    rw [BitVec.getElem_eq_testBit_toNat]
-    rw [Nat.testBit_succ, Nat.testBit_zero]
-    -- Goal: ((t.toNat / 2) % 2 == 1) = false.
-    have h_div_mod : (t.toNat / 2) % 2 = 0 := by omega
-    simp [h_div_mod]
-  -- Now compute both fields of execute_BEQ_pure under the bit
-  -- equalities. The structure of execute_BEQ_pure is:
-  --   throws := !skip && (bit0 == 1)
-  --   fails  := throws || (!skip && (bit1 == 1))
-  --   success := !fails
-  -- With bit0 = bit1 = false, throws = false and fails = false, so
-  -- success = true, regardless of `skip`.
-  refine ⟨?_, ?_⟩
-  · -- throws = false
-    simp [PureSpec.execute_BEQ_pure, ← h_t, h_bit0]
-  · -- success = true
-    simp [PureSpec.execute_BEQ_pure, ← h_t, h_bit0, h_bit1]
-
-/-- **Pilot wrapper for `equiv_BEQ`.** Discharges the two
-    pure-spec exception promises (`h_not_throws`, `h_success`)
-    from a single SPEC-PRE 4-byte-alignment hypothesis.
-
-    Caller obligations (signature header, ordered):
-    1. The Sail-side inputs (`state`, `beq_input`, `imm`, `r1`, `r2`,
-       `misa_val`).
-    2. The structural bus row (`exec_row`).
-    3. The Sail `read_xreg` / PC / misa state predicates (pass-through
-       from `equiv_BEQ`).
-    4. The `misa[C] = 0` ZisK-config pin `h_misa_c` (pass-through).
-    5. The SPEC-PRE alignment witness `h_target_aligned`. ZisK's
-       assembler / transpiler guarantees this on every BEQ
-       instruction; Compliance.lean delivers it from the program-
-       level well-formedness invariant.
-    6. The bus-shape pins (`h_exec_len`, `h_e0_mult`, `h_e1_mult`,
-       `h_nextPC_matches`) — pass-through from `equiv_BEQ`.
-
-    Derived internally (NOT caller-supplied):
-    * `h_not_throws : (execute_BEQ_pure beq_input).throws = false`
-    * `h_success : (execute_BEQ_pure beq_input).success = true`
-    Both derived from `h_target_aligned` via
-    `beq_pure_no_exception_of_aligned`.
-
-    Trust footprint: `equiv_BEQ`'s existing closure (no new axioms).
-    Zero new axioms — matches `docs/fv/per-air-axiom-map.md`'s
-    prediction for ControlFlow branches. -/
+/-- **Pilot wrapper for `equiv_BEQ`.** Pure pass-through to the canonical
+    `equiv_BEQ` over a fully-constructed `BranchPromises` bundle. -/
 theorem equiv_BEQ_from_trust
     (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
     (beq_input : PureSpec.BeqInput)
@@ -233,46 +35,16 @@ theorem equiv_BEQ_from_trust
     (r1 r2 : regidx)
     (misa_val : RegisterType Register.misa)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
-    -- Sail-side state predicates (SPEC-PRE).
-    (h_input_imm : beq_input.imm = imm)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok beq_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok beq_input.r2_val state)
-    (h_input_pc : state.regs.get? Register.PC = .some beq_input.PC)
-    (h_input_misa : state.regs.get? Register.misa = .some misa_val)
-    (h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1)
-    -- SPEC-PRE alignment witness on the branch target. ZisK's
-    -- assembler/transpiler invariant; Compliance.lean delivers
-    -- from the program-level well-formedness obligation.
-    (h_target_aligned :
-      (beq_input.PC + BitVec.signExtend 64 beq_input.imm).toNat % 4 = 0)
-    -- Bus-shape structural hypotheses — pass-through from `equiv_BEQ`.
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_BEQ_pure beq_input).nextPC) :
+    (promises : ZiskFv.Equivalence.Promises.BranchPromises
+        state beq_input.imm beq_input.r1_val beq_input.r2_val beq_input.PC
+        misa_val
+        (PureSpec.execute_BEQ_pure beq_input).nextPC
+        (PureSpec.execute_BEQ_pure beq_input).throws
+        (PureSpec.execute_BEQ_pure beq_input).success
+        imm r1 r2 exec_row) :
     execute_instruction (instruction.BTYPE (imm, r2, r1, bop.BEQ)) state
-      = (bus_effect exec_row [] state).2 := by
-  -- ============ Discharge `h_not_throws` and `h_success` from `h_target_aligned` ============
-  obtain ⟨h_not_throws, h_success⟩ :=
-    beq_pure_no_exception_of_aligned beq_input h_target_aligned
-  -- ============ Delegate to canonical `equiv_BEQ` ============
-  exact ZiskFv.Equivalence.BranchEqual.equiv_BEQ
-    state beq_input imm r1 r2 misa_val exec_row
-    { input_imm_eq := h_input_imm
-      input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_pc_eq := h_input_pc
-      input_misa_eq := h_input_misa
-      misa_c_zero := h_misa_c
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      not_throws := h_not_throws
-      success := h_success }
+      = (bus_effect exec_row [] state).2 :=
+  ZiskFv.Equivalence.BranchEqual.equiv_BEQ
+    state beq_input imm r1 r2 misa_val exec_row promises
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Bge.lean
+++ b/ZiskFv/Compliance/FromTrust/Bge.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.BranchGreaterEqual
+import ZiskFv.Equivalence.Promises.BranchHelpers
 import ZiskFv.SailSpec.bge
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
@@ -8,8 +9,8 @@ import ZiskFv.Airs.Main.Main
 /-!
 # `equiv_BGE` Compliance wrapper — ControlFlow branches
 
-Within-shape companion to `FromTrust/Beq.lean` / `FromTrust/Blt.lean`.
-Zero new axioms.
+Pure pass-through. The previous internal derivation lives in
+`Equivalence/Promises/BranchHelpers.lean` (`BranchPromises.of_aligned_BGE`).
 -/
 
 namespace ZiskFv.Compliance
@@ -20,25 +21,9 @@ open ZiskFv.Airs.Main
 
 variable {C : Type → Type → Type} [Circuit FGL FGL C]
 
-private theorem bge_pure_no_exception_of_aligned
-    (input : PureSpec.BgeInput)
-    (h_aligned : (input.PC + BitVec.signExtend 64 input.imm).toNat % 4 = 0) :
-    (PureSpec.execute_BGE_pure input).throws = false
-    ∧ (PureSpec.execute_BGE_pure input).success = true := by
-  set t : BitVec 64 := input.PC + BitVec.signExtend 64 input.imm with h_t
-  have h_bit0 : t[0] = false := by
-    rw [BitVec.getElem_eq_testBit_toNat, Nat.testBit_zero]
-    have h_mod2 : t.toNat % 2 = 0 := by omega
-    simp [h_mod2]
-  have h_bit1 : t[1] = false := by
-    rw [BitVec.getElem_eq_testBit_toNat, Nat.testBit_succ, Nat.testBit_zero]
-    have h_div_mod : (t.toNat / 2) % 2 = 0 := by omega
-    simp [h_div_mod]
-  refine ⟨?_, ?_⟩
-  · simp [PureSpec.execute_BGE_pure, ← h_t, h_bit0]
-  · simp [PureSpec.execute_BGE_pure, ← h_t, h_bit0, h_bit1]
-
-/-- **Compliance wrapper for `equiv_BGE`.** -/
+/-- **Compliance wrapper for `equiv_BGE`.** Pure pass-through to the
+    canonical `equiv_BGE` over a fully-constructed `BranchPromises`
+    bundle. -/
 theorem equiv_BGE_from_trust
     (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
     (bge_input : PureSpec.BgeInput)
@@ -46,39 +31,16 @@ theorem equiv_BGE_from_trust
     (r1 r2 : regidx)
     (misa_val : RegisterType Register.misa)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
-    (h_input_imm : bge_input.imm = imm)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok bge_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok bge_input.r2_val state)
-    (h_input_pc : state.regs.get? Register.PC = .some bge_input.PC)
-    (h_input_misa : state.regs.get? Register.misa = .some misa_val)
-    (h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1)
-    (h_target_aligned :
-      (bge_input.PC + BitVec.signExtend 64 bge_input.imm).toNat % 4 = 0)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_BGE_pure bge_input).nextPC) :
+    (promises : ZiskFv.Equivalence.Promises.BranchPromises
+        state bge_input.imm bge_input.r1_val bge_input.r2_val bge_input.PC
+        misa_val
+        (PureSpec.execute_BGE_pure bge_input).nextPC
+        (PureSpec.execute_BGE_pure bge_input).throws
+        (PureSpec.execute_BGE_pure bge_input).success
+        imm r1 r2 exec_row) :
     execute_instruction (instruction.BTYPE (imm, r2, r1, bop.BGE)) state
-      = (bus_effect exec_row [] state).2 := by
-  obtain ⟨h_not_throws, h_success⟩ :=
-    bge_pure_no_exception_of_aligned bge_input h_target_aligned
-  exact ZiskFv.Equivalence.BranchGreaterEqual.equiv_BGE
-    state bge_input imm r1 r2 misa_val exec_row
-    { input_imm_eq := h_input_imm
-      input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_pc_eq := h_input_pc
-      input_misa_eq := h_input_misa
-      misa_c_zero := h_misa_c
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      not_throws := h_not_throws
-      success := h_success }
+      = (bus_effect exec_row [] state).2 :=
+  ZiskFv.Equivalence.BranchGreaterEqual.equiv_BGE
+    state bge_input imm r1 r2 misa_val exec_row promises
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Bgeu.lean
+++ b/ZiskFv/Compliance/FromTrust/Bgeu.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.BranchGreaterEqualUnsigned
+import ZiskFv.Equivalence.Promises.BranchHelpers
 import ZiskFv.SailSpec.bgeu
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
@@ -8,8 +9,8 @@ import ZiskFv.Airs.Main.Main
 /-!
 # `equiv_BGEU` Compliance wrapper — ControlFlow branches
 
-Within-shape companion to `FromTrust/Beq.lean`. Unsigned comparison;
-zero new axioms.
+Pure pass-through. The previous internal derivation lives in
+`Equivalence/Promises/BranchHelpers.lean` (`BranchPromises.of_aligned_BGEU`).
 -/
 
 namespace ZiskFv.Compliance
@@ -20,25 +21,9 @@ open ZiskFv.Airs.Main
 
 variable {C : Type → Type → Type} [Circuit FGL FGL C]
 
-private theorem bgeu_pure_no_exception_of_aligned
-    (input : PureSpec.BgeuInput)
-    (h_aligned : (input.PC + BitVec.signExtend 64 input.imm).toNat % 4 = 0) :
-    (PureSpec.execute_BGEU_pure input).throws = false
-    ∧ (PureSpec.execute_BGEU_pure input).success = true := by
-  set t : BitVec 64 := input.PC + BitVec.signExtend 64 input.imm with h_t
-  have h_bit0 : t[0] = false := by
-    rw [BitVec.getElem_eq_testBit_toNat, Nat.testBit_zero]
-    have h_mod2 : t.toNat % 2 = 0 := by omega
-    simp [h_mod2]
-  have h_bit1 : t[1] = false := by
-    rw [BitVec.getElem_eq_testBit_toNat, Nat.testBit_succ, Nat.testBit_zero]
-    have h_div_mod : (t.toNat / 2) % 2 = 0 := by omega
-    simp [h_div_mod]
-  refine ⟨?_, ?_⟩
-  · simp [PureSpec.execute_BGEU_pure, ← h_t, h_bit0]
-  · simp [PureSpec.execute_BGEU_pure, ← h_t, h_bit0, h_bit1]
-
-/-- **Compliance wrapper for `equiv_BGEU`.** -/
+/-- **Compliance wrapper for `equiv_BGEU`.** Pure pass-through to the
+    canonical `equiv_BGEU` over a fully-constructed `BranchPromises`
+    bundle. -/
 theorem equiv_BGEU_from_trust
     (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
     (bgeu_input : PureSpec.BgeuInput)
@@ -46,39 +31,16 @@ theorem equiv_BGEU_from_trust
     (r1 r2 : regidx)
     (misa_val : RegisterType Register.misa)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
-    (h_input_imm : bgeu_input.imm = imm)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok bgeu_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok bgeu_input.r2_val state)
-    (h_input_pc : state.regs.get? Register.PC = .some bgeu_input.PC)
-    (h_input_misa : state.regs.get? Register.misa = .some misa_val)
-    (h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1)
-    (h_target_aligned :
-      (bgeu_input.PC + BitVec.signExtend 64 bgeu_input.imm).toNat % 4 = 0)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_BGEU_pure bgeu_input).nextPC) :
+    (promises : ZiskFv.Equivalence.Promises.BranchPromises
+        state bgeu_input.imm bgeu_input.r1_val bgeu_input.r2_val bgeu_input.PC
+        misa_val
+        (PureSpec.execute_BGEU_pure bgeu_input).nextPC
+        (PureSpec.execute_BGEU_pure bgeu_input).throws
+        (PureSpec.execute_BGEU_pure bgeu_input).success
+        imm r1 r2 exec_row) :
     execute_instruction (instruction.BTYPE (imm, r2, r1, bop.BGEU)) state
-      = (bus_effect exec_row [] state).2 := by
-  obtain ⟨h_not_throws, h_success⟩ :=
-    bgeu_pure_no_exception_of_aligned bgeu_input h_target_aligned
-  exact ZiskFv.Equivalence.BranchGreaterEqualUnsigned.equiv_BGEU
-    state bgeu_input imm r1 r2 misa_val exec_row
-    { input_imm_eq := h_input_imm
-      input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_pc_eq := h_input_pc
-      input_misa_eq := h_input_misa
-      misa_c_zero := h_misa_c
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      not_throws := h_not_throws
-      success := h_success }
+      = (bus_effect exec_row [] state).2 :=
+  ZiskFv.Equivalence.BranchGreaterEqualUnsigned.equiv_BGEU
+    state bgeu_input imm r1 r2 misa_val exec_row promises
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Blt.lean
+++ b/ZiskFv/Compliance/FromTrust/Blt.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.BranchLessThan
+import ZiskFv.Equivalence.Promises.BranchHelpers
 import ZiskFv.SailSpec.blt
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
@@ -8,17 +9,8 @@ import ZiskFv.Airs.Main.Main
 /-!
 # `equiv_BLT` Compliance wrapper — ControlFlow branches
 
-Within-shape companion to `FromTrust/Beq.lean`. The pure-spec
-`throws`/`fails`/`success` shape on BLT is structurally identical to
-BEQ; the signed-comparison decision affects only `taken` and hence
-`nextPC` (carried by `h_nextPC_matches`). The alignment-implies-no-
-exception discharge is opcode-agnostic.
-
-Zero new axioms. Signed comparison sign-witness pins, when required
-by a Binary-flag-correctness discharge of `h_nextPC_matches`, would
-live in `Bridge/ControlFlow.lean` (not added here per the
-discharge-recipe — `h_nextPC_matches` is passed through as a
-structural bus pin).
+Pure pass-through. The previous internal derivation lives in
+`Equivalence/Promises/BranchHelpers.lean` (`BranchPromises.of_aligned_BLT`).
 -/
 
 namespace ZiskFv.Compliance
@@ -29,25 +21,9 @@ open ZiskFv.Airs.Main
 
 variable {C : Type → Type → Type} [Circuit FGL FGL C]
 
-private theorem blt_pure_no_exception_of_aligned
-    (input : PureSpec.BltInput)
-    (h_aligned : (input.PC + BitVec.signExtend 64 input.imm).toNat % 4 = 0) :
-    (PureSpec.execute_BLT_pure input).throws = false
-    ∧ (PureSpec.execute_BLT_pure input).success = true := by
-  set t : BitVec 64 := input.PC + BitVec.signExtend 64 input.imm with h_t
-  have h_bit0 : t[0] = false := by
-    rw [BitVec.getElem_eq_testBit_toNat, Nat.testBit_zero]
-    have h_mod2 : t.toNat % 2 = 0 := by omega
-    simp [h_mod2]
-  have h_bit1 : t[1] = false := by
-    rw [BitVec.getElem_eq_testBit_toNat, Nat.testBit_succ, Nat.testBit_zero]
-    have h_div_mod : (t.toNat / 2) % 2 = 0 := by omega
-    simp [h_div_mod]
-  refine ⟨?_, ?_⟩
-  · simp [PureSpec.execute_BLT_pure, ← h_t, h_bit0]
-  · simp [PureSpec.execute_BLT_pure, ← h_t, h_bit0, h_bit1]
-
-/-- **Compliance wrapper for `equiv_BLT`.** -/
+/-- **Compliance wrapper for `equiv_BLT`.** Pure pass-through to the
+    canonical `equiv_BLT` over a fully-constructed `BranchPromises`
+    bundle. -/
 theorem equiv_BLT_from_trust
     (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
     (blt_input : PureSpec.BltInput)
@@ -55,39 +31,16 @@ theorem equiv_BLT_from_trust
     (r1 r2 : regidx)
     (misa_val : RegisterType Register.misa)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
-    (h_input_imm : blt_input.imm = imm)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok blt_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok blt_input.r2_val state)
-    (h_input_pc : state.regs.get? Register.PC = .some blt_input.PC)
-    (h_input_misa : state.regs.get? Register.misa = .some misa_val)
-    (h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1)
-    (h_target_aligned :
-      (blt_input.PC + BitVec.signExtend 64 blt_input.imm).toNat % 4 = 0)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_BLT_pure blt_input).nextPC) :
+    (promises : ZiskFv.Equivalence.Promises.BranchPromises
+        state blt_input.imm blt_input.r1_val blt_input.r2_val blt_input.PC
+        misa_val
+        (PureSpec.execute_BLT_pure blt_input).nextPC
+        (PureSpec.execute_BLT_pure blt_input).throws
+        (PureSpec.execute_BLT_pure blt_input).success
+        imm r1 r2 exec_row) :
     execute_instruction (instruction.BTYPE (imm, r2, r1, bop.BLT)) state
-      = (bus_effect exec_row [] state).2 := by
-  obtain ⟨h_not_throws, h_success⟩ :=
-    blt_pure_no_exception_of_aligned blt_input h_target_aligned
-  exact ZiskFv.Equivalence.BranchLessThan.equiv_BLT
-    state blt_input imm r1 r2 misa_val exec_row
-    { input_imm_eq := h_input_imm
-      input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_pc_eq := h_input_pc
-      input_misa_eq := h_input_misa
-      misa_c_zero := h_misa_c
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      not_throws := h_not_throws
-      success := h_success }
+      = (bus_effect exec_row [] state).2 :=
+  ZiskFv.Equivalence.BranchLessThan.equiv_BLT
+    state blt_input imm r1 r2 misa_val exec_row promises
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Bltu.lean
+++ b/ZiskFv/Compliance/FromTrust/Bltu.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.BranchLessThanUnsigned
+import ZiskFv.Equivalence.Promises.BranchHelpers
 import ZiskFv.SailSpec.bltu
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
@@ -8,8 +9,8 @@ import ZiskFv.Airs.Main.Main
 /-!
 # `equiv_BLTU` Compliance wrapper — ControlFlow branches
 
-Within-shape companion to `FromTrust/Beq.lean`. Unsigned comparison;
-zero new axioms.
+Pure pass-through. The previous internal derivation lives in
+`Equivalence/Promises/BranchHelpers.lean` (`BranchPromises.of_aligned_BLTU`).
 -/
 
 namespace ZiskFv.Compliance
@@ -20,25 +21,9 @@ open ZiskFv.Airs.Main
 
 variable {C : Type → Type → Type} [Circuit FGL FGL C]
 
-private theorem bltu_pure_no_exception_of_aligned
-    (input : PureSpec.BltuInput)
-    (h_aligned : (input.PC + BitVec.signExtend 64 input.imm).toNat % 4 = 0) :
-    (PureSpec.execute_BLTU_pure input).throws = false
-    ∧ (PureSpec.execute_BLTU_pure input).success = true := by
-  set t : BitVec 64 := input.PC + BitVec.signExtend 64 input.imm with h_t
-  have h_bit0 : t[0] = false := by
-    rw [BitVec.getElem_eq_testBit_toNat, Nat.testBit_zero]
-    have h_mod2 : t.toNat % 2 = 0 := by omega
-    simp [h_mod2]
-  have h_bit1 : t[1] = false := by
-    rw [BitVec.getElem_eq_testBit_toNat, Nat.testBit_succ, Nat.testBit_zero]
-    have h_div_mod : (t.toNat / 2) % 2 = 0 := by omega
-    simp [h_div_mod]
-  refine ⟨?_, ?_⟩
-  · simp [PureSpec.execute_BLTU_pure, ← h_t, h_bit0]
-  · simp [PureSpec.execute_BLTU_pure, ← h_t, h_bit0, h_bit1]
-
-/-- **Compliance wrapper for `equiv_BLTU`.** -/
+/-- **Compliance wrapper for `equiv_BLTU`.** Pure pass-through to the
+    canonical `equiv_BLTU` over a fully-constructed `BranchPromises`
+    bundle. -/
 theorem equiv_BLTU_from_trust
     (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
     (bltu_input : PureSpec.BltuInput)
@@ -46,39 +31,16 @@ theorem equiv_BLTU_from_trust
     (r1 r2 : regidx)
     (misa_val : RegisterType Register.misa)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
-    (h_input_imm : bltu_input.imm = imm)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok bltu_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok bltu_input.r2_val state)
-    (h_input_pc : state.regs.get? Register.PC = .some bltu_input.PC)
-    (h_input_misa : state.regs.get? Register.misa = .some misa_val)
-    (h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1)
-    (h_target_aligned :
-      (bltu_input.PC + BitVec.signExtend 64 bltu_input.imm).toNat % 4 = 0)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_BLTU_pure bltu_input).nextPC) :
+    (promises : ZiskFv.Equivalence.Promises.BranchPromises
+        state bltu_input.imm bltu_input.r1_val bltu_input.r2_val bltu_input.PC
+        misa_val
+        (PureSpec.execute_BLTU_pure bltu_input).nextPC
+        (PureSpec.execute_BLTU_pure bltu_input).throws
+        (PureSpec.execute_BLTU_pure bltu_input).success
+        imm r1 r2 exec_row) :
     execute_instruction (instruction.BTYPE (imm, r2, r1, bop.BLTU)) state
-      = (bus_effect exec_row [] state).2 := by
-  obtain ⟨h_not_throws, h_success⟩ :=
-    bltu_pure_no_exception_of_aligned bltu_input h_target_aligned
-  exact ZiskFv.Equivalence.BranchLessThanUnsigned.equiv_BLTU
-    state bltu_input imm r1 r2 misa_val exec_row
-    { input_imm_eq := h_input_imm
-      input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_pc_eq := h_input_pc
-      input_misa_eq := h_input_misa
-      misa_c_zero := h_misa_c
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      not_throws := h_not_throws
-      success := h_success }
+      = (bus_effect exec_row [] state).2 :=
+  ZiskFv.Equivalence.BranchLessThanUnsigned.equiv_BLTU
+    state bltu_input imm r1 r2 misa_val exec_row promises
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Bne.lean
+++ b/ZiskFv/Compliance/FromTrust/Bne.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.BranchNotEqual
+import ZiskFv.Equivalence.Promises.BranchHelpers
 import ZiskFv.SailSpec.bne
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
@@ -8,12 +9,8 @@ import ZiskFv.Airs.Main.Main
 /-!
 # `equiv_BNE` Compliance wrapper — ControlFlow branches
 
-Within-shape companion to `FromTrust/Beq.lean`. The pure-spec
-`throws` / `fails` / `success` formula on BNE is structurally
-identical to BEQ (only the `taken` predicate flips polarity); the
-alignment-implies-no-exception discharge is therefore opcode-agnostic.
-
-Zero new axioms.
+Pure pass-through. The previous internal derivation lives in
+`Equivalence/Promises/BranchHelpers.lean` (`BranchPromises.of_aligned_BNE`).
 -/
 
 namespace ZiskFv.Compliance
@@ -24,27 +21,9 @@ open ZiskFv.Airs.Main
 
 variable {C : Type → Type → Type} [Circuit FGL FGL C]
 
-/-- **Alignment-implies-no-exception lemma for BNE.** Same proof
-    structure as `beq_pure_no_exception_of_aligned`. -/
-private theorem bne_pure_no_exception_of_aligned
-    (input : PureSpec.BneInput)
-    (h_aligned : (input.PC + BitVec.signExtend 64 input.imm).toNat % 4 = 0) :
-    (PureSpec.execute_BNE_pure input).throws = false
-    ∧ (PureSpec.execute_BNE_pure input).success = true := by
-  set t : BitVec 64 := input.PC + BitVec.signExtend 64 input.imm with h_t
-  have h_bit0 : t[0] = false := by
-    rw [BitVec.getElem_eq_testBit_toNat, Nat.testBit_zero]
-    have h_mod2 : t.toNat % 2 = 0 := by omega
-    simp [h_mod2]
-  have h_bit1 : t[1] = false := by
-    rw [BitVec.getElem_eq_testBit_toNat, Nat.testBit_succ, Nat.testBit_zero]
-    have h_div_mod : (t.toNat / 2) % 2 = 0 := by omega
-    simp [h_div_mod]
-  refine ⟨?_, ?_⟩
-  · simp [PureSpec.execute_BNE_pure, ← h_t, h_bit0]
-  · simp [PureSpec.execute_BNE_pure, ← h_t, h_bit0, h_bit1]
-
-/-- **Compliance wrapper for `equiv_BNE`.** -/
+/-- **Compliance wrapper for `equiv_BNE`.** Pure pass-through to the
+    canonical `equiv_BNE` over a fully-constructed `BranchPromises`
+    bundle. -/
 theorem equiv_BNE_from_trust
     (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
     (bne_input : PureSpec.BneInput)
@@ -52,40 +31,16 @@ theorem equiv_BNE_from_trust
     (r1 r2 : regidx)
     (misa_val : RegisterType Register.misa)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
-    (h_input_imm : bne_input.imm = imm)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok bne_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok bne_input.r2_val state)
-    (h_input_pc : state.regs.get? Register.PC = .some bne_input.PC)
-    (h_input_misa : state.regs.get? Register.misa = .some misa_val)
-    (h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1)
-    -- SPEC-PRE alignment witness (ZisK assembler/transpiler invariant).
-    (h_target_aligned :
-      (bne_input.PC + BitVec.signExtend 64 bne_input.imm).toNat % 4 = 0)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_BNE_pure bne_input).nextPC) :
+    (promises : ZiskFv.Equivalence.Promises.BranchPromises
+        state bne_input.imm bne_input.r1_val bne_input.r2_val bne_input.PC
+        misa_val
+        (PureSpec.execute_BNE_pure bne_input).nextPC
+        (PureSpec.execute_BNE_pure bne_input).throws
+        (PureSpec.execute_BNE_pure bne_input).success
+        imm r1 r2 exec_row) :
     execute_instruction (instruction.BTYPE (imm, r2, r1, bop.BNE)) state
-      = (bus_effect exec_row [] state).2 := by
-  obtain ⟨h_not_throws, h_success⟩ :=
-    bne_pure_no_exception_of_aligned bne_input h_target_aligned
-  exact ZiskFv.Equivalence.BranchNotEqual.equiv_BNE
-    state bne_input imm r1 r2 misa_val exec_row
-    { input_imm_eq := h_input_imm
-      input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_pc_eq := h_input_pc
-      input_misa_eq := h_input_misa
-      misa_c_zero := h_misa_c
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      not_throws := h_not_throws
-      success := h_success }
+      = (bus_effect exec_row [] state).2 :=
+  ZiskFv.Equivalence.BranchNotEqual.equiv_BNE
+    state bne_input imm r1 r2 misa_val exec_row promises
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Div.lean
+++ b/ZiskFv/Compliance/FromTrust/Div.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Div
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Equivalence.Bridge.Arith
 import ZiskFv.Equivalence.Bridge.SailStateBridge
 import ZiskFv.Airs.Arith.Ranges
@@ -97,24 +98,13 @@ theorem equiv_DIV_from_trust
     (h_match_primary :
       matches_entry (opBus_row_Main m r_main)
                     (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv v r_a))
-    -- ============ STRUCTURAL BUS / EXEC SHAPE (passed through) ============
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_DIVREM_div_pure div_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : div_input.rd = Transpiler.wrap_to_regidx e2.ptr)
-    -- ============ SAIL-SIDE STATE PREDICATES (SPEC-PRE) ============
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok div_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok div_input.r2_val state)
-    (h_input_rd : div_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some div_input.PC)
+    -- ============ STRUCTURAL PROMISE BUNDLE (15 fields) ============
+    -- Subsumes the prior inline structural bus / exec shape +
+    -- Sail-side state predicate binders.
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state div_input.r1_val div_input.r2_val div_input.rd div_input.PC
+        (PureSpec.execute_DIVREM_div_pure div_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_op2_ne : div_input.r2_val.toInt ≠ 0)
     (h_no_overflow :
       ¬ (div_input.r1_val.toInt = -(2:ℤ)^63 ∧ div_input.r2_val.toInt = -1))
@@ -140,6 +130,11 @@ theorem equiv_DIV_from_trust
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.DIV (r2, r1, rd, false))) state
       = (bus_effect exec_row [e0, e1, e2] state).2 := by
+  -- ============ Project bus-bundle fields used by the body ============
+  have h_input_r1 := promises.input_r1_eq
+  have h_input_r2 := promises.input_r2_eq
+  have h_m2_mult := promises.m2_mult
+  have h_m2_as := promises.m2_as
   -- ============ DERIVE arith-side opcode literal () ============
   -- `matches_entry`'s op-slot equality projects to
   -- `m.op r_main = v.op r_a` (the bus opcode column IS the
@@ -425,21 +420,7 @@ theorem equiv_DIV_from_trust
   -- The Sail `instruction.DIV` LHS matches; all derived hypotheses fit.
   exact ZiskFv.Equivalence.Div.equiv_DIV
     state div_input r1 r2 rd exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     v r_a h_chain h_na_bool h_nb_bool h_nr_bool h_np_xor h_nr_pin
     h_sext h_m32 h_div h_byte_lo h_byte_hi h_rs1_value h_rs2_value
     h_op2_ne h_no_overflow h_r_abs h_r_sign

--- a/ZiskFv/Compliance/FromTrust/Divu.lean
+++ b/ZiskFv/Compliance/FromTrust/Divu.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Divu
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Equivalence.Bridge.Arith
 import ZiskFv.Equivalence.Bridge.SailStateBridge
 import ZiskFv.Airs.Arith.Ranges
@@ -50,22 +51,10 @@ theorem equiv_DIVU_from_trust
     (h_match_primary :
       matches_entry (opBus_row_Main m r_main)
                     (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv v r_a))
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok divu_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok divu_input.r2_val state)
-    (h_input_rd : divu_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some divu_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_DIVREM_divu_pure divu_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : divu_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state divu_input.r1_val divu_input.r2_val divu_input.rd divu_input.PC
+        (PureSpec.execute_DIVREM_divu_pure divu_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h0 : e2.x0.val < 256) (h1 : e2.x1.val < 256)
     (h2 : e2.x2.val < 256) (h3 : e2.x3.val < 256)
     (h4 : e2.x4.val < 256) (h5 : e2.x5.val < 256)
@@ -78,6 +67,11 @@ theorem equiv_DIVU_from_trust
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.DIV (r2, r1, rd, true))) state
       = (bus_effect exec_row [e0, e1, e2] state).2 := by
+  -- ============ Project bus-bundle fields used by the body ============
+  have h_input_r1 := promises.input_r1_eq
+  have h_input_r2 := promises.input_r2_eq
+  have h_m2_mult := promises.m2_mult
+  have h_m2_as := promises.m2_as
   -- ============ DERIVE arith-side opcode literal ============
   have h_op_eq : v.op r_a = m.op r_main := by
     have := h_match_primary
@@ -283,21 +277,7 @@ theorem equiv_DIVU_from_trust
   -- ============ Delegate to `equiv_DIVU` ============
   exact ZiskFv.Equivalence.Divu.equiv_DIVU
     state divu_input r1 r2 rd v r_a exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h0 h1 h2 h3 h4 h5 h6 h7
     h_chain h_na h_nb h_np h_nr h_sext h_m32 h_div
     h_byte_lo h_byte_hi h_rs1_value h_rs2_value h_op2_ne h_d_lt_b

--- a/ZiskFv/Compliance/FromTrust/Divuw.lean
+++ b/ZiskFv/Compliance/FromTrust/Divuw.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Divuw
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Equivalence.Bridge.Arith
 import ZiskFv.Equivalence.Bridge.SailStateBridge
 import ZiskFv.Airs.Arith.Ranges
@@ -61,22 +62,10 @@ theorem equiv_DIVUW_from_trust
     (h_match_primary :
       matches_entry (opBus_row_Main m r_main)
                     (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv v r_a))
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok divuw_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok divuw_input.r2_val state)
-    (h_input_rd : divuw_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some divuw_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_DIVREM_divuw_pure divuw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : divuw_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state divuw_input.r1_val divuw_input.r2_val divuw_input.rd divuw_input.PC
+        (PureSpec.execute_DIVREM_divuw_pure divuw_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_row_constraints :
       ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     -- Pass-through caller burdens (not class #6b — bus encoding / SPEC-PRE /
@@ -96,6 +85,9 @@ theorem equiv_DIVUW_from_trust
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.DIVW (r2, r1, rd, true))) state
       = (bus_effect exec_row [e0, e1, e2] state).2 := by
+  -- ============ Project bus-bundle fields used by the body ============
+  have h_m2_mult := promises.m2_mult
+  have h_m2_as := promises.m2_as
   -- ============ DERIVE arith-side opcode literal ============
   have h_op_eq : v.op r_a = m.op r_main := by
     have := h_match_primary
@@ -194,21 +186,7 @@ theorem equiv_DIVUW_from_trust
   -- ============ Delegate to `equiv_DIVUW` ============
   exact ZiskFv.Equivalence.Divuw.equiv_DIVUW
     state divuw_input r1 r2 rd v r_a exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_chain h_na h_nb h_np h_nr h_sext h_m32 h_div h_op_full h_c23
     h_byte_lo h_sext_choice h_rs1_value h_rs2_value h_op2_ne h_d_lt_b
 

--- a/ZiskFv/Compliance/FromTrust/Divw.lean
+++ b/ZiskFv/Compliance/FromTrust/Divw.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Divw
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Equivalence.Bridge.Arith
 import ZiskFv.Equivalence.Bridge.SailStateBridge
 import ZiskFv.Airs.Arith.Ranges
@@ -58,22 +59,10 @@ theorem equiv_DIVW_from_trust
     (h_match_primary :
       matches_entry (opBus_row_Main m r_main)
                     (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv v r_a))
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok divw_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok divw_input.r2_val state)
-    (h_input_rd : divw_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some divw_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_DIVREM_divw_pure divw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : divw_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state divw_input.r1_val divw_input.r2_val divw_input.rd divw_input.PC
+        (PureSpec.execute_DIVREM_divw_pure divw_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_row_constraints :
       ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     -- Sign-witness booleanity + XOR (CIRCUIT-CONSTRAINT — caller-supplied).
@@ -107,6 +96,9 @@ theorem equiv_DIVW_from_trust
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.DIVW (r2, r1, rd, false))) state
       = (bus_effect exec_row [e0, e1, e2] state).2 := by
+  -- ============ Project bus-bundle fields used by the body ============
+  have h_m2_mult := promises.m2_mult
+  have h_m2_as := promises.m2_as
   -- ============ DERIVE arith-side opcode literal ============
   have h_op_eq : v.op r_a = m.op r_main := by
     have := h_match_primary
@@ -269,21 +261,7 @@ theorem equiv_DIVW_from_trust
   -- ============ Delegate to `equiv_DIVW` ============
   exact ZiskFv.Equivalence.Divw.equiv_DIVW
     state divw_input r1 r2 rd v r_a exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_chain h_na_bool h_nb_bool h_nr_bool h_np_xor h_sext h_m32 h_div
     h_op_full h_op_signed h_c23 h_byte_lo h_sext_choice h_rs1_value h_rs2_value
     h_op2_ne h_no_overflow h_r_abs h_r_sign

--- a/ZiskFv/Compliance/FromTrust/Fence.lean
+++ b/ZiskFv/Compliance/FromTrust/Fence.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Fence
+import ZiskFv.Equivalence.Promises.Fence
 import ZiskFv.SailSpec.fence
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
@@ -110,26 +111,14 @@ theorem equiv_FENCE_from_trust
     -- has no provider AIR).
     (_h_main_active : main.is_external_op r_main = 0)
     (_h_main_op_fence : main.op r_main = OP_FLAG)
-    -- Sail-side state predicates (SPEC-PRE).
-    (h_input_pc : state.regs.get? Register.PC = .some fence_input.PC)
-    (h_input_priv :
-      state.regs.get? Register.cur_privilege = .some Privilege.Machine)
-    -- Bus-shape structural hypotheses.
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_FENCE_pure fence_input).nextPC) :
+    -- Structural promise bundle (6 fields, see Promises/Fence.lean).
+    (promises : ZiskFv.Equivalence.Promises.FencePromises
+        state fence_input.PC
+        (PureSpec.execute_FENCE_pure fence_input).nextPC
+        exec_row) :
     execute_instruction (instruction.FENCE (fm, pred, succ, rs, rd)) state
       = (bus_effect exec_row [] state).2 :=
   ZiskFv.Equivalence.Fence.equiv_FENCE
-    state fence_input fm pred succ rs rd exec_row
-    { input_pc_eq := h_input_pc
-      input_priv_eq := h_input_priv
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches }
+    state fence_input fm pred succ rs rd exec_row promises
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Jal.lean
+++ b/ZiskFv/Compliance/FromTrust/Jal.lean
@@ -1,41 +1,18 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Jal
+import ZiskFv.Equivalence.Promises.Jump
+import ZiskFv.Equivalence.Promises.JumpHelpers
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 
 /-!
 # `equiv_JAL` Compliance wrapper — ControlFlow non-branch
 
-> **Status:** within-shape wrapper, derived mechanically from
-> `FromTrust/Lui.lean`. Lives outside the canonical
-> surface so V1 anti-laundering metrics on the canonical theorem
-> are unaffected.
-
-## 5-category discharge applied
-
-* **Lane-match.** Internalized by `equiv_JAL` via
-  `jal_discharge_lanes` (consumes `main_store_pc_emission_bundle`,
-  trust class #4). Pre-discharged on the canonical surface.
-* **Mode pins.** N/A on the provider side (no provider AIR). The
-  Main-side mode pins (`m32 = 0`, `set_pc = 0`, `store_pc = 1`,
-  `jmp_offset2 = 4`) come from `transpile_JAL` (class #1) — already
-  consumed inside `equiv_JAL`'s proof.
-* **Sign-witness pins.** N/A.
-* **Range/bound.** Internalized by `equiv_JAL` via
-  `memory_bus_entry_byte_range_perm_sound` (class #5b).
-* **Operand bridges.** N/A (no register read).
-
-## Anti-laundering report
-
-* **Zero new axioms** — consumes `transpile_JAL` (class #1) plus
-  `equiv_JAL`'s existing closure. Matches the per-AIR axiom map's
-  0-new-axioms prediction for ControlFlow.
-* **Caller-burden** structural-unpacking, parallel to LUI exemplar
-  (+1 hypothesis from unpacking `h_circuit` into `h_main_active`,
-  `h_main_op_jal`, `h_jal_subset`). At the global Compliance.lean
-  level the burden strictly shrinks via shared `(main, ∀ r, ...)`
-  parameters across the eleven ControlFlow opcodes.
+The wrapper takes the structural `JumpPromises` bundle along with the
+upstream activation/opcode pins on Main and the per-row JAL subset
+constraint, and internally calls `jal_h_circuit_of_main_constraints`
+(which transitively consumes `transpile_JAL`) to derive `h_circuit`.
 -/
 
 namespace ZiskFv.Compliance
@@ -46,82 +23,43 @@ open ZiskFv.Airs.Main
 
 variable {C : Type → Type → Type} [Circuit FGL FGL C]
 
-/-- **Compliance wrapper for `equiv_JAL`.** Mirrors `equiv_LUI_from_trust`'s
-    structure with `transpile_JAL` substituted for `transpile_LUI` and
-    the JAL mode/subset definitions in place of LUI's. -/
+/-- **Compliance wrapper for `equiv_JAL`.** Derives `h_circuit` from
+    `jal_h_circuit_of_main_constraints` (consuming `transpile_JAL`)
+    and delegates to canonical `equiv_JAL`. -/
 theorem equiv_JAL_from_trust
     (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
     (jal_input : PureSpec.JalInput)
     (imm : BitVec 21)
     (rd : regidx)
     (misa_val : RegisterType Register.misa)
-    -- AIR validator + row index.
     (m : Valid_Main C FGL FGL) (r_main : ℕ) (next_pc : FGL)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e_rd : Interaction.MemoryBusEntry FGL)
     (nextPC_val : BitVec 64)
-    -- Activation + opcode pins (Compliance ROM handshake).
+    -- Activation / opcode pins on Main + per-row subset constraint.
     (h_main_active : m.is_external_op r_main = 0)
     (h_main_op_jal : m.op r_main = OP_FLAG)
-    -- Per-row Main constraint bundle (universal-row Main validity).
     (h_jal_subset :
       ZiskFv.Airs.Main.jump_subset_holds m r_main next_pc)
-    -- Sail-side state predicates (SPEC-PRE).
+    -- Structural `JumpPromises` bundle.
+    (promises : ZiskFv.Equivalence.Promises.JumpPromises
+        state jal_input.PC jal_input.rd misa_val
+        (PureSpec.execute_JAL_pure jal_input).success
+        (PureSpec.execute_JAL_pure jal_input).nextPC
+        rd exec_row e_rd nextPC_val)
     (h_input_imm : jal_input.imm = imm)
-    (h_input_rd : jal_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some jal_input.PC)
-    (h_input_misa : state.regs.get? Register.misa = .some misa_val)
-    (h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1)
-    -- Bus-shape structural hypotheses — pass-through from `equiv_JAL`.
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = nextPC_val)
-    (h_rd_mult : e_rd.multiplicity = 1) (h_rd_as : e_rd.as.val = 1)
-    -- Happy-path hypotheses (ZisK SPEC-PRE: branch targets aligned).
     (h_not_throws : (PureSpec.execute_JAL_pure jal_input).throws = false)
-    (h_success : (PureSpec.execute_JAL_pure jal_input).success = true)
-    (h_nextPC_option :
-      (PureSpec.execute_JAL_pure jal_input).nextPC = .some nextPC_val)
-    (h_rd_idx : jal_input.rd = Transpiler.wrap_to_regidx e_rd.ptr)
-    -- Range/no-wrap obligations.
     (h_pc_bound : jal_input.PC.toNat < GL_prime - 4)
     (h_lo_bound : (m.pc r_main + 4 : FGL).val < 4294967296)
     (h_pc_offset_lt_2_32 : (jal_input.PC + 4#64).toNat < 4294967296) :
     execute_instruction (instruction.JAL (imm, rd)) state
-      = (bus_effect exec_row [e_rd] state).2 := by
-  -- ============ Derive routing mode pins via `transpile_JAL` ============
-  have h_tr := ZiskFv.Trusted.transpile_JAL m r_main (0 : Fin 32)
-    (0 : FGL) { xreg := fun _ => 0#64, pc := 0#64 } h_main_active h_main_op_jal
-  obtain ⟨h_m32, h_set_pc, h_store_pc, _, _, _, _, _, _⟩ := h_tr
-  -- ============ Assemble `main_row_in_jal_mode` ============
-  have h_jal_mode : ZiskFv.ZiskCircuit.Jal.main_row_in_jal_mode m r_main := by
-    refine ⟨h_main_active, ?_, h_m32, h_set_pc, h_store_pc⟩
-    -- `OP_FLAG := 0` definitionally; the mode predicate expects
-    -- `m.op r_main = (0 : FGL)`.
-    rw [h_main_op_jal]; rfl
-  -- ============ Assemble `jal_circuit_holds` ============
-  have h_circuit : ZiskFv.ZiskCircuit.Jal.jal_circuit_holds m r_main next_pc :=
-    ⟨h_jal_subset, h_jal_mode⟩
-  -- ============ Delegate to canonical `equiv_JAL` ============
-  exact ZiskFv.Equivalence.Jal.equiv_JAL state jal_input imm rd misa_val
+      = (bus_effect exec_row [e_rd] state).2 :=
+  have h_circuit :=
+    ZiskFv.Equivalence.Promises.jal_h_circuit_of_main_constraints
+      m r_main next_pc h_main_active h_main_op_jal h_jal_subset
+  ZiskFv.Equivalence.Jal.equiv_JAL state jal_input imm rd misa_val
     exec_row e_rd nextPC_val m r_main next_pc
-    { input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      input_misa_eq := h_input_misa
-      misa_c_zero := h_misa_c
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      rd_mult := h_rd_mult
-      rd_as := h_rd_as
-      success := h_success
-      nextPC_option := h_nextPC_option
-      rd_idx := h_rd_idx }
-    h_input_imm h_not_throws
+    promises h_input_imm h_not_throws
     h_circuit h_pc_bound h_lo_bound h_pc_offset_lt_2_32
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Jalr.lean
+++ b/ZiskFv/Compliance/FromTrust/Jalr.lean
@@ -1,6 +1,8 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Jalr
+import ZiskFv.Equivalence.Promises.Jump
+import ZiskFv.Equivalence.Promises.JumpHelpers
 import ZiskFv.Tactics.JumpArchetype
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
@@ -8,27 +10,10 @@ import ZiskFv.Airs.Main.Main
 /-!
 # `equiv_JALR` Compliance wrapper — ControlFlow non-branch
 
-> **Status:** within-shape wrapper, derived mechanically from
-> `FromTrust/Lui.lean`. Lives outside the canonical
-> surface so V1 anti-laundering metrics on the canonical theorem
-> are unaffected.
-
-## 5-category discharge applied
-
-* **Lane-match.** Internalized by `equiv_JALR` via
-  `jalr_discharge_lanes` (consumes `main_store_pc_emission_bundle`,
-  trust class #4). Pre-discharged on the canonical surface.
-* **Mode pins.** N/A on the provider side. Main-side mode pins come
-  from `transpile_JALR` (class #1).
-* **Sign-witness pins.** N/A.
-* **Range/bound.** Internalized by `equiv_JALR`.
-* **Operand bridges.** `read_xreg rs1` is consumed by
-  `equiv_JALR_sail`; the wrapper passes it through.
-
-## Anti-laundering report
-
-* **Zero new axioms** — consumes `transpile_JALR` (class #1) plus
-  `equiv_JALR`'s existing closure.
+The wrapper takes the structural `JumpPromises` bundle along with the
+upstream activation/opcode pins on Main and the per-row JALR subset
+constraint, and internally calls `jalr_h_circuit_of_main_constraints`
+(which transitively consumes `transpile_JALR`) to derive `h_circuit`.
 -/
 
 namespace ZiskFv.Compliance
@@ -39,11 +24,9 @@ open ZiskFv.Airs.Main
 
 variable {C : Type → Type → Type} [Circuit FGL FGL C]
 
-/-- **Compliance wrapper for `equiv_JALR`.** Mirrors
-    `equiv_LUI_from_trust`'s structure with `transpile_JALR` substituted
-    for `transpile_LUI` and JALR's mode/subset definitions in place of
-    LUI's. JALR uses `OP_COPYB` activation (internal copyb route per
-    archetype-validation modeling). -/
+/-- **Compliance wrapper for `equiv_JALR`.** Derives `h_circuit` from
+    `jalr_h_circuit_of_main_constraints` (consuming `transpile_JALR`)
+    and delegates to canonical `equiv_JALR`. -/
 theorem equiv_JALR_from_trust
     (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
     (jalr_input : PureSpec.JalrInput)
@@ -54,79 +37,39 @@ theorem equiv_JALR_from_trust
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e_rd : Interaction.MemoryBusEntry FGL)
     (nextPC_val : BitVec 64)
-    -- AIR validator + row index.
     (m : Valid_Main C FGL FGL) (r_main : ℕ) (next_pc : FGL)
-    -- Activation + opcode pins (Compliance ROM handshake).
+    -- Activation / opcode pins on Main + per-row subset constraint.
     (h_main_active : m.is_external_op r_main = 0)
     (h_main_op_jalr : m.op r_main = OP_COPYB)
-    -- Per-row Main constraint bundle.
     (h_jalr_subset :
       ZiskFv.Tactics.JumpArchetype.jalr_subset_holds m r_main next_pc)
-    -- Sail-side state predicates (SPEC-PRE).
+    -- Structural `JumpPromises` bundle.
+    (promises : ZiskFv.Equivalence.Promises.JumpPromises
+        state jalr_input.PC jalr_input.rd misa_val
+        (PureSpec.execute_JALR_pure jalr_input).success
+        (PureSpec.execute_JALR_pure jalr_input).nextPC
+        rd exec_row e_rd nextPC_val)
     (h_input_imm : jalr_input.imm = imm)
-    (h_input_rd : jalr_input.rd = regidx_to_fin rd)
     (h_input_rs1 : read_xreg (regidx_to_fin rs1) state
       = EStateM.Result.ok jalr_input.rs1_val state)
-    (h_input_pc : state.regs.get? Register.PC = .some jalr_input.PC)
-    (h_input_misa : state.regs.get? Register.misa = .some misa_val)
-    (h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1)
     (h_cur_privilege : Sail.readReg Register.cur_privilege state
       = EStateM.Result.ok Privilege.Machine state)
     (h_mseccfg : Sail.readReg Register.mseccfg state
       = EStateM.Result.ok mseccfg state)
-    -- Bus-shape structural hypotheses — pass-through from `equiv_JALR`.
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = nextPC_val)
-    (h_rd_mult : e_rd.multiplicity = 1) (h_rd_as : e_rd.as.val = 1)
-    -- Happy-path hypothesis (ZisK target-aligned SPEC-PRE).
-    (h_success : (PureSpec.execute_JALR_pure jalr_input).success = true)
-    (h_nextPC_option :
-      (PureSpec.execute_JALR_pure jalr_input).nextPC = .some nextPC_val)
-    (h_rd_idx : jalr_input.rd = Transpiler.wrap_to_regidx e_rd.ptr)
-    -- Range/no-wrap obligations.
     (h_pc_bound : jalr_input.PC.toNat < GL_prime - 4)
     (h_lo_bound : (m.pc r_main + 4 : FGL).val < 4294967296)
     (h_pc_offset_lt_2_32 : (jalr_input.PC + 4#64).toNat < 4294967296) :
     (do
         Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
         LeanRV64D.Functions.execute (instruction.JALR (imm, rs1, rd))) state
-      = (bus_effect exec_row [e_rd] state).2 := by
-  -- ============ Derive routing mode pins via `transpile_JALR` ============
-  have h_tr := ZiskFv.Trusted.transpile_JALR m r_main (0 : Fin 32) (0 : Fin 32)
-    (0 : FGL) { xreg := fun _ => 0#64, pc := 0#64 } h_main_active h_main_op_jalr
-  obtain ⟨h_m32, h_set_pc, h_store_pc, _, _, _, _⟩ := h_tr
-  -- ============ Assemble `jalr_circuit_holds` ============
-  -- The canonical `jalr_circuit_holds` predicate packs the
-  -- jalr-subset + mode pins; under the archetype-validation route,
-  -- the mode pins are `is_external_op = 0`, `op = 1`, `m32 = 0`,
-  -- `set_pc = 1`, `store_pc = 1`. We have these from
-  -- `h_main_active` + `h_main_op_jalr` + the transpile-derived ones.
-  have h_circuit : ZiskFv.ZiskCircuit.Jalr.jalr_circuit_holds m r_main next_pc := by
-    refine ⟨h_jalr_subset, ?_⟩
-    refine ⟨h_main_active, ?_, h_m32, h_set_pc, h_store_pc⟩
-    rw [h_main_op_jalr]; rfl
-  -- ============ Delegate to canonical `equiv_JALR` ============
-  exact ZiskFv.Equivalence.Jalr.equiv_JALR
+      = (bus_effect exec_row [e_rd] state).2 :=
+  have h_circuit :=
+    ZiskFv.Equivalence.Promises.jalr_h_circuit_of_main_constraints
+      m r_main next_pc h_main_active h_main_op_jalr h_jalr_subset
+  ZiskFv.Equivalence.Jalr.equiv_JALR
     state jalr_input imm rs1 rd misa_val mseccfg
     exec_row e_rd nextPC_val m r_main next_pc
-    { input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      input_misa_eq := h_input_misa
-      misa_c_zero := h_misa_c
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      rd_mult := h_rd_mult
-      rd_as := h_rd_as
-      success := h_success
-      nextPC_option := h_nextPC_option
-      rd_idx := h_rd_idx }
-    h_input_imm h_input_rs1 h_cur_privilege h_mseccfg
+    promises h_input_imm h_input_rs1 h_cur_privilege h_mseccfg
     h_circuit h_pc_bound h_lo_bound h_pc_offset_lt_2_32
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Lb.lean
+++ b/ZiskFv/Compliance/FromTrust/Lb.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Lb
+import ZiskFv.Equivalence.Promises.Load
 import ZiskFv.Equivalence.Bridge.Mem
 import ZiskFv.Equivalence.Bridge.BinaryExtension
 import ZiskFv.Trusted.Transpiler
@@ -71,21 +72,12 @@ theorem equiv_LB_from_trust
     -- Activation + opcode pin (Compliance ROM handshake).
     (h_main_active : main.is_external_op r_main = 1)
     (h_main_op : main.op r_main = ZiskFv.Trusted.OP_SIGNEXTEND_B)
-    -- Sail-side state predicates (SPEC-PRE).
-    (risc_v_assumptions :
-      RISC_V_assumptions state mstatus pmaRegion misa mseccfg)
-    (h_opcode_assumptions :
-      PureSpec.lb_state_assumptions lb_input state)
-    -- Bus-protocol structural hypotheses.
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_LOADB_pure lb_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 2)
-    (h_m2_mult : e2.multiplicity = 1)  (h_m2_as : e2.as.val = 1) :
+    -- Structural promise bundle (12 fields, see Promises/Load.lean).
+    (promises : ZiskFv.Equivalence.Promises.LoadPromises
+        state mstatus pmaRegion misa mseccfg
+        (PureSpec.lb_state_assumptions lb_input state)
+        (PureSpec.execute_LOADB_pure lb_input).nextPC
+        exec_row e0 e1 e2) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -96,6 +88,12 @@ theorem equiv_LB_from_trust
         false,
         1
       ))) state = (bus_effect exec_row [e0, e1, e2] state).2 := by
+  -- Bundle fields used later in the proof body (do NOT consume `promises`
+  -- with `obtain` since it is passed through to `equiv_LB`).
+  have h_m1_mult := promises.m1_mult
+  have h_m1_as := promises.m1_as
+  have h_m2_mult := promises.m2_mult
+  have h_m2_as := promises.m2_as
   -- ============ Derive (r_binary, h_match) via op-bus permutation soundness ============
   -- `OP_SIGNEXTEND_B = 39 = 0x27` matches the 7th disjunct of
   -- `op_bus_perm_sound_BinaryExtension`'s opcode coverage.
@@ -146,18 +144,7 @@ theorem equiv_LB_from_trust
   exact ZiskFv.Equivalence.Lb.equiv_LB
     state lb_input mstatus pmaRegion misa mseccfg
     exec_row e0 e1 e2
-    { risc_v_assumptions := risc_v_assumptions
-      opcode_assumptions_ := h_opcode_assumptions
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as }
+    promises
     main mem r_main h_main_active h_main_op
     v r_binary h_op_binary h_bytes hc_lo_sum_lt hc_hi_sum_lt
     h_match_clo h_match_chi

--- a/ZiskFv/Compliance/FromTrust/Lbu.lean
+++ b/ZiskFv/Compliance/FromTrust/Lbu.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.LoadBU
+import ZiskFv.Equivalence.Promises.Load
 import ZiskFv.Equivalence.Bridge.Mem
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
@@ -71,21 +72,12 @@ theorem equiv_LBU_from_trust
     (h_main_active : main.is_external_op r_main = 0)
     (h_main_op_lbu : main.op r_main = OP_COPYB)
     (h_width : main.ind_width r_main = (1 : FGL))
-    -- Sail-side state predicates (SPEC-PRE).
-    (risc_v_assumptions :
-      RISC_V_assumptions state mstatus pmaRegion misa mseccfg)
-    (h_opcode_assumptions :
-      PureSpec.lbu_state_assumptions lbu_input state)
-    -- Bus-protocol structural hypotheses.
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_LOADBU_pure lbu_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 2)
-    (h_m2_mult : e2.multiplicity = 1)  (h_m2_as : e2.as.val = 1) :
+    -- Structural promise bundle (12 fields, see Promises/Load.lean).
+    (promises : ZiskFv.Equivalence.Promises.LoadPromises
+        state mstatus pmaRegion misa mseccfg
+        (PureSpec.lbu_state_assumptions lbu_input state)
+        (PureSpec.execute_LOADBU_pure lbu_input).nextPC
+        exec_row e0 e1 e2) :
     execute_instruction (instruction.LOAD (
       lbu_input.imm,
       regidx.Regidx lbu_input.r1,
@@ -99,18 +91,7 @@ theorem equiv_LBU_from_trust
   exact ZiskFv.Equivalence.LoadBU.equiv_LBU
     state lbu_input mstatus pmaRegion misa mseccfg
     exec_row e0 e1 e2
-    { risc_v_assumptions := risc_v_assumptions
-      opcode_assumptions_ := h_opcode_assumptions
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as }
+    promises
     main mem r_main mab marb ma h_low h_main_active h_op h_width
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Ld.lean
+++ b/ZiskFv/Compliance/FromTrust/Ld.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.LoadD
+import ZiskFv.Equivalence.Promises.Load
 import ZiskFv.Equivalence.Bridge.Mem
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
@@ -200,21 +201,12 @@ theorem equiv_LD_from_trust
     -- from Main's ROM handshake on the row hosting LD.
     (h_main_active : main.is_external_op r_main = 0)
     (h_main_op_ld : main.op r_main = OP_COPYB)
-    -- Sail-side state predicates (SPEC-PRE).
-    (risc_v_assumptions :
-      RISC_V_assumptions state mstatus pmaRegion misa mseccfg)
-    (h_opcode_assumptions :
-      PureSpec.ld_state_assumptions ld_input state)
-    -- Bus-protocol structural hypotheses — pass-through from `equiv_LD`.
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_LOADD_pure ld_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 2)
-    (h_m2_mult : e2.multiplicity = 1)  (h_m2_as : e2.as.val = 1) :
+    -- Structural promise bundle (12 fields, see Promises/Load.lean).
+    (promises : ZiskFv.Equivalence.Promises.LoadPromises
+        state mstatus pmaRegion misa mseccfg
+        (PureSpec.ld_state_assumptions ld_input state)
+        (PureSpec.execute_LOADD_pure ld_input).nextPC
+        exec_row e0 e1 e2) :
     execute_instruction (instruction.LOAD (
       ld_input.imm,
       regidx.Regidx ld_input.r1,
@@ -230,18 +222,7 @@ theorem equiv_LD_from_trust
   exact ZiskFv.Equivalence.LoadD.equiv_LD
     state ld_input mstatus pmaRegion misa mseccfg
     exec_row e0 e1 e2
-    { risc_v_assumptions := risc_v_assumptions
-      opcode_assumptions_ := h_opcode_assumptions
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as }
+    promises
     main mem r_main h_main_active h_op
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Lh.lean
+++ b/ZiskFv/Compliance/FromTrust/Lh.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Lh
+import ZiskFv.Equivalence.Promises.Load
 import ZiskFv.Equivalence.Bridge.Mem
 import ZiskFv.Equivalence.Bridge.BinaryExtension
 import ZiskFv.Trusted.Transpiler
@@ -72,21 +73,12 @@ theorem equiv_LH_from_trust
     -- Activation + opcode pin (Compliance ROM handshake).
     (h_main_active : main.is_external_op r_main = 1)
     (h_main_op : main.op r_main = ZiskFv.Trusted.OP_SIGNEXTEND_H)
-    -- Sail-side state predicates (SPEC-PRE).
-    (risc_v_assumptions :
-      RISC_V_assumptions state mstatus pmaRegion misa mseccfg)
-    (h_opcode_assumptions :
-      PureSpec.lh_state_assumptions lh_input state)
-    -- Bus-protocol structural hypotheses.
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_LOADH_pure lh_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 2)
-    (h_m2_mult : e2.multiplicity = 1)  (h_m2_as : e2.as.val = 1) :
+    -- Structural promise bundle (12 fields, see Promises/Load.lean).
+    (promises : ZiskFv.Equivalence.Promises.LoadPromises
+        state mstatus pmaRegion misa mseccfg
+        (PureSpec.lh_state_assumptions lh_input state)
+        (PureSpec.execute_LOADH_pure lh_input).nextPC
+        exec_row e0 e1 e2) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -97,6 +89,12 @@ theorem equiv_LH_from_trust
         false,
         2
       ))) state = (bus_effect exec_row [e0, e1, e2] state).2 := by
+  -- Bundle fields used later in the proof body (do NOT consume `promises`
+  -- with `obtain` since it is passed through to `equiv_LH`).
+  have h_m1_mult := promises.m1_mult
+  have h_m1_as := promises.m1_as
+  have h_m2_mult := promises.m2_mult
+  have h_m2_as := promises.m2_as
   -- ============ Derive (r_binary, h_match) via op-bus permutation soundness ============
   -- `OP_SIGNEXTEND_H = 40 = 0x28` matches the 8th disjunct of
   -- `op_bus_perm_sound_BinaryExtension`'s opcode coverage.
@@ -147,18 +145,7 @@ theorem equiv_LH_from_trust
   exact ZiskFv.Equivalence.Lh.equiv_LH
     state lh_input mstatus pmaRegion misa mseccfg
     exec_row e0 e1 e2
-    { risc_v_assumptions := risc_v_assumptions
-      opcode_assumptions_ := h_opcode_assumptions
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as }
+    promises
     main mem r_main h_main_active h_main_op
     v r_binary h_op_binary h_bytes hc_lo_sum_lt hc_hi_sum_lt
     h_match_clo h_match_chi

--- a/ZiskFv/Compliance/FromTrust/Lhu.lean
+++ b/ZiskFv/Compliance/FromTrust/Lhu.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.LoadHU
+import ZiskFv.Equivalence.Promises.Load
 import ZiskFv.Equivalence.Bridge.Mem
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
@@ -44,19 +45,11 @@ theorem equiv_LHU_from_trust
     (h_main_active : main.is_external_op r_main = 0)
     (h_main_op_lhu : main.op r_main = OP_COPYB)
     (h_width : main.ind_width r_main = (2 : FGL))
-    (risc_v_assumptions :
-      RISC_V_assumptions state mstatus pmaRegion misa mseccfg)
-    (h_opcode_assumptions :
-      PureSpec.lhu_state_assumptions lhu_input state)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_LOADHU_pure lhu_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 2)
-    (h_m2_mult : e2.multiplicity = 1)  (h_m2_as : e2.as.val = 1) :
+    (promises : ZiskFv.Equivalence.Promises.LoadPromises
+        state mstatus pmaRegion misa mseccfg
+        (PureSpec.lhu_state_assumptions lhu_input state)
+        (PureSpec.execute_LOADHU_pure lhu_input).nextPC
+        exec_row e0 e1 e2) :
     execute_instruction (instruction.LOAD (
       lhu_input.imm,
       regidx.Regidx lhu_input.r1,
@@ -69,18 +62,7 @@ theorem equiv_LHU_from_trust
   exact ZiskFv.Equivalence.LoadHU.equiv_LHU
     state lhu_input mstatus pmaRegion misa mseccfg
     exec_row e0 e1 e2
-    { risc_v_assumptions := risc_v_assumptions
-      opcode_assumptions_ := h_opcode_assumptions
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as }
+    promises
     main mem r_main mab marb ma h_low h_main_active h_op h_width
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Lui.lean
+++ b/ZiskFv/Compliance/FromTrust/Lui.lean
@@ -1,122 +1,21 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Lui
+import ZiskFv.Equivalence.Promises.UType
+import ZiskFv.Equivalence.Promises.UTypeHelpers
 import ZiskFv.Tactics.UTypeArchetype
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 
 /-!
-# `equiv_LUI` trust-discharge wrapper — ControlFlow non-branch shape exemplar
-## Why LUI
+# `equiv_LUI` Compliance wrapper — ControlFlow non-branch shape exemplar
 
-LUI is the cheapest non-branch ControlFlow opcode:
-
-* No `rs1` / `rs2` read (no operand bridge — category 5 is N/A).
-* No PC offset / no-wrap precondition (unlike AUIPC's
-  `h_no_wrap` / `h_lo_bound` / `h_pc_offset_lt_2_32`).
-* No signed-vs-unsigned distinction (category 3 N/A).
-* No mode columns on a provider AIR (category 2 N/A — LUI is
-  Main-only, no provider).
-* Range/bound (category 4) is fully discharged inside the
-  canonical `equiv_LUI` via `memory_bus_entry_byte_range_perm_sound`.
-* Lane-match (category 1) is fully discharged inside the canonical
-  `equiv_LUI` via `Bridge/ControlFlow.lui_discharge_lanes`.
-
-The remaining discharge target is the bundled
-`h_circuit : lui_archetype_circuit_holds m r_main next_pc` — a
-**constructibility obligation** packing per-row constraints + mode
-pins. This wrapper shows how `Compliance.lean` will supply
-`h_circuit` from three trust-ledger-style ingredients:
-
-1. The activation pin `m.is_external_op r_main = 0` (Compliance.lean
-   delivers this from the Main AIR's ROM handshake on the row hosting
-   the LUI instruction).
-2. The opcode pin `m.op r_main = OP_COPYB` (likewise from the
-   ROM handshake).
-3. The per-row Main constraint bundle `lui_subset_holds m r_main next_pc`
-   (Compliance.lean delivers this from
-   `∀ r, lui_universal_row m r`, the universal-row Main validity).
-
-Together with `transpile_LUI` (class #1) — which derives the routing
-pins `m32 = 0`, `set_pc = 0`, `store_pc = 0` from activation + opcode
-pin — we assemble `lui_archetype_circuit_holds` and delegate to
-`equiv_LUI`.
-
-## 5-category discharge applied
-
-* **Lane-match.** Internalized by `equiv_LUI` via
-  `lui_discharge_lanes` (consumes `main_store_pc_emission_bundle`,
-  trust class #4). Pre-discharged on the canonical surface.
-* **Mode pins.** N/A for the provider-AIR sense (no provider AIR).
-  The Main-side mode pins (`m32 = 0`, `set_pc = 0`, `store_pc = 0`,
-  `jmp_offset2 = 4`, `b_0 = imm_lo`, `b_1 = imm_hi`) come from
-  `transpile_LUI` (class #1) — already consumed inside `equiv_LUI`'s
-  proof.
-* **Sign-witness pins.** N/A (no signed-vs-unsigned distinction at
-  the operand-pack layer).
-* **Range/bound.** Internalized by `equiv_LUI` via
-  `memory_bus_entry_byte_range_perm_sound` (class #5b).
-  Pre-discharged on the canonical surface.
-* **Operand bridges.** N/A — no register read. State-bridge
-  hypotheses (`h_input_imm`, `h_input_rd`, `h_input_pc`) pass
-  through unmodified.
-
-## Anti-laundering report
-
-Per the discharge-recipe.md wrapper-specific checks:
-
-* **No new axioms.** This wrapper consumes only `transpile_LUI`
-  (class #1) and `equiv_LUI` itself. Trust ledger unchanged at 116
-  axioms — matches the per-AIR axiom map's 0-new-axioms prediction
-  for ControlFlow.
-* **Bridges cross-shape if possible.** N/A — this opcode adds no
-  helpers; the only derivation (mode pins from activation +
-  opcode pin) is a 4-line application of `transpile_LUI`.
-* **Caller-burden shrinks.** See the count below.
-
-## Caller-burden
-
-`equiv_LUI` (canonical): 22 binders / 12 hypotheses.
-`equiv_LUI_from_trust` (this file): 22 binders / 13 hypotheses.
-
-The hypothesis-count *grows by 1* on this opcode because the
-discharged `h_circuit` is itself a *bundle* of two structural
-parts (`lui_subset_holds` + `main_row_in_lui_mode`), and the
-wrapper unpacks it into three caller-supplied ingredients
-(`h_main_active`, `h_main_op_lui`, `h_lui_subset`). The two added
-hypotheses minus the removed one (and minus the removed
-`h_nextPC_eq` / `nextPC_val` made `rfl` by setting
-`nextPC_val := lui_input.PC + 4#64`) yields +1 net hypothesis at the
-per-opcode level.
-
-This is the **structural-unpacking pattern** documented in
-`trust/structural-unpacking-exceptions.txt` (though LUI itself is
-not on that list because no canonical-theorem refactor occurred —
-the unpacking happens only in this Compliance wrapper). The Compliance
-caller collapses `(m, ∀ r, lui_universal_row m r)` into one set of
-shared parameters across all eleven ControlFlow opcodes plus all
-Main-only opcodes — so at the *global* level the trust footprint
-strictly shrinks.
-
-The two `h_main_active` / `h_main_op_lui` pins themselves come from
-Compliance.lean's program-counter handshake — they are SHARED with
-the eventual ControlFlow branch wrappers and the other UTYPE
-wrapper (AUIPC) once those are authored.
-
-## Cross-shape lesson
-
-ControlFlow non-branch needs **no per-opcode trust-ledger axiom**.
-The only ingredients are:
-1. `transpile_<OP>` (class #1) — already in place for LUI / JAL /
-   JALR / AUIPC.
-2. The universal per-row Main constraint bundle (a constructibility
-   obligation on `Valid_Main`, not an axiom).
-3. The activation / opcode pin (delivered by Compliance.lean from
-   the Main AIR's ROM handshake).
-
-This generalizes mechanically to JAL / JALR / AUIPC. The pilot
-confirms the per-AIR axiom map's prediction: 0 new axioms for
-ControlFlow.
+The wrapper takes the structural `UTypePromises` bundle along with the
+upstream activation/opcode pins and the per-row LUI subset constraint,
+and internally calls `lui_h_circuit_of_main_constraints` (which
+transitively consumes `transpile_LUI`) to derive `h_circuit`. This keeps
+`transpile_LUI` transitively reachable from the global compliance
+theorem.
 -/
 
 namespace ZiskFv.Compliance
@@ -128,119 +27,34 @@ open ZiskFv.Tactics.UTypeArchetype
 
 variable {C : Type → Type → Type} [Circuit FGL FGL C]
 
-/-- **Pilot wrapper for `equiv_LUI`.**
-
-    Caller obligations (signature header, ordered):
-    1. The Sail-side inputs (`state`, `lui_input`, `imm`, `rd`).
-    2. The Main AIR validator with its selected row index
-       (`m : Valid_Main`, `r_main`). Compliance.lean shares
-       `m` across all Main-only opcodes.
-    3. The next-PC Goldilocks witness `next_pc` (Compliance.lean
-       supplies this as `m.pc (r_main + 1)`, the next row's PC
-       column, via the PC handshake).
-    4. The structural bus rows (`exec_row`, `e_rd`).
-    5. The activation + opcode pins on Main (`h_main_active`,
-       `h_main_op_lui`). Both come from Compliance.lean's
-       program-counter handshake on the row hosting the LUI
-       instruction.
-    6. The per-row Main constraint bundle (`h_lui_subset`).
-       Compliance.lean delivers this from a universal
-       `∀ r, lui_universal_row m r` parameter shared across all
-       ControlFlow non-branch opcodes.
-    7. The structural exec/mem row shape — same shape `equiv_LUI`
-       accepts; passed through unchanged.
-    8. The SPEC-PRE preconditions on the Sail input
-       (`h_input_imm`, `h_input_rd`, `h_input_pc`).
-
-    Derived internally (NOT caller-supplied):
-    * `m.m32 r_main = 0`, `m.set_pc r_main = 0`,
-      `m.store_pc r_main = 0` — from `transpile_LUI` (class #1)
-      applied to `h_main_active` + `h_main_op_lui`.
-    * `h_circuit : lui_archetype_circuit_holds m r_main next_pc` —
-      from `h_lui_subset` + the four transpile-derived mode pins
-      packed together.
-    * `nextPC_val := lui_input.PC + 4#64`, with `h_nextPC_eq` as
-      definitional `rfl` from `execute_LUI_pure`'s definition.
-
-    Trust footprint: `transpile_LUI` + `equiv_LUI`'s closure (which
-    transitively consumes `main_store_pc_emission_bundle` (class #4),
-    `memory_bus_entry_byte_range_perm_sound` (class #5b),
-    `main_columns_in_range` (class #5b), plus platform-feature
-    auxiliaries). Zero new axioms — matches `docs/fv/per-air-axiom-map.md`'s
-    prediction. -/
+/-- **Pilot wrapper for `equiv_LUI`.** Derives `h_circuit` from
+    `lui_h_circuit_of_main_constraints` (consuming `transpile_LUI`)
+    and delegates to canonical `equiv_LUI`. -/
 theorem equiv_LUI_from_trust
     (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
     (lui_input : PureSpec.LuiInput)
     (imm : BitVec 20)
     (rd : regidx)
-    -- AIR validator + row index. Compliance.lean shares (m) across
-    -- all Main-only opcodes.
     (m : Valid_Main C FGL FGL) (r_main : ℕ) (next_pc : FGL)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e_rd : Interaction.MemoryBusEntry FGL)
-    -- Activation / opcode pins. Compliance.lean derives these from
-    -- the Main AIR's ROM handshake on the row hosting LUI.
+    -- Activation / opcode pins on Main + per-row subset constraint
+    -- (consumed by the UTypeHelpers helper that fires `transpile_LUI`).
     (h_main_active : m.is_external_op r_main = 0)
     (h_main_op_lui : m.op r_main = OP_COPYB)
-    -- Per-row Main constraint bundle. Compliance.lean delivers this
-    -- from `∀ r, lui_universal_row m r`, the universal-row Main
-    -- validity (shared across all ControlFlow non-branch opcodes
-    -- AND the UTYPE shape's twin AUIPC).
     (h_lui_subset : lui_subset_holds m r_main next_pc)
-    -- Sail-side state predicates (SPEC-PRE).
-    (h_input_imm : lui_input.imm = imm)
-    (h_input_rd : lui_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some lui_input.PC)
-    -- Bus-protocol structural hypotheses — pass-through from
-    -- `equiv_LUI`; Compliance.lean supplies these from the same
-    -- bus-shape obligations as every other opcode in the shape.
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = lui_input.PC + 4#64)
-    (h_rd_mult : e_rd.multiplicity = 1) (h_rd_as : e_rd.as.val = 1)
-    (h_rd_idx : lui_input.rd = Transpiler.wrap_to_regidx e_rd.ptr) :
+    -- Structural `UTypePromises` bundle.
+    (promises : ZiskFv.Equivalence.Promises.UTypePromises
+        state lui_input.imm lui_input.rd lui_input.PC
+        (PureSpec.execute_LUI_pure lui_input).nextPC
+        imm rd exec_row e_rd (lui_input.PC + 4#64)) :
     execute_instruction (instruction.UTYPE (imm, rd, uop.LUI)) state
-      = (bus_effect exec_row [e_rd] state).2 := by
-  -- ============ Derive routing mode pins via `transpile_LUI` ============
-  -- Fire `transpile_LUI` with arbitrary placeholders for the ghost
-  -- `Fin 32` / `FGL` / `RV64State` parameters; we consume only the
-  -- routing pins (`m32`, `set_pc`, `store_pc`), not the
-  -- `jmp_offset` / `a_*` / `b_*` columns (those are internal to
-  -- `equiv_LUI`'s `lui_discharge_full`).
-  have h_tr := ZiskFv.Trusted.transpile_LUI m r_main (0 : Fin 32)
-    (0 : FGL) (0 : FGL)
-    { xreg := fun _ => 0#64, pc := 0#64 } h_main_active h_main_op_lui
-  obtain ⟨h_m32, h_set_pc, h_store_pc, _, _, _, _, _, _⟩ := h_tr
-  -- ============ Assemble `main_row_in_lui_mode` ============
-  have h_lui_mode : main_row_in_lui_mode m r_main := by
-    refine ⟨h_main_active, ?_, h_m32, h_set_pc, h_store_pc⟩
-    -- `OP_COPYB := 1` definitionally; the constraint expects
-    -- `m.op r_main = (1 : FGL)`.
-    rw [h_main_op_lui]; rfl
-  -- ============ Assemble `lui_archetype_circuit_holds` ============
-  have h_circuit : lui_archetype_circuit_holds m r_main next_pc :=
-    ⟨h_lui_subset, h_lui_mode⟩
-  -- ============ Delegate to canonical `equiv_LUI` ============
-  -- `nextPC_val := lui_input.PC + 4#64` is the value
-  -- `execute_LUI_pure lui_input |>.nextPC` definitionally equals,
-  -- so `nextPC_eq` reduces to `rfl`. Construct the structural
-  -- `UTypePromises` bundle from the wrapper's own structural binders.
-  exact ZiskFv.Equivalence.Lui.equiv_LUI state lui_input imm rd
+      = (bus_effect exec_row [e_rd] state).2 :=
+  have h_circuit :=
+    ZiskFv.Equivalence.Promises.lui_h_circuit_of_main_constraints
+      m r_main next_pc h_main_active h_main_op_lui h_lui_subset
+  ZiskFv.Equivalence.Lui.equiv_LUI state lui_input imm rd
     m r_main next_pc exec_row e_rd (lui_input.PC + 4#64)
-    { input_imm_eq := h_input_imm
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      rd_mult := h_rd_mult
-      rd_as := h_rd_as
-      nextPC_eq := rfl  -- (execute_LUI_pure lui_input).nextPC = lui_input.PC + 4#64
-      rd_idx := h_rd_idx }
-    h_circuit
+    promises h_circuit
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Lw.lean
+++ b/ZiskFv/Compliance/FromTrust/Lw.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Lw
+import ZiskFv.Equivalence.Promises.Load
 import ZiskFv.Equivalence.Bridge.Mem
 import ZiskFv.Equivalence.Bridge.BinaryExtension
 import ZiskFv.Trusted.Transpiler
@@ -87,21 +88,12 @@ theorem equiv_LW_from_trust
     -- Activation + opcode pin (Compliance ROM handshake).
     (h_main_active : main.is_external_op r_main = 1)
     (h_main_op : main.op r_main = ZiskFv.Trusted.OP_SIGNEXTEND_W)
-    -- Sail-side state predicates (SPEC-PRE).
-    (risc_v_assumptions :
-      RISC_V_assumptions state mstatus pmaRegion misa mseccfg)
-    (h_opcode_assumptions :
-      PureSpec.lw_state_assumptions lw_input state)
-    -- Bus-protocol structural hypotheses.
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_LOADW_pure lw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 2)
-    (h_m2_mult : e2.multiplicity = 1)  (h_m2_as : e2.as.val = 1) :
+    -- Structural promise bundle (12 fields, see Promises/Load.lean).
+    (promises : ZiskFv.Equivalence.Promises.LoadPromises
+        state mstatus pmaRegion misa mseccfg
+        (PureSpec.lw_state_assumptions lw_input state)
+        (PureSpec.execute_LOADW_pure lw_input).nextPC
+        exec_row e0 e1 e2) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -112,6 +104,12 @@ theorem equiv_LW_from_trust
         false,
         4
       ))) state = (bus_effect exec_row [e0, e1, e2] state).2 := by
+  -- Bundle fields used later in the proof body (do NOT consume `promises`
+  -- with `obtain` since it is passed through to `equiv_LW`).
+  have h_m1_mult := promises.m1_mult
+  have h_m1_as := promises.m1_as
+  have h_m2_mult := promises.m2_mult
+  have h_m2_as := promises.m2_as
   -- ============ Derive (r_binary, h_match) via op-bus permutation soundness ============
   -- `OP_SIGNEXTEND_W = 41 = 0x29` matches the 9th disjunct of
   -- `op_bus_perm_sound_BinaryExtension`'s opcode coverage.
@@ -162,18 +160,7 @@ theorem equiv_LW_from_trust
   exact ZiskFv.Equivalence.Lw.equiv_LW
     state lw_input mstatus pmaRegion misa mseccfg
     exec_row e0 e1 e2
-    { risc_v_assumptions := risc_v_assumptions
-      opcode_assumptions_ := h_opcode_assumptions
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as }
+    promises
     main mem r_main h_main_active h_main_op
     v r_binary h_op_binary h_bytes hc_lo_sum_lt hc_hi_sum_lt
     h_match_clo h_match_chi

--- a/ZiskFv/Compliance/FromTrust/Lwu.lean
+++ b/ZiskFv/Compliance/FromTrust/Lwu.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.LoadWU
+import ZiskFv.Equivalence.Promises.Load
 import ZiskFv.Equivalence.Bridge.Mem
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
@@ -44,19 +45,11 @@ theorem equiv_LWU_from_trust
     (h_main_active : main.is_external_op r_main = 0)
     (h_main_op_lwu : main.op r_main = OP_COPYB)
     (h_width : main.ind_width r_main = (4 : FGL))
-    (risc_v_assumptions :
-      RISC_V_assumptions state mstatus pmaRegion misa mseccfg)
-    (h_opcode_assumptions :
-      PureSpec.lwu_state_assumptions lwu_input state)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_LOADWU_pure lwu_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 2)
-    (h_m2_mult : e2.multiplicity = 1)  (h_m2_as : e2.as.val = 1) :
+    (promises : ZiskFv.Equivalence.Promises.LoadPromises
+        state mstatus pmaRegion misa mseccfg
+        (PureSpec.lwu_state_assumptions lwu_input state)
+        (PureSpec.execute_LOADWU_pure lwu_input).nextPC
+        exec_row e0 e1 e2) :
     execute_instruction (instruction.LOAD (
       lwu_input.imm,
       regidx.Regidx lwu_input.r1,
@@ -69,18 +62,7 @@ theorem equiv_LWU_from_trust
   exact ZiskFv.Equivalence.LoadWU.equiv_LWU
     state lwu_input mstatus pmaRegion misa mseccfg
     exec_row e0 e1 e2
-    { risc_v_assumptions := risc_v_assumptions
-      opcode_assumptions_ := h_opcode_assumptions
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as }
+    promises
     main mem r_main mab marb ma h_low h_main_active h_op h_width
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Mul.lean
+++ b/ZiskFv/Compliance/FromTrust/Mul.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Mul
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Equivalence.Bridge.Arith
 import ZiskFv.Equivalence.Bridge.SailStateBridge
 import ZiskFv.Airs.Arith.Ranges
@@ -105,22 +106,10 @@ theorem equiv_MUL_from_trust
     (h_match_primary :
       matches_entry (opBus_row_Main m r_main)
                     (opBus_row_Arith v r_a))
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok mul_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok mul_input.r2_val state)
-    (h_input_rd : mul_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some mul_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_MULH_mul_pure mul_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : mul_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state mul_input.r1_val mul_input.r2_val mul_input.rd mul_input.PC
+        (PureSpec.execute_MULH_mul_pure mul_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h0 : e2.x0.val < 256) (h1 : e2.x1.val < 256)
     (h2 : e2.x2.val < 256) (h3 : e2.x3.val < 256)
     (h4 : e2.x4.val < 256) (h5 : e2.x5.val < 256)
@@ -138,6 +127,11 @@ theorem equiv_MUL_from_trust
              signed_rs1 := srs1
              signed_rs2 := srs2 }))) state
       = (bus_effect exec_row [e0, e1, e2] state).2 := by
+  -- ============ Project bus-bundle fields used by the body ============
+  have h_input_r1 := promises.input_r1_eq
+  have h_input_r2 := promises.input_r2_eq
+  have h_m2_mult := promises.m2_mult
+  have h_m2_as := promises.m2_as
   -- ============ DERIVE arith-side opcode literal ============
   have h_op_eq : v.op r_a = m.op r_main := by
     have := h_match_primary
@@ -337,21 +331,7 @@ theorem equiv_MUL_from_trust
   -- ============ Delegate to `equiv_MUL` ============
   exact ZiskFv.Equivalence.Mul.equiv_MUL
     state mul_input r1 r2 rd srs1 srs2 v r_a exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h0 h1 h2 h3 h4 h5 h6 h7
     h_chain h_na h_nb h_np h_nr h_sext h_m32 h_div
     h_byte_lo h_byte_hi h_rs1_value h_rs2_value

--- a/ZiskFv/Compliance/FromTrust/MulH.lean
+++ b/ZiskFv/Compliance/FromTrust/MulH.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.MulH
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Equivalence.Bridge.Arith
 import ZiskFv.Equivalence.Bridge.SailStateBridge
 import ZiskFv.Airs.Arith.Ranges
@@ -84,22 +85,10 @@ theorem equiv_MULH_from_trust
     (h_match_secondary :
       matches_entry (opBus_row_Main m r_main)
                     (opBus_row_ArithMulSecondary v r_a))
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok mulh_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok mulh_input.r2_val state)
-    (h_input_rd : mulh_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some mulh_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_MULH_mulh_pure mulh_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : mulh_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state mulh_input.r1_val mulh_input.r2_val mulh_input.rd mulh_input.PC
+        (PureSpec.execute_MULH_mulh_pure mulh_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_row_constraints :
       ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a)
     :
@@ -113,6 +102,11 @@ theorem equiv_MULH_from_trust
              signed_rs1 := .Signed
              signed_rs2 := .Signed }))) state
       = (bus_effect exec_row [e0, e1, e2] state).2 := by
+  -- ============ Project bus-bundle fields used by the body ============
+  have h_input_r1 := promises.input_r1_eq
+  have h_input_r2 := promises.input_r2_eq
+  have h_m2_mult := promises.m2_mult
+  have h_m2_as := promises.m2_as
   -- ============ DERIVE arith-side opcode literal ============
   have h_op_eq : v.op r_a = m.op r_main := by
     have := h_match_secondary
@@ -343,21 +337,7 @@ theorem equiv_MULH_from_trust
   -- ============ Delegate to `equiv_MULH` ============
   exact ZiskFv.Equivalence.MulH.equiv_MULH
     state mulh_input r1 r2 rd v r_a exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_chain h_na h_nb h_np h_nr_eq h_sext h_m32 h_div
     h_na_bool h_nb_bool h_np_xor
     h_byte_lo h_byte_hi h_rs1_value h_rs2_value

--- a/ZiskFv/Compliance/FromTrust/MulHSU.lean
+++ b/ZiskFv/Compliance/FromTrust/MulHSU.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.MulHSU
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Equivalence.Bridge.Arith
 import ZiskFv.Equivalence.Bridge.SailStateBridge
 import ZiskFv.Airs.Arith.Ranges
@@ -59,22 +60,10 @@ theorem equiv_MULHSU_from_trust
     (h_match_secondary :
       matches_entry (opBus_row_Main m r_main)
                     (opBus_row_ArithMulSecondary v r_a))
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok mulhsu_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok mulhsu_input.r2_val state)
-    (h_input_rd : mulhsu_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some mulhsu_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_MULH_mulhsu_pure mulhsu_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : mulhsu_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state mulhsu_input.r1_val mulhsu_input.r2_val mulhsu_input.rd mulhsu_input.PC
+        (PureSpec.execute_MULH_mulhsu_pure mulhsu_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_row_constraints :
       ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a)
     :
@@ -88,6 +77,11 @@ theorem equiv_MULHSU_from_trust
              signed_rs1 := .Signed
              signed_rs2 := .Unsigned }))) state
       = (bus_effect exec_row [e0, e1, e2] state).2 := by
+  -- ============ Project bus-bundle fields used by the body ============
+  have h_input_r1 := promises.input_r1_eq
+  have h_input_r2 := promises.input_r2_eq
+  have h_m2_mult := promises.m2_mult
+  have h_m2_as := promises.m2_as
   -- ============ DERIVE arith-side opcode literal ============
   have h_op_eq : v.op r_a = m.op r_main := by
     have := h_match_secondary
@@ -314,21 +308,7 @@ theorem equiv_MULHSU_from_trust
   -- ============ Delegate to `equiv_MULHSU` ============
   exact ZiskFv.Equivalence.MulHSU.equiv_MULHSU
     state mulhsu_input r1 r2 rd v r_a exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_chain h_na h_nb_zero h_np h_nr_eq h_sext h_m32 h_div
     h_na_bool h_nb_bool h_np_xor
     h_byte_lo h_byte_hi h_rs1_value h_rs2_value

--- a/ZiskFv/Compliance/FromTrust/MulHU.lean
+++ b/ZiskFv/Compliance/FromTrust/MulHU.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.MulHU
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Equivalence.Bridge.Arith
 import ZiskFv.Equivalence.Bridge.SailStateBridge
 import ZiskFv.Airs.Arith.Ranges
@@ -63,22 +64,10 @@ theorem equiv_MULHU_from_trust
     (h_match_secondary :
       matches_entry (opBus_row_Main m r_main)
                     (opBus_row_ArithMulSecondary v r_a))
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok mulhu_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok mulhu_input.r2_val state)
-    (h_input_rd : mulhu_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some mulhu_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_MULH_mulhu_pure mulhu_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : mulhu_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state mulhu_input.r1_val mulhu_input.r2_val mulhu_input.rd mulhu_input.PC
+        (PureSpec.execute_MULH_mulhu_pure mulhu_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h0 : e2.x0.val < 256) (h1 : e2.x1.val < 256)
     (h2 : e2.x2.val < 256) (h3 : e2.x3.val < 256)
     (h4 : e2.x4.val < 256) (h5 : e2.x5.val < 256)
@@ -96,6 +85,11 @@ theorem equiv_MULHU_from_trust
              signed_rs1 := .Unsigned
              signed_rs2 := .Unsigned }))) state
       = (bus_effect exec_row [e0, e1, e2] state).2 := by
+  -- ============ Project bus-bundle fields used by the body ============
+  have h_input_r1 := promises.input_r1_eq
+  have h_input_r2 := promises.input_r2_eq
+  have h_m2_mult := promises.m2_mult
+  have h_m2_as := promises.m2_as
   -- ============ DERIVE arith-side opcode literal ============
   have h_op_eq : v.op r_a = m.op r_main := by
     have := h_match_secondary
@@ -298,21 +292,7 @@ theorem equiv_MULHU_from_trust
   -- ============ Delegate to `equiv_MULHU` ============
   exact ZiskFv.Equivalence.MulHU.equiv_MULHU
     state mulhu_input r1 r2 rd v r_a exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h0 h1 h2 h3 h4 h5 h6 h7
     h_chain h_na h_nb h_np h_nr h_sext h_m32 h_div
     h_byte_lo h_byte_hi h_rs1_value h_rs2_value

--- a/ZiskFv/Compliance/FromTrust/MulW.lean
+++ b/ZiskFv/Compliance/FromTrust/MulW.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.MulW
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Equivalence.Bridge.Arith
 import ZiskFv.Equivalence.Bridge.SailStateBridge
 import ZiskFv.Airs.Arith.Ranges
@@ -72,22 +73,10 @@ theorem equiv_MULW_from_trust
     (h_match_primary :
       matches_entry (opBus_row_Main m r_main)
                     (opBus_row_Arith v r_a))
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok mulw_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok mulw_input.r2_val state)
-    (h_input_rd : mulw_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some mulw_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_MULW_pure mulw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : mulw_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state mulw_input.r1_val mulw_input.r2_val mulw_input.rd mulw_input.PC
+        (PureSpec.execute_MULW_pure mulw_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_row_constraints :
       ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a)
     -- Pass-through caller burdens (W-mode sign-extension + W-form operand bridges).
@@ -110,6 +99,9 @@ theorem equiv_MULW_from_trust
       LeanRV64D.Functions.execute
         (instruction.MULW (r2, r1, rd))) state
       = (bus_effect exec_row [e0, e1, e2] state).2 := by
+  -- ============ Project bus-bundle fields used by the body ============
+  have h_m2_mult := promises.m2_mult
+  have h_m2_as := promises.m2_as
   -- ============ DERIVE arith-side opcode literal ============
   have h_op_eq : v.op r_a = m.op r_main := by
     have := h_match_primary
@@ -173,21 +165,7 @@ theorem equiv_MULW_from_trust
   -- ============ Delegate to `equiv_MULW` ============
   exact ZiskFv.Equivalence.MulW.equiv_MULW
     state mulw_input r1 r2 rd v r_a exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_chain h_nr h_sext h_m32 h_div h_op_arith_mulw
     h_na_bool h_nb_bool h_np_xor h_byte_lo h_sext_choice h_rs1_value h_rs2_value
 

--- a/ZiskFv/Compliance/FromTrust/Or.lean
+++ b/ZiskFv/Compliance/FromTrust/Or.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Or
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -210,24 +211,12 @@ theorem equiv_OR_from_trust
     -- downstream from a Binary-side
     -- `main_external_logic_emission_bundle`.
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    -- Sail-side state predicates (SPEC-PRE).
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok or_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok or_input.r2_val state)
-    (h_input_rd : or_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some or_input.PC)
-    -- Bus-protocol structural hypotheses — pass-through from `equiv_OR`.
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_or_pure or_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : or_input.rd = Transpiler.wrap_to_regidx e2.ptr) :
+    -- Structural promise bundle (15 fields). Subsumes the prior inline
+    -- Sail-side state predicates + bus-protocol structural hypotheses.
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state or_input.r1_val or_input.r2_val or_input.rd or_input.PC
+        (PureSpec.execute_RTYPE_or_pure or_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -274,21 +263,7 @@ theorem equiv_OR_from_trust
   -- ============ Delegate to canonical `equiv_OR` ============
   exact ZiskFv.Equivalence.Or.equiv_OR
     state or_input r1 r2 rd m v r_main r_binary exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_main_active h_main_op_or h_match h_bop_or_sext h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Ori.lean
+++ b/ZiskFv/Compliance/FromTrust/Ori.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Ori
+import ZiskFv.Equivalence.Promises.IType
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -41,21 +42,10 @@ theorem equiv_ORI_from_trust
     (h_main_op_ori : m.op r_main = OP_OR)
     (h_ori_subset : itype_imm_subset_holds_main m r_main ori_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok ori_input.r1_val state)
-    (h_input_imm : ori_input.imm = imm)
-    (h_input_rd : ori_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some ori_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_ITYPE_ori_pure ori_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : ori_input.rd = Transpiler.wrap_to_regidx e2.ptr) :
+    (promises : ZiskFv.Equivalence.Promises.ITypePromises
+        state ori_input.r1_val ori_input.imm ori_input.rd ori_input.PC
+        (PureSpec.execute_ITYPE_ori_pure ori_input).nextPC
+        r1 rd imm exec_row e0 e1 e2) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -89,21 +79,7 @@ theorem equiv_ORI_from_trust
     binary_b_op_or_sext_eq_OP_OR v r_binary h_emit_op
   exact ZiskFv.Equivalence.Ori.equiv_ORI
     state ori_input r1 rd imm m v r_main r_binary exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_imm_eq := h_input_imm
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_main_active h_main_op_ori h_match h_bop_or_sext h_lane_rd h_ori_subset
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Rem.lean
+++ b/ZiskFv/Compliance/FromTrust/Rem.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Rem
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Equivalence.Bridge.Arith
 import ZiskFv.Equivalence.Bridge.SailStateBridge
 import ZiskFv.Airs.Arith.Ranges
@@ -44,22 +45,10 @@ theorem equiv_REM_from_trust
     (h_match_secondary :
       matches_entry (opBus_row_Main m r_main)
                     (ZiskFv.Airs.ArithDiv.opBus_row_ArithDivSecondary v r_a))
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_DIVREM_rem_pure rem_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : rem_input.rd = Transpiler.wrap_to_regidx e2.ptr)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok rem_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok rem_input.r2_val state)
-    (h_input_rd : rem_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some rem_input.PC)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state rem_input.r1_val rem_input.r2_val rem_input.rd rem_input.PC
+        (PureSpec.execute_DIVREM_rem_pure rem_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_op2_ne : rem_input.r2_val.toInt ≠ 0)
     (h_no_overflow :
       ¬ (rem_input.r1_val.toInt = -(2:ℤ)^63 ∧ rem_input.r2_val.toInt = -1))
@@ -78,6 +67,11 @@ theorem equiv_REM_from_trust
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.REM (r2, r1, rd, false))) state
       = (bus_effect exec_row [e0, e1, e2] state).2 := by
+  -- ============ Project bus-bundle fields used by the body ============
+  have h_input_r1 := promises.input_r1_eq
+  have h_input_r2 := promises.input_r2_eq
+  have h_m2_mult := promises.m2_mult
+  have h_m2_as := promises.m2_as
   -- ============ DERIVE arith-side opcode literal ============
   have h_op_eq : v.op r_a = m.op r_main := by
     have := h_match_secondary
@@ -318,21 +312,7 @@ theorem equiv_REM_from_trust
   -- ============ Delegate to `equiv_REM` ============
   exact ZiskFv.Equivalence.Rem.equiv_REM
     state rem_input r1 r2 rd exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     v r_a h_chain h_na_bool h_nb_bool h_nr_bool h_np_xor h_nr_pin
     h_sext h_m32 h_div h_byte_lo h_byte_hi h_rs1_value h_rs2_value
     h_op2_ne h_no_overflow h_r_abs h_r_sign

--- a/ZiskFv/Compliance/FromTrust/Remu.lean
+++ b/ZiskFv/Compliance/FromTrust/Remu.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Remu
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Equivalence.Bridge.Arith
 import ZiskFv.Equivalence.Bridge.SailStateBridge
 import ZiskFv.Airs.Arith.Ranges
@@ -40,22 +41,10 @@ theorem equiv_REMU_from_trust
     (h_match_secondary :
       matches_entry (opBus_row_Main m r_main)
                     (ZiskFv.Airs.ArithDiv.opBus_row_ArithDivSecondary v r_a))
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok remu_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok remu_input.r2_val state)
-    (h_input_rd : remu_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some remu_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_DIVREM_remu_pure remu_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : remu_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state remu_input.r1_val remu_input.r2_val remu_input.rd remu_input.PC
+        (PureSpec.execute_DIVREM_remu_pure remu_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h0 : e2.x0.val < 256) (h1 : e2.x1.val < 256)
     (h2 : e2.x2.val < 256) (h3 : e2.x3.val < 256)
     (h4 : e2.x4.val < 256) (h5 : e2.x5.val < 256)
@@ -68,6 +57,11 @@ theorem equiv_REMU_from_trust
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.REM (r2, r1, rd, true))) state
       = (bus_effect exec_row [e0, e1, e2] state).2 := by
+  -- ============ Project bus-bundle fields used by the body ============
+  have h_input_r1 := promises.input_r1_eq
+  have h_input_r2 := promises.input_r2_eq
+  have h_m2_mult := promises.m2_mult
+  have h_m2_as := promises.m2_as
   -- ============ DERIVE arith-side opcode literal ============
   have h_op_eq : v.op r_a = m.op r_main := by
     have := h_match_secondary
@@ -274,21 +268,7 @@ theorem equiv_REMU_from_trust
   -- ============ Delegate to `equiv_REMU` ============
   exact ZiskFv.Equivalence.Remu.equiv_REMU
     state remu_input r1 r2 rd v r_a exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h0 h1 h2 h3 h4 h5 h6 h7
     h_chain h_na h_nb h_np h_nr h_sext h_m32 h_div
     h_byte_lo h_byte_hi h_rs1_value h_rs2_value h_op2_ne h_d_lt_b

--- a/ZiskFv/Compliance/FromTrust/Remuw.lean
+++ b/ZiskFv/Compliance/FromTrust/Remuw.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Remuw
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Equivalence.Bridge.Arith
 import ZiskFv.Equivalence.Bridge.SailStateBridge
 import ZiskFv.Airs.Arith.Ranges
@@ -42,22 +43,10 @@ theorem equiv_REMUW_from_trust
     (h_match_secondary :
       matches_entry (opBus_row_Main m r_main)
                     (ZiskFv.Airs.ArithDiv.opBus_row_ArithDivSecondary v r_a))
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok remuw_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok remuw_input.r2_val state)
-    (h_input_rd : remuw_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some remuw_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_DIVREM_remuw_pure remuw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : remuw_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state remuw_input.r1_val remuw_input.r2_val remuw_input.rd remuw_input.PC
+        (PureSpec.execute_DIVREM_remuw_pure remuw_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_row_constraints :
       ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     -- Pass-through caller burdens (mirror DIVUW).
@@ -76,6 +65,9 @@ theorem equiv_REMUW_from_trust
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.REMW (r2, r1, rd, true))) state
       = (bus_effect exec_row [e0, e1, e2] state).2 := by
+  -- ============ Project bus-bundle fields used by the body ============
+  have h_m2_mult := promises.m2_mult
+  have h_m2_as := promises.m2_as
   -- ============ DERIVE arith-side opcode literal ============
   have h_op_eq : v.op r_a = m.op r_main := by
     have := h_match_secondary
@@ -170,21 +162,7 @@ theorem equiv_REMUW_from_trust
   -- ============ Delegate to `equiv_REMUW` ============
   exact ZiskFv.Equivalence.Remuw.equiv_REMUW
     state remuw_input r1 r2 rd v r_a exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_chain h_na h_nb h_np h_nr h_sext h_m32 h_div h_op_full h_c23
     h_byte_lo h_sext_choice h_rs1_value h_rs2_value h_op2_ne h_d_lt_b
 

--- a/ZiskFv/Compliance/FromTrust/Remw.lean
+++ b/ZiskFv/Compliance/FromTrust/Remw.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Remw
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Equivalence.Bridge.Arith
 import ZiskFv.Equivalence.Bridge.SailStateBridge
 import ZiskFv.Airs.Arith.Ranges
@@ -47,22 +48,10 @@ theorem equiv_REMW_from_trust
     (h_match_secondary :
       matches_entry (opBus_row_Main m r_main)
                     (ZiskFv.Airs.ArithDiv.opBus_row_ArithDivSecondary v r_a))
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok remw_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok remw_input.r2_val state)
-    (h_input_rd : remw_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some remw_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_DIVREM_remw_pure remw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : remw_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state remw_input.r1_val remw_input.r2_val remw_input.rd remw_input.PC
+        (PureSpec.execute_DIVREM_remw_pure remw_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_row_constraints :
       ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     -- Sign-witness booleanity + XOR (CIRCUIT-CONSTRAINT — caller-supplied).
@@ -96,6 +85,9 @@ theorem equiv_REMW_from_trust
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.REMW (r2, r1, rd, false))) state
       = (bus_effect exec_row [e0, e1, e2] state).2 := by
+  -- ============ Project bus-bundle fields used by the body ============
+  have h_m2_mult := promises.m2_mult
+  have h_m2_as := promises.m2_as
   -- ============ DERIVE arith-side opcode literal ============
   have h_op_eq : v.op r_a = m.op r_main := by
     have := h_match_secondary
@@ -192,21 +184,7 @@ theorem equiv_REMW_from_trust
   -- ============ Delegate to `equiv_REMW` ============
   exact ZiskFv.Equivalence.Remw.equiv_REMW
     state remw_input r1 r2 rd v r_a exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_chain h_sext h_m32 h_div h_op_signed
     h_na_bool h_nb_bool h_nr_bool h_np_xor
     h_c23 h_byte_lo h_sext_choice h_rs1_value h_rs2_value

--- a/ZiskFv/Compliance/FromTrust/Sb.lean
+++ b/ZiskFv/Compliance/FromTrust/Sb.lean
@@ -1,7 +1,8 @@
 import Mathlib
 
 import ZiskFv.Equivalence.StoreB
-import ZiskFv.Equivalence.Bridge.Mem
+import ZiskFv.Equivalence.Promises.Store
+import ZiskFv.Equivalence.Promises.StoreHelpers
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.MemoryBus
@@ -9,33 +10,12 @@ import ZiskFv.Airs.MemoryBus
 /-!
 # `equiv_SB` Compliance wrapper — Mem-stores shape, 1-byte width
 
-> **Status:** wrapper.
-> Mirrors `Compliance/FromTrust/Sd.lean` (SD pilot, commit `3a86908`)
-> specialized to SB's 1-byte store. Consumes
-> `main_store_emission_bundle_sb` (class #4, NEW) via
-> `Bridge.Mem.sb_discharge_full` to discharge the bundled
-> `h_mem_eq` hypothesis on the canonical `equiv_SB` theorem.
-
-## Discharge
-
-`equiv_SB` carries a single bundled `h_mem_eq` hypothesis equating
-the bus side's 8-insert chain on `state.mem` with the Sail spec's
-1-insert chain (via `modify_memory_1`). The RMW protocol of the
-MemAlign* providers ensures the high 7 byte lanes of the store bus
-entry equal the pre-existing memory contents at those addresses, so
-re-inserting them is a no-op (`Std.ExtHashMap.ext_getElem?` closure
-in `Bridge.Mem.sb_discharge_full`).
-
-## Anti-laundering report
-
-* **1 new axiom contributed to this wrapper.**
-  `main_store_emission_bundle_sb` (`MemBridge.lean`, class #4).
-  PIL-cited; same class as `main_store_emission_bundle_sd` —
-  narrow-width variant with RMW high-byte preservation.
-* **Caller-burden shrinks.** `h_mem_eq` (1 hypothesis encoding ptr +
-  low byte + 7 high-byte RMW preservations) is discharged; replaced
-  by `(main : Valid_Main, r_main, h_main_active, h_main_op,
-  h_ind_width)` (5 lighter parameters).
+The wrapper takes the structural `StorePromises` bundle along with the
+upstream activation/opcode/width pins on Main, and internally calls
+`sb_h_mem_eq_of_emission` (which transitively consumes
+`main_store_emission_bundle_sb` and `transpile_SB`) to derive the
+`h_mem_eq` premise that the canonical `equiv_SB` consumes. This keeps
+both axioms transitively reachable from the global compliance theorem.
 -/
 
 namespace ZiskFv.Compliance
@@ -50,8 +30,10 @@ open ZiskFv.ZiskCircuit.StoreB
 
 variable {C : Type → Type → Type} [Circuit FGL FGL C]
 
-/-- **Wrapper for `equiv_SB`.** Discharges `h_mem_eq` from the SB
-    emission bundle + RMW high-byte preservation. -/
+/-- **Wrapper for `equiv_SB`.** Derives `h_mem_eq` from
+    `sb_h_mem_eq_of_emission` (which consumes
+    `main_store_emission_bundle_sb` + `transpile_SB`) and delegates to
+    canonical `equiv_SB`. -/
 theorem equiv_SB_from_trust
     (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
     (sb_input : PureSpec.SbInput)
@@ -64,57 +46,33 @@ theorem equiv_SB_from_trust
     -- Structural bus rows.
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
-    -- Activation / opcode / width pins. Compliance.lean derives these
-    -- from Main's ROM handshake on the row hosting SB.
+    -- Activation / opcode / width pins on Main (consumed by the
+    -- StoreHelpers helper that transitively fires `transpile_SB` and
+    -- `main_store_emission_bundle_sb`).
     (h_main_active : main.is_external_op r_main = 0)
     (h_main_op : main.op r_main = OP_COPYB)
     (h_main_ind_width : main.ind_width r_main = 1)
-    -- Sail-side state predicates (SPEC-PRE).
-    (risc_v_assumptions :
-      RISC_V_assumptions state mstatus pmaRegion misa mseccfg)
-    (h_opcode_assumptions :
-      PureSpec.sb_state_assumptions sb_input state)
-    -- Bus-protocol structural hypotheses — pass-through from `equiv_SB`.
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_STOREB_pure sb_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1)  (h_m2_as : e2.as.val = 2) :
+    -- Sail-side opcode assumptions (also consumed by the helper).
+    (h_opcode_assumptions : PureSpec.sb_state_assumptions sb_input state)
+    -- Structural promise bundle (12 fields).
+    (promises : ZiskFv.Equivalence.Promises.StorePromises
+        state mstatus pmaRegion misa mseccfg
+        (PureSpec.sb_state_assumptions sb_input state)
+        (PureSpec.execute_STOREB_pure sb_input).nextPC
+        exec_row e0 e1 e2) :
     execute_instruction (instruction.STORE (
       sb_input.imm,
       regidx.Regidx sb_input.r2,
       regidx.Regidx sb_input.r1,
       1
-    )) state = (bus_effect exec_row [e0, e1, e2] state).2 := by
-  -- Extract the rX_bits reads from sb_state_assumptions.
-  have h_read_r1 := h_opcode_assumptions.2.1
-  have h_read_r2 := h_opcode_assumptions.2.2.1
-  -- Discharge h_mem_eq via the Mem-stores bridge.
+    )) state = (bus_effect exec_row [e0, e1, e2] state).2 :=
   have h_mem_eq :=
-    ZiskFv.Equivalence.Bridge.Mem.sb_discharge_full
+    ZiskFv.Equivalence.Promises.sb_h_mem_eq_of_emission
       main r_main e2 state sb_input
       h_main_active h_main_op h_main_ind_width
-      h_m2_mult h_m2_as h_read_r1 h_read_r2
-  -- Delegate to canonical `equiv_SB`.
-  exact ZiskFv.Equivalence.StoreB.equiv_SB
+      promises.m2_mult promises.m2_as h_opcode_assumptions
+  ZiskFv.Equivalence.StoreB.equiv_SB
     state sb_input mstatus pmaRegion misa mseccfg
-    exec_row e0 e1 e2
-    { risc_v_assumptions := risc_v_assumptions
-      opcode_assumptions_ := h_opcode_assumptions
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as }
-    h_mem_eq
+    exec_row e0 e1 e2 promises h_mem_eq
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Sd.lean
+++ b/ZiskFv/Compliance/FromTrust/Sd.lean
@@ -1,110 +1,20 @@
 import Mathlib
 
 import ZiskFv.Equivalence.StoreD
-import ZiskFv.Equivalence.Bridge.Mem
+import ZiskFv.Equivalence.Promises.Store
+import ZiskFv.Equivalence.Promises.StoreHelpers
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.MemoryBus
 
 /-!
-# `equiv_SD` trust-discharge wrapper — Mem-stores shape exemplar
-## Why SD
+# `equiv_SD` Compliance wrapper — Mem-stores shape, 8-byte width
 
-SD is the simplest store: all 8 bytes of `xreg rs2` flow through
-the memory-bus entry's byte lanes verbatim, ptr-match is the
-generic store-address formula `xreg rs1 + signExt(imm)`, and
-there is no sign-extension or width-pin coupling. The shape's
-narrower opcodes (SB / SH / SW) will reuse SD's discharge
-machinery plus a width-pin closing the high byte lanes to zero.
-
-## 5-category discharge applied
-
-* **Lane-match.** Internalized by the new
-  `main_store_emission_bundle_sd` (`MemBridge.lean`, class #4) —
-  it delivers the byte-extracted form of the store entry directly
-  (`(e_st.xi : BitVec 8) = BitVec.extractLsb _ _ r2_val`). The
-  bundle requires `transpile_SD`-derived lane equalities as
-  caller-supplied hypotheses, which the
-  `Bridge.Mem.sd_discharge_full` derivation discharges from a
-  Sail `read_xreg rs2` predicate (composing `transpile_SD` with
-  `Bridge.SailStateBridge.sail_to_rv64_xreg_eq_of_read_xreg`).
-* **Mode pins.** N/A on the provider side (Mem core has no mode
-  columns; the activation pins `is_external_op = 0`,
-  `op = OP_COPYB` are caller-supplied at the Compliance level
-  from the ROM-handshake on the row hosting SD).
-* **Sign-witness pins.** N/A — SD is unsigned data movement.
-* **Range/bound.** Byte ranges on the store entry are folded into
-  the bundle's class-#4 envelope (the byte-form conclusion uses
-  the same byte-range bus consequences as the lane-form would
-  via `memory_bus_entry_byte_range_perm_sound`). The address
-  range comes from the bus protocol itself; no further
-  range-bus entry is consumed at this layer.
-* **Operand bridges.** `read_xreg rs1` and `read_xreg rs2` are
-  routed through `Bridge.SailStateBridge.sail_to_rv64_xreg_eq_of_read_xreg`
-  (pure-Lean, no axiom) inside the `Bridge.Mem.sd_discharge_full`
-  composition.
-
-## Anti-laundering report
-
-* **1 new axiom.** `main_store_emission_bundle_sd`
-  (`MemBridge.lean`, class #4). PIL-cited; same class as
-  `main_load_emission_bundle` /
-  `main_external_arith_emission_bundle`. Matches the per-AIR
-  prediction map's 0-2 estimate for Mem-stores (lower-middle of
-  the range — only 1 new entry).
-* **No new bridges.** `Bridge.Mem.sd_discharge_full` is pure
-  Lean composing the new axiom with `transpile_SD` (class #1)
-  and `Bridge.SailStateBridge.sail_to_rv64_xreg_eq_of_read_xreg`
-  (pure Lean, no axiom).
-* **Caller-burden shrinks.** See the count below.
-
-## Caller-burden
-
-`equiv_SD` (canonical): 31 binders / 20 hypotheses.
-`equiv_SD_from_trust` (this file): 26 binders / 14 hypotheses.
-
-Net −5 binders / −6 hypotheses per Mem-store-shape opcode.
-Composition:
-
-* Drops `h_ptr_match` + 8 `h_byte_{0..7}` (9 binders, all
-  hypotheses): the entire byte-and-ptr promise bundle is
-  discharged via `Bridge.Mem.sd_discharge_full` consuming the
-  new `main_store_emission_bundle_sd` plus `transpile_SD`.
-* Adds `(main : Valid_Main)`, `(r_main : ℕ)` (2 non-hypothesis
-  binders) and `h_main_active`, `h_main_op` (2 hypothesis
-  binders) — Compliance.lean shares `(main, r_main)` across all
-  opcodes and derives `h_main_*` from its ROM handshake.
-
-Net: −9 (byte+ptr) + 4 (validator + activation) = −5 binders.
-Hypothesis count drops by −6 (the 9 promise hyps drop, 2 light
-activation pins added, plus the bundle-shape includes 1
-implicit hyp reduction).
-
-This matches the discharge-recipe.md "caller-burden must shrink"
-discipline. At the global `Compliance.lean` level the reduction
-extends further because `(main, r_main)` collapse into shared
-parameters across all 4 Mem-store opcodes (SD/SW/SH/SB), and
-`h_main_active` / `h_main_op` come from Compliance.lean's
-program-counter handshake.
-
-## Cross-shape lessons
-
-* The `Bridge.SailStateBridge.sail_to_rv64_xreg_eq_of_read_xreg`
-  utility composes cleanly with any opcode using
-  register-routed operands, not just ALU shapes. SD reuses it
-  verbatim for both rs1 (address base) and rs2 (store value).
-* The store-side **byte-form bundle** pattern (axiom delivering
-  byte extracts directly, rather than lane-form + pure-Lean
-  byte derivation) trades axiom-shape complexity for clean
-  caller composition. The auditability is preserved because the
-  byte extracts are PIL-derivable from the lane-form + byte-range
-  bus consequences (same class #4 envelope).
-* **Width specialization.** SD's bundle pins all 8 byte lanes
-  meaningful (`ind_width = 8`). SB/SH/SW each need their own
-  width-specialized bundle in their respective exemplar wrappers,
-  with the high byte lanes zero-pinned per the bus's `ind_width`
-  selector. The shape generalizes to a four-axiom family
-  (`main_store_emission_bundle_{sd,sw,sh,sb}`) all in class #4.
+The wrapper takes the structural `StorePromises` bundle along with the
+upstream activation/opcode pins on Main, and internally calls
+`sd_h_mem_eq_of_emission` (which transitively consumes
+`main_store_emission_bundle_sd` and `transpile_SD`) to derive the 9
+ptr/byte equalities that the canonical `equiv_SD` consumes.
 -/
 
 namespace ZiskFv.Compliance
@@ -118,36 +28,10 @@ open ZiskFv.ZiskCircuit.StoreD
 
 variable {C : Type → Type → Type} [Circuit FGL FGL C]
 
-/-- **Pilot wrapper for `equiv_SD`.**
-
-    Caller obligations (signature header, ordered):
-    1. Sail-side inputs (`state`, `sd_input`, `rs1`, `rs2`, and
-       the platform-state records `mstatus`, `pmaRegion`, `misa`,
-       `mseccfg`).
-    2. AIR validator + row index (`main : Valid_Main`,
-       `r_main : ℕ`). Compliance.lean shares `main` across all
-       opcodes.
-    3. The structural bus rows (`exec_row`, `e0`, `e1`, `e2`).
-    4. Activation + opcode pins on Main (`h_main_active`,
-       `h_main_op`). Both come from Compliance.lean's ROM
-       handshake on the row hosting the SD instruction.
-    5. Sail-side state predicates (SPEC-PRE):
-       `risc_v_assumptions`, `h_input_pc`, `h_input_r1`,
-       `h_input_r2`, plus the address-bound + alignment
-       precondition (`h_addr_bound`, `h_align`).
-    6. Bus-protocol structural hypotheses — pass-through from
-       `equiv_SD`.
-
-    Derived internally (NOT caller-supplied):
-    * `h_ptr_match : e2.ptr.toNat = (sd_input.r1_val + signExt(imm)).toNat` —
-      from `Bridge.Mem.sd_discharge_full`.
-    * `h_byte_0 .. h_byte_7 : (e2.xi : BitVec 8) = extractLsb _ _ sd_input.r2_val` —
-      from `Bridge.Mem.sd_discharge_full`.
-
-    Trust footprint: `main_store_emission_bundle_sd` (class #4,
-    NEW), `transpile_SD` (class #1), plus `equiv_SD`'s existing
-    closure. The `Bridge.SailStateBridge.sail_to_rv64_xreg_eq_of_read_xreg`
-    bridge is pure Lean (no axiom). -/
+/-- **Wrapper for `equiv_SD`.** Derives the 9 ptr+byte equalities from
+    `sd_h_mem_eq_of_emission` (which consumes
+    `main_store_emission_bundle_sd` + `transpile_SD`) and delegates to
+    canonical `equiv_SD`. -/
 theorem equiv_SD_from_trust
     (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
     (sd_input : PureSpec.SdInput)
@@ -155,87 +39,39 @@ theorem equiv_SD_from_trust
     (pmaRegion : PMA_Region)
     (misa : RegisterType Register.misa)
     (mseccfg : RegisterType Register.mseccfg)
-    -- AIR validator + row index. Compliance.lean shares `main`.
+    -- AIR validator + row index.
     (main : Valid_Main C FGL FGL) (r_main : ℕ)
     -- Structural bus rows.
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
-    -- Activation / opcode pins. Compliance.lean derives these
-    -- from Main's ROM handshake on the row hosting SD.
+    -- Activation / opcode pins on Main.
     (h_main_active : main.is_external_op r_main = 0)
     (h_main_op : main.op r_main = OP_COPYB)
-    -- Sail-side state predicates (SPEC-PRE), absorbed from
-    -- `sd_state_assumptions` and `RISC_V_assumptions`.
-    (risc_v_assumptions :
-      RISC_V_assumptions state mstatus pmaRegion misa mseccfg)
-    (h_opcode_assumptions :
-      PureSpec.sd_state_assumptions sd_input state)
-    -- Bus-protocol structural hypotheses — pass-through from `equiv_SD`.
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_STORED_pure sd_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1)  (h_m2_as : e2.as.val = 2) :
+    -- Sail-side opcode assumptions.
+    (h_opcode_assumptions : PureSpec.sd_state_assumptions sd_input state)
+    -- Structural promise bundle (12 fields).
+    (promises : ZiskFv.Equivalence.Promises.StorePromises
+        state mstatus pmaRegion misa mseccfg
+        (PureSpec.sd_state_assumptions sd_input state)
+        (PureSpec.execute_STORED_pure sd_input).nextPC
+        exec_row e0 e1 e2) :
     execute_instruction (instruction.STORE (
       sd_input.imm,
       regidx.Regidx sd_input.r2,
       regidx.Regidx sd_input.r1,
       8
-    )) state = (bus_effect exec_row [e0, e1, e2] state).2 := by
-  -- Discharge the 9 ptr+byte hypotheses via the Mem-stores bridge.
-  -- The bridge consumes the Sail `read_xreg` facts from
-  -- `sd_state_assumptions`, which lives at SPEC-PRE level (it is
-  -- already required by `equiv_SD` as `h_opcode_assumptions`).
-  have h_read_r1 := h_opcode_assumptions.2.1
-  have h_read_r2 := h_opcode_assumptions.2.2.1
-  -- Convert from `rX_bits (regidx.Regidx r) state` to
-  -- `read_xreg rs_fin state` via the existing
-  -- `rX_read_xreg_equiv` bridge.
-  have h_read_r1' :
-      read_xreg (regidx_to_fin (regidx.Regidx sd_input.r1)) state
-        = EStateM.Result.ok sd_input.r1_val state := by
-    rw [← rX_read_xreg_equiv state (regidx.Regidx sd_input.r1)
-          (regidx_to_fin (regidx.Regidx sd_input.r1))
-          (by simp [regidx_to_fin])]
-    exact h_read_r1
-  have h_read_r2' :
-      read_xreg (regidx_to_fin (regidx.Regidx sd_input.r2)) state
-        = EStateM.Result.ok sd_input.r2_val state := by
-    rw [← rX_read_xreg_equiv state (regidx.Regidx sd_input.r2)
-          (regidx_to_fin (regidx.Regidx sd_input.r2))
-          (by simp [regidx_to_fin])]
-    exact h_read_r2
-  -- Compose the discharge bundle.
-  obtain ⟨h_ptr_match, h_byte_0, h_byte_1, h_byte_2, h_byte_3,
-          h_byte_4, h_byte_5, h_byte_6, h_byte_7⟩ :=
-    ZiskFv.Equivalence.Bridge.Mem.sd_discharge_full
-      main r_main e2 state
-      (regidx_to_fin (regidx.Regidx sd_input.r1))
-      (regidx_to_fin (regidx.Regidx sd_input.r2))
-      sd_input.r1_val sd_input.r2_val sd_input.imm
-      h_main_active h_main_op h_m2_mult h_m2_as
-      h_read_r1' h_read_r2'
-  -- Delegate to canonical `equiv_SD`.
-  exact ZiskFv.Equivalence.StoreD.equiv_SD
+    )) state = (bus_effect exec_row [e0, e1, e2] state).2 :=
+  have h_mem_facts :=
+    ZiskFv.Equivalence.Promises.sd_h_mem_eq_of_emission
+      main r_main e2 state sd_input
+      h_main_active h_main_op
+      promises.m2_mult promises.m2_as h_opcode_assumptions
+  ZiskFv.Equivalence.StoreD.equiv_SD
     state sd_input mstatus pmaRegion misa mseccfg
-    exec_row e0 e1 e2
-    { risc_v_assumptions := risc_v_assumptions
-      opcode_assumptions_ := h_opcode_assumptions
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as }
-    h_ptr_match h_byte_0 h_byte_1 h_byte_2 h_byte_3
-    h_byte_4 h_byte_5 h_byte_6 h_byte_7
+    exec_row e0 e1 e2 promises
+    h_mem_facts.1 h_mem_facts.2.1 h_mem_facts.2.2.1 h_mem_facts.2.2.2.1
+    h_mem_facts.2.2.2.2.1 h_mem_facts.2.2.2.2.2.1
+    h_mem_facts.2.2.2.2.2.2.1 h_mem_facts.2.2.2.2.2.2.2.1
+    h_mem_facts.2.2.2.2.2.2.2.2
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Sh.lean
+++ b/ZiskFv/Compliance/FromTrust/Sh.lean
@@ -1,7 +1,8 @@
 import Mathlib
 
 import ZiskFv.Equivalence.StoreH
-import ZiskFv.Equivalence.Bridge.Mem
+import ZiskFv.Equivalence.Promises.Store
+import ZiskFv.Equivalence.Promises.StoreHelpers
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.MemoryBus
@@ -9,24 +10,11 @@ import ZiskFv.Airs.MemoryBus
 /-!
 # `equiv_SH` Compliance wrapper — Mem-stores shape, 2-byte width
 
-> **Status:** wrapper.
-> Mirrors `Compliance/FromTrust/Sb.lean` specialized to SH's 2-byte
-> store. Consumes `main_store_emission_bundle_sh` (class #4, NEW) via
-> `Bridge.Mem.sh_discharge_full` to discharge the bundled `h_mem_eq`
-> hypothesis on the canonical `equiv_SH` theorem.
-
-## Discharge
-
-`equiv_SH` carries a single bundled `h_mem_eq` hypothesis equating
-the bus side's 8-insert chain on `state.mem` with the Sail spec's
-2-insert chain (via `modify_memory_2`). The high 6 byte lanes of
-the store bus entry equal pre-existing memory contents (MemAlign RMW
-protocol); re-inserting them is a no-op closed in pure Lean.
-
-## Anti-laundering report
-
-* **1 new axiom contributed.** `main_store_emission_bundle_sh`
-  (class #4) — same family as the SB/SW siblings and SD pilot.
+The wrapper takes the structural `StorePromises` bundle along with the
+upstream activation/opcode/width pins on Main, and internally calls
+`sh_h_mem_eq_of_emission` (which transitively consumes
+`main_store_emission_bundle_sh` and `transpile_SH`) to derive the
+`h_mem_eq` premise that the canonical `equiv_SH` consumes.
 -/
 
 namespace ZiskFv.Compliance
@@ -40,8 +28,10 @@ open ZiskFv.ZiskCircuit.StoreD
 
 variable {C : Type → Type → Type} [Circuit FGL FGL C]
 
-/-- **Wrapper for `equiv_SH`.** Discharges `h_mem_eq` from the SH
-    emission bundle + RMW high-byte preservation. -/
+/-- **Wrapper for `equiv_SH`.** Derives `h_mem_eq` from
+    `sh_h_mem_eq_of_emission` (which consumes
+    `main_store_emission_bundle_sh` + `transpile_SH`) and delegates to
+    canonical `equiv_SH`. -/
 theorem equiv_SH_from_trust
     (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
     (sh_input : PureSpec.ShInput)
@@ -49,53 +39,36 @@ theorem equiv_SH_from_trust
     (pmaRegion : PMA_Region)
     (misa : RegisterType Register.misa)
     (mseccfg : RegisterType Register.mseccfg)
+    -- AIR validator + row index.
     (main : Valid_Main C FGL FGL) (r_main : ℕ)
+    -- Structural bus rows.
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
+    -- Activation / opcode / width pins on Main.
     (h_main_active : main.is_external_op r_main = 0)
     (h_main_op : main.op r_main = OP_COPYB)
     (h_main_ind_width : main.ind_width r_main = 2)
-    (risc_v_assumptions :
-      RISC_V_assumptions state mstatus pmaRegion misa mseccfg)
-    (h_opcode_assumptions :
-      PureSpec.sh_state_assumptions sh_input state)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_STOREH_pure sh_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1)  (h_m2_as : e2.as.val = 2) :
+    -- Sail-side opcode assumptions.
+    (h_opcode_assumptions : PureSpec.sh_state_assumptions sh_input state)
+    -- Structural promise bundle (12 fields).
+    (promises : ZiskFv.Equivalence.Promises.StorePromises
+        state mstatus pmaRegion misa mseccfg
+        (PureSpec.sh_state_assumptions sh_input state)
+        (PureSpec.execute_STOREH_pure sh_input).nextPC
+        exec_row e0 e1 e2) :
     execute_instruction (instruction.STORE (
       sh_input.imm,
       regidx.Regidx sh_input.r2,
       regidx.Regidx sh_input.r1,
       2
-    )) state = (bus_effect exec_row [e0, e1, e2] state).2 := by
-  have h_read_r1 := h_opcode_assumptions.2.1
-  have h_read_r2 := h_opcode_assumptions.2.2.1
+    )) state = (bus_effect exec_row [e0, e1, e2] state).2 :=
   have h_mem_eq :=
-    ZiskFv.Equivalence.Bridge.Mem.sh_discharge_full
+    ZiskFv.Equivalence.Promises.sh_h_mem_eq_of_emission
       main r_main e2 state sh_input
       h_main_active h_main_op h_main_ind_width
-      h_m2_mult h_m2_as h_read_r1 h_read_r2
-  exact ZiskFv.Equivalence.StoreH.equiv_SH
+      promises.m2_mult promises.m2_as h_opcode_assumptions
+  ZiskFv.Equivalence.StoreH.equiv_SH
     state sh_input mstatus pmaRegion misa mseccfg
-    exec_row e0 e1 e2
-    { risc_v_assumptions := risc_v_assumptions
-      opcode_assumptions_ := h_opcode_assumptions
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as }
-    h_mem_eq
+    exec_row e0 e1 e2 promises h_mem_eq
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/ShiftLI.lean
+++ b/ZiskFv/Compliance/FromTrust/ShiftLI.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.ShiftLI
+import ZiskFv.Equivalence.Promises.ShiftImm
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -28,20 +29,10 @@ theorem equiv_SLLIW_from_trust
     (r_main : ℕ)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
-    (h_input_r1_sail : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok slliw_input.r1_val state)
-    (h_input_rd : slliw_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some slliw_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_SHIFTIWOP_slliw_pure slliw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : slliw_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.ShiftWImmPromises
+        state slliw_input.r1_val slliw_input.rd slliw_input.PC
+        (PureSpec.execute_SHIFTIWOP_slliw_pure slliw_input).nextPC
+        r1 rd exec_row e0 e1 e2)
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op : m.op r_main = ZiskFv.Trusted.OP_SLL_W)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2) :
@@ -53,20 +44,7 @@ theorem equiv_SLLIW_from_trust
       (Or.inr (Or.inr (Or.inr (Or.inl h_main_op))))
   exact ZiskFv.Equivalence.ShiftLI.equiv_SLLIW state slliw_input r1 rd
     m v r_main r_binary exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1_sail
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_main_active h_main_op h_match h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/ShiftRAI.lean
+++ b/ZiskFv/Compliance/FromTrust/ShiftRAI.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.ShiftRAI
+import ZiskFv.Equivalence.Promises.ShiftImm
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -28,20 +29,10 @@ theorem equiv_SRAIW_from_trust
     (r_main : ℕ)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
-    (h_input_r1_sail : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok sraiw_input.r1_val state)
-    (h_input_rd : sraiw_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some sraiw_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_SHIFTIWOP_sraiw_pure sraiw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : sraiw_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.ShiftWImmPromises
+        state sraiw_input.r1_val sraiw_input.rd sraiw_input.PC
+        (PureSpec.execute_SHIFTIWOP_sraiw_pure sraiw_input).nextPC
+        r1 rd exec_row e0 e1 e2)
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op : m.op r_main = ZiskFv.Trusted.OP_SRA_W)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2) :
@@ -53,20 +44,7 @@ theorem equiv_SRAIW_from_trust
       (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl h_main_op))))))
   exact ZiskFv.Equivalence.ShiftRAI.equiv_SRAIW state sraiw_input r1 rd
     m v r_main r_binary exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1_sail
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_main_active h_main_op h_match h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/ShiftRLI.lean
+++ b/ZiskFv/Compliance/FromTrust/ShiftRLI.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.ShiftRLI
+import ZiskFv.Equivalence.Promises.ShiftImm
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -28,20 +29,10 @@ theorem equiv_SRLIW_from_trust
     (r_main : ℕ)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
-    (h_input_r1_sail : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok srliw_input.r1_val state)
-    (h_input_rd : srliw_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some srliw_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_SHIFTIWOP_srliw_pure srliw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : srliw_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.ShiftWImmPromises
+        state srliw_input.r1_val srliw_input.rd srliw_input.PC
+        (PureSpec.execute_SHIFTIWOP_srliw_pure srliw_input).nextPC
+        r1 rd exec_row e0 e1 e2)
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op : m.op r_main = ZiskFv.Trusted.OP_SRL_W)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2) :
@@ -53,20 +44,7 @@ theorem equiv_SRLIW_from_trust
       (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl h_main_op)))))
   exact ZiskFv.Equivalence.ShiftRLI.equiv_SRLIW state srliw_input r1 rd
     m v r_main r_binary exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1_sail
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_main_active h_main_op h_match h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Sll.lean
+++ b/ZiskFv/Compliance/FromTrust/Sll.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Sll
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -233,24 +234,12 @@ theorem equiv_SLL_from_trust
     (r_main : ℕ)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
-    -- Sail-side state predicates (SPEC-PRE).
-    (h_input_r1_sail : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok sll_input.r1_val state)
-    (h_input_r2_sail : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok sll_input.r2_val state)
-    (h_input_rd : sll_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some sll_input.PC)
-    -- Bus-protocol structural hypotheses — pass-through from `equiv_SLL`.
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_sll_pure sll_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : sll_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    -- Structural promise bundle (15 fields). Subsumes the prior inline
+    -- Sail-side state predicates + bus-protocol structural hypotheses.
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state sll_input.r1_val sll_input.r2_val sll_input.rd sll_input.PC
+        (PureSpec.execute_RTYPE_sll_pure sll_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     -- Activation / opcode pins. Compliance.lean derives these from
     -- the Main AIR's ROM handshake on the row hosting SLL.
     (h_main_active : m.is_external_op r_main = 1)
@@ -273,21 +262,7 @@ theorem equiv_SLL_from_trust
   -- ============ Delegate to canonical `equiv_SLL` ============
   exact ZiskFv.Equivalence.Sll.equiv_SLL state sll_input r1 r2 rd
     m v r_main r_binary exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1_sail
-      input_r2_eq := h_input_r2_sail
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_main_active h_main_op h_match h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Slli.lean
+++ b/ZiskFv/Compliance/FromTrust/Slli.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Slli
+import ZiskFv.Equivalence.Promises.ShiftImm
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -36,21 +37,10 @@ theorem equiv_SLLI_from_trust
     (r_main : ℕ)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
-    (h_input_r1_sail : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok slli_input.r1_val state)
-    (h_input_shamt : slli_input.shamt = shamt)
-    (h_input_rd : slli_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some slli_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_SHIFTIOP_slli_pure slli_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : slli_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.ShiftImmPromises
+        state slli_input.r1_val slli_input.shamt slli_input.rd slli_input.PC
+        (PureSpec.execute_SHIFTIOP_slli_pure slli_input).nextPC
+        r1 rd shamt exec_row e0 e1 e2)
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op : m.op r_main = ZiskFv.Trusted.OP_SLL)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2) :
@@ -61,21 +51,7 @@ theorem equiv_SLLI_from_trust
       (Or.inl h_main_op)
   exact ZiskFv.Equivalence.Slli.equiv_SLLI state slli_input r1 rd shamt
     m v r_main r_binary exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1_sail
-      input_shamt_eq := h_input_shamt
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_main_active h_main_op h_match h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Slt.lean
+++ b/ZiskFv/Compliance/FromTrust/Slt.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Slt
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -42,22 +43,10 @@ theorem equiv_SLT_from_trust
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op_slt : m.op r_main = OP_LT)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok slt_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok slt_input.r2_val state)
-    (h_input_rd : slt_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some slt_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_slt_pure slt_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : slt_input.rd = Transpiler.wrap_to_regidx e2.ptr) :
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state slt_input.r1_val slt_input.r2_val slt_input.rd slt_input.PC
+        (PureSpec.execute_RTYPE_slt_pure slt_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -216,21 +205,7 @@ theorem equiv_SLT_from_trust
   -- ============ Delegate to canonical equiv_SLT ============
   exact ZiskFv.Equivalence.Slt.equiv_SLT
     state slt_input r1 r2 rd m r_main exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     v r_binary h_main_active h_main_op_slt h_match
     (v.free_in_c_0 r_binary) (v.free_in_c_1 r_binary) (v.free_in_c_2 r_binary)
     (v.free_in_c_3 r_binary) (v.free_in_c_4 r_binary) (v.free_in_c_5 r_binary)

--- a/ZiskFv/Compliance/FromTrust/Slti.lean
+++ b/ZiskFv/Compliance/FromTrust/Slti.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Slti
+import ZiskFv.Equivalence.Promises.IType
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -83,21 +84,10 @@ theorem equiv_SLTI_from_trust
     (h_main_op_slti : m.op r_main = OP_LT)
     (h_slti_subset : itype_imm_subset_holds_main m r_main slti_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok slti_input.r1_val state)
-    (h_input_imm : slti_input.imm = imm)
-    (h_input_rd : slti_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some slti_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_ITYPE_slti_pure slti_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : slti_input.rd = Transpiler.wrap_to_regidx e2.ptr) :
+    (promises : ZiskFv.Equivalence.Promises.ITypePromises
+        state slti_input.r1_val slti_input.imm slti_input.rd slti_input.PC
+        (PureSpec.execute_ITYPE_slti_pure slti_input).nextPC
+        r1 rd imm exec_row e0 e1 e2) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -261,21 +251,7 @@ theorem equiv_SLTI_from_trust
   -- ============ Delegate to canonical equiv_SLTI ============
   exact ZiskFv.Equivalence.Slti.equiv_SLTI
     state slti_input r1 rd imm m r_main exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_imm_eq := h_input_imm
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     v r_binary h_main_active h_main_op_slti h_match
     (v.free_in_c_0 r_binary) (v.free_in_c_1 r_binary) (v.free_in_c_2 r_binary)
     (v.free_in_c_3 r_binary) (v.free_in_c_4 r_binary) (v.free_in_c_5 r_binary)

--- a/ZiskFv/Compliance/FromTrust/Sltiu.lean
+++ b/ZiskFv/Compliance/FromTrust/Sltiu.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Sltiu
+import ZiskFv.Equivalence.Promises.IType
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -85,21 +86,10 @@ theorem equiv_SLTIU_from_trust
     (h_main_op_sltiu : m.op r_main = OP_LTU)
     (h_sltiu_subset : itype_imm_subset_holds_main m r_main sltiu_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok sltiu_input.r1_val state)
-    (h_input_imm : sltiu_input.imm = imm)
-    (h_input_rd : sltiu_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some sltiu_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_ITYPE_sltiu_pure sltiu_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : sltiu_input.rd = Transpiler.wrap_to_regidx e2.ptr) :
+    (promises : ZiskFv.Equivalence.Promises.ITypePromises
+        state sltiu_input.r1_val sltiu_input.imm sltiu_input.rd sltiu_input.PC
+        (PureSpec.execute_ITYPE_sltiu_pure sltiu_input).nextPC
+        r1 rd imm exec_row e0 e1 e2) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -264,21 +254,7 @@ theorem equiv_SLTIU_from_trust
   -- ============ Delegate to canonical equiv_SLTIU ============
   exact ZiskFv.Equivalence.Sltiu.equiv_SLTIU
     state sltiu_input r1 rd imm m r_main exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_imm_eq := h_input_imm
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     v r_binary h_main_active h_main_op_sltiu h_match
     (v.free_in_c_0 r_binary) (v.free_in_c_1 r_binary) (v.free_in_c_2 r_binary)
     (v.free_in_c_3 r_binary) (v.free_in_c_4 r_binary) (v.free_in_c_5 r_binary)

--- a/ZiskFv/Compliance/FromTrust/Sltu.lean
+++ b/ZiskFv/Compliance/FromTrust/Sltu.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Sltu
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -42,22 +43,10 @@ theorem equiv_SLTU_from_trust
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op_sltu : m.op r_main = OP_LTU)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok sltu_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok sltu_input.r2_val state)
-    (h_input_rd : sltu_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some sltu_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_sltu_pure sltu_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : sltu_input.rd = Transpiler.wrap_to_regidx e2.ptr) :
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state sltu_input.r1_val sltu_input.r2_val sltu_input.rd sltu_input.PC
+        (PureSpec.execute_RTYPE_sltu_pure sltu_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -214,21 +203,7 @@ theorem equiv_SLTU_from_trust
   -- ============ Delegate to canonical equiv_SLTU ============
   exact ZiskFv.Equivalence.Sltu.equiv_SLTU
     state sltu_input r1 r2 rd m r_main exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     v r_binary h_main_active h_main_op_sltu h_match
     (v.free_in_c_0 r_binary) (v.free_in_c_1 r_binary) (v.free_in_c_2 r_binary)
     (v.free_in_c_3 r_binary) (v.free_in_c_4 r_binary) (v.free_in_c_5 r_binary)

--- a/ZiskFv/Compliance/FromTrust/Sra.lean
+++ b/ZiskFv/Compliance/FromTrust/Sra.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Sra
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -32,22 +33,10 @@ theorem equiv_SRA_from_trust
     (r_main : ℕ)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
-    (h_input_r1_sail : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok sra_input.r1_val state)
-    (h_input_r2_sail : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok sra_input.r2_val state)
-    (h_input_rd : sra_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some sra_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_sra_pure sra_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : sra_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state sra_input.r1_val sra_input.r2_val sra_input.rd sra_input.PC
+        (PureSpec.execute_RTYPE_sra_pure sra_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op : m.op r_main = ZiskFv.Trusted.OP_SRA)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2) :
@@ -59,21 +48,7 @@ theorem equiv_SRA_from_trust
       (Or.inr (Or.inr (Or.inl h_main_op)))
   exact ZiskFv.Equivalence.Sra.equiv_SRA state sra_input r1 r2 rd
     m v r_main r_binary exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1_sail
-      input_r2_eq := h_input_r2_sail
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_main_active h_main_op h_match h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Srai.lean
+++ b/ZiskFv/Compliance/FromTrust/Srai.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Srai
+import ZiskFv.Equivalence.Promises.ShiftImm
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -28,21 +29,10 @@ theorem equiv_SRAI_from_trust
     (r_main : ℕ)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok srai_input.r1_val state)
-    (h_input_shamt : srai_input.shamt = shamt)
-    (h_input_rd : srai_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some srai_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_SHIFTIOP_srai_pure srai_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : srai_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.ShiftImmPromises
+        state srai_input.r1_val srai_input.shamt srai_input.rd srai_input.PC
+        (PureSpec.execute_SHIFTIOP_srai_pure srai_input).nextPC
+        r1 rd shamt exec_row e0 e1 e2)
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op : m.op r_main = ZiskFv.Trusted.OP_SRA)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2) :
@@ -53,21 +43,7 @@ theorem equiv_SRAI_from_trust
       (Or.inr (Or.inr (Or.inl h_main_op)))
   exact ZiskFv.Equivalence.Srai.equiv_SRAI state srai_input r1 rd shamt
     m v r_main r_binary exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_shamt_eq := h_input_shamt
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_main_active h_main_op h_match h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Srl.lean
+++ b/ZiskFv/Compliance/FromTrust/Srl.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Srl
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -33,22 +34,10 @@ theorem equiv_SRL_from_trust
     (r_main : ℕ)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok srl_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok srl_input.r2_val state)
-    (h_input_rd : srl_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some srl_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_srl_pure srl_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : srl_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state srl_input.r1_val srl_input.r2_val srl_input.rd srl_input.PC
+        (PureSpec.execute_RTYPE_srl_pure srl_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2)
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op : m.op r_main = ZiskFv.Trusted.OP_SRL)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2) :
@@ -59,21 +48,7 @@ theorem equiv_SRL_from_trust
       (Or.inr (Or.inl h_main_op))
   exact ZiskFv.Equivalence.Srl.equiv_SRL state srl_input r1 r2 rd
     m v r_main r_binary exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_main_active h_main_op h_match h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Srli.lean
+++ b/ZiskFv/Compliance/FromTrust/Srli.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Srli
+import ZiskFv.Equivalence.Promises.ShiftImm
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -28,21 +29,10 @@ theorem equiv_SRLI_from_trust
     (r_main : ℕ)
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok srli_input.r1_val state)
-    (h_input_shamt : srli_input.shamt = shamt)
-    (h_input_rd : srli_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some srli_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_SHIFTIOP_srli_pure srli_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : srli_input.rd = Transpiler.wrap_to_regidx e2.ptr)
+    (promises : ZiskFv.Equivalence.Promises.ShiftImmPromises
+        state srli_input.r1_val srli_input.shamt srli_input.rd srli_input.PC
+        (PureSpec.execute_SHIFTIOP_srli_pure srli_input).nextPC
+        r1 rd shamt exec_row e0 e1 e2)
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op : m.op r_main = ZiskFv.Trusted.OP_SRL)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2) :
@@ -53,21 +43,7 @@ theorem equiv_SRLI_from_trust
       (Or.inr (Or.inl h_main_op))
   exact ZiskFv.Equivalence.Srli.equiv_SRLI state srli_input r1 rd shamt
     m v r_main r_binary exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_shamt_eq := h_input_shamt
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_main_active h_main_op h_match h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Sub.lean
+++ b/ZiskFv/Compliance/FromTrust/Sub.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Sub
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -53,22 +54,10 @@ theorem equiv_SUB_from_trust
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op_sub : m.op r_main = OP_SUB)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok sub_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok sub_input.r2_val state)
-    (h_input_rd : sub_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some sub_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_sub_pure sub_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : sub_input.rd = Transpiler.wrap_to_regidx e2.ptr) :
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state sub_input.r1_val sub_input.r2_val sub_input.rd sub_input.PC
+        (PureSpec.execute_RTYPE_sub_pure sub_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -257,21 +246,7 @@ theorem equiv_SUB_from_trust
   -- ============ Delegate to canonical equiv_SUB ============
   exact ZiskFv.Equivalence.Sub.equiv_SUB
     state sub_input r1 r2 rd m r_main exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     v r_binary h_main_active h_main_op_sub h_match
     (v.free_in_c_0 r_binary) (v.free_in_c_1 r_binary) (v.free_in_c_2 r_binary)
     (v.free_in_c_3 r_binary) (v.free_in_c_4 r_binary) (v.free_in_c_5 r_binary)

--- a/ZiskFv/Compliance/FromTrust/Subw.lean
+++ b/ZiskFv/Compliance/FromTrust/Subw.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Subw
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -57,22 +58,10 @@ theorem equiv_SUBW_from_trust
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op_subw : m.op r_main = OP_SUB_W)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok subw_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok subw_input.r2_val state)
-    (h_input_rd : subw_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some subw_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_subw_pure subw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : subw_input.rd = Transpiler.wrap_to_regidx e2.ptr) :
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state subw_input.r1_val subw_input.r2_val subw_input.rd subw_input.PC
+        (PureSpec.execute_RTYPE_subw_pure subw_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -204,21 +193,7 @@ theorem equiv_SUBW_from_trust
   -- ============ Delegate to canonical equiv_SUBW ============
   exact ZiskFv.Equivalence.Subw.equiv_SUBW
     state subw_input r1 r2 rd m r_main exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     v r_binary h_main_active h_main_op_subw h_match
     (v.free_in_c_0 r_binary) (v.free_in_c_1 r_binary) (v.free_in_c_2 r_binary)
     (v.free_in_c_3 r_binary) (v.free_in_c_4 r_binary) (v.free_in_c_5 r_binary)

--- a/ZiskFv/Compliance/FromTrust/Sw.lean
+++ b/ZiskFv/Compliance/FromTrust/Sw.lean
@@ -1,7 +1,8 @@
 import Mathlib
 
 import ZiskFv.Equivalence.StoreW
-import ZiskFv.Equivalence.Bridge.Mem
+import ZiskFv.Equivalence.Promises.Store
+import ZiskFv.Equivalence.Promises.StoreHelpers
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.MemoryBus
@@ -9,24 +10,11 @@ import ZiskFv.Airs.MemoryBus
 /-!
 # `equiv_SW` Compliance wrapper — Mem-stores shape, 4-byte width
 
-> **Status:** wrapper.
-> Mirrors `Compliance/FromTrust/Sb.lean` specialized to SW's 4-byte
-> store. Consumes `main_store_emission_bundle_sw` (class #4, NEW) via
-> `Bridge.Mem.sw_discharge_full` to discharge the bundled `h_mem_eq`
-> hypothesis on the canonical `equiv_SW` theorem.
-
-## Discharge
-
-`equiv_SW` carries a single bundled `h_mem_eq` hypothesis equating
-the bus side's 8-insert chain on `state.mem` with the Sail spec's
-4-insert chain (via `modify_memory_4`). The high 4 byte lanes of
-the store bus entry equal pre-existing memory contents (MemAlign RMW
-protocol); re-inserting them is a no-op closed in pure Lean.
-
-## Anti-laundering report
-
-* **1 new axiom contributed.** `main_store_emission_bundle_sw`
-  (class #4) — same family as SB/SH siblings and SD pilot.
+The wrapper takes the structural `StorePromises` bundle along with the
+upstream activation/opcode/width pins on Main, and internally calls
+`sw_h_mem_eq_of_emission` (which transitively consumes
+`main_store_emission_bundle_sw` and `transpile_SW`) to derive the
+`h_mem_eq` premise that the canonical `equiv_SW` consumes.
 -/
 
 namespace ZiskFv.Compliance
@@ -40,8 +28,10 @@ open ZiskFv.ZiskCircuit.StoreD
 
 variable {C : Type → Type → Type} [Circuit FGL FGL C]
 
-/-- **Wrapper for `equiv_SW`.** Discharges `h_mem_eq` from the SW
-    emission bundle + RMW high-byte preservation. -/
+/-- **Wrapper for `equiv_SW`.** Derives `h_mem_eq` from
+    `sw_h_mem_eq_of_emission` (which consumes
+    `main_store_emission_bundle_sw` + `transpile_SW`) and delegates to
+    canonical `equiv_SW`. -/
 theorem equiv_SW_from_trust
     (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
     (sw_input : PureSpec.SwInput)
@@ -49,53 +39,36 @@ theorem equiv_SW_from_trust
     (pmaRegion : PMA_Region)
     (misa : RegisterType Register.misa)
     (mseccfg : RegisterType Register.mseccfg)
+    -- AIR validator + row index.
     (main : Valid_Main C FGL FGL) (r_main : ℕ)
+    -- Structural bus rows.
     (exec_row : List (Interaction.ExecutionBusEntry FGL))
     (e0 e1 e2 : Interaction.MemoryBusEntry FGL)
+    -- Activation / opcode / width pins on Main.
     (h_main_active : main.is_external_op r_main = 0)
     (h_main_op : main.op r_main = OP_COPYB)
     (h_main_ind_width : main.ind_width r_main = 4)
-    (risc_v_assumptions :
-      RISC_V_assumptions state mstatus pmaRegion misa mseccfg)
-    (h_opcode_assumptions :
-      PureSpec.sw_state_assumptions sw_input state)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_STOREW_pure sw_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1)  (h_m2_as : e2.as.val = 2) :
+    -- Sail-side opcode assumptions.
+    (h_opcode_assumptions : PureSpec.sw_state_assumptions sw_input state)
+    -- Structural promise bundle (12 fields).
+    (promises : ZiskFv.Equivalence.Promises.StorePromises
+        state mstatus pmaRegion misa mseccfg
+        (PureSpec.sw_state_assumptions sw_input state)
+        (PureSpec.execute_STOREW_pure sw_input).nextPC
+        exec_row e0 e1 e2) :
     execute_instruction (instruction.STORE (
       sw_input.imm,
       regidx.Regidx sw_input.r2,
       regidx.Regidx sw_input.r1,
       4
-    )) state = (bus_effect exec_row [e0, e1, e2] state).2 := by
-  have h_read_r1 := h_opcode_assumptions.2.1
-  have h_read_r2 := h_opcode_assumptions.2.2.1
+    )) state = (bus_effect exec_row [e0, e1, e2] state).2 :=
   have h_mem_eq :=
-    ZiskFv.Equivalence.Bridge.Mem.sw_discharge_full
+    ZiskFv.Equivalence.Promises.sw_h_mem_eq_of_emission
       main r_main e2 state sw_input
       h_main_active h_main_op h_main_ind_width
-      h_m2_mult h_m2_as h_read_r1 h_read_r2
-  exact ZiskFv.Equivalence.StoreW.equiv_SW
+      promises.m2_mult promises.m2_as h_opcode_assumptions
+  ZiskFv.Equivalence.StoreW.equiv_SW
     state sw_input mstatus pmaRegion misa mseccfg
-    exec_row e0 e1 e2
-    { risc_v_assumptions := risc_v_assumptions
-      opcode_assumptions_ := h_opcode_assumptions
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as }
-    h_mem_eq
+    exec_row e0 e1 e2 promises h_mem_eq
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Xor.lean
+++ b/ZiskFv/Compliance/FromTrust/Xor.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Xor
+import ZiskFv.Equivalence.Promises.RType
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -37,22 +38,10 @@ theorem equiv_XOR_from_trust
     (h_main_active : m.is_external_op r_main = 1)
     (h_main_op_xor : m.op r_main = OP_XOR)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok xor_input.r1_val state)
-    (h_input_r2 : read_xreg (regidx_to_fin r2) state
-      = EStateM.Result.ok xor_input.r2_val state)
-    (h_input_rd : xor_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some xor_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_RTYPE_xor_pure xor_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : xor_input.rd = Transpiler.wrap_to_regidx e2.ptr) :
+    (promises : ZiskFv.Equivalence.Promises.RTypePromises
+        state xor_input.r1_val xor_input.r2_val xor_input.rd xor_input.PC
+        (PureSpec.execute_RTYPE_xor_pure xor_input).nextPC
+        r1 r2 rd exec_row e0 e1 e2) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -86,21 +75,7 @@ theorem equiv_XOR_from_trust
     binary_b_op_or_sext_eq_OP_XOR v r_binary h_emit_op
   exact ZiskFv.Equivalence.Xor.equiv_XOR
     state xor_input r1 r2 rd m v r_main r_binary exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_r2_eq := h_input_r2
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_main_active h_main_op_xor h_match h_bop_or_sext h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/FromTrust/Xori.lean
+++ b/ZiskFv/Compliance/FromTrust/Xori.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 import ZiskFv.Equivalence.Xori
+import ZiskFv.Equivalence.Promises.IType
 import ZiskFv.Trusted.Transpiler
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
@@ -41,21 +42,10 @@ theorem equiv_XORI_from_trust
     (h_main_op_xori : m.op r_main = OP_XOR)
     (h_xori_subset : itype_imm_subset_holds_main m r_main xori_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2)
-    (h_input_r1 : read_xreg (regidx_to_fin r1) state
-      = EStateM.Result.ok xori_input.r1_val state)
-    (h_input_imm : xori_input.imm = imm)
-    (h_input_rd : xori_input.rd = regidx_to_fin rd)
-    (h_input_pc : state.regs.get? Register.PC = .some xori_input.PC)
-    (h_exec_len : exec_row.length = 2)
-    (h_e0_mult : exec_row[0]!.multiplicity = -1)
-    (h_e1_mult : exec_row[1]!.multiplicity = 1)
-    (h_nextPC_matches :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
-        = (PureSpec.execute_ITYPE_xori_pure xori_input).nextPC)
-    (h_m0_mult : e0.multiplicity = -1) (h_m0_as : e0.as.val = 1)
-    (h_m1_mult : e1.multiplicity = -1) (h_m1_as : e1.as.val = 1)
-    (h_m2_mult : e2.multiplicity = 1) (h_m2_as : e2.as.val = 1)
-    (h_rd_idx : xori_input.rd = Transpiler.wrap_to_regidx e2.ptr) :
+    (promises : ZiskFv.Equivalence.Promises.ITypePromises
+        state xori_input.r1_val xori_input.imm xori_input.rd xori_input.PC
+        (PureSpec.execute_ITYPE_xori_pure xori_input).nextPC
+        r1 rd imm exec_row e0 e1 e2) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -89,21 +79,7 @@ theorem equiv_XORI_from_trust
     binary_b_op_or_sext_eq_OP_XOR v r_binary h_emit_op
   exact ZiskFv.Equivalence.Xori.equiv_XORI
     state xori_input r1 rd imm m v r_main r_binary exec_row e0 e1 e2
-    { input_r1_eq := h_input_r1
-      input_imm_eq := h_input_imm
-      input_rd_eq := h_input_rd
-      input_pc_eq := h_input_pc
-      exec_len := h_exec_len
-      e0_mult := h_e0_mult
-      e1_mult := h_e1_mult
-      nextPC_matches := h_nextPC_matches
-      m0_mult := h_m0_mult
-      m0_as := h_m0_as
-      m1_mult := h_m1_mult
-      m1_as := h_m1_as
-      m2_mult := h_m2_mult
-      m2_as := h_m2_as
-      rd_idx := h_rd_idx }
+    promises
     h_main_active h_main_op_xori h_match h_bop_or_sext h_lane_rd h_xori_subset
 
 end ZiskFv.Compliance

--- a/ZiskFv/Equivalence/Promises/BranchHelpers.lean
+++ b/ZiskFv/Equivalence/Promises/BranchHelpers.lean
@@ -1,0 +1,424 @@
+import Mathlib
+
+import ZiskFv.Equivalence.Promises.Branch
+import ZiskFv.SailSpec.beq
+import ZiskFv.SailSpec.bne
+import ZiskFv.SailSpec.blt
+import ZiskFv.SailSpec.bge
+import ZiskFv.SailSpec.bltu
+import ZiskFv.SailSpec.bgeu
+
+/-!
+# `BranchPromises` smart constructors
+
+Per-branch builders that derive the no-exception bundle fields
+(`not_throws`, `success`) from a single 4-byte-alignment hypothesis
+on the branch target, and package the result as a full
+`BranchPromises` bundle.
+
+The alignment-implies-no-exception lemma is a pure BitVec computation:
+bits 0 and 1 of an address ≡ 0 mod 4 are both zero, so both
+`BitVec.ofBool x[i] == 1#1` checks inside `execute_<OP>_pure` fail
+uniformly (regardless of taken/not-taken). The same 6-step proof
+works for every branch — only the `execute_<OP>_pure` symbol differs.
+
+These helpers were extracted from the per-opcode `Compliance/FromTrust/<Op>.lean`
+wrappers (where they previously lived inline as `private theorem
+<op>_pure_no_exception_of_aligned`). The wrappers are now pure
+pass-throughs that take a fully-populated `BranchPromises` bundle.
+-/
+
+namespace ZiskFv.Equivalence.Promises
+
+open ZiskFv.Trusted
+
+/-! ## BEQ -/
+
+private theorem beq_pure_no_exception_of_aligned
+    (input : PureSpec.BeqInput)
+    (h_aligned : (input.PC + BitVec.signExtend 64 input.imm).toNat % 4 = 0) :
+    (PureSpec.execute_BEQ_pure input).throws = false
+    ∧ (PureSpec.execute_BEQ_pure input).success = true := by
+  set t : BitVec 64 := input.PC + BitVec.signExtend 64 input.imm with h_t
+  have h_bit0 : t[0] = false := by
+    rw [BitVec.getElem_eq_testBit_toNat, Nat.testBit_zero]
+    have h_mod2 : t.toNat % 2 = 0 := by omega
+    simp [h_mod2]
+  have h_bit1 : t[1] = false := by
+    rw [BitVec.getElem_eq_testBit_toNat, Nat.testBit_succ, Nat.testBit_zero]
+    have h_div_mod : (t.toNat / 2) % 2 = 0 := by omega
+    simp [h_div_mod]
+  refine ⟨?_, ?_⟩
+  · simp [PureSpec.execute_BEQ_pure, ← h_t, h_bit0]
+  · simp [PureSpec.execute_BEQ_pure, ← h_t, h_bit0, h_bit1]
+
+/-- Build a `BranchPromises` bundle for BEQ from a 4-byte-alignment
+    hypothesis on the branch target plus the structural pass-through
+    pins. ZisK's assembler/transpiler invariant guarantees the
+    alignment; the not-throws and success bundle fields are derived
+    here via `beq_pure_no_exception_of_aligned`. -/
+def BranchPromises.of_aligned_BEQ
+    {state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource}
+    (beq_input : PureSpec.BeqInput)
+    {imm : BitVec 13} {r1 r2 : regidx}
+    {misa_val : RegisterType Register.misa}
+    {exec_row : List (Interaction.ExecutionBusEntry FGL)}
+    (h_input_imm : beq_input.imm = imm)
+    (h_input_r1 : read_xreg (regidx_to_fin r1) state
+      = EStateM.Result.ok beq_input.r1_val state)
+    (h_input_r2 : read_xreg (regidx_to_fin r2) state
+      = EStateM.Result.ok beq_input.r2_val state)
+    (h_input_pc : state.regs.get? Register.PC = .some beq_input.PC)
+    (h_input_misa : state.regs.get? Register.misa = .some misa_val)
+    (h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1)
+    (h_target_aligned :
+      (beq_input.PC + BitVec.signExtend 64 beq_input.imm).toNat % 4 = 0)
+    (h_exec_len : exec_row.length = 2)
+    (h_e0_mult : exec_row[0]!.multiplicity = -1)
+    (h_e1_mult : exec_row[1]!.multiplicity = 1)
+    (h_nextPC_matches :
+      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
+        = (PureSpec.execute_BEQ_pure beq_input).nextPC) :
+    BranchPromises state beq_input.imm beq_input.r1_val beq_input.r2_val
+      beq_input.PC misa_val
+      (PureSpec.execute_BEQ_pure beq_input).nextPC
+      (PureSpec.execute_BEQ_pure beq_input).throws
+      (PureSpec.execute_BEQ_pure beq_input).success
+      imm r1 r2 exec_row :=
+  let ⟨h_not_throws, h_success⟩ :=
+    beq_pure_no_exception_of_aligned beq_input h_target_aligned
+  { input_imm_eq := h_input_imm
+    input_r1_eq := h_input_r1
+    input_r2_eq := h_input_r2
+    input_pc_eq := h_input_pc
+    input_misa_eq := h_input_misa
+    misa_c_zero := h_misa_c
+    exec_len := h_exec_len
+    e0_mult := h_e0_mult
+    e1_mult := h_e1_mult
+    nextPC_matches := h_nextPC_matches
+    not_throws := h_not_throws
+    success := h_success }
+
+/-! ## BNE -/
+
+private theorem bne_pure_no_exception_of_aligned
+    (input : PureSpec.BneInput)
+    (h_aligned : (input.PC + BitVec.signExtend 64 input.imm).toNat % 4 = 0) :
+    (PureSpec.execute_BNE_pure input).throws = false
+    ∧ (PureSpec.execute_BNE_pure input).success = true := by
+  set t : BitVec 64 := input.PC + BitVec.signExtend 64 input.imm with h_t
+  have h_bit0 : t[0] = false := by
+    rw [BitVec.getElem_eq_testBit_toNat, Nat.testBit_zero]
+    have h_mod2 : t.toNat % 2 = 0 := by omega
+    simp [h_mod2]
+  have h_bit1 : t[1] = false := by
+    rw [BitVec.getElem_eq_testBit_toNat, Nat.testBit_succ, Nat.testBit_zero]
+    have h_div_mod : (t.toNat / 2) % 2 = 0 := by omega
+    simp [h_div_mod]
+  refine ⟨?_, ?_⟩
+  · simp [PureSpec.execute_BNE_pure, ← h_t, h_bit0]
+  · simp [PureSpec.execute_BNE_pure, ← h_t, h_bit0, h_bit1]
+
+/-- Build a `BranchPromises` bundle for BNE from a 4-byte-alignment
+    hypothesis on the branch target. Mirrors `of_aligned_BEQ`. -/
+def BranchPromises.of_aligned_BNE
+    {state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource}
+    (bne_input : PureSpec.BneInput)
+    {imm : BitVec 13} {r1 r2 : regidx}
+    {misa_val : RegisterType Register.misa}
+    {exec_row : List (Interaction.ExecutionBusEntry FGL)}
+    (h_input_imm : bne_input.imm = imm)
+    (h_input_r1 : read_xreg (regidx_to_fin r1) state
+      = EStateM.Result.ok bne_input.r1_val state)
+    (h_input_r2 : read_xreg (regidx_to_fin r2) state
+      = EStateM.Result.ok bne_input.r2_val state)
+    (h_input_pc : state.regs.get? Register.PC = .some bne_input.PC)
+    (h_input_misa : state.regs.get? Register.misa = .some misa_val)
+    (h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1)
+    (h_target_aligned :
+      (bne_input.PC + BitVec.signExtend 64 bne_input.imm).toNat % 4 = 0)
+    (h_exec_len : exec_row.length = 2)
+    (h_e0_mult : exec_row[0]!.multiplicity = -1)
+    (h_e1_mult : exec_row[1]!.multiplicity = 1)
+    (h_nextPC_matches :
+      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
+        = (PureSpec.execute_BNE_pure bne_input).nextPC) :
+    BranchPromises state bne_input.imm bne_input.r1_val bne_input.r2_val
+      bne_input.PC misa_val
+      (PureSpec.execute_BNE_pure bne_input).nextPC
+      (PureSpec.execute_BNE_pure bne_input).throws
+      (PureSpec.execute_BNE_pure bne_input).success
+      imm r1 r2 exec_row :=
+  let ⟨h_not_throws, h_success⟩ :=
+    bne_pure_no_exception_of_aligned bne_input h_target_aligned
+  { input_imm_eq := h_input_imm
+    input_r1_eq := h_input_r1
+    input_r2_eq := h_input_r2
+    input_pc_eq := h_input_pc
+    input_misa_eq := h_input_misa
+    misa_c_zero := h_misa_c
+    exec_len := h_exec_len
+    e0_mult := h_e0_mult
+    e1_mult := h_e1_mult
+    nextPC_matches := h_nextPC_matches
+    not_throws := h_not_throws
+    success := h_success }
+
+/-! ## BLT -/
+
+private theorem blt_pure_no_exception_of_aligned
+    (input : PureSpec.BltInput)
+    (h_aligned : (input.PC + BitVec.signExtend 64 input.imm).toNat % 4 = 0) :
+    (PureSpec.execute_BLT_pure input).throws = false
+    ∧ (PureSpec.execute_BLT_pure input).success = true := by
+  set t : BitVec 64 := input.PC + BitVec.signExtend 64 input.imm with h_t
+  have h_bit0 : t[0] = false := by
+    rw [BitVec.getElem_eq_testBit_toNat, Nat.testBit_zero]
+    have h_mod2 : t.toNat % 2 = 0 := by omega
+    simp [h_mod2]
+  have h_bit1 : t[1] = false := by
+    rw [BitVec.getElem_eq_testBit_toNat, Nat.testBit_succ, Nat.testBit_zero]
+    have h_div_mod : (t.toNat / 2) % 2 = 0 := by omega
+    simp [h_div_mod]
+  refine ⟨?_, ?_⟩
+  · simp [PureSpec.execute_BLT_pure, ← h_t, h_bit0]
+  · simp [PureSpec.execute_BLT_pure, ← h_t, h_bit0, h_bit1]
+
+/-- Build a `BranchPromises` bundle for BLT. Mirrors `of_aligned_BEQ`. -/
+def BranchPromises.of_aligned_BLT
+    {state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource}
+    (blt_input : PureSpec.BltInput)
+    {imm : BitVec 13} {r1 r2 : regidx}
+    {misa_val : RegisterType Register.misa}
+    {exec_row : List (Interaction.ExecutionBusEntry FGL)}
+    (h_input_imm : blt_input.imm = imm)
+    (h_input_r1 : read_xreg (regidx_to_fin r1) state
+      = EStateM.Result.ok blt_input.r1_val state)
+    (h_input_r2 : read_xreg (regidx_to_fin r2) state
+      = EStateM.Result.ok blt_input.r2_val state)
+    (h_input_pc : state.regs.get? Register.PC = .some blt_input.PC)
+    (h_input_misa : state.regs.get? Register.misa = .some misa_val)
+    (h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1)
+    (h_target_aligned :
+      (blt_input.PC + BitVec.signExtend 64 blt_input.imm).toNat % 4 = 0)
+    (h_exec_len : exec_row.length = 2)
+    (h_e0_mult : exec_row[0]!.multiplicity = -1)
+    (h_e1_mult : exec_row[1]!.multiplicity = 1)
+    (h_nextPC_matches :
+      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
+        = (PureSpec.execute_BLT_pure blt_input).nextPC) :
+    BranchPromises state blt_input.imm blt_input.r1_val blt_input.r2_val
+      blt_input.PC misa_val
+      (PureSpec.execute_BLT_pure blt_input).nextPC
+      (PureSpec.execute_BLT_pure blt_input).throws
+      (PureSpec.execute_BLT_pure blt_input).success
+      imm r1 r2 exec_row :=
+  let ⟨h_not_throws, h_success⟩ :=
+    blt_pure_no_exception_of_aligned blt_input h_target_aligned
+  { input_imm_eq := h_input_imm
+    input_r1_eq := h_input_r1
+    input_r2_eq := h_input_r2
+    input_pc_eq := h_input_pc
+    input_misa_eq := h_input_misa
+    misa_c_zero := h_misa_c
+    exec_len := h_exec_len
+    e0_mult := h_e0_mult
+    e1_mult := h_e1_mult
+    nextPC_matches := h_nextPC_matches
+    not_throws := h_not_throws
+    success := h_success }
+
+/-! ## BGE -/
+
+private theorem bge_pure_no_exception_of_aligned
+    (input : PureSpec.BgeInput)
+    (h_aligned : (input.PC + BitVec.signExtend 64 input.imm).toNat % 4 = 0) :
+    (PureSpec.execute_BGE_pure input).throws = false
+    ∧ (PureSpec.execute_BGE_pure input).success = true := by
+  set t : BitVec 64 := input.PC + BitVec.signExtend 64 input.imm with h_t
+  have h_bit0 : t[0] = false := by
+    rw [BitVec.getElem_eq_testBit_toNat, Nat.testBit_zero]
+    have h_mod2 : t.toNat % 2 = 0 := by omega
+    simp [h_mod2]
+  have h_bit1 : t[1] = false := by
+    rw [BitVec.getElem_eq_testBit_toNat, Nat.testBit_succ, Nat.testBit_zero]
+    have h_div_mod : (t.toNat / 2) % 2 = 0 := by omega
+    simp [h_div_mod]
+  refine ⟨?_, ?_⟩
+  · simp [PureSpec.execute_BGE_pure, ← h_t, h_bit0]
+  · simp [PureSpec.execute_BGE_pure, ← h_t, h_bit0, h_bit1]
+
+/-- Build a `BranchPromises` bundle for BGE. Mirrors `of_aligned_BEQ`. -/
+def BranchPromises.of_aligned_BGE
+    {state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource}
+    (bge_input : PureSpec.BgeInput)
+    {imm : BitVec 13} {r1 r2 : regidx}
+    {misa_val : RegisterType Register.misa}
+    {exec_row : List (Interaction.ExecutionBusEntry FGL)}
+    (h_input_imm : bge_input.imm = imm)
+    (h_input_r1 : read_xreg (regidx_to_fin r1) state
+      = EStateM.Result.ok bge_input.r1_val state)
+    (h_input_r2 : read_xreg (regidx_to_fin r2) state
+      = EStateM.Result.ok bge_input.r2_val state)
+    (h_input_pc : state.regs.get? Register.PC = .some bge_input.PC)
+    (h_input_misa : state.regs.get? Register.misa = .some misa_val)
+    (h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1)
+    (h_target_aligned :
+      (bge_input.PC + BitVec.signExtend 64 bge_input.imm).toNat % 4 = 0)
+    (h_exec_len : exec_row.length = 2)
+    (h_e0_mult : exec_row[0]!.multiplicity = -1)
+    (h_e1_mult : exec_row[1]!.multiplicity = 1)
+    (h_nextPC_matches :
+      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
+        = (PureSpec.execute_BGE_pure bge_input).nextPC) :
+    BranchPromises state bge_input.imm bge_input.r1_val bge_input.r2_val
+      bge_input.PC misa_val
+      (PureSpec.execute_BGE_pure bge_input).nextPC
+      (PureSpec.execute_BGE_pure bge_input).throws
+      (PureSpec.execute_BGE_pure bge_input).success
+      imm r1 r2 exec_row :=
+  let ⟨h_not_throws, h_success⟩ :=
+    bge_pure_no_exception_of_aligned bge_input h_target_aligned
+  { input_imm_eq := h_input_imm
+    input_r1_eq := h_input_r1
+    input_r2_eq := h_input_r2
+    input_pc_eq := h_input_pc
+    input_misa_eq := h_input_misa
+    misa_c_zero := h_misa_c
+    exec_len := h_exec_len
+    e0_mult := h_e0_mult
+    e1_mult := h_e1_mult
+    nextPC_matches := h_nextPC_matches
+    not_throws := h_not_throws
+    success := h_success }
+
+/-! ## BLTU -/
+
+private theorem bltu_pure_no_exception_of_aligned
+    (input : PureSpec.BltuInput)
+    (h_aligned : (input.PC + BitVec.signExtend 64 input.imm).toNat % 4 = 0) :
+    (PureSpec.execute_BLTU_pure input).throws = false
+    ∧ (PureSpec.execute_BLTU_pure input).success = true := by
+  set t : BitVec 64 := input.PC + BitVec.signExtend 64 input.imm with h_t
+  have h_bit0 : t[0] = false := by
+    rw [BitVec.getElem_eq_testBit_toNat, Nat.testBit_zero]
+    have h_mod2 : t.toNat % 2 = 0 := by omega
+    simp [h_mod2]
+  have h_bit1 : t[1] = false := by
+    rw [BitVec.getElem_eq_testBit_toNat, Nat.testBit_succ, Nat.testBit_zero]
+    have h_div_mod : (t.toNat / 2) % 2 = 0 := by omega
+    simp [h_div_mod]
+  refine ⟨?_, ?_⟩
+  · simp [PureSpec.execute_BLTU_pure, ← h_t, h_bit0]
+  · simp [PureSpec.execute_BLTU_pure, ← h_t, h_bit0, h_bit1]
+
+/-- Build a `BranchPromises` bundle for BLTU. Mirrors `of_aligned_BEQ`. -/
+def BranchPromises.of_aligned_BLTU
+    {state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource}
+    (bltu_input : PureSpec.BltuInput)
+    {imm : BitVec 13} {r1 r2 : regidx}
+    {misa_val : RegisterType Register.misa}
+    {exec_row : List (Interaction.ExecutionBusEntry FGL)}
+    (h_input_imm : bltu_input.imm = imm)
+    (h_input_r1 : read_xreg (regidx_to_fin r1) state
+      = EStateM.Result.ok bltu_input.r1_val state)
+    (h_input_r2 : read_xreg (regidx_to_fin r2) state
+      = EStateM.Result.ok bltu_input.r2_val state)
+    (h_input_pc : state.regs.get? Register.PC = .some bltu_input.PC)
+    (h_input_misa : state.regs.get? Register.misa = .some misa_val)
+    (h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1)
+    (h_target_aligned :
+      (bltu_input.PC + BitVec.signExtend 64 bltu_input.imm).toNat % 4 = 0)
+    (h_exec_len : exec_row.length = 2)
+    (h_e0_mult : exec_row[0]!.multiplicity = -1)
+    (h_e1_mult : exec_row[1]!.multiplicity = 1)
+    (h_nextPC_matches :
+      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
+        = (PureSpec.execute_BLTU_pure bltu_input).nextPC) :
+    BranchPromises state bltu_input.imm bltu_input.r1_val bltu_input.r2_val
+      bltu_input.PC misa_val
+      (PureSpec.execute_BLTU_pure bltu_input).nextPC
+      (PureSpec.execute_BLTU_pure bltu_input).throws
+      (PureSpec.execute_BLTU_pure bltu_input).success
+      imm r1 r2 exec_row :=
+  let ⟨h_not_throws, h_success⟩ :=
+    bltu_pure_no_exception_of_aligned bltu_input h_target_aligned
+  { input_imm_eq := h_input_imm
+    input_r1_eq := h_input_r1
+    input_r2_eq := h_input_r2
+    input_pc_eq := h_input_pc
+    input_misa_eq := h_input_misa
+    misa_c_zero := h_misa_c
+    exec_len := h_exec_len
+    e0_mult := h_e0_mult
+    e1_mult := h_e1_mult
+    nextPC_matches := h_nextPC_matches
+    not_throws := h_not_throws
+    success := h_success }
+
+/-! ## BGEU -/
+
+private theorem bgeu_pure_no_exception_of_aligned
+    (input : PureSpec.BgeuInput)
+    (h_aligned : (input.PC + BitVec.signExtend 64 input.imm).toNat % 4 = 0) :
+    (PureSpec.execute_BGEU_pure input).throws = false
+    ∧ (PureSpec.execute_BGEU_pure input).success = true := by
+  set t : BitVec 64 := input.PC + BitVec.signExtend 64 input.imm with h_t
+  have h_bit0 : t[0] = false := by
+    rw [BitVec.getElem_eq_testBit_toNat, Nat.testBit_zero]
+    have h_mod2 : t.toNat % 2 = 0 := by omega
+    simp [h_mod2]
+  have h_bit1 : t[1] = false := by
+    rw [BitVec.getElem_eq_testBit_toNat, Nat.testBit_succ, Nat.testBit_zero]
+    have h_div_mod : (t.toNat / 2) % 2 = 0 := by omega
+    simp [h_div_mod]
+  refine ⟨?_, ?_⟩
+  · simp [PureSpec.execute_BGEU_pure, ← h_t, h_bit0]
+  · simp [PureSpec.execute_BGEU_pure, ← h_t, h_bit0, h_bit1]
+
+/-- Build a `BranchPromises` bundle for BGEU. Mirrors `of_aligned_BEQ`. -/
+def BranchPromises.of_aligned_BGEU
+    {state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource}
+    (bgeu_input : PureSpec.BgeuInput)
+    {imm : BitVec 13} {r1 r2 : regidx}
+    {misa_val : RegisterType Register.misa}
+    {exec_row : List (Interaction.ExecutionBusEntry FGL)}
+    (h_input_imm : bgeu_input.imm = imm)
+    (h_input_r1 : read_xreg (regidx_to_fin r1) state
+      = EStateM.Result.ok bgeu_input.r1_val state)
+    (h_input_r2 : read_xreg (regidx_to_fin r2) state
+      = EStateM.Result.ok bgeu_input.r2_val state)
+    (h_input_pc : state.regs.get? Register.PC = .some bgeu_input.PC)
+    (h_input_misa : state.regs.get? Register.misa = .some misa_val)
+    (h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1)
+    (h_target_aligned :
+      (bgeu_input.PC + BitVec.signExtend 64 bgeu_input.imm).toNat % 4 = 0)
+    (h_exec_len : exec_row.length = 2)
+    (h_e0_mult : exec_row[0]!.multiplicity = -1)
+    (h_e1_mult : exec_row[1]!.multiplicity = 1)
+    (h_nextPC_matches :
+      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val))
+        = (PureSpec.execute_BGEU_pure bgeu_input).nextPC) :
+    BranchPromises state bgeu_input.imm bgeu_input.r1_val bgeu_input.r2_val
+      bgeu_input.PC misa_val
+      (PureSpec.execute_BGEU_pure bgeu_input).nextPC
+      (PureSpec.execute_BGEU_pure bgeu_input).throws
+      (PureSpec.execute_BGEU_pure bgeu_input).success
+      imm r1 r2 exec_row :=
+  let ⟨h_not_throws, h_success⟩ :=
+    bgeu_pure_no_exception_of_aligned bgeu_input h_target_aligned
+  { input_imm_eq := h_input_imm
+    input_r1_eq := h_input_r1
+    input_r2_eq := h_input_r2
+    input_pc_eq := h_input_pc
+    input_misa_eq := h_input_misa
+    misa_c_zero := h_misa_c
+    exec_len := h_exec_len
+    e0_mult := h_e0_mult
+    e1_mult := h_e1_mult
+    nextPC_matches := h_nextPC_matches
+    not_throws := h_not_throws
+    success := h_success }
+
+end ZiskFv.Equivalence.Promises

--- a/ZiskFv/Equivalence/Promises/JumpHelpers.lean
+++ b/ZiskFv/Equivalence/Promises/JumpHelpers.lean
@@ -1,0 +1,65 @@
+import Mathlib
+
+import LeanZKCircuit.OpenVM.Circuit
+import ZiskFv.Equivalence.Promises.Jump
+import ZiskFv.ZiskCircuit.Jal
+import ZiskFv.ZiskCircuit.Jalr
+import ZiskFv.Tactics.JumpArchetype
+import ZiskFv.Trusted.Transpiler
+import ZiskFv.Airs.Main.Main
+
+/-!
+# `JumpPromises` companion helpers
+
+For each JUMP opcode (JAL, JALR), provides a single helper that
+assembles `h_circuit` — the `<op>_circuit_holds` term that
+`equiv_<OP>` accepts alongside the structural `JumpPromises`
+bundle — from the Main-AIR activation pin, opcode pin, and per-row
+subset constraint.
+
+The helper internally fires `transpile_<OP>` (class #1) to derive the
+routing pins, then packs them with the subset hypothesis. Extracted
+from the per-opcode `Compliance/FromTrust/<Op>.lean` wrappers.
+-/
+
+namespace ZiskFv.Equivalence.Promises
+
+open ZiskFv.Trusted
+open ZiskFv.Airs.Main
+
+variable {C : Type → Type → Type} [Circuit FGL FGL C]
+
+/-- Assemble JAL's `h_circuit` from the Main-side activation/opcode
+    pins and the per-row JAL subset constraint. -/
+def jal_h_circuit_of_main_constraints
+    (m : Valid_Main C FGL FGL) (r_main : ℕ) (next_pc : FGL)
+    (h_main_active : m.is_external_op r_main = 0)
+    (h_main_op_jal : m.op r_main = OP_FLAG)
+    (h_jal_subset : ZiskFv.Airs.Main.jump_subset_holds m r_main next_pc) :
+    ZiskFv.ZiskCircuit.Jal.jal_circuit_holds m r_main next_pc :=
+  let h_tr := ZiskFv.Trusted.transpile_JAL m r_main (0 : Fin 32)
+    (0 : FGL) { xreg := fun _ => 0#64, pc := 0#64 }
+    h_main_active h_main_op_jal
+  let ⟨h_m32, h_set_pc, h_store_pc, _, _, _, _, _, _⟩ := h_tr
+  let h_jal_mode : ZiskFv.ZiskCircuit.Jal.main_row_in_jal_mode m r_main :=
+    ⟨h_main_active, by rw [h_main_op_jal]; rfl, h_m32, h_set_pc, h_store_pc⟩
+  ⟨h_jal_subset, h_jal_mode⟩
+
+/-- Assemble JALR's `h_circuit` from the Main-side activation/opcode
+    pins and the per-row JALR subset constraint. -/
+def jalr_h_circuit_of_main_constraints
+    (m : Valid_Main C FGL FGL) (r_main : ℕ) (next_pc : FGL)
+    (h_main_active : m.is_external_op r_main = 0)
+    (h_main_op_jalr : m.op r_main = OP_COPYB)
+    (h_jalr_subset :
+      ZiskFv.Tactics.JumpArchetype.jalr_subset_holds m r_main next_pc) :
+    ZiskFv.ZiskCircuit.Jalr.jalr_circuit_holds m r_main next_pc := by
+  have h_tr := ZiskFv.Trusted.transpile_JALR m r_main (0 : Fin 32) (0 : Fin 32)
+    (0 : FGL) { xreg := fun _ => 0#64, pc := 0#64 }
+    h_main_active h_main_op_jalr
+  obtain ⟨h_m32, h_set_pc, h_store_pc, _, _, _, _⟩ := h_tr
+  refine ⟨h_jalr_subset, ?_⟩
+  refine ⟨h_main_active, ?_, h_m32, h_set_pc, h_store_pc⟩
+  rw [h_main_op_jalr]; rfl
+
+end ZiskFv.Equivalence.Promises

--- a/ZiskFv/Equivalence/Promises/StoreHelpers.lean
+++ b/ZiskFv/Equivalence/Promises/StoreHelpers.lean
@@ -1,0 +1,177 @@
+import Mathlib
+
+import LeanZKCircuit.OpenVM.Circuit
+import ZiskFv.Equivalence.Promises.Store
+import ZiskFv.Equivalence.Bridge.Mem
+import ZiskFv.Airs.Main.Main
+import ZiskFv.SailSpec.sb
+import ZiskFv.SailSpec.sh
+import ZiskFv.SailSpec.sw
+import ZiskFv.SailSpec.sd
+
+/-!
+# `StorePromises` companion helpers
+
+For each STORE opcode (SB, SH, SW, SD), provides a single helper that
+derives `h_mem_eq` — the additional canonical-side argument that
+`equiv_<OP>` accepts alongside the structural `StorePromises` bundle.
+
+These helpers were extracted from the per-opcode
+`Compliance/FromTrust/<Op>.lean` wrappers, where they previously lived
+inline as a call to `Equivalence.Bridge.Mem.<op>_discharge_full` with
+some `h_opcode_assumptions`-projection prep. The wrappers are now pure
+pass-throughs that take the bundle and `h_mem_eq` directly.
+
+The `StorePromises` bundle itself is trivially constructible from
+pass-through binders, so no bundle-constructor helper is provided.
+-/
+
+namespace ZiskFv.Equivalence.Promises
+
+open ZiskFv.Trusted
+open ZiskFv.Airs.Main
+
+variable {C : Type → Type → Type} [Circuit FGL FGL C]
+
+/-- Derive SB's `h_mem_eq` from the SB emission bundle. Repackages
+    `Bridge.Mem.sb_discharge_full` with the `h_opcode_assumptions`
+    projection step baked in. -/
+lemma sb_h_mem_eq_of_emission
+    (main : Valid_Main C FGL FGL) (r_main : ℕ)
+    (e_st : Interaction.MemoryBusEntry FGL)
+    (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
+    (sb_input : PureSpec.SbInput)
+    (h_active : main.is_external_op r_main = 0)
+    (h_op_main : main.op r_main = OP_COPYB)
+    (h_ind_width : main.ind_width r_main = 1)
+    (h_e_st_mult : e_st.multiplicity = 1) (h_e_st_as_val : e_st.as.val = 2)
+    (h_opcode_assumptions : PureSpec.sb_state_assumptions sb_input state) :
+    (((((((state.mem.insert e_st.ptr.toNat e_st.x0
+        ).insert (e_st.ptr.toNat + 1) e_st.x1
+        ).insert (e_st.ptr.toNat + 2) e_st.x2
+        ).insert (e_st.ptr.toNat + 3) e_st.x3
+        ).insert (e_st.ptr.toNat + 4) e_st.x4
+        ).insert (e_st.ptr.toNat + 5) e_st.x5
+        ).insert (e_st.ptr.toNat + 6) e_st.x6
+        ).insert (e_st.ptr.toNat + 7) e_st.x7
+      = state.mem.insert
+          (PureSpec.execute_STOREB_pure sb_input).data0.1
+          (PureSpec.execute_STOREB_pure sb_input).data0.2 :=
+  ZiskFv.Equivalence.Bridge.Mem.sb_discharge_full
+    main r_main e_st state sb_input
+    h_active h_op_main h_ind_width h_e_st_mult h_e_st_as_val
+    h_opcode_assumptions.2.1 h_opcode_assumptions.2.2.1
+
+/-- Derive SH's `h_mem_eq` from the SH emission bundle. -/
+lemma sh_h_mem_eq_of_emission
+    (main : Valid_Main C FGL FGL) (r_main : ℕ)
+    (e_st : Interaction.MemoryBusEntry FGL)
+    (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
+    (sh_input : PureSpec.ShInput)
+    (h_active : main.is_external_op r_main = 0)
+    (h_op_main : main.op r_main = OP_COPYB)
+    (h_ind_width : main.ind_width r_main = 2)
+    (h_e_st_mult : e_st.multiplicity = 1) (h_e_st_as_val : e_st.as.val = 2)
+    (h_opcode_assumptions : PureSpec.sh_state_assumptions sh_input state) :
+    (((((((state.mem.insert e_st.ptr.toNat e_st.x0
+        ).insert (e_st.ptr.toNat + 1) e_st.x1
+        ).insert (e_st.ptr.toNat + 2) e_st.x2
+        ).insert (e_st.ptr.toNat + 3) e_st.x3
+        ).insert (e_st.ptr.toNat + 4) e_st.x4
+        ).insert (e_st.ptr.toNat + 5) e_st.x5
+        ).insert (e_st.ptr.toNat + 6) e_st.x6
+        ).insert (e_st.ptr.toNat + 7) e_st.x7
+      = (state.mem.insert
+            (PureSpec.execute_STOREH_pure sh_input).data0.1
+            (PureSpec.execute_STOREH_pure sh_input).data0.2
+        ).insert
+            (PureSpec.execute_STOREH_pure sh_input).data1.1
+            (PureSpec.execute_STOREH_pure sh_input).data1.2 :=
+  ZiskFv.Equivalence.Bridge.Mem.sh_discharge_full
+    main r_main e_st state sh_input
+    h_active h_op_main h_ind_width h_e_st_mult h_e_st_as_val
+    h_opcode_assumptions.2.1 h_opcode_assumptions.2.2.1
+
+/-- Derive SW's `h_mem_eq` from the SW emission bundle. -/
+lemma sw_h_mem_eq_of_emission
+    (main : Valid_Main C FGL FGL) (r_main : ℕ)
+    (e_st : Interaction.MemoryBusEntry FGL)
+    (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
+    (sw_input : PureSpec.SwInput)
+    (h_active : main.is_external_op r_main = 0)
+    (h_op_main : main.op r_main = OP_COPYB)
+    (h_ind_width : main.ind_width r_main = 4)
+    (h_e_st_mult : e_st.multiplicity = 1) (h_e_st_as_val : e_st.as.val = 2)
+    (h_opcode_assumptions : PureSpec.sw_state_assumptions sw_input state) :
+    (((((((state.mem.insert e_st.ptr.toNat e_st.x0
+        ).insert (e_st.ptr.toNat + 1) e_st.x1
+        ).insert (e_st.ptr.toNat + 2) e_st.x2
+        ).insert (e_st.ptr.toNat + 3) e_st.x3
+        ).insert (e_st.ptr.toNat + 4) e_st.x4
+        ).insert (e_st.ptr.toNat + 5) e_st.x5
+        ).insert (e_st.ptr.toNat + 6) e_st.x6
+        ).insert (e_st.ptr.toNat + 7) e_st.x7
+      = (((state.mem.insert
+              (PureSpec.execute_STOREW_pure sw_input).data0.1
+              (PureSpec.execute_STOREW_pure sw_input).data0.2
+            ).insert
+              (PureSpec.execute_STOREW_pure sw_input).data1.1
+              (PureSpec.execute_STOREW_pure sw_input).data1.2
+          ).insert
+              (PureSpec.execute_STOREW_pure sw_input).data2.1
+              (PureSpec.execute_STOREW_pure sw_input).data2.2
+        ).insert
+            (PureSpec.execute_STOREW_pure sw_input).data3.1
+            (PureSpec.execute_STOREW_pure sw_input).data3.2 :=
+  ZiskFv.Equivalence.Bridge.Mem.sw_discharge_full
+    main r_main e_st state sw_input
+    h_active h_op_main h_ind_width h_e_st_mult h_e_st_as_val
+    h_opcode_assumptions.2.1 h_opcode_assumptions.2.2.1
+
+/-- Derive SD's `h_mem_eq` from the SD emission bundle. Unlike the
+    narrow stores, SD's `discharge_full` consumes `read_xreg`-form
+    reads; this helper does the `rX_bits → read_xreg` conversion
+    via `rX_read_xreg_equiv`. -/
+lemma sd_h_mem_eq_of_emission
+    (main : Valid_Main C FGL FGL) (r_main : ℕ)
+    (e_st : Interaction.MemoryBusEntry FGL)
+    (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
+    (sd_input : PureSpec.SdInput)
+    (h_active : main.is_external_op r_main = 0)
+    (h_op_main : main.op r_main = OP_COPYB)
+    (h_e_st_mult : e_st.multiplicity = 1) (h_e_st_as_val : e_st.as.val = 2)
+    (h_opcode_assumptions : PureSpec.sd_state_assumptions sd_input state) :
+    e_st.ptr.toNat = (sd_input.r1_val + BitVec.signExtend 64 sd_input.imm).toNat
+    ∧ (e_st.x0 : BitVec 8) = BitVec.extractLsb 7 0 sd_input.r2_val
+    ∧ (e_st.x1 : BitVec 8) = BitVec.extractLsb 15 8 sd_input.r2_val
+    ∧ (e_st.x2 : BitVec 8) = BitVec.extractLsb 23 16 sd_input.r2_val
+    ∧ (e_st.x3 : BitVec 8) = BitVec.extractLsb 31 24 sd_input.r2_val
+    ∧ (e_st.x4 : BitVec 8) = BitVec.extractLsb 39 32 sd_input.r2_val
+    ∧ (e_st.x5 : BitVec 8) = BitVec.extractLsb 47 40 sd_input.r2_val
+    ∧ (e_st.x6 : BitVec 8) = BitVec.extractLsb 55 48 sd_input.r2_val
+    ∧ (e_st.x7 : BitVec 8) = BitVec.extractLsb 63 56 sd_input.r2_val := by
+  have h_read_r1 := h_opcode_assumptions.2.1
+  have h_read_r2 := h_opcode_assumptions.2.2.1
+  have h_read_r1' :
+      read_xreg (regidx_to_fin (regidx.Regidx sd_input.r1)) state
+        = EStateM.Result.ok sd_input.r1_val state := by
+    rw [← rX_read_xreg_equiv state (regidx.Regidx sd_input.r1)
+          (regidx_to_fin (regidx.Regidx sd_input.r1))
+          (by simp [regidx_to_fin])]
+    exact h_read_r1
+  have h_read_r2' :
+      read_xreg (regidx_to_fin (regidx.Regidx sd_input.r2)) state
+        = EStateM.Result.ok sd_input.r2_val state := by
+    rw [← rX_read_xreg_equiv state (regidx.Regidx sd_input.r2)
+          (regidx_to_fin (regidx.Regidx sd_input.r2))
+          (by simp [regidx_to_fin])]
+    exact h_read_r2
+  exact ZiskFv.Equivalence.Bridge.Mem.sd_discharge_full
+    main r_main e_st state
+    (regidx_to_fin (regidx.Regidx sd_input.r1))
+    (regidx_to_fin (regidx.Regidx sd_input.r2))
+    sd_input.r1_val sd_input.r2_val sd_input.imm
+    h_active h_op_main h_e_st_mult h_e_st_as_val
+    h_read_r1' h_read_r2'
+
+end ZiskFv.Equivalence.Promises

--- a/ZiskFv/Equivalence/Promises/UTypeHelpers.lean
+++ b/ZiskFv/Equivalence/Promises/UTypeHelpers.lean
@@ -1,0 +1,64 @@
+import Mathlib
+
+import LeanZKCircuit.OpenVM.Circuit
+import ZiskFv.Equivalence.Promises.UType
+import ZiskFv.Tactics.UTypeArchetype
+import ZiskFv.Trusted.Transpiler
+import ZiskFv.Airs.Main.Main
+
+/-!
+# `UTypePromises` companion helpers
+
+For each U-TYPE opcode (LUI, AUIPC), provides a single helper that
+assembles `h_circuit` — the `<op>_archetype_circuit_holds` term that
+`equiv_<OP>` accepts alongside the structural `UTypePromises`
+bundle — from three trust-ledger-style ingredients: the Main-AIR
+activation pin, the opcode pin, and the per-row constraint subset.
+
+The helper internally fires `transpile_<OP>` (class #1) to derive
+the `m32`, `set_pc`, `store_pc` routing pins, then packs them
+together with the subset hypothesis. Extracted from the per-opcode
+`Compliance/FromTrust/<Op>.lean` wrappers.
+-/
+
+namespace ZiskFv.Equivalence.Promises
+
+open ZiskFv.Trusted
+open ZiskFv.Airs.Main
+open ZiskFv.Tactics.UTypeArchetype
+
+variable {C : Type → Type → Type} [Circuit FGL FGL C]
+
+/-- Assemble LUI's `h_circuit` from the Main-side activation/opcode
+    pins and the per-row LUI subset constraint. -/
+def lui_h_circuit_of_main_constraints
+    (m : Valid_Main C FGL FGL) (r_main : ℕ) (next_pc : FGL)
+    (h_main_active : m.is_external_op r_main = 0)
+    (h_main_op_lui : m.op r_main = OP_COPYB)
+    (h_lui_subset : lui_subset_holds m r_main next_pc) :
+    lui_archetype_circuit_holds m r_main next_pc :=
+  let h_tr := ZiskFv.Trusted.transpile_LUI m r_main (0 : Fin 32)
+    (0 : FGL) (0 : FGL)
+    { xreg := fun _ => 0#64, pc := 0#64 } h_main_active h_main_op_lui
+  let ⟨h_m32, h_set_pc, h_store_pc, _, _, _, _, _, _⟩ := h_tr
+  let h_lui_mode : main_row_in_lui_mode m r_main :=
+    ⟨h_main_active, by rw [h_main_op_lui]; rfl, h_m32, h_set_pc, h_store_pc⟩
+  ⟨h_lui_subset, h_lui_mode⟩
+
+/-- Assemble AUIPC's `h_circuit` from the Main-side activation/opcode
+    pins and the per-row AUIPC subset constraint. -/
+def auipc_h_circuit_of_main_constraints
+    (m : Valid_Main C FGL FGL) (r_main : ℕ) (next_pc : FGL)
+    (h_main_active : m.is_external_op r_main = 0)
+    (h_main_op_auipc : m.op r_main = OP_FLAG)
+    (h_auipc_subset : auipc_subset_holds m r_main next_pc) :
+    auipc_archetype_circuit_holds m r_main next_pc :=
+  let h_tr := ZiskFv.Trusted.transpile_AUIPC m r_main (0 : Fin 32)
+    (0 : FGL) { xreg := fun _ => 0#64, pc := 0#64 }
+    h_main_active h_main_op_auipc
+  let ⟨h_m32, h_set_pc, h_store_pc, _, _, _, _, _, _⟩ := h_tr
+  let h_auipc_mode : main_row_in_auipc_mode m r_main :=
+    ⟨h_main_active, by rw [h_main_op_auipc]; rfl, h_m32, h_set_pc, h_store_pc⟩
+  ⟨h_auipc_subset, h_auipc_mode⟩
+
+end ZiskFv.Equivalence.Promises

--- a/trust/baseline-wrapper-caller-burden.txt
+++ b/trust/baseline-wrapper-caller-burden.txt
@@ -12,18 +12,18 @@
 #             bus_shape | transpile | byte_chain | loose | row |
 #             instance | other
 #
-# Total rows: 1951
+# Total rows: 1187
 # Total wrappers: 63
-# Category bridge: 22
-# Category bus_shape: 509
+# Category bridge: 66
+# Category bus_shape: 27
 # Category entry: 67
 # Category loose: 156
 # Category match: 120
-# Category other: 493
+# Category other: 441
 # Category range: 38
 # Category row: 57
-# Category state: 217
-# Category transpile: 155
+# Category state: 73
+# Category transpile: 25
 # Category validator: 117
 #
 ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
@@ -46,22 +46,8 @@ ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 016 _ [other] per-row ADD-s
 ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 017 h_main_subset [other] add_subset_holds m r_main
 ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 018 h_b_core [other] ∀ r, ZiskFv.Airs.BinaryAdd.core_every_row b r
 ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 019 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
-ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 020 _ [other] SPEC-PRE
-ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 021 h_input_r1_sail [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok add_input.r1_val state
-ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 022 h_input_r2_sail [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok add_input.r2_val state
-ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 023 h_input_rd [transpile] add_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 024 h_input_pc [state] state.regs.get? Register.PC = .some add_input.PC
-ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 025 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 026 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 027 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 028 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 029 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 030 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 031 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 032 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 033 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 034 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 035 h_rd_idx [transpile] add_input.rd = Transpiler.wrap_to_regidx e2.ptr
+ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 020 _ [other] 15 fields
+ZiskFv.Compliance.FromTrust.Add.equiv_ADD_from_trust 021 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state add_input.r1_val add_input.r2_va
 ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 001 addi_input [other] PureSpec.AddiInput
 ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 002 r1 [other] regidx
@@ -82,21 +68,8 @@ ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 016 h_b_core [other] ∀ 
 ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 017 h_addi_subset [other] itype_imm_subset_holds_main m r_main addi_input.imm
 ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 018 _ [other] deferred to Mem pilot
 ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 019 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
-ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 020 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok addi_input.r1_val state
-ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 021 h_input_imm [other] addi_input.imm = imm
-ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 022 h_input_rd [transpile] addi_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 023 h_input_pc [state] state.regs.get? Register.PC = .some addi_input.PC
-ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 024 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 025 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 026 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 027 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 028 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 029 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 030 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 031 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 032 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 033 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 034 h_rd_idx [transpile] addi_input.rd = Transpiler.wrap_to_regidx e2.ptr
+ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 020 _ [other] 14 fields, see Promises/IType.lean
+ZiskFv.Compliance.FromTrust.Addi.equiv_ADDI_from_trust 021 promises [bridge] ZiskFv.Equivalence.Promises.ITypePromises state addi_input.r1_val addi_input.imm
 ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 001 addiw_input [other] PureSpec.AddiwInput
 ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 002 r1 [other] regidx
@@ -113,21 +86,7 @@ ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 012 h_main_active [matc
 ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 013 h_main_op_addiw [match] m.op r_main = OP_ADD_W
 ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 014 h_addiw_subset [other] itype_imm_subset_holds_main m r_main addiw_input.imm
 ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 015 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
-ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 016 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok addiw_input.r1_val state
-ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 017 h_input_imm [other] addiw_input.imm = imm
-ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 018 h_input_rd [transpile] addiw_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 019 h_input_pc [state] state.regs.get? Register.PC = .some addiw_input.PC
-ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 020 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 021 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 022 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 023 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 024 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 025 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 026 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 027 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 028 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 029 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 030 h_rd_idx [transpile] addiw_input.rd = Transpiler.wrap_to_regidx e2.ptr
+ZiskFv.Compliance.FromTrust.Addiw.equiv_ADDIW_from_trust 016 promises [bridge] ZiskFv.Equivalence.Promises.ITypePromises state addiw_input.r1_val addiw_input.i
 ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 001 addw_input [other] PureSpec.AddwInput
 ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 002 r1 [other] regidx
@@ -143,21 +102,7 @@ ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 011 e2 [loose] Interactio
 ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 012 h_main_active [match] m.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 013 h_main_op_addw [match] m.op r_main = OP_ADD_W
 ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 014 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
-ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 015 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok addw_input.r1_val state
-ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 016 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok addw_input.r2_val state
-ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 017 h_input_rd [transpile] addw_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 018 h_input_pc [state] state.regs.get? Register.PC = .some addw_input.PC
-ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 019 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 020 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 021 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 022 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 023 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 024 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 025 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 026 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 027 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 028 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 029 h_rd_idx [transpile] addw_input.rd = Transpiler.wrap_to_regidx e2.ptr
+ZiskFv.Compliance.FromTrust.Addw.equiv_ADDW_from_trust 015 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state addw_input.r1_val addw_input.r2_
 ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 001 and_input [other] PureSpec.AndInput
 ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 002 r1 [other] regidx
@@ -173,21 +118,7 @@ ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 011 e2 [loose] Interaction.
 ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 012 h_main_active [match] m.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 013 h_main_op_and [match] m.op r_main = OP_AND
 ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 014 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
-ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 015 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok and_input.r1_val state
-ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 016 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok and_input.r2_val state
-ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 017 h_input_rd [transpile] and_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 018 h_input_pc [state] state.regs.get? Register.PC = .some and_input.PC
-ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 019 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 020 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 021 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 022 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 023 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 024 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 025 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 026 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 027 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 028 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 029 h_rd_idx [transpile] and_input.rd = Transpiler.wrap_to_regidx e2.ptr
+ZiskFv.Compliance.FromTrust.And.equiv_AND_from_trust 015 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state and_input.r1_val and_input.r2_va
 ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 001 andi_input [other] PureSpec.AndiInput
 ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 002 r1 [other] regidx
@@ -204,21 +135,7 @@ ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 012 h_main_active [match]
 ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 013 h_main_op_andi [match] m.op r_main = OP_AND
 ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 014 h_andi_subset [other] itype_imm_subset_holds_main m r_main andi_input.imm
 ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 015 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
-ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 016 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok andi_input.r1_val state
-ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 017 h_input_imm [other] andi_input.imm = imm
-ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 018 h_input_rd [transpile] andi_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 019 h_input_pc [state] state.regs.get? Register.PC = .some andi_input.PC
-ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 020 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 021 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 022 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 023 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 024 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 025 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 026 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 027 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 028 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 029 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 030 h_rd_idx [transpile] andi_input.rd = Transpiler.wrap_to_regidx e2.ptr
+ZiskFv.Compliance.FromTrust.Andi.equiv_ANDI_from_trust 016 promises [bridge] ZiskFv.Equivalence.Promises.ITypePromises state andi_input.r1_val andi_input.imm
 ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 001 auipc_input [other] PureSpec.AuipcInput
 ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 002 imm [other] BitVec 20
@@ -229,25 +146,13 @@ ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 006 nextPC_val [other] 
 ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 007 m [validator] Valid_Main C FGL FGL
 ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 008 r_main [row] ℕ
 ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 009 next_pc [other] FGL
-ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 010 _ [other] Compliance ROM handshake
-ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 011 h_main_active [match] m.is_external_op r_main = 0
-ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 012 h_main_op_auipc [match] m.op r_main = OP_FLAG
-ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 013 h_auipc_subset [other] auipc_subset_holds m r_main next_pc
-ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 014 _ [other] SPEC-PRE
-ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 015 h_input_imm [other] auipc_input.imm = imm
-ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 016 h_input_rd [transpile] auipc_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 017 h_input_pc [state] state.regs.get? Register.PC = .some auipc_input.PC
-ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 018 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 019 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 020 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 021 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = nextPC_val
-ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 022 h_rd_mult [bus_shape] e_rd.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 023 h_rd_as [bus_shape] e_rd.as.val = 1
-ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 024 h_nextPC_eq [transpile] (PureSpec.execute_AUIPC_pure auipc_input).nextPC = nextPC_val
-ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 025 h_rd_idx [transpile] auipc_input.rd = Transpiler.wrap_to_regidx e_rd.ptr
-ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 026 h_no_wrap [other] auipc_input.PC.toNat + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12)
-ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 027 h_lo_bound [range] (m.pc r_main + m.jmp_offset2 r_main : FGL).val < 4294967296
-ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 028 h_pc_offset_lt_2_32 [range] (auipc_input.PC + BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toN
+ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 010 h_main_active [match] m.is_external_op r_main = 0
+ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 011 h_main_op_auipc [match] m.op r_main = OP_FLAG
+ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 012 h_auipc_subset [other] auipc_subset_holds m r_main next_pc
+ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 013 promises [transpile] ZiskFv.Equivalence.Promises.UTypePromises state auipc_input.imm auipc_input.rd a
+ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 014 h_no_wrap [other] auipc_input.PC.toNat + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12)
+ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 015 h_lo_bound [range] (m.pc r_main + m.jmp_offset2 r_main : FGL).val < 4294967296
+ZiskFv.Compliance.FromTrust.Auipc.equiv_AUIPC_from_trust 016 h_pc_offset_lt_2_32 [range] (auipc_input.PC + BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toN
 ZiskFv.Compliance.FromTrust.Beq.equiv_BEQ_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Beq.equiv_BEQ_from_trust 001 beq_input [other] PureSpec.BeqInput
 ZiskFv.Compliance.FromTrust.Beq.equiv_BEQ_from_trust 002 imm [other] BitVec 13
@@ -255,18 +160,7 @@ ZiskFv.Compliance.FromTrust.Beq.equiv_BEQ_from_trust 003 r1 [other] regidx
 ZiskFv.Compliance.FromTrust.Beq.equiv_BEQ_from_trust 004 r2 [other] regidx
 ZiskFv.Compliance.FromTrust.Beq.equiv_BEQ_from_trust 005 misa_val [other] RegisterType Register.misa
 ZiskFv.Compliance.FromTrust.Beq.equiv_BEQ_from_trust 006 exec_row [entry] List (Interaction.ExecutionBusEntry FGL)
-ZiskFv.Compliance.FromTrust.Beq.equiv_BEQ_from_trust 007 _ [other] SPEC-PRE
-ZiskFv.Compliance.FromTrust.Beq.equiv_BEQ_from_trust 008 h_input_imm [other] beq_input.imm = imm
-ZiskFv.Compliance.FromTrust.Beq.equiv_BEQ_from_trust 009 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok beq_input.r1_val state
-ZiskFv.Compliance.FromTrust.Beq.equiv_BEQ_from_trust 010 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok beq_input.r2_val state
-ZiskFv.Compliance.FromTrust.Beq.equiv_BEQ_from_trust 011 h_input_pc [state] state.regs.get? Register.PC = .some beq_input.PC
-ZiskFv.Compliance.FromTrust.Beq.equiv_BEQ_from_trust 012 h_input_misa [state] state.regs.get? Register.misa = .some misa_val
-ZiskFv.Compliance.FromTrust.Beq.equiv_BEQ_from_trust 013 h_misa_c [other] Sail.BitVec.extractLsb misa_val 2 2 = 0#1
-ZiskFv.Compliance.FromTrust.Beq.equiv_BEQ_from_trust 014 h_target_aligned [other] (beq_input.PC + BitVec.signExtend 64 beq_input.imm).toNat % 4 = 0
-ZiskFv.Compliance.FromTrust.Beq.equiv_BEQ_from_trust 015 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Beq.equiv_BEQ_from_trust 016 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Beq.equiv_BEQ_from_trust 017 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Beq.equiv_BEQ_from_trust 018 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
+ZiskFv.Compliance.FromTrust.Beq.equiv_BEQ_from_trust 007 promises [bridge] ZiskFv.Equivalence.Promises.BranchPromises state beq_input.imm beq_input.r1_val 
 ZiskFv.Compliance.FromTrust.Bge.equiv_BGE_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Bge.equiv_BGE_from_trust 001 bge_input [other] PureSpec.BgeInput
 ZiskFv.Compliance.FromTrust.Bge.equiv_BGE_from_trust 002 imm [other] BitVec 13
@@ -274,17 +168,7 @@ ZiskFv.Compliance.FromTrust.Bge.equiv_BGE_from_trust 003 r1 [other] regidx
 ZiskFv.Compliance.FromTrust.Bge.equiv_BGE_from_trust 004 r2 [other] regidx
 ZiskFv.Compliance.FromTrust.Bge.equiv_BGE_from_trust 005 misa_val [other] RegisterType Register.misa
 ZiskFv.Compliance.FromTrust.Bge.equiv_BGE_from_trust 006 exec_row [entry] List (Interaction.ExecutionBusEntry FGL)
-ZiskFv.Compliance.FromTrust.Bge.equiv_BGE_from_trust 007 h_input_imm [other] bge_input.imm = imm
-ZiskFv.Compliance.FromTrust.Bge.equiv_BGE_from_trust 008 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok bge_input.r1_val state
-ZiskFv.Compliance.FromTrust.Bge.equiv_BGE_from_trust 009 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok bge_input.r2_val state
-ZiskFv.Compliance.FromTrust.Bge.equiv_BGE_from_trust 010 h_input_pc [state] state.regs.get? Register.PC = .some bge_input.PC
-ZiskFv.Compliance.FromTrust.Bge.equiv_BGE_from_trust 011 h_input_misa [state] state.regs.get? Register.misa = .some misa_val
-ZiskFv.Compliance.FromTrust.Bge.equiv_BGE_from_trust 012 h_misa_c [other] Sail.BitVec.extractLsb misa_val 2 2 = 0#1
-ZiskFv.Compliance.FromTrust.Bge.equiv_BGE_from_trust 013 h_target_aligned [other] (bge_input.PC + BitVec.signExtend 64 bge_input.imm).toNat % 4 = 0
-ZiskFv.Compliance.FromTrust.Bge.equiv_BGE_from_trust 014 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Bge.equiv_BGE_from_trust 015 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Bge.equiv_BGE_from_trust 016 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Bge.equiv_BGE_from_trust 017 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
+ZiskFv.Compliance.FromTrust.Bge.equiv_BGE_from_trust 007 promises [bridge] ZiskFv.Equivalence.Promises.BranchPromises state bge_input.imm bge_input.r1_val 
 ZiskFv.Compliance.FromTrust.Bgeu.equiv_BGEU_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Bgeu.equiv_BGEU_from_trust 001 bgeu_input [other] PureSpec.BgeuInput
 ZiskFv.Compliance.FromTrust.Bgeu.equiv_BGEU_from_trust 002 imm [other] BitVec 13
@@ -292,17 +176,7 @@ ZiskFv.Compliance.FromTrust.Bgeu.equiv_BGEU_from_trust 003 r1 [other] regidx
 ZiskFv.Compliance.FromTrust.Bgeu.equiv_BGEU_from_trust 004 r2 [other] regidx
 ZiskFv.Compliance.FromTrust.Bgeu.equiv_BGEU_from_trust 005 misa_val [other] RegisterType Register.misa
 ZiskFv.Compliance.FromTrust.Bgeu.equiv_BGEU_from_trust 006 exec_row [entry] List (Interaction.ExecutionBusEntry FGL)
-ZiskFv.Compliance.FromTrust.Bgeu.equiv_BGEU_from_trust 007 h_input_imm [other] bgeu_input.imm = imm
-ZiskFv.Compliance.FromTrust.Bgeu.equiv_BGEU_from_trust 008 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok bgeu_input.r1_val state
-ZiskFv.Compliance.FromTrust.Bgeu.equiv_BGEU_from_trust 009 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok bgeu_input.r2_val state
-ZiskFv.Compliance.FromTrust.Bgeu.equiv_BGEU_from_trust 010 h_input_pc [state] state.regs.get? Register.PC = .some bgeu_input.PC
-ZiskFv.Compliance.FromTrust.Bgeu.equiv_BGEU_from_trust 011 h_input_misa [state] state.regs.get? Register.misa = .some misa_val
-ZiskFv.Compliance.FromTrust.Bgeu.equiv_BGEU_from_trust 012 h_misa_c [other] Sail.BitVec.extractLsb misa_val 2 2 = 0#1
-ZiskFv.Compliance.FromTrust.Bgeu.equiv_BGEU_from_trust 013 h_target_aligned [other] (bgeu_input.PC + BitVec.signExtend 64 bgeu_input.imm).toNat % 4 = 0
-ZiskFv.Compliance.FromTrust.Bgeu.equiv_BGEU_from_trust 014 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Bgeu.equiv_BGEU_from_trust 015 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Bgeu.equiv_BGEU_from_trust 016 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Bgeu.equiv_BGEU_from_trust 017 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
+ZiskFv.Compliance.FromTrust.Bgeu.equiv_BGEU_from_trust 007 promises [bridge] ZiskFv.Equivalence.Promises.BranchPromises state bgeu_input.imm bgeu_input.r1_va
 ZiskFv.Compliance.FromTrust.Blt.equiv_BLT_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Blt.equiv_BLT_from_trust 001 blt_input [other] PureSpec.BltInput
 ZiskFv.Compliance.FromTrust.Blt.equiv_BLT_from_trust 002 imm [other] BitVec 13
@@ -310,17 +184,7 @@ ZiskFv.Compliance.FromTrust.Blt.equiv_BLT_from_trust 003 r1 [other] regidx
 ZiskFv.Compliance.FromTrust.Blt.equiv_BLT_from_trust 004 r2 [other] regidx
 ZiskFv.Compliance.FromTrust.Blt.equiv_BLT_from_trust 005 misa_val [other] RegisterType Register.misa
 ZiskFv.Compliance.FromTrust.Blt.equiv_BLT_from_trust 006 exec_row [entry] List (Interaction.ExecutionBusEntry FGL)
-ZiskFv.Compliance.FromTrust.Blt.equiv_BLT_from_trust 007 h_input_imm [other] blt_input.imm = imm
-ZiskFv.Compliance.FromTrust.Blt.equiv_BLT_from_trust 008 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok blt_input.r1_val state
-ZiskFv.Compliance.FromTrust.Blt.equiv_BLT_from_trust 009 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok blt_input.r2_val state
-ZiskFv.Compliance.FromTrust.Blt.equiv_BLT_from_trust 010 h_input_pc [state] state.regs.get? Register.PC = .some blt_input.PC
-ZiskFv.Compliance.FromTrust.Blt.equiv_BLT_from_trust 011 h_input_misa [state] state.regs.get? Register.misa = .some misa_val
-ZiskFv.Compliance.FromTrust.Blt.equiv_BLT_from_trust 012 h_misa_c [other] Sail.BitVec.extractLsb misa_val 2 2 = 0#1
-ZiskFv.Compliance.FromTrust.Blt.equiv_BLT_from_trust 013 h_target_aligned [other] (blt_input.PC + BitVec.signExtend 64 blt_input.imm).toNat % 4 = 0
-ZiskFv.Compliance.FromTrust.Blt.equiv_BLT_from_trust 014 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Blt.equiv_BLT_from_trust 015 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Blt.equiv_BLT_from_trust 016 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Blt.equiv_BLT_from_trust 017 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
+ZiskFv.Compliance.FromTrust.Blt.equiv_BLT_from_trust 007 promises [bridge] ZiskFv.Equivalence.Promises.BranchPromises state blt_input.imm blt_input.r1_val 
 ZiskFv.Compliance.FromTrust.Bltu.equiv_BLTU_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Bltu.equiv_BLTU_from_trust 001 bltu_input [other] PureSpec.BltuInput
 ZiskFv.Compliance.FromTrust.Bltu.equiv_BLTU_from_trust 002 imm [other] BitVec 13
@@ -328,17 +192,7 @@ ZiskFv.Compliance.FromTrust.Bltu.equiv_BLTU_from_trust 003 r1 [other] regidx
 ZiskFv.Compliance.FromTrust.Bltu.equiv_BLTU_from_trust 004 r2 [other] regidx
 ZiskFv.Compliance.FromTrust.Bltu.equiv_BLTU_from_trust 005 misa_val [other] RegisterType Register.misa
 ZiskFv.Compliance.FromTrust.Bltu.equiv_BLTU_from_trust 006 exec_row [entry] List (Interaction.ExecutionBusEntry FGL)
-ZiskFv.Compliance.FromTrust.Bltu.equiv_BLTU_from_trust 007 h_input_imm [other] bltu_input.imm = imm
-ZiskFv.Compliance.FromTrust.Bltu.equiv_BLTU_from_trust 008 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok bltu_input.r1_val state
-ZiskFv.Compliance.FromTrust.Bltu.equiv_BLTU_from_trust 009 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok bltu_input.r2_val state
-ZiskFv.Compliance.FromTrust.Bltu.equiv_BLTU_from_trust 010 h_input_pc [state] state.regs.get? Register.PC = .some bltu_input.PC
-ZiskFv.Compliance.FromTrust.Bltu.equiv_BLTU_from_trust 011 h_input_misa [state] state.regs.get? Register.misa = .some misa_val
-ZiskFv.Compliance.FromTrust.Bltu.equiv_BLTU_from_trust 012 h_misa_c [other] Sail.BitVec.extractLsb misa_val 2 2 = 0#1
-ZiskFv.Compliance.FromTrust.Bltu.equiv_BLTU_from_trust 013 h_target_aligned [other] (bltu_input.PC + BitVec.signExtend 64 bltu_input.imm).toNat % 4 = 0
-ZiskFv.Compliance.FromTrust.Bltu.equiv_BLTU_from_trust 014 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Bltu.equiv_BLTU_from_trust 015 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Bltu.equiv_BLTU_from_trust 016 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Bltu.equiv_BLTU_from_trust 017 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
+ZiskFv.Compliance.FromTrust.Bltu.equiv_BLTU_from_trust 007 promises [bridge] ZiskFv.Equivalence.Promises.BranchPromises state bltu_input.imm bltu_input.r1_va
 ZiskFv.Compliance.FromTrust.Bne.equiv_BNE_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Bne.equiv_BNE_from_trust 001 bne_input [other] PureSpec.BneInput
 ZiskFv.Compliance.FromTrust.Bne.equiv_BNE_from_trust 002 imm [other] BitVec 13
@@ -346,18 +200,7 @@ ZiskFv.Compliance.FromTrust.Bne.equiv_BNE_from_trust 003 r1 [other] regidx
 ZiskFv.Compliance.FromTrust.Bne.equiv_BNE_from_trust 004 r2 [other] regidx
 ZiskFv.Compliance.FromTrust.Bne.equiv_BNE_from_trust 005 misa_val [other] RegisterType Register.misa
 ZiskFv.Compliance.FromTrust.Bne.equiv_BNE_from_trust 006 exec_row [entry] List (Interaction.ExecutionBusEntry FGL)
-ZiskFv.Compliance.FromTrust.Bne.equiv_BNE_from_trust 007 h_input_imm [other] bne_input.imm = imm
-ZiskFv.Compliance.FromTrust.Bne.equiv_BNE_from_trust 008 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok bne_input.r1_val state
-ZiskFv.Compliance.FromTrust.Bne.equiv_BNE_from_trust 009 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok bne_input.r2_val state
-ZiskFv.Compliance.FromTrust.Bne.equiv_BNE_from_trust 010 h_input_pc [state] state.regs.get? Register.PC = .some bne_input.PC
-ZiskFv.Compliance.FromTrust.Bne.equiv_BNE_from_trust 011 h_input_misa [state] state.regs.get? Register.misa = .some misa_val
-ZiskFv.Compliance.FromTrust.Bne.equiv_BNE_from_trust 012 h_misa_c [other] Sail.BitVec.extractLsb misa_val 2 2 = 0#1
-ZiskFv.Compliance.FromTrust.Bne.equiv_BNE_from_trust 013 _ [other] ZisK assembler/transpiler invariant
-ZiskFv.Compliance.FromTrust.Bne.equiv_BNE_from_trust 014 h_target_aligned [other] (bne_input.PC + BitVec.signExtend 64 bne_input.imm).toNat % 4 = 0
-ZiskFv.Compliance.FromTrust.Bne.equiv_BNE_from_trust 015 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Bne.equiv_BNE_from_trust 016 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Bne.equiv_BNE_from_trust 017 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Bne.equiv_BNE_from_trust 018 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
+ZiskFv.Compliance.FromTrust.Bne.equiv_BNE_from_trust 007 promises [bridge] ZiskFv.Equivalence.Promises.BranchPromises state bne_input.imm bne_input.r1_val 
 ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 001 div_input [other] PureSpec.DivInput
 ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 002 r1 [other] regidx
@@ -376,36 +219,21 @@ ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 014 h_main_active [match] m
 ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 015 h_main_op_div [match] m.op r_main = OP_DIV
 ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 016 _ [other] Compliance.lean will obtain `r_a` via -- `op_bus_perm_sound_ArithDiv` and pass i
 ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 017 h_match_primary [other] matches_entry (opBus_row_Main m r_main) (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 018 _ [other] passed through
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 019 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 020 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 021 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 022 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 023 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 024 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 025 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 026 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 027 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 028 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 029 h_rd_idx [transpile] div_input.rd = Transpiler.wrap_to_regidx e2.ptr
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 030 _ [other] SPEC-PRE
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 031 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok div_input.r1_val state
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 032 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok div_input.r2_val state
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 033 h_input_rd [transpile] div_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 034 h_input_pc [state] state.regs.get? Register.PC = .some div_input.PC
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 035 h_op2_ne [bridge] div_input.r2_val.toInt ≠ 0
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 036 h_no_overflow [bridge] ¬ (div_input.r1_val.toInt = -(2:ℤ)^63 ∧ div_input.r2_val.toInt = -1)
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 037 _ [other] constructibility
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 038 _ [other] constraints 6-8 + 31-38
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 039 `bus_res1` [other] 263`, required for -- the hi-lane discharge via `div_bus_res1_eq_a_hi`
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 040 normalization [other] 263`, required for -- the hi-lane discharge via `div_bus_res1_eq_a_hi`
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 041 at [other] 263`, required for -- the hi-lane discharge via `div_bus_res1_eq_a_hi`
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 042 `arith.pil [other] 263`, required for -- the hi-lane discharge via `div_bus_res1_eq_a_hi`
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 043 h_row_constraints [other] ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 044 h_na_bool [other] v.na r_a = 0 ∨ v.na r_a = 1
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 045 h_nb_bool [other] v.nb r_a = 0 ∨ v.nb r_a = 1
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 046 h_nr_bool [other] v.nr r_a = 0 ∨ v.nr r_a = 1
-ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 047 h_np_xor [other] toIntZ (v.np r_a) = toIntZ (v.na r_a) + toIntZ (v.nb r_a) - 2 * toIntZ (v.na r_a
+ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 018 _ [other] 15 fields
+ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 019 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state div_input.r1_val div_input.r2_va
+ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 020 h_op2_ne [bridge] div_input.r2_val.toInt ≠ 0
+ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 021 h_no_overflow [bridge] ¬ (div_input.r1_val.toInt = -(2:ℤ)^63 ∧ div_input.r2_val.toInt = -1)
+ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 022 _ [other] constructibility
+ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 023 _ [other] constraints 6-8 + 31-38
+ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 024 `bus_res1` [other] 263`, required for -- the hi-lane discharge via `div_bus_res1_eq_a_hi`
+ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 025 normalization [other] 263`, required for -- the hi-lane discharge via `div_bus_res1_eq_a_hi`
+ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 026 at [other] 263`, required for -- the hi-lane discharge via `div_bus_res1_eq_a_hi`
+ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 027 `arith.pil [other] 263`, required for -- the hi-lane discharge via `div_bus_res1_eq_a_hi`
+ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 028 h_row_constraints [other] ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a
+ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 029 h_na_bool [other] v.na r_a = 0 ∨ v.na r_a = 1
+ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 030 h_nb_bool [other] v.nb r_a = 0 ∨ v.nb r_a = 1
+ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 031 h_nr_bool [other] v.nr r_a = 0 ∨ v.nr r_a = 1
+ZiskFv.Compliance.FromTrust.Div.equiv_DIV_from_trust 032 h_np_xor [other] toIntZ (v.np r_a) = toIntZ (v.na r_a) + toIntZ (v.nb r_a) - 2 * toIntZ (v.na r_a
 ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 001 divu_input [other] PureSpec.DivuInput
 ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 002 r1 [other] regidx
@@ -422,31 +250,17 @@ ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 012 r_a [other] ℕ
 ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 013 h_main_active [match] m.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 014 h_main_op_divu [match] m.op r_main = OP_DIVU
 ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 015 h_match_primary [other] matches_entry (opBus_row_Main m r_main) (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 016 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok divu_input.r1_val state
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 017 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok divu_input.r2_val state
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 018 h_input_rd [transpile] divu_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 019 h_input_pc [state] state.regs.get? Register.PC = .some divu_input.PC
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 020 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 021 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 022 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 023 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 024 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 025 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 026 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 027 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 028 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 029 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 030 h_rd_idx [transpile] divu_input.rd = Transpiler.wrap_to_regidx e2.ptr
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 031 h0 [range] e2.x0.val < 256
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 032 h1 [range] e2.x1.val < 256
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 033 h2 [range] e2.x2.val < 256
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 034 h3 [range] e2.x3.val < 256
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 035 h4 [range] e2.x4.val < 256
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 036 h5 [range] e2.x5.val < 256
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 037 h6 [range] e2.x6.val < 256
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 038 h7 [range] e2.x7.val < 256
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 039 h_row_constraints [other] ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a
-ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 040 h_op2_ne [bridge] divu_input.r2_val.toNat ≠ 0
+ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 016 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state divu_input.r1_val divu_input.r2_
+ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 017 h0 [range] e2.x0.val < 256
+ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 018 h1 [range] e2.x1.val < 256
+ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 019 h2 [range] e2.x2.val < 256
+ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 020 h3 [range] e2.x3.val < 256
+ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 021 h4 [range] e2.x4.val < 256
+ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 022 h5 [range] e2.x5.val < 256
+ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 023 h6 [range] e2.x6.val < 256
+ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 024 h7 [range] e2.x7.val < 256
+ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 025 h_row_constraints [other] ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a
+ZiskFv.Compliance.FromTrust.Divu.equiv_DIVU_from_trust 026 h_op2_ne [bridge] divu_input.r2_val.toNat ≠ 0
 ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 001 divuw_input [other] PureSpec.DivuwInput
 ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 002 r1 [other] regidx
@@ -463,27 +277,13 @@ ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 012 r_a [other] ℕ
 ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 013 h_main_active [match] m.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 014 h_main_op_divuw [match] m.op r_main = OP_DIVU_W
 ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 015 h_match_primary [other] matches_entry (opBus_row_Main m r_main) (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv
-ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 016 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok divuw_input.r1_val state
-ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 017 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok divuw_input.r2_val state
-ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 018 h_input_rd [transpile] divuw_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 019 h_input_pc [state] state.regs.get? Register.PC = .some divuw_input.PC
-ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 020 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 021 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 022 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 023 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 024 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 025 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 026 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 027 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 028 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 029 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 030 h_rd_idx [transpile] divuw_input.rd = Transpiler.wrap_to_regidx e2.ptr
-ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 031 h_row_constraints [other] ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a
-ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 032 _ [other] not class #6b — bus encoding / SPEC-PRE / -- operand bridge in W-form
-ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 033 h_sext_choice [other] ((e2.x4.val = 0 ∧ e2.x5.val = 0 ∧ e2.x6.val = 0 ∧ e2.x7.val = 0) ∧ (v.a_0 r_a).v
-ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 034 h_rs1_value [bridge] (Sail.BitVec.extractLsb divuw_input.r1_val 31 0).toNat = (v.c_0 r_a).val + (v.c_
-ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 035 h_rs2_value [bridge] (Sail.BitVec.extractLsb divuw_input.r2_val 31 0).toNat = (v.b_0 r_a).val + (v.b_
-ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 036 h_op2_ne [bridge] (Sail.BitVec.extractLsb divuw_input.r2_val 31 0).toNat ≠ 0
+ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 016 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state divuw_input.r1_val divuw_input.r
+ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 017 h_row_constraints [other] ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a
+ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 018 _ [other] not class #6b — bus encoding / SPEC-PRE / -- operand bridge in W-form
+ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 019 h_sext_choice [other] ((e2.x4.val = 0 ∧ e2.x5.val = 0 ∧ e2.x6.val = 0 ∧ e2.x7.val = 0) ∧ (v.a_0 r_a).v
+ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 020 h_rs1_value [bridge] (Sail.BitVec.extractLsb divuw_input.r1_val 31 0).toNat = (v.c_0 r_a).val + (v.c_
+ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 021 h_rs2_value [bridge] (Sail.BitVec.extractLsb divuw_input.r2_val 31 0).toNat = (v.b_0 r_a).val + (v.b_
+ZiskFv.Compliance.FromTrust.Divuw.equiv_DIVUW_from_trust 022 h_op2_ne [bridge] (Sail.BitVec.extractLsb divuw_input.r2_val 31 0).toNat ≠ 0
 ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 001 divw_input [other] PureSpec.DivwInput
 ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 002 r1 [other] regidx
@@ -500,32 +300,18 @@ ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 012 r_a [other] ℕ
 ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 013 h_main_active [match] m.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 014 h_main_op_divw [match] m.op r_main = OP_DIV_W
 ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 015 h_match_primary [other] matches_entry (opBus_row_Main m r_main) (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 016 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok divw_input.r1_val state
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 017 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok divw_input.r2_val state
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 018 h_input_rd [transpile] divw_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 019 h_input_pc [state] state.regs.get? Register.PC = .some divw_input.PC
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 020 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 021 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 022 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 023 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 024 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 025 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 026 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 027 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 028 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 029 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 030 h_rd_idx [transpile] divw_input.rd = Transpiler.wrap_to_regidx e2.ptr
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 031 h_row_constraints [other] ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 032 _ [other] CIRCUIT-CONSTRAINT — caller-supplied
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 033 h_na_bool [other] v.na r_a = 0 ∨ v.na r_a = 1
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 034 h_nb_bool [other] v.nb r_a = 0 ∨ v.nb r_a = 1
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 035 h_nr_bool [other] v.nr r_a = 0 ∨ v.nr r_a = 1
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 036 h_np_xor [other] toIntZ (v.np r_a) = toIntZ (v.na r_a) + toIntZ (v.nb r_a) - 2 * toIntZ (v.na r_a
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 037 h_sext_choice [other] ((e2.x4.val = 0 ∧ e2.x5.val = 0 ∧ e2.x6.val = 0 ∧ e2.x7.val = 0) ∧ (v.a_0 r_a).v
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 038 h_rs1_value [bridge] (Sail.BitVec.extractLsb divw_input.r1_val 31 0).toInt = ((v.c_0 r_a).val + (v.c_
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 039 h_rs2_value [bridge] (Sail.BitVec.extractLsb divw_input.r2_val 31 0).toInt = ((v.b_0 r_a).val + (v.b_
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 040 h_op2_ne [bridge] Sail.BitVec.extractLsb divw_input.r2_val 31 0 ≠ 0#32
-ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 041 h_no_overflow [bridge] ¬ (Sail.BitVec.extractLsb divw_input.r1_val 31 0 = BitVec.ofNat 32 (2^31) ∧ Sail
+ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 016 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state divw_input.r1_val divw_input.r2_
+ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 017 h_row_constraints [other] ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a
+ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 018 _ [other] CIRCUIT-CONSTRAINT — caller-supplied
+ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 019 h_na_bool [other] v.na r_a = 0 ∨ v.na r_a = 1
+ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 020 h_nb_bool [other] v.nb r_a = 0 ∨ v.nb r_a = 1
+ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 021 h_nr_bool [other] v.nr r_a = 0 ∨ v.nr r_a = 1
+ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 022 h_np_xor [other] toIntZ (v.np r_a) = toIntZ (v.na r_a) + toIntZ (v.nb r_a) - 2 * toIntZ (v.na r_a
+ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 023 h_sext_choice [other] ((e2.x4.val = 0 ∧ e2.x5.val = 0 ∧ e2.x6.val = 0 ∧ e2.x7.val = 0) ∧ (v.a_0 r_a).v
+ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 024 h_rs1_value [bridge] (Sail.BitVec.extractLsb divw_input.r1_val 31 0).toInt = ((v.c_0 r_a).val + (v.c_
+ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 025 h_rs2_value [bridge] (Sail.BitVec.extractLsb divw_input.r2_val 31 0).toInt = ((v.b_0 r_a).val + (v.b_
+ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 026 h_op2_ne [bridge] Sail.BitVec.extractLsb divw_input.r2_val 31 0 ≠ 0#32
+ZiskFv.Compliance.FromTrust.Divw.equiv_DIVW_from_trust 027 h_no_overflow [bridge] ¬ (Sail.BitVec.extractLsb divw_input.r1_val 31 0 = BitVec.ofNat 32 (2^31) ∧ Sail
 ZiskFv.Compliance.FromTrust.Fence.equiv_FENCE_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Fence.equiv_FENCE_from_trust 001 fence_input [other] PureSpec.FenceInput
 ZiskFv.Compliance.FromTrust.Fence.equiv_FENCE_from_trust 002 fm [other] BitVec 4
@@ -539,13 +325,8 @@ ZiskFv.Compliance.FromTrust.Fence.equiv_FENCE_from_trust 009 exec_row [entry] Li
 ZiskFv.Compliance.FromTrust.Fence.equiv_FENCE_from_trust 010 _ [other] Compliance-handshake; tracked here -- for uniformity but not consumed by the pro
 ZiskFv.Compliance.FromTrust.Fence.equiv_FENCE_from_trust 011 _h_main_active [match] main.is_external_op r_main = 0
 ZiskFv.Compliance.FromTrust.Fence.equiv_FENCE_from_trust 012 _h_main_op_fence [match] main.op r_main = OP_FLAG
-ZiskFv.Compliance.FromTrust.Fence.equiv_FENCE_from_trust 013 _ [other] SPEC-PRE
-ZiskFv.Compliance.FromTrust.Fence.equiv_FENCE_from_trust 014 h_input_pc [state] state.regs.get? Register.PC = .some fence_input.PC
-ZiskFv.Compliance.FromTrust.Fence.equiv_FENCE_from_trust 015 h_input_priv [state] state.regs.get? Register.cur_privilege = .some Privilege.Machine
-ZiskFv.Compliance.FromTrust.Fence.equiv_FENCE_from_trust 016 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Fence.equiv_FENCE_from_trust 017 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Fence.equiv_FENCE_from_trust 018 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Fence.equiv_FENCE_from_trust 019 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
+ZiskFv.Compliance.FromTrust.Fence.equiv_FENCE_from_trust 013 _ [other] 6 fields, see Promises/Fence.lean
+ZiskFv.Compliance.FromTrust.Fence.equiv_FENCE_from_trust 014 promises [transpile] ZiskFv.Equivalence.Promises.FencePromises state fence_input.PC (PureSpec.execute
 ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 001 jal_input [other] PureSpec.JalInput
 ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 002 imm [other] BitVec 21
@@ -557,32 +338,15 @@ ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 007 next_pc [other] FGL
 ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 008 exec_row [entry] List (Interaction.ExecutionBusEntry FGL)
 ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 009 e_rd [entry] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 010 nextPC_val [other] BitVec 64
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 011 _ [other] Compliance ROM handshake
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 012 h_main_active [match] m.is_external_op r_main = 0
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 013 h_main_op_jal [match] m.op r_main = OP_FLAG
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 014 _ [other] universal-row Main validity
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 015 h_jal_subset [other] ZiskFv.Airs.Main.jump_subset_holds m r_main next_pc
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 016 _ [other] SPEC-PRE
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 017 h_input_imm [other] jal_input.imm = imm
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 018 h_input_rd [transpile] jal_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 019 h_input_pc [state] state.regs.get? Register.PC = .some jal_input.PC
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 020 h_input_misa [state] state.regs.get? Register.misa = .some misa_val
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 021 h_misa_c [other] Sail.BitVec.extractLsb misa_val 2 2 = 0#1
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 022 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 023 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 024 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 025 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = nextPC_val
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 026 h_rd_mult [bus_shape] e_rd.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 027 h_rd_as [bus_shape] e_rd.as.val = 1
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 028 ZisK [other] branch targets aligned
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 029 SPEC-PRE [other] branch targets aligned
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 030 h_not_throws [other] (PureSpec.execute_JAL_pure jal_input).throws = false
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 031 h_success [other] (PureSpec.execute_JAL_pure jal_input).success = true
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 032 h_nextPC_option [transpile] (PureSpec.execute_JAL_pure jal_input).nextPC = .some nextPC_val
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 033 h_rd_idx [transpile] jal_input.rd = Transpiler.wrap_to_regidx e_rd.ptr
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 034 h_pc_bound [other] jal_input.PC.toNat < GL_prime - 4
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 035 h_lo_bound [range] (m.pc r_main + 4 : FGL).val < 4294967296
-ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 036 h_pc_offset_lt_2_32 [range] (jal_input.PC + 4#64).toNat < 4294967296
+ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 011 h_main_active [match] m.is_external_op r_main = 0
+ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 012 h_main_op_jal [match] m.op r_main = OP_FLAG
+ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 013 h_jal_subset [other] ZiskFv.Airs.Main.jump_subset_holds m r_main next_pc
+ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 014 promises [transpile] ZiskFv.Equivalence.Promises.JumpPromises state jal_input.PC jal_input.rd misa_va
+ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 015 h_input_imm [other] jal_input.imm = imm
+ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 016 h_not_throws [other] (PureSpec.execute_JAL_pure jal_input).throws = false
+ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 017 h_pc_bound [other] jal_input.PC.toNat < GL_prime - 4
+ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 018 h_lo_bound [range] (m.pc r_main + 4 : FGL).val < 4294967296
+ZiskFv.Compliance.FromTrust.Jal.equiv_JAL_from_trust 019 h_pc_offset_lt_2_32 [range] (jal_input.PC + 4#64).toNat < 4294967296
 ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 001 jalr_input [other] PureSpec.JalrInput
 ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 002 imm [other] BitVec 12
@@ -596,32 +360,17 @@ ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 009 nextPC_val [other] Bi
 ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 010 m [validator] Valid_Main C FGL FGL
 ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 011 r_main [row] ℕ
 ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 012 next_pc [other] FGL
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 013 _ [other] Compliance ROM handshake
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 014 h_main_active [match] m.is_external_op r_main = 0
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 015 h_main_op_jalr [match] m.op r_main = OP_COPYB
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 016 h_jalr_subset [other] ZiskFv.Tactics.JumpArchetype.jalr_subset_holds m r_main next_pc
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 017 _ [other] SPEC-PRE
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 018 h_input_imm [other] jalr_input.imm = imm
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 019 h_input_rd [transpile] jalr_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 020 h_input_rs1 [state] read_xreg (regidx_to_fin rs1) state = EStateM.Result.ok jalr_input.rs1_val state
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 021 h_input_pc [state] state.regs.get? Register.PC = .some jalr_input.PC
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 022 h_input_misa [state] state.regs.get? Register.misa = .some misa_val
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 023 h_misa_c [other] Sail.BitVec.extractLsb misa_val 2 2 = 0#1
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 024 h_cur_privilege [other] Sail.readReg Register.cur_privilege state = EStateM.Result.ok Privilege.Machine 
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 025 h_mseccfg [other] Sail.readReg Register.mseccfg state = EStateM.Result.ok mseccfg state
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 026 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 027 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 028 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 029 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = nextPC_val
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 030 h_rd_mult [bus_shape] e_rd.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 031 h_rd_as [bus_shape] e_rd.as.val = 1
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 032 _ [other] ZisK target-aligned SPEC-PRE
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 033 h_success [other] (PureSpec.execute_JALR_pure jalr_input).success = true
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 034 h_nextPC_option [transpile] (PureSpec.execute_JALR_pure jalr_input).nextPC = .some nextPC_val
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 035 h_rd_idx [transpile] jalr_input.rd = Transpiler.wrap_to_regidx e_rd.ptr
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 036 h_pc_bound [other] jalr_input.PC.toNat < GL_prime - 4
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 037 h_lo_bound [range] (m.pc r_main + 4 : FGL).val < 4294967296
-ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 038 h_pc_offset_lt_2_32 [range] (jalr_input.PC + 4#64).toNat < 4294967296
+ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 013 h_main_active [match] m.is_external_op r_main = 0
+ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 014 h_main_op_jalr [match] m.op r_main = OP_COPYB
+ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 015 h_jalr_subset [other] ZiskFv.Tactics.JumpArchetype.jalr_subset_holds m r_main next_pc
+ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 016 promises [transpile] ZiskFv.Equivalence.Promises.JumpPromises state jalr_input.PC jalr_input.rd misa_
+ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 017 h_input_imm [other] jalr_input.imm = imm
+ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 018 h_input_rs1 [state] read_xreg (regidx_to_fin rs1) state = EStateM.Result.ok jalr_input.rs1_val state
+ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 019 h_cur_privilege [other] Sail.readReg Register.cur_privilege state = EStateM.Result.ok Privilege.Machine 
+ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 020 h_mseccfg [other] Sail.readReg Register.mseccfg state = EStateM.Result.ok mseccfg state
+ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 021 h_pc_bound [other] jalr_input.PC.toNat < GL_prime - 4
+ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 022 h_lo_bound [range] (m.pc r_main + 4 : FGL).val < 4294967296
+ZiskFv.Compliance.FromTrust.Jalr.equiv_JALR_from_trust 023 h_pc_offset_lt_2_32 [range] (jalr_input.PC + 4#64).toNat < 4294967296
 ZiskFv.Compliance.FromTrust.Lb.equiv_LB_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Lb.equiv_LB_from_trust 001 lb_input [other] PureSpec.LbInput
 ZiskFv.Compliance.FromTrust.Lb.equiv_LB_from_trust 002 mstatus [other] RegisterType Register.mstatus
@@ -639,19 +388,8 @@ ZiskFv.Compliance.FromTrust.Lb.equiv_LB_from_trust 013 e2 [loose] Interaction.Me
 ZiskFv.Compliance.FromTrust.Lb.equiv_LB_from_trust 014 _ [other] Compliance ROM handshake
 ZiskFv.Compliance.FromTrust.Lb.equiv_LB_from_trust 015 h_main_active [match] main.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.Lb.equiv_LB_from_trust 016 h_main_op [match] main.op r_main = ZiskFv.Trusted.OP_SIGNEXTEND_B
-ZiskFv.Compliance.FromTrust.Lb.equiv_LB_from_trust 017 _ [other] SPEC-PRE
-ZiskFv.Compliance.FromTrust.Lb.equiv_LB_from_trust 018 risc_v_assumptions [state] RISC_V_assumptions state mstatus pmaRegion misa mseccfg
-ZiskFv.Compliance.FromTrust.Lb.equiv_LB_from_trust 019 h_opcode_assumptions [other] PureSpec.lb_state_assumptions lb_input state
-ZiskFv.Compliance.FromTrust.Lb.equiv_LB_from_trust 020 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Lb.equiv_LB_from_trust 021 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Lb.equiv_LB_from_trust 022 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Lb.equiv_LB_from_trust 023 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Lb.equiv_LB_from_trust 024 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Lb.equiv_LB_from_trust 025 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Lb.equiv_LB_from_trust 026 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Lb.equiv_LB_from_trust 027 h_m1_as [bus_shape] e1.as.val = 2
-ZiskFv.Compliance.FromTrust.Lb.equiv_LB_from_trust 028 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Lb.equiv_LB_from_trust 029 h_m2_as [bus_shape] e2.as.val = 1
+ZiskFv.Compliance.FromTrust.Lb.equiv_LB_from_trust 017 _ [other] 12 fields, see Promises/Load.lean
+ZiskFv.Compliance.FromTrust.Lb.equiv_LB_from_trust 018 promises [transpile] ZiskFv.Equivalence.Promises.LoadPromises state mstatus pmaRegion misa mseccfg (P
 ZiskFv.Compliance.FromTrust.Lbu.equiv_LBU_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Lbu.equiv_LBU_from_trust 001 lbu_input [other] PureSpec.LbuInput
 ZiskFv.Compliance.FromTrust.Lbu.equiv_LBU_from_trust 002 mstatus [other] RegisterType Register.mstatus
@@ -673,19 +411,8 @@ ZiskFv.Compliance.FromTrust.Lbu.equiv_LBU_from_trust 017 _ [other] Compliance RO
 ZiskFv.Compliance.FromTrust.Lbu.equiv_LBU_from_trust 018 h_main_active [match] main.is_external_op r_main = 0
 ZiskFv.Compliance.FromTrust.Lbu.equiv_LBU_from_trust 019 h_main_op_lbu [match] main.op r_main = OP_COPYB
 ZiskFv.Compliance.FromTrust.Lbu.equiv_LBU_from_trust 020 h_width [match] main.ind_width r_main = (1 : FGL)
-ZiskFv.Compliance.FromTrust.Lbu.equiv_LBU_from_trust 021 _ [other] SPEC-PRE
-ZiskFv.Compliance.FromTrust.Lbu.equiv_LBU_from_trust 022 risc_v_assumptions [state] RISC_V_assumptions state mstatus pmaRegion misa mseccfg
-ZiskFv.Compliance.FromTrust.Lbu.equiv_LBU_from_trust 023 h_opcode_assumptions [other] PureSpec.lbu_state_assumptions lbu_input state
-ZiskFv.Compliance.FromTrust.Lbu.equiv_LBU_from_trust 024 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Lbu.equiv_LBU_from_trust 025 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Lbu.equiv_LBU_from_trust 026 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Lbu.equiv_LBU_from_trust 027 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Lbu.equiv_LBU_from_trust 028 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Lbu.equiv_LBU_from_trust 029 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Lbu.equiv_LBU_from_trust 030 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Lbu.equiv_LBU_from_trust 031 h_m1_as [bus_shape] e1.as.val = 2
-ZiskFv.Compliance.FromTrust.Lbu.equiv_LBU_from_trust 032 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Lbu.equiv_LBU_from_trust 033 h_m2_as [bus_shape] e2.as.val = 1
+ZiskFv.Compliance.FromTrust.Lbu.equiv_LBU_from_trust 021 _ [other] 12 fields, see Promises/Load.lean
+ZiskFv.Compliance.FromTrust.Lbu.equiv_LBU_from_trust 022 promises [transpile] ZiskFv.Equivalence.Promises.LoadPromises state mstatus pmaRegion misa mseccfg (P
 ZiskFv.Compliance.FromTrust.Ld.equiv_LD_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Ld.equiv_LD_from_trust 001 ld_input [other] PureSpec.LdInput
 ZiskFv.Compliance.FromTrust.Ld.equiv_LD_from_trust 002 mstatus [other] RegisterType Register.mstatus
@@ -702,19 +429,8 @@ ZiskFv.Compliance.FromTrust.Ld.equiv_LD_from_trust 012 e1 [loose] Interaction.Me
 ZiskFv.Compliance.FromTrust.Ld.equiv_LD_from_trust 013 e2 [loose] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.Ld.equiv_LD_from_trust 014 h_main_active [match] main.is_external_op r_main = 0
 ZiskFv.Compliance.FromTrust.Ld.equiv_LD_from_trust 015 h_main_op_ld [match] main.op r_main = OP_COPYB
-ZiskFv.Compliance.FromTrust.Ld.equiv_LD_from_trust 016 _ [other] SPEC-PRE
-ZiskFv.Compliance.FromTrust.Ld.equiv_LD_from_trust 017 risc_v_assumptions [state] RISC_V_assumptions state mstatus pmaRegion misa mseccfg
-ZiskFv.Compliance.FromTrust.Ld.equiv_LD_from_trust 018 h_opcode_assumptions [other] PureSpec.ld_state_assumptions ld_input state
-ZiskFv.Compliance.FromTrust.Ld.equiv_LD_from_trust 019 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Ld.equiv_LD_from_trust 020 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Ld.equiv_LD_from_trust 021 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Ld.equiv_LD_from_trust 022 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Ld.equiv_LD_from_trust 023 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Ld.equiv_LD_from_trust 024 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Ld.equiv_LD_from_trust 025 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Ld.equiv_LD_from_trust 026 h_m1_as [bus_shape] e1.as.val = 2
-ZiskFv.Compliance.FromTrust.Ld.equiv_LD_from_trust 027 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Ld.equiv_LD_from_trust 028 h_m2_as [bus_shape] e2.as.val = 1
+ZiskFv.Compliance.FromTrust.Ld.equiv_LD_from_trust 016 _ [other] 12 fields, see Promises/Load.lean
+ZiskFv.Compliance.FromTrust.Ld.equiv_LD_from_trust 017 promises [transpile] ZiskFv.Equivalence.Promises.LoadPromises state mstatus pmaRegion misa mseccfg (P
 ZiskFv.Compliance.FromTrust.Lh.equiv_LH_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Lh.equiv_LH_from_trust 001 lh_input [other] PureSpec.LhInput
 ZiskFv.Compliance.FromTrust.Lh.equiv_LH_from_trust 002 mstatus [other] RegisterType Register.mstatus
@@ -732,19 +448,8 @@ ZiskFv.Compliance.FromTrust.Lh.equiv_LH_from_trust 013 e2 [loose] Interaction.Me
 ZiskFv.Compliance.FromTrust.Lh.equiv_LH_from_trust 014 _ [other] Compliance ROM handshake
 ZiskFv.Compliance.FromTrust.Lh.equiv_LH_from_trust 015 h_main_active [match] main.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.Lh.equiv_LH_from_trust 016 h_main_op [match] main.op r_main = ZiskFv.Trusted.OP_SIGNEXTEND_H
-ZiskFv.Compliance.FromTrust.Lh.equiv_LH_from_trust 017 _ [other] SPEC-PRE
-ZiskFv.Compliance.FromTrust.Lh.equiv_LH_from_trust 018 risc_v_assumptions [state] RISC_V_assumptions state mstatus pmaRegion misa mseccfg
-ZiskFv.Compliance.FromTrust.Lh.equiv_LH_from_trust 019 h_opcode_assumptions [other] PureSpec.lh_state_assumptions lh_input state
-ZiskFv.Compliance.FromTrust.Lh.equiv_LH_from_trust 020 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Lh.equiv_LH_from_trust 021 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Lh.equiv_LH_from_trust 022 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Lh.equiv_LH_from_trust 023 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Lh.equiv_LH_from_trust 024 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Lh.equiv_LH_from_trust 025 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Lh.equiv_LH_from_trust 026 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Lh.equiv_LH_from_trust 027 h_m1_as [bus_shape] e1.as.val = 2
-ZiskFv.Compliance.FromTrust.Lh.equiv_LH_from_trust 028 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Lh.equiv_LH_from_trust 029 h_m2_as [bus_shape] e2.as.val = 1
+ZiskFv.Compliance.FromTrust.Lh.equiv_LH_from_trust 017 _ [other] 12 fields, see Promises/Load.lean
+ZiskFv.Compliance.FromTrust.Lh.equiv_LH_from_trust 018 promises [transpile] ZiskFv.Equivalence.Promises.LoadPromises state mstatus pmaRegion misa mseccfg (P
 ZiskFv.Compliance.FromTrust.Lhu.equiv_LHU_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Lhu.equiv_LHU_from_trust 001 lhu_input [other] PureSpec.LhuInput
 ZiskFv.Compliance.FromTrust.Lhu.equiv_LHU_from_trust 002 mstatus [other] RegisterType Register.mstatus
@@ -765,43 +470,21 @@ ZiskFv.Compliance.FromTrust.Lhu.equiv_LHU_from_trust 016 e2 [loose] Interaction.
 ZiskFv.Compliance.FromTrust.Lhu.equiv_LHU_from_trust 017 h_main_active [match] main.is_external_op r_main = 0
 ZiskFv.Compliance.FromTrust.Lhu.equiv_LHU_from_trust 018 h_main_op_lhu [match] main.op r_main = OP_COPYB
 ZiskFv.Compliance.FromTrust.Lhu.equiv_LHU_from_trust 019 h_width [match] main.ind_width r_main = (2 : FGL)
-ZiskFv.Compliance.FromTrust.Lhu.equiv_LHU_from_trust 020 risc_v_assumptions [state] RISC_V_assumptions state mstatus pmaRegion misa mseccfg
-ZiskFv.Compliance.FromTrust.Lhu.equiv_LHU_from_trust 021 h_opcode_assumptions [other] PureSpec.lhu_state_assumptions lhu_input state
-ZiskFv.Compliance.FromTrust.Lhu.equiv_LHU_from_trust 022 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Lhu.equiv_LHU_from_trust 023 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Lhu.equiv_LHU_from_trust 024 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Lhu.equiv_LHU_from_trust 025 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Lhu.equiv_LHU_from_trust 026 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Lhu.equiv_LHU_from_trust 027 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Lhu.equiv_LHU_from_trust 028 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Lhu.equiv_LHU_from_trust 029 h_m1_as [bus_shape] e1.as.val = 2
-ZiskFv.Compliance.FromTrust.Lhu.equiv_LHU_from_trust 030 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Lhu.equiv_LHU_from_trust 031 h_m2_as [bus_shape] e2.as.val = 1
+ZiskFv.Compliance.FromTrust.Lhu.equiv_LHU_from_trust 020 promises [transpile] ZiskFv.Equivalence.Promises.LoadPromises state mstatus pmaRegion misa mseccfg (P
 ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 001 lui_input [other] PureSpec.LuiInput
 ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 002 imm [other] BitVec 20
 ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 003 rd [other] regidx
-ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 004 _ [other] m
-ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 005 m [validator] Valid_Main C FGL FGL
-ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 006 r_main [row] ℕ
-ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 007 next_pc [other] FGL
-ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 008 exec_row [entry] List (Interaction.ExecutionBusEntry FGL)
-ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 009 e_rd [entry] Interaction.MemoryBusEntry FGL
+ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 004 m [validator] Valid_Main C FGL FGL
+ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 005 r_main [row] ℕ
+ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 006 next_pc [other] FGL
+ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 007 exec_row [entry] List (Interaction.ExecutionBusEntry FGL)
+ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 008 e_rd [entry] Interaction.MemoryBusEntry FGL
+ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 009 _ [other] consumed by the UTypeHelpers helper that fires `transpile_LUI`
 ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 010 h_main_active [match] m.is_external_op r_main = 0
 ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 011 h_main_op_lui [match] m.op r_main = OP_COPYB
-ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 012 _ [other] shared across all ControlFlow non-branch opcodes -- AND the UTYPE shape's twin A
-ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 013 h_lui_subset [other] lui_subset_holds m r_main next_pc
-ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 014 _ [other] SPEC-PRE
-ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 015 h_input_imm [other] lui_input.imm = imm
-ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 016 h_input_rd [transpile] lui_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 017 h_input_pc [state] state.regs.get? Register.PC = .some lui_input.PC
-ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 018 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 019 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 020 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 021 h_nextPC_matches [other] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = lui_input.P
-ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 022 h_rd_mult [bus_shape] e_rd.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 023 h_rd_as [bus_shape] e_rd.as.val = 1
-ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 024 h_rd_idx [transpile] lui_input.rd = Transpiler.wrap_to_regidx e_rd.ptr
+ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 012 h_lui_subset [other] lui_subset_holds m r_main next_pc
+ZiskFv.Compliance.FromTrust.Lui.equiv_LUI_from_trust 013 promises [transpile] ZiskFv.Equivalence.Promises.UTypePromises state lui_input.imm lui_input.rd lui_i
 ZiskFv.Compliance.FromTrust.Lw.equiv_LW_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Lw.equiv_LW_from_trust 001 lw_input [other] PureSpec.LwInput
 ZiskFv.Compliance.FromTrust.Lw.equiv_LW_from_trust 002 mstatus [other] RegisterType Register.mstatus
@@ -819,19 +502,8 @@ ZiskFv.Compliance.FromTrust.Lw.equiv_LW_from_trust 013 e2 [loose] Interaction.Me
 ZiskFv.Compliance.FromTrust.Lw.equiv_LW_from_trust 014 _ [other] Compliance ROM handshake
 ZiskFv.Compliance.FromTrust.Lw.equiv_LW_from_trust 015 h_main_active [match] main.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.Lw.equiv_LW_from_trust 016 h_main_op [match] main.op r_main = ZiskFv.Trusted.OP_SIGNEXTEND_W
-ZiskFv.Compliance.FromTrust.Lw.equiv_LW_from_trust 017 _ [other] SPEC-PRE
-ZiskFv.Compliance.FromTrust.Lw.equiv_LW_from_trust 018 risc_v_assumptions [state] RISC_V_assumptions state mstatus pmaRegion misa mseccfg
-ZiskFv.Compliance.FromTrust.Lw.equiv_LW_from_trust 019 h_opcode_assumptions [other] PureSpec.lw_state_assumptions lw_input state
-ZiskFv.Compliance.FromTrust.Lw.equiv_LW_from_trust 020 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Lw.equiv_LW_from_trust 021 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Lw.equiv_LW_from_trust 022 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Lw.equiv_LW_from_trust 023 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Lw.equiv_LW_from_trust 024 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Lw.equiv_LW_from_trust 025 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Lw.equiv_LW_from_trust 026 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Lw.equiv_LW_from_trust 027 h_m1_as [bus_shape] e1.as.val = 2
-ZiskFv.Compliance.FromTrust.Lw.equiv_LW_from_trust 028 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Lw.equiv_LW_from_trust 029 h_m2_as [bus_shape] e2.as.val = 1
+ZiskFv.Compliance.FromTrust.Lw.equiv_LW_from_trust 017 _ [other] 12 fields, see Promises/Load.lean
+ZiskFv.Compliance.FromTrust.Lw.equiv_LW_from_trust 018 promises [transpile] ZiskFv.Equivalence.Promises.LoadPromises state mstatus pmaRegion misa mseccfg (P
 ZiskFv.Compliance.FromTrust.Lwu.equiv_LWU_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Lwu.equiv_LWU_from_trust 001 lwu_input [other] PureSpec.LwuInput
 ZiskFv.Compliance.FromTrust.Lwu.equiv_LWU_from_trust 002 mstatus [other] RegisterType Register.mstatus
@@ -852,18 +524,7 @@ ZiskFv.Compliance.FromTrust.Lwu.equiv_LWU_from_trust 016 e2 [loose] Interaction.
 ZiskFv.Compliance.FromTrust.Lwu.equiv_LWU_from_trust 017 h_main_active [match] main.is_external_op r_main = 0
 ZiskFv.Compliance.FromTrust.Lwu.equiv_LWU_from_trust 018 h_main_op_lwu [match] main.op r_main = OP_COPYB
 ZiskFv.Compliance.FromTrust.Lwu.equiv_LWU_from_trust 019 h_width [match] main.ind_width r_main = (4 : FGL)
-ZiskFv.Compliance.FromTrust.Lwu.equiv_LWU_from_trust 020 risc_v_assumptions [state] RISC_V_assumptions state mstatus pmaRegion misa mseccfg
-ZiskFv.Compliance.FromTrust.Lwu.equiv_LWU_from_trust 021 h_opcode_assumptions [other] PureSpec.lwu_state_assumptions lwu_input state
-ZiskFv.Compliance.FromTrust.Lwu.equiv_LWU_from_trust 022 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Lwu.equiv_LWU_from_trust 023 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Lwu.equiv_LWU_from_trust 024 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Lwu.equiv_LWU_from_trust 025 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Lwu.equiv_LWU_from_trust 026 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Lwu.equiv_LWU_from_trust 027 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Lwu.equiv_LWU_from_trust 028 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Lwu.equiv_LWU_from_trust 029 h_m1_as [bus_shape] e1.as.val = 2
-ZiskFv.Compliance.FromTrust.Lwu.equiv_LWU_from_trust 030 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Lwu.equiv_LWU_from_trust 031 h_m2_as [bus_shape] e2.as.val = 1
+ZiskFv.Compliance.FromTrust.Lwu.equiv_LWU_from_trust 020 promises [transpile] ZiskFv.Equivalence.Promises.LoadPromises state mstatus pmaRegion misa mseccfg (P
 ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 001 mul_input [other] PureSpec.MulInput
 ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 002 r1 [other] regidx
@@ -882,30 +543,16 @@ ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 014 r_a [other] ℕ
 ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 015 h_main_active [match] m.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 016 h_main_op_mul [match] m.op r_main = OP_MUL
 ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 017 h_match_primary [other] matches_entry (opBus_row_Main m r_main) (opBus_row_Arith v r_a)
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 018 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok mul_input.r1_val state
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 019 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok mul_input.r2_val state
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 020 h_input_rd [transpile] mul_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 021 h_input_pc [state] state.regs.get? Register.PC = .some mul_input.PC
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 022 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 023 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 024 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 025 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 026 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 027 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 028 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 029 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 030 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 031 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 032 h_rd_idx [transpile] mul_input.rd = Transpiler.wrap_to_regidx e2.ptr
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 033 h0 [range] e2.x0.val < 256
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 034 h1 [range] e2.x1.val < 256
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 035 h2 [range] e2.x2.val < 256
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 036 h3 [range] e2.x3.val < 256
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 037 h4 [range] e2.x4.val < 256
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 038 h5 [range] e2.x5.val < 256
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 039 h6 [range] e2.x6.val < 256
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 040 h7 [range] e2.x7.val < 256
-ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 041 h_row_constraints [other] ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a
+ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 018 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state mul_input.r1_val mul_input.r2_va
+ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 019 h0 [range] e2.x0.val < 256
+ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 020 h1 [range] e2.x1.val < 256
+ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 021 h2 [range] e2.x2.val < 256
+ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 022 h3 [range] e2.x3.val < 256
+ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 023 h4 [range] e2.x4.val < 256
+ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 024 h5 [range] e2.x5.val < 256
+ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 025 h6 [range] e2.x6.val < 256
+ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 026 h7 [range] e2.x7.val < 256
+ZiskFv.Compliance.FromTrust.Mul.equiv_MUL_from_trust 027 h_row_constraints [other] ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a
 ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 001 mulh_input [other] PureSpec.MulhInput
 ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 002 r1 [other] regidx
@@ -922,22 +569,8 @@ ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 012 r_a [other] ℕ
 ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 013 h_main_active [match] m.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 014 h_main_op_mulh [match] m.op r_main = OP_MULH
 ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 015 h_match_secondary [other] matches_entry (opBus_row_Main m r_main) (opBus_row_ArithMulSecondary v r_a)
-ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 016 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok mulh_input.r1_val state
-ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 017 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok mulh_input.r2_val state
-ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 018 h_input_rd [transpile] mulh_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 019 h_input_pc [state] state.regs.get? Register.PC = .some mulh_input.PC
-ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 020 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 021 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 022 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 023 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 024 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 025 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 026 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 027 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 028 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 029 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 030 h_rd_idx [transpile] mulh_input.rd = Transpiler.wrap_to_regidx e2.ptr
-ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 031 h_row_constraints [other] ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a
+ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 016 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state mulh_input.r1_val mulh_input.r2_
+ZiskFv.Compliance.FromTrust.MulH.equiv_MULH_from_trust 017 h_row_constraints [other] ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a
 ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 001 mulhsu_input [other] PureSpec.MulhsuInput
 ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 002 r1 [other] regidx
@@ -954,22 +587,8 @@ ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 012 r_a [other] ℕ
 ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 013 h_main_active [match] m.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 014 h_main_op_mulhsu [match] m.op r_main = OP_MULSUH
 ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 015 h_match_secondary [other] matches_entry (opBus_row_Main m r_main) (opBus_row_ArithMulSecondary v r_a)
-ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 016 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok mulhsu_input.r1_val state
-ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 017 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok mulhsu_input.r2_val state
-ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 018 h_input_rd [transpile] mulhsu_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 019 h_input_pc [state] state.regs.get? Register.PC = .some mulhsu_input.PC
-ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 020 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 021 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 022 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 023 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 024 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 025 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 026 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 027 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 028 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 029 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 030 h_rd_idx [transpile] mulhsu_input.rd = Transpiler.wrap_to_regidx e2.ptr
-ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 031 h_row_constraints [other] ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a
+ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 016 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state mulhsu_input.r1_val mulhsu_input
+ZiskFv.Compliance.FromTrust.MulHSU.equiv_MULHSU_from_trust 017 h_row_constraints [other] ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a
 ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 001 mulhu_input [other] PureSpec.MulhuInput
 ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 002 r1 [other] regidx
@@ -986,30 +605,16 @@ ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 012 r_a [other] ℕ
 ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 013 h_main_active [match] m.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 014 h_main_op_mulhu [match] m.op r_main = OP_MULUH
 ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 015 h_match_secondary [other] matches_entry (opBus_row_Main m r_main) (opBus_row_ArithMulSecondary v r_a)
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 016 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok mulhu_input.r1_val state
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 017 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok mulhu_input.r2_val state
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 018 h_input_rd [transpile] mulhu_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 019 h_input_pc [state] state.regs.get? Register.PC = .some mulhu_input.PC
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 020 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 021 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 022 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 023 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 024 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 025 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 026 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 027 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 028 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 029 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 030 h_rd_idx [transpile] mulhu_input.rd = Transpiler.wrap_to_regidx e2.ptr
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 031 h0 [range] e2.x0.val < 256
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 032 h1 [range] e2.x1.val < 256
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 033 h2 [range] e2.x2.val < 256
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 034 h3 [range] e2.x3.val < 256
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 035 h4 [range] e2.x4.val < 256
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 036 h5 [range] e2.x5.val < 256
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 037 h6 [range] e2.x6.val < 256
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 038 h7 [range] e2.x7.val < 256
-ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 039 h_row_constraints [other] ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a
+ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 016 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state mulhu_input.r1_val mulhu_input.r
+ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 017 h0 [range] e2.x0.val < 256
+ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 018 h1 [range] e2.x1.val < 256
+ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 019 h2 [range] e2.x2.val < 256
+ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 020 h3 [range] e2.x3.val < 256
+ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 021 h4 [range] e2.x4.val < 256
+ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 022 h5 [range] e2.x5.val < 256
+ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 023 h6 [range] e2.x6.val < 256
+ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 024 h7 [range] e2.x7.val < 256
+ZiskFv.Compliance.FromTrust.MulHU.equiv_MULHU_from_trust 025 h_row_constraints [other] ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a
 ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 001 mulw_input [other] PureSpec.MulwInput
 ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 002 r1 [other] regidx
@@ -1026,26 +631,12 @@ ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 012 r_a [other] ℕ
 ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 013 h_main_active [match] m.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 014 h_main_op_mulw [match] m.op r_main = OP_MUL_W
 ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 015 h_match_primary [other] matches_entry (opBus_row_Main m r_main) (opBus_row_Arith v r_a)
-ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 016 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok mulw_input.r1_val state
-ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 017 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok mulw_input.r2_val state
-ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 018 h_input_rd [transpile] mulw_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 019 h_input_pc [state] state.regs.get? Register.PC = .some mulw_input.PC
-ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 020 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 021 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 022 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 023 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 024 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 025 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 026 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 027 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 028 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 029 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 030 h_rd_idx [transpile] mulw_input.rd = Transpiler.wrap_to_regidx e2.ptr
-ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 031 h_row_constraints [other] ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a
-ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 032 _ [other] W-mode sign-extension + W-form operand bridges
-ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 033 h_sext_choice [other] ((e2.x4.val = 0 ∧ e2.x5.val = 0 ∧ e2.x6.val = 0 ∧ e2.x7.val = 0) ∧ (v.c_0 r_a).v
-ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 034 h_rs1_value [bridge] (Sail.BitVec.extractLsb mulw_input.r1_val 31 0).toInt = ((v.a_0 r_a).val + (v.a_
-ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 035 h_rs2_value [bridge] (Sail.BitVec.extractLsb mulw_input.r2_val 31 0).toInt = ((v.b_0 r_a).val + (v.b_
+ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 016 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state mulw_input.r1_val mulw_input.r2_
+ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 017 h_row_constraints [other] ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a
+ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 018 _ [other] W-mode sign-extension + W-form operand bridges
+ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 019 h_sext_choice [other] ((e2.x4.val = 0 ∧ e2.x5.val = 0 ∧ e2.x6.val = 0 ∧ e2.x7.val = 0) ∧ (v.c_0 r_a).v
+ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 020 h_rs1_value [bridge] (Sail.BitVec.extractLsb mulw_input.r1_val 31 0).toInt = ((v.a_0 r_a).val + (v.a_
+ZiskFv.Compliance.FromTrust.MulW.equiv_MULW_from_trust 021 h_rs2_value [bridge] (Sail.BitVec.extractLsb mulw_input.r2_val 31 0).toInt = ((v.b_0 r_a).val + (v.b_
 ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 001 or_input [other] PureSpec.OrInput
 ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 002 r1 [other] regidx
@@ -1063,22 +654,8 @@ ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 013 e2 [loose] Interaction.Me
 ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 014 h_main_active [match] m.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 015 h_main_op_or [match] m.op r_main = OP_OR
 ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 016 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
-ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 017 _ [other] SPEC-PRE
-ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 018 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok or_input.r1_val state
-ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 019 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok or_input.r2_val state
-ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 020 h_input_rd [transpile] or_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 021 h_input_pc [state] state.regs.get? Register.PC = .some or_input.PC
-ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 022 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 023 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 024 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 025 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 026 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 027 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 028 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 029 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 030 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 031 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 032 h_rd_idx [transpile] or_input.rd = Transpiler.wrap_to_regidx e2.ptr
+ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 017 _ [other] 15 fields
+ZiskFv.Compliance.FromTrust.Or.equiv_OR_from_trust 018 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state or_input.r1_val or_input.r2_val 
 ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 001 ori_input [other] PureSpec.OriInput
 ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 002 r1 [other] regidx
@@ -1095,21 +672,7 @@ ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 012 h_main_active [match] m
 ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 013 h_main_op_ori [match] m.op r_main = OP_OR
 ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 014 h_ori_subset [other] itype_imm_subset_holds_main m r_main ori_input.imm
 ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 015 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
-ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 016 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok ori_input.r1_val state
-ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 017 h_input_imm [other] ori_input.imm = imm
-ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 018 h_input_rd [transpile] ori_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 019 h_input_pc [state] state.regs.get? Register.PC = .some ori_input.PC
-ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 020 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 021 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 022 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 023 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 024 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 025 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 026 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 027 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 028 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 029 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 030 h_rd_idx [transpile] ori_input.rd = Transpiler.wrap_to_regidx e2.ptr
+ZiskFv.Compliance.FromTrust.Ori.equiv_ORI_from_trust 016 promises [bridge] ZiskFv.Equivalence.Promises.ITypePromises state ori_input.r1_val ori_input.imm o
 ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 001 rem_input [other] PureSpec.RemInput
 ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 002 r1 [other] regidx
@@ -1126,28 +689,14 @@ ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 012 r_a [other] ℕ
 ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 013 h_main_active [match] m.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 014 h_main_op_rem [match] m.op r_main = OP_REM
 ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 015 h_match_secondary [other] matches_entry (opBus_row_Main m r_main) (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv
-ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 016 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 017 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 018 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 019 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 020 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 021 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 022 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 023 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 024 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 025 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 026 h_rd_idx [transpile] rem_input.rd = Transpiler.wrap_to_regidx e2.ptr
-ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 027 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok rem_input.r1_val state
-ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 028 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok rem_input.r2_val state
-ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 029 h_input_rd [transpile] rem_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 030 h_input_pc [state] state.regs.get? Register.PC = .some rem_input.PC
-ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 031 h_op2_ne [bridge] rem_input.r2_val.toInt ≠ 0
-ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 032 h_no_overflow [bridge] ¬ (rem_input.r1_val.toInt = -(2:ℤ)^63 ∧ rem_input.r2_val.toInt = -1)
-ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 033 h_row_constraints [other] ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a
-ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 034 h_na_bool [other] v.na r_a = 0 ∨ v.na r_a = 1
-ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 035 h_nb_bool [other] v.nb r_a = 0 ∨ v.nb r_a = 1
-ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 036 h_nr_bool [other] v.nr r_a = 0 ∨ v.nr r_a = 1
-ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 037 h_np_xor [other] toIntZ (v.np r_a) = toIntZ (v.na r_a) + toIntZ (v.nb r_a) - 2 * toIntZ (v.na r_a
+ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 016 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state rem_input.r1_val rem_input.r2_va
+ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 017 h_op2_ne [bridge] rem_input.r2_val.toInt ≠ 0
+ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 018 h_no_overflow [bridge] ¬ (rem_input.r1_val.toInt = -(2:ℤ)^63 ∧ rem_input.r2_val.toInt = -1)
+ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 019 h_row_constraints [other] ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a
+ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 020 h_na_bool [other] v.na r_a = 0 ∨ v.na r_a = 1
+ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 021 h_nb_bool [other] v.nb r_a = 0 ∨ v.nb r_a = 1
+ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 022 h_nr_bool [other] v.nr r_a = 0 ∨ v.nr r_a = 1
+ZiskFv.Compliance.FromTrust.Rem.equiv_REM_from_trust 023 h_np_xor [other] toIntZ (v.np r_a) = toIntZ (v.na r_a) + toIntZ (v.nb r_a) - 2 * toIntZ (v.na r_a
 ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 001 remu_input [other] PureSpec.RemuInput
 ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 002 r1 [other] regidx
@@ -1164,31 +713,17 @@ ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 012 r_a [other] ℕ
 ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 013 h_main_active [match] m.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 014 h_main_op_remu [match] m.op r_main = OP_REMU
 ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 015 h_match_secondary [other] matches_entry (opBus_row_Main m r_main) (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 016 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok remu_input.r1_val state
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 017 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok remu_input.r2_val state
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 018 h_input_rd [transpile] remu_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 019 h_input_pc [state] state.regs.get? Register.PC = .some remu_input.PC
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 020 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 021 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 022 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 023 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 024 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 025 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 026 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 027 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 028 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 029 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 030 h_rd_idx [transpile] remu_input.rd = Transpiler.wrap_to_regidx e2.ptr
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 031 h0 [range] e2.x0.val < 256
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 032 h1 [range] e2.x1.val < 256
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 033 h2 [range] e2.x2.val < 256
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 034 h3 [range] e2.x3.val < 256
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 035 h4 [range] e2.x4.val < 256
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 036 h5 [range] e2.x5.val < 256
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 037 h6 [range] e2.x6.val < 256
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 038 h7 [range] e2.x7.val < 256
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 039 h_row_constraints [other] ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a
-ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 040 h_op2_ne [bridge] remu_input.r2_val.toNat ≠ 0
+ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 016 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state remu_input.r1_val remu_input.r2_
+ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 017 h0 [range] e2.x0.val < 256
+ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 018 h1 [range] e2.x1.val < 256
+ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 019 h2 [range] e2.x2.val < 256
+ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 020 h3 [range] e2.x3.val < 256
+ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 021 h4 [range] e2.x4.val < 256
+ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 022 h5 [range] e2.x5.val < 256
+ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 023 h6 [range] e2.x6.val < 256
+ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 024 h7 [range] e2.x7.val < 256
+ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 025 h_row_constraints [other] ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a
+ZiskFv.Compliance.FromTrust.Remu.equiv_REMU_from_trust 026 h_op2_ne [bridge] remu_input.r2_val.toNat ≠ 0
 ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 001 remuw_input [other] PureSpec.RemuwInput
 ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 002 r1 [other] regidx
@@ -1205,27 +740,13 @@ ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 012 r_a [other] ℕ
 ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 013 h_main_active [match] m.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 014 h_main_op_remuw [match] m.op r_main = OP_REMU_W
 ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 015 h_match_secondary [other] matches_entry (opBus_row_Main m r_main) (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv
-ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 016 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok remuw_input.r1_val state
-ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 017 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok remuw_input.r2_val state
-ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 018 h_input_rd [transpile] remuw_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 019 h_input_pc [state] state.regs.get? Register.PC = .some remuw_input.PC
-ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 020 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 021 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 022 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 023 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 024 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 025 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 026 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 027 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 028 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 029 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 030 h_rd_idx [transpile] remuw_input.rd = Transpiler.wrap_to_regidx e2.ptr
-ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 031 h_row_constraints [other] ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a
-ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 032 _ [other] mirror DIVUW
-ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 033 h_sext_choice [other] ((e2.x4.val = 0 ∧ e2.x5.val = 0 ∧ e2.x6.val = 0 ∧ e2.x7.val = 0) ∧ (v.d_0 r_a).v
-ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 034 h_rs1_value [bridge] (Sail.BitVec.extractLsb remuw_input.r1_val 31 0).toNat = (v.c_0 r_a).val + (v.c_
-ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 035 h_rs2_value [bridge] (Sail.BitVec.extractLsb remuw_input.r2_val 31 0).toNat = (v.b_0 r_a).val + (v.b_
-ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 036 h_op2_ne [bridge] (Sail.BitVec.extractLsb remuw_input.r2_val 31 0).toNat ≠ 0
+ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 016 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state remuw_input.r1_val remuw_input.r
+ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 017 h_row_constraints [other] ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a
+ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 018 _ [other] mirror DIVUW
+ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 019 h_sext_choice [other] ((e2.x4.val = 0 ∧ e2.x5.val = 0 ∧ e2.x6.val = 0 ∧ e2.x7.val = 0) ∧ (v.d_0 r_a).v
+ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 020 h_rs1_value [bridge] (Sail.BitVec.extractLsb remuw_input.r1_val 31 0).toNat = (v.c_0 r_a).val + (v.c_
+ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 021 h_rs2_value [bridge] (Sail.BitVec.extractLsb remuw_input.r2_val 31 0).toNat = (v.b_0 r_a).val + (v.b_
+ZiskFv.Compliance.FromTrust.Remuw.equiv_REMUW_from_trust 022 h_op2_ne [bridge] (Sail.BitVec.extractLsb remuw_input.r2_val 31 0).toNat ≠ 0
 ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 001 remw_input [other] PureSpec.RemwInput
 ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 002 r1 [other] regidx
@@ -1242,32 +763,18 @@ ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 012 r_a [other] ℕ
 ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 013 h_main_active [match] m.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 014 h_main_op_remw [match] m.op r_main = OP_REM_W
 ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 015 h_match_secondary [other] matches_entry (opBus_row_Main m r_main) (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 016 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok remw_input.r1_val state
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 017 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok remw_input.r2_val state
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 018 h_input_rd [transpile] remw_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 019 h_input_pc [state] state.regs.get? Register.PC = .some remw_input.PC
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 020 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 021 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 022 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 023 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 024 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 025 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 026 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 027 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 028 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 029 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 030 h_rd_idx [transpile] remw_input.rd = Transpiler.wrap_to_regidx e2.ptr
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 031 h_row_constraints [other] ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 032 _ [other] CIRCUIT-CONSTRAINT — caller-supplied
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 033 h_na_bool [other] v.na r_a = 0 ∨ v.na r_a = 1
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 034 h_nb_bool [other] v.nb r_a = 0 ∨ v.nb r_a = 1
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 035 h_nr_bool [other] v.nr r_a = 0 ∨ v.nr r_a = 1
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 036 h_np_xor [other] toIntZ (v.np r_a) = toIntZ (v.na r_a) + toIntZ (v.nb r_a) - 2 * toIntZ (v.na r_a
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 037 h_sext_choice [other] ((e2.x4.val = 0 ∧ e2.x5.val = 0 ∧ e2.x6.val = 0 ∧ e2.x7.val = 0) ∧ (v.d_0 r_a).v
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 038 h_rs1_value [bridge] (Sail.BitVec.extractLsb remw_input.r1_val 31 0).toInt = ((v.c_0 r_a).val + (v.c_
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 039 h_rs2_value [bridge] (Sail.BitVec.extractLsb remw_input.r2_val 31 0).toInt = ((v.b_0 r_a).val + (v.b_
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 040 h_op2_ne [bridge] Sail.BitVec.extractLsb remw_input.r2_val 31 0 ≠ 0#32
-ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 041 h_no_overflow_w [bridge] ¬ (Sail.BitVec.extractLsb remw_input.r1_val 31 0 = (BitVec.ofNat 32 (2^31)) ∧ Sa
+ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 016 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state remw_input.r1_val remw_input.r2_
+ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 017 h_row_constraints [other] ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a
+ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 018 _ [other] CIRCUIT-CONSTRAINT — caller-supplied
+ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 019 h_na_bool [other] v.na r_a = 0 ∨ v.na r_a = 1
+ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 020 h_nb_bool [other] v.nb r_a = 0 ∨ v.nb r_a = 1
+ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 021 h_nr_bool [other] v.nr r_a = 0 ∨ v.nr r_a = 1
+ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 022 h_np_xor [other] toIntZ (v.np r_a) = toIntZ (v.na r_a) + toIntZ (v.nb r_a) - 2 * toIntZ (v.na r_a
+ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 023 h_sext_choice [other] ((e2.x4.val = 0 ∧ e2.x5.val = 0 ∧ e2.x6.val = 0 ∧ e2.x7.val = 0) ∧ (v.d_0 r_a).v
+ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 024 h_rs1_value [bridge] (Sail.BitVec.extractLsb remw_input.r1_val 31 0).toInt = ((v.c_0 r_a).val + (v.c_
+ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 025 h_rs2_value [bridge] (Sail.BitVec.extractLsb remw_input.r2_val 31 0).toInt = ((v.b_0 r_a).val + (v.b_
+ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 026 h_op2_ne [bridge] Sail.BitVec.extractLsb remw_input.r2_val 31 0 ≠ 0#32
+ZiskFv.Compliance.FromTrust.Remw.equiv_REMW_from_trust 027 h_no_overflow_w [bridge] ¬ (Sail.BitVec.extractLsb remw_input.r1_val 31 0 = (BitVec.ofNat 32 (2^31)) ∧ Sa
 ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 001 sb_input [other] PureSpec.SbInput
 ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 002 mstatus [other] RegisterType Register.mstatus
@@ -1280,22 +787,14 @@ ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 008 exec_row [entry] List (In
 ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 009 e0 [loose] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 010 e1 [loose] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 011 e2 [loose] Interaction.MemoryBusEntry FGL
-ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 012 h_main_active [match] main.is_external_op r_main = 0
-ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 013 h_main_op [match] main.op r_main = OP_COPYB
-ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 014 h_main_ind_width [match] main.ind_width r_main = 1
-ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 015 _ [other] SPEC-PRE
-ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 016 risc_v_assumptions [state] RISC_V_assumptions state mstatus pmaRegion misa mseccfg
+ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 012 _ [other] consumed by the -- StoreHelpers helper that transitively fires `transpile_SB` an
+ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 013 h_main_active [match] main.is_external_op r_main = 0
+ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 014 h_main_op [match] main.op r_main = OP_COPYB
+ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 015 h_main_ind_width [match] main.ind_width r_main = 1
+ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 016 _ [other] also consumed by the helper
 ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 017 h_opcode_assumptions [other] PureSpec.sb_state_assumptions sb_input state
-ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 018 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 019 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 020 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 021 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 022 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 023 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 024 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 025 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 026 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 027 h_m2_as [bus_shape] e2.as.val = 2
+ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 018 _ [other] 12 fields
+ZiskFv.Compliance.FromTrust.Sb.equiv_SB_from_trust 019 promises [transpile] ZiskFv.Equivalence.Promises.StorePromises state mstatus pmaRegion misa mseccfg (
 ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 001 sd_input [other] PureSpec.SdInput
 ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 002 mstatus [other] RegisterType Register.mstatus
@@ -1310,19 +809,9 @@ ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 010 e1 [loose] Interaction.Me
 ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 011 e2 [loose] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 012 h_main_active [match] main.is_external_op r_main = 0
 ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 013 h_main_op [match] main.op r_main = OP_COPYB
-ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 014 _ [other] SPEC-PRE
-ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 015 risc_v_assumptions [state] RISC_V_assumptions state mstatus pmaRegion misa mseccfg
-ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 016 h_opcode_assumptions [other] PureSpec.sd_state_assumptions sd_input state
-ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 017 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 018 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 019 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 020 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 021 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 022 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 023 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 024 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 025 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 026 h_m2_as [bus_shape] e2.as.val = 2
+ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 014 h_opcode_assumptions [other] PureSpec.sd_state_assumptions sd_input state
+ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 015 _ [other] 12 fields
+ZiskFv.Compliance.FromTrust.Sd.equiv_SD_from_trust 016 promises [transpile] ZiskFv.Equivalence.Promises.StorePromises state mstatus pmaRegion misa mseccfg (
 ZiskFv.Compliance.FromTrust.Sh.equiv_SH_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Sh.equiv_SH_from_trust 001 sh_input [other] PureSpec.ShInput
 ZiskFv.Compliance.FromTrust.Sh.equiv_SH_from_trust 002 mstatus [other] RegisterType Register.mstatus
@@ -1338,18 +827,9 @@ ZiskFv.Compliance.FromTrust.Sh.equiv_SH_from_trust 011 e2 [loose] Interaction.Me
 ZiskFv.Compliance.FromTrust.Sh.equiv_SH_from_trust 012 h_main_active [match] main.is_external_op r_main = 0
 ZiskFv.Compliance.FromTrust.Sh.equiv_SH_from_trust 013 h_main_op [match] main.op r_main = OP_COPYB
 ZiskFv.Compliance.FromTrust.Sh.equiv_SH_from_trust 014 h_main_ind_width [match] main.ind_width r_main = 2
-ZiskFv.Compliance.FromTrust.Sh.equiv_SH_from_trust 015 risc_v_assumptions [state] RISC_V_assumptions state mstatus pmaRegion misa mseccfg
-ZiskFv.Compliance.FromTrust.Sh.equiv_SH_from_trust 016 h_opcode_assumptions [other] PureSpec.sh_state_assumptions sh_input state
-ZiskFv.Compliance.FromTrust.Sh.equiv_SH_from_trust 017 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Sh.equiv_SH_from_trust 018 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sh.equiv_SH_from_trust 019 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Sh.equiv_SH_from_trust 020 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Sh.equiv_SH_from_trust 021 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sh.equiv_SH_from_trust 022 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Sh.equiv_SH_from_trust 023 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sh.equiv_SH_from_trust 024 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Sh.equiv_SH_from_trust 025 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Sh.equiv_SH_from_trust 026 h_m2_as [bus_shape] e2.as.val = 2
+ZiskFv.Compliance.FromTrust.Sh.equiv_SH_from_trust 015 h_opcode_assumptions [other] PureSpec.sh_state_assumptions sh_input state
+ZiskFv.Compliance.FromTrust.Sh.equiv_SH_from_trust 016 _ [other] 12 fields
+ZiskFv.Compliance.FromTrust.Sh.equiv_SH_from_trust 017 promises [transpile] ZiskFv.Equivalence.Promises.StorePromises state mstatus pmaRegion misa mseccfg (
 ZiskFv.Compliance.FromTrust.Shift.equiv_SLLW_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Shift.equiv_SLLW_from_trust 001 sllw_input [other] PureSpec.SllwInput
 ZiskFv.Compliance.FromTrust.Shift.equiv_SLLW_from_trust 002 r1 [other] regidx
@@ -1391,23 +871,10 @@ ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 007 exec_row [entry] 
 ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 008 e0 [loose] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 009 e1 [loose] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 010 e2 [loose] Interaction.MemoryBusEntry FGL
-ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 011 h_input_r1_sail [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok slliw_input.r1_val state
-ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 012 h_input_rd [transpile] slliw_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 013 h_input_pc [state] state.regs.get? Register.PC = .some slliw_input.PC
-ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 014 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 015 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 016 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 017 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 018 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 019 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 020 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 021 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 022 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 023 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 024 h_rd_idx [transpile] slliw_input.rd = Transpiler.wrap_to_regidx e2.ptr
-ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 025 h_main_active [match] m.is_external_op r_main = 1
-ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 026 h_main_op [match] m.op r_main = ZiskFv.Trusted.OP_SLL_W
-ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 027 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
+ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 011 promises [bridge] ZiskFv.Equivalence.Promises.ShiftWImmPromises state slliw_input.r1_val slliw_inp
+ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 012 h_main_active [match] m.is_external_op r_main = 1
+ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 013 h_main_op [match] m.op r_main = ZiskFv.Trusted.OP_SLL_W
+ZiskFv.Compliance.FromTrust.ShiftLI.equiv_SLLIW_from_trust 014 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
 ZiskFv.Compliance.FromTrust.ShiftR.equiv_SRLW_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.ShiftR.equiv_SRLW_from_trust 001 srlw_input [other] PureSpec.SrlwInput
 ZiskFv.Compliance.FromTrust.ShiftR.equiv_SRLW_from_trust 002 r1 [other] regidx
@@ -1479,23 +946,10 @@ ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 007 exec_row [entry]
 ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 008 e0 [loose] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 009 e1 [loose] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 010 e2 [loose] Interaction.MemoryBusEntry FGL
-ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 011 h_input_r1_sail [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok sraiw_input.r1_val state
-ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 012 h_input_rd [transpile] sraiw_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 013 h_input_pc [state] state.regs.get? Register.PC = .some sraiw_input.PC
-ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 014 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 015 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 016 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 017 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 018 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 019 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 020 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 021 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 022 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 023 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 024 h_rd_idx [transpile] sraiw_input.rd = Transpiler.wrap_to_regidx e2.ptr
-ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 025 h_main_active [match] m.is_external_op r_main = 1
-ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 026 h_main_op [match] m.op r_main = ZiskFv.Trusted.OP_SRA_W
-ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 027 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
+ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 011 promises [bridge] ZiskFv.Equivalence.Promises.ShiftWImmPromises state sraiw_input.r1_val sraiw_inp
+ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 012 h_main_active [match] m.is_external_op r_main = 1
+ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 013 h_main_op [match] m.op r_main = ZiskFv.Trusted.OP_SRA_W
+ZiskFv.Compliance.FromTrust.ShiftRAI.equiv_SRAIW_from_trust 014 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
 ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 001 srliw_input [other] PureSpec.SrliwInput
 ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 002 r1 [other] regidx
@@ -1507,23 +961,10 @@ ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 007 exec_row [entry]
 ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 008 e0 [loose] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 009 e1 [loose] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 010 e2 [loose] Interaction.MemoryBusEntry FGL
-ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 011 h_input_r1_sail [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok srliw_input.r1_val state
-ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 012 h_input_rd [transpile] srliw_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 013 h_input_pc [state] state.regs.get? Register.PC = .some srliw_input.PC
-ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 014 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 015 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 016 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 017 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 018 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 019 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 020 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 021 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 022 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 023 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 024 h_rd_idx [transpile] srliw_input.rd = Transpiler.wrap_to_regidx e2.ptr
-ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 025 h_main_active [match] m.is_external_op r_main = 1
-ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 026 h_main_op [match] m.op r_main = ZiskFv.Trusted.OP_SRL_W
-ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 027 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
+ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 011 promises [bridge] ZiskFv.Equivalence.Promises.ShiftWImmPromises state srliw_input.r1_val srliw_inp
+ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 012 h_main_active [match] m.is_external_op r_main = 1
+ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 013 h_main_op [match] m.op r_main = ZiskFv.Trusted.OP_SRL_W
+ZiskFv.Compliance.FromTrust.ShiftRLI.equiv_SRLIW_from_trust 014 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
 ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 001 sll_input [other] PureSpec.SllInput
 ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 002 r1 [other] regidx
@@ -1538,25 +979,11 @@ ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 010 exec_row [entry] List (
 ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 011 e0 [loose] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 012 e1 [loose] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 013 e2 [loose] Interaction.MemoryBusEntry FGL
-ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 014 _ [other] SPEC-PRE
-ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 015 h_input_r1_sail [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok sll_input.r1_val state
-ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 016 h_input_r2_sail [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok sll_input.r2_val state
-ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 017 h_input_rd [transpile] sll_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 018 h_input_pc [state] state.regs.get? Register.PC = .some sll_input.PC
-ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 019 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 020 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 021 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 022 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 023 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 024 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 025 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 026 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 027 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 028 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 029 h_rd_idx [transpile] sll_input.rd = Transpiler.wrap_to_regidx e2.ptr
-ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 030 h_main_active [match] m.is_external_op r_main = 1
-ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 031 h_main_op [match] m.op r_main = ZiskFv.Trusted.OP_SLL
-ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 032 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
+ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 014 _ [other] 15 fields
+ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 015 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state sll_input.r1_val sll_input.r2_va
+ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 016 h_main_active [match] m.is_external_op r_main = 1
+ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 017 h_main_op [match] m.op r_main = ZiskFv.Trusted.OP_SLL
+ZiskFv.Compliance.FromTrust.Sll.equiv_SLL_from_trust 018 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
 ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 001 slli_input [other] PureSpec.SlliInput
 ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 002 r1 [other] regidx
@@ -1569,24 +996,10 @@ ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 008 exec_row [entry] List
 ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 009 e0 [loose] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 010 e1 [loose] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 011 e2 [loose] Interaction.MemoryBusEntry FGL
-ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 012 h_input_r1_sail [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok slli_input.r1_val state
-ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 013 h_input_shamt [other] slli_input.shamt = shamt
-ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 014 h_input_rd [transpile] slli_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 015 h_input_pc [state] state.regs.get? Register.PC = .some slli_input.PC
-ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 016 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 017 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 018 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 019 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 020 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 021 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 022 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 023 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 024 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 025 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 026 h_rd_idx [transpile] slli_input.rd = Transpiler.wrap_to_regidx e2.ptr
-ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 027 h_main_active [match] m.is_external_op r_main = 1
-ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 028 h_main_op [match] m.op r_main = ZiskFv.Trusted.OP_SLL
-ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 029 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
+ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 012 promises [bridge] ZiskFv.Equivalence.Promises.ShiftImmPromises state slli_input.r1_val slli_input.
+ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 013 h_main_active [match] m.is_external_op r_main = 1
+ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 014 h_main_op [match] m.op r_main = ZiskFv.Trusted.OP_SLL
+ZiskFv.Compliance.FromTrust.Slli.equiv_SLLI_from_trust 015 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
 ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 001 slt_input [other] PureSpec.SltInput
 ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 002 r1 [other] regidx
@@ -1602,21 +1015,7 @@ ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 011 e2 [loose] Interaction.
 ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 012 h_main_active [match] m.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 013 h_main_op_slt [match] m.op r_main = OP_LT
 ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 014 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
-ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 015 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok slt_input.r1_val state
-ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 016 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok slt_input.r2_val state
-ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 017 h_input_rd [transpile] slt_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 018 h_input_pc [state] state.regs.get? Register.PC = .some slt_input.PC
-ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 019 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 020 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 021 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 022 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 023 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 024 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 025 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 026 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 027 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 028 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 029 h_rd_idx [transpile] slt_input.rd = Transpiler.wrap_to_regidx e2.ptr
+ZiskFv.Compliance.FromTrust.Slt.equiv_SLT_from_trust 015 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state slt_input.r1_val slt_input.r2_va
 ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 001 slti_input [other] PureSpec.SltiInput
 ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 002 r1 [other] regidx
@@ -1633,21 +1032,7 @@ ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 012 h_main_active [match]
 ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 013 h_main_op_slti [match] m.op r_main = OP_LT
 ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 014 h_slti_subset [other] itype_imm_subset_holds_main m r_main slti_input.imm
 ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 015 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
-ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 016 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok slti_input.r1_val state
-ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 017 h_input_imm [other] slti_input.imm = imm
-ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 018 h_input_rd [transpile] slti_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 019 h_input_pc [state] state.regs.get? Register.PC = .some slti_input.PC
-ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 020 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 021 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 022 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 023 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 024 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 025 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 026 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 027 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 028 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 029 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 030 h_rd_idx [transpile] slti_input.rd = Transpiler.wrap_to_regidx e2.ptr
+ZiskFv.Compliance.FromTrust.Slti.equiv_SLTI_from_trust 016 promises [bridge] ZiskFv.Equivalence.Promises.ITypePromises state slti_input.r1_val slti_input.imm
 ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 001 sltiu_input [other] PureSpec.SltiuInput
 ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 002 r1 [other] regidx
@@ -1664,21 +1049,7 @@ ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 012 h_main_active [matc
 ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 013 h_main_op_sltiu [match] m.op r_main = OP_LTU
 ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 014 h_sltiu_subset [other] itype_imm_subset_holds_main m r_main sltiu_input.imm
 ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 015 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
-ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 016 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok sltiu_input.r1_val state
-ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 017 h_input_imm [other] sltiu_input.imm = imm
-ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 018 h_input_rd [transpile] sltiu_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 019 h_input_pc [state] state.regs.get? Register.PC = .some sltiu_input.PC
-ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 020 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 021 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 022 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 023 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 024 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 025 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 026 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 027 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 028 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 029 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 030 h_rd_idx [transpile] sltiu_input.rd = Transpiler.wrap_to_regidx e2.ptr
+ZiskFv.Compliance.FromTrust.Sltiu.equiv_SLTIU_from_trust 016 promises [bridge] ZiskFv.Equivalence.Promises.ITypePromises state sltiu_input.r1_val sltiu_input.i
 ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 001 sltu_input [other] PureSpec.SltuInput
 ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 002 r1 [other] regidx
@@ -1694,21 +1065,7 @@ ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 011 e2 [loose] Interactio
 ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 012 h_main_active [match] m.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 013 h_main_op_sltu [match] m.op r_main = OP_LTU
 ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 014 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
-ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 015 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok sltu_input.r1_val state
-ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 016 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok sltu_input.r2_val state
-ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 017 h_input_rd [transpile] sltu_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 018 h_input_pc [state] state.regs.get? Register.PC = .some sltu_input.PC
-ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 019 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 020 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 021 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 022 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 023 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 024 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 025 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 026 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 027 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 028 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 029 h_rd_idx [transpile] sltu_input.rd = Transpiler.wrap_to_regidx e2.ptr
+ZiskFv.Compliance.FromTrust.Sltu.equiv_SLTU_from_trust 015 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state sltu_input.r1_val sltu_input.r2_
 ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 001 sra_input [other] PureSpec.SraInput
 ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 002 r1 [other] regidx
@@ -1721,24 +1078,10 @@ ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 008 exec_row [entry] List (
 ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 009 e0 [loose] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 010 e1 [loose] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 011 e2 [loose] Interaction.MemoryBusEntry FGL
-ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 012 h_input_r1_sail [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok sra_input.r1_val state
-ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 013 h_input_r2_sail [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok sra_input.r2_val state
-ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 014 h_input_rd [transpile] sra_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 015 h_input_pc [state] state.regs.get? Register.PC = .some sra_input.PC
-ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 016 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 017 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 018 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 019 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 020 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 021 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 022 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 023 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 024 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 025 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 026 h_rd_idx [transpile] sra_input.rd = Transpiler.wrap_to_regidx e2.ptr
-ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 027 h_main_active [match] m.is_external_op r_main = 1
-ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 028 h_main_op [match] m.op r_main = ZiskFv.Trusted.OP_SRA
-ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 029 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
+ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 012 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state sra_input.r1_val sra_input.r2_va
+ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 013 h_main_active [match] m.is_external_op r_main = 1
+ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 014 h_main_op [match] m.op r_main = ZiskFv.Trusted.OP_SRA
+ZiskFv.Compliance.FromTrust.Sra.equiv_SRA_from_trust 015 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
 ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 001 srai_input [other] PureSpec.SraiInput
 ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 002 r1 [other] regidx
@@ -1751,24 +1094,10 @@ ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 008 exec_row [entry] List
 ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 009 e0 [loose] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 010 e1 [loose] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 011 e2 [loose] Interaction.MemoryBusEntry FGL
-ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 012 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok srai_input.r1_val state
-ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 013 h_input_shamt [other] srai_input.shamt = shamt
-ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 014 h_input_rd [transpile] srai_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 015 h_input_pc [state] state.regs.get? Register.PC = .some srai_input.PC
-ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 016 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 017 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 018 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 019 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 020 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 021 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 022 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 023 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 024 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 025 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 026 h_rd_idx [transpile] srai_input.rd = Transpiler.wrap_to_regidx e2.ptr
-ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 027 h_main_active [match] m.is_external_op r_main = 1
-ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 028 h_main_op [match] m.op r_main = ZiskFv.Trusted.OP_SRA
-ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 029 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
+ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 012 promises [bridge] ZiskFv.Equivalence.Promises.ShiftImmPromises state srai_input.r1_val srai_input.
+ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 013 h_main_active [match] m.is_external_op r_main = 1
+ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 014 h_main_op [match] m.op r_main = ZiskFv.Trusted.OP_SRA
+ZiskFv.Compliance.FromTrust.Srai.equiv_SRAI_from_trust 015 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
 ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 001 srl_input [other] PureSpec.SrlInput
 ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 002 r1 [other] regidx
@@ -1781,24 +1110,10 @@ ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 008 exec_row [entry] List (
 ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 009 e0 [loose] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 010 e1 [loose] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 011 e2 [loose] Interaction.MemoryBusEntry FGL
-ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 012 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok srl_input.r1_val state
-ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 013 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok srl_input.r2_val state
-ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 014 h_input_rd [transpile] srl_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 015 h_input_pc [state] state.regs.get? Register.PC = .some srl_input.PC
-ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 016 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 017 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 018 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 019 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 020 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 021 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 022 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 023 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 024 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 025 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 026 h_rd_idx [transpile] srl_input.rd = Transpiler.wrap_to_regidx e2.ptr
-ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 027 h_main_active [match] m.is_external_op r_main = 1
-ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 028 h_main_op [match] m.op r_main = ZiskFv.Trusted.OP_SRL
-ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 029 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
+ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 012 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state srl_input.r1_val srl_input.r2_va
+ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 013 h_main_active [match] m.is_external_op r_main = 1
+ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 014 h_main_op [match] m.op r_main = ZiskFv.Trusted.OP_SRL
+ZiskFv.Compliance.FromTrust.Srl.equiv_SRL_from_trust 015 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
 ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 001 srli_input [other] PureSpec.SrliInput
 ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 002 r1 [other] regidx
@@ -1811,24 +1126,10 @@ ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 008 exec_row [entry] List
 ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 009 e0 [loose] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 010 e1 [loose] Interaction.MemoryBusEntry FGL
 ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 011 e2 [loose] Interaction.MemoryBusEntry FGL
-ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 012 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok srli_input.r1_val state
-ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 013 h_input_shamt [other] srli_input.shamt = shamt
-ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 014 h_input_rd [transpile] srli_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 015 h_input_pc [state] state.regs.get? Register.PC = .some srli_input.PC
-ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 016 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 017 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 018 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 019 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 020 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 021 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 022 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 023 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 024 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 025 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 026 h_rd_idx [transpile] srli_input.rd = Transpiler.wrap_to_regidx e2.ptr
-ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 027 h_main_active [match] m.is_external_op r_main = 1
-ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 028 h_main_op [match] m.op r_main = ZiskFv.Trusted.OP_SRL
-ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 029 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
+ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 012 promises [bridge] ZiskFv.Equivalence.Promises.ShiftImmPromises state srli_input.r1_val srli_input.
+ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 013 h_main_active [match] m.is_external_op r_main = 1
+ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 014 h_main_op [match] m.op r_main = ZiskFv.Trusted.OP_SRL
+ZiskFv.Compliance.FromTrust.Srli.equiv_SRLI_from_trust 015 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
 ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 001 sub_input [other] PureSpec.SubInput
 ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 002 r1 [other] regidx
@@ -1844,21 +1145,7 @@ ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 011 e2 [loose] Interaction.
 ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 012 h_main_active [match] m.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 013 h_main_op_sub [match] m.op r_main = OP_SUB
 ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 014 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
-ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 015 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok sub_input.r1_val state
-ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 016 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok sub_input.r2_val state
-ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 017 h_input_rd [transpile] sub_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 018 h_input_pc [state] state.regs.get? Register.PC = .some sub_input.PC
-ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 019 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 020 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 021 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 022 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 023 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 024 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 025 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 026 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 027 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 028 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 029 h_rd_idx [transpile] sub_input.rd = Transpiler.wrap_to_regidx e2.ptr
+ZiskFv.Compliance.FromTrust.Sub.equiv_SUB_from_trust 015 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state sub_input.r1_val sub_input.r2_va
 ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 001 subw_input [other] PureSpec.SubwInput
 ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 002 r1 [other] regidx
@@ -1874,21 +1161,7 @@ ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 011 e2 [loose] Interactio
 ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 012 h_main_active [match] m.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 013 h_main_op_subw [match] m.op r_main = OP_SUB_W
 ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 014 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
-ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 015 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok subw_input.r1_val state
-ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 016 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok subw_input.r2_val state
-ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 017 h_input_rd [transpile] subw_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 018 h_input_pc [state] state.regs.get? Register.PC = .some subw_input.PC
-ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 019 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 020 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 021 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 022 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 023 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 024 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 025 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 026 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 027 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 028 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 029 h_rd_idx [transpile] subw_input.rd = Transpiler.wrap_to_regidx e2.ptr
+ZiskFv.Compliance.FromTrust.Subw.equiv_SUBW_from_trust 015 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state subw_input.r1_val subw_input.r2_
 ZiskFv.Compliance.FromTrust.Sw.equiv_SW_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Sw.equiv_SW_from_trust 001 sw_input [other] PureSpec.SwInput
 ZiskFv.Compliance.FromTrust.Sw.equiv_SW_from_trust 002 mstatus [other] RegisterType Register.mstatus
@@ -1904,18 +1177,9 @@ ZiskFv.Compliance.FromTrust.Sw.equiv_SW_from_trust 011 e2 [loose] Interaction.Me
 ZiskFv.Compliance.FromTrust.Sw.equiv_SW_from_trust 012 h_main_active [match] main.is_external_op r_main = 0
 ZiskFv.Compliance.FromTrust.Sw.equiv_SW_from_trust 013 h_main_op [match] main.op r_main = OP_COPYB
 ZiskFv.Compliance.FromTrust.Sw.equiv_SW_from_trust 014 h_main_ind_width [match] main.ind_width r_main = 4
-ZiskFv.Compliance.FromTrust.Sw.equiv_SW_from_trust 015 risc_v_assumptions [state] RISC_V_assumptions state mstatus pmaRegion misa mseccfg
-ZiskFv.Compliance.FromTrust.Sw.equiv_SW_from_trust 016 h_opcode_assumptions [other] PureSpec.sw_state_assumptions sw_input state
-ZiskFv.Compliance.FromTrust.Sw.equiv_SW_from_trust 017 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Sw.equiv_SW_from_trust 018 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sw.equiv_SW_from_trust 019 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Sw.equiv_SW_from_trust 020 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Sw.equiv_SW_from_trust 021 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sw.equiv_SW_from_trust 022 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Sw.equiv_SW_from_trust 023 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Sw.equiv_SW_from_trust 024 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Sw.equiv_SW_from_trust 025 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Sw.equiv_SW_from_trust 026 h_m2_as [bus_shape] e2.as.val = 2
+ZiskFv.Compliance.FromTrust.Sw.equiv_SW_from_trust 015 h_opcode_assumptions [other] PureSpec.sw_state_assumptions sw_input state
+ZiskFv.Compliance.FromTrust.Sw.equiv_SW_from_trust 016 _ [other] 12 fields
+ZiskFv.Compliance.FromTrust.Sw.equiv_SW_from_trust 017 promises [transpile] ZiskFv.Equivalence.Promises.StorePromises state mstatus pmaRegion misa mseccfg (
 ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 001 xor_input [other] PureSpec.XorInput
 ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 002 r1 [other] regidx
@@ -1931,21 +1195,7 @@ ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 011 e2 [loose] Interaction.
 ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 012 h_main_active [match] m.is_external_op r_main = 1
 ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 013 h_main_op_xor [match] m.op r_main = OP_XOR
 ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 014 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
-ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 015 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok xor_input.r1_val state
-ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 016 h_input_r2 [state] read_xreg (regidx_to_fin r2) state = EStateM.Result.ok xor_input.r2_val state
-ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 017 h_input_rd [transpile] xor_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 018 h_input_pc [state] state.regs.get? Register.PC = .some xor_input.PC
-ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 019 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 020 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 021 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 022 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 023 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 024 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 025 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 026 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 027 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 028 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 029 h_rd_idx [transpile] xor_input.rd = Transpiler.wrap_to_regidx e2.ptr
+ZiskFv.Compliance.FromTrust.Xor.equiv_XOR_from_trust 015 promises [bridge] ZiskFv.Equivalence.Promises.RTypePromises state xor_input.r1_val xor_input.r2_va
 ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 000 state [state] PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 001 xori_input [other] PureSpec.XoriInput
 ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 002 r1 [other] regidx
@@ -1962,18 +1212,4 @@ ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 012 h_main_active [match]
 ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 013 h_main_op_xori [match] m.op r_main = OP_XOR
 ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 014 h_xori_subset [other] itype_imm_subset_holds_main m r_main xori_input.imm
 ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 015 h_lane_rd [other] ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main e2
-ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 016 h_input_r1 [state] read_xreg (regidx_to_fin r1) state = EStateM.Result.ok xori_input.r1_val state
-ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 017 h_input_imm [other] xori_input.imm = imm
-ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 018 h_input_rd [transpile] xori_input.rd = regidx_to_fin rd
-ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 019 h_input_pc [state] state.regs.get? Register.PC = .some xori_input.PC
-ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 020 h_exec_len [bus_shape] exec_row.length = 2
-ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 021 h_e0_mult [bus_shape] exec_row[0]!.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 022 h_e1_mult [bus_shape] exec_row[1]!.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 023 h_nextPC_matches [transpile] (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = (PureSpec.e
-ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 024 h_m0_mult [bus_shape] e0.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 025 h_m0_as [bus_shape] e0.as.val = 1
-ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 026 h_m1_mult [bus_shape] e1.multiplicity = -1
-ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 027 h_m1_as [bus_shape] e1.as.val = 1
-ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 028 h_m2_mult [bus_shape] e2.multiplicity = 1
-ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 029 h_m2_as [bus_shape] e2.as.val = 1
-ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 030 h_rd_idx [transpile] xori_input.rd = Transpiler.wrap_to_regidx e2.ptr
+ZiskFv.Compliance.FromTrust.Xori.equiv_XORI_from_trust 016 promises [bridge] ZiskFv.Equivalence.Promises.ITypePromises state xori_input.r1_val xori_input.imm

--- a/trust/baseline-zisk-riscv-compliant.txt
+++ b/trust/baseline-zisk-riscv-compliant.txt
@@ -23,7 +23,7 @@
 #     > trust/baseline-zisk-riscv-compliant.txt
 #
 # Refresh via `trust/scripts/regenerate.sh` (requires `lake build`
-# artefacts under `.lake/build/`). Last regenerated: 2026-05-16.
+# artefacts under `.lake/build/`). Last regenerated: 2026-05-17.
 #
 # Total entries: 122
 #


### PR DESCRIPTION
## Summary

For each of the 63 RV64IM opcodes, the wrapper layer (`Compliance/FromTrust/<Op>.lean`) and the `OpEnvelope` arms in `Compliance.lean` previously spelled out ~12 bus structural binders inline (`h_input_*`, `h_exec_len`, `h_e0_mult`, `h_nextPC_matches`, `h_m0_*`, `h_m1_*`, `h_m2_*`, `h_rd_idx`, ...) and then rebuilt the corresponding `*Promises` bundle inline before calling the canonical `equiv_<OP>`.

The canonical `equiv_<OP>` theorems already accept the bundle — this PR threads the bundle through one layer up. Both the wrappers and the `OpEnvelope` arms now take a single `(promises : <Shape>Promises ...)` parameter and pass it through.

Implements suggestion #2 from a recent simplification scan; builds on PR #33.

### Smart wrappers (Branch / Store / UType / Jump, 14 total)

These wrappers still derive non-bundle canonical-side arguments (`h_circuit`, `h_mem_eq`) internally — keeping the global theorem's axiom closure at 122. New convenience helpers live in `Equivalence/Promises/{Branch,Store,UType,Jump}Helpers.lean` for external callers who want to construct bundles from upstream inputs (alignment hypothesis, `transpile_<OP>` derivation, `opcode_assumptions` projection).

The 6 branch wrappers became fully pure-pass-through because the alignment-derivation lemma (a pure BitVec computation) consumes no axioms — moving it to a helper had no closure impact.

### Anti-laundering / trust-baseline movement

| Baseline | Before | After | Note |
|---|---|---|---|
| `baseline-axioms.txt` | 122 | 122 | unchanged |
| `baseline-hypothesis-count.txt` (canonical) | — | — | unchanged |
| `baseline-caller-burden.txt` (canonical) | — | — | unchanged |
| `baseline-equiv-axiom-deps.txt` | — | — | unchanged |
| `baseline-zisk-riscv-compliant.txt` | 122 | 122 | header date only |
| **`baseline-wrapper-caller-burden.txt`** | 1951 | **1187** | **−764 rows** |

The shrinkage in `baseline-wrapper-caller-burden.txt` is the structural-unpacking-in-reverse the gate is built to scrutinize: ~764 individual h-binders consolidated into 63 bundle parameters. No hypotheses hidden — the bundle fields are exactly the obligations that were inline before.

## Test plan

- [x] `nix develop --command lake build` — succeeds (the formal-verification claim)
- [x] `nix develop --command trust/scripts/check-all.sh` — V1 syntactic gate (9 checks): ALL PASS
- [x] `nix develop --command trust/scripts/check-all-semantic.sh` — V2 semantic gate (3 checks): ALL PASS (including `check-closure-vs-baseline` — closure unchanged at 122)
- [ ] `nix run .#test` (CI will run the full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)