### PR TITLE
Endgame P1-5: audit envelope burdens

### DIFF
--- a/trust/envelope-burden-audit.md
+++ b/trust/envelope-burden-audit.md
@@ -1,0 +1,138 @@
+# OpEnvelope burden audit
+
+This audit is the issue #61 three-bucket classification for the current
+`OpEnvelope` surface. It covers the 65 `OpEnvelope` constructors in
+`ZiskFv/Compliance/OpEnvelope.lean`, which cover the 63 canonical RV64IM
+opcode theorems plus the `auipc_x0` and `jal_x0` no-rd-write route variants.
+The route-named constructors are the seven documented in
+`trust/op-envelope-route-constructors.txt`.
+
+Inputs reviewed:
+
+- `ZiskFv/Compliance/OpEnvelope.lean`
+- `ZiskFv/Compliance.lean`
+- `ZiskFv/Compliance/AeneasBridgeTrust.lean`
+- `ZiskFv/Compliance/Defects.lean`
+- `ZiskFv/Compliance/SharedBundles.lean`
+- `ZiskFv/EquivCore/Promises/*.lean`
+- `trust/envelope-surface-add.md`
+- `trust/generated/baseline-caller-burden.txt` (63 canonical theorems, 1062 rows)
+- `trust/generated/baseline-wrapper-caller-burden.txt` (63 wrappers, 1117 rows)
+
+Buckets:
+
+- (a) Derivable by the construction theorem from accepted trace data:
+  component constraints, selected rows, channel balance, static tables, and
+  named trace-level premises such as program binding and machine-profile
+  invariants.
+- (b) Genuine named top-level premise for the trace-level theorem: boot/profile
+  assumptions, program binding, `aeneasBridgeTrust`, load memory timeline until
+  #76, and `Defects.NoKnownDefect`.
+- (c) Neither: constructor-carried facts that are not consequences of
+  constraints/channel balance and should not appear as standalone public
+  assumptions.
+
+## Result
+
+Most constructor fields are bucket (a): they are selected trace data, row
+membership, lookup/table soundness, bus entry matching, finite arithmetic
+facts, or promise-bundle projections. The public theorem still needs bucket (b)
+premises for the Rust/Aeneas lowering boundary, the memory replay boundary, the
+machine profile, program binding, and known-defect exclusions.
+
+Bucket (c) is not empty. The sub-doubleword store constructors (`sb`, `sh`,
+`sw`) expose high-byte read-modify-write facts (`h_m1` through `h_m7`, with the
+width-specific subset per opcode) that are not covered by the current named
+load-only `OpEnvelope.memoryTimelineEvidence`. These facts should be folded into
+the #76 memory replay/timeline construction or replaced by a named memory-replay
+premise that covers store events; they should not become per-store public
+premises.
+
+## Bucket (b) Premises
+
+| Premise class | Current surface | Final trace-level role |
+|---------------|-----------------|------------------------|
+| Program binding and decode | Pure input records, `r1`/`r2`/`rd`/`imm`/`shamt`/`fm`/`pred`/`succ`, opcode pins | Named `ProgramBinding`/decode premise; constructor projections should be generated |
+| Boot/profile state | `misa` C-bit facts, `cur_privilege = Machine`, `RISC_V_assumptions`, `ModeRegsFull`, PMA/mstatus/mseccfg values | Named initial-state/profile invariant; not 63 separate assumptions |
+| Aeneas lowering bridge | `env.aeneasBridgeTrust` in `Compliance.lean` | Named bridge premise until generated Aeneas Lean is imported by the main proof |
+| Load memory timeline | `env.memoryTimelineEvidence` for LD/LBU/LHU/LWU/LB/LH/LW routes | Named memory premise until #76 derives it from Mem AIR/replay |
+| Known defects | `Defects.NoKnownDefect env` | Named claim-weakening premise until signed MUL, signed DIV/REM, and FENCE defects retire |
+
+The raw `False` binders that still appear in the legacy signed-MUL and
+signed-DIV/REM wrappers are not `OpEnvelope` fields. The global theorem obtains
+them only by applying `Defects.NoKnownDefect`, so the trace-level statement
+should expose the named defect predicate, not raw contradictions.
+
+## Field-Shape Classification
+
+| Field shape | Examples | Bucket | Disposition |
+|-------------|----------|--------|-------------|
+| Data records and operands | `PureSpec.*Input`, `BranchInstrOperands`, `ModeRegsFull`, `BusRows`, `r1`, `r2`, `rd`, `imm`, `shamt`, `misa_val`, `mseccfg` | (a)/(b source) | Data is selected from the accepted trace; program/profile meaning comes from named bucket-(b) premises |
+| Main row activation and opcode pins | `MainRowPins`, `h_flag`, `h_m32`, `h_set_pc`, `h_store_pc`, `row_mode`, jump/FENCE mode pins | (a) except defect/profile pins | Derived from Main constraints, decode, and Aeneas-backed row lowering; FENCE good-shape restriction is `NoKnownDefect` |
+| Provider validators and row indices | `Valid_Binary`, `Valid_BinaryExtension`, `Valid_Mem`, `Valid_ArithMul`, `Valid_ArithDiv`, `r_main`, `r_mem`, `r_a`, `r_binary` | (a) | Selected by the accepted trace and channel-balance witnesses |
+| Static lookup witnesses | `providerTable`, `providerRow`, `h_component`, `h_table_spec`, `h_provider_row`, `StaticLookupSoundness`, `Arith*TableWitness` | (a) | Derivable from component constraints and lookup-aware Clean soundness |
+| Operation-bus matches | `h_match_static`, `h_match_primary`, `h_match_secondary`, `h_msg`, Main/Mem provider interaction equality | (a) | Derivable from channel balance plus selected provider rows |
+| Memory-bus entry matches | `StorePcMemoryWitness`, `ExternalArithMemoryWitness`, `h_main_b_match`, `h_main_c_match`, `register_write_lanes_match` | (a) | Derivable from Main/Mem row constraints and memory-bus channel balance |
+| Promise bundles | `RTypePromises`, `ITypePromises`, `BranchPromises`, `UTypePromises`, `JumpPromises`, `Shift*Promises`, `LoadStructuralPromises`, `StorePromises`, `FencePromises` | (a)/(b source) | Bus shape and register/PC bridges are generated; embedded profile facts are projections of named boot/profile premises |
+| Pure/state bridge equalities | `input_r1_eq`, `input_r2_eq`, `input_pc_eq`, `h_input_rs1`, `h_cur_privilege`, `h_mseccfg`, `h_input_imm`, `h_not_throws` | (a)/(b source) | Construct input records from state/program data; privilege/profile facts come from bucket (b) profile invariant |
+| Arithmetic row facts and ranges | `h_row_constraints`, `ByteBounds`, `Arith*ChunkRangeWitness`, `Arith*CarryRangeWitness`, `h_rs*_value`, `h_a23`, `h_b23`, `h_c23`, `h_sext_choice`, `h_na_bool`, `h_nb_bool`, `h_nr_bool`, `h_np_xor`, `remainder_bound` | (a), with defect-gated exceptions | Unsigned paths are constructive today; signed defect paths remain under `NoKnownDefect` until repaired |
+| Load memory timeline | `OpEnvelope.memoryTimelineEvidence` for load arms; `LoadStructuralPromises.withMemoryTimelineEvidence` in dispatch | (b) now, (a) after #76 | Named residual memory boundary |
+| Subword-store preserved bytes | `sb.h_m1..h_m7`, `sh.h_m2..h_m7`, `sw.h_m4..h_m7` | (c) | See bucket-(c) finding below |
+
+## Per-Family Classification
+
+| Family / constructors | Bucket (a) constructor burden | Bucket (b) premise source | Bucket (c) |
+|-----------------------|-------------------------------|---------------------------|------------|
+| Branch: `beq`, `bne`, `blt`, `bge`, `bltu`, `bgeu` | Branch input, operands, exec-row shape, PC/nextPC bus bridge, Main row pins | Program binding; `misa.C = 0` as profile invariant; `aeneasBridgeTrust` until imported | None |
+| FENCE: `fence` | `exec_row`, `MainRowPins`, PC bus shape | Machine privilege/profile; `NoKnownDefect` restricts to ZisK's known-good FENCE shape | None |
+| U/J control flow: `lui`, `auipc`, `auipc_x0`, `jal`, `jal_x0`, `jalr` | Store-PC memory witness, row provenance, subset facts, PC/offset finite arithmetic, no-write variants | Program binding; `misa`, privilege, and `mseccfg` profile facts; `aeneasBridgeTrust` | None |
+| Binary/Add/ITYPE: `add_via_binary`, `addi_via_binary`, `addw`, `subw`, `addiw`, `sub`, `and`, `or`, `xor`, `slt`, `sltu`, `andi`, `ori`, `xori`, `slti`, `sltiu` | Static Binary lookup table, provider row, operation-bus match, input-lane bridges, write-lane bridge, R/I-type promises | Program binding and Aeneas bridge | None |
+| Shift: `sll`, `srl`, `sra`, `slli`, `srli`, `srai`, `sllw`, `srlw`, `sraw`, `slliw`, `srliw`, `sraiw` | Static BinaryExtension lookup, shift amount pins, R/shift promise bundles or expanded W-form promise fields | Program binding and Aeneas bridge | None |
+| Stores: `sd` | Main c/store row, `StorePromises`, store-PC zero, address bridge, store byte lanes | Program/profile assumptions for Sail store semantics | None |
+| Stores: `sb`, `sh`, `sw` | Same Main c/store row facts as `sd`, plus opcode width pins and low written-byte lanes | Program/profile assumptions for Sail store semantics | Preserved high-byte memory facts, listed below |
+| Loads: `ld`, `lbu`, `lhu`, `lwu`, `lb_via_static_match`, `lh_via_static_match`, `lw_via_static_match` | Main b/c rows, Mem provider row, `Valid_Mem`, MemAlign witnesses for narrow zero-extend loads, BinaryExtension sign-extension provider for LB/LH/LW, address and rd-index facts | `memoryTimelineEvidence` until #76; program/profile assumptions | None beyond the named memory premise |
+| ArithMul unsigned/non-defect: `mulhu`, `mulw` | ArithMul row constraints, table/range/carry witnesses, op-bus match, external-arith memory witness, operand/result packing facts | Program binding and Aeneas bridge | None |
+| ArithMul signed defect-gated: `mul`, `mulh`, `mulhsu` | Constructor fields are ordinary row/table/bus facts, but dispatch false-eliminates from `NoKnownDefect` | `NoKnownDefect` excludes the current signed-MUL defect region | None under current defect-qualified theorem |
+| ArithDiv unsigned/non-defect: `divu`, `divuw`, `remu`, `remuw` | ArithDiv row constraints, table/range/carry/remainder witnesses, op-bus match, external-arith memory witness, operand/result packing facts | Program binding and Aeneas bridge | None |
+| ArithDiv signed defect-gated: `div`, `divw`, `rem`, `remw` | Constructor fields include dynamic sign/overflow/divisor facts, but dispatch is defect-qualified | `NoKnownDefect` excludes the current signed-DIV/REM defect region | None under current defect-qualified theorem |
+
+## Bucket-(c) Finding: Subword Store Preserved Bytes
+
+`OpEnvelope.sb`, `OpEnvelope.sh`, and `OpEnvelope.sw` carry the preserved
+high-byte facts that let Sail's byte/halfword/word store update be compared to
+ZisK's 8-lane memory-bus store entry:
+
+- `sb`: `h_m1`, `h_m2`, `h_m3`, `h_m4`, `h_m5`, `h_m6`, `h_m7`
+- `sh`: `h_m2`, `h_m3`, `h_m4`, `h_m5`, `h_m6`, `h_m7`
+- `sw`: `h_m4`, `h_m5`, `h_m6`, `h_m7`
+
+Each fact has shape `state.mem[bus.e2.ptr.toNat + i]? = some (byteAt bus.e2 i :
+BitVec 8)` for a byte lane not overwritten by the narrow store. It assumes that
+the store event's preserved byte lanes already agree with Sail memory before
+the store.
+
+This is not derivable from Main row constraints or channel balance alone. Those
+facts determine the store pointer and the low written bytes, but they do not by
+themselves connect the pre-store Sail memory map to the high lanes of the
+memory-bus event. It is also not a defensible final public premise to ask the
+trace theorem caller for per-store preserved-byte equalities.
+
+Disposition: move this burden into the memory replay construction. The right
+target is either an extension of `OpEnvelope.memoryTimelineEvidence` to store
+events or, preferably, #76 deriving the store replay step from Mem AIR accepted
+rows so these facts become bucket (a). Until then, the trace-level theorem
+should not claim that all store-memory facts have been hidden behind named
+public premises.
+
+## Non-Findings
+
+Load byte agreement is not bucket (c) anymore. It is exposed as
+`OpEnvelope.memoryTimelineEvidence` and threaded through
+`LoadStructuralPromises.withMemoryTimelineEvidence`, so it is bucket (b) until
+#76 derives it.
+
+The signed MUL and signed DIV/REM contradiction binders in wrappers are not
+bucket (c) constructor fields. They are legacy wrapper surfaces reached from
+the global theorem only through `Defects.NoKnownDefect`. When those defects are
+retired, the relevant arithmetic operand/sign/range fields must move to bucket
+(a), not become new public premises.


### PR DESCRIPTION
Queued for Claude review — do not merge.

Depends on PR #82 (`endgame-p1-pr4`). This PR is based on that branch so the review diff is only the PR5 audit payload.

Summary:
- Adds `trust/envelope-burden-audit.md`, covering the current `OpEnvelope` constructor surface for all 63 canonical opcode theorem surfaces and route variants.
- Classifies constructor field shapes into bucket (a) construction burden, bucket (b) named trace-level premises, and bucket (c) neither.
- Records the non-empty bucket-(c) finding: subword store preserved-byte RMW facts (`sb`/`sh`/`sw` `h_m*`) need to move into the memory replay/timeline construction rather than the final public theorem signature.

Verification:
- Baseline before the docs-only edit: `lake build` passed.
- After the audit doc: `trust/scripts/check-all.sh` passed.
- After the audit doc: `trust/scripts/check-all-semantic.sh` passed.
- Docs-only PR; did not rerun `nix run .#test` after the audit document change.
