### PR TITLE
Run heavy proofs only on main

### DIFF
--- a/.github/workflows/proofs.yml
+++ b/.github/workflows/proofs.yml
@@ -10,29 +10,6 @@ name: proofs
 # nixpkgs rev) by content hash, so the same build runs across machines.
 
 on:
-  # On PRs the workflow is opt-in: the heavy job only runs when the
-  # `run-ci` label is present. Labels require Triage role or higher to
-  # apply, so an external contributor cannot self-trigger a ~30-50 min
-  # CI run from a fork. The job-level `if:` below enforces the gate;
-  # `types: [labeled, synchronize]` re-triggers on label apply and on
-  # subsequent pushes to an already-labeled PR. Path filters still apply
-  # as a secondary gate so pure-doc commits on a labeled PR don't burn
-  # runner time. Push to main and manual `workflow_dispatch` are
-  # unaffected.
-  pull_request:
-    types: [labeled, synchronize]
-    branches: [main]
-    paths:
-      - 'ZiskFv/**'
-      - 'tools/pil-extract/**'
-      - 'lake-manifest.json'
-      - 'lakefile.toml'
-      - 'lean-toolchain'
-      - 'flake.nix'
-      - 'flake.lock'
-      - 'nix/**'
-      - 'trust/**'
-      - '.github/workflows/proofs.yml'
   push:
     branches: [main]
     paths:
@@ -53,18 +30,56 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pick-runner:
+    name: probe cachix and select runner
+    runs-on: ubuntu-latest
+    outputs:
+      runner: ${{ steps.pick.outputs.runner }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Resolve pilout derivation output hash
+        id: eval
+        run: |
+          set -euo pipefail
+          path=$(nix eval --raw .#zisk-pilout.outPath)
+          name=${path##*/}
+          hash=${name%%-*}
+          echo "path=$path"
+          echo "hash=$hash"
+          echo "hash=$hash" >> "$GITHUB_OUTPUT"
+
+      - name: Probe zisk-fv.cachix.org for pilout
+        id: pick
+        run: |
+          set -uo pipefail
+          hash="${{ steps.eval.outputs.hash }}"
+          status=$(curl -sIo /dev/null -w "%{http_code}" \
+            "https://zisk-fv.cachix.org/${hash}.narinfo" || echo "000")
+          echo "narinfo HTTP $status for $hash"
+          if [ "$status" = "200" ]; then
+            echo "pilout cached; routing to size-l-x64"
+            echo "runner=size-l-x64" >> "$GITHUB_OUTPUT"
+          else
+            echo "pilout NOT cached; routing to size-xl-x64 for cold build"
+            echo "runner=size-xl-x64" >> "$GITHUB_OUTPUT"
+          fi
+
   lake-build:
     name: lake build (full FV check)
-    if: >-
-      github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'run-ci')
-    # XL (32 GiB) is required for both cold pilout rebuilds and warm
-    # lake builds: the 2026-05-29 fresh build at LEAN_NUM_THREADS=3
-    # peaked at 27.9 GiB summed Lean RSS (12.1 GiB max single Lean
-    # process), so proof runs no longer target the 16 GiB L runner.
-    # Subsequent runs hit the cachix cache for Nix outputs and the
-    # actions/cache entry for .lake.
-    runs-on: ["self-hosted-ghr", "size-xl-x64"]
+    needs: pick-runner
+    # Cached `nix populate` runs target the 16 GiB L runner again. The
+    # successful 2026-06-02 main run after the sd proof-memory fix peaked
+    # at 10.5 GiB kernel used memory with LEAN_NUM_THREADS=4. Cold pilout
+    # cache misses still route to the 32 GiB XL runner.
+    runs-on: ["self-hosted-ghr", "${{ needs.pick-runner.outputs.runner }}"]
     timeout-minutes: 240
     steps:
       - uses: actions/checkout@v4
@@ -120,14 +135,10 @@ jobs:
 
       - name: nix run .#test (cargo + lake + trust gate + flake check)
         env:
-          # threads=4 in CI. Run 26661855178's mem-trace (2026-05-29,
-          # warm cache, this branch) measured peak kernel `used` =
-          # 12.4 GiB and MemAvailable = 19 GiB on the 32 GiB XL runner
-          # at threads=3, so a 4th thread comfortably fits. Earlier
-          # threads=4 attempt OOM-killed at ZiskFv.Sail.sd back when
-          # sd.lean's elaboration peaked at 42 GiB; PR #4's layered
-          # dsimp+rw refactor cut it to ~8 GiB PSS, which is what makes
-          # 4 viable now. nix/test.nix's default is matched at 4.
+          # threads=4 in CI. Run 26850299478's mem-trace (2026-06-02,
+          # warm cache, main) measured peak kernel `used` = 10.5 GiB.
+          # That fits the 16 GiB L runner with headroom after the sd
+          # proof-memory fix, and matches nix/test.nix's default.
           LEAN_NUM_THREADS: "4"
         run: |
           # Memory + lean-process sidecar. Run 25230110804 died with no
@@ -144,7 +155,8 @@ jobs:
             while true; do
               ts=$(date -u +%H:%M:%S)
               mem=$(awk '/MemTotal/{t=$2} /MemAvailable/{a=$2} END{printf "tot=%.1fG avail=%.1fG used=%.1fG", t/1048576, a/1048576, (t-a)/1048576}' /proc/meminfo)
-              leans=$(pgrep -c '^lean$' || echo 0)
+              leans=$(pgrep -c '^lean$' || true)
+              leans=${leans:-0}
               lean_rss=$(awk '$2 == "lean" {sum += $1} END {printf "%.1fG", sum/1048576}' <(ps -eo rss,comm))
               load=$(awk '{print $1}' /proc/loadavg)
               line="[mem $ts] $mem leans=$leans lean_rss=$lean_rss load=$load"


### PR DESCRIPTION
## Summary
- remove the pull_request trigger from the heavy `proofs` workflow so stale/cancelled PR proof checks cannot affect the merged commit rollup
- restore cached-run routing to `size-l-x64`, with `size-xl-x64` reserved for cold pilout cache misses
- clean up the memory sidecar so `leans=0` does not split trace lines

## Evidence
- Successful `main` proofs run 26850299478 peaked at `used=10.5G` / `avail=20.9G` on the 32 GiB runner, so warm cached proof runs fit the 16 GiB L runner with headroom.
- Git history shows the prior cached-run route was `size-l-x64`, while cache misses routed to `size-xl-x64`.

## Testing
- `python3`/PyYAML parsed `.github/workflows/proofs.yml`
- `git diff --check`

Note: I did not dispatch the full proof workflow on this branch because this PR intentionally removes pull-request proof CI; the next full run should be the `main` push after merge.