### PR TITLE
Clean integration Phase 1: typed channels (OpBus, MemBus, RangeBus)

### DIFF
--- a/ZiskFv/Channels/MemoryBus.lean
+++ b/ZiskFv/Channels/MemoryBus.lean
@@ -1,0 +1,97 @@
+import Clean.Circuit.Channel
+import Clean.Circuit.Provable
+import Clean.Utils.Tactics.ProvableStructDeriving
+import ZiskFv.Field.Goldilocks
+import ZiskFv.Airs.Bus.Interaction
+
+/-!
+# MemoryBus typed channel
+
+ZisK's memory-bus channel: Main pushes register/memory read/write
+requests; Mem (the memory AIR) consumes them and emits provider
+rows; MemAlign* sub-byte read providers handle aligned loads.
+
+This file introduces the channel as
+`Clean.Channel FGL MemBusMessage`. The 11-slot `MemBusMessage`
+mirrors `Interaction.MemoryBusEntry` minus the multiplicity (Clean
+carries multiplicity as `ChannelInteraction.mult`). A round-trip
+equivalence with `Interaction.MemoryBusEntry FGL` is provided.
+
+## Trust note
+
+Same pattern as `Channels/OperationBus.lean` — no new axioms. The
+1 memory-bus axiom `lookup_consumer_matches_provider_load` (in
+`Airs/MemoryBus/MemBridge.lean`) can be retired in Phase 3 once
+Mem + MemAlign* are rewritten as Clean components.
+-/
+
+namespace ZiskFv.Channels.MemoryBus
+
+open Goldilocks
+
+/-- The 11-slot memory-bus message. Mirrors
+    `Interaction.MemoryBusEntry FGL` minus the multiplicity. -/
+structure MemBusMessage (F : Type) where
+  as : F
+  ptr : F
+  x0 : F
+  x1 : F
+  x2 : F
+  x3 : F
+  x4 : F
+  x5 : F
+  x6 : F
+  x7 : F
+  timestamp : F
+deriving ProvableStruct
+
+@[reducible]
+def MemBusMessage.toEntry (msg : MemBusMessage FGL) (multiplicity : FGL)
+    : Interaction.MemoryBusEntry FGL :=
+  { multiplicity := multiplicity
+  , as := msg.as
+  , ptr := msg.ptr
+  , x0 := msg.x0
+  , x1 := msg.x1
+  , x2 := msg.x2
+  , x3 := msg.x3
+  , x4 := msg.x4
+  , x5 := msg.x5
+  , x6 := msg.x6
+  , x7 := msg.x7
+  , timestamp := msg.timestamp
+  }
+
+@[reducible]
+def MemBusMessage.ofEntry (entry : Interaction.MemoryBusEntry FGL)
+    : MemBusMessage FGL :=
+  { as := entry.as
+  , ptr := entry.ptr
+  , x0 := entry.x0
+  , x1 := entry.x1
+  , x2 := entry.x2
+  , x3 := entry.x3
+  , x4 := entry.x4
+  , x5 := entry.x5
+  , x6 := entry.x6
+  , x7 := entry.x7
+  , timestamp := entry.timestamp
+  }
+
+theorem MemBusMessage.ofEntry_toEntry (msg : MemBusMessage FGL) (mult : FGL) :
+    MemBusMessage.ofEntry (MemBusMessage.toEntry msg mult) = msg := by
+  rfl
+
+theorem MemBusMessage.toEntry_ofEntry (entry : Interaction.MemoryBusEntry FGL) :
+    MemBusMessage.toEntry (MemBusMessage.ofEntry entry) entry.multiplicity = entry := by
+  rfl
+
+/-- The MemoryBus channel. As with `OpBusChannel`, the guarantee is
+    `True`: cross-AIR consistency is enforced by `Air.Balance`, and
+    per-opcode load/store semantics are layered in via the per-opcode
+    wrappers in Phase 4 — not bundled into the channel guarantee. -/
+instance MemBusChannel : Channel FGL MemBusMessage where
+  name := "MemoryBus"
+  Guarantees _msg _data := True
+
+end ZiskFv.Channels.MemoryBus

--- a/ZiskFv/Channels/OperationBus.lean
+++ b/ZiskFv/Channels/OperationBus.lean
@@ -1,0 +1,135 @@
+import Clean.Circuit.Channel
+import Clean.Circuit.Provable
+import Clean.Utils.Tactics.ProvableStructDeriving
+import ZiskFv.Field.Goldilocks
+import ZiskFv.Airs.OperationBus.OperationBus
+
+/-!
+# OperationBus typed channel
+
+ZisK's primary cross-AIR channel. Main pulls a per-row tuple
+describing the executed instruction; the corresponding provider AIR
+(BinaryAdd / Binary / BinaryExtension / Arith*) pushes a matching
+tuple.
+
+This file introduces the channel as a `Clean.Channel FGL OpBusMessage`.
+The 11-slot `OpBusMessage` mirrors the existing `OperationBusEntry`
+record (minus the multiplicity, which Clean carries as a separate
+`ChannelInteraction.mult`). A round-trip equivalence with
+`OperationBusEntry` lives at the bottom — Phase 2 will use it to
+state `state_effect_via_channels_eq_bus_effect_2`.
+
+## Trust note
+
+This file does NOT add any axiom. The channel's `Guarantees` is
+*defined* — whether a particular provider's push discharges the
+guarantee is each provider AIR's local proof obligation, and the
+cross-AIR consistency is `Clean.Air.Balance.BalancedInteractions`'s
+output, which is a theorem (not an axiom).
+
+The 1 operation-bus axiom currently in
+`trust/baseline-axioms.txt::op_bus_permutation_sound`
+(consolidated form on `clean-integration`) can be retired in Phase 3
+once each provider AIR is rewritten as a Clean component.
+-/
+
+namespace ZiskFv.Channels.OperationBus
+
+open Goldilocks
+
+/-- The 11-slot operation-bus message. Mirrors `OperationBusEntry`
+    minus the multiplicity (Clean carries multiplicity as a separate
+    `ChannelInteraction.mult`).
+
+    Slot semantics match `Airs/OperationBus/OperationBus.lean::OperationBusEntry`. -/
+structure OpBusMessage (F : Type) where
+  op : F
+  a_lo : F
+  a_hi : F
+  b_lo : F
+  b_hi : F
+  c_lo : F
+  c_hi : F
+  flag : F
+  main_step : F
+  extended_arg : F
+  extra_args_0 : F
+deriving ProvableStruct
+
+/-- Convert a `Clean.OpBusMessage` to the existing zisk-fv
+    `OperationBusEntry`, supplying a multiplicity. The multiplicity
+    is the bridge: in Clean's model it lives on the channel
+    interaction; in zisk-fv's `OperationBusEntry` it's a record field. -/
+@[reducible]
+def OpBusMessage.toEntry (msg : OpBusMessage FGL) (multiplicity : FGL)
+    : ZiskFv.Airs.OperationBus.OperationBusEntry FGL :=
+  { multiplicity := multiplicity
+  , op := msg.op
+  , a_lo := msg.a_lo
+  , a_hi := msg.a_hi
+  , b_lo := msg.b_lo
+  , b_hi := msg.b_hi
+  , c_lo := msg.c_lo
+  , c_hi := msg.c_hi
+  , flag := msg.flag
+  , main_step := msg.main_step
+  , extended_arg := msg.extended_arg
+  , extra_args_0 := msg.extra_args_0
+  }
+
+/-- Inverse direction — project an `OperationBusEntry` to a `OpBusMessage`.
+    The multiplicity is dropped (recovered separately). -/
+@[reducible]
+def OpBusMessage.ofEntry (entry : ZiskFv.Airs.OperationBus.OperationBusEntry FGL)
+    : OpBusMessage FGL :=
+  { op := entry.op
+  , a_lo := entry.a_lo
+  , a_hi := entry.a_hi
+  , b_lo := entry.b_lo
+  , b_hi := entry.b_hi
+  , c_lo := entry.c_lo
+  , c_hi := entry.c_hi
+  , flag := entry.flag
+  , main_step := entry.main_step
+  , extended_arg := entry.extended_arg
+  , extra_args_0 := entry.extra_args_0
+  }
+
+theorem OpBusMessage.ofEntry_toEntry (msg : OpBusMessage FGL) (mult : FGL) :
+    OpBusMessage.ofEntry (OpBusMessage.toEntry msg mult) = msg := by
+  rfl
+
+theorem OpBusMessage.toEntry_ofEntry (entry : ZiskFv.Airs.OperationBus.OperationBusEntry FGL) :
+    OpBusMessage.toEntry (OpBusMessage.ofEntry entry) entry.multiplicity = entry := by
+  rfl
+
+/-- The 64-bit packed value of the `a` lane. -/
+@[reducible]
+def OpBusMessage.aPacked (msg : OpBusMessage FGL) : ℕ :=
+  msg.a_lo.val + msg.a_hi.val * 2 ^ 32
+
+@[reducible]
+def OpBusMessage.bPacked (msg : OpBusMessage FGL) : ℕ :=
+  msg.b_lo.val + msg.b_hi.val * 2 ^ 32
+
+@[reducible]
+def OpBusMessage.cPacked (msg : OpBusMessage FGL) : ℕ :=
+  msg.c_lo.val + msg.c_hi.val * 2 ^ 32
+
+/-- The OperationBus channel — uninhabited semantic gate.
+
+    `Guarantees` is `True` for now: the channel acts as a structural
+    pipe whose payload's *consistency* across pushes and pulls is
+    enforced by `Clean.Air.Balance`. Per-opcode semantic guarantees
+    (e.g. ADD's `c-packed = a-packed + b-packed mod 2^64`) are
+    layered in *separately* via `OpEnvelope`-dispatched per-opcode
+    proofs in Phase 4, not bundled into the channel guarantee.
+
+    This keeps the channel as a single shared bus across all opcodes
+    while letting per-opcode semantics be discharged in their own
+    files. -/
+instance OpBusChannel : Channel FGL OpBusMessage where
+  name := "OperationBus"
+  Guarantees _msg _data := True
+
+end ZiskFv.Channels.OperationBus

--- a/ZiskFv/Channels/RangeBus.lean
+++ b/ZiskFv/Channels/RangeBus.lean
@@ -1,0 +1,69 @@
+import Clean.Circuit.Channel
+import Clean.Circuit.Provable
+import Clean.Utils.Tactics.ProvableStructDeriving
+import ZiskFv.Field.Goldilocks
+
+/-!
+# RangeBus typed channel (byte-range lookup table)
+
+ZisK's byte-range bus: AIRs whose witness columns are bit-width-bounded
+(`bits(8)` annotation in PIL) pull from the byte-range channel,
+asserting `0 ≤ value < 256`. The provider is the static table
+`{0, 1, ..., 255}`.
+
+This is a `StaticLookupChannel` — a special form where the channel's
+table is fixed and its `Guarantees` is set-membership in that table.
+
+## Trust note
+
+Same pattern as the other channels — no new axioms. The 3 byte-range
+axioms in `Airs/Main/Ranges.lean`, `Airs/Binary/BinaryAddRanges.lean`,
+and `Airs/MemoryBus/EntryRanges.lean` consolidate into this single
+StaticLookupChannel-derived statement in Phase 3 (when the per-AIR
+ranges become *derived* from the lookup channel's Guarantees rather
+than axiomatized).
+-/
+
+namespace ZiskFv.Channels.RangeBus
+
+open Goldilocks
+
+/-- Single-slot field message — the byte-range channel carries one
+    field element per interaction. Reuses Clean's existing
+    `field` TypeMap pattern. -/
+abbrev ByteMsg (F : Type) := field F
+
+/-- Lift a single FGL value into a `ByteMsg` (i.e. into the
+    `field FGL` TypeMap). -/
+@[reducible]
+def ByteMsg.ofFGL (x : FGL) : ByteMsg FGL := x
+
+/-- The byte-range static lookup table: `{0, 1, ..., 255}` viewed as
+    `FGL` values. -/
+def BytesTable : StaticLookupChannel FGL field where
+  name := "ByteRange"
+  -- The list of 256 byte values, lifted into FGL via Nat → FGL coercion.
+  table := (List.finRange 256).map (fun i => (i.val : FGL))
+  Guarantees msg := msg.val < 256
+  guarantees_iff := by
+    intro (msg : FGL)
+    simp only [List.mem_map, List.mem_finRange, true_and]
+    constructor
+    · intro h_lt
+      refine ⟨⟨msg.val, h_lt⟩, ?_⟩
+      have : (msg.val : FGL) = msg := by
+        apply Fin.ext
+        simp
+      simp [this]
+    · rintro ⟨⟨b, hb⟩, h_eq⟩
+      rw [← h_eq]
+      simp [Fin.val_natCast, Nat.mod_eq_of_lt
+        (Nat.lt_of_lt_of_le hb (by decide : (256 : ℕ) ≤ GL_prime))]
+      exact hb
+
+/-- The byte-range channel — the typed `Channel` view of the static
+    lookup table. Pulling from this channel gives `msg.val < 256`. -/
+abbrev BytesChannel : Channel FGL field :=
+  Channel.fromStatic FGL field BytesTable
+
+end ZiskFv.Channels.RangeBus

--- a/docs/clean-feedback.md
+++ b/docs/clean-feedback.md
@@ -204,3 +204,74 @@ has consolidatable structure:
 from MemBus emission bundles + OpBus consolidation + lookup-table
 consolidation), not the 20+ estimated in the original plan. Range
 bus stays as-is.
+
+---
+
+### `import Clean` umbrella collides with Mathlib's Batteries.Data.Fin.Fold
+
+**Observed:** `ZiskFv/Channels/OperationBus.lean` initial draft, line 1.
+
+**Reproduction:**
+
+```lean
+-- file: scratch/CleanImportCollision.lean
+import Clean
+import Mathlib
+example : True := trivial
+```
+
+Yields:
+
+```
+error: import Batteries.Data.Fin.Fold failed,
+       environment already contains 'Fin.foldl_eq_foldl_finRange'
+       from Clean.Utils.Misc
+```
+
+The collision is structural: `Clean.Utils.Misc` (line 62) defines
+`Fin.foldl_eq_foldl_finRange`, and Lean's stdlib / Batteries
+`Data.Fin.Fold` define the same name. Order-of-import flips which
+one wins; loading both fails.
+
+**Ask:**
+
+Option A — rename Clean's lemma (preferred, since the stdlib one is
+the more canonical home).
+Option B — make the top-level `Clean` umbrella module skip
+`Clean.Utils.Misc`'s utility lemmas that already live in stdlib.
+
+**Severity:** friction — `import Clean` is the documented entry
+point in `~/clean/Clean/Examples/`, so anyone integrating Clean
+*alongside* Mathlib has to discover the narrower-imports workaround.
+
+**Workaround used:** Import only `Clean.Circuit.Channel` +
+`Clean.Circuit.Provable` + `Clean.Utils.Tactics.ProvableStructDeriving`,
+which avoids pulling `Clean.Utils.Misc` and the collision.
+
+---
+
+### `[Field F]` requirement on TypeMap-shaped records
+
+**Observed:** `ZiskFv/Airs/OperationBus/OperationBus.lean::OperationBusEntry`,
+`ZiskFv/Airs/Bus/Interaction.lean::MemoryBusEntry`.
+
+**Reproduction:** zisk-fv's existing bus-entry records declare
+`structure OperationBusEntry (F : Type) [Field F] where ...`. Clean's
+`ProvableType` / `TypeMap` machinery operates over `Type → Type` with
+no `[Field F]` constraint on the structure itself. Trying to use
+`OperationBusEntry` directly as a `Message` in `Channel F Message`
+fails with the typeclass mismatch.
+
+**Ask:** Documentation note in Clean's `ProvableType` / `Channel`
+section explaining the convention — "your Message type should be
+declared `structure Foo (F : Type) where ...` without `[Field F]`
+unless its fields require it". The narrowing is straightforward
+once you know to do it, but the failure mode is opaque to a first-
+time integrator.
+
+**Severity:** friction (documentation, no code change in Clean).
+
+**Workaround used:** Introduced parallel TypeMap records
+(`OpBusMessage`, `MemBusMessage`) without `[Field F]`, with
+@[reducible] conversions to/from the existing zisk-fv records.
+


### PR DESCRIPTION
## Summary

Stacked on #39 (Phase 0). Introduce the first three typed channels as \`Clean.Channel FGL <Msg>\` instances. No axioms added or removed; pure scaffolding to be consumed by Phase 2's \`state_effect_via_channels\` and Phase 3's per-AIR Clean-component rewrites.

- \`ZiskFv/Channels/OperationBus.lean\` — \`OpBusMessage\` ProvableStruct, \`OpBusChannel : Channel FGL OpBusMessage\`, round-trip with existing \`OperationBusEntry\`
- \`ZiskFv/Channels/MemoryBus.lean\` — analogous for \`Interaction.MemoryBusEntry\`
- \`ZiskFv/Channels/RangeBus.lean\` — \`BytesTable : StaticLookupChannel\`, \`BytesChannel := Channel.fromStatic ... BytesTable\`

Remaining 4 channels (BinaryTable, BinaryExtensionTable, ArithTable, MemAlignRom) and the 22 per-AIR ProvableStruct row types are deferred to Phase 3 — they'll be introduced alongside the AIR rewrite that consumes them, so each PR carries the channel + ProvableStruct + Clean component as a single auditable unit.

## Feedback to Clean upstream

Two entries added to \`docs/clean-feedback.md\`:

1. **\`import Clean\` collides with Mathlib's Batteries.Data.Fin.Fold** — both define \`Fin.foldl_eq_foldl_finRange\`. Resolved by narrowing imports to \`Clean.Circuit.Channel\` + \`Clean.Circuit.Provable\` + \`Clean.Utils.Tactics.ProvableStructDeriving\`.
2. **\`[Field F]\` requirement on TypeMap-shaped records** — Clean's \`ProvableType\` / \`TypeMap\` machinery expects \`Type → Type\` without \`[Field F]\`. Existing zisk-fv records use the constraint; workaround was a parallel TypeMap pattern.

Tag: \`phase-1-clean-full\`.

## Trust gate

- V1: 10/10
- V2 semantic: closure matches baseline (116 names; unchanged)
- \`lake build\`: 8508 jobs clean

## Test plan

- [ ] \`lake build ZiskFv.Channels.OperationBus ZiskFv.Channels.MemoryBus ZiskFv.Channels.RangeBus\` succeeds
- [ ] No change to \`trust/baseline-axioms.txt\` (Phase 1 is pure scaffolding)
- [ ] \`docs/clean-feedback.md\` has the two new entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)