### PR TITLE
Fix proof workflow runner and dependencies

### DIFF
--- a/.github/workflows/proofs.yml
+++ b/.github/workflows/proofs.yml
@@ -118,9 +118,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # zisk/ submodule is a citation surface for transpile_*
-          # axiom rationales; the build does not read it.
-          submodules: false
+          # tools/transpiler-diff depends on zisk/{riscv,core} as
+          # path dependencies. The formal build inputs still come from
+          # flake.lock; this checkout is only for the differential pin.
+          submodules: true
 
       # cachix/install-nix-action (rather than DeterminateSystems') —
       # cachix-action assumes paths set up by this installer; using

--- a/.github/workflows/proofs.yml
+++ b/.github/workflows/proofs.yml
@@ -52,68 +52,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pick-runner:
-    # Pre-flight on a free GitHub-hosted runner: evaluate the pilout
-    # derivation's output store path and ask cachix whether it's already
-    # cached, so logs still explain whether the run is warm or cold.
-    # The proof job itself always uses the eth-act XL runner
-    # (`size-xl-x64`, 32 GiB). The cold pilout build needs >16 GiB, and
-    # the 2026-05-29 Clean AIR integration fresh `lake build` measured
-    # 27.9 GiB summed Lean RSS at LEAN_NUM_THREADS=3, so warm proof runs
-    # no longer fit the 16 GiB L runner either.
-    name: probe cachix and select XL runner
-    if: >-
-      github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'run-ci')
-    runs-on: ubuntu-latest
-    outputs:
-      runner: ${{ steps.pick.outputs.runner }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: false
-
-      - uses: cachix/install-nix-action@v27
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-
-      - name: Resolve pilout derivation output hash
-        id: eval
-        run: |
-          set -euo pipefail
-          path=$(nix eval --raw .#zisk-pilout.outPath)
-          hash=$(basename "$path" | cut -d- -f1)
-          echo "path=$path"
-          echo "hash=$hash"
-          echo "hash=$hash" >> "$GITHUB_OUTPUT"
-
-      - name: Probe zisk-fv.cachix.org for pilout
-        id: pick
-        run: |
-          set -uo pipefail
-          hash="${{ steps.eval.outputs.hash }}"
-          status=$(curl -sIo /dev/null -w "%{http_code}" \
-            "https://zisk-fv.cachix.org/${hash}.narinfo" || echo "000")
-          echo "narinfo HTTP $status for $hash"
-          if [ "$status" = "200" ]; then
-            echo "→ pilout cached; routing to size-xl-x64 for lake build headroom"
-          else
-            echo "→ pilout NOT cached; routing to size-xl-x64 for cold build"
-          fi
-          echo "runner=size-xl-x64" >> "$GITHUB_OUTPUT"
-
   lake-build:
     name: lake build (full FV check)
-    needs: pick-runner
-    # XL (32 GiB) is required for both cold pilout rebuilds and this
-    # branch's warm lake build: the 2026-05-29 fresh build at
-    # LEAN_NUM_THREADS=3 peaked at 27.9 GiB summed Lean RSS (12.1 GiB
-    # max single Lean process). Cold first run: ~30 min nix populate +
-    # ~90 min lake build (single-thread perf on the self-hosted runners
-    # is much slower than typical dev boxes). Subsequent runs hit the
-    # cachix cache for nix outputs and the actions/cache for .lake.
-    runs-on: ["self-hosted-ghr", "${{ needs.pick-runner.outputs.runner }}"]
+    # XL (32 GiB) is required for both cold pilout rebuilds and warm
+    # lake builds: the 2026-05-29 fresh build at LEAN_NUM_THREADS=3
+    # peaked at 27.9 GiB summed Lean RSS (12.1 GiB max single Lean
+    # process), so proof runs no longer target the 16 GiB L runner.
+    # Subsequent runs hit the cachix cache for Nix outputs and the
+    # actions/cache entry for .lake.
+    runs-on: ["self-hosted-ghr", "size-xl-x64"]
     timeout-minutes: 240
     steps:
       - uses: actions/checkout@v4

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -56,6 +56,7 @@ writeShellApplication {
 
     # 2. Default Rust-vs-Lean static-transpiler differential pinning.
     run "2/6 transpiler differential pinning" bash -c '
+      lake build ZiskFv.Transpiler.Static
       cargo run --manifest-path tools/transpiler-diff/Cargo.toml --quiet
     '
 

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -1,4 +1,5 @@
-{ writeShellApplication, elan, cargo, rustc, protobuf, python3, jq, git }:
+{ writeShellApplication, elan, cargo, rustc, protobuf, python3, jq, git
+, gcc, gnumake, nasm, gmp }:
 
 # Top-level test entry point. Single source of truth for "is the
 # project green?" Runs every check in dependency order so a clean
@@ -17,12 +18,25 @@ writeShellApplication {
   # are tracked via `overall` and surfaced in the final exit code.
   bashOptions = [ "nounset" "pipefail" ];
 
-  runtimeInputs = [ elan cargo rustc protobuf python3 jq git ];
+  runtimeInputs = [ elan cargo rustc protobuf python3 jq git gcc gnumake nasm ];
 
   text = ''
     cd "$(git rev-parse --show-toplevel)" || exit 1
 
     overall=0
+
+    export CPATH="${gmp.dev}/include''${CPATH:+:$CPATH}"
+    export LIBRARY_PATH="${gmp.out}/lib''${LIBRARY_PATH:+:$LIBRARY_PATH}"
+
+    prepare_zisk_rust_deps() {
+      # zisk-core's build.rs includes the float ELF unconditionally, but
+      # the RV64IM transpiler differential never executes the float runtime.
+      # Keep cargo focused on the static transpiler without requiring the
+      # RISC-V embedded C toolchain in this top-level test app.
+      mkdir -p zisk/lib-float/c/lib
+      touch zisk/lib-float/c/lib/libziskfloat.a zisk/lib-float/c/lib/ziskfloat.elf
+    }
+    prepare_zisk_rust_deps
 
     run() {
       local name=$1; shift


### PR DESCRIPTION
## Summary
- checkout the zisk submodule in the proof workflow
- add native zisk Rust build dependencies to the Nix test app
- build the transpiler oracle dependency before running the diff
- run the proof workflow directly on the XL self-hosted runner while keeping Cachix

## Testing
- nix run .#test
- GitHub Actions proof workflow triggered on ci/proof-workflow-fixes: https://github.com/eth-act/zisk-fv/actions/runs/26725194277