### PR TITLE
Endgame P3-4: memory timeline construction core

### DIFF
--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -128,6 +128,7 @@ import ZiskFv.AirsClean.ArithTableProjections
 import ZiskFv.AirsClean.BinaryFamily.Balance
 import ZiskFv.AirsClean.FullEnsemble
 import ZiskFv.AirsClean.FullEnsemble.Balance
+import ZiskFv.ZiskCircuit.MemTimeline.Construction
 import ZiskFv.ZiskCircuit.MemTimeline.Linkage
 import ZiskFv.Compliance.RowProvenance
 import ZiskFv.Compliance

--- a/ZiskFv/ZiskCircuit/MemTimeline/Construction.lean
+++ b/ZiskFv/ZiskCircuit/MemTimeline/Construction.lean
@@ -1,0 +1,216 @@
+import ZiskFv.ZiskCircuit.MemTimeline.Linkage
+import ZiskFv.ZiskCircuit.MemTimeline.Ordering
+
+/-!
+# Memory timeline construction
+
+This module packages the memory-timeline constructor used before removing the
+global `h_memory_timeline` premise.  The circuit side supplies generated replay
+facts and selected-row coverage; the remaining named boundary is that the Sail
+state at the load is the state obtained by replaying the accepted chronological
+memory prefix.
+-/
+
+namespace ZiskFv.ZiskCircuit.MemTimeline
+
+open Goldilocks
+open Air.Flat
+open Interaction
+open ZiskFv.ZiskCircuit.MemTrace
+
+/-- P4-bound trace/state alignment for a selected accepted memory prefix.
+
+This is intentionally stronger and more structural than the byte-local
+`stateBytesAtPrefix` field: P4's accepted-trace construction should identify
+the load's Sail state with the result of applying the accepted chronological
+memory-bus prefix to the initial Sail state. -/
+@[reducible]
+def MemoryPrefixStateAlignment
+    (initialState state : SailState)
+    (priorRows : List (MemoryBusEntry FGL)) : Prop :=
+  state = stateAfterMemoryBusRows initialState priorRows
+
+/-- The P4-bound prefix alignment plus generated replay initial agreement gives
+the byte-local `stateBytesAtPrefix` field required by
+`MemoryTimelineEvidence`. -/
+theorem stateBytesAtPrefix_of_memoryPrefixStateAlignment
+    {initialState state : SailState}
+    {rows priorRows : List (MemoryBusEntry FGL)}
+    {entry : MemoryBusEntry FGL}
+    (facts : ZiskFv.AirsClean.Mem.GeneratedMemReplayFacts initialState rows)
+    (h_alignment : MemoryPrefixStateAlignment initialState state priorRows) :
+    ReplayMemoryAgreementOnBytes state
+      (replayMemoryAfterBusRows facts.initialMemory priorRows)
+      entry.ptr.toNat := by
+  unfold MemoryPrefixStateAlignment at h_alignment
+  subst state
+  intro i _hi
+  exact
+    replayAgreement_after_memoryBusRows
+      initialState priorRows facts.initialMemory facts.initialAgreement
+      (entry.ptr.toNat + i)
+
+/-- Construct timeline evidence from generated replay facts, a selected trace
+split, the selected-read fact, and the named prefix state alignment. -/
+@[reducible]
+def memoryTimelineEvidence_of_generated_replay_facts
+    {initialState state : SailState}
+    {rows : List (MemoryBusEntry FGL)}
+    {entry : MemoryBusEntry FGL}
+    (facts : ZiskFv.AirsClean.Mem.GeneratedMemReplayFacts initialState rows)
+    (priorRows laterRows : List (MemoryBusEntry FGL))
+    (h_traceSplit : rows = priorRows ++ entry :: laterRows)
+    (h_selectedRead :
+      memoryBusTraceEventOfRow entry = some (MemoryBusTraceEvent.read entry))
+    (h_alignment : MemoryPrefixStateAlignment initialState state priorRows) :
+    MemoryTimelineEvidence state entry where
+  acceptedReplay := acceptedMemoryReplayEvidenceOfGeneratedReplayFacts facts
+  priorRows := priorRows
+  laterRows := laterRows
+  traceSplit := by
+    simpa [acceptedMemoryReplayEvidenceOfGeneratedReplayFacts] using h_traceSplit
+  selectedRead := h_selectedRead
+  stateBytesAtPrefix :=
+    stateBytesAtPrefix_of_memoryPrefixStateAlignment
+      (entry := entry) facts h_alignment
+
+/-- Load structural promises provide the selected-read tag fact; generated replay
+facts and the named prefix alignment provide the rest of the timeline evidence. -/
+@[reducible]
+def memoryTimelineEvidence_of_load_structural_promises
+    {initialState state : SailState}
+    {mstatus : RegisterType Register.mstatus}
+    {pmaRegion : PMA_Region}
+    {misa : RegisterType Register.misa}
+    {mseccfg : RegisterType Register.mseccfg}
+    {opcode_assumptions : Prop}
+    {pure_nextPC : BitVec 64}
+    {exec_row : List (ExecutionBusEntry FGL)}
+    {e0 e1 e2 : MemoryBusEntry FGL}
+    {rows : List (MemoryBusEntry FGL)}
+    (facts : ZiskFv.AirsClean.Mem.GeneratedMemReplayFacts initialState rows)
+    (promises :
+      ZiskFv.EquivCore.Promises.LoadStructuralPromises state mstatus pmaRegion
+        misa mseccfg opcode_assumptions pure_nextPC exec_row e0 e1 e2)
+    (priorRows laterRows : List (MemoryBusEntry FGL))
+    (h_traceSplit : rows = priorRows ++ e1 :: laterRows)
+    (h_alignment : MemoryPrefixStateAlignment initialState state priorRows) :
+    MemoryTimelineEvidence state e1 :=
+  memoryTimelineEvidence_of_generated_replay_facts
+    facts priorRows laterRows h_traceSplit
+    (selectedRead_of_load_structural_promises promises)
+    h_alignment
+
+/-- Existential selected-row coverage plus a split-indexed prefix alignment gives
+nonempty timeline evidence for the load read row. -/
+theorem nonempty_memoryTimelineEvidence_of_load_structural_promises_split
+    {initialState state : SailState}
+    {mstatus : RegisterType Register.mstatus}
+    {pmaRegion : PMA_Region}
+    {misa : RegisterType Register.misa}
+    {mseccfg : RegisterType Register.mseccfg}
+    {opcode_assumptions : Prop}
+    {pure_nextPC : BitVec 64}
+    {exec_row : List (ExecutionBusEntry FGL)}
+    {e0 e1 e2 : MemoryBusEntry FGL}
+    {rows : List (MemoryBusEntry FGL)}
+    (facts : ZiskFv.AirsClean.Mem.GeneratedMemReplayFacts initialState rows)
+    (promises :
+      ZiskFv.EquivCore.Promises.LoadStructuralPromises state mstatus pmaRegion
+        misa mseccfg opcode_assumptions pure_nextPC exec_row e0 e1 e2)
+    (h_split : ∃ priorRows laterRows, rows = priorRows ++ e1 :: laterRows)
+    (h_alignment :
+      ∀ priorRows laterRows,
+        rows = priorRows ++ e1 :: laterRows →
+          MemoryPrefixStateAlignment initialState state priorRows) :
+    Nonempty (MemoryTimelineEvidence state e1) := by
+  obtain ⟨priorRows, laterRows, h_traceSplit⟩ := h_split
+  exact
+    ⟨memoryTimelineEvidence_of_load_structural_promises
+      facts promises priorRows laterRows h_traceSplit
+      (h_alignment priorRows laterRows h_traceSplit)⟩
+
+/-- Primary Mem provider coverage, selected-read load tags, and the P4-bound
+prefix alignment construct nonempty timeline evidence. -/
+theorem nonempty_memoryTimelineEvidence_of_primary_mem_provider_read_match
+    {initialState state : SailState}
+    {mstatus : RegisterType Register.mstatus}
+    {pmaRegion : PMA_Region}
+    {misa : RegisterType Register.misa}
+    {mseccfg : RegisterType Register.mseccfg}
+    {opcode_assumptions : Prop}
+    {pure_nextPC : BitVec 64}
+    {exec_row : List (ExecutionBusEntry FGL)}
+    {e0 e1 e2 : MemoryBusEntry FGL}
+    {rows : List (MemoryBusEntry FGL)}
+    {table : Table FGL}
+    {providerRow : Array FGL}
+    (facts : ZiskFv.AirsClean.Mem.GeneratedMemReplayFacts initialState rows)
+    (promises :
+      ZiskFv.EquivCore.Promises.LoadStructuralPromises state mstatus pmaRegion
+        misa mseccfg opcode_assumptions pure_nextPC exec_row e0 e1 e2)
+    (h_embedded : ZiskFv.AirsClean.FullEnsemble.MemReplayRowsEmbeddedInTrace table rows)
+    (h_row : providerRow ∈ table.table)
+    (h_wr :
+      (eval (table.environment providerRow)
+        ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar).wr = 0)
+    (h_match :
+      ZiskFv.Airs.MemoryBus.matches_memory_entry e1
+        (ZiskFv.AirsClean.FullEnsemble.memPrimaryReadReplayEntryOfRow
+          (eval (table.environment providerRow)
+            ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar)))
+    (h_alignment :
+      ∀ priorRows laterRows,
+        rows = priorRows ++ e1 :: laterRows →
+          MemoryPrefixStateAlignment initialState state priorRows) :
+    Nonempty (MemoryTimelineEvidence state e1) :=
+  nonempty_memoryTimelineEvidence_of_load_structural_promises_split
+    facts promises
+    (memoryBusTraceSplit_of_primary_mem_provider_read_match
+      h_embedded h_row h_wr h_match)
+    h_alignment
+
+/-- Dual Mem provider coverage, selected-read load tags, and the P4-bound prefix
+alignment construct nonempty timeline evidence. -/
+theorem nonempty_memoryTimelineEvidence_of_dual_mem_provider_read_match
+    {initialState state : SailState}
+    {mstatus : RegisterType Register.mstatus}
+    {pmaRegion : PMA_Region}
+    {misa : RegisterType Register.misa}
+    {mseccfg : RegisterType Register.mseccfg}
+    {opcode_assumptions : Prop}
+    {pure_nextPC : BitVec 64}
+    {exec_row : List (ExecutionBusEntry FGL)}
+    {e0 e1 e2 : MemoryBusEntry FGL}
+    {rows : List (MemoryBusEntry FGL)}
+    {table : Table FGL}
+    {providerRow : Array FGL}
+    (facts : ZiskFv.AirsClean.Mem.GeneratedMemReplayFacts initialState rows)
+    (promises :
+      ZiskFv.EquivCore.Promises.LoadStructuralPromises state mstatus pmaRegion
+        misa mseccfg opcode_assumptions pure_nextPC exec_row e0 e1 e2)
+    (h_embedded : ZiskFv.AirsClean.FullEnsemble.MemReplayRowsEmbeddedInTrace table rows)
+    (h_row : providerRow ∈ table.table)
+    (h_match :
+      ZiskFv.Airs.MemoryBus.matches_memory_entry e1
+        (ZiskFv.AirsClean.FullEnsemble.memDualReadReplayEntryOfRow
+          (eval (table.environment providerRow)
+            ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar)))
+    (h_alignment :
+      ∀ priorRows laterRows,
+        rows = priorRows ++ e1 :: laterRows →
+          MemoryPrefixStateAlignment initialState state priorRows) :
+    Nonempty (MemoryTimelineEvidence state e1) :=
+  nonempty_memoryTimelineEvidence_of_load_structural_promises_split
+    facts promises
+    (memoryBusTraceSplit_of_dual_mem_provider_read_match
+      h_embedded h_row h_match)
+    h_alignment
+
+#print axioms stateBytesAtPrefix_of_memoryPrefixStateAlignment
+#print axioms memoryTimelineEvidence_of_generated_replay_facts
+#print axioms memoryTimelineEvidence_of_load_structural_promises
+#print axioms nonempty_memoryTimelineEvidence_of_primary_mem_provider_read_match
+#print axioms nonempty_memoryTimelineEvidence_of_dual_mem_provider_read_match
+
+end ZiskFv.ZiskCircuit.MemTimeline

--- a/trust/consistency/memory_timeline_construction_witness.lean
+++ b/trust/consistency/memory_timeline_construction_witness.lean
@@ -1,0 +1,90 @@
+import ZiskFv.ZiskCircuit.MemTimeline.Construction
+
+namespace ZiskFv.TrustConsistency
+
+open Goldilocks
+open Interaction
+open ZiskFv.Channels.MemoryBusBytes (byteAt byteOf)
+open ZiskFv.EquivCore.Promises
+open ZiskFv.ZiskCircuit.MemTrace
+open ZiskFv.ZiskCircuit.MemTimeline
+
+private def selectedReadEntry : MemoryBusEntry FGL where
+  multiplicity := -1
+  as := 2
+  ptr := 0
+  value_0 := 0
+  value_1 := 0
+  timestamp := 1
+
+private def initialReplayMemory : Std.ExtHashMap ℕ (BitVec 8) :=
+  Std.ExtHashMap.insert
+    (Std.ExtHashMap.insert
+      (Std.ExtHashMap.insert
+        (Std.ExtHashMap.insert
+          (Std.ExtHashMap.insert
+            (Std.ExtHashMap.insert
+              (Std.ExtHashMap.insert
+                (Std.ExtHashMap.insert
+                  (default : PreSail.SequentialState RegisterType Sail.trivialChoiceSource).mem
+                  selectedReadEntry.ptr.toNat (byteAt selectedReadEntry 0))
+                (selectedReadEntry.ptr.toNat + 1) (byteAt selectedReadEntry 1))
+              (selectedReadEntry.ptr.toNat + 2) (byteAt selectedReadEntry 2))
+            (selectedReadEntry.ptr.toNat + 3) (byteAt selectedReadEntry 3))
+          (selectedReadEntry.ptr.toNat + 4) (byteAt selectedReadEntry 4))
+        (selectedReadEntry.ptr.toNat + 5) (byteAt selectedReadEntry 5))
+      (selectedReadEntry.ptr.toNat + 6) (byteAt selectedReadEntry 6))
+    (selectedReadEntry.ptr.toNat + 7) (byteAt selectedReadEntry 7)
+
+private def witnessState : PreSail.SequentialState RegisterType Sail.trivialChoiceSource :=
+  { (default : PreSail.SequentialState RegisterType Sail.trivialChoiceSource) with
+    mem := initialReplayMemory }
+
+private theorem initialAgreement :
+    ReplayMemoryAgreement witnessState initialReplayMemory := by
+  intro addr
+  rfl
+
+private theorem selectedReadReplayAgreement :
+    ReadEventReplayAgreement initialReplayMemory (eventOfEntry selectedReadEntry) := by
+  unfold ReadEventReplayAgreement eventOfEntry initialReplayMemory selectedReadEntry
+  simp [Std.ExtHashMap.getElem_insert, Std.ExtHashMap.getElem_insert_self,
+    MemEvent.byteAt, byteAt, byteOf]
+
+private theorem prefixReadSound :
+    MemoryBusRowsPrefixReadSound initialReplayMemory [selectedReadEntry] := by
+  intro priorRows row laterRows h_rows _h_as _h_mult
+  cases priorRows with
+  | nil =>
+      simp at h_rows
+      rcases h_rows with ⟨h_row, _h_laterRows⟩
+      subst row
+      exact selectedReadReplayAgreement
+  | cons _priorHead priorTail =>
+      cases priorTail <;> simp at h_rows
+
+private def generatedReplayFacts :
+    ZiskFv.AirsClean.Mem.GeneratedMemReplayFacts witnessState [selectedReadEntry] :=
+  { initialMemory := initialReplayMemory
+    prefixReadSound := prefixReadSound
+    initialAgreement := initialAgreement }
+
+private theorem witnessPrefixAlignment :
+    MemoryPrefixStateAlignment witnessState witnessState [] := by
+  rfl
+
+private def constructedTimelineWitness :
+    MemoryTimelineEvidence witnessState selectedReadEntry :=
+  memoryTimelineEvidence_of_generated_replay_facts
+    generatedReplayFacts [] [] rfl
+    (by simp [memoryBusTraceEventOfRow, selectedReadEntry])
+    witnessPrefixAlignment
+
+private theorem load_byte_agreement_of_constructed_timeline_witness :
+    LoadByteAgreement witnessState selectedReadEntry :=
+  loadByteAgreement_of_memory_timeline_evidence
+    witnessState selectedReadEntry constructedTimelineWitness
+
+#print axioms load_byte_agreement_of_constructed_timeline_witness
+
+end ZiskFv.TrustConsistency

--- a/trust/scripts/check-all-semantic.sh
+++ b/trust/scripts/check-all-semantic.sh
@@ -54,15 +54,17 @@ run_witnesses() {
   return $ok
 }
 
-run "1/7 axiom-deps baseline (V2)"        "$dir/check-axiom-deps.sh"
-run "2/7 forbidden types (V2)"            "$dir/check-no-output-eq-v2.sh"
-run "3/7 closure vs baseline-axioms (V2)" "$dir/check-closure-vs-baseline.sh"
-run "4/7 consistency false probe rejected" reject_false_probe
-run "5/7 Sail memory timeline witness" \
+run "1/8 axiom-deps baseline (V2)"        "$dir/check-axiom-deps.sh"
+run "2/8 forbidden types (V2)"            "$dir/check-no-output-eq-v2.sh"
+run "3/8 closure vs baseline-axioms (V2)" "$dir/check-closure-vs-baseline.sh"
+run "4/8 consistency false probe rejected" reject_false_probe
+run "5/8 Sail memory timeline witness" \
   run_lean_no_sorry trust/consistency/load_byte_agreement_witness.lean
-run "6/7 global ADD theorem instantiation" \
+run "6/8 memory timeline construction witness" \
+  run_lean_no_sorry trust/consistency/memory_timeline_construction_witness.lean
+run "7/8 global ADD theorem instantiation" \
   run_lean_no_sorry trust/consistency/global_theorem_instantiation_add.lean
-run "7/7 Clean completeness witnesses" run_witnesses
+run "8/8 Clean completeness witnesses" run_witnesses
 
 if [ $overall -eq 0 ]; then
   echo "trust-gate (V2 semantic): ALL CHECKS PASSED."


### PR DESCRIPTION
Queued for Claude review — do not merge.

## What changed
- Adds `MemoryPrefixStateAlignment` as the named P4-bound residual: the load Sail state equals replaying the accepted chronological memory prefix from the initial state.
- Derives the byte-local `stateBytesAtPrefix` obligation from generated replay initial agreement plus replay-after-prefix facts.
- Adds constructors for `MemoryTimelineEvidence` from generated replay facts, load structural promises, and primary/dual Mem provider coverage from P3-2/P3-3.
- Adds a positive construction witness to the V2 semantic gate; the new witness closes with only standard Lean axioms (`propext`, `Classical.choice`, `Quot.sound`).

## Review shape
This PR is stacked on `endgame-p3-pr4-base`, which contains the P3-2 and P3-3 dependency commits for a clean four-file PR4 diff. Retarget to `main` after #85 and #86 merge.

## Verification
- `lake build ZiskFv.ZiskCircuit.MemTimeline.Construction`
- `lake env lean trust/consistency/memory_timeline_construction_witness.lean`
- `lake build`
- `trust/scripts/check-all.sh`
- `trust/scripts/check-all-semantic.sh`
- `nix run .#test`
- `git diff --check`
- `git diff --cached --check`
- `lake exe trust-gate print-axiom-closure ZiskFv.Compliance.zisk_riscv_compliant_program_bus` produced only the known TrustGate `String.trim` warnings and no project axiom names.