### PR TITLE
Clean completeness Wave 2: byte/mem mux family

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -25,6 +25,10 @@ build and witness typecheck pass. Mem now has `memRowOf`,
 `memRowOf_constraintsHold`, all three completeness fields proved, and
 `trust/consistency/completeness_witness_mem.lean` covering all three
 ProverAssumptions; focused component build and witness typecheck pass.
+Docstrings are updated; stale non-claim scan is clean for the three Wave 2
+files. `lake build ZiskFv.AirsClean.FullEnsemble` and
+`lake build ZiskFv.AirsClean.FullEnsemble.Balance` passed without ensemble
+call-site edits.
 
-Next step: run ensemble build/perf checks, update any required ensemble call
-sites, then run the Wave 2 verification block.
+Next step: run the remaining Wave 2 verification block, then open the review
+PR per protocol.

--- a/STATUS.md
+++ b/STATUS.md
@@ -18,6 +18,10 @@ Progress: Wave 2 worktree is ready and start scan `rg "completeness :="
 ZiskFv` matches the plan. MemAlignReadByte now has
 `memAlignReadByteRowOf`, a builder-existential completeness proof, and
 `trust/consistency/completeness_witness_memalignreadbyte.lean`; focused
-component build and witness typecheck pass.
+component build and witness typecheck pass. MemAlignByte now has
+`memAlignByteRowOf`, a builder-existential completeness proof, and
+`trust/consistency/completeness_witness_memalignbyte.lean`; focused component
+build and witness typecheck pass.
 
-Next step: implement MemAlignByte builder, completeness proof, and witness.
+Next step: implement the shared Mem builder/constraints lemma, the three Mem
+completeness fields, and the Mem witness.

--- a/STATUS.md
+++ b/STATUS.md
@@ -14,11 +14,10 @@ get` found missing path deps; retry of `lake exe cache get` succeeded. The
 `zisk` submodule is initialized at pinned `4148c25e`. `lake build repl`, full
 baseline `lake build`, and `trust/scripts/check-all.sh` passed.
 
-Progress: Wave 2 worktree is ready for proof edits. Start scan
-`rg "completeness :=" ZiskFv` matches the plan: Wave 2 owns
-MemAlignReadByte, MemAlignByte, and Mem's three circuits; Wave 1
-MemAlign/BinaryAdd are already genuine, and BinaryExtension plain is already
-complete.
+Progress: Wave 2 worktree is ready and start scan `rg "completeness :="
+ZiskFv` matches the plan. MemAlignReadByte now has
+`memAlignReadByteRowOf`, a builder-existential completeness proof, and
+`trust/consistency/completeness_witness_memalignreadbyte.lean`; focused
+component build and witness typecheck pass.
 
-Next step: read the Wave 1 reference implementations and the Wave 2
-Constraints/Spec/Circuit files, then implement MemAlignReadByte first.
+Next step: implement MemAlignByte builder, completeness proof, and witness.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,38 +1,24 @@
 Active plan: docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
 
-Current focus: Wave 1 pilot for genuine Clean completeness proofs on branch
-`clean-completeness-wave1` in `.worktrees/completeness-wave1`: shared helpers,
-MemAlign, BinaryAdd, and witness-gate wiring.
+Current focus: Wave 2 byte/mem mux family on branch
+`clean-completeness-wave2` in `.worktrees/completeness-wave2`: prove genuine
+Clean completeness for MemAlignReadByte, MemAlignByte, and the three Mem
+circuits, with builder-existential ProverAssumptions and witnesses.
 
-Blocking: none. Do not merge the PR; hand off for external review only.
+Blocking: none. PR #69/Wave 1 is not merged to `origin/main`; this worktree is
+stacked on `origin/clean-completeness-wave1` at `5c10ecc6` so the base includes
+Wave 1 helpers and the hardened witness gate. Do not merge PRs.
 
-Setup: worktree created from `origin/main` at `e3b87fc0`; `nix run .#populate`
-now works and populated generated inputs; `lake exe cache get`, `lake build
-repl`, full baseline `lake build`, and `trust/scripts/check-all.sh` passed.
-The `zisk` submodule is initialized at pinned `4148c25e`.
+Setup: `nix run .#populate` populated generated inputs after `lake exe cache
+get` found missing path deps; retry of `lake exe cache get` succeeded. The
+`zisk` submodule is initialized at pinned `4148c25e`. `lake build repl`, full
+baseline `lake build`, and `trust/scripts/check-all.sh` passed.
 
-Progress: initial STATUS/project trail bookkeeping committed as `fb021f11`.
-Helpers and MemAlign are committed. BinaryAdd now has `binaryAddRowOf`, a real
-builder-existential completeness proof, and
-`trust/consistency/completeness_witness_binaryadd.lean`; focused BinaryAdd
-circuit build and witness typecheck both pass. `FullEnsemble` and
-`FullEnsemble/Balance` needed local proof-performance tightenings after the
-larger completeness fields and now build focused. Full `lake build`,
-`trust/scripts/check-all.sh`, and `trust/scripts/check-all-semantic.sh` pass;
-the semantic gate found both Wave 1 witness files. `nix run .#test` passed
-all 8 steps. Trust generated/baseline diff is empty; trust-surface diff is
-limited to the witness files and semantic script; canonical closure print
-shows no project axioms. BinaryAdd/gate proof chunk committed as `60c645c6`.
-Review PR opened: https://github.com/eth-act/zisk-fv/pull/69. Do not merge
-until external review completes. Review feedback fix pushed as `91679f42`: the
-semantic witness gate now fails on Lean `sorry` warnings, the pre-existing Sail
-memory witness uses the same wrapper, and BinaryAdd/MemAlign docstrings state
-their proved constructibility scopes.
+Progress: Wave 2 worktree is ready for proof edits. Start scan
+`rg "completeness :=" ZiskFv` matches the plan: Wave 2 owns
+MemAlignReadByte, MemAlignByte, and Mem's three circuits; Wave 1
+MemAlign/BinaryAdd are already genuine, and BinaryExtension plain is already
+complete.
 
-Verification after feedback: temporary `completeness_witness_sorry_probe.lean`
-made `trust/scripts/check-all-semantic.sh` fail as expected on the Lean `sorry`
-warning; after deleting the probe, these passed: focused BinaryAdd/MemAlign
-circuit build, semantic gate, V1 gate, shell syntax check, and
-`git diff --check`.
-
-Next step: wait for external review feedback on PR #69.
+Next step: read the Wave 1 reference implementations and the Wave 2
+Constraints/Spec/Circuit files, then implement MemAlignReadByte first.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,9 +1,9 @@
 Active plan: docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
 
 Current focus: Wave 2 byte/mem mux family on branch
-`clean-completeness-wave2` in `.worktrees/completeness-wave2`: prove genuine
-Clean completeness for MemAlignReadByte, MemAlignByte, and the three Mem
-circuits, with builder-existential ProverAssumptions and witnesses.
+`clean-completeness-wave2` in `.worktrees/completeness-wave2`: final
+verification is green; open the stacked review PR against
+`clean-completeness-wave1`.
 
 Blocking: none. PR #69/Wave 1 is not merged to `origin/main`; this worktree is
 stacked on `origin/clean-completeness-wave1` at `5c10ecc6` so the base includes
@@ -28,7 +28,11 @@ ProverAssumptions; focused component build and witness typecheck pass.
 Docstrings are updated; stale non-claim scan is clean for the three Wave 2
 files. `lake build ZiskFv.AirsClean.FullEnsemble` and
 `lake build ZiskFv.AirsClean.FullEnsemble.Balance` passed without ensemble
-call-site edits.
+call-site edits. Final gates passed: full `lake build`,
+`trust/scripts/check-all.sh`, `trust/scripts/check-all-semantic.sh`,
+`nix run .#test`, empty trust generated/baseline diff against
+`origin/clean-completeness-wave1`, `git diff --check`, clean status after
+restoring generated `zisk/lib-float` artifacts, and closure print with no
+project axiom lines.
 
-Next step: run the remaining Wave 2 verification block, then open the review
-PR per protocol.
+Next step: open the review PR per protocol; do not merge.

--- a/STATUS.md
+++ b/STATUS.md
@@ -21,7 +21,10 @@ ZiskFv` matches the plan. MemAlignReadByte now has
 component build and witness typecheck pass. MemAlignByte now has
 `memAlignByteRowOf`, a builder-existential completeness proof, and
 `trust/consistency/completeness_witness_memalignbyte.lean`; focused component
-build and witness typecheck pass.
+build and witness typecheck pass. Mem now has `memRowOf`,
+`memRowOf_constraintsHold`, all three completeness fields proved, and
+`trust/consistency/completeness_witness_mem.lean` covering all three
+ProverAssumptions; focused component build and witness typecheck pass.
 
-Next step: implement the shared Mem builder/constraints lemma, the three Mem
-completeness fields, and the Mem witness.
+Next step: run ensemble build/perf checks, update any required ensemble call
+sites, then run the Wave 2 verification block.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,8 @@
 Active plan: docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
 
 Current focus: Wave 2 byte/mem mux family on branch
-`clean-completeness-wave2` in `.worktrees/completeness-wave2`: final
-verification is green; open the stacked review PR against
+`clean-completeness-wave2` in `.worktrees/completeness-wave2`: review PR
+https://github.com/eth-act/zisk-fv/pull/70 is open against
 `clean-completeness-wave1`.
 
 Blocking: none. PR #69/Wave 1 is not merged to `origin/main`; this worktree is
@@ -35,4 +35,5 @@ call-site edits. Final gates passed: full `lake build`,
 restoring generated `zisk/lib-float` artifacts, and closure print with no
 project axiom lines.
 
-Next step: open the review PR per protocol; do not merge.
+Next step: wait for external Claude review; do not merge and do not start the
+next wave from this worktree.

--- a/ZiskFv/AirsClean/Mem/Circuit.lean
+++ b/ZiskFv/AirsClean/Mem/Circuit.lean
@@ -1,5 +1,6 @@
 import ZiskFv.AirsClean.Mem.Constraints
 import ZiskFv.AirsClean.Mem.Soundness
+import ZiskFv.AirsClean.CompletenessHelpers
 import Clean.Air.FlatComponent
 import Clean.Utils.Tactics
 
@@ -16,8 +17,11 @@ lookup/permutation promise.
 
 ## Trust note
 
-No axioms. Completeness is intentionally a visible non-claim, so this component
-does not claim honest-prover constructibility beyond the soundness theorem.
+No axioms. Completeness is a constructibility claim for rows equal to
+`memRowOf ...`: primary/dual selectors, write flag, and address-change flag
+are Boolean, the selector implications are explicit semantic side-conditions,
+and `read_same_addr` plus read-on-address-change value zeroing are computed by
+the builder. Cross-row memory consistency remains outside this row-local proof.
 -/
 
 namespace ZiskFv.AirsClean.Mem
@@ -26,16 +30,57 @@ open Goldilocks
 open ZiskFv.Channels.MemoryBus (MemBusChannel)
 open Air.Flat
 
+/-- Honest `read_same_addr` column for Mem. -/
+def memReadSameAddrOf (addrChanges wr : Bool) : FGL :=
+  (1 - boolF addrChanges) * (1 - boolF wr)
+
+/-- Honest Mem value chunk: address-changing reads are zeroed, all other rows
+    keep the caller-supplied chunk. -/
+def memValueOf (addrChanges wr : Bool) (value : FGL) : FGL :=
+  if addrChanges && !wr then 0 else value
+
+/-- Honest row for Mem's row-local constraints. Selector columns are Boolean,
+    `read_same_addr` is computed, and address-changing reads zero the value
+    chunks constrained by this slice. -/
+def memRowOf (sel selDual wr addrChanges : Bool)
+    (addr step stepDual previousStep increment_0 increment_1 value_0 value_1 : FGL) :
+    MemRow FGL :=
+  { addr := addr
+    step := step
+    sel := boolF sel
+    addr_changes := boolF addrChanges
+    step_dual := stepDual
+    sel_dual := boolF selDual
+    value_0 := memValueOf addrChanges wr value_0
+    value_1 := memValueOf addrChanges wr value_1
+    wr := boolF wr
+    previous_step := previousStep
+    increment_0 := increment_0
+    increment_1 := increment_1
+    read_same_addr := memReadSameAddrOf addrChanges wr }
+
+lemma memRowOf_constraintsHold (sel selDual wr addrChanges : Bool)
+    (addr step stepDual previousStep increment_0 increment_1 value_0 value_1 : FGL)
+    (h_selDual : selDual = true → sel = true)
+    (h_wr : wr = true → sel = true) :
+    Spec (memRowOf sel selDual wr addrChanges
+      addr step stepDual previousStep increment_0 increment_1 value_0 value_1) := by
+  cases sel <;> cases selDual <;> cases wr <;> cases addrChanges <;>
+    simp [Spec, memRowOf, memReadSameAddrOf, memValueOf, boolF] at h_selDual h_wr ⊢
+
 /-- Mem as a Clean `GeneralFormalCircuit`. -/
 def circuit : GeneralFormalCircuit FGL MemRow unit :=
   { memElaborated with
     Assumptions := fun _ _ => True
     Spec := fun row _ _ => Spec row
-    -- Completeness is intentionally NOT claimed (zisk-fv is soundness-
-    -- only). `ProverAssumptions := False` makes this field a visible
-    -- non-claim. See trust/defects.md
-    -- ZISK-DEFECT-CLEAN-COMPLETENESS-TRIVIAL-AXIOMS.
-    ProverAssumptions := fun _ _ _ => False
+    -- Completeness covers rows built by `memRowOf`; the two selector
+    -- implications are semantic side-conditions, not hidden constraints.
+    ProverAssumptions := fun row _ _ =>
+      ∃ sel selDual wr addrChanges addr step stepDual previousStep
+        increment_0 increment_1 value_0 value_1,
+        (selDual = true → sel = true) ∧ (wr = true → sel = true) ∧
+          row = memRowOf sel selDual wr addrChanges
+            addr step stepDual previousStep increment_0 increment_1 value_0 value_1
     ProverSpec := fun _ _ _ => True
     soundness := by
       circuit_proof_start
@@ -49,7 +94,19 @@ def circuit : GeneralFormalCircuit FGL MemRow unit :=
             , by simpa only [sub_eq_add_neg] using h6
             , by simpa only [sub_eq_add_neg] using h7
             , by simpa only [sub_eq_add_neg] using h8 ⟩
-    completeness := fun _ _ _ _ _ _ h => h.elim }
+    completeness := by
+      circuit_proof_start
+      obtain ⟨sel, selDual, wr, addrChanges, addr, step, stepDual, previousStep,
+        increment_0, increment_1, value_0, value_1, h_selDual, h_wr, hrow⟩ :=
+        h_assumptions
+      injection hrow with h_addr h_step h_sel h_addr_changes h_step_dual h_sel_dual
+        h_value_0 h_value_1 h_wr_col h_previous_step h_increment_0 h_increment_1
+        h_read_same_addr
+      subst_vars
+      simpa only [Spec, memRowOf, memReadSameAddrOf, memValueOf, sub_eq_add_neg] using
+        memRowOf_constraintsHold sel selDual wr addrChanges
+          addr step stepDual previousStep increment_0 increment_1 value_0 value_1
+          h_selDual h_wr }
 
 /-- Mem as a Clean `Air.Flat.Component`. -/
 def component : Air.Flat.Component FGL := ⟨ circuit ⟩
@@ -66,11 +123,14 @@ def circuitWithMemBus : GeneralFormalCircuit FGL MemRow unit :=
   { memWithMemBusElaborated with
     Assumptions := fun _ _ => True
     Spec := fun row _ _ => Spec row
-    -- Completeness is intentionally NOT claimed (zisk-fv is soundness-
-    -- only). `ProverAssumptions := False` makes this field a visible
-    -- non-claim. See trust/defects.md
-    -- ZISK-DEFECT-CLEAN-COMPLETENESS-TRIVIAL-AXIOMS.
-    ProverAssumptions := fun _ _ _ => False
+    -- Completeness covers the same honest rows as `circuit`; the memory-bus
+    -- emission adds only a trivially-true channel guarantee.
+    ProverAssumptions := fun row _ _ =>
+      ∃ sel selDual wr addrChanges addr step stepDual previousStep
+        increment_0 increment_1 value_0 value_1,
+        (selDual = true → sel = true) ∧ (wr = true → sel = true) ∧
+          row = memRowOf sel selDual wr addrChanges
+            addr step stepDual previousStep increment_0 increment_1 value_0 value_1
     ProverSpec := fun _ _ _ => True
     soundness := by
       circuit_proof_start
@@ -87,7 +147,19 @@ def circuitWithMemBus : GeneralFormalCircuit FGL MemRow unit :=
               , by simpa only [sub_eq_add_neg] using h8 ⟩
       · intro _
         trivial
-    completeness := fun _ _ _ _ _ _ h => h.elim }
+    completeness := by
+      circuit_proof_start [MemBusChannel]
+      obtain ⟨sel, selDual, wr, addrChanges, addr, step, stepDual, previousStep,
+        increment_0, increment_1, value_0, value_1, h_selDual, h_wr, hrow⟩ :=
+        h_assumptions
+      injection hrow with h_addr h_step h_sel h_addr_changes h_step_dual h_sel_dual
+        h_value_0 h_value_1 h_wr_col h_previous_step h_increment_0 h_increment_1
+        h_read_same_addr
+      subst_vars
+      simpa only [Spec, memRowOf, memReadSameAddrOf, memValueOf, sub_eq_add_neg] using
+        memRowOf_constraintsHold sel selDual wr addrChanges
+          addr step stepDual previousStep increment_0 increment_1 value_0 value_1
+          h_selDual h_wr }
 
 /-- Mem as a Clean `Air.Flat.Component` exposing the memory-bus
     provider emission. Used by Clean memory-bus component assembly. -/
@@ -101,11 +173,14 @@ def circuitWithDualMemBus : GeneralFormalCircuit FGL MemRow unit :=
   { memWithDualMemBusElaborated with
     Assumptions := fun _ _ => True
     Spec := fun row _ _ => Spec row
-    -- Completeness is intentionally NOT claimed (zisk-fv is soundness-
-    -- only). `ProverAssumptions := False` makes this field a visible
-    -- non-claim. See trust/defects.md
-    -- ZISK-DEFECT-CLEAN-COMPLETENESS-TRIVIAL-AXIOMS.
-    ProverAssumptions := fun _ _ _ => False
+    -- Completeness covers the same honest rows as `circuit`; the two memory-bus
+    -- emissions add only trivially-true channel guarantees.
+    ProverAssumptions := fun row _ _ =>
+      ∃ sel selDual wr addrChanges addr step stepDual previousStep
+        increment_0 increment_1 value_0 value_1,
+        (selDual = true → sel = true) ∧ (wr = true → sel = true) ∧
+          row = memRowOf sel selDual wr addrChanges
+            addr step stepDual previousStep increment_0 increment_1 value_0 value_1
     ProverSpec := fun _ _ _ => True
     soundness := by
       circuit_proof_start
@@ -121,7 +196,19 @@ def circuitWithDualMemBus : GeneralFormalCircuit FGL MemRow unit :=
               , by simpa only [sub_eq_add_neg] using h7
               , by simpa only [sub_eq_add_neg] using h8 ⟩
       · exact ⟨by intro _; trivial, by intro _; trivial⟩
-    completeness := fun _ _ _ _ _ _ h => h.elim }
+    completeness := by
+      circuit_proof_start [MemBusChannel]
+      obtain ⟨sel, selDual, wr, addrChanges, addr, step, stepDual, previousStep,
+        increment_0, increment_1, value_0, value_1, h_selDual, h_wr, hrow⟩ :=
+        h_assumptions
+      injection hrow with h_addr h_step h_sel h_addr_changes h_step_dual h_sel_dual
+        h_value_0 h_value_1 h_wr_col h_previous_step h_increment_0 h_increment_1
+        h_read_same_addr
+      subst_vars
+      simpa only [Spec, memRowOf, memReadSameAddrOf, memValueOf, sub_eq_add_neg] using
+        memRowOf_constraintsHold sel selDual wr addrChanges
+          addr step stepDual previousStep increment_0 increment_1 value_0 value_1
+          h_selDual h_wr }
 
 /-- Mem as a Clean `Air.Flat.Component` exposing both primary and dual
     memory-bus provider emissions. -/

--- a/ZiskFv/AirsClean/MemAlignByte/Circuit.lean
+++ b/ZiskFv/AirsClean/MemAlignByte/Circuit.lean
@@ -1,5 +1,6 @@
 import ZiskFv.AirsClean.MemAlignByte.Constraints
 import ZiskFv.AirsClean.MemAlignByte.Soundness
+import ZiskFv.AirsClean.CompletenessHelpers
 import Clean.Air.FlatComponent
 import Clean.Utils.Tactics
 
@@ -13,14 +14,19 @@ Packages ZisK's MemAlignByte AIR as a Clean `Air.Flat.Component`:
   emits the 9 `assertZero` algebraic constraints and the memory-bus
   proves-side `push`.
 * `circuit` — the `GeneralFormalCircuit`. `Assumptions := True` for
-  soundness; completeness is intentionally a visible non-claim.
+  soundness; completeness is proved for honest rows built from Boolean byte
+  selectors, a Boolean write flag, and 8-bit read/write byte values.
 * `component` — the `Air.Flat.Component`.
 
 ## Trust note
 
 `Assumptions := True` is what lets the Component compose into an ensemble
 non-vacuously (the `AssumptionsConsistency` obligation becomes trivial).
-No completeness claim is made; the `soundness` field is genuinely proved.
+Completeness is a constructibility claim for rows equal to
+`memAlignByteRowOf ...` with `byteVal < 2^8` and `writtenByteVal < 2^8`: the
+builder computes the read/write composed values, write-lane muxes, and bus
+byte used by this constraint slice. It does not claim that arbitrary input
+rows are honest MemAlignByte executions.
 -/
 
 namespace ZiskFv.AirsClean.MemAlignByte
@@ -28,6 +34,63 @@ namespace ZiskFv.AirsClean.MemAlignByte
 open Goldilocks
 open ZiskFv.Channels.MemoryBus (MemBusChannel)
 open Air.Flat
+
+/-- Read/write byte reconstruction used by the MemAlignByte honest-row builder. -/
+def memAlignByteComposedValueOf (sel_high_2b sel_high_b : Bool)
+    (byte_value value_8b value_16b : FGL) : FGL :=
+  byte_value * byte_value_factor (boolF sel_high_2b) (boolF sel_high_b)
+    + value_8b * value_8b_factor (boolF sel_high_2b) (boolF sel_high_b)
+    + value_16b * value_16b_factor (boolF sel_high_2b)
+
+/-- Honest low write lane for MemAlignByte. -/
+def memAlignByteMemWriteValues0Of (sel_high_4b : Bool)
+    (direct_value written_composed_value : FGL) : FGL :=
+  boolF sel_high_4b * (direct_value - written_composed_value) + written_composed_value
+
+/-- Honest high write lane for MemAlignByte. -/
+def memAlignByteMemWriteValues1Of (sel_high_4b : Bool)
+    (direct_value written_composed_value : FGL) : FGL :=
+  boolF sel_high_4b * (written_composed_value - direct_value) + direct_value
+
+/-- Honest memory-bus byte mux for MemAlignByte. -/
+def memAlignByteBusByteOf (isWrite : Bool) (byte_value written_byte_value : FGL) : FGL :=
+  boolF isWrite * (written_byte_value - byte_value) + byte_value
+
+lemma memAlignByteBusByteOf_eq (isWrite : Bool) (byte_value written_byte_value : FGL) :
+    memAlignByteBusByteOf isWrite byte_value written_byte_value =
+      if isWrite then written_byte_value else byte_value := by
+  cases isWrite <;> simp [memAlignByteBusByteOf, boolF]
+
+/-- Honest row for MemAlignByte: selectors and write flag are Boolean, byte
+    operands are range-bounded naturals, and dependent mux/reconstruction
+    columns are computed. -/
+def memAlignByteRowOf (sel_high_4b sel_high_2b sel_high_b isWrite : Bool)
+    (byteVal writtenByteVal : ℕ)
+    (direct_value value_16b value_8b addr_w step : FGL) : MemAlignByteRow FGL :=
+  let byte_value : FGL := (byteVal : FGL)
+  let written_byte_value : FGL := (writtenByteVal : FGL)
+  let composed_value :=
+    memAlignByteComposedValueOf sel_high_2b sel_high_b byte_value value_8b value_16b
+  let written_composed_value :=
+    memAlignByteComposedValueOf sel_high_2b sel_high_b written_byte_value value_8b value_16b
+  { sel_high_4b := boolF sel_high_4b
+    sel_high_2b := boolF sel_high_2b
+    sel_high_b := boolF sel_high_b
+    direct_value := direct_value
+    composed_value := composed_value
+    written_composed_value := written_composed_value
+    written_byte_value := written_byte_value
+    value_16b := value_16b
+    value_8b := value_8b
+    byte_value := byte_value
+    addr_w := addr_w
+    step := step
+    is_write := boolF isWrite
+    mem_write_values_0 := memAlignByteMemWriteValues0Of sel_high_4b direct_value
+      written_composed_value
+    mem_write_values_1 := memAlignByteMemWriteValues1Of sel_high_4b direct_value
+      written_composed_value
+    bus_byte := memAlignByteBusByteOf isWrite byte_value written_byte_value }
 
 set_option maxHeartbeats 1000000 in
 /-- MemAlignByte as a Clean `GeneralFormalCircuit`. `Assumptions := True` —
@@ -46,11 +109,14 @@ def circuit : GeneralFormalCircuit FGL MemAlignByteRow unit :=
   { memAlignByteElaborated with
     Assumptions := fun _ _ => True
     Spec := fun row _ _ => Spec row
-    -- Completeness is intentionally NOT claimed (zisk-fv is soundness-
-    -- only). `ProverAssumptions := False` makes this field a visible
-    -- non-claim. See trust/defects.md
-    -- ZISK-DEFECT-CLEAN-COMPLETENESS-TRIVIAL-AXIOMS.
-    ProverAssumptions := fun _ _ _ => False
+    -- Completeness covers rows built by `memAlignByteRowOf`; fields not
+    -- constrained by this slice remain free operands.
+    ProverAssumptions := fun row _ _ =>
+      ∃ sel_high_4b sel_high_2b sel_high_b isWrite byteVal writtenByteVal
+        direct_value value_16b value_8b addr_w step,
+        byteVal < 2 ^ 8 ∧ writtenByteVal < 2 ^ 8 ∧
+          row = memAlignByteRowOf sel_high_4b sel_high_2b sel_high_b isWrite
+            byteVal writtenByteVal direct_value value_16b value_8b addr_w step
     ProverSpec := fun _ _ _ => True
     soundness := by
       circuit_proof_start
@@ -76,7 +142,35 @@ def circuit : GeneralFormalCircuit FGL MemAlignByteRow unit :=
         -- is `True`.
         intro _
         trivial
-    completeness := fun _ _ _ _ _ _ h => h.elim }
+    completeness := by
+      circuit_proof_start [MemBusChannel, Lookup.completeness_def]
+      obtain ⟨sel_high_4b, sel_high_2b, sel_high_b, isWrite, byteVal, writtenByteVal,
+        direct_value, value_16b, value_8b, addr_w, step, h_byte, h_written, hrow⟩ :=
+        h_assumptions
+      injection hrow with h_sel_high_4b h_sel_high_2b h_sel_high_b h_direct_value
+        h_composed_value h_written_composed_value h_written_byte_value h_value_16b
+        h_value_8b h_byte_value h_addr_w h_step h_is_write h_mem_write_values_0
+        h_mem_write_values_1 h_bus_byte
+      subst_vars
+      simp [memAlignByteComposedValueOf, memAlignByteMemWriteValues0Of,
+        memAlignByteMemWriteValues1Of, byte_value_factor, value_8b_factor,
+        value_16b_factor] at h_input ⊢
+      refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+      · simp only [RangeTables.rangeTable8, RangeTables.rangeStaticTable]
+        rw [memAlignByteBusByteOf_eq]
+        cases isWrite
+        · exact fgl_natCast_val_lt_of_lt (by decide) h_byte
+        · exact fgl_natCast_val_lt_of_lt (by decide) h_written
+      · simp only [RangeTables.rangeTable8, RangeTables.rangeStaticTable]
+        exact fgl_natCast_val_lt_of_lt (by decide) h_byte
+      · simp only [RangeTables.rangeTable1, RangeTables.rangeStaticTable]
+        cases isWrite <;> simp [boolF]
+      · ring
+      · ring
+      · ring
+      · ring
+      · simp [memAlignByteBusByteOf]
+        ring }
 
 /-- MemAlignByte as a Clean `Air.Flat.Component`. -/
 def component : Air.Flat.Component FGL := ⟨ circuit ⟩

--- a/ZiskFv/AirsClean/MemAlignReadByte/Circuit.lean
+++ b/ZiskFv/AirsClean/MemAlignReadByte/Circuit.lean
@@ -1,5 +1,6 @@
 import ZiskFv.AirsClean.MemAlignReadByte.Constraints
 import ZiskFv.AirsClean.MemAlignReadByte.Soundness
+import ZiskFv.AirsClean.CompletenessHelpers
 import Clean.Air.FlatComponent
 import Clean.Utils.Tactics
 
@@ -13,14 +14,18 @@ Packages ZisK's MemAlignReadByte AIR as a Clean `Air.Flat.Component`:
   Its `main` emits the 4 `assertZero` algebraic constraints and the
   memory-bus proves-side `push`.
 * `circuit` — the `GeneralFormalCircuit`. `Assumptions := True` for
-  soundness; completeness is intentionally a visible non-claim.
+  soundness; completeness is proved for honest rows built from Boolean byte
+  selectors and an 8-bit byte value.
 * `component` — the `Air.Flat.Component`.
 
 ## Trust note
 
 `Assumptions := True` is what lets the Component compose into an ensemble
 non-vacuously (the `AssumptionsConsistency` obligation becomes trivial).
-No completeness claim is made; the `soundness` field is genuinely proved.
+Completeness is a constructibility claim for rows equal to
+`memAlignReadByteRowOf ...` with `byteVal < 2^8`: the builder computes the
+`composed_value` byte reconstruction used by this constraint slice. It does
+not claim that arbitrary input rows are honest MemAlignReadByte executions.
 -/
 
 namespace ZiskFv.AirsClean.MemAlignReadByte
@@ -28,6 +33,32 @@ namespace ZiskFv.AirsClean.MemAlignReadByte
 open Goldilocks
 open ZiskFv.Channels.MemoryBus (MemBusChannel)
 open Air.Flat
+
+/-- Honest read-side byte reconstruction for MemAlignReadByte. -/
+def memAlignReadByteComposedValueOf (sel_high_2b sel_high_b : Bool)
+    (byte_value value_8b value_16b : FGL) : FGL :=
+  byte_value * byte_value_factor (boolF sel_high_2b) (boolF sel_high_b)
+    + value_8b * value_8b_factor (boolF sel_high_2b) (boolF sel_high_b)
+    + value_16b * value_16b_factor (boolF sel_high_2b)
+
+/-- Honest row for MemAlignReadByte: byte selectors are Boolean, the byte value
+    is range-bounded, and `composed_value` is computed from the read-side
+    reconstruction expression. -/
+def memAlignReadByteRowOf (sel_high_4b sel_high_2b sel_high_b : Bool)
+    (byteVal : ℕ) (direct_value value_16b value_8b addr_w step : FGL) :
+    MemAlignReadByteRow FGL :=
+  { sel_high_4b := boolF sel_high_4b
+    sel_high_2b := boolF sel_high_2b
+    sel_high_b := boolF sel_high_b
+    direct_value := direct_value
+    composed_value :=
+      memAlignReadByteComposedValueOf sel_high_2b sel_high_b
+        (byteVal : FGL) value_8b value_16b
+    value_16b := value_16b
+    value_8b := value_8b
+    byte_value := (byteVal : FGL)
+    addr_w := addr_w
+    step := step }
 
 set_option maxHeartbeats 1000000 in
 /-- MemAlignReadByte as a Clean `GeneralFormalCircuit`. `Assumptions := True`
@@ -46,11 +77,14 @@ def circuit : GeneralFormalCircuit FGL MemAlignReadByteRow unit :=
   { memAlignReadByteElaborated with
     Assumptions := fun _ _ => True
     Spec := fun row _ _ => Spec row
-    -- Completeness is intentionally NOT claimed (zisk-fv is soundness-
-    -- only). `ProverAssumptions := False` makes this field a visible
-    -- non-claim. See trust/defects.md
-    -- ZISK-DEFECT-CLEAN-COMPLETENESS-TRIVIAL-AXIOMS.
-    ProverAssumptions := fun _ _ _ => False
+    -- Completeness covers rows built by `memAlignReadByteRowOf`; fields not
+    -- constrained by this slice remain free operands.
+    ProverAssumptions := fun row _ _ =>
+      ∃ sel_high_4b sel_high_2b sel_high_b byteVal
+        direct_value value_16b value_8b addr_w step,
+        byteVal < 2 ^ 8 ∧
+          row = memAlignReadByteRowOf sel_high_4b sel_high_2b sel_high_b
+            byteVal direct_value value_16b value_8b addr_w step
     ProverSpec := fun _ _ _ => True
     soundness := by
       circuit_proof_start
@@ -69,7 +103,20 @@ def circuit : GeneralFormalCircuit FGL MemAlignReadByteRow unit :=
         -- is `True`.
         intro _
         trivial
-    completeness := fun _ _ _ _ _ _ h => h.elim }
+    completeness := by
+      circuit_proof_start [MemBusChannel, Lookup.completeness_def]
+      obtain ⟨sel_high_4b, sel_high_2b, sel_high_b, byteVal,
+        direct_value, value_16b, value_8b, addr_w, step, h_byte, hrow⟩ :=
+        h_assumptions
+      injection hrow with h_sel_high_4b h_sel_high_2b h_sel_high_b h_direct_value
+        h_composed_value h_value_16b h_value_8b h_byte_value h_addr_w h_step
+      subst_vars
+      simp [memAlignReadByteComposedValueOf, byte_value_factor, value_8b_factor,
+        value_16b_factor] at h_input ⊢
+      refine ⟨?_, ?_⟩
+      · simp only [RangeTables.rangeTable8, RangeTables.rangeStaticTable]
+        exact fgl_natCast_val_lt_of_lt (by decide) h_byte
+      · ring }
 
 /-- MemAlignReadByte as a Clean `Air.Flat.Component`. -/
 def component : Air.Flat.Component FGL := ⟨ circuit ⟩

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -597,3 +597,9 @@ and STOP.
   `lake build ZiskFv.AirsClean.FullEnsemble` and
   `lake build ZiskFv.AirsClean.FullEnsemble.Balance` passed with no ensemble
   call-site edits needed.
+- W2: 2026-06-12: final Wave 2 verification passed: full `lake build`,
+  `trust/scripts/check-all.sh`, `trust/scripts/check-all-semantic.sh`,
+  `nix run .#test`, empty trust generated/baseline diff against
+  `origin/clean-completeness-wave1`, `git diff --check`, clean status after
+  restoring generated `zisk/lib-float` artifacts, and closure print with no
+  project axiom lines. PR remains to be opened.

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -254,7 +254,7 @@ column in order.
 ### Checklist
 
 - [x] Worktree + cache + green baseline; STATUS.md; log line `W2: started`.
-- [ ] MemAlignReadByte builder + completeness + witness.
+- [x] MemAlignReadByte builder + completeness + witness.
 - [ ] MemAlignByte builder + completeness + witness.
 - [ ] Mem shared builder + one shared constraints lemma + all 3 completeness
       fields + witness.
@@ -584,3 +584,6 @@ and STOP.
   not yet contain Wave 1; populated generated inputs, initialized pinned
   `zisk` submodule, and passed `lake exe cache get`, `lake build repl`, full
   `lake build`, and `trust/scripts/check-all.sh`.
+- W2: 2026-06-12: MemAlignReadByte builder, completeness proof, and witness
+  added; focused `lake build ZiskFv.AirsClean.MemAlignReadByte.Circuit` and
+  witness typecheck passed.

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -253,7 +253,7 @@ column in order.
 
 ### Checklist
 
-- [ ] Worktree + cache + green baseline; STATUS.md; log line `W2: started`.
+- [x] Worktree + cache + green baseline; STATUS.md; log line `W2: started`.
 - [ ] MemAlignReadByte builder + completeness + witness.
 - [ ] MemAlignByte builder + completeness + witness.
 - [ ] Mem shared builder + one shared constraints lemma + all 3 completeness
@@ -579,3 +579,8 @@ and STOP.
   promoted to reference implementation, Wave 3 index-route made primary,
   ensemble call-site duty (§6) added, PR protocol switched to
   queue-for-Claude-review with no human pre-ack.
+- W2: 2026-06-12: started Wave 2 worktree `clean-completeness-wave2` from
+  `origin/clean-completeness-wave1` at `5c10ecc6` because `origin/main` does
+  not yet contain Wave 1; populated generated inputs, initialized pinned
+  `zisk` submodule, and passed `lake exe cache get`, `lake build repl`, full
+  `lake build`, and `trust/scripts/check-all.sh`.

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -258,7 +258,7 @@ column in order.
 - [x] MemAlignByte builder + completeness + witness.
 - [x] Mem shared builder + one shared constraints lemma + all 3 completeness
       fields + witness.
-- [ ] Docstrings per recipe §5; ensemble call sites per §6.
+- [x] Docstrings per recipe §5; ensemble call sites per §6.
 - [ ] Verification block; open PR per protocol.
 
 ### MemAlignReadByte (`circuit`, smallest — do first)
@@ -593,3 +593,7 @@ and STOP.
 - W2: 2026-06-12: Mem shared builder, constraints lemma, all three
   completeness fields, and witness added; focused
   `lake build ZiskFv.AirsClean.Mem.Circuit` and witness typecheck passed.
+- W2: 2026-06-12: Wave 2 docstrings updated; stale non-claim scan is clean;
+  `lake build ZiskFv.AirsClean.FullEnsemble` and
+  `lake build ZiskFv.AirsClean.FullEnsemble.Balance` passed with no ensemble
+  call-site edits needed.

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -256,7 +256,7 @@ column in order.
 - [x] Worktree + cache + green baseline; STATUS.md; log line `W2: started`.
 - [x] MemAlignReadByte builder + completeness + witness.
 - [x] MemAlignByte builder + completeness + witness.
-- [ ] Mem shared builder + one shared constraints lemma + all 3 completeness
+- [x] Mem shared builder + one shared constraints lemma + all 3 completeness
       fields + witness.
 - [ ] Docstrings per recipe §5; ensemble call sites per §6.
 - [ ] Verification block; open PR per protocol.
@@ -590,3 +590,6 @@ and STOP.
 - W2: 2026-06-12: MemAlignByte builder, completeness proof, and witness added;
   focused `lake build ZiskFv.AirsClean.MemAlignByte.Circuit` and witness
   typecheck passed.
+- W2: 2026-06-12: Mem shared builder, constraints lemma, all three
+  completeness fields, and witness added; focused
+  `lake build ZiskFv.AirsClean.Mem.Circuit` and witness typecheck passed.

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -255,7 +255,7 @@ column in order.
 
 - [x] Worktree + cache + green baseline; STATUS.md; log line `W2: started`.
 - [x] MemAlignReadByte builder + completeness + witness.
-- [ ] MemAlignByte builder + completeness + witness.
+- [x] MemAlignByte builder + completeness + witness.
 - [ ] Mem shared builder + one shared constraints lemma + all 3 completeness
       fields + witness.
 - [ ] Docstrings per recipe §5; ensemble call sites per §6.
@@ -587,3 +587,6 @@ and STOP.
 - W2: 2026-06-12: MemAlignReadByte builder, completeness proof, and witness
   added; focused `lake build ZiskFv.AirsClean.MemAlignReadByte.Circuit` and
   witness typecheck passed.
+- W2: 2026-06-12: MemAlignByte builder, completeness proof, and witness added;
+  focused `lake build ZiskFv.AirsClean.MemAlignByte.Circuit` and witness
+  typecheck passed.

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -259,7 +259,7 @@ column in order.
 - [x] Mem shared builder + one shared constraints lemma + all 3 completeness
       fields + witness.
 - [x] Docstrings per recipe §5; ensemble call sites per §6.
-- [ ] Verification block; open PR per protocol.
+- [x] Verification block; open PR per protocol.
 
 ### MemAlignReadByte (`circuit`, smallest — do first)
 
@@ -602,4 +602,7 @@ and STOP.
   `nix run .#test`, empty trust generated/baseline diff against
   `origin/clean-completeness-wave1`, `git diff --check`, clean status after
   restoring generated `zisk/lib-float` artifacts, and closure print with no
-  project axiom lines. PR remains to be opened.
+  project axiom lines.
+- W2: 2026-06-12: opened review PR
+  https://github.com/eth-act/zisk-fv/pull/70 against
+  `clean-completeness-wave1`; queued for Claude review, do not merge.

--- a/trust/consistency/completeness_witness_mem.lean
+++ b/trust/consistency/completeness_witness_mem.lean
@@ -1,0 +1,44 @@
+import ZiskFv.AirsClean.Mem.Circuit
+
+namespace ZiskFv.TrustConsistency
+
+open Goldilocks
+open ZiskFv.AirsClean.Mem
+
+private def memWitnessRow : MemRow FGL :=
+  memRowOf true true true false 16 9 10 8 1 2 42 43
+
+private theorem memWitnessCircuitProverAssumptions
+    (data : ProverData FGL) (hint : ProverHint FGL) :
+    circuit.ProverAssumptions memWitnessRow data hint := by
+  refine ⟨true, true, true, false, 16, 9, 10, 8, 1, 2, 42, 43,
+    (by intro _; rfl), (by intro _; rfl), ?_⟩
+  rfl
+
+private theorem memWitnessWithMemBusProverAssumptions
+    (data : ProverData FGL) (hint : ProverHint FGL) :
+    circuitWithMemBus.ProverAssumptions memWitnessRow data hint := by
+  refine ⟨true, true, true, false, 16, 9, 10, 8, 1, 2, 42, 43,
+    (by intro _; rfl), (by intro _; rfl), ?_⟩
+  rfl
+
+private theorem memWitnessWithDualMemBusProverAssumptions
+    (data : ProverData FGL) (hint : ProverHint FGL) :
+    circuitWithDualMemBus.ProverAssumptions memWitnessRow data hint := by
+  refine ⟨true, true, true, false, 16, 9, 10, 8, 1, 2, 42, 43,
+    (by intro _; rfl), (by intro _; rfl), ?_⟩
+  rfl
+
+theorem completeness_witness_mem :
+    ∃ row : MemRow FGL,
+      (∀ data hint, circuit.ProverAssumptions row data hint) ∧
+      (∀ data hint, circuitWithMemBus.ProverAssumptions row data hint) ∧
+      (∀ data hint, circuitWithDualMemBus.ProverAssumptions row data hint) := by
+  exact ⟨memWitnessRow,
+    memWitnessCircuitProverAssumptions,
+    memWitnessWithMemBusProverAssumptions,
+    memWitnessWithDualMemBusProverAssumptions⟩
+
+#print axioms completeness_witness_mem
+
+end ZiskFv.TrustConsistency

--- a/trust/consistency/completeness_witness_memalignbyte.lean
+++ b/trust/consistency/completeness_witness_memalignbyte.lean
@@ -1,0 +1,24 @@
+import ZiskFv.AirsClean.MemAlignByte.Circuit
+
+namespace ZiskFv.TrustConsistency
+
+open Goldilocks
+open ZiskFv.AirsClean.MemAlignByte
+
+private def memAlignByteWitnessRow : MemAlignByteRow FGL :=
+  memAlignByteRowOf false true false true 42 99 1000 2 3 4 5
+
+private theorem memAlignByteWitnessProverAssumptions
+    (data : ProverData FGL) (hint : ProverHint FGL) :
+    circuit.ProverAssumptions memAlignByteWitnessRow data hint := by
+  refine ⟨false, true, false, true, 42, 99, 1000, 2, 3, 4, 5,
+    by norm_num, by norm_num, ?_⟩
+  rfl
+
+theorem completeness_witness_memalignbyte :
+    ∃ row : MemAlignByteRow FGL, ∀ data hint, circuit.ProverAssumptions row data hint := by
+  exact ⟨memAlignByteWitnessRow, memAlignByteWitnessProverAssumptions⟩
+
+#print axioms completeness_witness_memalignbyte
+
+end ZiskFv.TrustConsistency

--- a/trust/consistency/completeness_witness_memalignreadbyte.lean
+++ b/trust/consistency/completeness_witness_memalignreadbyte.lean
@@ -1,0 +1,23 @@
+import ZiskFv.AirsClean.MemAlignReadByte.Circuit
+
+namespace ZiskFv.TrustConsistency
+
+open Goldilocks
+open ZiskFv.AirsClean.MemAlignReadByte
+
+private def memAlignReadByteWitnessRow : MemAlignReadByteRow FGL :=
+  memAlignReadByteRowOf false true false 42 1000 2 3 4 5
+
+private theorem memAlignReadByteWitnessProverAssumptions
+    (data : ProverData FGL) (hint : ProverHint FGL) :
+    circuit.ProverAssumptions memAlignReadByteWitnessRow data hint := by
+  refine ⟨false, true, false, 42, 1000, 2, 3, 4, 5, by norm_num, ?_⟩
+  rfl
+
+theorem completeness_witness_memalignreadbyte :
+    ∃ row : MemAlignReadByteRow FGL, ∀ data hint, circuit.ProverAssumptions row data hint := by
+  exact ⟨memAlignReadByteWitnessRow, memAlignReadByteWitnessProverAssumptions⟩
+
+#print axioms completeness_witness_memalignreadbyte
+
+end ZiskFv.TrustConsistency


### PR DESCRIPTION
Queued for Claude review — do not merge.

## Summary
- Proved genuine Clean completeness for MemAlignReadByte, MemAlignByte, and all three Mem circuits.
- Added builder-existential ProverAssumptions, row builders/constraint lemmas, and anti-vacuity witnesses for each Wave 2 component.
- No ensemble call-site edits were needed; the FullEnsemble and Balance builds stayed green.

## Scope notes
- This PR is stacked on clean-completeness-wave1 because origin/main did not contain Wave 1 when this worktree started.
- The Mem witness covers circuit, circuitWithMemBus, and circuitWithDualMemBus ProverAssumptions.
- Coverage is row-local constructibility for honest builder rows; it does not claim arbitrary input rows are honest executions or prove cross-row memory consistency.

## Verification
- lake build ZiskFv.AirsClean.MemAlignReadByte.Circuit
- lake build ZiskFv.AirsClean.MemAlignByte.Circuit
- lake build ZiskFv.AirsClean.Mem.Circuit
- lake build ZiskFv.AirsClean.FullEnsemble
- lake build ZiskFv.AirsClean.FullEnsemble.Balance
- lake build: passed, final line Build completed successfully (8675 jobs).
- trust/scripts/check-all.sh: trust-gate: ALL CHECKS PASSED.
- trust/scripts/check-all-semantic.sh: trust-gate (V2 semantic): ALL CHECKS PASSED.
- nix run .#test: passed all 8 steps, including embedded V1/V2 trust gates and flake repro.
- git diff origin/clean-completeness-wave1 -- trust/generated trust/baseline-axioms.txt trust/baseline-hypothesis-count.txt trust/baseline-caller-burden.txt: empty.
- lake exe trust-gate print-axiom-closure ZiskFv.Compliance.zisk_riscv_compliant_program_bus: only existing TrustGate.Main deprecation warnings; no project axiom lines printed.
- Witness files discovered: completeness_witness_binaryadd, completeness_witness_mem, completeness_witness_memalign, completeness_witness_memalignbyte, completeness_witness_memalignreadbyte.
- git diff --check: passed; worktree status clean after restoring generated zisk/lib-float artifacts from nix run .#test.

## Notes for later waves
- For narrow lookup proofs, after simp the booleanity goals tend to close with the helper lemmas; range and algebraic goals remain.
- For Mem-like row constructors, inject hrow directly rather than rewriting h_input.
- No ensemble call-site edits were needed for Wave 2, but keep running both ensemble builds after each component wave.
