### PR TITLE
Endgame P1-2: kernel-only field and signed proof sites

### DIFF
--- a/ZiskFv/Bits/PackedBitVec/Signed.lean
+++ b/ZiskFv/Bits/PackedBitVec/Signed.lean
@@ -78,7 +78,7 @@ lemma bv_toNat_lt_of_msb_false (v : BitVec 64) (h : v.msb = false) :
     `np = 0`), which makes the field-level identity consistent despite the
     hardware overflow. -/
 lemma int_tdiv_overflow_case :
-    Int.tdiv (-(2 : ℤ)^63) (-(1 : ℤ)) = (2 : ℤ)^63 := by native_decide
+    Int.tdiv (-(2 : ℤ)^63) (-(1 : ℤ)) = (2 : ℤ)^63 := by rfl
 
 lemma int_tdiv_intmin_neg1_eq :
     Int.tdiv (-(2 : ℤ)^63) (-(1 : ℤ)) = (2 : ℤ)^63 := int_tdiv_overflow_case

--- a/ZiskFv/Bits/PackedBitVec/SignedNoWrap.lean
+++ b/ZiskFv/Bits/PackedBitVec/SignedNoWrap.lean
@@ -269,18 +269,18 @@ lemma int_tdiv_overflow_full :
     W-variant (DIVW / REMW) boundary case, mirroring the full 64-bit
     `int_tdiv_overflow_full`. -/
 lemma int_tdiv_overflow_w :
-    Int.tdiv (-(2 : ℤ)^31) (-(1 : ℤ)) = (2 : ℤ)^31 := by native_decide
+    Int.tdiv (-(2 : ℤ)^31) (-(1 : ℤ)) = (2 : ℤ)^31 := by rfl
 
 /-- **`Int.tmod` at INT_MIN / -1.** Lean's `Int.tmod` gives `0` at the
     overflow boundary (since the exact quotient is mathematically clean,
     even if hardware overflows). Used by REM/REMW callers to discharge
     the `r2 = -1 ∧ r1 = INT_MIN` branch. -/
 lemma int_tmod_overflow_full :
-    Int.tmod (-(2 : ℤ)^63) (-(1 : ℤ)) = 0 := by native_decide
+    Int.tmod (-(2 : ℤ)^63) (-(1 : ℤ)) = 0 := by rfl
 
 /-- **32-bit `Int.tmod` at INT_MIN / -1.** The W-variant analogue. -/
 lemma int_tmod_overflow_w :
-    Int.tmod (-(2 : ℤ)^31) (-(1 : ℤ)) = 0 := by native_decide
+    Int.tmod (-(2 : ℤ)^31) (-(1 : ℤ)) = 0 := by rfl
 
 /-! ## Part 4 — 32-bit BitVec.toInt sign cases (W-variants)
 

--- a/ZiskFv/Field/Goldilocks.lean
+++ b/ZiskFv/Field/Goldilocks.lean
@@ -20,10 +20,9 @@ notation "FGL" => Fin GL_prime
 
 `p - 1 = 2^32 · 3 · 5 · 17 · 257 · 65537`, and `7` is a primitive root mod `p`.
 
-Each prime factor is ≤ 65537 and handled by a `.small` sub-certificate that
-defers to `Nat.decidablePrime` (fast under `native_decide`). Replaces a
-`native_decide` on `Nat.Prime p` that trial-divides up to `sqrt p ≈ 2^32`
-and took ~6 minutes cold. -/
+Each prime factor is ≤ 65537 and handled by a `.small` sub-certificate; the
+proof below unfolds the concrete verifier and discharges the arithmetic with
+`norm_num`. -/
 def goldilocks_pratt : ZiskFv.Pratt :=
   .step 18446744069414584321 7
     [ (2,     32, .small 2)
@@ -35,7 +34,8 @@ def goldilocks_pratt : ZiskFv.Pratt :=
     ]
 
 lemma prime_GoldilocksPrime : Nat.Prime GL_prime :=
-  ZiskFv.Pratt.verify_correct goldilocks_pratt (by native_decide)
+  ZiskFv.Pratt.verify_correct goldilocks_pratt (by
+    norm_num [goldilocks_pratt, ZiskFv.Pratt.verify, ZiskFv.Pratt.prime, ZiskFv.powMod])
 
 instance Fact_GLPrime : Fact (Nat.Prime GL_prime) := ⟨prime_GoldilocksPrime⟩
 instance : NeZero GL_prime := by constructor; decide

--- a/ZiskFv/Field/GoldilocksPrimality.lean
+++ b/ZiskFv/Field/GoldilocksPrimality.lean
@@ -1,4 +1,5 @@
 import Mathlib
+import Mathlib.Tactic.NormNum.Prime
 
 /-!
 # Pratt primality certificates
@@ -13,9 +14,9 @@ recursive Pratt certificates for each `qᵢ`, the verifier checks
 
 and certifies that `p` is prime.
 
-This is used to prove `Nat.Prime 18446744069414584321` (Goldilocks) quickly,
-replacing a `native_decide` that trial-divides up to `sqrt p ≈ 2^32` and
-takes ~6 minutes cold.
+This is used to prove `Nat.Prime 18446744069414584321` (Goldilocks) by
+normalizing a concrete certificate, avoiding a large direct primality
+decision on `p`.
 -/
 
 namespace ZiskFv
@@ -64,8 +65,8 @@ lemma powMod_eq (a : ℕ) : ∀ n p : ℕ, powMod a n p = a ^ n % p
 
 Two constructors:
 
-* `small p` — defers to mathlib's `Nat.decidablePrime` (for small primes such
-  as 2, 3, 5, 17, 257, 65537 this is essentially instant under `native_decide`).
+* `small p` — defers to mathlib's `Nat.decidablePrime`; in the concrete
+  Goldilocks certificate these are the small primes 2, 3, 5, 17, 257, 65537.
 * `step p a factors` — the recursive Lucas certificate:
   `factors = [(q₁, e₁, c₁), …, (qₖ, eₖ, cₖ)]`, with each `cᵢ : Pratt` a
   sub-certificate whose top-level prime equals `qᵢ`. -/

--- a/ZiskFv/Field/README.md
+++ b/ZiskFv/Field/README.md
@@ -10,9 +10,9 @@ for ZisK's algebraic constraints.
   shadowing creates a dummy instance that defeats `ring` and breaks
   `linear_combination` in subtle ways.
 - **`GoldilocksPrimality.lean`** — Pratt-style primality certificate
-  for *p*, proved via `native_decide`. **The slowest single proof in
-  the build (~6 min cold).** Mathlib's Azure cache covers everything
-  else, but this proof is project-local.
+  for *p*, proved by normalizing the concrete certificate with `norm_num`.
+  Mathlib's Azure cache covers everything else, but this proof is
+  project-local.
 - **`GoldilocksBridge.lean`** — ties the Mathlib `Field` / `ZMod`
   formalisation to the `Fin p` representation used elsewhere in the
   tree.


### PR DESCRIPTION
Queued for Claude review — do not merge.

## Summary

- Replaced the Goldilocks primality proof route with `norm_num` over the concrete Pratt certificate, using `Mathlib.Tactic.NormNum.Prime`.
- Replaced the signed `PackedBitVec` `Int.tdiv`/`Int.tmod` overflow boundary facts with direct kernel reductions (`rfl`).
- Removed stale Field documentation/comments that referred to the old executable decision route.

## Scope notes

- No soundness statement, `Spec :=`, `Assumptions :=`, `soundness :=`, or canonical `equiv_<OP>` signature changed.
- `trust/scripts/regenerate.sh` was run. Current canonical/global baselines on `origin/main` did not mention these touched closures, so regeneration produced no semantic `trust/generated` diff; the only generated change was a timestamp and it was restored.
- `git diff origin/main -- trust/` is empty for this PR.
- PR #79 remains open; this branch is independent from `origin/main` per the P1 plan.

## Verification

- Focused builds: `lake build ZiskFv.Field.Goldilocks`, `lake build ZiskFv.Bits.PackedBitVec.Signed`, and `lake build ZiskFv.Bits.PackedBitVec.SignedNoWrap` passed.
- Changed-declaration closure checks no longer contain `Lean.ofReduceBool` or `Lean.trustCompiler`:
  - `Goldilocks.prime_GoldilocksPrime`: `[propext, Classical.choice, Quot.sound]`
  - `Goldilocks.Fact_GLPrime`: `[propext, Classical.choice, Quot.sound]`
  - signed overflow declarations in `Signed` / `SignedNoWrap`: `[propext]`
- `lake build` passed; measured post-change full build time was `4:26.04` total. No pre-edit wall-time measurement was captured, so this PR makes no percentage comparison claim.
- `trust/scripts/check-all.sh` passed all 17 checks.
- `trust/scripts/check-all-semantic.sh` passed all 6 checks.
- `nix run .#test` passed all 8 stages.
- `git diff origin/main -- trust/` is empty.
- `git diff --check` is clean.
- Scoped `native_decide` sweep over `ZiskFv/Field`, `ZiskFv/Bits/PackedBitVec/Signed.lean`, and `ZiskFv/Bits/PackedBitVec/SignedNoWrap.lean` is empty.
- `lake exe trust-gate print-axiom-closure ZiskFv.Compliance.zisk_riscv_compliant_program_bus` completed successfully and emitted no closure lines beyond the existing TrustGate `String.trim` deprecation warnings.

## Notes

Remaining `native_decide` sites are intentionally left for P1-PR3 scope, including `ZiskFv/AirsClean/BinaryTable.lean`, `ZiskFv/Completeness/Rv64im/{SailDecode,Shapes}.lean`, and `trust/consistency/*` witness/probe files.
