### PR TITLE
Clean completeness Wave 1: MemAlign and BinaryAdd constructibility

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,50 +1,18 @@
-Active plan: docs/ai/plan/PLAN_RV64IM_COMPLETENESS_RESTACK.md
+Active plan: docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
 
-Current focus: replacement review PR #68 for `rv64im-completeness-v2`.
-The worktree was created from fetched `origin/main` at `6aa01c3e`; generated
-inputs were populated with `nix run .#populate`; `lake exe cache get`
-completed after the initial expected fresh-worktree path-dependency failure;
-`zisk` was fast-forwarded from `03e886f6` to `4148c25e`.
+Current focus: Wave 1 pilot for genuine Clean completeness proofs on branch
+`clean-completeness-wave1` in `.worktrees/completeness-wave1`: shared helpers,
+MemAlign, BinaryAdd, and witness-gate wiring.
 
-Blocking: waiting for PR #68 review and explicit merge approval.
+Blocking: none. Do not merge the PR; hand off for external review only.
 
-Phase 1-2 progress: payload, root imports, Aeneas script extension, no-sorry
-gate, and `nix/test.nix` Aeneas wiring are committed as `3d889970` and
-`da5be91d`. Focused checks passed; generated trust ledgers stayed
-byte-identical with 0 source axioms and 0 global-closure entries.
+Setup: worktree created from `origin/main` at `e3b87fc0`; `nix run .#populate`
+now works and populated generated inputs; `lake exe cache get`, `lake build
+repl`, full baseline `lake build`, and `trust/scripts/check-all.sh` passed.
+The `zisk` submodule is initialized at pinned `4148c25e`.
 
-Phase 3 progress: `README.md`, `trust/README.md`, `CLAUDE.md`, and
-`trust/defects.md` now frame `rv64im_completeness` as RV64IM
-acceptance/coverage completeness, document Aeneas interface mediation, and
-explicitly preserve the demoted Clean completeness non-claims. Phase 3
-checkpoint committed as `7914198c` (`Document RV64IM completeness framing`).
+Progress: Wave 1 plan copy is in this worktree and initial STATUS/project
+trail bookkeeping is being committed before Lean edits.
 
-Phase 4 progress: `nix develop --command lake build` passed (8674 jobs);
-`trust/scripts/check-all.sh` passed 17/17; `trust/scripts/check-all-semantic.sh`
-passed 5/5. A narrow V1 production-boundary gate update was needed so the
-new raw materialization helper is recognized and required to delegate through
-the accepted-raw helper.
-
-Explicit Aeneas RV64IM completeness extraction passed after the JALR
-target-mask extractor was updated for main's current Sail-side JALR shape:
-69 starts, 202 declarations, and 1759 generated Lean jobs built.
-
-Cargo verification: all four required `zisk/` tests passed (two `riscv`
-decoder tests and two `zisk-core --features aeneas_extract` raw-extraction
-gate tests).
-
-Aggregate verification: `nix run .#test` passed all 8 stages, including the
-wired Aeneas production extraction and V1/V2 trust gates.
-
-Final hygiene: submodule tracked build artifacts were restored; only ignored
-build dirs remain in `zisk/`. `git diff --check` and the generated-ledger drift
-check passed.
-
-PR #67 was accidentally merged as `9b44c42b`; Cody reset `main` back to
-`6aa01c3e`. Replacement review PR #68 is open at
-https://github.com/eth-act/zisk-fv/pull/68.
-
-Superseded PR #60 is closed with comments pointing to active PR #68 and
-preserving branch `rv64im-completeness` as the historical record.
-
-Next step: monitor PR #68 for review. Do not merge without explicit approval.
+Next step: add `ZiskFv/AirsClean/CompletenessHelpers.lean`, then implement the
+MemAlign builder/completeness/witness before moving to BinaryAdd.

--- a/STATUS.md
+++ b/STATUS.md
@@ -24,6 +24,16 @@ all 8 steps. Trust generated/baseline diff is empty; trust-surface diff is
 limited to the witness files and semantic script; canonical closure print
 shows no project axioms. BinaryAdd/gate proof chunk committed as `60c645c6`.
 Review PR opened: https://github.com/eth-act/zisk-fv/pull/69. Do not merge
-until external review completes.
+until external review completes. Review feedback addressed locally: the
+semantic witness gate now fails on Lean `sorry` warnings, the pre-existing Sail
+memory witness uses the same wrapper, and BinaryAdd/MemAlign docstrings state
+their proved constructibility scopes.
 
-Next step: wait for external review feedback on PR #69.
+Verification after feedback: temporary `completeness_witness_sorry_probe.lean`
+made `trust/scripts/check-all-semantic.sh` fail as expected on the Lean `sorry`
+warning; after deleting the probe, these passed: focused BinaryAdd/MemAlign
+circuit build, semantic gate, V1 gate, shell syntax check, and
+`git diff --check`.
+
+Next step: commit and push the review-fix chunk to PR #69, then wait for
+external review.

--- a/STATUS.md
+++ b/STATUS.md
@@ -24,7 +24,7 @@ all 8 steps. Trust generated/baseline diff is empty; trust-surface diff is
 limited to the witness files and semantic script; canonical closure print
 shows no project axioms. BinaryAdd/gate proof chunk committed as `60c645c6`.
 Review PR opened: https://github.com/eth-act/zisk-fv/pull/69. Do not merge
-until external review completes. Review feedback addressed locally: the
+until external review completes. Review feedback fix pushed as `91679f42`: the
 semantic witness gate now fails on Lean `sorry` warnings, the pre-existing Sail
 memory witness uses the same wrapper, and BinaryAdd/MemAlign docstrings state
 their proved constructibility scopes.
@@ -35,5 +35,4 @@ warning; after deleting the probe, these passed: focused BinaryAdd/MemAlign
 circuit build, semantic gate, V1 gate, shell syntax check, and
 `git diff --check`.
 
-Next step: commit and push the review-fix chunk to PR #69, then wait for
-external review.
+Next step: wait for external review feedback on PR #69.

--- a/STATUS.md
+++ b/STATUS.md
@@ -23,6 +23,7 @@ the semantic gate found both Wave 1 witness files. `nix run .#test` passed
 all 8 steps. Trust generated/baseline diff is empty; trust-surface diff is
 limited to the witness files and semantic script; canonical closure print
 shows no project axioms. BinaryAdd/gate proof chunk committed as `60c645c6`.
+Review PR opened: https://github.com/eth-act/zisk-fv/pull/69. Do not merge
+until external review completes.
 
-Next step: push `clean-completeness-wave1`, open the review PR, and do not
-merge it.
+Next step: wait for external review feedback on PR #69.

--- a/STATUS.md
+++ b/STATUS.md
@@ -12,8 +12,10 @@ repl`, full baseline `lake build`, and `trust/scripts/check-all.sh` passed.
 The `zisk` submodule is initialized at pinned `4148c25e`.
 
 Progress: initial STATUS/project trail bookkeeping committed as `fb021f11`.
-`ZiskFv.AirsClean.CompletenessHelpers` now provides `boolF` and
-`boolF_booleanity`; focused helper build passed.
+`ZiskFv.AirsClean.CompletenessHelpers` now provides `boolF` helpers; focused
+helper build passed. MemAlign has `memAlignRowOf`, a real builder-existential
+completeness proof, and `trust/consistency/completeness_witness_memalign.lean`;
+the focused circuit build and witness typecheck both pass.
 
-Next step: implement the MemAlign builder/completeness proof and witness,
-then run the focused MemAlign circuit/witness checks.
+Next step: implement the BinaryAdd builder/completeness proof and witness,
+then run focused BinaryAdd checks.

--- a/STATUS.md
+++ b/STATUS.md
@@ -22,7 +22,7 @@ larger completeness fields and now build focused. Full `lake build`,
 the semantic gate found both Wave 1 witness files. `nix run .#test` passed
 all 8 steps. Trust generated/baseline diff is empty; trust-surface diff is
 limited to the witness files and semantic script; canonical closure print
-shows no project axioms.
+shows no project axioms. BinaryAdd/gate proof chunk committed as `60c645c6`.
 
-Next step: commit the Wave 1 proof chunk, then prepare the review PR without
-merging it.
+Next step: push `clean-completeness-wave1`, open the review PR, and do not
+merge it.

--- a/STATUS.md
+++ b/STATUS.md
@@ -12,10 +12,17 @@ repl`, full baseline `lake build`, and `trust/scripts/check-all.sh` passed.
 The `zisk` submodule is initialized at pinned `4148c25e`.
 
 Progress: initial STATUS/project trail bookkeeping committed as `fb021f11`.
-`ZiskFv.AirsClean.CompletenessHelpers` now provides `boolF` helpers; focused
-helper build passed. MemAlign has `memAlignRowOf`, a real builder-existential
-completeness proof, and `trust/consistency/completeness_witness_memalign.lean`;
-the focused circuit build and witness typecheck both pass.
+Helpers and MemAlign are committed. BinaryAdd now has `binaryAddRowOf`, a real
+builder-existential completeness proof, and
+`trust/consistency/completeness_witness_binaryadd.lean`; focused BinaryAdd
+circuit build and witness typecheck both pass. `FullEnsemble` and
+`FullEnsemble/Balance` needed local proof-performance tightenings after the
+larger completeness fields and now build focused. Full `lake build`,
+`trust/scripts/check-all.sh`, and `trust/scripts/check-all-semantic.sh` pass;
+the semantic gate found both Wave 1 witness files. `nix run .#test` passed
+all 8 steps. Trust generated/baseline diff is empty; trust-surface diff is
+limited to the witness files and semantic script; canonical closure print
+shows no project axioms.
 
-Next step: implement the BinaryAdd builder/completeness proof and witness,
-then run focused BinaryAdd checks.
+Next step: commit the Wave 1 proof chunk, then prepare the review PR without
+merging it.

--- a/STATUS.md
+++ b/STATUS.md
@@ -11,8 +11,9 @@ now works and populated generated inputs; `lake exe cache get`, `lake build
 repl`, full baseline `lake build`, and `trust/scripts/check-all.sh` passed.
 The `zisk` submodule is initialized at pinned `4148c25e`.
 
-Progress: Wave 1 plan copy is in this worktree and initial STATUS/project
-trail bookkeeping is being committed before Lean edits.
+Progress: initial STATUS/project trail bookkeeping committed as `fb021f11`.
+`ZiskFv.AirsClean.CompletenessHelpers` now provides `boolF` and
+`boolF_booleanity`; focused helper build passed.
 
-Next step: add `ZiskFv/AirsClean/CompletenessHelpers.lean`, then implement the
-MemAlign builder/completeness/witness before moving to BinaryAdd.
+Next step: implement the MemAlign builder/completeness proof and witness,
+then run the focused MemAlign circuit/witness checks.

--- a/ZiskFv/AirsClean/BinaryAdd/Circuit.lean
+++ b/ZiskFv/AirsClean/BinaryAdd/Circuit.lean
@@ -1,5 +1,6 @@
 import ZiskFv.AirsClean.BinaryAdd.Constraints
 import ZiskFv.AirsClean.BinaryAdd.Soundness
+import ZiskFv.AirsClean.CompletenessHelpers
 import Clean.Air.FlatComponent
 import Clean.Utils.Tactics
 
@@ -27,6 +28,83 @@ open Goldilocks
 open Air.Flat
 open ZiskFv.Channels.OperationBus (OpBusChannel)
 
+/-- Low 32-bit limb used by the BinaryAdd honest-row builder. -/
+def binaryAddLo32 (x : ℕ) : ℕ := x % 2 ^ 32
+
+/-- High 32-bit limb used by the BinaryAdd honest-row builder. -/
+def binaryAddHi32 (x : ℕ) : ℕ := x / 2 ^ 32 % 2 ^ 32
+
+/-- The `k`th 16-bit chunk of a natural number. -/
+def binaryAddChunk16 (x k : ℕ) : ℕ := x / (2 ^ 16) ^ k % 2 ^ 16
+
+/-- Honest row for BinaryAdd: 32-bit operand limbs, 16-bit result chunks, and
+    the two carry bits are computed from the natural operands. -/
+def binaryAddRowOf (a b : ℕ) : BinaryAddRow FGL :=
+  let s := (a + b) % 2 ^ 64
+  let carry0 : ℕ := (binaryAddLo32 a + binaryAddLo32 b) / 2 ^ 32
+  let carry1 : ℕ := (binaryAddHi32 a + binaryAddHi32 b + carry0) / 2 ^ 32
+  { a_0 := (binaryAddLo32 a : FGL)
+    a_1 := (binaryAddHi32 a : FGL)
+    b_0 := (binaryAddLo32 b : FGL)
+    b_1 := (binaryAddHi32 b : FGL)
+    c_chunks_0 := (binaryAddChunk16 s 0 : FGL)
+    c_chunks_1 := (binaryAddChunk16 s 1 : FGL)
+    c_chunks_2 := (binaryAddChunk16 s 2 : FGL)
+    c_chunks_3 := (binaryAddChunk16 s 3 : FGL)
+    cout_0 := (carry0 : FGL)
+    cout_1 := (carry1 : FGL) }
+
+lemma binaryAdd_carry0_lt_two (a b : ℕ) :
+    (binaryAddLo32 a + binaryAddLo32 b) / 2 ^ 32 < 2 := by
+  unfold binaryAddLo32
+  omega
+
+lemma binaryAdd_carry1_lt_two (a b : ℕ) (_ha : a < 2 ^ 64) (_hb : b < 2 ^ 64) :
+    (binaryAddHi32 a + binaryAddHi32 b +
+        (binaryAddLo32 a + binaryAddLo32 b) / 2 ^ 32) / 2 ^ 32 < 2 := by
+  unfold binaryAddLo32 binaryAddHi32
+  omega
+
+lemma binaryAdd_low_half_eq (a b : ℕ) :
+    binaryAddLo32 a + binaryAddLo32 b =
+      (binaryAddLo32 a + binaryAddLo32 b) / 2 ^ 32 * 2 ^ 32 +
+        binaryAddChunk16 ((a + b) % 2 ^ 64) 1 * 2 ^ 16 +
+        binaryAddChunk16 ((a + b) % 2 ^ 64) 0 := by
+  unfold binaryAddLo32 binaryAddChunk16
+  omega
+
+lemma binaryAdd_high_half_eq (a b : ℕ) (ha : a < 2 ^ 64) (hb : b < 2 ^ 64) :
+    binaryAddHi32 a + binaryAddHi32 b +
+        (binaryAddLo32 a + binaryAddLo32 b) / 2 ^ 32 =
+      (binaryAddHi32 a + binaryAddHi32 b +
+          (binaryAddLo32 a + binaryAddLo32 b) / 2 ^ 32) / 2 ^ 32 * 2 ^ 32 +
+        binaryAddChunk16 ((a + b) % 2 ^ 64) 3 * 2 ^ 16 +
+        binaryAddChunk16 ((a + b) % 2 ^ 64) 2 := by
+  unfold binaryAddLo32 binaryAddHi32 binaryAddChunk16
+  have ha_hi : a / 2 ^ 32 < 2 ^ 32 := by omega
+  have hb_hi : b / 2 ^ 32 < 2 ^ 32 := by omega
+  have ha_mod : a / 2 ^ 32 % 2 ^ 32 = a / 2 ^ 32 := Nat.mod_eq_of_lt ha_hi
+  have hb_mod : b / 2 ^ 32 % 2 ^ 32 = b / 2 ^ 32 := Nat.mod_eq_of_lt hb_hi
+  rw [ha_mod, hb_mod]
+  let lo := (a % 2 ^ 32 + b % 2 ^ 32) % 2 ^ 32
+  let hi := (a / 2 ^ 32 + b / 2 ^ 32 + (a % 2 ^ 32 + b % 2 ^ 32) / 2 ^ 32) % 2 ^ 32
+  let carry := (a / 2 ^ 32 + b / 2 ^ 32 + (a % 2 ^ 32 + b % 2 ^ 32) / 2 ^ 32) / 2 ^ 32
+  have hsplit : (a + b) % 2 ^ 64 = lo + hi * 2 ^ 32 := by
+    dsimp [lo, hi]
+    omega
+  have hhi : (a + b) % 2 ^ 64 / 2 ^ 32 = hi := by omega
+  have hhi48 : (a + b) % 2 ^ 64 / 2 ^ 48 = hi / 2 ^ 16 := by omega
+  have hcarry :
+      a / 2 ^ 32 + b / 2 ^ 32 + (a % 2 ^ 32 + b % 2 ^ 32) / 2 ^ 32 =
+        carry * 2 ^ 32 + hi := by
+    dsimp [carry, hi]
+    omega
+  norm_num [show ((2 ^ 16 : ℕ) ^ 2) = 2 ^ 32 by norm_num,
+    show ((2 ^ 16 : ℕ) ^ 3) = 2 ^ 48 by norm_num]
+  norm_num at hhi hhi48
+  rw [hhi, hhi48]
+  omega
+
 /-- BinaryAdd as a Clean `GeneralFormalCircuit`. `Assumptions := True` —
     the 8 column range bounds the soundness proof needs are supplied by
     Clean static lookups, not by a caller assumption. -/
@@ -34,11 +112,9 @@ def circuit : GeneralFormalCircuit FGL BinaryAddRow unit :=
   { binaryAddElaborated with
     Assumptions := fun _ _ => True
     Spec := fun row _ _ => Spec row
-    -- Completeness is intentionally NOT claimed (zisk-fv is soundness-
-    -- only). `ProverAssumptions := False` makes this field a visible
-    -- non-claim. See trust/defects.md
-    -- ZISK-DEFECT-CLEAN-COMPLETENESS-TRIVIAL-AXIOMS.
-    ProverAssumptions := fun _ _ _ => False
+    -- Completeness covers honest BinaryAdd rows built from two 64-bit operands.
+    ProverAssumptions := fun row _ _ =>
+      ∃ a b, a < 2 ^ 64 ∧ b < 2 ^ 64 ∧ row = binaryAddRowOf a b
     ProverSpec := fun _ _ _ => True
     soundness := by
       circuit_proof_start
@@ -53,7 +129,85 @@ def circuit : GeneralFormalCircuit FGL BinaryAddRow unit :=
       · -- the op-bus push's requirement: `OpBusChannel.Guarantees` is `True`
         intro _
         trivial
-    completeness := fun _ _ _ _ _ _ h => h.elim }
+    completeness := by
+      circuit_proof_start [OpBusChannel, Lookup.completeness_def]
+      obtain ⟨a, b, ha, hb, hrow⟩ := h_assumptions
+      injection hrow with h_a_0 h_a_1 h_b_0 h_b_1 h_c_chunks_0 h_c_chunks_1
+        h_c_chunks_2 h_c_chunks_3 h_cout_0 h_cout_1
+      subst_vars
+      simp [binaryAddLo32, binaryAddHi32, binaryAddChunk16] at h_input ⊢
+      refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+      · simp only [RangeTables.rangeTable32, RangeTables.rangeStaticTable]
+        exact fgl_natCast_val_lt_of_lt (by decide) (by omega)
+      · simp only [RangeTables.rangeTable32, RangeTables.rangeStaticTable]
+        exact fgl_natCast_val_lt_of_lt (by decide) (by omega)
+      · simp only [RangeTables.rangeTable32, RangeTables.rangeStaticTable]
+        exact fgl_natCast_val_lt_of_lt (by decide) (by omega)
+      · simp only [RangeTables.rangeTable32, RangeTables.rangeStaticTable]
+        exact fgl_natCast_val_lt_of_lt (by decide) (by omega)
+      · simp only [RangeTables.rangeTable16, RangeTables.rangeStaticTable]
+        exact fgl_natCast_val_lt_of_lt (by decide) (by omega)
+      · simp only [RangeTables.rangeTable16, RangeTables.rangeStaticTable]
+        exact fgl_natCast_val_lt_of_lt (by decide) (by omega)
+      · simp only [RangeTables.rangeTable16, RangeTables.rangeStaticTable]
+        exact fgl_natCast_val_lt_of_lt (by decide) (by omega)
+      · simp only [RangeTables.rangeTable16, RangeTables.rangeStaticTable]
+        exact fgl_natCast_val_lt_of_lt (by decide) (by omega)
+      · have hcarry := binaryAdd_carry0_lt_two a b
+        have hcases :
+            (a % 4294967296 + b % 4294967296) / 4294967296 = 0 ∨
+              (a % 4294967296 + b % 4294967296) / 4294967296 = 1 := by
+          unfold binaryAddLo32 at hcarry
+          omega
+        rcases hcases with hzero | hone
+        · left
+          simp [hzero]
+        · right
+          simp [hone]
+      · have hnat := binaryAdd_low_half_eq a b
+        unfold binaryAddLo32 binaryAddChunk16 at hnat
+        norm_num at hnat
+        have hcast :
+            ((a % 4294967296 + b % 4294967296 : ℕ) : FGL) =
+              (((a % 4294967296 + b % 4294967296) / 4294967296 * 4294967296 +
+                ((a + b) % 18446744073709551616 / 65536 % 65536) * 65536 +
+                ((a + b) % 65536) : ℕ) : FGL) :=
+          congrArg (fun n : ℕ => (n : FGL)) hnat
+        norm_num at hcast ⊢
+        linear_combination hcast
+      · have hcarry := binaryAdd_carry1_lt_two a b ha hb
+        have hcases :
+            (a / 4294967296 % 4294967296 + b / 4294967296 % 4294967296 +
+                  (a % 4294967296 + b % 4294967296) / 4294967296) /
+                4294967296 =
+              0 ∨
+            (a / 4294967296 % 4294967296 + b / 4294967296 % 4294967296 +
+                  (a % 4294967296 + b % 4294967296) / 4294967296) /
+                4294967296 =
+              1 := by
+          unfold binaryAddLo32 binaryAddHi32 at hcarry
+          omega
+        rcases hcases with hzero | hone
+        · left
+          simp [hzero]
+        · right
+          simp [hone]
+      · have hnat := binaryAdd_high_half_eq a b ha hb
+        unfold binaryAddLo32 binaryAddHi32 binaryAddChunk16 at hnat
+        norm_num at hnat
+        have hcast :
+            ((a / 4294967296 % 4294967296 + b / 4294967296 % 4294967296 +
+                (a % 4294967296 + b % 4294967296) / 4294967296 : ℕ) : FGL) =
+              (((a / 4294967296 % 4294967296 + b / 4294967296 % 4294967296 +
+                    (a % 4294967296 + b % 4294967296) / 4294967296) /
+                    4294967296 * 4294967296 +
+                  ((a + b) % 18446744073709551616 / 281474976710656 % 65536) *
+                    65536 +
+                  ((a + b) % 18446744073709551616 / 4294967296 % 65536) : ℕ) :
+                FGL) :=
+          congrArg (fun n : ℕ => (n : FGL)) hnat
+        norm_num at hcast ⊢
+        linear_combination hcast }
 
 /-- BinaryAdd as a Clean `Air.Flat.Component`. -/
 def component : Air.Flat.Component FGL := ⟨ circuit ⟩

--- a/ZiskFv/AirsClean/BinaryAdd/Circuit.lean
+++ b/ZiskFv/AirsClean/BinaryAdd/Circuit.lean
@@ -12,14 +12,18 @@ Packages ZisK's BinaryAdd AIR as a Clean `Air.Flat.Component`:
 * `binaryAddElaborated` — the `ElaboratedCircuit` over `main` — lives in
   `Constraints.lean`.
 * `circuit` — the `GeneralFormalCircuit`. `Assumptions := True` for
-  soundness; completeness is intentionally a visible non-claim.
+  soundness; completeness is proved for honest rows built from two 64-bit
+  operands.
 * `component` — the `Air.Flat.Component`.
 
 ## Trust note
 
 `Assumptions := True` is what lets the Component compose into an ensemble
 non-vacuously (the `AssumptionsConsistency` obligation becomes trivial).
-No completeness claim is made; the `soundness` field is genuinely proved.
+Completeness is a constructibility claim for rows equal to `binaryAddRowOf a b`
+with `a < 2^64` and `b < 2^64`: the builder computes the 32-bit limbs,
+16-bit result chunks, and carry bits used by this constraint slice. It does
+not claim that arbitrary input rows are honest BinaryAdd executions.
 -/
 
 namespace ZiskFv.AirsClean.BinaryAdd

--- a/ZiskFv/AirsClean/CompletenessHelpers.lean
+++ b/ZiskFv/AirsClean/CompletenessHelpers.lean
@@ -19,7 +19,17 @@ open Goldilocks
 def boolF (b : Bool) : FGL := if b then 1 else 0
 
 @[simp]
+lemma boolF_false : boolF false = 0 := rfl
+
+@[simp]
+lemma boolF_true : boolF true = 1 := rfl
+
+@[simp]
 lemma boolF_booleanity (b : Bool) : boolF b * (1 - boolF b) = 0 := by
   cases b <;> simp [boolF]
+
+@[simp]
+lemma boolF_booleanity_add (b : Bool) : boolF b * (1 + -boolF b) = 0 := by
+  simpa [sub_eq_add_neg] using boolF_booleanity b
 
 end ZiskFv.AirsClean

--- a/ZiskFv/AirsClean/CompletenessHelpers.lean
+++ b/ZiskFv/AirsClean/CompletenessHelpers.lean
@@ -1,0 +1,25 @@
+import ZiskFv.Field.Goldilocks
+
+/-!
+# Clean completeness helper lemmas
+
+Small constructive helpers shared by honest-row completeness proofs.
+
+## Trust note
+
+No axioms. These are plain data constructors and elementary lemmas used by
+builder-existential `ProverAssumptions`.
+-/
+
+namespace ZiskFv.AirsClean
+
+open Goldilocks
+
+/-- Encode a Boolean selector as a Goldilocks field element. -/
+def boolF (b : Bool) : FGL := if b then 1 else 0
+
+@[simp]
+lemma boolF_booleanity (b : Bool) : boolF b * (1 - boolF b) = 0 := by
+  cases b <;> simp [boolF]
+
+end ZiskFv.AirsClean

--- a/ZiskFv/AirsClean/CompletenessHelpers.lean
+++ b/ZiskFv/AirsClean/CompletenessHelpers.lean
@@ -32,4 +32,10 @@ lemma boolF_booleanity (b : Bool) : boolF b * (1 - boolF b) = 0 := by
 lemma boolF_booleanity_add (b : Bool) : boolF b * (1 + -boolF b) = 0 := by
   simpa [sub_eq_add_neg] using boolF_booleanity b
 
+/-- A small natural below a Goldilocks-bounded range remains small after casting to `FGL`. -/
+lemma fgl_natCast_val_lt_of_lt {n bound : ℕ} (h_bound : bound ≤ GL_prime)
+    (h_n : n < bound) : ((n : FGL).val < bound) := by
+  rw [Fin.val_natCast]
+  omega
+
 end ZiskFv.AirsClean

--- a/ZiskFv/AirsClean/FullEnsemble.lean
+++ b/ZiskFv/AirsClean/FullEnsemble.lean
@@ -105,12 +105,10 @@ def fullRv64imEnsemble (length : ℕ) (program : Program length) :
           ZiskFv.AirsClean.Mem.circuitWithDualMemBus,
           ZiskFv.AirsClean.Mem.memWithDualMemBusElaborated])
     |>.addTable ZiskFv.AirsClean.MemAlign.component
-        (by simp [circuit_norm, ZiskFv.AirsClean.MemAlign.component,
-          ZiskFv.AirsClean.MemAlign.circuit,
-          ZiskFv.AirsClean.MemAlign.memAlignWithMemBusElaborated])
-        (by simp [circuit_norm, ZiskFv.AirsClean.MemAlign.component,
-          ZiskFv.AirsClean.MemAlign.circuit,
-          ZiskFv.AirsClean.MemAlign.memAlignWithMemBusElaborated])
+        (by
+          change ([] : List (RawChannel FGL)) ⊆ _
+          simp)
+        (by simp [circuit_norm])
     |>.addTable ZiskFv.AirsClean.MemAlignByte.component
         (by simp [circuit_norm, ZiskFv.AirsClean.MemAlignByte.component,
           ZiskFv.AirsClean.MemAlignByte.circuit,
@@ -136,37 +134,7 @@ def fullRv64imEnsemble (length : ℕ) (program : Program length) :
           rcases h with
             h | h | h | h | h | h | h | h | h | h | h <;>
             (rw [h]
-             simp [circuit_norm, Air.Flat.Component.Assumptions,
-               ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus,
-               ZiskFv.AirsClean.Main.circuitWithRomMemAndOpBus,
-               ZiskFv.AirsClean.Main.mainWithRomMemAndOpBusElaborated,
-               ZiskFv.AirsClean.BinaryAdd.component,
-               ZiskFv.AirsClean.BinaryAdd.circuit,
-               ZiskFv.AirsClean.BinaryAdd.binaryAddElaborated,
-               ZiskFv.AirsClean.Binary.staticLookupComponent,
-               ZiskFv.AirsClean.Binary.staticLookupCircuit,
-               ZiskFv.AirsClean.Binary.binaryWithStaticBinaryTableElaborated,
-               ZiskFv.AirsClean.BinaryExtension.staticLookupComponent,
-               ZiskFv.AirsClean.BinaryExtension.staticLookupCircuit,
-               ZiskFv.AirsClean.BinaryExtension.binaryExtensionWithStaticTableElaborated,
-               ZiskFv.AirsClean.ArithMul.component,
-               ZiskFv.AirsClean.ArithMul.circuit,
-               ZiskFv.AirsClean.ArithMul.arithMulElaborated,
-               ZiskFv.AirsClean.ArithDiv.component,
-               ZiskFv.AirsClean.ArithDiv.circuit,
-               ZiskFv.AirsClean.ArithDiv.arithDivElaborated,
-               ZiskFv.AirsClean.Mem.componentWithDualMemBus,
-               ZiskFv.AirsClean.Mem.circuitWithDualMemBus,
-               ZiskFv.AirsClean.Mem.memWithDualMemBusElaborated,
-               ZiskFv.AirsClean.MemAlign.component,
-               ZiskFv.AirsClean.MemAlign.circuit,
-               ZiskFv.AirsClean.MemAlign.memAlignWithMemBusElaborated,
-               ZiskFv.AirsClean.MemAlignByte.component,
-               ZiskFv.AirsClean.MemAlignByte.circuit,
-               ZiskFv.AirsClean.MemAlignByte.memAlignByteElaborated,
-               ZiskFv.AirsClean.MemAlignReadByte.component,
-               ZiskFv.AirsClean.MemAlignReadByte.circuit,
-               ZiskFv.AirsClean.MemAlignReadByte.memAlignReadByteElaborated]))
+             trivial))
         (by intro _ _; trivial)
 
 end ZiskFv.AirsClean.FullEnsemble

--- a/ZiskFv/AirsClean/FullEnsemble/Balance.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance.lean
@@ -174,10 +174,11 @@ theorem memAlign_table_interactionsWith_opBus_nil
   have h_not :
       OpBusChannel.toRaw ∉
         ZiskFv.AirsClean.MemAlign.component.circuit.channels := by
-    simp [circuit_norm, ZiskFv.AirsClean.MemAlign.component,
-      ZiskFv.AirsClean.MemAlign.circuit,
-      ZiskFv.AirsClean.MemAlign.memAlignWithMemBusElaborated,
-      OpBusChannel, MemBusChannel]
+    change OpBusChannel.toRaw ∉ [MemBusChannel.toRaw]
+    simp only [List.mem_singleton]
+    intro h
+    have h_name := congrArg (fun c : RawChannel FGL => c.name) h
+    simp [OpBusChannel, MemBusChannel, Channel.toRaw] at h_name
   apply Table.interactionsWith_nil_of_channel_not_mem
   rw [h_component]
   exact h_not
@@ -226,10 +227,11 @@ theorem binaryAdd_table_interactionsWith_memBus_nil
   have h_not :
       MemBusChannel.toRaw ∉
         ZiskFv.AirsClean.BinaryAdd.component.circuit.channels := by
-    simp [circuit_norm, ZiskFv.AirsClean.BinaryAdd.component,
-      ZiskFv.AirsClean.BinaryAdd.circuit,
-      ZiskFv.AirsClean.BinaryAdd.binaryAddElaborated,
-      OpBusChannel, MemBusChannel]
+    change MemBusChannel.toRaw ∉ [OpBusChannel.toRaw]
+    simp only [List.mem_singleton]
+    intro h
+    have h_name := congrArg (fun c : RawChannel FGL => c.name) h
+    simp [OpBusChannel, MemBusChannel, Channel.toRaw] at h_name
   apply Table.interactionsWith_nil_of_channel_not_mem
   rw [h_component]
   exact h_not

--- a/ZiskFv/AirsClean/MemAlign/Circuit.lean
+++ b/ZiskFv/AirsClean/MemAlign/Circuit.lean
@@ -1,5 +1,6 @@
 import ZiskFv.AirsClean.MemAlign.Constraints
 import ZiskFv.AirsClean.MemAlign.Soundness
+import ZiskFv.AirsClean.CompletenessHelpers
 import Clean.Air.FlatComponent
 import Clean.Utils.Tactics
 
@@ -25,16 +26,133 @@ open Goldilocks
 open Air.Flat
 open ZiskFv.Channels.MemoryBus (MemBusChannel)
 
+/-- Honest MemAlign phase: prove row, up-to-down transition,
+    down-to-up transition, or idle. -/
+inductive MemAlignPhase
+  | prove
+  | upToDown
+  | downToUp
+  | idle
+deriving DecidableEq, Repr
+
+namespace MemAlignPhase
+
+/-- Field selector for the prover row phase. -/
+@[simp]
+def selProve : MemAlignPhase → FGL
+  | prove => 1
+  | upToDown => 0
+  | downToUp => 0
+  | idle => 0
+
+/-- Field selector for the up-to-down transition phase. -/
+@[simp]
+def selUpToDown : MemAlignPhase → FGL
+  | prove => 0
+  | upToDown => 1
+  | downToUp => 0
+  | idle => 0
+
+/-- Field selector for the down-to-up transition phase. -/
+@[simp]
+def selDownToUp : MemAlignPhase → FGL
+  | prove => 0
+  | upToDown => 0
+  | downToUp => 1
+  | idle => 0
+
+end MemAlignPhase
+
+/-- Four-byte lane reconstruction used by the MemAlign honest-row builder. -/
+def memAlignLane (r0 r1 r2 r3 : FGL) : FGL :=
+  r0 + r1 * 256 + r2 * 65536 + r3 * 16777216
+
+/-- Honest value_0 for MemAlign, computed from phase, selectors, and registers. -/
+def memAlignValue0Of (phase : MemAlignPhase)
+    (sel_0 sel_1 sel_2 sel_3 sel_4 sel_5 sel_6 sel_7 : Bool)
+    (reg_0 reg_1 reg_2 reg_3 reg_4 reg_5 reg_6 reg_7 : FGL) : FGL :=
+  phase.selProve *
+    (boolF sel_0 * memAlignLane reg_0 reg_1 reg_2 reg_3 +
+     boolF sel_1 * memAlignLane reg_1 reg_2 reg_3 reg_4 +
+     boolF sel_2 * memAlignLane reg_2 reg_3 reg_4 reg_5 +
+     boolF sel_3 * memAlignLane reg_3 reg_4 reg_5 reg_6 +
+     boolF sel_4 * memAlignLane reg_4 reg_5 reg_6 reg_7 +
+     boolF sel_5 * memAlignLane reg_5 reg_6 reg_7 reg_0 +
+     boolF sel_6 * memAlignLane reg_6 reg_7 reg_0 reg_1 +
+     boolF sel_7 * memAlignLane reg_7 reg_0 reg_1 reg_2) +
+  (phase.selUpToDown + phase.selDownToUp) * memAlignLane reg_0 reg_1 reg_2 reg_3
+
+/-- Honest value_1 for MemAlign, computed from phase, selectors, and registers. -/
+def memAlignValue1Of (phase : MemAlignPhase)
+    (sel_0 sel_1 sel_2 sel_3 sel_4 sel_5 sel_6 sel_7 : Bool)
+    (reg_0 reg_1 reg_2 reg_3 reg_4 reg_5 reg_6 reg_7 : FGL) : FGL :=
+  phase.selProve *
+    (boolF sel_0 * memAlignLane reg_4 reg_5 reg_6 reg_7 +
+     boolF sel_1 * memAlignLane reg_5 reg_6 reg_7 reg_0 +
+     boolF sel_2 * memAlignLane reg_6 reg_7 reg_0 reg_1 +
+     boolF sel_3 * memAlignLane reg_7 reg_0 reg_1 reg_2 +
+     boolF sel_4 * memAlignLane reg_0 reg_1 reg_2 reg_3 +
+     boolF sel_5 * memAlignLane reg_1 reg_2 reg_3 reg_4 +
+     boolF sel_6 * memAlignLane reg_2 reg_3 reg_4 reg_5 +
+     boolF sel_7 * memAlignLane reg_3 reg_4 reg_5 reg_6) +
+  (phase.selUpToDown + phase.selDownToUp) * memAlignLane reg_4 reg_5 reg_6 reg_7
+
+/-- Honest row for MemAlign: phase and Boolean flags are encoded as field bits.
+    Dependent `pc`, `preL1`, `sel_*`, and `value_*` columns are computed; address
+    and register columns outside these equations are supplied by the caller. -/
+def memAlignRowOf (phase : MemAlignPhase) (isBoot wr reset : Bool)
+    (sel_0 sel_1 sel_2 sel_3 sel_4 sel_5 sel_6 sel_7 : Bool)
+    (reg_0 reg_1 reg_2 reg_3 reg_4 reg_5 reg_6 reg_7 : FGL)
+    (addr offset width step delta_addr pcVal : FGL) : MemAlignRow FGL :=
+  { addr := addr
+    offset := offset
+    width := width
+    wr := boolF wr
+    pc := if isBoot then 0 else pcVal
+    reset := boolF reset
+    sel_up_to_down := phase.selUpToDown
+    sel_down_to_up := phase.selDownToUp
+    reg_0 := reg_0
+    reg_1 := reg_1
+    reg_2 := reg_2
+    reg_3 := reg_3
+    reg_4 := reg_4
+    reg_5 := reg_5
+    reg_6 := reg_6
+    reg_7 := reg_7
+    sel_0 := boolF sel_0
+    sel_1 := boolF sel_1
+    step := step
+    sel_2 := boolF sel_2
+    sel_3 := boolF sel_3
+    sel_4 := boolF sel_4
+    sel_5 := boolF sel_5
+    sel_6 := boolF sel_6
+    sel_7 := boolF sel_7
+    sel_prove := phase.selProve
+    preL1 := boolF isBoot
+    delta_addr := delta_addr
+    value_0 := memAlignValue0Of phase sel_0 sel_1 sel_2 sel_3 sel_4 sel_5 sel_6 sel_7
+      reg_0 reg_1 reg_2 reg_3 reg_4 reg_5 reg_6 reg_7
+    value_1 := memAlignValue1Of phase sel_0 sel_1 sel_2 sel_3 sel_4 sel_5 sel_6 sel_7
+      reg_0 reg_1 reg_2 reg_3 reg_4 reg_5 reg_6 reg_7 }
+
 set_option maxRecDepth 2000 in
+set_option maxHeartbeats 4000000 in
 def circuit : GeneralFormalCircuit FGL MemAlignRow unit :=
   { memAlignWithMemBusElaborated with
     Assumptions := fun _ _ => True
     Spec := fun row _ _ => Spec row
-    -- Completeness is intentionally NOT claimed (zisk-fv is soundness-
-    -- only). `ProverAssumptions := False` makes this field a visible
-    -- non-claim. See trust/defects.md
-    -- ZISK-DEFECT-CLEAN-COMPLETENESS-TRIVIAL-AXIOMS.
-    ProverAssumptions := fun _ _ _ => False
+    -- Completeness covers rows built by `memAlignRowOf`: phase and Boolean
+    -- columns are honest, while unconstrained address/register data remains free.
+    ProverAssumptions := fun row _ _ =>
+      ∃ phase isBoot wr reset sel_0 sel_1 sel_2 sel_3 sel_4 sel_5 sel_6 sel_7
+        reg_0 reg_1 reg_2 reg_3 reg_4 reg_5 reg_6 reg_7
+        addr offset width step delta_addr pcVal,
+        row = memAlignRowOf phase isBoot wr reset
+          sel_0 sel_1 sel_2 sel_3 sel_4 sel_5 sel_6 sel_7
+          reg_0 reg_1 reg_2 reg_3 reg_4 reg_5 reg_6 reg_7
+          addr offset width step delta_addr pcVal
     ProverSpec := fun _ _ _ => True
     soundness := by
       circuit_proof_start
@@ -59,7 +177,29 @@ def circuit : GeneralFormalCircuit FGL MemAlignRow unit :=
               , by simpa only [sub_eq_add_neg] using h15 ⟩
       · intro _
         trivial
-    completeness := fun _ _ _ _ _ _ h => h.elim }
+    completeness := by
+      circuit_proof_start_core
+      simp only [mainWithMemBus, main, circuit_norm, selAssumeExpr,
+        memBusMessageExpr, MemBusChannel]
+      obtain ⟨phase, isBoot, wr, reset, sel_0, sel_1, sel_2, sel_3,
+        sel_4, sel_5, sel_6, sel_7, reg_0, reg_1, reg_2, reg_3,
+        reg_4, reg_5, reg_6, reg_7, addr, offset, width, step,
+        delta_addr, pcVal, hrow⟩ := h_assumptions
+      rw [hrow] at h_input
+      simp only [circuit_norm] at h_input
+      injection h_input with h_addr h_offset h_width h_wr h_pc h_reset h_sel_up_to_down
+        h_sel_down_to_up h_reg_0 h_reg_1 h_reg_2 h_reg_3 h_reg_4 h_reg_5
+        h_reg_6 h_reg_7 h_sel_0 h_sel_1 h_step h_sel_2 h_sel_3 h_sel_4
+        h_sel_5 h_sel_6 h_sel_7 h_sel_prove h_preL1 h_delta_addr
+        h_value_0 h_value_1
+      cases isBoot <;> cases phase <;>
+        simp [h_wr, h_pc, h_reset, h_sel_up_to_down, h_sel_down_to_up, h_reg_0,
+          h_reg_1, h_reg_2, h_reg_3, h_reg_4, h_reg_5, h_reg_6, h_reg_7, h_sel_0,
+          h_sel_1, h_sel_2, h_sel_3, h_sel_4, h_sel_5, h_sel_6, h_sel_7,
+          h_sel_prove, h_preL1, h_value_0, h_value_1, memAlignValue0Of,
+          memAlignValue1Of, memAlignLane] <;>
+        ring_nf <;>
+        simp }
 
 def component : Air.Flat.Component FGL := ⟨ circuit ⟩
 

--- a/ZiskFv/AirsClean/MemAlign/Circuit.lean
+++ b/ZiskFv/AirsClean/MemAlign/Circuit.lean
@@ -16,8 +16,10 @@ continuity remains in `CrossRow.lean`.
 
 ## Trust note
 
-No axioms. Completeness is intentionally a visible non-claim, following the
-soundness-only project boundary.
+No axioms. Completeness is a constructibility claim for rows equal to
+`memAlignRowOf ...`: a concrete phase, Boolean flags/selectors, registers, and
+address fields with `value_0`, `value_1`, `preL1`, and `pc` computed by the
+builder. Cross-row continuity remains outside this row-local proof.
 -/
 
 namespace ZiskFv.AirsClean.MemAlign

--- a/docs/ai/PROJECTS.md
+++ b/docs/ai/PROJECTS.md
@@ -1,5 +1,13 @@
 # Projects
 
+## Clean Completeness Proofs
+
+Plan: `docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md`. Wave 1 is active in
+`.worktrees/completeness-wave1` on branch `clean-completeness-wave1`, upgrading
+MemAlign and BinaryAdd from explicit Clean completeness non-claims to honest
+builder-existential constructibility proofs with gate-wired witnesses. Scope is
+review handoff only: open/push the PR when ready, but do not merge it.
+
 ## RV64IM Completeness Restack
 
 Plan: `docs/ai/plan/PLAN_RV64IM_COMPLETENESS_RESTACK.md`. PR #68 is the active

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -1,53 +1,68 @@
 # Plan: Clean Completeness Proofs
 
-Status: READY FOR EXECUTION. Base: `origin/main` at `e3b87fc0` or later.
-This file is the handoff document — it is written to be executed by agents
-without further design work. Read it fully before editing anything.
+Status: Wave 1 COMPLETE (PR #69). Waves 2–5 READY FOR EXECUTION.
+This file is the handoff document — execute it without further design work.
+Wave 1's merged code is the REFERENCE IMPLEMENTATION for everything below;
+when this plan and that code disagree, copy the code.
 
-## How to run this stream
+## How to run a wave
 
 - One worktree per wave: `git worktree add .worktrees/completeness-<wave>
-  origin/main` (create MANUALLY — never agent worktree isolation).
-- FIRST command in every new worktree: `lake exe cache get`. If it complains
-  about missing path deps, run `nix run .#populate`, then retry. Then a full
-  `lake build` + `trust/scripts/check-all.sh` BEFORE any edit (green baseline).
-- Copy this plan into the worktree's `docs/ai/plan/` and commit it there
-  (docs/ai is local-excluded in the parent checkout). Keep the worktree's
-  `STATUS.md` and this file's checklists current at every progress report.
-  Tick checkboxes and append short log lines only — do NOT expand this plan.
-- Commit and push freely on the wave branch. ASK CODY before opening each PR.
-- Wave 1 goes first and fixes the idiom. Waves 2–5 run in parallel after
-  Wave 1's PR merges (they copy its idiom; Waves 2,3,5 also use its helpers).
-- Sub-agent prompts must include the CLAUDE.md anti-laundering principle
-  verbatim and require reading `trust/README.md#anti-laundering-terms`.
-  Vocabulary note: this stream is **completeness / constructibility** work,
-  NOT promise discharge — use those words in PR titles/bodies/commits.
+  origin/main` (MANUALLY — never agent worktree isolation). Base must contain
+  the Wave 1 merge (CompletenessHelpers + hardened witness gate).
+- FIRST command in the new worktree: `lake exe cache get`. If it complains
+  about missing path deps: `nix run .#populate`, retry. Then full
+  `lake build` + `trust/scripts/check-all.sh` green BEFORE any edit.
+- This plan file is tracked in the repo. Edit ONLY your wave's checklist
+  boxes and append log lines prefixed `W<n>:`. Never touch another wave's
+  section. On rebase conflicts in this file or STATUS.md, keep both sides.
+- Commit and push freely on the wave branch.
+
+### PR protocol (UPDATED 2026-06-12 — no human pre-ack needed)
+
+When your wave's checklist is done and ALL verification commands pass, OPEN
+THE PR YOURSELF — do not wait for permission. Requirements:
+
+- Title: `Clean completeness Wave <n>: <components>`.
+- First body line: `Queued for Claude review — do not merge.`
+- Body sections, in order: Summary; Scope notes (any documented partial
+  coverage — Wave 3 table ops, Wave 4 unsigned modes); Verification (paste
+  the gate tails, the empty trust-diff confirmation, the closure-print
+  result, and the witness file list); Notes for later waves (anything the
+  next agents must copy or avoid).
+- Review is performed by Claude (Cody's reviewing agent), not by you.
+  Expect the review to: re-run both gates and the build, diff-check the
+  baselines, grep for soundness-side edits, hand-check your builder against
+  the constraint expressions, and negative-test your witness. Write the PR
+  so all of that passes on the first try.
+- After opening the PR, STOP. Do not merge, do not self-approve, do not
+  start another wave's components.
+
+### Sub-agent rule
+
+Any sub-agent prompt must include the CLAUDE.md anti-laundering principle
+verbatim and require reading `trust/README.md#anti-laundering-terms` first.
+Vocabulary: this stream is **completeness / constructibility** work, NOT
+promise discharge — use those words in PR titles/bodies/commits.
 
 ## Context
 
 PR #66 (`2c862063`) demoted all dishonest Clean completeness fields to
-explicit non-claims: `ProverAssumptions := fun _ _ _ => False` with ex-falso
-bodies. History: the six original axioms were FALSE as stated (trivial
-ProverAssumptions over input-only rows — see
+explicit non-claims (`ProverAssumptions := fun _ _ _ => False`, ex-falso
+bodies). History: the six original axioms were FALSE as stated (see
 `ZISK-DEFECT-CLEAN-COMPLETENESS-TRIVIAL-AXIOMS` in `trust/defects.md`), and
-the earlier PR #56 "proofs" were circular (`ProverAssumptions := Spec row`
-where Spec restates the constraints — reverted by PR #62 as a launder).
+PR #56's "proofs" were circular (`ProverAssumptions := Spec row` restating
+the constraints — reverted by PR #62 as a launder).
 
 This stream upgrades all 16 demoted fields to GENUINE completeness proofs:
-for each component, an honest-row builder, a builder-existential
+per component, an honest-row builder, a builder-existential
 `ProverAssumptions`, a real proof, and a gate-wired anti-vacuity witness.
-The payoff is proved satisfiability of each constraint slice by honest rows
-(constructibility), which also protects the soundness theorems from
-overstrong-validator vacuity. Purely additive: no axioms, no ledger changes,
-no canonical-theorem changes.
-
-The 16 fields (post-#66 tree; re-run `rg "completeness :=" ZiskFv` and
-reconcile before starting — line numbers drift):
+Purely additive: no axioms, no ledger changes, no canonical-theorem changes.
+Wave 1 (PR #69) delivered MemAlign + BinaryAdd + helpers + the hardened
+witness gate. Remaining fields:
 
 | Component file (`ZiskFv/AirsClean/`) | Circuits to complete | Wave |
 |---|---|---|
-| BinaryAdd/Circuit.lean | `circuit` | 1 |
-| MemAlign/Circuit.lean | `circuit` | 1 |
 | MemAlignReadByte/Circuit.lean | `circuit` | 2 |
 | MemAlignByte/Circuit.lean | `circuit` | 2 |
 | Mem/Circuit.lean | `circuit`, `circuitWithMemBus`, `circuitWithDualMemBus` | 2 |
@@ -57,400 +72,475 @@ reconcile before starting — line numbers drift):
 | ArithDiv/Circuit.lean | `circuit` | 4 |
 | Main/Circuit.lean | `circuit`, `circuitWithRomAndMemBus`, `circuitWithRomMemAndOpBus` | 5 |
 
-`BinaryExtension/Circuit.lean` (plain circuit, push-only) is ALREADY genuinely
-complete with `ProverAssumptions := True` — leave it untouched.
+`BinaryExtension/Circuit.lean` (plain, push-only) is already genuinely
+complete — leave it untouched. Re-run `rg "completeness :=" ZiskFv` at the
+start of your wave and reconcile against this table.
 
-## Technical groundwork (verified 2026-06-12 — trust this, don't re-derive)
+## Reference implementations (READ THE CODE FIRST)
 
-What `GeneralFormalCircuit.Completeness` demands, per operation in `main`:
+Wave 1 proved the idiom end to end. Before writing anything, read:
 
-- `assertZero e` → goal `env e = 0` (a Goldilocks field equation).
-- `lookup (Table.fromStatic t) entry` → goal = `t.Spec (eval env entry)`,
-  reached via `Lookup.completeness_def`
-  (`build/clean-lean/Clean/Circuit/Lookup.lean:107`; StaticTable's
-  `Completeness := Spec` at `Lookup.lean:137-153`). For
-  `rangeTable32/16/8` the Spec is `val < 2^32 / 2^16 / 2^8`
-  (`ZiskFv/AirsClean/RangeTables.lean:58-74`). For the ROM table the Spec is
-  `∃ i, msg = program i` (`ZiskFv/AirsClean/ZiskInstructionRom.lean:56-67`).
-- `OpBusChannel.push` / `MemBusChannel.emit` → goal `Guarantees env`, which
-  is `True` for both buses (`ZiskFv/Channels/OperationBus.lean:145`,
-  `ZiskFv/Channels/MemoryBus.lean:105`). `circuit_proof_start [<Channel>]`
-  discharges these automatically.
-- `env.UsesLocalWitnessesCompleteness` is a HYPOTHESIS and is vacuously true
-  for every component here (`localLength = 0`, no witness ops/subcircuits).
-- Binder order after the statement unfolds: `offset env input_var h_env
-  input h_input h_assumptions ⊢ ConstraintsHold.Completeness … ∧ ProverSpec …`.
-  With `ProverSpec := True` the second conjunct is `trivial`.
-- `circuit_proof_start` handles completeness goals (recognizes
-  `GeneralFormalCircuit.Completeness`,
-  `build/clean-lean/Clean/Utils/Tactics/CircuitProofStart.lean:65-69`).
-  For WIDE rows (43-column ArithMul/ArithDiv) its `provable_struct_simp` is
-  too slow — use `circuit_proof_start_core` + `subst` + targeted
-  `simp only [circuit_norm, main]`, exactly as the existing
-  `ArithDiv.circuit.soundness` does (`ZiskFv/AirsClean/ArithDiv/Circuit.lean`).
-- Nothing downstream consumes `completeness` or `ProverAssumptions`
-  (`FormalEnsemble` has no completeness field) — these edits cannot break
-  soundness consumers; `lake build` confirms per wave.
+| What you need | Copy from |
+|---|---|
+| Helpers (`boolF`, `boolF_booleanity`, `boolF_booleanity_add`, `fgl_natCast_val_lt_of_lt`) | `ZiskFv/AirsClean/CompletenessHelpers.lean` |
+| Nat-operand builder + chunk/carry lemmas + range-lookup discharge | `ZiskFv/AirsClean/BinaryAdd/Circuit.lean` (builder `binaryAddRowOf`, lemmas `binaryAdd_*`, the `completeness :=` block) |
+| Bool/enum-operand builder + computed mux columns + case-split proof | `ZiskFv/AirsClean/MemAlign/Circuit.lean` (`MemAlignPhase`, `memAlignRowOf`, the `completeness :=` block) |
+| Witness file shape | `trust/consistency/completeness_witness_binaryadd.lean` and `_memalign.lean` |
+| Scoped docstring wording (states what IS proved and what is NOT claimed) | The module docstrings of both Wave 1 files (post-`91679f42`) |
+| Principled ensemble proof patterns (channel-name discrimination, `change` to the channel-list goal) | `ZiskFv/AirsClean/FullEnsemble.lean` MemAlign `.addTable` args; `FullEnsemble/Balance.lean::memAlign_table_interactionsWith_opBus_nil` and `binaryAdd_table_interactionsWith_memBus_nil` |
 
-## The idiom (fixed — every component follows this exactly)
+## The proven recipe (follow mechanically)
+
+### 1. Builder
 
 ```lean
-/-- Honest row for <Air>: <one-line semantics>. Dependent columns are
-    COMPUTED from operands; columns outside this constraint slice are free. -/
-def <air>RowOf (<semantic operands>) (free : <Air>FreeCols FGL) : <Air>Row FGL :=
-  { <col> := <computed or copied> , … }
-
--- in the circuit definition:
-    ProverAssumptions := fun row _ _ =>
-      ∃ <operands> free, <semantic side-conditions> ∧ row = <air>RowOf <operands> free
-    ProverSpec := fun _ _ _ => True
-    completeness := by
-      circuit_proof_start [<Channel names>]      -- or _core route for wide rows
-      obtain ⟨<operands>, free, h_side, rfl⟩ := h_assumptions
-      -- h_input : eval env input_var = <air>RowOf …; split per-column:
-      --   simp only [circuit_norm] at h_input; dsimp only [<air>RowOf] at h_input
-      --   then `<Air>Row.mk.injEq` / `injection` to get per-column equations,
-      --   rewrite them into the constraint goals.
-      refine ⟨?_, …⟩  -- one goal per assertZero/lookup, then discharge
+def <air>RowOf (<semantic operands>) : <Air>Row FGL := { <every column> := … }
 ```
 
-Rules:
+- Dependent columns (carries, mux outputs, composed values, result chunks)
+  are COMPUTED by the builder. Never operands.
+- Boolean-constrained columns take `Bool` operands via `boolF`. Columns with
+  a one-hot-or-idle constraint take a small enum (see `MemAlignPhase`).
+- Columns not occurring in any constraint of the slice are free `FGL`
+  operands (bundle as a `<Air>FreeCols` structure when there are many).
+- Mux/composed columns must mirror the `Constraints.lean` expressions
+  VERBATIM (with operands substituted) — then those constraints discharge by
+  `ring`/`simp`, no case analysis on the muxed branches.
 
-1. Dependent columns (carries, mux outputs, composed values, c-chunks) are
-   computed BY the builder. Never operands.
-2. Side-conditions are SEMANTIC operand facts only: numeric ranges
-   (`a < 2^64`), `Bool`-typed flags, program-entry coherence. A
-   side-condition that restates a constraint polynomial = the PR #56 launder
-   = reject the work.
-3. Free columns (not occurring in any constraint of the slice) are bundled in
-   a `<Air>FreeCols` structure so honesty is maximal (any honest value
-   allowed).
-4. Replace the PR #66 doc comment ("Completeness is intentionally NOT
-   claimed…") with one stating what IS now proved, including scope caveats.
-5. New top-level defs get the hidden-promise review: builders and FreeCols
-   are constructive data (fine as plain defs); do NOT introduce named Prop
-   abbreviations for ProverAssumptions — keep the existential inline and
-   visible.
-6. Every component ships, in the same PR, a witness file
-   `trust/consistency/completeness_witness_<air>.lean`: concrete operands,
-   `example`/`theorem` applying the proved completeness statement or at
-   minimum proving `ProverAssumptions (<air>RowOf <concrete>) …` is
-   inhabited and the row satisfies the constraint equations. Follow the
-   structure of `trust/consistency/load_byte_agreement_witness.lean`
-   (private defs + one public theorem). Prefer `decide`/`norm_num` over
-   `native_decide` where feasible.
+### 2. ProverAssumptions
 
-## Gate wiring (Wave 1 does this ONCE)
-
-Add to `trust/scripts/check-all-semantic.sh`, after the existing check 5/5,
-a single globbing check so later waves add witness files without ever
-editing the script (no merge conflicts):
-
-```bash
-run_witnesses() {
-  local ok=0
-  for f in trust/consistency/completeness_witness_*.lean; do
-    [ -e "$f" ] || continue
-    lake env lean "$f" || ok=1
-  done
-  return $ok
-}
-run "6/6 Clean completeness witnesses" run_witnesses
+```lean
+ProverAssumptions := fun row _ _ =>
+  ∃ <operands>, <semantic side-conditions> ∧ row = <air>RowOf <operands>
 ```
 
-(Match the script's existing `run` helper conventions; renumber the label if
-the script counts checks differently.)
+Side-conditions are SEMANTIC operand facts only: numeric ranges
+(`a < 2^64`), Bool implications, table-entry coherence (Waves 3/5). A
+side-condition that restates a constraint polynomial is the banned PR #56
+shape and fails review. Keep the existential inline — no named Prop wrappers.
 
-## Wave 1 — pilot: helpers + MemAlign + BinaryAdd (1 agent, 1 PR)
+### 3. Completeness proof — the working skeleton
+
+Narrow rows (≤ ~30 cols), as in BinaryAdd:
+
+```lean
+completeness := by
+  circuit_proof_start [<Channels>, Lookup.completeness_def]  -- channels only if the circuit pushes
+  obtain ⟨<operands>, hrow⟩ := h_assumptions
+  injection hrow with h_<col1> h_<col2> …    -- one name per column, in order
+  subst_vars
+  -- then refine ⟨?_, …⟩ with one goal per lookup/assertZero and discharge
+```
+
+Wide rows (43-col Arith) or when `circuit_proof_start` is slow, as in
+MemAlign:
+
+```lean
+set_option maxRecDepth 2000 in
+set_option maxHeartbeats 4000000 in
+def circuit : … := { … with
+  completeness := by
+    circuit_proof_start_core
+    simp only [<main defs>, circuit_norm, <message exprs>, <Channel>]
+    obtain ⟨<operands>, hrow⟩ := h_assumptions
+    rw [hrow] at h_input
+    simp only [circuit_norm] at h_input
+    injection h_input with h_<col1> …       -- nested rows: injection AGAIN per sub-struct
+    <case splits> <;> simp [h_…, <builder defs>] <;> ring_nf <;> simp }
+```
+
+Per-goal discharge:
+
+- **Range lookup** (`rangeTable32/16/8`):
+  `simp only [RangeTables.rangeTable<N>, RangeTables.rangeStaticTable]`,
+  then `exact fgl_natCast_val_lt_of_lt (by decide) (by omega)`.
+- **Static-table lookup** (BinaryTable / BinaryExtensionTable / ROM): the
+  goal is `∃ i, <tuple> = rowOfIndex i.val` (resp. `= program i`). Build the
+  row FROM table indices so this closes with `exact ⟨i_k, rfl⟩` (Wave 3/5
+  recipes below).
+- **Booleanity**: `boolF_booleanity` / `boolF_booleanity_add` (the goal may
+  arrive in `a + -b` normal form — the `_add` variant or
+  `simpa only [sub_eq_add_neg]` handles it).
+- **Carry/chunk equations**: prove the Nat identity by `omega` in a
+  standalone lemma, cast via `congrArg (fun n : ℕ => (n : FGL))` +
+  `push_cast`/`norm_num`, close with `linear_combination`. Keep power
+  literals in ONE form per proof (CLAUDE.md trap #2).
+- **Channel pushes**: no goal, or `trivial` — `circuit_proof_start
+  [<Channel>]` absorbs them.
+
+### 4. Witness file (verbatim shape from Wave 1)
+
+`trust/consistency/completeness_witness_<air>.lean` (single lowercase word
+after the prefix — the gate globs `completeness_witness_*.lean`):
+
+```lean
+import ZiskFv.AirsClean.<Air>.Circuit
+namespace ZiskFv.TrustConsistency
+open Goldilocks ZiskFv.AirsClean.<Air>
+
+private def <air>WitnessRow : <Air>Row FGL := <air>RowOf <concrete operands>
+
+private theorem <air>WitnessProverAssumptions
+    (data : ProverData FGL) (hint : ProverHint FGL) :
+    circuit.ProverAssumptions <air>WitnessRow data hint := by
+  refine ⟨<concrete operands>, <side-condition proofs by norm_num/decide>, ?_⟩
+  rfl
+
+theorem completeness_witness_<air> :
+    ∃ row : <Air>Row FGL, ∀ data hint, circuit.ProverAssumptions row data hint :=
+  ⟨<air>WitnessRow, <air>WitnessProverAssumptions⟩
+
+#print axioms completeness_witness_<air>
+end ZiskFv.TrustConsistency
+```
+
+The semantic gate (check 6/6) discovers it automatically and FAILS on
+`sorry` — `sorry` in a witness is caught mechanically, don't try. DO NOT
+edit `trust/scripts/check-all-semantic.sh`; it is final as of `91679f42`.
+
+### 5. Docstring (audit surface — reviewers read this first)
+
+Replace the PR #66 "intentionally NOT claimed" comment with the Wave 1
+post-fix wording style: state the proved scope ("Completeness is a
+constructibility claim for rows equal to `<air>RowOf …` with <conditions>")
+AND the explicit non-claims ("It does not claim that arbitrary input rows
+are honest <Air> executions"; cross-row/out-of-slice caveats where relevant).
+
+### 6. Ensemble call sites (perf trap — handle in the SAME PR)
+
+`FullEnsemble.lean` and `FullEnsemble/Balance.lean` contain
+`simp [circuit_norm, ZiskFv.AirsClean.<X>.component, …<elaborated>]` proofs
+that unfold your component record. Once your completeness field is a large
+term, those `simp`s can slow down or time out. Rule: after your component
+edit, run `lake build ZiskFv.AirsClean.FullEnsemble` and `lake build
+ZiskFv.AirsClean.FullEnsemble.Balance`. If slow or failing, convert YOUR
+component's call sites to the Wave 1 patterns (statements unchanged, proof
+bodies only):
+
+- channel-subset arg: `(by change ([] : List (RawChannel FGL)) ⊆ _; simp)`
+  or `(by simp [circuit_norm])`.
+- `interactionsWith … = []` lemmas in Balance.lean:
+  `change <Other>Channel.toRaw ∉ [<Mine>Channel.toRaw]`, then the
+  name-discrimination block from
+  `Balance.lean::memAlign_table_interactionsWith_opBus_nil`.
+- Assumptions-consistency arg: `trivial` (all components have
+  `Assumptions := True`).
+
+Call sites by wave (grep `simp \[circuit_norm, ZiskFv` to get current
+lines): Wave 2 — MemAlignByte, MemAlignReadByte, Mem.componentWithDualMemBus
+(2 sites each in FullEnsemble.lean + 1 each in Balance.lean). Wave 3 —
+Binary.staticLookupComponent, BinaryExtension.staticLookupComponent. Wave 4
+— ArithMul.component, ArithDiv.component (ArithDiv has 2 Balance sites).
+Wave 5 — Main sites were already converted in Wave 1; verify with the grep.
+
+## Wave 1 — COMPLETE (PR #69)
+
+- [x] Worktree + cache + green baseline; commit plan copy + STATUS.md.
+- [x] `ZiskFv/AirsClean/CompletenessHelpers.lean`.
+- [x] MemAlign builder + completeness + witness.
+- [x] BinaryAdd builder + completeness + witness.
+- [x] Globbing witness check in `check-all-semantic.sh` (+ post-review
+      hardening: fails on `sorry`; also wraps check 5/5).
+- [x] Gates; PR opened and review-fixed (`91679f42`).
+
+Outcome notes for later waves: `lake build ZiskFv.AirsClean` is NOT a
+target — use `lake build ZiskFv.AirsClean.<Component>.Circuit`. Broad
+`simp` over component records in ensemble proofs is the main perf hazard
+(section 6). The `injection`-based `h_input` split is reliable; name every
+column in order.
+
+## Wave 2 — byte/mem mux family (1 agent, 1 PR)
 
 ### Checklist
 
-- [x] Worktree + cache + green baseline; commit plan copy + STATUS.md.
-- [x] `ZiskFv/AirsClean/CompletenessHelpers.lean`: `boolF`,
-      `boolF_booleanity`, shared plumbing lemmas discovered during the pilot.
-- [x] MemAlign builder + completeness + witness.
-- [x] BinaryAdd builder + completeness + witness.
-- [x] Globbing witness check in `check-all-semantic.sh`.
-- [x] Gates (see Verification); ask Cody; open PR.
-- [x] Record in the PR body any idiom adjustments waves 2–5 must copy.
+- [ ] Worktree + cache + green baseline; STATUS.md; log line `W2: started`.
+- [ ] MemAlignReadByte builder + completeness + witness.
+- [ ] MemAlignByte builder + completeness + witness.
+- [ ] Mem shared builder + one shared constraints lemma + all 3 completeness
+      fields + witness.
+- [ ] Docstrings per recipe §5; ensemble call sites per §6.
+- [ ] Verification block; open PR per protocol.
 
-### Helpers
+### MemAlignReadByte (`circuit`, smallest — do first)
 
-```lean
-def boolF (b : Bool) : FGL := if b then 1 else 0
-@[simp] lemma boolF_booleanity (b : Bool) : boolF b * (1 - boolF b) = 0 := by
-  cases b <;> simp [boolF]
-```
+Row columns: `sel_high_4b sel_high_2b sel_high_b direct_value composed_value
+value_16b value_8b byte_value addr_w step`. Constraints (mirror
+`Constraints.lean` exactly — counts in this plan are approximate): selector
+booleanities + the composed-value reconstruction + a `rangeTable8` lookup on
+`byte_value`.
 
-### MemAlign (`MemAlign/Circuit.lean::circuit`, 16 assertZeros + MemBus emit, no lookups)
+Builder: `(s4 s2 s1 : Bool)` selectors; `(byteVal : ℕ)` with side-condition
+`byteVal < 2^8`; `value_16b value_8b direct_value addr_w step : FGL` free;
+`composed_value` COMPUTED as the `Constraints.lean` reconstruction
+expression with `boolF`-substituted selectors (this component's Spec.lean
+byte-factor polynomials show the shape — but transcribe from
+Constraints.lean, which is what the proof must match). Discharge: booleanity
+helper; reconstruction by `ring` after substitution (selector case analysis
+NOT needed — the value is defined as the expression); range lookup via
+`fgl_natCast_val_lt_of_lt`.
 
-Lowest-risk validation of the existential/`h_input` idiom. Constraints:
-12 booleanities + `preL1 * pc = 0` + `sel_prove * (sel_up + sel_down) = 0`
-+ two 8-way multiplexer value reconstructions (`Spec.lean:50-88`,
-`Constraints.lean:54-78`).
+### MemAlignByte (`circuit`)
 
-Builder vocabulary:
+Superset with the write path. Row adds: `is_write written_composed_value
+written_byte_value mem_write_values_0 mem_write_values_1 bus_byte`.
+Builder adds: `(isWrite : Bool)`, `(writtenByteVal : ℕ)` with `< 2^8`
+side-condition, `written_composed_value` computed like the read
+reconstruction over the written byte, `mem_write_values_0/1` computed as the
+`sel_high_4b` muxes, `bus_byte` computed as the `is_write` mux
+(`boolF isWrite * (written_byte - byte) + byte`). All from
+`Constraints.lean` verbatim. Discharge identical in kind to ReadByte; the
+extra `rangeTable8` lookups close from the `< 2^8` side-conditions.
 
-```lean
-inductive MemAlignPhase | prove | upToDown | downToUp | idle
--- maps to (sel_prove, sel_up_to_down, sel_down_to_up) ∈ {(1,0,0),(0,1,0),(0,0,1),(0,0,0)}
--- NOTE sel_prove has NO booleanity constraint; the phase enum keeps it honest.
+### Mem (3 circuits, ONE builder, ONE lemma)
 
-def memAlignRowOf (phase : MemAlignPhase) (isBoot wr reset : Bool)
-    (sel_0 … sel_7 : Bool) (reg_0 … reg_7 : FGL)
-    (addr offset width step delta_addr pcVal : FGL) : MemAlignRow FGL
--- pc := if isBoot then 0 else pcVal; preL1 := boolF isBoot
--- value_0 / value_1 := the mux expressions from Constraints.lean VERBATIM,
---   with boolF/phase values substituted  ← this is the key trick
-```
+Row columns: `addr step sel addr_changes step_dual sel_dual value_0 value_1
+wr previous_step increment_0 increment_1 read_same_addr`. The 9 constraints:
+booleanities (sel_dual, sel, addr_changes, wr) + the two implication
+products (`(1-sel)*sel_dual`, `wr*(1-sel)`), the `read_same_addr`
+definitional identity, and the two `(addr_changes*(1-wr))*value_i = 0`
+zeroing constraints.
 
-Discharge: booleanities by `boolF_booleanity`; `preL1*pc` by `cases isBoot`;
-disjointness by `cases phase <;> norm_num [boolF]`; the two mux constraints
-by `ring`/`sub_self` after substitution — NO selector case analysis, because
-`value_0/1` are defined as the mux expressions. Watch the `a + -b` vs `a - b`
-normal-form mismatch: `simpa only [sub_eq_add_neg]` (same fix as this file's
-soundness proof). Channel: `circuit_proof_start [MemBusChannel]`.
-
-### BinaryAdd (`BinaryAdd/Circuit.lean::circuit`, 4 assertZeros + 8 range lookups + OpBus push)
-
-Validates the range-lookup discharge. Constraints (`Constraints.lean:60-66`):
-2 carry booleanities + the two carry-equations over 32-bit limbs / 16-bit
-chunks. Builder:
+Builder:
 
 ```lean
-def binaryAddRowOf (a b : ℕ) : BinaryAddRow FGL :=
-  -- a_0 := ↑(a % 2^32), a_1 := ↑(a / 2^32 % 2^32)  (same for b)
-  -- s := (a + b) % 2^64; c_chunks_k := ↑(s / 2^16^k % 2^16) for k = 0..3
-  -- cout_0 := ↑((a % 2^32 + b % 2^32) / 2^32)         -- 0 or 1
-  -- cout_1 := ↑((a / 2^32 % 2^32 + b / 2^32 % 2^32 + carry0) / 2^32)
+def memRowOf (sel selDual wr addrChanges : Bool)
+    (addr step stepDual previousStep increment_0 increment_1 v0 v1 : FGL) : MemRow FGL
+-- sel/sel_dual/wr/addr_changes := boolF …
+-- read_same_addr := (1 - boolF addrChanges) * (1 - boolF wr)   (computed)
+-- value_0 := if addrChanges && !wr then 0 else v0   (same for value_1)
 
-ProverAssumptions := fun row _ _ => ∃ a b, a < 2^64 ∧ b < 2^64 ∧ row = binaryAddRowOf a b
+ProverAssumptions := fun row _ _ => ∃ sel selDual wr addrChanges …,
+  (selDual = true → sel = true) ∧ (wr = true → sel = true)
+  ∧ row = memRowOf …
 ```
 
-Discharge: booleanities — the quotient is 0/1 (`Nat.div_lt_iff` / `omega`),
-then `cases`-style or `mul_self` arithmetic. The two carry equations: cast
-the Nat identities `a%2^32 + b%2^32 = cout_0*2^32 + (low 32 bits of s)` (by
-`omega` on the chunk definitions) into FGL via `push_cast`, then
-`linear_combination`/`ring`. Lookups: `chunk < 2^32` / `< 2^16` facts are
-`Nat.mod_lt`/`omega`; pipe through `Lookup.completeness_def` →
-`rangeTable32.Spec` = `val < 2^32` (cast-of-small-Nat val lemma; check
-`Fundamentals/Goldilocks.lean` for an existing `val_natCast`-style lemma
-before writing one). CLAUDE.md trap #2 applies: write `4294967296` factored
-consistently when `linear_combination` is involved.
+Prove ONE lemma `memRowOf_constraintsHold` covering the 9 equations by
+`cases` on the four Bools (the implications kill the impossible cases) +
+`simp [boolF]`; the three completeness fields (`circuit`,
+`circuitWithMemBus` with `[MemBusChannel]`, `circuitWithDualMemBus` with
+`[MemBusChannel]`) each consume it. The bus variants add only trivially-true
+Guarantees goals.
 
-## Wave 2 — byte/mem mux family (1 agent, 1 PR, after Wave 1)
+Risk: low. If the `if … then 0 else` form fights `circuit_norm`
+normalization in `h_input`, switch the value columns to
+`(1 - boolF addrChanges * (1 - boolF wr)) * v0`-style computed products —
+either is honest; pick whichever makes the zeroing constraints close by
+`ring`/`cases`.
 
-- [ ] **MemAlignReadByte** (S): operands `(byteVal : ℕ < 2^8, value_8b
-      value_16b : FGL, 3 sel Bools, addr_w step direct_value : FGL)`;
-      `composed_value` computed via the byte-factor expressions from its
-      Spec.lean; 3 booleanities + 1 `rangeTable8` lookup + composed-value
-      equation by `ring` after substitution.
-- [ ] **MemAlignByte** (M): superset with write path — also compute
-      `written_composed_value`, `mem_write_values_0/1` (the `sel_high_4b`
-      muxes), `bus_byte` (the `is_write` mux); 9 assertZeros + 3
-      `rangeTable8` lookups. Same recipe; more columns.
-- [ ] **Mem** (M): ONE builder serves all 3 circuits (the WithMemBus /
-      WithDualMemBus variants only add trivially-true emits). Operands:
-      `(sel sel_dual wr addr_changes : Bool)` with side-conditions
-      `sel_dual → sel` and `wr → sel` (as Bool implications), values
-      `(addr step value_0 value_1 previous_step increment_0 increment_1
-      step_dual : FGL)`; builder zeroes `value_0/1` when
-      `addr_changes ∧ ¬wr` and computes
-      `read_same_addr := boolF (!addr_changes && !wr)`. All 9 constraints
-      by `cases` on the four Bools + `boolF` simp; write the three
-      completeness fields by proving ONE shared lemma and reusing it.
-- [ ] Witness file per component; gates; ask Cody; PR.
+## Wave 3 — table-lookup family (1 agent, 1 PR)
 
-## Wave 3 — table-lookup family (1 agent, 1 PR, after Wave 1)
+New content vs Wave 1: static-table membership obligations. Both tables are
+`StaticTable`s with `Spec t := ∃ i : Fin tableSize, t = rowOfIndex i.val`
+and DEFINITIONAL `contains_iff` (`BinaryTable.lean:382-388`,
+`BinaryExtensionTable.lean:223-229`). **Primary recipe — the index route:
+take table indices as operands.** The honest prover's lookups ARE table
+rows, so `i_0 … i_7 : Fin tableSize` operands are fully honest, and every
+lookup goal closes with `exact ⟨i_k, rfl⟩` — zero table semantics needed.
 
-The new content here is table-membership completeness: builders must COMPUTE
-result bytes from the tables' defining semantics so the lookup obligations
-(`t.Spec tuple`, via `contains_iff`) close. FIRST read the table definitions
-(`ZiskFv/AirsClean/` BinaryTable / BinaryExtensionTable files) and the
-existing lookup-witness lemmas referenced in
-`ZiskFv/ZiskCircuit/SextLoadBridge.lean` — reuse before writing new.
+The work is making the 8 looked-up tuples consistent with SHARED row
+columns. Method, mechanically:
 
-- [ ] **Binary plain `circuit`** (7 assertZeros): operands = 4 mode Bools +
-      free byte/carry columns; `b_op_or_sext` and `mode32_and_c_is_signed`
-      computed. Easy.
-- [ ] **Binary `staticLookupCircuit`** (+8 BinaryTable lookups): builder
-      takes per-byte op inputs `(op : <table op enum/code>, a_i b_i bytes,
-      carry-in)` and computes `c_i` bytes + carry-out from the table's
-      defining function. If universal membership proofs are heavy, SCOPE the
-      existential to a documented subset of ops (e.g. ADD-family rows) —
-      same honesty rule as Wave 4's unsigned scope: documented partial
-      coverage is fine, silent narrowing is not. Record chosen scope in the
-      PR body and this file's log.
-- [ ] **BinaryExtension `staticLookupCircuit` + `shiftStaticLookupCircuit`**
-      (0 assertZeros; 8 BinaryExtensionTable lookups; shift variant adds the
-      `ShiftB0RangeSpecFact` obligation): builder computes the 16 result
-      bytes for a chosen documented op scope (the SLL/SRL/SRA/SE families
-      the table defines); `binary_extension_sext_*` lemmas are candidates
-      for reuse.
-- [ ] Witnesses; gates; ask Cody; PR.
+1. Read the 8 `lookupMessage<k>` expressions in the component's
+   Constraints/Circuit files. Each is a tuple of row-column expressions.
+2. For each row column appearing in exactly one message: builder sets it to
+   the corresponding projection of `rowOfIndex i_k`.
+3. For each slot SHARED between messages (mode/flag packings, chained
+   carries — e.g. message k's carry-out is message k+1's carry-in):
+   side-condition equating the two entries' projections, e.g.
+   `(rowOfIndex i_0.val).<slot> = (rowOfIndex i_1.val).<slot>`. These are
+   semantic table-entry facts — allowed. Derive the EXACT side-condition
+   list from the message expressions; do not guess.
+4. The witness file instantiates concrete indices (compute a real op row's
+   indices once, with explicit numerals and `decide`/`norm_num`) — this also
+   proves the side-conditions are satisfiable.
 
-## Wave 4 — Arith pair, unsigned scope (1 agent, 1 PR, after Wave 1)
+Fallback (only if the index route stalls): builders over a documented op
+subset computing result bytes via the table's defining function
+(`rowOfIndex` composed with index arithmetic). Record any scope cut in the
+PR body and the log — documented partial coverage is fine, silent narrowing
+is not.
 
-Scope DECIDED BY CODY: unsigned modes only (`na=nb=np=nr=m32=0`; MUL:
-`div=0`; DIV: `div=1`). Signed/m32 modes are follow-up disjuncts
-(`∨ row = …SignedRowOf …`) — record as follow-up at closeout, and say so in
-the builder docstrings. Key verified facts: the AirsClean Arith components
-constrain ONLY the 11 equations (3 sign pins + 8 carry-chain) — no range
-checks on carries/chunks, no flag booleanities, no ArithTable lookup (those
-live elsewhere). So carries are pinned only by the chain equations, and since
-`(65536 : FGL)` is a unit each equation has a UNIQUE field solution for its
-new carry — define carries as those solutions; they provably coincide with
-the honest integer carries.
+### Checklist
 
-- [ ] New shared `ZiskFv/Airs/Arith/CarryChainCompleteness.lean`
-      (pure math, build it green before touching components):
-      - `def chunk16 (x k : ℕ) : ℕ := x / 65536 ^ k % 65536`;
-        `chunk16_lt : chunk16 x k < 65536`.
-      - `nat_decomp4` / `nat_decomp8`: `x < 65536^4 (resp ^8)` →
-        x = Σ chunk16 x k * 65536^k (by `omega`).
-      - `fgl_decomp4` / `fgl_decomp8`: the FGL casts (`push_cast`).
-      - `lemma fgl_65536_ne_zero : (65536 : FGL) ≠ 0 := by decide`.
-      - Field-solved carries, generic over `[Field F] (B : F) (hB : B ≠ 0)`:
-        `cc0 e0 := e0 / B`, …, `cc6 e0…e6 := (e0 + e1*B + … + e6*B^6) / B^7`;
-        `chain_eq_0 : e0 - cc0*B = 0`; `chain_eq_k : e_k + cc_{k-1} - cc_k*B = 0`
-        (k=1..6); `chain_last (h : Σ e_k*B^k = 0) : e7 + cc6 = 0`.
-        If `field_simp` blows up, state pre-cleared forms
-        (`cc_k * B^(k+1) = Σ_{j≤k} e_j*B^j` via `div_mul_cancel₀`) and
-        `linear_combination` against those. Keep `65536` powers FACTORED
-        (CLAUDE.md trap #2).
-- [ ] **ArithMul** (`circuit`, 11 assertZeros + OpBus push):
-      ```lean
-      structure ArithMulFreeCols (F) where  -- the 11 columns in no constraint:
-        sext div_by_zero div_overflow main_div main_mul signed
-        range_ab range_cd op bus_res1 multiplicity : F
-      def arithMulRowOf (a b : ℕ) (free : ArithMulFreeCols FGL) : ArithMulRow FGL
-      -- a_k/b_k := chunk16 casts; c_k := ↑(chunk16 (a*b) k); d_k := ↑(chunk16 (a*b) (k+4))
-      -- flags na nb np nr m32 div := 0; fab := 1; na_fb := nb_fa := 0
-      -- carry_k := cc_k applied to this row's chain numerators e_k
-      ProverAssumptions := fun row _ _ =>
-        ∃ a b free, a < 65536^4 ∧ b < 65536^4 ∧ row = arithMulRowOf a b free
-      ```
-      Discharge: C6/C7/C8 by `norm_num` after substitution; C31–C37 by
-      `linear_combination (chain_eq_k …)`; C38 via `chain_last` with
-      `h_packed : ↑a * ↑b = c_packed + d_packed * B^4` from `fgl_decomp4 a/b`
-      + `fgl_decomp8 (a*b)` + `Nat.cast_mul`. MANDATORY: the
-      `circuit_proof_start_core` route (43-column row; pattern in this
-      file's own soundness proof), `set_option maxHeartbeats 4000000` if
-      needed.
-- [ ] **ArithDiv** (`circuit`, 11 assertZeros, NO push — strictly easier):
-      same skeleton; operands `(c b : ℕ)` = dividend, divisor; roles
-      a := chunks of `c / b` (quotient), d := chunks of `c % b` (remainder);
-      include `b ≠ 0` side-condition (documentation honesty — ZisK flags
-      div-by-zero rows separately); `h_packed` from `Nat.div_add_mod`.
-      Same agent, Mul first as the template.
-- [ ] Witnesses (concrete a,b — e.g. 6×7 and 100/7); gates; ask Cody; PR.
+- [ ] Worktree + cache + baseline; STATUS.md; log `W3: started`.
+- [ ] Survey: list the 8 message exprs + shared slots for Binary and
+      BinaryExtension; write the derived side-condition list into the PR
+      body (this is the review surface for honesty).
+- [ ] Binary plain `circuit` (7 assertZeros, no lookups): Bool mode flags
+      (`mode32 result_is_a use_first_byte c_is_signed`, `carry_7 : Bool`);
+      `b_op_or_sext` and `mode32_and_c_is_signed` COMPUTED; free byte/carry
+      columns. Plain-recipe discharge.
+- [ ] Binary `staticLookupCircuit`: index-route builder extending the plain
+      one + witness.
+- [ ] BinaryExtension `staticLookupCircuit` (0 assertZeros, 8 lookups):
+      index-route builder + witness.
+- [ ] BinaryExtension `shiftStaticLookupCircuit`: same builder + whatever
+      `ShiftB0RangeSpecFact` demands — read its definition first; expect a
+      range/shape fact on `b_0`, supplied as an operand side-condition or by
+      computing `b_0` from a bounded operand.
+- [ ] Docstrings §5 (state the index-route scope); ensemble call sites §6.
+- [ ] Verification block; open PR per protocol.
 
-## Wave 5 — Main, 3 circuits + finalization (1 agent, 1 PR, after Wave 1)
+## Wave 4 — Arith pair, unsigned scope (1 agent, 1 PR)
 
-- [ ] **Plain `circuit`** (9 assertZeros + OpBus emit): the internal-op
-      conditionals force exactly three honest shapes —
+Scope FIXED BY CODY: unsigned modes only (`na=nb=np=nr=m32=0`; MUL `div=0`,
+DIV `div=1`; `fab=1`, `na_fb=nb_fa=0`). Signed/m32 modes are follow-up
+disjuncts — say so in the docstrings and the PR body. Verified facts: these
+component slices emit ONLY the 11 equations (3 sign pins + 8 carry-chain) —
+no range checks on carries/chunks, no flag booleanities, no ArithTable
+lookup. Carries are pinned only by the chain equations; since
+`(65536 : FGL)` is a unit, each equation has a UNIQUE field solution for its
+new carry — define carries as those solutions (they provably coincide with
+the honest integer carries; note this in the docstring).
+
+### Checklist
+
+- [ ] Worktree + cache + baseline; STATUS.md; log `W4: started`.
+- [ ] Shared `ZiskFv/Airs/Arith/CarryChainCompleteness.lean` — build it
+      green BEFORE touching components:
+      `chunk16 (x k : ℕ) := x / 65536 ^ k % 65536`; `chunk16_lt`;
+      `nat_decomp4/8` (by `omega`); `fgl_decomp4/8` (`push_cast`);
+      `fgl_65536_ne_zero : (65536 : FGL) ≠ 0 := by decide`;
+      field-solved carries generic over `[Field F] (B : F) (hB : B ≠ 0)`:
+      `cc0 e0 := e0 / B` … `cc6 … := (e0 + e1*B + … + e6*B^6) / B^7`;
+      `chain_eq_0 : e0 - cc0*B = 0`; `chain_eq_k (k=1..6)`;
+      `chain_last (h : Σ e_k*B^k = 0) : e7 + cc6 = 0`.
+      If `field_simp` blows up: state pre-cleared forms
+      (`cc_k * B^(k+1) = Σ_{j≤k} e_j*B^j` via `div_mul_cancel₀`) and
+      `linear_combination` against those. Keep `65536` powers FACTORED.
+- [ ] ArithMul `circuit` (11 assertZeros + OpBus push):
+      `ArithMulFreeCols` = the 11 unconstrained columns (`sext div_by_zero
+      div_overflow main_div main_mul signed range_ab range_cd op bus_res1
+      multiplicity`); builder `arithMulRowOf (a b : ℕ) (free)` — a/b chunks
+      via `chunk16`, c/d := chunks of `a*b` (the GENUINE product chunks),
+      zero flags, `fab := 1`, carries := `cc_k` of this row's chain
+      numerators. ProverAssumptions: `a < 65536^4 ∧ b < 65536^4 ∧ row = …`.
+      Discharge: C6/7/8 `norm_num`; C31–C37 `linear_combination (chain_eq_k …)`;
+      C38 via `chain_last` with `h_packed : ↑a * ↑b = c_packed + d_packed *
+      B^4` from `fgl_decomp4 a/b` + `fgl_decomp8 (a*b)` + `Nat.cast_mul`.
+- [ ] ArithDiv `circuit` (11 assertZeros, NO push — easier): operands
+      `(c b : ℕ)` = dividend, divisor; a := chunks of `c / b`, d := chunks
+      of `c % b`; side-conditions `c < 65536^4 ∧ b < 65536^4 ∧ b ≠ 0`
+      (`b ≠ 0` is documentation honesty); `h_packed` from `Nat.div_add_mod`.
+      Mul first, Div as template copy.
+- [ ] Witnesses (e.g. `6 * 7` and `100 / 7`); docstrings §5 (unsigned scope
+      + the field-solved-carry note); ensemble sites §6 (ArithDiv has TWO
+      Balance.lean sites).
+- [ ] Verification block; open PR per protocol.
+
+MANDATORY mechanics for both: the `circuit_proof_start_core` route (the
+plain tactic is too slow on 43-column rows — documented from the soundness
+work), `set_option maxHeartbeats 4000000`, and NESTED `injection`:
+`ArithMulRow`/`ArithDivRow` are `{chunks, flags, carries/aux}` sub-structs,
+so the first `injection` yields sub-struct equations — `injection` each of
+those again to reach per-column equations.
+
+## Wave 5 — Main, 3 circuits + stream finalization (1 agent, 1 PR)
+
+### Checklist
+
+- [ ] Worktree + cache + baseline; STATUS.md; log `W5: started`.
+- [ ] Plain `circuit` (9 assertZeros + OpBus emit). The internal-op
+      conditionals force exactly three honest shapes:
       ```lean
       inductive MainExecKind (F)
         | external (op : F) (flag : Bool) (c_0 c_1 set_pc : F)
-            -- builder sets set_pc column := if flag then 0 else set_pc
-        | internalFlag                  -- op := 0, c := 0, flag := 1, set_pc := 0
-        | internalCopyB (set_pc : F)    -- op := 1, c_i := b_i, flag := 0
+            -- builder: set_pc column := if flag then 0 else set_pc
+        | internalFlag                 -- op := 0, c := 0, flag := 1, set_pc := 0
+        | internalCopyB (set_pc : F)   -- op := 1, c_i := b_i, flag := 0
       ```
       plus `MainFreeCols` (a/b operands, pc, m32, ind_width, jmp offsets,
-      store_pc, im_high_degree_2, segment_l1). All 9 goals by `cases k` +
-      `boolF_booleanity` / `norm_num` / `ring`.
-- [ ] **`circuitWithRomAndMemBus length program`** (adds 14 ROM-flag
-      booleanities + the static ROM lookup + 3 MemBus emits). Builder takes
-      the program ENTRY so the lookup closes by construction:
-      ```lean
-      structure RomFlagBits where  -- 15 Bools, bit order of romFlags (main.pil:483-486)
-        a_src_imm a_src_mem is_precompiled b_src_imm b_src_mem is_external_op
-        store_pc store_mem store_ind set_pc m32 b_src_ind a_src_reg b_src_reg
-        store_reg : Bool
-      def packFlags (bits : RomFlagBits) : FGL  -- verbatim romFlags polynomial shape
-      def mainRomRowOf (msg : ZiskRomMessage FGL) (bits : RomFlagBits)
-          (k : MainRomExecKind FGL) (free : MainRomFreeCols FGL) : MainRowWithRom FGL
-      -- pc/op/ind_width/jmp_offsets/imm fields copied from msg;
-      -- flag columns := boolF of bits; flag/c columns from k as in plain Main
-      ProverAssumptions := fun row _ _ => ∃ i bits k free,
-        (program i).flags = packFlags bits        -- entry decodes to these bits
-        ∧ <kind coherence: external ↔ bits.is_external_op; internal kinds fix msg.op = 0/1>
-        ∧ <flag=1 cases force bits.set_pc = false>
-        ∧ row = mainRomRowOf (program i) bits k free
-      ```
-      ROM lookup obligation unfolds to `∃ i, eval … = program i` — close with
-      witness `i` using the EXISTING `eval_romMessageExpr` /
-      `eval_romFlagsExpr` (`Main/Constraints.lean:176,184`); mirror the
-      unfold path of `romSpec_of_mainWithRomAndMemBus_constraints`
-      (`Main/Circuit.lean` ~line 154). The 10 data slots are rfl-equal by
-      construction; the flags slot closes by the `packFlags` hypothesis.
+      store_pc, im_high_degree_2, segment_l1). Discharge by `cases k` +
+      helpers.
+- [ ] `circuitWithRomAndMemBus length program` — builder from the program
+      ENTRY so the ROM lookup closes by construction:
+      `RomFlagBits` (15 Bools, bit order of `romFlags`, main.pil:483-486);
+      `packFlags : RomFlagBits → FGL` (verbatim `romFlags` polynomial);
+      `mainRomRowOf (msg : ZiskRomMessage FGL) (bits) (k : MainRomExecKind)
+      (free)` copying pc/op/ind_width/jmp_offsets/imm fields from `msg`.
+      ProverAssumptions: `∃ i bits k free, (program i).flags = packFlags bits
+      ∧ <kind coherence: external ↔ bits.is_external_op; internal kinds fix
+      msg.op = 0/1> ∧ <flag=1 forces bits.set_pc = false> ∧ row = mainRomRowOf
+      (program i) bits k free`. The lookup goal is
+      `∃ j, eval … = program j` — close with `⟨i, …⟩` via the EXISTING
+      `eval_romMessageExpr` / `eval_romFlagsExpr`
+      (`Main/Constraints.lean:176,184`); mirror the unfold path of
+      `romSpec_of_mainWithRomAndMemBus_constraints` (`Main/Circuit.lean`
+      ~154). Ten data slots are `rfl` by construction; the flags slot closes
+      by the `packFlags` hypothesis. Prove this as a STANDALONE
+      `theorem mainWithRomAndMemBus_completeness` (not inline).
       Fallback if `circuit_proof_start` decomposes the lookup entry too
       eagerly: `_core` route, keep `h_input` whole, apply
       `Lookup.completeness_def` + `eval_romMessageExpr` manually, split
-      `h_input` only for the assertZero goals. Prove this as a STANDALONE
-      `theorem mainWithRomAndMemBus_completeness …` (not inline).
-- [ ] **`circuitWithRomMemAndOpBus`**: ~15-line `simpa [mainWithRomMemAndOpBus,
+      `h_input` only for the assertZero goals. `MainRowWithRom` is a nested
+      `{core, rom}` struct — nested `injection` as in Wave 4.
+- [ ] `circuitWithRomMemAndOpBus`: ~15-line `simpa [mainWithRomMemAndOpBus,
       circuit_norm, OpBusChannel, MemBusChannel]` wrapper around the
-      standalone theorem — mirror `mainWithRomMemAndOpBus_soundness`
-      (`Main/Circuit.lean` ~line 205). Same ProverAssumptions for both.
-- [ ] Witness: a concrete 1-instruction `Program` + one honest row per kind.
-- [ ] Finalization sweep (this wave, after all others merge): CLAUDE.md
-      status paragraph (Clean completeness fields now proved; state the
-      Arith/table scopes), append an upgrade note to
-      `ZISK-DEFECT-CLEAN-COMPLETENESS-TRIVIAL-AXIOMS` in `trust/defects.md`,
-      PROJECTS.md/STATUS.md closeout, record follow-up items (signed Arith
-      disjuncts, any table-op scope gaps). Do not edit the RV64IM
-      completeness modules (`ZiskFv/Completeness/**`) — different stream.
-- [ ] Gates; ask Cody; PR.
+      standalone theorem (mirror `mainWithRomMemAndOpBus_soundness`). Same
+      ProverAssumptions for both.
+- [ ] Witness: concrete 1-instruction `Program` + one honest row per
+      `MainExecKind`; concrete `RomFlagBits` proving the coherence
+      side-conditions are satisfiable.
+- [ ] Finalization sweep (only after Waves 2–4 have merged): CLAUDE.md
+      status paragraph (completeness fields now proved; state the Wave 3/4
+      scopes); append an upgrade note to
+      `ZISK-DEFECT-CLEAN-COMPLETENESS-TRIVIAL-AXIOMS` in `trust/defects.md`;
+      PROJECTS.md/STATUS.md closeout; list follow-ups (signed Arith
+      disjuncts, table-op gaps). Do NOT touch `ZiskFv/Completeness/**`
+      (the RV64IM stream's surface).
+- [ ] Verification block; open PR per protocol.
 
-## Hard invariants (every wave — violations mean the PR is rejected)
+## Hard invariants (every wave — violations fail review)
 
 - ZERO new `axiom` / `sorry` / `opaque` / `partial def` / `unsafe def`.
-  `trust/allowed-axiom-files.txt`, `trust/tolerated-completeness-axioms.txt`,
-  and ALL of `trust/generated/*` + `trust/baseline-*` must be byte-identical
-  to base (`git diff origin/main -- trust/` shows only
-  `check-all-semantic.sh` (Wave 1) and `trust/consistency/` additions).
-- Soundness fields, `Spec` definitions, `main` do-blocks, and elaborated
-  circuits UNTOUCHED. Builders/witnesses are new defs only.
-- ProverAssumptions: inline existential over builder + semantic
-  side-conditions. No constraint-equation side-conditions; no named Prop
-  wrappers.
-- Each component's witness file lands in the SAME PR as its proof.
-- Edit surface: `ZiskFv/AirsClean/**` (new defs + the 16 field bodies +
-  doc comments), `ZiskFv/Airs/Arith/CarryChainCompleteness.lean`,
-  `trust/consistency/completeness_witness_*.lean`,
-  `trust/scripts/check-all-semantic.sh` (Wave 1 only), docs. Nothing else.
-- Never commit files from `~/ai-workflow`. No wall-time estimates anywhere.
+  `git diff origin/main -- trust/` shows ONLY
+  `trust/consistency/completeness_witness_*.lean` additions (the gate
+  script is final; baselines and `trust/generated/*` byte-identical).
+- Soundness fields, `Spec` definitions, `main` do-blocks, elaborated
+  circuits, and all theorem STATEMENTS untouched. Ensemble proof-body
+  conversions (§6) are the only permitted edits outside your component's
+  new defs + the 16 field bodies + docstrings.
+- ProverAssumptions: inline builder existential, semantic side-conditions
+  only.
+- Witness file lands in the SAME PR as its proofs.
+- Edit surface: `ZiskFv/AirsClean/**`,
+  `ZiskFv/Airs/Arith/CarryChainCompleteness.lean` (Wave 4),
+  `trust/consistency/completeness_witness_*.lean`, FullEnsemble proof
+  bodies per §6, docs. Nothing else.
+- Never commit files from `~/ai-workflow`. No wall-time estimates. Plan
+  edits limited to your own wave's boxes + `W<n>:` log lines.
 
-## Verification (every wave, in order)
+## Verification (run in this order before opening the PR)
 
 ```bash
 lake build ZiskFv.AirsClean.<Component>.Circuit   # inner loop, per component
-lake build                                        # full, before commit of a chunk
-trust/scripts/check-all.sh                        # V1, seconds
-trust/scripts/check-all-semantic.sh               # V2 + witness glob check
-nix run .#test                                    # before PR
+lake build ZiskFv.AirsClean.FullEnsemble          # ensemble perf check (§6)
+lake build                                        # full
+trust/scripts/check-all.sh
+trust/scripts/check-all-semantic.sh               # must show your witness in 6/6
+nix run .#test
 git diff origin/main -- trust/generated trust/baseline-axioms.txt \
-  trust/baseline-hypothesis-count.txt trust/baseline-caller-burden.txt  # must be empty
+  trust/baseline-hypothesis-count.txt trust/baseline-caller-burden.txt  # EMPTY
 lake exe trust-gate print-axiom-closure ZiskFv.Compliance.zisk_riscv_compliant_program_bus
-# must print no project axioms
+# no project axioms
 ```
 
-Paste the gate tail, the empty-diff confirmation, and the witness file list
-into each PR body.
+Paste the gate tails, the empty-diff confirmation, the closure result, and
+the witness file list into the PR body, then open the PR per the protocol
+and STOP.
 
-## Acceptance criteria (stream closeout)
+## Acceptance criteria (stream closeout, Wave 5)
 
 1. All 16 demoted fields are genuine proofs with builder-existential
    ProverAssumptions; the already-honest BinaryExtension plain field
-   untouched; every scope restriction (Arith unsigned, table-op subsets)
-   stated in docstrings and listed as follow-ups in this file.
+   untouched; every scope restriction stated in docstrings and listed as
+   follow-ups here.
 2. ≥10 `trust/consistency/completeness_witness_*.lean` files typecheck
-   inside the semantic gate's glob check.
+   inside the semantic gate's 6/6 check.
 3. Ledgers and anti-laundering baselines byte-identical to base; closure
    print unchanged; `nix run .#test` green on every PR.
-4. PR bodies use completeness/constructibility vocabulary (not promise
-   discharge) and include the verification evidence.
+4. PR bodies use completeness/constructibility vocabulary and carry the
+   verification evidence.
 
 ## Log
 
@@ -485,3 +575,7 @@ into each PR body.
   `bash -n trust/scripts/check-all-semantic.sh`, and `git diff --check` passed.
 - 2026-06-12: review feedback fix pushed to PR #69 as `91679f42`; next step is
   external review, do not merge.
+- 2026-06-12: plan strengthened for Waves 2–5 (Cody-directed): Wave 1 recipe
+  promoted to reference implementation, Wave 3 index-route made primary,
+  ensemble call-site duty (§6) added, PR protocol switched to
+  queue-for-Claude-review with no human pre-ack.

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -1,0 +1,461 @@
+# Plan: Clean Completeness Proofs
+
+Status: READY FOR EXECUTION. Base: `origin/main` at `e3b87fc0` or later.
+This file is the handoff document — it is written to be executed by agents
+without further design work. Read it fully before editing anything.
+
+## How to run this stream
+
+- One worktree per wave: `git worktree add .worktrees/completeness-<wave>
+  origin/main` (create MANUALLY — never agent worktree isolation).
+- FIRST command in every new worktree: `lake exe cache get`. If it complains
+  about missing path deps, run `nix run .#populate`, then retry. Then a full
+  `lake build` + `trust/scripts/check-all.sh` BEFORE any edit (green baseline).
+- Copy this plan into the worktree's `docs/ai/plan/` and commit it there
+  (docs/ai is local-excluded in the parent checkout). Keep the worktree's
+  `STATUS.md` and this file's checklists current at every progress report.
+  Tick checkboxes and append short log lines only — do NOT expand this plan.
+- Commit and push freely on the wave branch. ASK CODY before opening each PR.
+- Wave 1 goes first and fixes the idiom. Waves 2–5 run in parallel after
+  Wave 1's PR merges (they copy its idiom; Waves 2,3,5 also use its helpers).
+- Sub-agent prompts must include the CLAUDE.md anti-laundering principle
+  verbatim and require reading `trust/README.md#anti-laundering-terms`.
+  Vocabulary note: this stream is **completeness / constructibility** work,
+  NOT promise discharge — use those words in PR titles/bodies/commits.
+
+## Context
+
+PR #66 (`2c862063`) demoted all dishonest Clean completeness fields to
+explicit non-claims: `ProverAssumptions := fun _ _ _ => False` with ex-falso
+bodies. History: the six original axioms were FALSE as stated (trivial
+ProverAssumptions over input-only rows — see
+`ZISK-DEFECT-CLEAN-COMPLETENESS-TRIVIAL-AXIOMS` in `trust/defects.md`), and
+the earlier PR #56 "proofs" were circular (`ProverAssumptions := Spec row`
+where Spec restates the constraints — reverted by PR #62 as a launder).
+
+This stream upgrades all 16 demoted fields to GENUINE completeness proofs:
+for each component, an honest-row builder, a builder-existential
+`ProverAssumptions`, a real proof, and a gate-wired anti-vacuity witness.
+The payoff is proved satisfiability of each constraint slice by honest rows
+(constructibility), which also protects the soundness theorems from
+overstrong-validator vacuity. Purely additive: no axioms, no ledger changes,
+no canonical-theorem changes.
+
+The 16 fields (post-#66 tree; re-run `rg "completeness :=" ZiskFv` and
+reconcile before starting — line numbers drift):
+
+| Component file (`ZiskFv/AirsClean/`) | Circuits to complete | Wave |
+|---|---|---|
+| BinaryAdd/Circuit.lean | `circuit` | 1 |
+| MemAlign/Circuit.lean | `circuit` | 1 |
+| MemAlignReadByte/Circuit.lean | `circuit` | 2 |
+| MemAlignByte/Circuit.lean | `circuit` | 2 |
+| Mem/Circuit.lean | `circuit`, `circuitWithMemBus`, `circuitWithDualMemBus` | 2 |
+| Binary/Circuit.lean | `circuit`, `staticLookupCircuit` | 3 |
+| BinaryExtension/StaticCircuit.lean | `staticLookupCircuit`, `shiftStaticLookupCircuit` | 3 |
+| ArithMul/Circuit.lean | `circuit` | 4 |
+| ArithDiv/Circuit.lean | `circuit` | 4 |
+| Main/Circuit.lean | `circuit`, `circuitWithRomAndMemBus`, `circuitWithRomMemAndOpBus` | 5 |
+
+`BinaryExtension/Circuit.lean` (plain circuit, push-only) is ALREADY genuinely
+complete with `ProverAssumptions := True` — leave it untouched.
+
+## Technical groundwork (verified 2026-06-12 — trust this, don't re-derive)
+
+What `GeneralFormalCircuit.Completeness` demands, per operation in `main`:
+
+- `assertZero e` → goal `env e = 0` (a Goldilocks field equation).
+- `lookup (Table.fromStatic t) entry` → goal = `t.Spec (eval env entry)`,
+  reached via `Lookup.completeness_def`
+  (`build/clean-lean/Clean/Circuit/Lookup.lean:107`; StaticTable's
+  `Completeness := Spec` at `Lookup.lean:137-153`). For
+  `rangeTable32/16/8` the Spec is `val < 2^32 / 2^16 / 2^8`
+  (`ZiskFv/AirsClean/RangeTables.lean:58-74`). For the ROM table the Spec is
+  `∃ i, msg = program i` (`ZiskFv/AirsClean/ZiskInstructionRom.lean:56-67`).
+- `OpBusChannel.push` / `MemBusChannel.emit` → goal `Guarantees env`, which
+  is `True` for both buses (`ZiskFv/Channels/OperationBus.lean:145`,
+  `ZiskFv/Channels/MemoryBus.lean:105`). `circuit_proof_start [<Channel>]`
+  discharges these automatically.
+- `env.UsesLocalWitnessesCompleteness` is a HYPOTHESIS and is vacuously true
+  for every component here (`localLength = 0`, no witness ops/subcircuits).
+- Binder order after the statement unfolds: `offset env input_var h_env
+  input h_input h_assumptions ⊢ ConstraintsHold.Completeness … ∧ ProverSpec …`.
+  With `ProverSpec := True` the second conjunct is `trivial`.
+- `circuit_proof_start` handles completeness goals (recognizes
+  `GeneralFormalCircuit.Completeness`,
+  `build/clean-lean/Clean/Utils/Tactics/CircuitProofStart.lean:65-69`).
+  For WIDE rows (43-column ArithMul/ArithDiv) its `provable_struct_simp` is
+  too slow — use `circuit_proof_start_core` + `subst` + targeted
+  `simp only [circuit_norm, main]`, exactly as the existing
+  `ArithDiv.circuit.soundness` does (`ZiskFv/AirsClean/ArithDiv/Circuit.lean`).
+- Nothing downstream consumes `completeness` or `ProverAssumptions`
+  (`FormalEnsemble` has no completeness field) — these edits cannot break
+  soundness consumers; `lake build` confirms per wave.
+
+## The idiom (fixed — every component follows this exactly)
+
+```lean
+/-- Honest row for <Air>: <one-line semantics>. Dependent columns are
+    COMPUTED from operands; columns outside this constraint slice are free. -/
+def <air>RowOf (<semantic operands>) (free : <Air>FreeCols FGL) : <Air>Row FGL :=
+  { <col> := <computed or copied> , … }
+
+-- in the circuit definition:
+    ProverAssumptions := fun row _ _ =>
+      ∃ <operands> free, <semantic side-conditions> ∧ row = <air>RowOf <operands> free
+    ProverSpec := fun _ _ _ => True
+    completeness := by
+      circuit_proof_start [<Channel names>]      -- or _core route for wide rows
+      obtain ⟨<operands>, free, h_side, rfl⟩ := h_assumptions
+      -- h_input : eval env input_var = <air>RowOf …; split per-column:
+      --   simp only [circuit_norm] at h_input; dsimp only [<air>RowOf] at h_input
+      --   then `<Air>Row.mk.injEq` / `injection` to get per-column equations,
+      --   rewrite them into the constraint goals.
+      refine ⟨?_, …⟩  -- one goal per assertZero/lookup, then discharge
+```
+
+Rules:
+
+1. Dependent columns (carries, mux outputs, composed values, c-chunks) are
+   computed BY the builder. Never operands.
+2. Side-conditions are SEMANTIC operand facts only: numeric ranges
+   (`a < 2^64`), `Bool`-typed flags, program-entry coherence. A
+   side-condition that restates a constraint polynomial = the PR #56 launder
+   = reject the work.
+3. Free columns (not occurring in any constraint of the slice) are bundled in
+   a `<Air>FreeCols` structure so honesty is maximal (any honest value
+   allowed).
+4. Replace the PR #66 doc comment ("Completeness is intentionally NOT
+   claimed…") with one stating what IS now proved, including scope caveats.
+5. New top-level defs get the hidden-promise review: builders and FreeCols
+   are constructive data (fine as plain defs); do NOT introduce named Prop
+   abbreviations for ProverAssumptions — keep the existential inline and
+   visible.
+6. Every component ships, in the same PR, a witness file
+   `trust/consistency/completeness_witness_<air>.lean`: concrete operands,
+   `example`/`theorem` applying the proved completeness statement or at
+   minimum proving `ProverAssumptions (<air>RowOf <concrete>) …` is
+   inhabited and the row satisfies the constraint equations. Follow the
+   structure of `trust/consistency/load_byte_agreement_witness.lean`
+   (private defs + one public theorem). Prefer `decide`/`norm_num` over
+   `native_decide` where feasible.
+
+## Gate wiring (Wave 1 does this ONCE)
+
+Add to `trust/scripts/check-all-semantic.sh`, after the existing check 5/5,
+a single globbing check so later waves add witness files without ever
+editing the script (no merge conflicts):
+
+```bash
+run_witnesses() {
+  local ok=0
+  for f in trust/consistency/completeness_witness_*.lean; do
+    [ -e "$f" ] || continue
+    lake env lean "$f" || ok=1
+  done
+  return $ok
+}
+run "6/6 Clean completeness witnesses" run_witnesses
+```
+
+(Match the script's existing `run` helper conventions; renumber the label if
+the script counts checks differently.)
+
+## Wave 1 — pilot: helpers + MemAlign + BinaryAdd (1 agent, 1 PR)
+
+### Checklist
+
+- [x] Worktree + cache + green baseline; commit plan copy + STATUS.md.
+- [ ] `ZiskFv/AirsClean/CompletenessHelpers.lean`: `boolF`,
+      `boolF_booleanity`, shared plumbing lemmas discovered during the pilot.
+- [ ] MemAlign builder + completeness + witness.
+- [ ] BinaryAdd builder + completeness + witness.
+- [ ] Globbing witness check in `check-all-semantic.sh`.
+- [ ] Gates (see Verification); ask Cody; open PR.
+- [ ] Record in the PR body any idiom adjustments waves 2–5 must copy.
+
+### Helpers
+
+```lean
+def boolF (b : Bool) : FGL := if b then 1 else 0
+@[simp] lemma boolF_booleanity (b : Bool) : boolF b * (1 - boolF b) = 0 := by
+  cases b <;> simp [boolF]
+```
+
+### MemAlign (`MemAlign/Circuit.lean::circuit`, 16 assertZeros + MemBus emit, no lookups)
+
+Lowest-risk validation of the existential/`h_input` idiom. Constraints:
+12 booleanities + `preL1 * pc = 0` + `sel_prove * (sel_up + sel_down) = 0`
++ two 8-way multiplexer value reconstructions (`Spec.lean:50-88`,
+`Constraints.lean:54-78`).
+
+Builder vocabulary:
+
+```lean
+inductive MemAlignPhase | prove | upToDown | downToUp | idle
+-- maps to (sel_prove, sel_up_to_down, sel_down_to_up) ∈ {(1,0,0),(0,1,0),(0,0,1),(0,0,0)}
+-- NOTE sel_prove has NO booleanity constraint; the phase enum keeps it honest.
+
+def memAlignRowOf (phase : MemAlignPhase) (isBoot wr reset : Bool)
+    (sel_0 … sel_7 : Bool) (reg_0 … reg_7 : FGL)
+    (addr offset width step delta_addr pcVal : FGL) : MemAlignRow FGL
+-- pc := if isBoot then 0 else pcVal; preL1 := boolF isBoot
+-- value_0 / value_1 := the mux expressions from Constraints.lean VERBATIM,
+--   with boolF/phase values substituted  ← this is the key trick
+```
+
+Discharge: booleanities by `boolF_booleanity`; `preL1*pc` by `cases isBoot`;
+disjointness by `cases phase <;> norm_num [boolF]`; the two mux constraints
+by `ring`/`sub_self` after substitution — NO selector case analysis, because
+`value_0/1` are defined as the mux expressions. Watch the `a + -b` vs `a - b`
+normal-form mismatch: `simpa only [sub_eq_add_neg]` (same fix as this file's
+soundness proof). Channel: `circuit_proof_start [MemBusChannel]`.
+
+### BinaryAdd (`BinaryAdd/Circuit.lean::circuit`, 4 assertZeros + 8 range lookups + OpBus push)
+
+Validates the range-lookup discharge. Constraints (`Constraints.lean:60-66`):
+2 carry booleanities + the two carry-equations over 32-bit limbs / 16-bit
+chunks. Builder:
+
+```lean
+def binaryAddRowOf (a b : ℕ) : BinaryAddRow FGL :=
+  -- a_0 := ↑(a % 2^32), a_1 := ↑(a / 2^32 % 2^32)  (same for b)
+  -- s := (a + b) % 2^64; c_chunks_k := ↑(s / 2^16^k % 2^16) for k = 0..3
+  -- cout_0 := ↑((a % 2^32 + b % 2^32) / 2^32)         -- 0 or 1
+  -- cout_1 := ↑((a / 2^32 % 2^32 + b / 2^32 % 2^32 + carry0) / 2^32)
+
+ProverAssumptions := fun row _ _ => ∃ a b, a < 2^64 ∧ b < 2^64 ∧ row = binaryAddRowOf a b
+```
+
+Discharge: booleanities — the quotient is 0/1 (`Nat.div_lt_iff` / `omega`),
+then `cases`-style or `mul_self` arithmetic. The two carry equations: cast
+the Nat identities `a%2^32 + b%2^32 = cout_0*2^32 + (low 32 bits of s)` (by
+`omega` on the chunk definitions) into FGL via `push_cast`, then
+`linear_combination`/`ring`. Lookups: `chunk < 2^32` / `< 2^16` facts are
+`Nat.mod_lt`/`omega`; pipe through `Lookup.completeness_def` →
+`rangeTable32.Spec` = `val < 2^32` (cast-of-small-Nat val lemma; check
+`Fundamentals/Goldilocks.lean` for an existing `val_natCast`-style lemma
+before writing one). CLAUDE.md trap #2 applies: write `4294967296` factored
+consistently when `linear_combination` is involved.
+
+## Wave 2 — byte/mem mux family (1 agent, 1 PR, after Wave 1)
+
+- [ ] **MemAlignReadByte** (S): operands `(byteVal : ℕ < 2^8, value_8b
+      value_16b : FGL, 3 sel Bools, addr_w step direct_value : FGL)`;
+      `composed_value` computed via the byte-factor expressions from its
+      Spec.lean; 3 booleanities + 1 `rangeTable8` lookup + composed-value
+      equation by `ring` after substitution.
+- [ ] **MemAlignByte** (M): superset with write path — also compute
+      `written_composed_value`, `mem_write_values_0/1` (the `sel_high_4b`
+      muxes), `bus_byte` (the `is_write` mux); 9 assertZeros + 3
+      `rangeTable8` lookups. Same recipe; more columns.
+- [ ] **Mem** (M): ONE builder serves all 3 circuits (the WithMemBus /
+      WithDualMemBus variants only add trivially-true emits). Operands:
+      `(sel sel_dual wr addr_changes : Bool)` with side-conditions
+      `sel_dual → sel` and `wr → sel` (as Bool implications), values
+      `(addr step value_0 value_1 previous_step increment_0 increment_1
+      step_dual : FGL)`; builder zeroes `value_0/1` when
+      `addr_changes ∧ ¬wr` and computes
+      `read_same_addr := boolF (!addr_changes && !wr)`. All 9 constraints
+      by `cases` on the four Bools + `boolF` simp; write the three
+      completeness fields by proving ONE shared lemma and reusing it.
+- [ ] Witness file per component; gates; ask Cody; PR.
+
+## Wave 3 — table-lookup family (1 agent, 1 PR, after Wave 1)
+
+The new content here is table-membership completeness: builders must COMPUTE
+result bytes from the tables' defining semantics so the lookup obligations
+(`t.Spec tuple`, via `contains_iff`) close. FIRST read the table definitions
+(`ZiskFv/AirsClean/` BinaryTable / BinaryExtensionTable files) and the
+existing lookup-witness lemmas referenced in
+`ZiskFv/ZiskCircuit/SextLoadBridge.lean` — reuse before writing new.
+
+- [ ] **Binary plain `circuit`** (7 assertZeros): operands = 4 mode Bools +
+      free byte/carry columns; `b_op_or_sext` and `mode32_and_c_is_signed`
+      computed. Easy.
+- [ ] **Binary `staticLookupCircuit`** (+8 BinaryTable lookups): builder
+      takes per-byte op inputs `(op : <table op enum/code>, a_i b_i bytes,
+      carry-in)` and computes `c_i` bytes + carry-out from the table's
+      defining function. If universal membership proofs are heavy, SCOPE the
+      existential to a documented subset of ops (e.g. ADD-family rows) —
+      same honesty rule as Wave 4's unsigned scope: documented partial
+      coverage is fine, silent narrowing is not. Record chosen scope in the
+      PR body and this file's log.
+- [ ] **BinaryExtension `staticLookupCircuit` + `shiftStaticLookupCircuit`**
+      (0 assertZeros; 8 BinaryExtensionTable lookups; shift variant adds the
+      `ShiftB0RangeSpecFact` obligation): builder computes the 16 result
+      bytes for a chosen documented op scope (the SLL/SRL/SRA/SE families
+      the table defines); `binary_extension_sext_*` lemmas are candidates
+      for reuse.
+- [ ] Witnesses; gates; ask Cody; PR.
+
+## Wave 4 — Arith pair, unsigned scope (1 agent, 1 PR, after Wave 1)
+
+Scope DECIDED BY CODY: unsigned modes only (`na=nb=np=nr=m32=0`; MUL:
+`div=0`; DIV: `div=1`). Signed/m32 modes are follow-up disjuncts
+(`∨ row = …SignedRowOf …`) — record as follow-up at closeout, and say so in
+the builder docstrings. Key verified facts: the AirsClean Arith components
+constrain ONLY the 11 equations (3 sign pins + 8 carry-chain) — no range
+checks on carries/chunks, no flag booleanities, no ArithTable lookup (those
+live elsewhere). So carries are pinned only by the chain equations, and since
+`(65536 : FGL)` is a unit each equation has a UNIQUE field solution for its
+new carry — define carries as those solutions; they provably coincide with
+the honest integer carries.
+
+- [ ] New shared `ZiskFv/Airs/Arith/CarryChainCompleteness.lean`
+      (pure math, build it green before touching components):
+      - `def chunk16 (x k : ℕ) : ℕ := x / 65536 ^ k % 65536`;
+        `chunk16_lt : chunk16 x k < 65536`.
+      - `nat_decomp4` / `nat_decomp8`: `x < 65536^4 (resp ^8)` →
+        x = Σ chunk16 x k * 65536^k (by `omega`).
+      - `fgl_decomp4` / `fgl_decomp8`: the FGL casts (`push_cast`).
+      - `lemma fgl_65536_ne_zero : (65536 : FGL) ≠ 0 := by decide`.
+      - Field-solved carries, generic over `[Field F] (B : F) (hB : B ≠ 0)`:
+        `cc0 e0 := e0 / B`, …, `cc6 e0…e6 := (e0 + e1*B + … + e6*B^6) / B^7`;
+        `chain_eq_0 : e0 - cc0*B = 0`; `chain_eq_k : e_k + cc_{k-1} - cc_k*B = 0`
+        (k=1..6); `chain_last (h : Σ e_k*B^k = 0) : e7 + cc6 = 0`.
+        If `field_simp` blows up, state pre-cleared forms
+        (`cc_k * B^(k+1) = Σ_{j≤k} e_j*B^j` via `div_mul_cancel₀`) and
+        `linear_combination` against those. Keep `65536` powers FACTORED
+        (CLAUDE.md trap #2).
+- [ ] **ArithMul** (`circuit`, 11 assertZeros + OpBus push):
+      ```lean
+      structure ArithMulFreeCols (F) where  -- the 11 columns in no constraint:
+        sext div_by_zero div_overflow main_div main_mul signed
+        range_ab range_cd op bus_res1 multiplicity : F
+      def arithMulRowOf (a b : ℕ) (free : ArithMulFreeCols FGL) : ArithMulRow FGL
+      -- a_k/b_k := chunk16 casts; c_k := ↑(chunk16 (a*b) k); d_k := ↑(chunk16 (a*b) (k+4))
+      -- flags na nb np nr m32 div := 0; fab := 1; na_fb := nb_fa := 0
+      -- carry_k := cc_k applied to this row's chain numerators e_k
+      ProverAssumptions := fun row _ _ =>
+        ∃ a b free, a < 65536^4 ∧ b < 65536^4 ∧ row = arithMulRowOf a b free
+      ```
+      Discharge: C6/C7/C8 by `norm_num` after substitution; C31–C37 by
+      `linear_combination (chain_eq_k …)`; C38 via `chain_last` with
+      `h_packed : ↑a * ↑b = c_packed + d_packed * B^4` from `fgl_decomp4 a/b`
+      + `fgl_decomp8 (a*b)` + `Nat.cast_mul`. MANDATORY: the
+      `circuit_proof_start_core` route (43-column row; pattern in this
+      file's own soundness proof), `set_option maxHeartbeats 4000000` if
+      needed.
+- [ ] **ArithDiv** (`circuit`, 11 assertZeros, NO push — strictly easier):
+      same skeleton; operands `(c b : ℕ)` = dividend, divisor; roles
+      a := chunks of `c / b` (quotient), d := chunks of `c % b` (remainder);
+      include `b ≠ 0` side-condition (documentation honesty — ZisK flags
+      div-by-zero rows separately); `h_packed` from `Nat.div_add_mod`.
+      Same agent, Mul first as the template.
+- [ ] Witnesses (concrete a,b — e.g. 6×7 and 100/7); gates; ask Cody; PR.
+
+## Wave 5 — Main, 3 circuits + finalization (1 agent, 1 PR, after Wave 1)
+
+- [ ] **Plain `circuit`** (9 assertZeros + OpBus emit): the internal-op
+      conditionals force exactly three honest shapes —
+      ```lean
+      inductive MainExecKind (F)
+        | external (op : F) (flag : Bool) (c_0 c_1 set_pc : F)
+            -- builder sets set_pc column := if flag then 0 else set_pc
+        | internalFlag                  -- op := 0, c := 0, flag := 1, set_pc := 0
+        | internalCopyB (set_pc : F)    -- op := 1, c_i := b_i, flag := 0
+      ```
+      plus `MainFreeCols` (a/b operands, pc, m32, ind_width, jmp offsets,
+      store_pc, im_high_degree_2, segment_l1). All 9 goals by `cases k` +
+      `boolF_booleanity` / `norm_num` / `ring`.
+- [ ] **`circuitWithRomAndMemBus length program`** (adds 14 ROM-flag
+      booleanities + the static ROM lookup + 3 MemBus emits). Builder takes
+      the program ENTRY so the lookup closes by construction:
+      ```lean
+      structure RomFlagBits where  -- 15 Bools, bit order of romFlags (main.pil:483-486)
+        a_src_imm a_src_mem is_precompiled b_src_imm b_src_mem is_external_op
+        store_pc store_mem store_ind set_pc m32 b_src_ind a_src_reg b_src_reg
+        store_reg : Bool
+      def packFlags (bits : RomFlagBits) : FGL  -- verbatim romFlags polynomial shape
+      def mainRomRowOf (msg : ZiskRomMessage FGL) (bits : RomFlagBits)
+          (k : MainRomExecKind FGL) (free : MainRomFreeCols FGL) : MainRowWithRom FGL
+      -- pc/op/ind_width/jmp_offsets/imm fields copied from msg;
+      -- flag columns := boolF of bits; flag/c columns from k as in plain Main
+      ProverAssumptions := fun row _ _ => ∃ i bits k free,
+        (program i).flags = packFlags bits        -- entry decodes to these bits
+        ∧ <kind coherence: external ↔ bits.is_external_op; internal kinds fix msg.op = 0/1>
+        ∧ <flag=1 cases force bits.set_pc = false>
+        ∧ row = mainRomRowOf (program i) bits k free
+      ```
+      ROM lookup obligation unfolds to `∃ i, eval … = program i` — close with
+      witness `i` using the EXISTING `eval_romMessageExpr` /
+      `eval_romFlagsExpr` (`Main/Constraints.lean:176,184`); mirror the
+      unfold path of `romSpec_of_mainWithRomAndMemBus_constraints`
+      (`Main/Circuit.lean` ~line 154). The 10 data slots are rfl-equal by
+      construction; the flags slot closes by the `packFlags` hypothesis.
+      Fallback if `circuit_proof_start` decomposes the lookup entry too
+      eagerly: `_core` route, keep `h_input` whole, apply
+      `Lookup.completeness_def` + `eval_romMessageExpr` manually, split
+      `h_input` only for the assertZero goals. Prove this as a STANDALONE
+      `theorem mainWithRomAndMemBus_completeness …` (not inline).
+- [ ] **`circuitWithRomMemAndOpBus`**: ~15-line `simpa [mainWithRomMemAndOpBus,
+      circuit_norm, OpBusChannel, MemBusChannel]` wrapper around the
+      standalone theorem — mirror `mainWithRomMemAndOpBus_soundness`
+      (`Main/Circuit.lean` ~line 205). Same ProverAssumptions for both.
+- [ ] Witness: a concrete 1-instruction `Program` + one honest row per kind.
+- [ ] Finalization sweep (this wave, after all others merge): CLAUDE.md
+      status paragraph (Clean completeness fields now proved; state the
+      Arith/table scopes), append an upgrade note to
+      `ZISK-DEFECT-CLEAN-COMPLETENESS-TRIVIAL-AXIOMS` in `trust/defects.md`,
+      PROJECTS.md/STATUS.md closeout, record follow-up items (signed Arith
+      disjuncts, any table-op scope gaps). Do not edit the RV64IM
+      completeness modules (`ZiskFv/Completeness/**`) — different stream.
+- [ ] Gates; ask Cody; PR.
+
+## Hard invariants (every wave — violations mean the PR is rejected)
+
+- ZERO new `axiom` / `sorry` / `opaque` / `partial def` / `unsafe def`.
+  `trust/allowed-axiom-files.txt`, `trust/tolerated-completeness-axioms.txt`,
+  and ALL of `trust/generated/*` + `trust/baseline-*` must be byte-identical
+  to base (`git diff origin/main -- trust/` shows only
+  `check-all-semantic.sh` (Wave 1) and `trust/consistency/` additions).
+- Soundness fields, `Spec` definitions, `main` do-blocks, and elaborated
+  circuits UNTOUCHED. Builders/witnesses are new defs only.
+- ProverAssumptions: inline existential over builder + semantic
+  side-conditions. No constraint-equation side-conditions; no named Prop
+  wrappers.
+- Each component's witness file lands in the SAME PR as its proof.
+- Edit surface: `ZiskFv/AirsClean/**` (new defs + the 16 field bodies +
+  doc comments), `ZiskFv/Airs/Arith/CarryChainCompleteness.lean`,
+  `trust/consistency/completeness_witness_*.lean`,
+  `trust/scripts/check-all-semantic.sh` (Wave 1 only), docs. Nothing else.
+- Never commit files from `~/ai-workflow`. No wall-time estimates anywhere.
+
+## Verification (every wave, in order)
+
+```bash
+lake build ZiskFv.AirsClean.<Component>.Circuit   # inner loop, per component
+lake build                                        # full, before commit of a chunk
+trust/scripts/check-all.sh                        # V1, seconds
+trust/scripts/check-all-semantic.sh               # V2 + witness glob check
+nix run .#test                                    # before PR
+git diff origin/main -- trust/generated trust/baseline-axioms.txt \
+  trust/baseline-hypothesis-count.txt trust/baseline-caller-burden.txt  # must be empty
+lake exe trust-gate print-axiom-closure ZiskFv.Compliance.zisk_riscv_compliant_program_bus
+# must print no project axioms
+```
+
+Paste the gate tail, the empty-diff confirmation, and the witness file list
+into each PR body.
+
+## Acceptance criteria (stream closeout)
+
+1. All 16 demoted fields are genuine proofs with builder-existential
+   ProverAssumptions; the already-honest BinaryExtension plain field
+   untouched; every scope restriction (Arith unsigned, table-op subsets)
+   stated in docstrings and listed as follow-ups in this file.
+2. ≥10 `trust/consistency/completeness_witness_*.lean` files typecheck
+   inside the semantic gate's glob check.
+3. Ledgers and anti-laundering baselines byte-identical to base; closure
+   print unchanged; `nix run .#test` green on every PR.
+4. PR bodies use completeness/constructibility vocabulary (not promise
+   discharge) and include the verification evidence.
+
+## Log
+
+(append one line per milestone; do not expand the plan body)
+
+- 2026-06-12: Wave 1 worktree `clean-completeness-wave1` created from
+  `origin/main` at `e3b87fc0`; generated inputs populated via Nix; `repl`,
+  full `lake build`, and `trust/scripts/check-all.sh` are green at baseline.

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -473,3 +473,5 @@ into each PR body.
 - 2026-06-12: trust generated/baseline diff is empty; `trust/` diff is limited
   to witness files plus `check-all-semantic.sh`; canonical closure print shows
   no project axioms.
+- 2026-06-12: BinaryAdd proof/gate chunk committed as `60c645c6`; next step is
+  push and review PR without merging.

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -477,3 +477,9 @@ into each PR body.
   push and review PR without merging.
 - 2026-06-12: opened review PR https://github.com/eth-act/zisk-fv/pull/69;
   do not merge until external review completes.
+- 2026-06-12: review feedback in progress: harden semantic witness checks to
+  fail on Lean `sorry` warnings and refresh stale BinaryAdd/MemAlign docstrings.
+- 2026-06-12: addressed review feedback; temporary sorry witness made the
+  semantic gate fail as expected, then focused BinaryAdd/MemAlign build,
+  `trust/scripts/check-all-semantic.sh`, `trust/scripts/check-all.sh`,
+  `bash -n trust/scripts/check-all-semantic.sh`, and `git diff --check` passed.

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -483,3 +483,5 @@ into each PR body.
   semantic gate fail as expected, then focused BinaryAdd/MemAlign build,
   `trust/scripts/check-all-semantic.sh`, `trust/scripts/check-all.sh`,
   `bash -n trust/scripts/check-all-semantic.sh`, and `git diff --check` passed.
+- 2026-06-12: review feedback fix pushed to PR #69 as `91679f42`; next step is
+  external review, do not merge.

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -171,8 +171,8 @@ the script counts checks differently.)
 - [x] MemAlign builder + completeness + witness.
 - [x] BinaryAdd builder + completeness + witness.
 - [x] Globbing witness check in `check-all-semantic.sh`.
-- [ ] Gates (see Verification); ask Cody; open PR.
-- [ ] Record in the PR body any idiom adjustments waves 2–5 must copy.
+- [x] Gates (see Verification); ask Cody; open PR.
+- [x] Record in the PR body any idiom adjustments waves 2–5 must copy.
 
 ### Helpers
 
@@ -475,3 +475,5 @@ into each PR body.
   no project axioms.
 - 2026-06-12: BinaryAdd proof/gate chunk committed as `60c645c6`; next step is
   push and review PR without merging.
+- 2026-06-12: opened review PR https://github.com/eth-act/zisk-fv/pull/69;
+  do not merge until external review completes.

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -168,7 +168,7 @@ the script counts checks differently.)
 - [x] Worktree + cache + green baseline; commit plan copy + STATUS.md.
 - [x] `ZiskFv/AirsClean/CompletenessHelpers.lean`: `boolF`,
       `boolF_booleanity`, shared plumbing lemmas discovered during the pilot.
-- [ ] MemAlign builder + completeness + witness.
+- [x] MemAlign builder + completeness + witness.
 - [ ] BinaryAdd builder + completeness + witness.
 - [ ] Globbing witness check in `check-all-semantic.sh`.
 - [ ] Gates (see Verification); ask Cody; open PR.
@@ -461,3 +461,5 @@ into each PR body.
   full `lake build`, and `trust/scripts/check-all.sh` are green at baseline.
 - 2026-06-12: added `ZiskFv.AirsClean.CompletenessHelpers` with `boolF` and
   `boolF_booleanity`; `lake build ZiskFv.AirsClean.CompletenessHelpers` passed.
+- 2026-06-12: MemAlign builder, completeness proof, and witness added; focused
+  `lake build ZiskFv.AirsClean.MemAlign.Circuit` and witness typecheck passed.

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -169,8 +169,8 @@ the script counts checks differently.)
 - [x] `ZiskFv/AirsClean/CompletenessHelpers.lean`: `boolF`,
       `boolF_booleanity`, shared plumbing lemmas discovered during the pilot.
 - [x] MemAlign builder + completeness + witness.
-- [ ] BinaryAdd builder + completeness + witness.
-- [ ] Globbing witness check in `check-all-semantic.sh`.
+- [x] BinaryAdd builder + completeness + witness.
+- [x] Globbing witness check in `check-all-semantic.sh`.
 - [ ] Gates (see Verification); ask Cody; open PR.
 - [ ] Record in the PR body any idiom adjustments waves 2–5 must copy.
 
@@ -463,3 +463,13 @@ into each PR body.
   `boolF_booleanity`; `lake build ZiskFv.AirsClean.CompletenessHelpers` passed.
 - 2026-06-12: MemAlign builder, completeness proof, and witness added; focused
   `lake build ZiskFv.AirsClean.MemAlign.Circuit` and witness typecheck passed.
+- 2026-06-12: BinaryAdd builder, completeness proof, and witness added; focused
+  `lake build ZiskFv.AirsClean.BinaryAdd.Circuit` and witness typecheck passed.
+- 2026-06-12: Full `lake build`, `trust/scripts/check-all.sh`, and
+  `trust/scripts/check-all-semantic.sh` passed; semantic gate glob picked up
+  BinaryAdd and MemAlign completeness witnesses.
+- 2026-06-12: `nix run .#test` passed all 8 steps, including embedded V1/V2
+  trust gates and flake reproduction.
+- 2026-06-12: trust generated/baseline diff is empty; `trust/` diff is limited
+  to witness files plus `check-all-semantic.sh`; canonical closure print shows
+  no project axioms.

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -166,7 +166,7 @@ the script counts checks differently.)
 ### Checklist
 
 - [x] Worktree + cache + green baseline; commit plan copy + STATUS.md.
-- [ ] `ZiskFv/AirsClean/CompletenessHelpers.lean`: `boolF`,
+- [x] `ZiskFv/AirsClean/CompletenessHelpers.lean`: `boolF`,
       `boolF_booleanity`, shared plumbing lemmas discovered during the pilot.
 - [ ] MemAlign builder + completeness + witness.
 - [ ] BinaryAdd builder + completeness + witness.
@@ -459,3 +459,5 @@ into each PR body.
 - 2026-06-12: Wave 1 worktree `clean-completeness-wave1` created from
   `origin/main` at `e3b87fc0`; generated inputs populated via Nix; `repl`,
   full `lake build`, and `trust/scripts/check-all.sh` are green at baseline.
+- 2026-06-12: added `ZiskFv.AirsClean.CompletenessHelpers` with `boolF` and
+  `boolF_booleanity`; `lake build ZiskFv.AirsClean.CompletenessHelpers` passed.

--- a/trust/consistency/completeness_witness_binaryadd.lean
+++ b/trust/consistency/completeness_witness_binaryadd.lean
@@ -1,0 +1,23 @@
+import ZiskFv.AirsClean.BinaryAdd.Circuit
+
+namespace ZiskFv.TrustConsistency
+
+open Goldilocks
+open ZiskFv.AirsClean.BinaryAdd
+
+private def binaryAddWitnessRow : BinaryAddRow FGL :=
+  binaryAddRowOf 40 2
+
+private theorem binaryAddWitnessProverAssumptions
+    (data : ProverData FGL) (hint : ProverHint FGL) :
+    circuit.ProverAssumptions binaryAddWitnessRow data hint := by
+  refine ⟨40, 2, by norm_num, by norm_num, ?_⟩
+  rfl
+
+theorem completeness_witness_binaryadd :
+    ∃ row : BinaryAddRow FGL, ∀ data hint, circuit.ProverAssumptions row data hint := by
+  exact ⟨binaryAddWitnessRow, binaryAddWitnessProverAssumptions⟩
+
+#print axioms completeness_witness_binaryadd
+
+end ZiskFv.TrustConsistency

--- a/trust/consistency/completeness_witness_memalign.lean
+++ b/trust/consistency/completeness_witness_memalign.lean
@@ -1,0 +1,29 @@
+import ZiskFv.AirsClean.MemAlign.Circuit
+
+namespace ZiskFv.TrustConsistency
+
+open Goldilocks
+open ZiskFv.AirsClean.MemAlign
+
+private def memAlignWitnessRow : MemAlignRow FGL :=
+  memAlignRowOf .prove false false false
+    true false false false false false false false
+    1 2 3 4 5 6 7 8
+    16 0 4 9 0 123
+
+private theorem memAlignWitnessProverAssumptions
+    (data : ProverData FGL) (hint : ProverHint FGL) :
+    circuit.ProverAssumptions memAlignWitnessRow data hint := by
+  refine ⟨.prove, false, false, false,
+    true, false, false, false, false, false, false, false,
+    1, 2, 3, 4, 5, 6, 7, 8,
+    16, 0, 4, 9, 0, 123, ?_⟩
+  rfl
+
+theorem completeness_witness_memalign :
+    ∃ row : MemAlignRow FGL, ∀ data hint, circuit.ProverAssumptions row data hint := by
+  exact ⟨memAlignWitnessRow, memAlignWitnessProverAssumptions⟩
+
+#print axioms completeness_witness_memalign
+
+end ZiskFv.TrustConsistency

--- a/trust/scripts/check-all-semantic.sh
+++ b/trust/scripts/check-all-semantic.sh
@@ -29,12 +29,22 @@ reject_false_probe() {
   fi
 }
 
-run "1/5 axiom-deps baseline (V2)"        "$dir/check-axiom-deps.sh"
-run "2/5 forbidden types (V2)"            "$dir/check-no-output-eq-v2.sh"
-run "3/5 closure vs baseline-axioms (V2)" "$dir/check-closure-vs-baseline.sh"
-run "4/5 consistency false probe rejected" reject_false_probe
-run "5/5 Sail memory timeline witness" \
+run_witnesses() {
+  local ok=0
+  for f in trust/consistency/completeness_witness_*.lean; do
+    [ -e "$f" ] || continue
+    lake env lean "$f" || ok=1
+  done
+  return $ok
+}
+
+run "1/6 axiom-deps baseline (V2)"        "$dir/check-axiom-deps.sh"
+run "2/6 forbidden types (V2)"            "$dir/check-no-output-eq-v2.sh"
+run "3/6 closure vs baseline-axioms (V2)" "$dir/check-closure-vs-baseline.sh"
+run "4/6 consistency false probe rejected" reject_false_probe
+run "5/6 Sail memory timeline witness" \
   lake env lean trust/consistency/load_byte_agreement_witness.lean
+run "6/6 Clean completeness witnesses" run_witnesses
 
 if [ $overall -eq 0 ]; then
   echo "trust-gate (V2 semantic): ALL CHECKS PASSED."

--- a/trust/scripts/check-all-semantic.sh
+++ b/trust/scripts/check-all-semantic.sh
@@ -29,11 +29,27 @@ reject_false_probe() {
   fi
 }
 
+run_lean_no_sorry() {
+  local output status
+  output="$(lake env lean "$@" 2>&1)"
+  status=$?
+  if [ -n "$output" ]; then
+    printf '%s\n' "$output"
+  fi
+  if [ "$status" -ne 0 ]; then
+    return "$status"
+  fi
+  if grep -q 'uses `sorry`' <<<"$output"; then
+    echo "Lean file unexpectedly contains sorry: $*"
+    return 1
+  fi
+}
+
 run_witnesses() {
   local ok=0
   for f in trust/consistency/completeness_witness_*.lean; do
     [ -e "$f" ] || continue
-    lake env lean "$f" || ok=1
+    run_lean_no_sorry "$f" || ok=1
   done
   return $ok
 }
@@ -43,7 +59,7 @@ run "2/6 forbidden types (V2)"            "$dir/check-no-output-eq-v2.sh"
 run "3/6 closure vs baseline-axioms (V2)" "$dir/check-closure-vs-baseline.sh"
 run "4/6 consistency false probe rejected" reject_false_probe
 run "5/6 Sail memory timeline witness" \
-  lake env lean trust/consistency/load_byte_agreement_witness.lean
+  run_lean_no_sorry trust/consistency/load_byte_agreement_witness.lean
 run "6/6 Clean completeness witnesses" run_witnesses
 
 if [ $overall -eq 0 ]; then


### PR DESCRIPTION
Queued for Claude review — do not merge.

## Summary
- Adds shared Clean completeness helpers for Bool-to-field selectors and FGL Nat range bounds.
- Replaces the demoted False completeness non-claims for MemAlign and BinaryAdd with builder-existential ProverAssumptions and real completeness proofs.
- Adds concrete anti-vacuity witnesses for MemAlign and BinaryAdd.
- Wires trust/scripts/check-all-semantic.sh to glob completeness_witness_*.lean so later waves only add witness files.
- Tightens two FullEnsemble structural proofs to avoid unfolding larger completeness fields during unrelated checks.

## Scope notes
- This is Wave 1 and the reference implementation for later Clean completeness waves.
- Completeness is row-local constructibility for rows equal to the honest builders. It does not claim arbitrary input rows are honest component executions.
- The semantic witness gate hardening in this PR makes witness sorry warnings fail mechanically.

## Verification
- lake build: passed.
- trust/scripts/check-all.sh: trust-gate: ALL CHECKS PASSED.
- trust/scripts/check-all-semantic.sh: trust-gate (V2 semantic): ALL CHECKS PASSED.
- nix run .#test: passed all 8 steps, final line ALL CHECKS PASSED.
- Generated trust baseline diff against origin/main was empty.
- Closure print emitted no project axiom names; only existing TrustGate.Main deprecation warnings appeared.
- Negative witness hardening check: a temporary sorry witness made the semantic gate fail as expected, then was removed before final gates.

Witness files discovered in the Wave 1 semantic gate:
- trust/consistency/completeness_witness_binaryadd.lean
- trust/consistency/completeness_witness_memalign.lean

## Notes for later waves
- Keep ProverAssumptions inline as a builder existential; do not introduce named Prop wrappers.
- Builders compute dependent columns. Side conditions should be semantic operand facts only, not constraint equations.
- Later waves should add trust/consistency/completeness_witness_*.lean files; the semantic gate glob discovers them without script edits.
- Avoid broad simp that unfolds complete component records in ensemble wrappers. Larger completeness fields can make unrelated structural proofs time out.
- Reuse boolF, boolF_booleanity_add, and fgl_natCast_val_lt_of_lt for selector/range plumbing.