### PR TITLE
Clean completeness Wave 4: Arith pair

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,8 +17,9 @@ Progress: Wave 4 scope is unsigned-only ArithMul/ArithDiv completeness:
 equations, with signed/m32 modes left as documented follow-up disjuncts.
 `ZiskFv/Airs/Arith/CarryChainCompleteness.lean` now builds and provides
 `chunk16`, Nat/FGL decompositions, `fgl_65536_ne_zero`, and `cc0..cc6`
-field-solved carry lemmas.
+field-solved carry lemmas. ArithMul `circuit` now has a real unsigned
+builder-existential completeness proof; focused
+`lake build ZiskFv.AirsClean.ArithMul.Circuit` passes.
 
-Next step: implement the unsigned ArithMul honest-row builder and
-builder-existential `ProverAssumptions`, then prove `circuit.completeness`
-with the `circuit_proof_start_core` route.
+Next step: implement the unsigned ArithDiv honest-row builder and
+builder-existential `ProverAssumptions`, using ArithMul as the template.

--- a/STATUS.md
+++ b/STATUS.md
@@ -22,7 +22,10 @@ builder-existential completeness proof; focused
 `lake build ZiskFv.AirsClean.ArithMul.Circuit` passes. ArithDiv `circuit`
 now has a real unsigned nonzero-divisor builder-existential completeness
 proof; `lake env lean ZiskFv/AirsClean/ArithDiv/Circuit.lean` and focused
-`lake build ZiskFv.AirsClean.ArithDiv.Circuit` pass.
+`lake build ZiskFv.AirsClean.ArithDiv.Circuit` pass. ArithMul/ArithDiv
+witness files now typecheck and print standard closure; Arith audit
+docstrings state the unsigned constructibility scope and signed/W non-claims;
+`FullEnsemble` and `FullEnsemble/Balance` focused builds pass.
 
-Next step: add ArithMul/ArithDiv witnesses, update audit docstrings, handle
-ensemble call sites, then run the Wave 4 verification block.
+Next step: run the Wave 4 verification block, then commit/push/open the review
+PR without merging.

--- a/STATUS.md
+++ b/STATUS.md
@@ -19,7 +19,10 @@ equations, with signed/m32 modes left as documented follow-up disjuncts.
 `chunk16`, Nat/FGL decompositions, `fgl_65536_ne_zero`, and `cc0..cc6`
 field-solved carry lemmas. ArithMul `circuit` now has a real unsigned
 builder-existential completeness proof; focused
-`lake build ZiskFv.AirsClean.ArithMul.Circuit` passes.
+`lake build ZiskFv.AirsClean.ArithMul.Circuit` passes. ArithDiv `circuit`
+now has a real unsigned nonzero-divisor builder-existential completeness
+proof; `lake env lean ZiskFv/AirsClean/ArithDiv/Circuit.lean` and focused
+`lake build ZiskFv.AirsClean.ArithDiv.Circuit` pass.
 
-Next step: implement the unsigned ArithDiv honest-row builder and
-builder-existential `ProverAssumptions`, using ArithMul as the template.
+Next step: add ArithMul/ArithDiv witnesses, update audit docstrings, handle
+ensemble call sites, then run the Wave 4 verification block.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,11 +1,11 @@
 Active plan: docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
 
 Current focus: Wave 4 Arith pair, unsigned scope, on branch
-`clean-completeness-wave4` in `.worktrees/completeness-wave4`.
+`clean-completeness-wave4` in `.worktrees/completeness-wave4`, rebased onto
+updated `origin/main` for sequential merge of PR #72.
 
-Blocking: none. This worktree is based on `origin/clean-completeness-wave1`
-at `5c10ecc6`, matching the parallel Wave 2/3 PR style. PRs #69, #70, and
-#71 are still open; do not merge PRs.
+Blocking: none. PRs #69, #70, and #71 are squash-merged. Wave 4 is ready to
+push with lease and squash-merge as PR #72.
 
 Setup: `git submodule update --init zisk` checked out pinned `4148c25e`;
 `nix run .#populate`, `lake exe cache get`, `lake build repl`, full
@@ -30,5 +30,5 @@ verification block also passed: full `lake build`, V1/V2 trust gates, empty
 generated/baseline diff, empty project-axiom closure print, and `nix run .#test`
 after clearing reproducible caches from an initial disk-full failure.
 
-Next step: commit this verification checkpoint, push `clean-completeness-wave4`,
-and open the queued external-review PR without merging.
+Next step: push `clean-completeness-wave4`, squash-merge PR #72, then retarget
+and rebase Wave 5 for PR #73.

--- a/STATUS.md
+++ b/STATUS.md
@@ -25,7 +25,10 @@ proof; `lake env lean ZiskFv/AirsClean/ArithDiv/Circuit.lean` and focused
 `lake build ZiskFv.AirsClean.ArithDiv.Circuit` pass. ArithMul/ArithDiv
 witness files now typecheck and print standard closure; Arith audit
 docstrings state the unsigned constructibility scope and signed/W non-claims;
-`FullEnsemble` and `FullEnsemble/Balance` focused builds pass.
+`FullEnsemble` and `FullEnsemble/Balance` focused builds pass. The full
+verification block also passed: full `lake build`, V1/V2 trust gates, empty
+generated/baseline diff, empty project-axiom closure print, and `nix run .#test`
+after clearing reproducible caches from an initial disk-full failure.
 
-Next step: run the Wave 4 verification block, then commit/push/open the review
-PR without merging.
+Next step: commit this verification checkpoint, push `clean-completeness-wave4`,
+and open the queued external-review PR without merging.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,32 +1,24 @@
 Active plan: docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
 
-Current focus: Wave 3 table-lookup family on branch
-`clean-completeness-wave3` in `.worktrees/completeness-wave3`: implemented,
-fully gated, and ready to queue for external PR review.
+Current focus: Wave 4 Arith pair, unsigned scope, on branch
+`clean-completeness-wave4` in `.worktrees/completeness-wave4`.
 
-Blocking: none. PR #69/Wave 1 is not merged to `origin/main`, so this
-worktree is based on `origin/clean-completeness-wave1` at `5c10ecc6`. Do not
-merge PRs.
+Blocking: none. This worktree is based on `origin/clean-completeness-wave1`
+at `5c10ecc6`, matching the parallel Wave 2/3 PR style. PRs #69, #70, and
+#71 are still open; do not merge PRs.
 
-Setup: first `lake exe cache get` found missing path deps; `nix run
-.#populate` populated generated inputs and retry of `lake exe cache get`
-succeeded. `lake build repl` passed. The `zisk` submodule is initialized at
-pinned `4148c25e`. Baseline full `lake build` and
-`trust/scripts/check-all.sh` passed.
+Setup: `git submodule update --init zisk` checked out pinned `4148c25e`;
+`nix run .#populate`, `lake exe cache get`, `lake build repl`, full
+`lake build`, and `trust/scripts/check-all.sh` passed.
 
-Progress: replaced the four Wave 3 ex-falso completeness fields in
-`Binary/Circuit.lean` and `BinaryExtension/StaticCircuit.lean`. Added genuine
-index-route builders for Binary static lookups and BinaryExtension static /
-shift-static lookups, plus witness files in `trust/consistency/`. Updated the
-stale Binary/BinaryExtension docstrings and narrowed Wave 3 ensemble proof
-obligations, including the BinaryFamily ensemble call sites exposed by the
-full build.
+Progress: Wave 4 scope is unsigned-only ArithMul/ArithDiv completeness:
+`na=nb=np=nr=m32=0`; MUL has `div=0`, DIV has `div=1`; `fab=1` and
+`na_fb=nb_fa=0`. Carries will be field-solved from the 65536-base chain
+equations, with signed/m32 modes left as documented follow-up disjuncts.
+`ZiskFv/Airs/Arith/CarryChainCompleteness.lean` now builds and provides
+`chunk16`, Nat/FGL decompositions, `fgl_65536_ne_zero`, and `cc0..cc6`
+field-solved carry lemmas.
 
-Verification: `lake build`, `trust/scripts/check-all.sh`,
-`trust/scripts/check-all-semantic.sh`, and `nix run .#test` pass. Trust diff
-vs `origin/clean-completeness-wave1` only adds the two Wave 3 witness files;
-no trust generated/baseline/script diffs. Ex-falso and suspicious-token scans
-are clean for Wave 3 code; `git diff --check` passes.
-
-Next step: push the final docs commit and open the Wave 3 PR with first body
-line `Queued for Claude review — do not merge.` Do not merge PRs.
+Next step: implement the unsigned ArithMul honest-row builder and
+builder-existential `ProverAssumptions`, then prove `circuit.completeness`
+with the `circuit_proof_start_core` route.

--- a/ZiskFv/Airs/Arith/CarryChainCompleteness.lean
+++ b/ZiskFv/Airs/Arith/CarryChainCompleteness.lean
@@ -1,0 +1,141 @@
+import Mathlib
+
+import ZiskFv.Field.Goldilocks
+
+/-!
+# Arith carry-chain completeness helpers
+
+These helpers build honest 16-bit chunk rows and field-solved carries for the
+Clean Arith completeness proofs.  They do not assert range facts about the
+carry witnesses; the base component only constrains them through the eight
+carry-chain equations.
+-/
+
+namespace ZiskFv.Airs.ArithCarryChainCompleteness
+
+open Goldilocks
+
+/-- The 16-bit limb at index `k`, little-endian. -/
+def chunk16 (x k : ℕ) : ℕ :=
+  x / 65536 ^ k % 65536
+
+lemma chunk16_lt (x k : ℕ) : chunk16 x k < 65536 := by
+  unfold chunk16
+  exact Nat.mod_lt _ (by norm_num)
+
+lemma nat_decomp4 (x : ℕ) (h : x < 65536 ^ 4) :
+    x = chunk16 x 0 + chunk16 x 1 * 65536 + chunk16 x 2 * 65536 ^ 2 +
+      chunk16 x 3 * 65536 ^ 3 := by
+  unfold chunk16 at *
+  omega
+
+lemma nat_decomp8 (x : ℕ) (h : x < 65536 ^ 8) :
+    x = chunk16 x 0 + chunk16 x 1 * 65536 + chunk16 x 2 * 65536 ^ 2 +
+      chunk16 x 3 * 65536 ^ 3 + chunk16 x 4 * 65536 ^ 4 +
+      chunk16 x 5 * 65536 ^ 5 + chunk16 x 6 * 65536 ^ 6 +
+      chunk16 x 7 * 65536 ^ 7 := by
+  unfold chunk16 at *
+  omega
+
+lemma fgl_decomp4 (x : ℕ) (h : x < 65536 ^ 4) :
+    (x : FGL) = chunk16 x 0 + chunk16 x 1 * 65536 +
+      chunk16 x 2 * (65536 ^ 2 : FGL) + chunk16 x 3 * (65536 ^ 3 : FGL) := by
+  have hcast := congrArg (fun n : ℕ => (n : FGL)) (nat_decomp4 x h)
+  norm_num at hcast ⊢
+  simpa using hcast
+
+lemma fgl_decomp8 (x : ℕ) (h : x < 65536 ^ 8) :
+    (x : FGL) = chunk16 x 0 + chunk16 x 1 * 65536 +
+      chunk16 x 2 * (65536 ^ 2 : FGL) + chunk16 x 3 * (65536 ^ 3 : FGL) +
+      chunk16 x 4 * (65536 ^ 4 : FGL) + chunk16 x 5 * (65536 ^ 5 : FGL) +
+      chunk16 x 6 * (65536 ^ 6 : FGL) + chunk16 x 7 * (65536 ^ 7 : FGL) := by
+  have hcast := congrArg (fun n : ℕ => (n : FGL)) (nat_decomp8 x h)
+  norm_num at hcast ⊢
+  simpa using hcast
+
+lemma fgl_65536_ne_zero : (65536 : FGL) ≠ 0 := by
+  decide
+
+variable {F : Type} [Field F]
+
+/-- Field-solved carry after equation 0. -/
+def cc0 (B e0 : F) : F :=
+  e0 / B
+
+/-- Field-solved carry after equation 1. -/
+def cc1 (B e0 e1 : F) : F :=
+  (e0 + e1 * B) / B ^ 2
+
+/-- Field-solved carry after equation 2. -/
+def cc2 (B e0 e1 e2 : F) : F :=
+  (e0 + e1 * B + e2 * B ^ 2) / B ^ 3
+
+/-- Field-solved carry after equation 3. -/
+def cc3 (B e0 e1 e2 e3 : F) : F :=
+  (e0 + e1 * B + e2 * B ^ 2 + e3 * B ^ 3) / B ^ 4
+
+/-- Field-solved carry after equation 4. -/
+def cc4 (B e0 e1 e2 e3 e4 : F) : F :=
+  (e0 + e1 * B + e2 * B ^ 2 + e3 * B ^ 3 + e4 * B ^ 4) / B ^ 5
+
+/-- Field-solved carry after equation 5. -/
+def cc5 (B e0 e1 e2 e3 e4 e5 : F) : F :=
+  (e0 + e1 * B + e2 * B ^ 2 + e3 * B ^ 3 + e4 * B ^ 4 + e5 * B ^ 5) /
+    B ^ 6
+
+/-- Field-solved carry after equation 6. -/
+def cc6 (B e0 e1 e2 e3 e4 e5 e6 : F) : F :=
+  (e0 + e1 * B + e2 * B ^ 2 + e3 * B ^ 3 + e4 * B ^ 4 + e5 * B ^ 5 +
+    e6 * B ^ 6) / B ^ 7
+
+lemma chain_eq_0 {B e0 : F} (hB : B ≠ 0) :
+    e0 - cc0 B e0 * B = 0 := by
+  unfold cc0
+  field_simp [hB]
+  ring
+
+lemma chain_eq_1 {B e0 e1 : F} (hB : B ≠ 0) :
+    e1 + cc0 B e0 - cc1 B e0 e1 * B = 0 := by
+  unfold cc0 cc1
+  field_simp [hB]
+  ring
+
+lemma chain_eq_2 {B e0 e1 e2 : F} (hB : B ≠ 0) :
+    e2 + cc1 B e0 e1 - cc2 B e0 e1 e2 * B = 0 := by
+  unfold cc1 cc2
+  field_simp [hB]
+  ring
+
+lemma chain_eq_3 {B e0 e1 e2 e3 : F} (hB : B ≠ 0) :
+    e3 + cc2 B e0 e1 e2 - cc3 B e0 e1 e2 e3 * B = 0 := by
+  unfold cc2 cc3
+  field_simp [hB]
+  ring
+
+lemma chain_eq_4 {B e0 e1 e2 e3 e4 : F} (hB : B ≠ 0) :
+    e4 + cc3 B e0 e1 e2 e3 - cc4 B e0 e1 e2 e3 e4 * B = 0 := by
+  unfold cc3 cc4
+  field_simp [hB]
+  ring
+
+lemma chain_eq_5 {B e0 e1 e2 e3 e4 e5 : F} (hB : B ≠ 0) :
+    e5 + cc4 B e0 e1 e2 e3 e4 - cc5 B e0 e1 e2 e3 e4 e5 * B = 0 := by
+  unfold cc4 cc5
+  field_simp [hB]
+  ring
+
+lemma chain_eq_6 {B e0 e1 e2 e3 e4 e5 e6 : F} (hB : B ≠ 0) :
+    e6 + cc5 B e0 e1 e2 e3 e4 e5 - cc6 B e0 e1 e2 e3 e4 e5 e6 * B = 0 := by
+  unfold cc5 cc6
+  field_simp [hB]
+  ring
+
+lemma chain_last {B e0 e1 e2 e3 e4 e5 e6 e7 : F} (hB : B ≠ 0)
+    (h : e0 + e1 * B + e2 * B ^ 2 + e3 * B ^ 3 + e4 * B ^ 4 +
+      e5 * B ^ 5 + e6 * B ^ 6 + e7 * B ^ 7 = 0) :
+    e7 + cc6 B e0 e1 e2 e3 e4 e5 e6 = 0 := by
+  unfold cc6
+  field_simp [hB]
+  linear_combination h
+
+end ZiskFv.Airs.ArithCarryChainCompleteness

--- a/ZiskFv/AirsClean/ArithDiv/Circuit.lean
+++ b/ZiskFv/AirsClean/ArithDiv/Circuit.lean
@@ -20,16 +20,20 @@ Packages the Arith AIR's **DIV carry-chain sub-circuit** as a Clean
   11-clause carry-chain `Spec` follows from the 11 definitional
   `assertZero`s alone, with no range reasoning and no flag-value pins).
   `soundness` discharges the DIV carry-chain relation; completeness is
-  intentionally a visible non-claim.
+  proved for unsigned rows built from a 64-bit dividend and nonzero 64-bit
+  divisor.
 * `component` — the `Air.Flat.Component`.
 
 ## Trust note
 
 `Assumptions := True` is what lets the Component compose into an
 ensemble non-vacuously (the `AssumptionsConsistency` obligation becomes
-trivial). No completeness claim is made. The `soundness` field is
-genuinely proved from the 11 `assertZero` constraints by
-`linear_combination` (no range reasoning, hence no `range_bus_sound`).
+trivial). Completeness is a constructibility claim for rows equal to
+`arithDivRowOf c b free` with `c < 65536^4`, `b < 65536^4`, and `b ≠ 0`: the
+builder sets the unsigned DIV flags, computes quotient/remainder chunks from
+`c / b` and `c % b`, and chooses the unique field carries solving the 65536-base
+chain equations. It does not claim that arbitrary input rows are honest ArithDiv
+executions, and signed/W-mode rows remain a follow-up disjunct.
 -/
 
 namespace ZiskFv.AirsClean.ArithDiv
@@ -179,7 +183,8 @@ set_option maxHeartbeats 4000000 in
 /-- ArithDiv (the Arith AIR's DIV carry-chain sub-circuit) as a Clean
     `GeneralFormalCircuit`. `Assumptions := True` — the 11-clause
     carry-chain `Spec` follows from the 11 definitional `assertZero`
-    constraints alone (plan D-2 / F-4).
+    constraints alone (plan D-2 / F-4), and completeness constructs unsigned
+    rows from a 64-bit dividend and nonzero 64-bit divisor.
 
     The `soundness` field is **adapted from**
     `ArithDiv.soundness_of_constraints` (`Soundness.lean`) — the same

--- a/ZiskFv/AirsClean/ArithDiv/Circuit.lean
+++ b/ZiskFv/AirsClean/ArithDiv/Circuit.lean
@@ -1,5 +1,6 @@
 import ZiskFv.AirsClean.ArithDiv.Constraints
 import ZiskFv.AirsClean.ArithDiv.Soundness
+import ZiskFv.Airs.Arith.CarryChainCompleteness
 import Clean.Air.FlatComponent
 import Clean.Utils.Tactics
 
@@ -34,8 +35,147 @@ genuinely proved from the 11 `assertZero` constraints by
 namespace ZiskFv.AirsClean.ArithDiv
 
 open Goldilocks
+open ZiskFv.Airs.ArithCarryChainCompleteness
 
-set_option maxHeartbeats 1000000 in
+/-- Columns not constrained by the unsigned DIV carry-chain completeness slice. -/
+structure ArithDivFreeCols where
+  sext : FGL
+  div_by_zero : FGL
+  div_overflow : FGL
+  main_div : FGL
+  main_mul : FGL
+  signed : FGL
+  range_ab : FGL
+  range_cd : FGL
+  op : FGL
+  bus_res1 : FGL
+  multiplicity : FGL
+
+def arithDivE0 (c b : ℕ) : FGL :=
+  (chunk16 (c / b) 0 : FGL) * (chunk16 b 0 : FGL) + (chunk16 (c % b) 0 : FGL) -
+    (chunk16 c 0 : FGL)
+
+def arithDivE1 (c b : ℕ) : FGL :=
+  (chunk16 (c / b) 1 : FGL) * (chunk16 b 0 : FGL) +
+    (chunk16 (c / b) 0 : FGL) * (chunk16 b 1 : FGL) + (chunk16 (c % b) 1 : FGL) -
+    (chunk16 c 1 : FGL)
+
+def arithDivE2 (c b : ℕ) : FGL :=
+  (chunk16 (c / b) 2 : FGL) * (chunk16 b 0 : FGL) +
+    (chunk16 (c / b) 1 : FGL) * (chunk16 b 1 : FGL) +
+    (chunk16 (c / b) 0 : FGL) * (chunk16 b 2 : FGL) + (chunk16 (c % b) 2 : FGL) -
+    (chunk16 c 2 : FGL)
+
+def arithDivE3 (c b : ℕ) : FGL :=
+  (chunk16 (c / b) 3 : FGL) * (chunk16 b 0 : FGL) +
+    (chunk16 (c / b) 2 : FGL) * (chunk16 b 1 : FGL) +
+    (chunk16 (c / b) 1 : FGL) * (chunk16 b 2 : FGL) +
+    (chunk16 (c / b) 0 : FGL) * (chunk16 b 3 : FGL) + (chunk16 (c % b) 3 : FGL) -
+    (chunk16 c 3 : FGL)
+
+def arithDivE4 (c b : ℕ) : FGL :=
+  (chunk16 (c / b) 3 : FGL) * (chunk16 b 1 : FGL) +
+    (chunk16 (c / b) 2 : FGL) * (chunk16 b 2 : FGL) +
+    (chunk16 (c / b) 1 : FGL) * (chunk16 b 3 : FGL)
+
+def arithDivE5 (c b : ℕ) : FGL :=
+  (chunk16 (c / b) 3 : FGL) * (chunk16 b 2 : FGL) +
+    (chunk16 (c / b) 2 : FGL) * (chunk16 b 3 : FGL)
+
+def arithDivE6 (c b : ℕ) : FGL :=
+  (chunk16 (c / b) 3 : FGL) * (chunk16 b 3 : FGL)
+
+def arithDivE7 (_c _b : ℕ) : FGL :=
+  0
+
+lemma arithDivQuotient_lt (c b : ℕ) (hc : c < 65536 ^ 4) :
+    c / b < 65536 ^ 4 := by
+  have hle : c / b ≤ c := Nat.div_le_self c b
+  omega
+
+lemma arithDivRemainder_lt (c b : ℕ) (hb : b < 65536 ^ 4) (hb_ne : b ≠ 0) :
+    c % b < 65536 ^ 4 := by
+  have hb_pos : 0 < b := Nat.pos_of_ne_zero hb_ne
+  have hmod := Nat.mod_lt c hb_pos
+  omega
+
+lemma arithDivChainSum_zero (c b : ℕ) (hc : c < 65536 ^ 4) (hb : b < 65536 ^ 4)
+    (hb_ne : b ≠ 0) :
+    arithDivE0 c b + arithDivE1 c b * (65536 : FGL) +
+      arithDivE2 c b * (65536 : FGL) ^ 2 + arithDivE3 c b * (65536 : FGL) ^ 3 +
+      arithDivE4 c b * (65536 : FGL) ^ 4 + arithDivE5 c b * (65536 : FGL) ^ 5 +
+      arithDivE6 c b * (65536 : FGL) ^ 6 + arithDivE7 c b * (65536 : FGL) ^ 7 =
+        0 := by
+  have hq := arithDivQuotient_lt c b hc
+  have hr := arithDivRemainder_lt c b hb hb_ne
+  have hq_decomp := fgl_decomp4 (c / b) hq
+  have hb_decomp := fgl_decomp4 b hb
+  have hr_decomp := fgl_decomp4 (c % b) hr
+  have hc_decomp := fgl_decomp4 c hc
+  have hdiv :
+      ((c / b : ℕ) : FGL) * (b : FGL) + ((c % b : ℕ) : FGL) = (c : FGL) := by
+    have hcast := congrArg (fun n : ℕ => (n : FGL)) (Nat.div_add_mod c b)
+    simp only [Nat.cast_add, Nat.cast_mul] at hcast
+    simpa [mul_comm, mul_left_comm, mul_assoc] using hcast
+  rw [hq_decomp, hb_decomp, hr_decomp, hc_decomp] at hdiv
+  unfold arithDivE0 arithDivE1 arithDivE2 arithDivE3 arithDivE4 arithDivE5 arithDivE6
+    arithDivE7
+  linear_combination hdiv
+
+/-- Honest unsigned ArithDiv row built from a dividend and nonzero divisor. -/
+def arithDivRowOf (c b : ℕ) (free : ArithDivFreeCols) : ArithDivRow FGL :=
+  { chunks :=
+      { a_0 := (chunk16 (c / b) 0 : FGL)
+        a_1 := (chunk16 (c / b) 1 : FGL)
+        a_2 := (chunk16 (c / b) 2 : FGL)
+        a_3 := (chunk16 (c / b) 3 : FGL)
+        b_0 := (chunk16 b 0 : FGL)
+        b_1 := (chunk16 b 1 : FGL)
+        b_2 := (chunk16 b 2 : FGL)
+        b_3 := (chunk16 b 3 : FGL)
+        c_0 := (chunk16 c 0 : FGL)
+        c_1 := (chunk16 c 1 : FGL)
+        c_2 := (chunk16 c 2 : FGL)
+        c_3 := (chunk16 c 3 : FGL)
+        d_0 := (chunk16 (c % b) 0 : FGL)
+        d_1 := (chunk16 (c % b) 1 : FGL)
+        d_2 := (chunk16 (c % b) 2 : FGL)
+        d_3 := (chunk16 (c % b) 3 : FGL) }
+    flags :=
+      { na := 0
+        nb := 0
+        nr := 0
+        np := 0
+        sext := free.sext
+        m32 := 0
+        div := 1
+        div_by_zero := free.div_by_zero
+        div_overflow := free.div_overflow
+        main_div := free.main_div
+        main_mul := free.main_mul
+        signed := free.signed
+        range_ab := free.range_ab
+        range_cd := free.range_cd
+        op := free.op
+        bus_res1 := free.bus_res1
+        multiplicity := free.multiplicity }
+    aux :=
+      { carry_0 := cc0 65536 (arithDivE0 c b)
+        carry_1 := cc1 65536 (arithDivE0 c b) (arithDivE1 c b)
+        carry_2 := cc2 65536 (arithDivE0 c b) (arithDivE1 c b) (arithDivE2 c b)
+        carry_3 := cc3 65536 (arithDivE0 c b) (arithDivE1 c b) (arithDivE2 c b)
+          (arithDivE3 c b)
+        carry_4 := cc4 65536 (arithDivE0 c b) (arithDivE1 c b) (arithDivE2 c b)
+          (arithDivE3 c b) (arithDivE4 c b)
+        carry_5 := cc5 65536 (arithDivE0 c b) (arithDivE1 c b) (arithDivE2 c b)
+          (arithDivE3 c b) (arithDivE4 c b) (arithDivE5 c b)
+        carry_6 := cc6 65536 (arithDivE0 c b) (arithDivE1 c b) (arithDivE2 c b)
+          (arithDivE3 c b) (arithDivE4 c b) (arithDivE5 c b) (arithDivE6 c b)
+        fab := 1
+        na_fb := 0
+        nb_fa := 0 } }
+
+set_option maxHeartbeats 4000000 in
 /-- ArithDiv (the Arith AIR's DIV carry-chain sub-circuit) as a Clean
     `GeneralFormalCircuit`. `Assumptions := True` — the 11-clause
     carry-chain `Spec` follows from the 11 definitional `assertZero`
@@ -49,11 +189,10 @@ def circuit : GeneralFormalCircuit FGL ArithDivRow unit :=
   { arithDivElaborated with
     Assumptions := fun _ _ => True
     Spec := fun row _ _ => Spec row
-    -- Completeness is intentionally NOT claimed (zisk-fv is soundness-
-    -- only). `ProverAssumptions := False` makes this field a visible
-    -- non-claim. See trust/defects.md
-    -- ZISK-DEFECT-CLEAN-COMPLETENESS-TRIVIAL-AXIOMS.
-    ProverAssumptions := fun _ _ _ => False
+    -- Completeness covers unsigned rows built from a dividend and nonzero divisor.
+    ProverAssumptions := fun row _ _ =>
+      ∃ c b free, c < 65536 ^ 4 ∧ b < 65536 ^ 4 ∧ b ≠ 0 ∧
+        row = arithDivRowOf c b free
     ProverSpec := fun _ _ _ => True
     soundness := by
       -- `circuit_proof_start`'s `provable_struct_simp` step is far too
@@ -92,7 +231,60 @@ def circuit : GeneralFormalCircuit FGL ArithDivRow unit :=
         · linear_combination h38
       · -- no channel interaction → empty `Operations.Requirements`.
         simp only [circuit_norm, main]
-    completeness := fun _ _ _ _ _ _ h => h.elim }
+    completeness := by
+      circuit_proof_start_core
+      simp only [main, circuit_norm]
+      obtain ⟨c, b, free, hc, hb, hb_ne, hrow⟩ := h_assumptions
+      rw [hrow] at h_input
+      simp only [circuit_norm] at h_input
+      injection h_input with h_chunks h_flags h_aux
+      injection h_chunks with h_a_0 h_a_1 h_a_2 h_a_3 h_b_0 h_b_1 h_b_2 h_b_3
+        h_c_0 h_c_1 h_c_2 h_c_3 h_d_0 h_d_1 h_d_2 h_d_3
+      injection h_flags with h_na h_nb h_nr h_np h_sext h_m32 h_div h_div_by_zero
+        h_div_overflow h_main_div h_main_mul h_signed h_range_ab h_range_cd h_op h_bus_res1
+        h_multiplicity
+      injection h_aux with h_fab h_na_fb h_nb_fa h_carry_0 h_carry_1 h_carry_2
+        h_carry_3 h_carry_4 h_carry_5 h_carry_6
+      subst_vars
+      simp only [h_a_0, h_a_1, h_a_2, h_a_3, h_b_0, h_b_1, h_b_2, h_b_3,
+        h_c_0, h_c_1, h_c_2, h_c_3, h_d_0, h_d_1, h_d_2, h_d_3, h_na, h_nb,
+        h_nr, h_np, h_m32, h_div, h_carry_0, h_carry_1, h_carry_2, h_carry_3,
+        h_carry_4, h_carry_5, h_carry_6, h_fab, h_na_fb, h_nb_fa]
+      refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+      · ring
+      · ring
+      · ring
+      · simpa [arithDivE0, sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using
+          (chain_eq_0 (B := (65536 : FGL)) (e0 := arithDivE0 c b) fgl_65536_ne_zero)
+      · simpa [arithDivE1, sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using
+          (chain_eq_1 (B := (65536 : FGL)) (e0 := arithDivE0 c b)
+            (e1 := arithDivE1 c b) fgl_65536_ne_zero)
+      · simpa [arithDivE2, sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using
+          (chain_eq_2 (B := (65536 : FGL)) (e0 := arithDivE0 c b)
+            (e1 := arithDivE1 c b) (e2 := arithDivE2 c b) fgl_65536_ne_zero)
+      · simpa [arithDivE3, sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using
+          (chain_eq_3 (B := (65536 : FGL)) (e0 := arithDivE0 c b)
+            (e1 := arithDivE1 c b) (e2 := arithDivE2 c b) (e3 := arithDivE3 c b)
+            fgl_65536_ne_zero)
+      · simpa [arithDivE4, sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using
+          (chain_eq_4 (B := (65536 : FGL)) (e0 := arithDivE0 c b)
+            (e1 := arithDivE1 c b) (e2 := arithDivE2 c b) (e3 := arithDivE3 c b)
+            (e4 := arithDivE4 c b) fgl_65536_ne_zero)
+      · simpa [arithDivE5, sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using
+          (chain_eq_5 (B := (65536 : FGL)) (e0 := arithDivE0 c b)
+            (e1 := arithDivE1 c b) (e2 := arithDivE2 c b) (e3 := arithDivE3 c b)
+            (e4 := arithDivE4 c b) (e5 := arithDivE5 c b) fgl_65536_ne_zero)
+      · simpa [arithDivE6, sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using
+          (chain_eq_6 (B := (65536 : FGL)) (e0 := arithDivE0 c b)
+            (e1 := arithDivE1 c b) (e2 := arithDivE2 c b) (e3 := arithDivE3 c b)
+            (e4 := arithDivE4 c b) (e5 := arithDivE5 c b) (e6 := arithDivE6 c b)
+            fgl_65536_ne_zero)
+      · simpa [arithDivE7, sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using
+          (chain_last (B := (65536 : FGL)) (e0 := arithDivE0 c b)
+            (e1 := arithDivE1 c b) (e2 := arithDivE2 c b) (e3 := arithDivE3 c b)
+            (e4 := arithDivE4 c b) (e5 := arithDivE5 c b) (e6 := arithDivE6 c b)
+            (e7 := arithDivE7 c b) fgl_65536_ne_zero
+            (arithDivChainSum_zero c b hc hb hb_ne)) }
 
 /-- ArithDiv as a Clean `Air.Flat.Component`. -/
 def component : Air.Flat.Component FGL := ⟨ circuit ⟩

--- a/ZiskFv/AirsClean/ArithMul/Circuit.lean
+++ b/ZiskFv/AirsClean/ArithMul/Circuit.lean
@@ -19,16 +19,18 @@ Packages ZisK's Arith AIR (MUL-mode carry-chain view) as a Clean
   proof needs none; the 11-clause carry-chain `Spec` follows from the 11
   definitional `assertZero` constraints alone, by `linear_combination`).
   `soundness` discharges the ArithMul carry-chain relation; completeness is
-  intentionally a visible non-claim.
+  proved for unsigned rows built from two 64-bit operands.
 * `component` — the `Air.Flat.Component`.
 
 ## Trust note
 
 `Assumptions := True` is what lets the Component compose into an ensemble
 non-vacuously (the `AssumptionsConsistency` obligation becomes trivial).
-No completeness claim is made. Every soundness `Spec` clause is a syntactic
-re-expression of the corresponding `assertZero` constraint, closed by
-`linear_combination`, with no range reasoning.
+Completeness is a constructibility claim for rows equal to `arithMulRowOf a b free`
+with `a < 65536^4` and `b < 65536^4`: the builder sets the unsigned flags, computes
+the product chunks, and chooses the unique field carries solving the 65536-base
+chain equations. It does not claim that arbitrary input rows are honest ArithMul
+executions, and signed/W-mode rows remain a follow-up disjunct.
 -/
 
 namespace ZiskFv.AirsClean.ArithMul
@@ -160,7 +162,8 @@ def arithMulRowOf (a b : ℕ) (free : ArithMulFreeCols) : ArithMulRow FGL :=
 set_option maxHeartbeats 4000000 in
 /-- ArithMul as a Clean `GeneralFormalCircuit`. `Assumptions := True` —
     the 11-clause carry-chain `Spec` follows from the 11 definitional
-    `assertZero` constraints alone (plan D-2 / F-4).
+    `assertZero` constraints alone (plan D-2 / F-4), and completeness constructs
+    unsigned rows from two 64-bit operands.
 
     The `soundness` field is **adapted from** `ArithMul.soundness`
     (`Soundness.lean`) — same per-clause `linear_combination` discharge,

--- a/ZiskFv/AirsClean/ArithMul/Circuit.lean
+++ b/ZiskFv/AirsClean/ArithMul/Circuit.lean
@@ -1,5 +1,6 @@
 import ZiskFv.AirsClean.ArithMul.Constraints
 import ZiskFv.AirsClean.ArithMul.Soundness
+import ZiskFv.Airs.Arith.CarryChainCompleteness
 import Clean.Air.FlatComponent
 import Clean.Utils.Tactics
 
@@ -35,8 +36,128 @@ namespace ZiskFv.AirsClean.ArithMul
 open Goldilocks
 open ZiskFv.Channels.OperationBus (OpBusChannel)
 open Air.Flat
+open ZiskFv.Airs.ArithCarryChainCompleteness
 
-set_option maxHeartbeats 1000000 in
+/-- Columns not constrained by the unsigned carry-chain completeness slice. -/
+structure ArithMulFreeCols where
+  sext : FGL
+  div_by_zero : FGL
+  div_overflow : FGL
+  main_div : FGL
+  main_mul : FGL
+  signed : FGL
+  range_ab : FGL
+  range_cd : FGL
+  op : FGL
+  bus_res1 : FGL
+  multiplicity : FGL
+
+def arithMulE0 (a b : ℕ) : FGL :=
+  (chunk16 a 0 : FGL) * (chunk16 b 0 : FGL) - (chunk16 (a * b) 0 : FGL)
+
+def arithMulE1 (a b : ℕ) : FGL :=
+  (chunk16 a 1 : FGL) * (chunk16 b 0 : FGL) +
+    (chunk16 a 0 : FGL) * (chunk16 b 1 : FGL) - (chunk16 (a * b) 1 : FGL)
+
+def arithMulE2 (a b : ℕ) : FGL :=
+  (chunk16 a 2 : FGL) * (chunk16 b 0 : FGL) +
+    (chunk16 a 1 : FGL) * (chunk16 b 1 : FGL) +
+    (chunk16 a 0 : FGL) * (chunk16 b 2 : FGL) - (chunk16 (a * b) 2 : FGL)
+
+def arithMulE3 (a b : ℕ) : FGL :=
+  (chunk16 a 3 : FGL) * (chunk16 b 0 : FGL) +
+    (chunk16 a 2 : FGL) * (chunk16 b 1 : FGL) +
+    (chunk16 a 1 : FGL) * (chunk16 b 2 : FGL) +
+    (chunk16 a 0 : FGL) * (chunk16 b 3 : FGL) - (chunk16 (a * b) 3 : FGL)
+
+def arithMulE4 (a b : ℕ) : FGL :=
+  (chunk16 a 3 : FGL) * (chunk16 b 1 : FGL) +
+    (chunk16 a 2 : FGL) * (chunk16 b 2 : FGL) +
+    (chunk16 a 1 : FGL) * (chunk16 b 3 : FGL) - (chunk16 (a * b) 4 : FGL)
+
+def arithMulE5 (a b : ℕ) : FGL :=
+  (chunk16 a 3 : FGL) * (chunk16 b 2 : FGL) +
+    (chunk16 a 2 : FGL) * (chunk16 b 3 : FGL) - (chunk16 (a * b) 5 : FGL)
+
+def arithMulE6 (a b : ℕ) : FGL :=
+  (chunk16 a 3 : FGL) * (chunk16 b 3 : FGL) - (chunk16 (a * b) 6 : FGL)
+
+def arithMulE7 (a b : ℕ) : FGL :=
+  -(chunk16 (a * b) 7 : FGL)
+
+lemma arithMulProduct_lt (a b : ℕ) (ha : a < 65536 ^ 4) (hb : b < 65536 ^ 4) :
+    a * b < 65536 ^ 8 := by
+  nlinarith [Nat.mul_lt_mul'' ha hb]
+
+lemma arithMulChainSum_zero (a b : ℕ) (ha : a < 65536 ^ 4) (hb : b < 65536 ^ 4) :
+    arithMulE0 a b + arithMulE1 a b * (65536 : FGL) +
+      arithMulE2 a b * (65536 : FGL) ^ 2 + arithMulE3 a b * (65536 : FGL) ^ 3 +
+      arithMulE4 a b * (65536 : FGL) ^ 4 + arithMulE5 a b * (65536 : FGL) ^ 5 +
+      arithMulE6 a b * (65536 : FGL) ^ 6 + arithMulE7 a b * (65536 : FGL) ^ 7 =
+        0 := by
+  have hab := arithMulProduct_lt a b ha hb
+  have ha_decomp := fgl_decomp4 a ha
+  have hb_decomp := fgl_decomp4 b hb
+  have hp_decomp := fgl_decomp8 (a * b) hab
+  have hmul : (a : FGL) * (b : FGL) = ((a * b : ℕ) : FGL) := by norm_num
+  rw [ha_decomp, hb_decomp, hp_decomp] at hmul
+  unfold arithMulE0 arithMulE1 arithMulE2 arithMulE3 arithMulE4 arithMulE5 arithMulE6 arithMulE7
+  linear_combination hmul
+
+/-- Honest unsigned ArithMul row built from two 64-bit natural operands. -/
+def arithMulRowOf (a b : ℕ) (free : ArithMulFreeCols) : ArithMulRow FGL :=
+  { chunks :=
+      { a_0 := (chunk16 a 0 : FGL)
+        a_1 := (chunk16 a 1 : FGL)
+        a_2 := (chunk16 a 2 : FGL)
+        a_3 := (chunk16 a 3 : FGL)
+        b_0 := (chunk16 b 0 : FGL)
+        b_1 := (chunk16 b 1 : FGL)
+        b_2 := (chunk16 b 2 : FGL)
+        b_3 := (chunk16 b 3 : FGL)
+        c_0 := (chunk16 (a * b) 0 : FGL)
+        c_1 := (chunk16 (a * b) 1 : FGL)
+        c_2 := (chunk16 (a * b) 2 : FGL)
+        c_3 := (chunk16 (a * b) 3 : FGL)
+        d_0 := (chunk16 (a * b) 4 : FGL)
+        d_1 := (chunk16 (a * b) 5 : FGL)
+        d_2 := (chunk16 (a * b) 6 : FGL)
+        d_3 := (chunk16 (a * b) 7 : FGL) }
+    flags :=
+      { na := 0
+        nb := 0
+        nr := 0
+        np := 0
+        sext := free.sext
+        m32 := 0
+        div := 0
+        div_by_zero := free.div_by_zero
+        div_overflow := free.div_overflow
+        main_div := free.main_div
+        main_mul := free.main_mul
+        signed := free.signed
+        range_ab := free.range_ab
+        range_cd := free.range_cd
+        op := free.op
+        bus_res1 := free.bus_res1
+        multiplicity := free.multiplicity }
+    carries :=
+      { carry_0 := cc0 65536 (arithMulE0 a b)
+        carry_1 := cc1 65536 (arithMulE0 a b) (arithMulE1 a b)
+        carry_2 := cc2 65536 (arithMulE0 a b) (arithMulE1 a b) (arithMulE2 a b)
+        carry_3 := cc3 65536 (arithMulE0 a b) (arithMulE1 a b) (arithMulE2 a b)
+          (arithMulE3 a b)
+        carry_4 := cc4 65536 (arithMulE0 a b) (arithMulE1 a b) (arithMulE2 a b)
+          (arithMulE3 a b) (arithMulE4 a b)
+        carry_5 := cc5 65536 (arithMulE0 a b) (arithMulE1 a b) (arithMulE2 a b)
+          (arithMulE3 a b) (arithMulE4 a b) (arithMulE5 a b)
+        carry_6 := cc6 65536 (arithMulE0 a b) (arithMulE1 a b) (arithMulE2 a b)
+          (arithMulE3 a b) (arithMulE4 a b) (arithMulE5 a b) (arithMulE6 a b)
+        fab := 1
+        na_fb := 0
+        nb_fa := 0 } }
+
+set_option maxHeartbeats 4000000 in
 /-- ArithMul as a Clean `GeneralFormalCircuit`. `Assumptions := True` —
     the 11-clause carry-chain `Spec` follows from the 11 definitional
     `assertZero` constraints alone (plan D-2 / F-4).
@@ -49,11 +170,9 @@ def circuit : GeneralFormalCircuit FGL ArithMulRow unit :=
   { arithMulElaborated with
     Assumptions := fun _ _ => True
     Spec := fun row _ _ => Spec row
-    -- Completeness is intentionally NOT claimed (zisk-fv is soundness-
-    -- only). `ProverAssumptions := False` makes this field a visible
-    -- non-claim. See trust/defects.md
-    -- ZISK-DEFECT-CLEAN-COMPLETENESS-TRIVIAL-AXIOMS.
-    ProverAssumptions := fun _ _ _ => False
+    -- Completeness covers unsigned rows built from two 64-bit operands.
+    ProverAssumptions := fun row _ _ =>
+      ∃ a b free, a < 65536 ^ 4 ∧ b < 65536 ^ 4 ∧ row = arithMulRowOf a b free
     ProverSpec := fun _ _ _ => True
     soundness := by
       circuit_proof_start
@@ -77,7 +196,60 @@ def circuit : GeneralFormalCircuit FGL ArithMulRow unit :=
       · -- the op-bus push's requirement: `OpBusChannel.Guarantees` is `True`.
         intro _
         trivial
-    completeness := fun _ _ _ _ _ _ h => h.elim }
+    completeness := by
+      circuit_proof_start_core
+      simp only [main, circuit_norm, primaryOpBusMessageExpr, OpBusChannel]
+      obtain ⟨a, b, free, ha, hb, hrow⟩ := h_assumptions
+      rw [hrow] at h_input
+      simp only [circuit_norm] at h_input
+      injection h_input with h_chunks h_flags h_carries
+      injection h_chunks with h_a_0 h_a_1 h_a_2 h_a_3 h_b_0 h_b_1 h_b_2 h_b_3
+        h_c_0 h_c_1 h_c_2 h_c_3 h_d_0 h_d_1 h_d_2 h_d_3
+      injection h_flags with h_na h_nb h_nr h_np h_sext h_m32 h_div h_div_by_zero
+        h_div_overflow h_main_div h_main_mul h_signed h_range_ab h_range_cd h_op h_bus_res1
+        h_multiplicity
+      injection h_carries with h_carry_0 h_carry_1 h_carry_2 h_carry_3 h_carry_4
+        h_carry_5 h_carry_6 h_fab h_na_fb h_nb_fa
+      subst_vars
+      simp only [h_a_0, h_a_1, h_a_2, h_a_3, h_b_0, h_b_1, h_b_2, h_b_3,
+        h_c_0, h_c_1, h_c_2, h_c_3, h_d_0, h_d_1, h_d_2, h_d_3, h_na, h_nb,
+        h_nr, h_np, h_m32, h_div, h_carry_0, h_carry_1, h_carry_2, h_carry_3,
+        h_carry_4, h_carry_5, h_carry_6, h_fab, h_na_fb, h_nb_fa]
+      refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+      · ring
+      · ring
+      · ring
+      · simpa [arithMulE0, sub_eq_add_neg] using
+          (chain_eq_0 (B := (65536 : FGL)) (e0 := arithMulE0 a b) fgl_65536_ne_zero)
+      · simpa [arithMulE1, sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using
+          (chain_eq_1 (B := (65536 : FGL)) (e0 := arithMulE0 a b)
+            (e1 := arithMulE1 a b) fgl_65536_ne_zero)
+      · simpa [arithMulE2, sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using
+          (chain_eq_2 (B := (65536 : FGL)) (e0 := arithMulE0 a b)
+            (e1 := arithMulE1 a b) (e2 := arithMulE2 a b) fgl_65536_ne_zero)
+      · simpa [arithMulE3, sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using
+          (chain_eq_3 (B := (65536 : FGL)) (e0 := arithMulE0 a b)
+            (e1 := arithMulE1 a b) (e2 := arithMulE2 a b) (e3 := arithMulE3 a b)
+            fgl_65536_ne_zero)
+      · simpa [arithMulE4, sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using
+          (chain_eq_4 (B := (65536 : FGL)) (e0 := arithMulE0 a b)
+            (e1 := arithMulE1 a b) (e2 := arithMulE2 a b) (e3 := arithMulE3 a b)
+            (e4 := arithMulE4 a b) fgl_65536_ne_zero)
+      · simpa [arithMulE5, sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using
+          (chain_eq_5 (B := (65536 : FGL)) (e0 := arithMulE0 a b)
+            (e1 := arithMulE1 a b) (e2 := arithMulE2 a b) (e3 := arithMulE3 a b)
+            (e4 := arithMulE4 a b) (e5 := arithMulE5 a b) fgl_65536_ne_zero)
+      · simpa [arithMulE6, sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using
+          (chain_eq_6 (B := (65536 : FGL)) (e0 := arithMulE0 a b)
+            (e1 := arithMulE1 a b) (e2 := arithMulE2 a b) (e3 := arithMulE3 a b)
+            (e4 := arithMulE4 a b) (e5 := arithMulE5 a b) (e6 := arithMulE6 a b)
+            fgl_65536_ne_zero)
+      · simpa [arithMulE7, sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using
+          (chain_last (B := (65536 : FGL)) (e0 := arithMulE0 a b)
+            (e1 := arithMulE1 a b) (e2 := arithMulE2 a b) (e3 := arithMulE3 a b)
+            (e4 := arithMulE4 a b) (e5 := arithMulE5 a b) (e6 := arithMulE6 a b)
+            (e7 := arithMulE7 a b) fgl_65536_ne_zero
+            (arithMulChainSum_zero a b ha hb)) }
 
 /-- ArithMul as a Clean `Air.Flat.Component`. -/
 def component : Air.Flat.Component FGL := ⟨ circuit ⟩

--- a/ZiskFv/AirsClean/FullEnsemble.lean
+++ b/ZiskFv/AirsClean/FullEnsemble.lean
@@ -31,8 +31,8 @@ theorems may be claimed to be rooted on this ensemble.
 ## Trust note
 
 No axioms.  This file only composes existing components into a
-`FormalEnsemble`; the demoted component completeness fields are visible
-non-claims, not source trust.
+`FormalEnsemble`; component completeness fields are local constructibility
+claims, not sources of cross-row honesty.
 -/
 
 namespace ZiskFv.AirsClean.FullEnsemble

--- a/ZiskFv/AirsClean/FullEnsemble/Balance.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance.lean
@@ -209,10 +209,8 @@ theorem arithDiv_table_interactionsWith_opBus_nil
   have h_not :
       OpBusChannel.toRaw ∉
         ZiskFv.AirsClean.ArithDiv.component.circuit.channels := by
-    simp [circuit_norm, ZiskFv.AirsClean.ArithDiv.component,
-      ZiskFv.AirsClean.ArithDiv.circuit,
-      ZiskFv.AirsClean.ArithDiv.arithDivElaborated,
-      OpBusChannel]
+    change OpBusChannel.toRaw ∉ ([] : List (RawChannel FGL))
+    simp
   apply Table.interactionsWith_nil_of_channel_not_mem
   rw [h_component]
   exact h_not
@@ -283,10 +281,11 @@ theorem arithMul_table_interactionsWith_memBus_nil
   have h_not :
       MemBusChannel.toRaw ∉
         ZiskFv.AirsClean.ArithMul.component.circuit.channels := by
-    simp [circuit_norm, ZiskFv.AirsClean.ArithMul.component,
-      ZiskFv.AirsClean.ArithMul.circuit,
-      ZiskFv.AirsClean.ArithMul.arithMulElaborated,
-      OpBusChannel, MemBusChannel]
+    change MemBusChannel.toRaw ∉ [OpBusChannel.toRaw]
+    simp only [List.mem_singleton]
+    intro h
+    have h_name := congrArg (fun c : RawChannel FGL => c.name) h
+    simp [OpBusChannel, MemBusChannel, Channel.toRaw] at h_name
   apply Table.interactionsWith_nil_of_channel_not_mem
   rw [h_component]
   exact h_not
@@ -300,10 +299,8 @@ theorem arithDiv_table_interactionsWith_memBus_nil
   have h_not :
       MemBusChannel.toRaw ∉
         ZiskFv.AirsClean.ArithDiv.component.circuit.channels := by
-    simp [circuit_norm, ZiskFv.AirsClean.ArithDiv.component,
-      ZiskFv.AirsClean.ArithDiv.circuit,
-      ZiskFv.AirsClean.ArithDiv.arithDivElaborated,
-      MemBusChannel]
+    change MemBusChannel.toRaw ∉ ([] : List (RawChannel FGL))
+    simp
   apply Table.interactionsWith_nil_of_channel_not_mem
   rw [h_component]
   exact h_not

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -455,7 +455,7 @@ the honest integer carries; note this in the docstring).
 - [x] Witnesses (e.g. `6 * 7` and `100 / 7`); docstrings §5 (unsigned scope
       + the field-solved-carry note); ensemble sites §6 (ArithDiv has TWO
       Balance.lean sites).
-- [ ] Verification block; open PR per protocol.
+- [x] Verification block; open PR per protocol.
 
 MANDATORY mechanics for both: the `circuit_proof_start_core` route (the
 plain tactic is too slow on 43-column rows — documented from the soundness
@@ -493,6 +493,12 @@ component records. The witness files, `FullEnsemble.lean`, and
 `FullEnsemble/Balance.lean` typecheck; focused `lake build
 ZiskFv.AirsClean.FullEnsemble` and `lake build ZiskFv.AirsClean.FullEnsemble.Balance`
 both pass.
+W4: Verification block passed: focused Arith/ensemble builds, full `lake
+build`, V1/V2 trust gates, source/trust scans, empty generated/baseline diff,
+empty project-axiom closure print, and `nix run .#test` all passed. The first
+Nix test attempt exhausted local disk and left a generated extraction object
+corrupt; after clearing reproducible caches and rerunning, all 8 Nix test
+steps passed.
 
 ## Wave 5 — Main, 3 circuits + stream finalization (1 agent, 1 PR)
 

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -424,8 +424,8 @@ the honest integer carries; note this in the docstring).
 
 ### Checklist
 
-- [ ] Worktree + cache + baseline; STATUS.md; log `W4: started`.
-- [ ] Shared `ZiskFv/Airs/Arith/CarryChainCompleteness.lean` — build it
+- [x] Worktree + cache + baseline; STATUS.md; log `W4: started`.
+- [x] Shared `ZiskFv/Airs/Arith/CarryChainCompleteness.lean` — build it
       green BEFORE touching components:
       `chunk16 (x k : ℕ) := x / 65536 ^ k % 65536`; `chunk16_lt`;
       `nat_decomp4/8` (by `omega`); `fgl_decomp4/8` (`push_cast`);
@@ -463,6 +463,19 @@ work), `set_option maxHeartbeats 4000000`, and NESTED `injection`:
 `ArithMulRow`/`ArithDivRow` are `{chunks, flags, carries/aux}` sub-structs,
 so the first `injection` yields sub-struct equations — `injection` each of
 those again to reach per-column equations.
+
+W4: started `clean-completeness-wave4` in `.worktrees/completeness-wave4` from
+`origin/clean-completeness-wave1` at `5c10ecc6`, matching the parallel Wave
+2/3 PR bases while PRs #69/#70/#71 remain open.
+W4: Setup baseline passed: `git submodule update --init zisk` checked out
+`4148c25e`, `nix run .#populate` populated generated inputs, `lake exe cache
+get` succeeded, `lake build repl` passed, full `lake build` passed, and
+`trust/scripts/check-all.sh` passed all 17 checks.
+W4: Added `ZiskFv/Airs/Arith/CarryChainCompleteness.lean` with 16-bit chunk
+decomposition, Goldilocks cast decompositions, `65536 ≠ 0`, and generic
+field-solved carry witnesses `cc0` through `cc6`; both `lake env lean
+ZiskFv/Airs/Arith/CarryChainCompleteness.lean` and `lake build
+ZiskFv.Airs.Arith.CarryChainCompleteness` pass.
 
 ## Wave 5 — Main, 3 circuits + stream finalization (1 agent, 1 PR)
 

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -499,6 +499,11 @@ empty project-axiom closure print, and `nix run .#test` all passed. The first
 Nix test attempt exhausted local disk and left a generated extraction object
 corrupt; after clearing reproducible caches and rerunning, all 8 Nix test
 steps passed.
+W4: Sequential merge prep after PRs #69/#70/#71 landed: retargeted PR #72 to
+`main`, rebased `clean-completeness-wave4` onto updated `origin/main`, resolved
+bookkeeping-only conflicts in `STATUS.md` and this plan, and confirmed the
+branch diff contains only Wave 4 files with `git diff --check
+origin/main..HEAD` clean.
 
 ## Wave 5 — Main, 3 circuits + stream finalization (1 agent, 1 PR)
 

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -437,7 +437,7 @@ the honest integer carries; note this in the docstring).
       If `field_simp` blows up: state pre-cleared forms
       (`cc_k * B^(k+1) = Σ_{j≤k} e_j*B^j` via `div_mul_cancel₀`) and
       `linear_combination` against those. Keep `65536` powers FACTORED.
-- [ ] ArithMul `circuit` (11 assertZeros + OpBus push):
+- [x] ArithMul `circuit` (11 assertZeros + OpBus push):
       `ArithMulFreeCols` = the 11 unconstrained columns (`sext div_by_zero
       div_overflow main_div main_mul signed range_ab range_cd op bus_res1
       multiplicity`); builder `arithMulRowOf (a b : ℕ) (free)` — a/b chunks
@@ -476,6 +476,10 @@ decomposition, Goldilocks cast decompositions, `65536 ≠ 0`, and generic
 field-solved carry witnesses `cc0` through `cc6`; both `lake env lean
 ZiskFv/Airs/Arith/CarryChainCompleteness.lean` and `lake build
 ZiskFv.Airs.Arith.CarryChainCompleteness` pass.
+W4: ArithMul `circuit` now has an unsigned honest-row builder,
+builder-existential `ProverAssumptions`, and a real completeness proof using
+`circuit_proof_start_core` plus the shared `cc0..cc6`/`chain_last` helpers.
+`lake build ZiskFv.AirsClean.ArithMul.Circuit` passes.
 
 ## Wave 5 — Main, 3 circuits + stream finalization (1 agent, 1 PR)
 

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -447,7 +447,7 @@ the honest integer carries; note this in the docstring).
       Discharge: C6/7/8 `norm_num`; C31–C37 `linear_combination (chain_eq_k …)`;
       C38 via `chain_last` with `h_packed : ↑a * ↑b = c_packed + d_packed *
       B^4` from `fgl_decomp4 a/b` + `fgl_decomp8 (a*b)` + `Nat.cast_mul`.
-- [ ] ArithDiv `circuit` (11 assertZeros, NO push — easier): operands
+- [x] ArithDiv `circuit` (11 assertZeros, NO push — easier): operands
       `(c b : ℕ)` = dividend, divisor; a := chunks of `c / b`, d := chunks
       of `c % b`; side-conditions `c < 65536^4 ∧ b < 65536^4 ∧ b ≠ 0`
       (`b ≠ 0` is documentation honesty); `h_packed` from `Nat.div_add_mod`.
@@ -480,6 +480,11 @@ W4: ArithMul `circuit` now has an unsigned honest-row builder,
 builder-existential `ProverAssumptions`, and a real completeness proof using
 `circuit_proof_start_core` plus the shared `cc0..cc6`/`chain_last` helpers.
 `lake build ZiskFv.AirsClean.ArithMul.Circuit` passes.
+W4: ArithDiv `circuit` now has an unsigned honest-row builder for nonzero
+divisors, builder-existential `ProverAssumptions`, and a real completeness
+proof from `Nat.div_add_mod` plus the shared carry-chain helpers.
+`lake env lean ZiskFv/AirsClean/ArithDiv/Circuit.lean` and
+`lake build ZiskFv.AirsClean.ArithDiv.Circuit` pass.
 
 ## Wave 5 — Main, 3 circuits + stream finalization (1 agent, 1 PR)
 

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -452,7 +452,7 @@ the honest integer carries; note this in the docstring).
       of `c % b`; side-conditions `c < 65536^4 ∧ b < 65536^4 ∧ b ≠ 0`
       (`b ≠ 0` is documentation honesty); `h_packed` from `Nat.div_add_mod`.
       Mul first, Div as template copy.
-- [ ] Witnesses (e.g. `6 * 7` and `100 / 7`); docstrings §5 (unsigned scope
+- [x] Witnesses (e.g. `6 * 7` and `100 / 7`); docstrings §5 (unsigned scope
       + the field-solved-carry note); ensemble sites §6 (ArithDiv has TWO
       Balance.lean sites).
 - [ ] Verification block; open PR per protocol.
@@ -485,6 +485,14 @@ divisors, builder-existential `ProverAssumptions`, and a real completeness
 proof from `Nat.div_add_mod` plus the shared carry-chain helpers.
 `lake env lean ZiskFv/AirsClean/ArithDiv/Circuit.lean` and
 `lake build ZiskFv.AirsClean.ArithDiv.Circuit` pass.
+W4: Added anti-vacuity witnesses `completeness_witness_arithmul.lean` and
+`completeness_witness_arithdiv.lean`, updated ArithMul/ArithDiv audit
+docstrings to state the unsigned constructibility scope and non-claims, and
+converted the Arith Balance no-channel proofs away from unfolding the completed
+component records. The witness files, `FullEnsemble.lean`, and
+`FullEnsemble/Balance.lean` typecheck; focused `lake build
+ZiskFv.AirsClean.FullEnsemble` and `lake build ZiskFv.AirsClean.FullEnsemble.Balance`
+both pass.
 
 ## Wave 5 — Main, 3 circuits + stream finalization (1 agent, 1 PR)
 

--- a/trust/consistency/completeness_witness_arithdiv.lean
+++ b/trust/consistency/completeness_witness_arithdiv.lean
@@ -1,0 +1,36 @@
+import ZiskFv.AirsClean.ArithDiv.Circuit
+
+namespace ZiskFv.TrustConsistency
+
+open Goldilocks
+open ZiskFv.AirsClean.ArithDiv
+
+private def arithDivWitnessFree : ArithDivFreeCols :=
+  { sext := 0
+    div_by_zero := 0
+    div_overflow := 0
+    main_div := 0
+    main_mul := 0
+    signed := 0
+    range_ab := 0
+    range_cd := 0
+    op := 0
+    bus_res1 := 0
+    multiplicity := 0 }
+
+private def arithDivWitnessRow : ArithDivRow FGL :=
+  arithDivRowOf 100 7 arithDivWitnessFree
+
+private theorem arithDivWitnessProverAssumptions
+    (data : ProverData FGL) (hint : ProverHint FGL) :
+    circuit.ProverAssumptions arithDivWitnessRow data hint := by
+  refine ⟨100, 7, arithDivWitnessFree, by norm_num, by norm_num, by norm_num, ?_⟩
+  rfl
+
+theorem completeness_witness_arithdiv :
+    ∃ row : ArithDivRow FGL, ∀ data hint, circuit.ProverAssumptions row data hint := by
+  exact ⟨arithDivWitnessRow, arithDivWitnessProverAssumptions⟩
+
+#print axioms completeness_witness_arithdiv
+
+end ZiskFv.TrustConsistency

--- a/trust/consistency/completeness_witness_arithmul.lean
+++ b/trust/consistency/completeness_witness_arithmul.lean
@@ -1,0 +1,36 @@
+import ZiskFv.AirsClean.ArithMul.Circuit
+
+namespace ZiskFv.TrustConsistency
+
+open Goldilocks
+open ZiskFv.AirsClean.ArithMul
+
+private def arithMulWitnessFree : ArithMulFreeCols :=
+  { sext := 0
+    div_by_zero := 0
+    div_overflow := 0
+    main_div := 0
+    main_mul := 0
+    signed := 0
+    range_ab := 0
+    range_cd := 0
+    op := 0
+    bus_res1 := 0
+    multiplicity := 0 }
+
+private def arithMulWitnessRow : ArithMulRow FGL :=
+  arithMulRowOf 6 7 arithMulWitnessFree
+
+private theorem arithMulWitnessProverAssumptions
+    (data : ProverData FGL) (hint : ProverHint FGL) :
+    circuit.ProverAssumptions arithMulWitnessRow data hint := by
+  refine ⟨6, 7, arithMulWitnessFree, by norm_num, by norm_num, ?_⟩
+  rfl
+
+theorem completeness_witness_arithmul :
+    ∃ row : ArithMulRow FGL, ∀ data hint, circuit.ProverAssumptions row data hint := by
+  exact ⟨arithMulWitnessRow, arithMulWitnessProverAssumptions⟩
+
+#print axioms completeness_witness_arithmul
+
+end ZiskFv.TrustConsistency


### PR DESCRIPTION
Queued for Claude review — do not merge.

## Summary
- Proves genuine Clean completeness for the Wave 4 Arith pair in the documented unsigned scope.
- Adds ZiskFv/Airs/Arith/CarryChainCompleteness.lean with chunk16, Nat/FGL decomposition lemmas, fgl_65536_ne_zero, and field-solved carry helpers.
- Replaces demoted ex-falso completeness fields for ArithMul.circuit and ArithDiv.circuit with unsigned builder-existential proofs.
- Adds anti-vacuity witnesses for ArithMul and ArithDiv.
- Updates Arith audit docstrings and the necessary FullEnsemble/Balance proof bodies.

## Scope notes
- This PR is stacked on clean-completeness-wave1, matching the parallel Wave 2/3 PR style.
- Scope is unsigned-only: na=nb=np=nr=m32=0; MUL has div=0; DIV has div=1; fab=1; na_fb=nb_fa=0.
- ArithDiv completeness also assumes a nonzero divisor in the honest builder side conditions.
- Signed modes and m32/W-mode disjuncts are intentionally not claimed here and remain follow-up work.
- Carries are field-solved from the 65536-base chain equations; this proves row-local constructibility for honest unsigned builder rows, not arbitrary-row honesty.

## Verification
- lake build ZiskFv.Airs.Arith.CarryChainCompleteness: passed.
- lake build ZiskFv.AirsClean.ArithMul.Circuit: passed.
- lake build ZiskFv.AirsClean.ArithDiv.Circuit: passed.
- lake build ZiskFv.AirsClean.FullEnsemble: passed.
- lake build ZiskFv.AirsClean.FullEnsemble.Balance: passed.
- lake build: passed.
- trust/scripts/check-all.sh: trust-gate: ALL CHECKS PASSED.
- trust/scripts/check-all-semantic.sh: trust-gate (V2 semantic): ALL CHECKS PASSED.
- nix run .#test: passed all 8 steps after clearing reproducible caches from an initial local disk-full failure.
- Generated trust baseline diff was empty; trust diff against clean-completeness-wave1 only adds the two Wave 4 witness files.
- Closure print emitted no project axiom names.
- git diff --check passed.

Witness files discovered in the Wave 4 semantic gate:
- trust/consistency/completeness_witness_arithdiv.lean
- trust/consistency/completeness_witness_arithmul.lean
- trust/consistency/completeness_witness_binaryadd.lean
- trust/consistency/completeness_witness_memalign.lean

## Notes for later waves
- Signed Arith and m32/W-mode completeness should be added as explicit future disjuncts.
- Keep the carry-chain helper file shared and focused on reusable base-65536 facts.
- Continue treating this as completeness / constructibility work, not promise discharge or caller-burden reduction.