### PR TITLE
Clean completeness Wave 5: Main trio

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,34 +1,24 @@
 Active plan: docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
 
-Current focus: Wave 4 Arith pair, unsigned scope, on branch
-`clean-completeness-wave4` in `.worktrees/completeness-wave4`, rebased onto
-updated `origin/main` for sequential merge of PR #72.
+Current focus: Wave 5 Main trio on branch `clean-completeness-wave5` in
+`.worktrees/completeness-wave5`, based on `origin/clean-completeness-wave1`.
 
-Blocking: none. PRs #69, #70, and #71 are squash-merged. Wave 4 is ready to
-push with lease and squash-merge as PR #72.
+Blocking: none for the Main proof work. The Wave 5 finalization sweep is
+explicitly deferred until Waves 2-4 merge; PRs #69-#72 are still open and must
+not be merged by this agent.
 
-Setup: `git submodule update --init zisk` checked out pinned `4148c25e`;
-`nix run .#populate`, `lake exe cache get`, `lake build repl`, full
-`lake build`, and `trust/scripts/check-all.sh` passed.
+Setup: `nix run .#populate` populated generated inputs after the first cache
+attempt reported missing path deps. `lake exe cache get` initially hit local
+disk-full while decompressing mathlib; after clearing reproducible caches and
+old generated worktree builds, retry passed. `git submodule update --init zisk`
+checked out pinned `4148c25e`; `lake build repl`, full baseline `lake build`,
+and `trust/scripts/check-all.sh` passed.
 
-Progress: Wave 4 scope is unsigned-only ArithMul/ArithDiv completeness:
-`na=nb=np=nr=m32=0`; MUL has `div=0`, DIV has `div=1`; `fab=1` and
-`na_fb=nb_fa=0`. Carries will be field-solved from the 65536-base chain
-equations, with signed/m32 modes left as documented follow-up disjuncts.
-`ZiskFv/Airs/Arith/CarryChainCompleteness.lean` now builds and provides
-`chunk16`, Nat/FGL decompositions, `fgl_65536_ne_zero`, and `cc0..cc6`
-field-solved carry lemmas. ArithMul `circuit` now has a real unsigned
-builder-existential completeness proof; focused
-`lake build ZiskFv.AirsClean.ArithMul.Circuit` passes. ArithDiv `circuit`
-now has a real unsigned nonzero-divisor builder-existential completeness
-proof; `lake env lean ZiskFv/AirsClean/ArithDiv/Circuit.lean` and focused
-`lake build ZiskFv.AirsClean.ArithDiv.Circuit` pass. ArithMul/ArithDiv
-witness files now typecheck and print standard closure; Arith audit
-docstrings state the unsigned constructibility scope and signed/W non-claims;
-`FullEnsemble` and `FullEnsemble/Balance` focused builds pass. The full
-verification block also passed: full `lake build`, V1/V2 trust gates, empty
-generated/baseline diff, empty project-axiom closure print, and `nix run .#test`
-after clearing reproducible caches from an initial disk-full failure.
+Progress: `ZiskFv/AirsClean/Main/Circuit.lean` now has honest builders and
+builder-existential completeness proofs for plain `circuit`,
+`circuitWithRomAndMemBus`, and `circuitWithRomMemAndOpBus`. `lake env lean
+ZiskFv/AirsClean/Main/Circuit.lean` and focused `lake build
+ZiskFv.AirsClean.Main.Circuit` pass.
 
-Next step: push `clean-completeness-wave4`, squash-merge PR #72, then retarget
-and rebase Wave 5 for PR #73.
+Next step: add the Main anti-vacuity witness covering a concrete one-row
+program and the three `MainRomExecKind` shapes, then run witness/focused gates.

--- a/STATUS.md
+++ b/STATUS.md
@@ -18,7 +18,9 @@ Progress: `ZiskFv/AirsClean/Main/Circuit.lean` now has honest builders and
 builder-existential completeness proofs for plain `circuit`,
 `circuitWithRomAndMemBus`, and `circuitWithRomMemAndOpBus`. `lake env lean
 ZiskFv/AirsClean/Main/Circuit.lean` and focused `lake build
-ZiskFv.AirsClean.Main.Circuit` pass.
+ZiskFv.AirsClean.Main.Circuit` pass. The Main witness file covers all three
+plain and ROM-backed execution shapes; its typecheck passes and prints only the
+standard closure.
 
-Next step: add the Main anti-vacuity witness covering a concrete one-row
-program and the three `MainRomExecKind` shapes, then run witness/focused gates.
+Next step: run the Wave 5 verification block, leaving the merge-dependent
+finalization sweep unchecked until Waves 2-4 merge.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,8 @@
 Active plan: docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
 
-Current focus: Wave 5 verification block on branch `clean-completeness-wave5`
-in `.worktrees/completeness-wave5`, based on `origin/clean-completeness-wave1`.
+Current focus: waiting on the Wave 5 merge gate on branch
+`clean-completeness-wave5` in `.worktrees/completeness-wave5`, based on
+`origin/clean-completeness-wave1`.
 
 Blocking: Main proof work is complete. The Wave 5 finalization sweep and PR
 are explicitly deferred until Waves 2-4 merge; PRs #69-#72 are still open and

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,12 +1,12 @@
 Active plan: docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
 
-Current focus: waiting on the Wave 5 merge gate on branch
-`clean-completeness-wave5` in `.worktrees/completeness-wave5`, based on
+Current focus: Wave 5 proof-only PR #73 is open on branch
+`clean-completeness-wave5` from `.worktrees/completeness-wave5`, based on
 `origin/clean-completeness-wave1`.
 
-Blocking: Main proof work is complete. The Wave 5 finalization sweep and PR
-are explicitly deferred until Waves 2-4 merge; PRs #69-#72 are still open and
-must not be merged by this agent.
+Blocking: Main proof work is complete. The Wave 5 finalization sweep is
+explicitly deferred until Waves 2-4 merge; PRs #69-#73 are open and must not
+be merged by this agent.
 
 Setup: `nix run .#populate` populated generated inputs after the first cache
 attempt reported missing path deps. `lake exe cache get` initially hit local
@@ -23,9 +23,9 @@ ZiskFv.AirsClean.Main.Circuit` pass. The Main witness file covers all three
 plain and ROM-backed execution shapes; its typecheck passes and prints only the
 standard closure.
 
-Next step: wait for the merge-dependent finalization sweep to become eligible,
-or open a proof-only Wave 5 PR only if Cody explicitly asks for that split. The
-full build, `trust/scripts/check-all.sh`,
+Next step: wait for the merge-dependent finalization sweep to become eligible.
+The full build, `trust/scripts/check-all.sh`,
 `trust/scripts/check-all-semantic.sh`, `nix run .#test`, trust diff checks,
 closure print, `git diff --check`, and final scans have passed; the semantic
-gates discover `completeness_witness_main`.
+gates discover `completeness_witness_main`. PR #73 has a non-empty review body,
+and PRs #69-#72 now have non-empty descriptions.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,11 +1,11 @@
 Active plan: docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
 
-Current focus: Wave 5 Main trio on branch `clean-completeness-wave5` in
-`.worktrees/completeness-wave5`, based on `origin/clean-completeness-wave1`.
+Current focus: Wave 5 verification block on branch `clean-completeness-wave5`
+in `.worktrees/completeness-wave5`, based on `origin/clean-completeness-wave1`.
 
-Blocking: none for the Main proof work. The Wave 5 finalization sweep is
-explicitly deferred until Waves 2-4 merge; PRs #69-#72 are still open and must
-not be merged by this agent.
+Blocking: Main proof work is complete. The Wave 5 finalization sweep and PR
+are explicitly deferred until Waves 2-4 merge; PRs #69-#72 are still open and
+must not be merged by this agent.
 
 Setup: `nix run .#populate` populated generated inputs after the first cache
 attempt reported missing path deps. `lake exe cache get` initially hit local
@@ -22,5 +22,9 @@ ZiskFv.AirsClean.Main.Circuit` pass. The Main witness file covers all three
 plain and ROM-backed execution shapes; its typecheck passes and prints only the
 standard closure.
 
-Next step: run the Wave 5 verification block, leaving the merge-dependent
-finalization sweep unchecked until Waves 2-4 merge.
+Next step: wait for the merge-dependent finalization sweep to become eligible,
+or open a proof-only Wave 5 PR only if Cody explicitly asks for that split. The
+full build, `trust/scripts/check-all.sh`,
+`trust/scripts/check-all-semantic.sh`, `nix run .#test`, trust diff checks,
+closure print, `git diff --check`, and final scans have passed; the semantic
+gates discover `completeness_witness_main`.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,12 +1,11 @@
 Active plan: docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
 
-Current focus: Wave 5 proof-only PR #73 is open on branch
-`clean-completeness-wave5` from `.worktrees/completeness-wave5`, based on
-`origin/clean-completeness-wave1`.
+Current focus: Wave 5 proof-only PR #73 on branch
+`clean-completeness-wave5` from `.worktrees/completeness-wave5`, rebased onto
+updated `origin/main` after PRs #69-#72 were squash-merged.
 
-Blocking: Main proof work is complete. The Wave 5 finalization sweep is
-explicitly deferred until Waves 2-4 merge; PRs #69-#73 are open and must not
-be merged by this agent.
+Blocking: none for proof-wave merge. The Wave 5 finalization sweep is now the
+remaining cleanup and is not included in proof-only PR #73.
 
 Setup: `nix run .#populate` populated generated inputs after the first cache
 attempt reported missing path deps. `lake exe cache get` initially hit local
@@ -24,11 +23,12 @@ plain and ROM-backed execution shapes; its typecheck passes and prints only the
 standard closure. Pre-merge review feedback has been addressed by marking the
 named `MainRomExecKind.Coherent` predicate `@[reducible]`.
 
-Next step: wait for the merge-dependent finalization sweep to become eligible.
-The focused post-review checks (`lake env lean` for Main and the Main witness,
-plus `lake build ZiskFv.AirsClean.Main.Circuit`) pass. The full build,
-`trust/scripts/check-all.sh`,
-`trust/scripts/check-all-semantic.sh`, `nix run .#test`, trust diff checks,
-closure print, `git diff --check`, and final scans have passed; the semantic
-gates discover `completeness_witness_main`. PR #73 has a non-empty review body,
-and PRs #69-#72 now have non-empty descriptions.
+Next step: push the rebased branch and squash-merge PR #73 if not already
+merged, then handle the separate finalization cleanup. The focused post-review
+checks (`lake env lean` for Main and the Main witness, plus `lake build
+ZiskFv.AirsClean.Main.Circuit`) pass. The full build,
+`trust/scripts/check-all.sh`, `trust/scripts/check-all-semantic.sh`,
+`nix run .#test`, trust diff checks, closure print, `git diff --check`, and
+final scans have passed; the semantic gates discover
+`completeness_witness_main`. PR #73 has a non-empty review body, and PRs
+#69-#72 now have non-empty descriptions.

--- a/STATUS.md
+++ b/STATUS.md
@@ -21,10 +21,13 @@ builder-existential completeness proofs for plain `circuit`,
 ZiskFv/AirsClean/Main/Circuit.lean` and focused `lake build
 ZiskFv.AirsClean.Main.Circuit` pass. The Main witness file covers all three
 plain and ROM-backed execution shapes; its typecheck passes and prints only the
-standard closure.
+standard closure. Pre-merge review feedback has been addressed by marking the
+named `MainRomExecKind.Coherent` predicate `@[reducible]`.
 
 Next step: wait for the merge-dependent finalization sweep to become eligible.
-The full build, `trust/scripts/check-all.sh`,
+The focused post-review checks (`lake env lean` for Main and the Main witness,
+plus `lake build ZiskFv.AirsClean.Main.Circuit`) pass. The full build,
+`trust/scripts/check-all.sh`,
 `trust/scripts/check-all-semantic.sh`, `nix run .#test`, trust diff checks,
 closure print, `git diff --check`, and final scans have passed; the semantic
 gates discover `completeness_witness_main`. PR #73 has a non-empty review body,

--- a/ZiskFv/AirsClean/Main/Circuit.lean
+++ b/ZiskFv/AirsClean/Main/Circuit.lean
@@ -1,6 +1,7 @@
 import ZiskFv.AirsClean.Main.Constraints
 import ZiskFv.AirsClean.Main.Soundness
 import ZiskFv.AirsClean.Main.Bridge
+import ZiskFv.AirsClean.CompletenessHelpers
 import Clean.Air.FlatComponent
 import Clean.Utils.Tactics
 
@@ -16,27 +17,117 @@ PIL-faithful operation-bus emission with multiplicity `-is_external_op`.
 
 ## Trust note
 
-No axioms. Completeness is intentionally a visible non-claim; the file's
-trusted content is the soundness direction.
+No axioms. Completeness is a constructibility claim for rows equal to the
+honest builders below: the builders choose one of the three Main execution
+shapes forced by the local constraints and compute the dependent `flag`,
+`is_external_op`, `op`, `c_*`, and `set_pc` columns. The ROM-backed builders
+also copy the selected program row into the ROM lookup columns and pack the
+instruction flags. Cross-row PC continuity and program semantics remain outside
+these row-local proofs.
 -/
 
 namespace ZiskFv.AirsClean.Main
 
 open Goldilocks
 open Air.Flat
+open ZiskFv.AirsClean (boolF)
 open ZiskFv.Channels.OperationBus (OpBusChannel)
 open ZiskFv.Channels.MemoryBus (MemBusChannel)
 open ZiskFv.AirsClean.ZiskInstructionRom (Program romStaticTable)
+
+/-- Columns of the plain Main row that are unconstrained by the local
+    `mainWithOpBus` constraint slice. -/
+structure MainFreeCols where
+  a_0 : FGL
+  a_1 : FGL
+  b_0 : FGL
+  b_1 : FGL
+  pc : FGL
+  m32 : FGL
+  ind_width : FGL
+  jmp_offset1 : FGL
+  jmp_offset2 : FGL
+  store_pc : FGL
+  im_high_degree_2 : FGL
+  segment_l1 : FGL
+
+/-- The three Main execution shapes forced by the local internal-op
+    constraints. External rows leave `op` and `c_*` free; internal op 0 sets
+    the flag and clears `c_*`; internal op 1 clears the flag and copies `b` to
+    `c`. -/
+inductive MainExecKind
+  | external (op : FGL) (flag : Bool) (c_0 c_1 set_pc : FGL)
+  | internalFlag
+  | internalCopyB (set_pc : FGL)
+
+/-- Honest row for the plain Main circuit. -/
+def mainRowOf : MainExecKind → MainFreeCols → MainRow FGL
+  | .external op flag c_0 c_1 set_pc, free =>
+      { a_0 := free.a_0
+        a_1 := free.a_1
+        b_0 := free.b_0
+        b_1 := free.b_1
+        c_0 := c_0
+        c_1 := c_1
+        flag := boolF flag
+        pc := free.pc
+        is_external_op := 1
+        op := op
+        m32 := free.m32
+        ind_width := free.ind_width
+        set_pc := if flag then 0 else set_pc
+        jmp_offset1 := free.jmp_offset1
+        jmp_offset2 := free.jmp_offset2
+        store_pc := free.store_pc
+        im_high_degree_2 := free.im_high_degree_2
+        segment_l1 := free.segment_l1 }
+  | .internalFlag, free =>
+      { a_0 := free.a_0
+        a_1 := free.a_1
+        b_0 := free.b_0
+        b_1 := free.b_1
+        c_0 := 0
+        c_1 := 0
+        flag := 1
+        pc := free.pc
+        is_external_op := 0
+        op := 0
+        m32 := free.m32
+        ind_width := free.ind_width
+        set_pc := 0
+        jmp_offset1 := free.jmp_offset1
+        jmp_offset2 := free.jmp_offset2
+        store_pc := free.store_pc
+        im_high_degree_2 := free.im_high_degree_2
+        segment_l1 := free.segment_l1 }
+  | .internalCopyB set_pc, free =>
+      { a_0 := free.a_0
+        a_1 := free.a_1
+        b_0 := free.b_0
+        b_1 := free.b_1
+        c_0 := free.b_0
+        c_1 := free.b_1
+        flag := 0
+        pc := free.pc
+        is_external_op := 0
+        op := 1
+        m32 := free.m32
+        ind_width := free.ind_width
+        set_pc := set_pc
+        jmp_offset1 := free.jmp_offset1
+        jmp_offset2 := free.jmp_offset2
+        store_pc := free.store_pc
+        im_high_degree_2 := free.im_high_degree_2
+        segment_l1 := free.segment_l1 }
 
 def circuit : GeneralFormalCircuit FGL MainRow unit :=
   { mainWithOpBusElaborated with
     Assumptions := fun _ _ => True
     Spec := fun row _ _ => Spec row
-    -- Completeness is intentionally NOT claimed (zisk-fv is soundness-
-    -- only). `ProverAssumptions := False` makes this field a visible
-    -- non-claim. See trust/defects.md
-    -- ZISK-DEFECT-CLEAN-COMPLETENESS-TRIVIAL-AXIOMS.
-    ProverAssumptions := fun _ _ _ => False
+    -- Completeness covers rows built from one of the three local Main
+    -- execution shapes; unconstrained data columns remain free.
+    ProverAssumptions := fun row _ _ =>
+      ∃ kind free, row = mainRowOf kind free
     ProverSpec := fun _ _ _ => True
     soundness := by
       circuit_proof_start
@@ -53,11 +144,171 @@ def circuit : GeneralFormalCircuit FGL MainRow unit :=
               , by simpa [sub_eq_add_neg] using h8 ⟩
       · intro _
         trivial
-    completeness := fun _ _ _ _ _ _ h => h.elim }
+    completeness := by
+      circuit_proof_start_core
+      simp only [mainWithOpBus, main, circuit_norm, opBusMessageExpr,
+        OpBusChannel]
+      obtain ⟨kind, free, hrow⟩ := h_assumptions
+      rw [hrow] at h_input
+      simp only [circuit_norm] at h_input
+      cases kind with
+      | external op flag c_0 c_1 set_pc =>
+        simp [mainRowOf, boolF] at h_input ⊢
+        obtain ⟨h_a_0, h_a_1, h_b_0, h_b_1, h_c_0, h_c_1, h_flag, h_pc,
+          h_is_external_op, h_op, h_m32, h_ind_width, h_set_pc, h_jmp_offset1,
+          h_jmp_offset2, h_store_pc, h_im_high_degree_2, h_segment_l1⟩ := h_input
+        cases flag <;>
+          simp [h_c_0, h_c_1, h_flag, h_is_external_op, h_op, h_set_pc]
+      | internalFlag =>
+        simp [mainRowOf] at h_input ⊢
+        obtain ⟨h_a_0, h_a_1, h_b_0, h_b_1, h_c_0, h_c_1, h_flag, h_pc,
+          h_is_external_op, h_op, h_m32, h_ind_width, h_set_pc, h_jmp_offset1,
+          h_jmp_offset2, h_store_pc, h_im_high_degree_2, h_segment_l1⟩ := h_input
+        simp [h_c_0, h_c_1, h_flag, h_is_external_op, h_op, h_set_pc]
+      | internalCopyB set_pc =>
+        simp [mainRowOf] at h_input ⊢
+        obtain ⟨h_a_0, h_a_1, h_b_0, h_b_1, h_c_0, h_c_1, h_flag, h_pc,
+          h_is_external_op, h_op, h_m32, h_ind_width, h_set_pc, h_jmp_offset1,
+          h_jmp_offset2, h_store_pc, h_im_high_degree_2, h_segment_l1⟩ := h_input
+        simp [h_b_0, h_b_1, h_c_0, h_c_1, h_flag, h_is_external_op, h_op] }
 
 def component : Air.Flat.Component FGL := ⟨ circuit ⟩
 
 /-! ## Main with ROM + memory-bus consumer emissions -/
+
+/-- The 15 instruction-flag bits packed into the ROM `flags` field. -/
+structure RomFlagBits where
+  a_src_imm : Bool
+  a_src_mem : Bool
+  is_precompiled : Bool
+  b_src_imm : Bool
+  b_src_mem : Bool
+  is_external_op : Bool
+  store_pc : Bool
+  store_mem : Bool
+  store_ind : Bool
+  set_pc : Bool
+  m32 : Bool
+  b_src_ind : Bool
+  a_src_reg : Bool
+  b_src_reg : Bool
+  store_reg : Bool
+
+/-- Concrete ROM-flag packing, matching `romFlagsExpr`. -/
+def packFlags (bits : RomFlagBits) : FGL :=
+  1
+  + 2 * boolF bits.a_src_imm
+  + 4 * boolF bits.a_src_mem
+  + 8 * boolF bits.is_precompiled
+  + 16 * boolF bits.b_src_imm
+  + 32 * boolF bits.b_src_mem
+  + 64 * boolF bits.is_external_op
+  + 128 * boolF bits.store_pc
+  + 256 * boolF bits.store_mem
+  + 512 * boolF bits.store_ind
+  + 1024 * boolF bits.set_pc
+  + 2048 * boolF bits.m32
+  + 4096 * boolF bits.b_src_ind
+  + 8192 * boolF bits.a_src_reg
+  + 16384 * boolF bits.b_src_reg
+  + 32768 * boolF bits.store_reg
+
+/-- Free witness columns in the ROM-backed Main row. Program-derived columns
+    and flag bits are copied from the selected program row and `RomFlagBits`;
+    dependent `c_*`/`flag` columns are selected by `MainRomExecKind`. -/
+structure MainRomFreeCols where
+  a_0 : FGL
+  a_1 : FGL
+  b_0 : FGL
+  b_1 : FGL
+  im_high_degree_2 : FGL
+  segment_l1 : FGL
+  addr0 : FGL
+  addr1 : FGL
+  addr2 : FGL
+  main_step : FGL
+
+/-- Main execution shapes for rows whose instruction data comes from the ROM
+    program row. The operation code itself is copied from the selected ROM
+    message, so internal cases require coherence side-conditions on that
+    message. -/
+inductive MainRomExecKind
+  | external (flag : Bool) (c_0 c_1 : FGL)
+  | internalFlag
+  | internalCopyB
+
+namespace MainRomExecKind
+
+/-- Semantic coherence between the ROM flag bits, the selected program row, and
+    the local Main execution shape. -/
+def Coherent (msg : ZiskFv.Channels.ZiskRomBus.ZiskRomMessage FGL)
+    (bits : RomFlagBits) : MainRomExecKind → Prop
+  | external flag _ _ =>
+      bits.is_external_op = true ∧ (flag = true → bits.set_pc = false)
+  | internalFlag =>
+      bits.is_external_op = false ∧ msg.op = 0 ∧ bits.set_pc = false
+  | internalCopyB =>
+      bits.is_external_op = false ∧ msg.op = 1
+
+end MainRomExecKind
+
+/-- Honest row for the ROM-backed Main circuits. The ROM lookup fields copy the
+    selected program message; runtime operand/address columns remain free. -/
+def mainRomRowOf (msg : ZiskFv.Channels.ZiskRomBus.ZiskRomMessage FGL)
+    (bits : RomFlagBits) (kind : MainRomExecKind) (free : MainRomFreeCols) :
+    MainRowWithRom FGL :=
+  { core :=
+      { a_0 := free.a_0
+        a_1 := free.a_1
+        b_0 := free.b_0
+        b_1 := free.b_1
+        c_0 :=
+          match kind with
+          | .external _ c_0 _ => c_0
+          | .internalFlag => 0
+          | .internalCopyB => free.b_0
+        c_1 :=
+          match kind with
+          | .external _ _ c_1 => c_1
+          | .internalFlag => 0
+          | .internalCopyB => free.b_1
+        flag :=
+          match kind with
+          | .external flag _ _ => boolF flag
+          | .internalFlag => 1
+          | .internalCopyB => 0
+        pc := msg.line
+        is_external_op := boolF bits.is_external_op
+        op := msg.op
+        m32 := boolF bits.m32
+        ind_width := msg.ind_width
+        set_pc := boolF bits.set_pc
+        jmp_offset1 := msg.jmp_offset1
+        jmp_offset2 := msg.jmp_offset2
+        store_pc := boolF bits.store_pc
+        im_high_degree_2 := free.im_high_degree_2
+        segment_l1 := free.segment_l1 }
+    rom :=
+      { a_offset_imm0 := msg.a_offset_imm0
+        a_imm1 := msg.a_imm1
+        b_offset_imm0 := msg.b_offset_imm0
+        b_imm1 := msg.b_imm1
+        store_offset := msg.store_offset
+        a_src_imm := boolF bits.a_src_imm
+        a_src_mem := boolF bits.a_src_mem
+        is_precompiled := boolF bits.is_precompiled
+        b_src_imm := boolF bits.b_src_imm
+        b_src_mem := boolF bits.b_src_mem
+        store_mem := boolF bits.store_mem
+        store_ind := boolF bits.store_ind
+        b_src_ind := boolF bits.b_src_ind
+        a_src_reg := boolF bits.a_src_reg
+        b_src_reg := boolF bits.b_src_reg
+        store_reg := boolF bits.store_reg
+        addr0 := free.addr0
+        addr1 := free.addr1
+        addr2 := free.addr2
+        main_step := free.main_step } }
 
 /-- The extra boolean obligations introduced by `mainWithRom`, beyond the
     original nine Main constraints. These are not part of Main's per-row
@@ -170,23 +421,73 @@ theorem romSpec_of_mainWithRomAndMemBus_constraints
     exact (Lookup.soundess_def table env (romMessageExpr row)).mp h_sound
   simpa [table, Table.fromStatic, StaticTable.toTable] using h_table_sound
 
+/-- Completeness for Main plus ROM lookup and memory-bus emissions. Rows are
+    constructible when they select a concrete program entry, provide flag bits
+    whose packed value equals that entry's ROM `flags`, choose a coherent local
+    Main execution shape, and otherwise fill only unconstrained runtime columns. -/
+theorem mainWithRomAndMemBus_completeness (length : ℕ) (program : Program length) :
+    GeneralFormalCircuit.Completeness FGL
+      (mainWithRomAndMemBusElaborated length program)
+      (fun row _ _ =>
+        ∃ i bits kind free,
+          (program i).flags = packFlags bits
+          ∧ MainRomExecKind.Coherent (program i) bits kind
+          ∧ row = mainRomRowOf (program i) bits kind free)
+      (fun _ _ _ => True) := by
+  circuit_proof_start_core
+  simp only [mainWithRomAndMemBus, mainWithRom, main, circuit_norm,
+    romMessageExpr, romFlagsExpr, aMemMessageExpr, bMemMessageExpr,
+    cMemMessageExpr, aMemOpExpr, bMemOpExpr, cMemOpExpr, storeValueLoExpr,
+    storeValueHiExpr, MemBusChannel, Lookup.completeness_def]
+  obtain ⟨i, bits, kind, free, h_flags, h_coherent, hrow⟩ := h_assumptions
+  rw [hrow] at h_input
+  simp only [circuit_norm] at h_input
+  cases kind with
+  | external flag c_0 c_1 =>
+    rcases h_coherent with ⟨h_ext, h_setpc⟩
+    cases flag
+    · simp_all [mainRomRowOf, packFlags, romStaticTable, boolF]
+      exact ⟨i, by
+        rw [ZiskFv.Channels.ZiskRomBus.ZiskRomMessage.mk.injEq]
+        simp [h_flags]⟩
+    · have h_setpc_false : bits.set_pc = false := h_setpc rfl
+      simp_all [mainRomRowOf, packFlags, romStaticTable, boolF]
+      exact ⟨i, by
+        rw [ZiskFv.Channels.ZiskRomBus.ZiskRomMessage.mk.injEq]
+        simp [h_flags]⟩
+  | internalFlag =>
+    rcases h_coherent with ⟨h_ext, h_op, h_setpc⟩
+    simp_all [mainRomRowOf, packFlags, romStaticTable, boolF]
+    exact ⟨i, by
+      rw [ZiskFv.Channels.ZiskRomBus.ZiskRomMessage.mk.injEq]
+      simp [h_flags, h_op]⟩
+  | internalCopyB =>
+    rcases h_coherent with ⟨h_ext, h_op⟩
+    simp_all [mainRomRowOf, packFlags, romStaticTable, boolF]
+    exact ⟨i, by
+      rw [ZiskFv.Channels.ZiskRomBus.ZiskRomMessage.mk.injEq]
+      simp [h_flags, h_op]⟩
+
 /-- Main as a Clean `GeneralFormalCircuit` exposing the ROM lookup and
-    the 3 memory-bus consumer emissions. Completeness is intentionally a
-    visible non-claim. -/
+    the 3 memory-bus consumer emissions. Completeness covers rows built from a
+    selected program entry, coherent ROM flag bits, and one local Main execution
+    shape. -/
 def circuitWithRomAndMemBus
     (length : ℕ) (program : Program length) :
     GeneralFormalCircuit FGL MainRowWithRom unit :=
   { mainWithRomAndMemBusElaborated length program with
     Assumptions := fun _ _ => True
     Spec := fun row _ _ => Spec row.core
-    -- Completeness is intentionally NOT claimed (zisk-fv is soundness-
-    -- only). `ProverAssumptions := False` makes this field a visible
-    -- non-claim. See trust/defects.md
-    -- ZISK-DEFECT-CLEAN-COMPLETENESS-TRIVIAL-AXIOMS.
-    ProverAssumptions := fun _ _ _ => False
+    -- Completeness covers rows whose ROM lookup columns are copied from a
+    -- concrete program entry and whose packed flag bits match that entry.
+    ProverAssumptions := fun row _ _ =>
+      ∃ i bits kind free,
+        (program i).flags = packFlags bits
+        ∧ MainRomExecKind.Coherent (program i) bits kind
+        ∧ row = mainRomRowOf (program i) bits kind free
     ProverSpec := fun _ _ _ => True
     soundness := mainWithRomAndMemBus_soundness length program
-    completeness := fun _ _ _ _ _ _ h => h.elim }
+    completeness := mainWithRomAndMemBus_completeness length program }
 
 /-- Main as a Clean `Air.Flat.Component` exposing the ROM lookup and
     the 3 memory-bus consumer interactions. Used by the full Clean
@@ -217,6 +518,27 @@ theorem mainWithRomMemAndOpBus_soundness (length : ℕ) (program : Program lengt
       offset env input_var input h_input h_assumptions h_mem
   simpa [mainWithRomMemAndOpBus, circuit_norm, OpBusChannel, MemBusChannel] using h_sound
 
+/-- Completeness wrapper for the unified ROM/memory/op-bus Main component.
+    The added operation-bus emission has a trivial channel guarantee, so the
+    ROM/memory constructibility theorem supplies the row-local work. -/
+theorem mainWithRomMemAndOpBus_completeness (length : ℕ) (program : Program length) :
+    GeneralFormalCircuit.Completeness FGL
+      (mainWithRomMemAndOpBusElaborated length program)
+      (fun row _ _ =>
+        ∃ i bits kind free,
+          (program i).flags = packFlags bits
+          ∧ MainRomExecKind.Coherent (program i) bits kind
+          ∧ row = mainRomRowOf (program i) bits kind free)
+      (fun _ _ _ => True) := by
+  intro offset env input_var h_env input h_input h_assumptions
+  have h_base :=
+    mainWithRomAndMemBus_completeness length program offset env input_var
+      (by
+        simp [mainWithRomMemAndOpBus, circuit_norm] at h_env
+        exact h_env)
+      input h_input h_assumptions
+  simpa [mainWithRomMemAndOpBus, circuit_norm, OpBusChannel, MemBusChannel] using h_base
+
 /-- Main as one Clean `GeneralFormalCircuit` exposing both Main channel
     surfaces from the same `MainRowWithRom`: the operation-bus consumer
     interaction and the ROM/memory-bus consumer interactions. -/
@@ -226,14 +548,16 @@ def circuitWithRomMemAndOpBus
   { mainWithRomMemAndOpBusElaborated length program with
     Assumptions := fun _ _ => True
     Spec := fun row _ _ => Spec row.core
-    -- Completeness is intentionally NOT claimed (zisk-fv is soundness-
-    -- only). `ProverAssumptions := False` makes this field a visible
-    -- non-claim. See trust/defects.md
-    -- ZISK-DEFECT-CLEAN-COMPLETENESS-TRIVIAL-AXIOMS.
-    ProverAssumptions := fun _ _ _ => False
+    -- Completeness uses the same ROM-backed honest-row predicate as
+    -- `circuitWithRomAndMemBus`; the added op-bus emission is structural.
+    ProverAssumptions := fun row _ _ =>
+      ∃ i bits kind free,
+        (program i).flags = packFlags bits
+        ∧ MainRomExecKind.Coherent (program i) bits kind
+        ∧ row = mainRomRowOf (program i) bits kind free
     ProverSpec := fun _ _ _ => True
     soundness := mainWithRomMemAndOpBus_soundness length program
-    completeness := fun _ _ _ _ _ _ h => h.elim }
+    completeness := mainWithRomMemAndOpBus_completeness length program }
 
 /-- Unified Main component used by the T7 full ensemble. -/
 def componentWithRomMemAndOpBus

--- a/ZiskFv/AirsClean/Main/Circuit.lean
+++ b/ZiskFv/AirsClean/Main/Circuit.lean
@@ -241,6 +241,7 @@ namespace MainRomExecKind
 
 /-- Semantic coherence between the ROM flag bits, the selected program row, and
     the local Main execution shape. -/
+@[reducible]
 def Coherent (msg : ZiskFv.Channels.ZiskRomBus.ZiskRomMessage FGL)
     (bits : RomFlagBits) : MainRomExecKind → Prop
   | external flag _ _ =>

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -548,7 +548,7 @@ origin/main..HEAD` clean.
       circuit_norm, OpBusChannel, MemBusChannel]` wrapper around the
       standalone theorem (mirror `mainWithRomMemAndOpBus_soundness`). Same
       ProverAssumptions for both.
-- [ ] Witness: concrete 1-instruction `Program` + one honest row per
+- [x] Witness: concrete 1-instruction `Program` + one honest row per
       `MainExecKind`; concrete `RomFlagBits` proving the coherence
       side-conditions are satisfiable.
 - [ ] Finalization sweep (only after Waves 2–4 have merged): CLAUDE.md
@@ -572,6 +572,12 @@ W5: Main `circuit`, `circuitWithRomAndMemBus`, and
 `circuitWithRomMemAndOpBus` now have builder-existential completeness proofs.
 `lake env lean ZiskFv/AirsClean/Main/Circuit.lean` and focused `lake build
 ZiskFv.AirsClean.Main.Circuit` pass.
+W5: Added `trust/consistency/completeness_witness_main.lean` with plain Main
+rows for all three `MainExecKind` shapes and ROM-backed one-instruction
+program witnesses for all three `MainRomExecKind` shapes across both
+ROM/memory circuits. `lake env lean
+trust/consistency/completeness_witness_main.lean` passes and prints only the
+standard closure.
 
 ## Hard invariants (every wave — violations fail review)
 

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -590,6 +590,11 @@ W5: Opened proof-only review PR #73 per Cody directive, with a non-empty body
 and first line `Queued for Claude review — do not merge.` Finalization sweep
 remains deferred until Waves 2-4 merge. Also filled non-empty descriptions on
 the other open Clean completeness PRs.
+W5: Addressed pre-merge review ask by marking
+`MainRomExecKind.Coherent` as `@[reducible]` so the named match-on-kind
+predicate remains transparent under the hidden-promise rule. Focused Main
+file check, Main witness check, focused Main build, and `git diff --check`
+passed after the change.
 
 ## Hard invariants (every wave — violations fail review)
 

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -558,7 +558,7 @@ origin/main..HEAD` clean.
       PROJECTS.md/STATUS.md closeout; list follow-ups (signed Arith
       disjuncts, table-op gaps). Do NOT touch `ZiskFv/Completeness/**`
       (the RV64IM stream's surface).
-- [ ] Verification block; open PR per protocol.
+- [x] Verification block; proof-only PR opened as #73 per Cody directive.
 
 W5: started `clean-completeness-wave5` in `.worktrees/completeness-wave5`
 from `origin/clean-completeness-wave1`, matching Waves 2-4 while PRs
@@ -583,8 +583,13 @@ full `lake build`, `trust/scripts/check-all.sh`,
 `trust/scripts/check-all-semantic.sh`, `nix run .#test`, empty trust
 generated/baseline diff, branch-local trust diff limited to
 `trust/consistency/completeness_witness_main.lean`, closure print with no
-project axiom names, `git diff --check`, and final source scans. Finalization
-sweep and PR opening remain deferred because Waves 2-4 are still open.
+project axiom names, `git diff --check`, and final source scans. At that
+checkpoint, finalization sweep and PR opening were deferred because Waves 2-4
+were still open.
+W5: Opened proof-only review PR #73 per Cody directive, with a non-empty body
+and first line `Queued for Claude review — do not merge.` Finalization sweep
+remains deferred until Waves 2-4 merge. Also filled non-empty descriptions on
+the other open Clean completeness PRs.
 
 ## Hard invariants (every wave — violations fail review)
 

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -509,8 +509,8 @@ origin/main..HEAD` clean.
 
 ### Checklist
 
-- [ ] Worktree + cache + baseline; STATUS.md; log `W5: started`.
-- [ ] Plain `circuit` (9 assertZeros + OpBus emit). The internal-op
+- [x] Worktree + cache + baseline; STATUS.md; log `W5: started`.
+- [x] Plain `circuit` (9 assertZeros + OpBus emit). The internal-op
       conditionals force exactly three honest shapes:
       ```lean
       inductive MainExecKind (F)
@@ -522,7 +522,7 @@ origin/main..HEAD` clean.
       plus `MainFreeCols` (a/b operands, pc, m32, ind_width, jmp offsets,
       store_pc, im_high_degree_2, segment_l1). Discharge by `cases k` +
       helpers.
-- [ ] `circuitWithRomAndMemBus length program` — builder from the program
+- [x] `circuitWithRomAndMemBus length program` — builder from the program
       ENTRY so the ROM lookup closes by construction:
       `RomFlagBits` (15 Bools, bit order of `romFlags`, main.pil:483-486);
       `packFlags : RomFlagBits → FGL` (verbatim `romFlags` polynomial);
@@ -544,7 +544,7 @@ origin/main..HEAD` clean.
       `Lookup.completeness_def` + `eval_romMessageExpr` manually, split
       `h_input` only for the assertZero goals. `MainRowWithRom` is a nested
       `{core, rom}` struct — nested `injection` as in Wave 4.
-- [ ] `circuitWithRomMemAndOpBus`: ~15-line `simpa [mainWithRomMemAndOpBus,
+- [x] `circuitWithRomMemAndOpBus`: ~15-line `simpa [mainWithRomMemAndOpBus,
       circuit_norm, OpBusChannel, MemBusChannel]` wrapper around the
       standalone theorem (mirror `mainWithRomMemAndOpBus_soundness`). Same
       ProverAssumptions for both.
@@ -559,6 +559,19 @@ origin/main..HEAD` clean.
       disjuncts, table-op gaps). Do NOT touch `ZiskFv/Completeness/**`
       (the RV64IM stream's surface).
 - [ ] Verification block; open PR per protocol.
+
+W5: started `clean-completeness-wave5` in `.worktrees/completeness-wave5`
+from `origin/clean-completeness-wave1`, matching Waves 2-4 while PRs
+#69-#72 remain open. Setup baseline passed: generated inputs populated,
+`lake exe cache get` passed after clearing local reproducible caches from an
+initial disk-full failure, `zisk` checked out pinned `4148c25e`, `lake build
+repl` passed, full `lake build` passed, and `trust/scripts/check-all.sh`
+passed all 17 checks. Finalization sweep remains deferred until Waves 2-4
+merge.
+W5: Main `circuit`, `circuitWithRomAndMemBus`, and
+`circuitWithRomMemAndOpBus` now have builder-existential completeness proofs.
+`lake env lean ZiskFv/AirsClean/Main/Circuit.lean` and focused `lake build
+ZiskFv.AirsClean.Main.Circuit` pass.
 
 ## Hard invariants (every wave — violations fail review)
 

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -595,6 +595,12 @@ W5: Addressed pre-merge review ask by marking
 predicate remains transparent under the hidden-promise rule. Focused Main
 file check, Main witness check, focused Main build, and `git diff --check`
 passed after the change.
+W5: Sequential merge prep after PRs #69/#70/#71/#72 landed: retargeted PR #73
+to `main`, rebased `clean-completeness-wave5` onto updated `origin/main`,
+resolved bookkeeping-only conflicts in `STATUS.md` and this plan, and confirmed
+the branch diff is limited to Wave 5 files with `git diff --check
+origin/main..HEAD` clean. The finalization sweep is now eligible but remains
+outside proof-only PR #73.
 
 ## Hard invariants (every wave — violations fail review)
 

--- a/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
+++ b/docs/ai/plan/PLAN_CLEAN_COMPLETENESS_PROOFS.md
@@ -578,6 +578,13 @@ program witnesses for all three `MainRomExecKind` shapes across both
 ROM/memory circuits. `lake env lean
 trust/consistency/completeness_witness_main.lean` passes and prints only the
 standard closure.
+W5: Verification passed: focused Main build, FullEnsemble and Balance builds,
+full `lake build`, `trust/scripts/check-all.sh`,
+`trust/scripts/check-all-semantic.sh`, `nix run .#test`, empty trust
+generated/baseline diff, branch-local trust diff limited to
+`trust/consistency/completeness_witness_main.lean`, closure print with no
+project axiom names, `git diff --check`, and final source scans. Finalization
+sweep and PR opening remain deferred because Waves 2-4 are still open.
 
 ## Hard invariants (every wave — violations fail review)
 

--- a/trust/consistency/completeness_witness_main.lean
+++ b/trust/consistency/completeness_witness_main.lean
@@ -1,0 +1,218 @@
+import ZiskFv.AirsClean.Main.Circuit
+
+namespace ZiskFv.TrustConsistency
+
+open Goldilocks
+open ZiskFv.AirsClean.Main
+
+private def mainFree : MainFreeCols :=
+  { a_0 := 10
+    a_1 := 11
+    b_0 := 20
+    b_1 := 21
+    pc := 0
+    m32 := 0
+    ind_width := 8
+    jmp_offset1 := 4
+    jmp_offset2 := 8
+    store_pc := 0
+    im_high_degree_2 := 0
+    segment_l1 := 0 }
+
+private def mainRomFree : MainRomFreeCols :=
+  { a_0 := 10
+    a_1 := 11
+    b_0 := 20
+    b_1 := 21
+    im_high_degree_2 := 0
+    segment_l1 := 0
+    addr0 := 100
+    addr1 := 200
+    addr2 := 300
+    main_step := 7 }
+
+private def finOne : Fin 1 := ⟨0, by decide⟩
+
+private def externalBits : RomFlagBits :=
+  { a_src_imm := false
+    a_src_mem := false
+    is_precompiled := false
+    b_src_imm := false
+    b_src_mem := false
+    is_external_op := true
+    store_pc := false
+    store_mem := false
+    store_ind := false
+    set_pc := false
+    m32 := false
+    b_src_ind := false
+    a_src_reg := true
+    b_src_reg := true
+    store_reg := true }
+
+private def internalFlagBits : RomFlagBits :=
+  { a_src_imm := false
+    a_src_mem := false
+    is_precompiled := false
+    b_src_imm := false
+    b_src_mem := false
+    is_external_op := false
+    store_pc := false
+    store_mem := false
+    store_ind := false
+    set_pc := false
+    m32 := false
+    b_src_ind := false
+    a_src_reg := false
+    b_src_reg := false
+    store_reg := false }
+
+private def internalCopyBits : RomFlagBits :=
+  { a_src_imm := false
+    a_src_mem := false
+    is_precompiled := false
+    b_src_imm := false
+    b_src_mem := false
+    is_external_op := false
+    store_pc := false
+    store_mem := false
+    store_ind := false
+    set_pc := true
+    m32 := false
+    b_src_ind := false
+    a_src_reg := false
+    b_src_reg := false
+    store_reg := false }
+
+private def romMsgOf (op flags : FGL) : ZiskFv.Channels.ZiskRomBus.ZiskRomMessage FGL :=
+  { line := 0
+    a_offset_imm0 := 1
+    a_imm1 := 2
+    b_offset_imm0 := 3
+    b_imm1 := 4
+    ind_width := 8
+    op := op
+    store_offset := 5
+    jmp_offset1 := 4
+    jmp_offset2 := 8
+    flags := flags }
+
+private def externalProgram : ZiskFv.AirsClean.ZiskInstructionRom.Program 1 :=
+  fun _ => romMsgOf 99 (packFlags externalBits)
+
+private def internalFlagProgram : ZiskFv.AirsClean.ZiskInstructionRom.Program 1 :=
+  fun _ => romMsgOf 0 (packFlags internalFlagBits)
+
+private def internalCopyProgram : ZiskFv.AirsClean.ZiskInstructionRom.Program 1 :=
+  fun _ => romMsgOf 1 (packFlags internalCopyBits)
+
+private def plainExternalRow : MainRow FGL :=
+  mainRowOf (.external 99 true 30 31 0) mainFree
+
+private def plainInternalFlagRow : MainRow FGL :=
+  mainRowOf .internalFlag mainFree
+
+private def plainInternalCopyRow : MainRow FGL :=
+  mainRowOf (.internalCopyB 42) mainFree
+
+private def romExternalRow : MainRowWithRom FGL :=
+  mainRomRowOf (externalProgram finOne) externalBits (.external true 30 31) mainRomFree
+
+private def romInternalFlagRow : MainRowWithRom FGL :=
+  mainRomRowOf (internalFlagProgram finOne) internalFlagBits .internalFlag mainRomFree
+
+private def romInternalCopyRow : MainRowWithRom FGL :=
+  mainRomRowOf (internalCopyProgram finOne) internalCopyBits .internalCopyB mainRomFree
+
+private theorem plainExternalWitness :
+    ∃ row : MainRow FGL, ∀ data hint, circuit.ProverAssumptions row data hint := by
+  refine ⟨plainExternalRow, ?_⟩
+  intro data hint
+  refine ⟨.external 99 true 30 31 0, mainFree, ?_⟩
+  rfl
+
+private theorem plainInternalFlagWitness :
+    ∃ row : MainRow FGL, ∀ data hint, circuit.ProverAssumptions row data hint := by
+  refine ⟨plainInternalFlagRow, ?_⟩
+  intro data hint
+  refine ⟨.internalFlag, mainFree, ?_⟩
+  rfl
+
+private theorem plainInternalCopyWitness :
+    ∃ row : MainRow FGL, ∀ data hint, circuit.ProverAssumptions row data hint := by
+  refine ⟨plainInternalCopyRow, ?_⟩
+  intro data hint
+  refine ⟨.internalCopyB 42, mainFree, ?_⟩
+  rfl
+
+private theorem romMemExternalWitness :
+    ∃ row : MainRowWithRom FGL, ∀ data hint,
+      (circuitWithRomAndMemBus 1 externalProgram).ProverAssumptions row data hint := by
+  refine ⟨romExternalRow, ?_⟩
+  intro data hint
+  refine ⟨finOne, externalBits, .external true 30 31, mainRomFree, rfl, ?_, rfl⟩
+  simp [MainRomExecKind.Coherent, externalBits]
+
+private theorem romMemInternalFlagWitness :
+    ∃ row : MainRowWithRom FGL, ∀ data hint,
+      (circuitWithRomAndMemBus 1 internalFlagProgram).ProverAssumptions row data hint := by
+  refine ⟨romInternalFlagRow, ?_⟩
+  intro data hint
+  refine ⟨finOne, internalFlagBits, .internalFlag, mainRomFree, rfl, ?_, rfl⟩
+  simp [MainRomExecKind.Coherent, internalFlagBits, internalFlagProgram, romMsgOf]
+
+private theorem romMemInternalCopyWitness :
+    ∃ row : MainRowWithRom FGL, ∀ data hint,
+      (circuitWithRomAndMemBus 1 internalCopyProgram).ProverAssumptions row data hint := by
+  refine ⟨romInternalCopyRow, ?_⟩
+  intro data hint
+  refine ⟨finOne, internalCopyBits, .internalCopyB, mainRomFree, rfl, ?_, rfl⟩
+  simp [MainRomExecKind.Coherent, internalCopyBits, internalCopyProgram, romMsgOf]
+
+private theorem romMemOpExternalWitness :
+    ∃ row : MainRowWithRom FGL, ∀ data hint,
+      (circuitWithRomMemAndOpBus 1 externalProgram).ProverAssumptions row data hint := by
+  refine ⟨romExternalRow, ?_⟩
+  intro data hint
+  refine ⟨finOne, externalBits, .external true 30 31, mainRomFree, rfl, ?_, rfl⟩
+  simp [MainRomExecKind.Coherent, externalBits]
+
+private theorem romMemOpInternalFlagWitness :
+    ∃ row : MainRowWithRom FGL, ∀ data hint,
+      (circuitWithRomMemAndOpBus 1 internalFlagProgram).ProverAssumptions row data hint := by
+  refine ⟨romInternalFlagRow, ?_⟩
+  intro data hint
+  refine ⟨finOne, internalFlagBits, .internalFlag, mainRomFree, rfl, ?_, rfl⟩
+  simp [MainRomExecKind.Coherent, internalFlagBits, internalFlagProgram, romMsgOf]
+
+private theorem romMemOpInternalCopyWitness :
+    ∃ row : MainRowWithRom FGL, ∀ data hint,
+      (circuitWithRomMemAndOpBus 1 internalCopyProgram).ProverAssumptions row data hint := by
+  refine ⟨romInternalCopyRow, ?_⟩
+  intro data hint
+  refine ⟨finOne, internalCopyBits, .internalCopyB, mainRomFree, rfl, ?_, rfl⟩
+  simp [MainRomExecKind.Coherent, internalCopyBits, internalCopyProgram, romMsgOf]
+
+theorem completeness_witness_main :
+    (∃ row : MainRow FGL, ∀ data hint, circuit.ProverAssumptions row data hint)
+    ∧ (∃ row : MainRow FGL, ∀ data hint, circuit.ProverAssumptions row data hint)
+    ∧ (∃ row : MainRow FGL, ∀ data hint, circuit.ProverAssumptions row data hint)
+    ∧ (∃ row : MainRowWithRom FGL, ∀ data hint,
+        (circuitWithRomAndMemBus 1 externalProgram).ProverAssumptions row data hint)
+    ∧ (∃ row : MainRowWithRom FGL, ∀ data hint,
+        (circuitWithRomAndMemBus 1 internalFlagProgram).ProverAssumptions row data hint)
+    ∧ (∃ row : MainRowWithRom FGL, ∀ data hint,
+        (circuitWithRomAndMemBus 1 internalCopyProgram).ProverAssumptions row data hint)
+    ∧ (∃ row : MainRowWithRom FGL, ∀ data hint,
+        (circuitWithRomMemAndOpBus 1 externalProgram).ProverAssumptions row data hint)
+    ∧ (∃ row : MainRowWithRom FGL, ∀ data hint,
+        (circuitWithRomMemAndOpBus 1 internalFlagProgram).ProverAssumptions row data hint)
+    ∧ (∃ row : MainRowWithRom FGL, ∀ data hint,
+        (circuitWithRomMemAndOpBus 1 internalCopyProgram).ProverAssumptions row data hint) := by
+  exact ⟨plainExternalWitness, plainInternalFlagWitness, plainInternalCopyWitness,
+    romMemExternalWitness, romMemInternalFlagWitness, romMemInternalCopyWitness,
+    romMemOpExternalWitness, romMemOpInternalFlagWitness, romMemOpInternalCopyWitness⟩
+
+#print axioms completeness_witness_main
+
+end ZiskFv.TrustConsistency


### PR DESCRIPTION
Queued for Claude review — do not merge.

## Summary
- Proves genuine Clean completeness for Main.circuit, circuitWithRomAndMemBus, and circuitWithRomMemAndOpBus.
- Adds honest row builders and builder-existential ProverAssumptions for plain and ROM-backed Main rows.
- Adds the Main anti-vacuity witness covering all three plain execution shapes and all three ROM-backed shapes across both ROM-backed circuits.

## Scope notes
- This is a proof-only Wave 5 PR stacked on clean-completeness-wave1. The stream finalization sweep remains deferred until Waves 2-4 merge.
- Completeness is row-local constructibility for rows equal to the Main builders with semantic ROM-entry coherence. It does not claim arbitrary input rows are honest executions.
- Cross-row PC evolution, program semantics beyond the selected ROM entry, and memory consistency remain out of scope for these component completeness fields.

## Verification
- lake build ZiskFv.AirsClean.Main.Circuit: passed.
- lake build ZiskFv.AirsClean.FullEnsemble: passed.
- lake build ZiskFv.AirsClean.FullEnsemble.Balance: passed.
- lake build: passed, final line Build completed successfully (8675 jobs).
- trust/scripts/check-all.sh: trust-gate: ALL CHECKS PASSED.
- trust/scripts/check-all-semantic.sh: trust-gate (V2 semantic): ALL CHECKS PASSED.
- nix run .#test: passed all 8 steps.
- Generated trust baseline diff was empty; branch-local trust diff only adds trust/consistency/completeness_witness_main.lean.
- Closure print emitted only existing TrustGate.Main deprecation warnings and no project axiom names.

Witness files discovered in the Wave 5 semantic gate:
- trust/consistency/completeness_witness_binaryadd.lean
- trust/consistency/completeness_witness_main.lean
- trust/consistency/completeness_witness_memalign.lean

## Notes for later waves
- After Waves 2-4 merge, run the finalization sweep: CLAUDE.md, trust/defects.md, PROJECTS.md/STATUS.md, and follow-up list.
- Do not touch ZiskFv/Completeness/** for this stream.
- Known follow-ups remain signed Arith disjuncts and documented table-op gaps.