### PR TITLE
Endgame P1-4: concrete ADD global theorem instantiation

### DIFF
--- a/trust/consistency/global_theorem_instantiation_add.lean
+++ b/trust/consistency/global_theorem_instantiation_add.lean
@@ -1,0 +1,230 @@
+import ZiskFv.Compliance
+
+namespace ZiskFv.TrustConsistency
+
+open Goldilocks
+open Interaction
+open ZiskFv.Airs.OperationBus
+open ZiskFv.AirsClean.Binary
+open ZiskFv.AirsClean.BinaryTable
+open ZiskFv.EquivCore.Promises
+
+private def addZeroBaseIndex : BinaryTableIndex :=
+  ⟨block10, by
+    norm_num [tableSize, block10, block9, block8, block7, block6, block5, block4,
+      block3, block2, block1, block0, minMaxBlockSize, absBlockSize, fullBlockSize,
+      bitwiseBlockSize, sextBlockSize]⟩
+
+private def addZeroFinalIndex : BinaryTableIndex :=
+  ⟨block10 + p2_16, by
+    norm_num [tableSize, block10, block9, block8, block7, block6, block5, block4,
+      block3, block2, block1, block0, minMaxBlockSize, absBlockSize, fullBlockSize,
+      bitwiseBlockSize, sextBlockSize, p2_16]⟩
+
+private def binaryAddZeroRow : BinaryRow FGL :=
+  binaryStaticRowOf false false false false false
+    addZeroBaseIndex addZeroBaseIndex addZeroBaseIndex addZeroBaseIndex
+    addZeroBaseIndex addZeroBaseIndex addZeroBaseIndex addZeroFinalIndex
+
+private theorem binaryAddZeroSpec : ZiskFv.AirsClean.Binary.Spec binaryAddZeroRow := by
+  norm_num [ZiskFv.AirsClean.Binary.Spec, binaryAddZeroRow, binaryStaticRowOf,
+    binaryRowOf, addZeroBaseIndex, addZeroFinalIndex, binaryBOpOrSextOf,
+    binaryMode32AndCIsSignedOf, rowOfIndex, lowByte, highByte, cOfIndex,
+    cinOfIndex, coutOfIndex, opOfIndex, opOfBlock, posIndOfIndex, relativeIndex,
+    startOfBlock, blockOfIndex, block10, block9, block8, block7, block6, block5,
+    block4, block3, block2, block1, block0, minMaxBlockSize, absBlockSize,
+    fullBlockSize, bitwiseBlockSize, sextBlockSize, p2_16, p2_17, p2_18, p2_19,
+    ZiskFv.Airs.Tables.BinaryTable.OP_ADD]
+
+private theorem binaryAddZeroStaticFacts : StaticBinaryTableSpecFacts binaryAddZeroRow := by
+  exact ⟨⟨addZeroBaseIndex, by rfl⟩, ⟨addZeroBaseIndex, by rfl⟩,
+    ⟨addZeroBaseIndex, by rfl⟩, ⟨addZeroBaseIndex, by rfl⟩,
+    ⟨addZeroBaseIndex, by rfl⟩, ⟨addZeroBaseIndex, by rfl⟩,
+    ⟨addZeroBaseIndex, by rfl⟩, ⟨addZeroFinalIndex, by rfl⟩⟩
+
+private theorem a64_zero :
+    ZiskFv.EquivCore.Add.binaryRowA64 binaryAddZeroRow = 0#64 := by
+  norm_num [ZiskFv.EquivCore.Add.binaryRowA64, binaryAddZeroRow,
+    binaryStaticRowOf, binaryRowOf, addZeroBaseIndex, addZeroFinalIndex,
+    binaryBOpOrSextOf, binaryMode32AndCIsSignedOf, rowOfIndex, lowByte,
+    highByte, cOfIndex, cinOfIndex, coutOfIndex, opOfIndex, opOfBlock,
+    posIndOfIndex, relativeIndex, startOfBlock, blockOfIndex, block10, block9,
+    block8, block7, block6, block5, block4, block3, block2, block1, block0,
+    minMaxBlockSize, absBlockSize, fullBlockSize, bitwiseBlockSize,
+    sextBlockSize, p2_16, p2_17, p2_18, p2_19,
+    ZiskFv.Airs.Tables.BinaryTable.OP_ADD]
+
+private theorem b64_zero :
+    ZiskFv.EquivCore.Add.binaryRowB64 binaryAddZeroRow = 0#64 := by
+  norm_num [ZiskFv.EquivCore.Add.binaryRowB64, binaryAddZeroRow,
+    binaryStaticRowOf, binaryRowOf, addZeroBaseIndex, addZeroFinalIndex,
+    binaryBOpOrSextOf, binaryMode32AndCIsSignedOf, rowOfIndex, lowByte,
+    highByte, cOfIndex, cinOfIndex, coutOfIndex, opOfIndex, opOfBlock,
+    posIndOfIndex, relativeIndex, startOfBlock, blockOfIndex, block10, block9,
+    block8, block7, block6, block5, block4, block3, block2, block1, block0,
+    minMaxBlockSize, absBlockSize, fullBlockSize, bitwiseBlockSize,
+    sextBlockSize, p2_16, p2_17, p2_18, p2_19,
+    ZiskFv.Airs.Tables.BinaryTable.OP_ADD]
+
+private def emptyData : ProverData FGL := fun _ _ => #[]
+
+private def providerRow : Array FGL := (toElements binaryAddZeroRow).toArray
+
+private def providerTable : Air.Flat.Table FGL where
+  component := staticLookupComponent
+  width := staticLookupComponent.width
+  table := [providerRow]
+  data := emptyData
+  uniform_width := by
+    intro row h_row
+    simp [providerRow] at h_row ⊢
+    subst row
+    rfl
+
+private theorem rowInput_provider :
+    staticLookupComponent.rowInput (providerTable.environment providerRow) =
+      binaryAddZeroRow := by
+  change staticLookupComponent.rowInput (Environment.fromArray providerRow emptyData) =
+    binaryAddZeroRow
+  simp [providerRow, staticLookupComponent, Air.Flat.Component.rowInput,
+    ProvableType.valueFromOffset_zero_fromInput_eq]
+
+private theorem providerTableSpec : providerTable.Spec := by
+  intro row h_row
+  simp [providerTable] at h_row
+  subst row
+  change staticLookupComponent.Spec (Environment.fromArray providerRow emptyData)
+  rw [staticLookupComponent_spec]
+  have h_row_input := rowInput_provider
+  change staticLookupComponent.rowInput (Environment.fromArray providerRow emptyData) =
+    binaryAddZeroRow at h_row_input
+  rw [h_row_input]
+  exact ⟨binaryAddZeroSpec, binaryAddZeroStaticFacts⟩
+
+private theorem providerRowMem : providerRow ∈ providerTable.table := by
+  simp [providerTable]
+
+private def witnessMainRow : ZiskFv.AirsClean.Main.MainRow FGL :=
+  { a_0 := 0, a_1 := 0, b_0 := 0, b_1 := 0, c_0 := 0, c_1 := 0, flag := 0,
+    pc := 0, is_external_op := 1, op := ZiskFv.Trusted.OP_ADD, m32 := 0,
+    ind_width := 8, set_pc := 0, jmp_offset1 := 4, jmp_offset2 := 4,
+    store_pc := 0, im_high_degree_2 := 0, segment_l1 := 1 }
+
+private def witnessMain : ZiskFv.Airs.Main.Valid_Main FGL FGL :=
+  ZiskFv.AirsClean.Main.validOfRow witnessMainRow
+
+private theorem addPins :
+    ZiskFv.Compliance.MainRowPins witnessMain 0 1 ZiskFv.Trusted.OP_ADD := by
+  exact ⟨rfl, rfl⟩
+
+private theorem opBusMatch :
+    matches_entry (opBus_row_Main witnessMain 0)
+      (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+        (ZiskFv.AirsClean.Binary.opBusMessage
+          (staticLookupComponent.rowInput (providerTable.environment providerRow))) 1) := by
+  rw [rowInput_provider]
+  norm_num [matches_entry, opBus_row_Main, witnessMain, witnessMainRow,
+    ZiskFv.AirsClean.Main.validOfRow, ZiskFv.AirsClean.Binary.opBusMessage,
+    binaryAddZeroRow, binaryStaticRowOf, binaryRowOf, addZeroBaseIndex,
+    addZeroFinalIndex, binaryBOpOrSextOf, binaryMode32AndCIsSignedOf, rowOfIndex,
+    lowByte, highByte, cOfIndex, cinOfIndex, coutOfIndex, opOfIndex, opOfBlock,
+    posIndOfIndex, relativeIndex, startOfBlock, blockOfIndex, block10, block9,
+    block8, block7, block6, block5, block4, block3, block2, block1, block0,
+    minMaxBlockSize, absBlockSize, fullBlockSize, bitwiseBlockSize, sextBlockSize,
+    p2_16, p2_17, p2_18, p2_19, ZiskFv.Airs.Tables.BinaryTable.OP_ADD,
+    ZiskFv.Trusted.OP_ADD]
+
+private def witnessState : PreSail.SequentialState RegisterType Sail.trivialChoiceSource :=
+  { (default : PreSail.SequentialState RegisterType Sail.trivialChoiceSource) with
+    regs := (default : PreSail.SequentialState RegisterType Sail.trivialChoiceSource).regs.insert
+      Register.PC (0#64) }
+
+private def addInput : PureSpec.AddInput :=
+  { r1_val := 0#64, r2_val := 0#64, rd := 0, PC := 0#64 }
+
+private def witnessExecRow : List (Interaction.ExecutionBusEntry FGL) :=
+  [ { multiplicity := -1, pc := 0, timestamp := 0 },
+    { multiplicity := 1, pc := 4, timestamp := 1 } ]
+
+private def memRead0 : Interaction.MemoryBusEntry FGL :=
+  { multiplicity := -1, as := 1, ptr := 0, value_0 := 0, value_1 := 0, timestamp := 0 }
+
+private def memRead1 : Interaction.MemoryBusEntry FGL :=
+  { multiplicity := -1, as := 1, ptr := 0, value_0 := 0, value_1 := 0, timestamp := 1 }
+
+private def memWrite0 : Interaction.MemoryBusEntry FGL :=
+  { multiplicity := 1, as := 1, ptr := 0, value_0 := 0, value_1 := 0, timestamp := 2 }
+
+private def witnessBus : ZiskFv.Compliance.BusRows :=
+  { exec_row := witnessExecRow, e0 := memRead0, e1 := memRead1, e2 := memWrite0 }
+
+private theorem inputR1Row :
+    addInput.r1_val =
+      ZiskFv.EquivCore.Add.binaryRowA64
+        (staticLookupComponent.rowInput (providerTable.environment providerRow)) := by
+  rw [rowInput_provider, a64_zero]
+  rfl
+
+private theorem inputR2Row :
+    addInput.r2_val =
+      ZiskFv.EquivCore.Add.binaryRowB64
+        (staticLookupComponent.rowInput (providerTable.environment providerRow)) := by
+  rw [rowInput_provider, b64_zero]
+  rfl
+
+private theorem laneRd :
+    ZiskFv.Airs.MemoryBus.register_write_lanes_match witnessMain 0 memWrite0 := by
+  simp [ZiskFv.Airs.MemoryBus.register_write_lanes_match, witnessMain, witnessMainRow,
+    ZiskFv.AirsClean.Main.validOfRow, memWrite0]
+
+private theorem promises :
+    RTypePromises witnessState addInput.r1_val addInput.r2_val addInput.rd addInput.PC
+      (PureSpec.execute_RTYPE_add_pure addInput).nextPC
+      (regidx.Regidx 0#5) (regidx.Regidx 0#5) (regidx.Regidx 0#5)
+      witnessExecRow memRead0 memRead1 memWrite0 := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · rfl
+  · rfl
+  · rfl
+  · simp [witnessState, addInput]
+  · rfl
+  · rfl
+  · rfl
+  · rfl
+  · rfl
+  · rfl
+  · rfl
+  · rfl
+  · rfl
+  · rfl
+  · rfl
+
+private def addZeroEnv : ZiskFv.Compliance.OpEnvelope witnessState witnessMain 0 :=
+  ZiskFv.Compliance.OpEnvelope.add_via_binary
+    addInput (regidx.Regidx 0#5) (regidx.Regidx 0#5) (regidx.Regidx 0#5)
+    witnessBus addPins providerTable providerRow rfl providerTableSpec providerRowMem
+    opBusMatch inputR1Row inputR2Row laneRd promises
+
+private theorem addZeroBridge : addZeroEnv.aeneasBridgeTrust := by
+  exact ⟨inputR1Row, inputR2Row⟩
+
+private theorem addZeroMemoryTimeline : addZeroEnv.memoryTimelineEvidence := by
+  trivial
+
+private theorem addZeroNoKnownDefect :
+    ZiskFv.Compliance.Defects.NoKnownDefect addZeroEnv := by
+  intro id h_block
+  cases id <;>
+    simp [ZiskFv.Compliance.Defects.Blocks,
+      ZiskFv.Compliance.Defects.MaliciousSignedMulWitnessShape,
+      ZiskFv.Compliance.Defects.ArithDivDynamicWitnessShape,
+      ZiskFv.Compliance.Defects.FenceKnownGoodShape, addZeroEnv] at h_block
+
+theorem global_theorem_instantiation_add :
+    addZeroEnv.exec_eq :=
+  ZiskFv.Compliance.zisk_riscv_compliant_program_bus
+    addZeroEnv addZeroBridge addZeroMemoryTimeline addZeroNoKnownDefect
+
+#print axioms global_theorem_instantiation_add
+
+end ZiskFv.TrustConsistency

--- a/trust/envelope-surface-add.md
+++ b/trust/envelope-surface-add.md
@@ -1,0 +1,62 @@
+# ADD envelope surface and LD survey
+
+This note records the concrete surface used by
+`trust/consistency/global_theorem_instantiation_add.lean` and the adjacent
+LD audit requested by issue #74.
+
+## ADD concrete instantiation
+
+| Surface | Concrete evidence |
+|---------|-------------------|
+| `OpEnvelope` arm | `OpEnvelope.add_via_binary` |
+| Pure input | `r1_val = 0#64`, `r2_val = 0#64`, `rd = 0`, `PC = 0#64` |
+| Sail registers | Default state with `PC` inserted as `0#64`; `x0` sources read as zero |
+| Main row pins | `is_external_op = 1`, `op = OP_ADD`, `m32 = 0`, `store_pc = 0` |
+| Main value lanes | `a_0/a_1/b_0/b_1/c_0/c_1/flag = 0` |
+| Binary provider | `staticLookupComponent`, one table row backed by `binaryAddZeroRow` |
+| Binary table indices | `block10` for bytes 0-6 and `block10 + 2^16` for byte 7 |
+| Binary row facts | `Binary.Spec`, eight `StaticBinaryTableSpecFacts`, `binaryRowA64 = 0#64`, `binaryRowB64 = 0#64` |
+| Operation bus | Main row matches Binary row message at multiplicity `1` |
+| Execution bus | Consumer `(multiplicity = -1, pc = 0, timestamp = 0)`, producer `(1, 4, 1)` |
+| Memory bus | Register reads `e0/e1` are consumers in address space `1`; register write `e2` is producer in address space `1` |
+| R-type promises | Source reads, `rd`, `PC`, next-PC, bus lengths, multiplicities, address spaces, and write-register index close by reduction |
+| Global theorem gates | `aeneasBridgeTrust`, non-load `memoryTimelineEvidence`, and `Defects.NoKnownDefect` close for this envelope |
+
+The checked theorem is:
+
+```lean
+theorem global_theorem_instantiation_add :
+    addZeroEnv.exec_eq
+```
+
+It is obtained by applying
+`ZiskFv.Compliance.zisk_riscv_compliant_program_bus` to the concrete ADD
+envelope and the three theorem-side gates above. The file uses explicit finite
+row reductions (`rfl`, `simp`, `norm_num`) and does not introduce a new axiom,
+`sorry`, or `native_decide`.
+
+## ADD bucket findings
+
+| Bucket | Finding |
+|--------|---------|
+| (a) Reducible constants and constructors | The concrete ADD envelope is constructible from existing row builders, `validOfRow`, `Environment.fromArray`, and the global theorem constructor surface. |
+| (b) Explicit table and bus evidence | The Binary static table membership and Main/Binary operation-bus match are explicit checked facts in the witness file. |
+| (c) Blockers | No ADD-specific blocker was found. The ADD arm is non-load, outside the signed multiplication, signed division/remainder, and FENCE defect predicates, and its memory-timeline gate reduces to `True`. |
+
+## LD survey
+
+| Surface | Required LD evidence |
+|---------|----------------------|
+| `OpEnvelope` arm | `OpEnvelope.ld` plus the `ldOfExtractedShape` wrapper route |
+| Main row pins | Load opcode pins, address lanes, destination lanes, and `m32`/mode facts for the selected LD row |
+| Mem provider | A concrete `Valid_Mem` row linked to the Main memory messages, including `mem.sel = 1` and `mem.wr = 0` |
+| Load promises | `LoadStructuralPromises`, `ModeRegsFull`, source register read, PC, next-PC, bus length and multiplicity facts |
+| Memory bus | Read and write entries must match the Main row/provider row interaction and the selected load byte/doubleword lanes |
+| Timeline gate | A nonempty `MemoryTimelineEvidence state bus.e1`, not `True` |
+| Existing witness | `trust/consistency/load_byte_agreement_witness.lean` proves the accepted replay/timeline shape for one selected read, but it is not yet wired into an `OpEnvelope.ld` constructor. |
+
+LD bucket-(c) finding: unlike ADD, the load route cannot close the global
+theorem's memory-timeline gate by reduction. A concrete LD instantiation needs
+accepted replay rows plus a concrete Mem provider row linked to the Main
+operation and memory messages before `OpEnvelope.ld` can be built. This is the
+remaining LD surface for the follow-on instantiation PR.

--- a/trust/scripts/check-all-semantic.sh
+++ b/trust/scripts/check-all-semantic.sh
@@ -54,13 +54,15 @@ run_witnesses() {
   return $ok
 }
 
-run "1/6 axiom-deps baseline (V2)"        "$dir/check-axiom-deps.sh"
-run "2/6 forbidden types (V2)"            "$dir/check-no-output-eq-v2.sh"
-run "3/6 closure vs baseline-axioms (V2)" "$dir/check-closure-vs-baseline.sh"
-run "4/6 consistency false probe rejected" reject_false_probe
-run "5/6 Sail memory timeline witness" \
+run "1/7 axiom-deps baseline (V2)"        "$dir/check-axiom-deps.sh"
+run "2/7 forbidden types (V2)"            "$dir/check-no-output-eq-v2.sh"
+run "3/7 closure vs baseline-axioms (V2)" "$dir/check-closure-vs-baseline.sh"
+run "4/7 consistency false probe rejected" reject_false_probe
+run "5/7 Sail memory timeline witness" \
   run_lean_no_sorry trust/consistency/load_byte_agreement_witness.lean
-run "6/6 Clean completeness witnesses" run_witnesses
+run "6/7 global ADD theorem instantiation" \
+  run_lean_no_sorry trust/consistency/global_theorem_instantiation_add.lean
+run "7/7 Clean completeness witnesses" run_witnesses
 
 if [ $overall -eq 0 ]; then
   echo "trust-gate (V2 semantic): ALL CHECKS PASSED."


### PR DESCRIPTION
Queued for Claude review — do not merge.

## Summary
- Adds `trust/consistency/global_theorem_instantiation_add.lean`, a concrete zero-operand ADD witness that builds `OpEnvelope.add_via_binary`, discharges `aeneasBridgeTrust`, non-load `memoryTimelineEvidence`, and `Defects.NoKnownDefect`, then applies `zisk_riscv_compliant_program_bus`.
- Wires the new witness into `trust/scripts/check-all-semantic.sh` as check 6/7.
- Adds `trust/envelope-surface-add.md` with the ADD field/fact survey and LD surface audit for issue #74.

## Bucket findings
- ADD bucket (a): constructible from existing row builders, `validOfRow`, `Environment.fromArray`, and the global theorem surface.
- ADD bucket (b): Binary static table membership and Main/Binary operation-bus match are explicit checked facts.
- ADD bucket (c): no ADD blocker found; the ADD arm is non-load and outside signed mul, signed div/rem, and FENCE defect predicates.
- LD bucket (c): concrete LD still needs accepted replay rows plus a concrete Mem provider row linked to Main memory/operation messages; unlike ADD, its memory-timeline gate does not reduce to `True`.

## Verification
- `lake env lean trust/consistency/global_theorem_instantiation_add.lean`
- `trust/scripts/check-all-semantic.sh`
- `trust/scripts/check-all.sh`
- `lake build`
- `nix run .#test`
- `lake exe trust-gate print-axiom-closure ZiskFv.Compliance.zisk_riscv_compliant_program_bus` (prints no project axioms after TrustGate replay warnings)
