### PR TITLE
Endgame P3 closeout: add global memory binder audit

### DIFF
--- a/bin/TrustGate/Main.lean
+++ b/bin/TrustGate/Main.lean
@@ -5,6 +5,7 @@ Subcommands:
   regenerate-deps              Print per-theorem axiom-dep baseline to stdout.
   check-deps PATH              Compare regenerated baseline against PATH.
   check-no-output-eq-v2 PATH   Type-walk; fail on forbidden Names from PATH.
+  print-global-binders         Print global theorem binder baseline rows.
   all                          Run check-deps + check-no-output-eq-v2 against
                                trust/generated/baseline-equiv-axiom-deps.txt and
                                trust/forbidden-types.txt.
@@ -79,6 +80,11 @@ def diffStrings (regenerated committed : String) : IO UInt32 := do
       if !rl.isEmpty then IO.eprintln s!"+{rl}"
       shown := shown + 1
   return 1
+
+/-- Collapse pretty-printer whitespace so generated baselines keep one row per
+binder even when the type is too wide for the default formatter. -/
+def normalizeWhitespace (s : String) : String :=
+  String.intercalate " " (s.splitToList (·.isWhitespace) |>.filter (!·.isEmpty))
 
 /-- Execute the type-walk against `forbidden`; returns 0 on clean run. -/
 def runTypeWalk (env : Environment) (forbidden : NameSet) : IO UInt32 := do
@@ -216,6 +222,17 @@ def cmdCheckClosureVsBaseline (env : Environment) (path : String)
   IO.eprintln "  and review (CODEOWNER required for ledger changes)."
   return 1
 
+/-- Subcommand: render the global theorem's elaborated binder list. This is a
+baseline-only audit surface; it does not apply policy or forbidden-name checks. -/
+def cmdPrintGlobalBinders (env : Environment) (theoremName : Name) : IO UInt32 := do
+  if (env.find? theoremName).isNone then
+    IO.eprintln s!"trust-gate: unknown const {theoremName}"
+    return 1
+  let rows ← runMeta env (TypeWalk.renderTheoremBinders theoremName)
+  for r in rows do
+    IO.println s!"{r.binderIdx} :: {r.binderName} :: {normalizeWhitespace r.binderType}"
+  return 0
+
 /-- Subcommand: enumerate every auditable `ZiskFv.*` const, subtract
 the reachable set, print the unreachable ones grouped by module. -/
 def cmdFindUnused (env : Environment) (path : String) : IO UInt32 := do
@@ -280,6 +297,7 @@ def usage : IO Unit := do
   IO.println "  print-reachable PATH           print every ZiskFv.* const reachable from entry-points in PATH"
   IO.println "  find-unused PATH               enumerate ZiskFv.* consts not reachable from PATH entry points"
   IO.println "  check-closure-vs-baseline PATH check zisk_riscv_compliant_program_bus axiom closure == generated/baseline-axioms.txt"
+  IO.println "  print-global-binders           print zisk_riscv_compliant_program_bus binder baseline rows"
   IO.println "  print-tree-edges NAME          emit TSV edge list (parent→child) for proof-tree visualizer"
 
 def dispatch (env : Environment) (args : List String) : IO UInt32 := do
@@ -306,6 +324,9 @@ def dispatch (env : Environment) (args : List String) : IO UInt32 := do
   | ["print-tree-edges", name] => cmdPrintTreeEdges env name
   | ["check-closure-vs-baseline", path] =>
     cmdCheckClosureVsBaseline env path
+      `ZiskFv.Compliance.zisk_riscv_compliant_program_bus
+  | ["print-global-binders"] =>
+    cmdPrintGlobalBinders env
       `ZiskFv.Compliance.zisk_riscv_compliant_program_bus
   | ["all"] =>
     let baseline ← IO.FS.readFile "trust/generated/baseline-equiv-axiom-deps.txt"

--- a/bin/TrustGate/TypeWalk.lean
+++ b/bin/TrustGate/TypeWalk.lean
@@ -80,6 +80,15 @@ structure Violation where
   hits       : Array Name
   deriving Inhabited
 
+/-- Rendered information for one theorem binder. This is an audit surface only:
+it records the elaborated binder name and type without applying any policy. -/
+structure BinderInfo where
+  thm        : Name
+  binderIdx  : Nat
+  binderName : Name
+  binderType : String
+  deriving Inhabited
+
 /-- For each parameter binder of `name`, scan its (reducible-closure)
 const set for forbidden Names. -/
 def checkTheorem (forbidden : NameSet) (name : Name)
@@ -103,5 +112,24 @@ def checkTheorem (forbidden : NameSet) (name : Name)
         viols := viols.push
           { thm := name, binderIdx := i, binderType := fmt.pretty, hits := hits }
     return viols
+
+/-- Render the parameter binders of `name` in elaborated order. -/
+def renderTheoremBinders (name : Name) : Meta.MetaM (Array BinderInfo) := do
+  let some ci := (← getEnv).find? name
+    | throwError s!"unknown const: {name}"
+  let typ := ci.type
+  Meta.forallTelescope typ fun args _ => do
+    let mut rows : Array BinderInfo := #[]
+    for h : i in [0:args.size] do
+      let arg := args[i]
+      let localDecl ← arg.fvarId!.getDecl
+      let bt ← Meta.inferType arg
+      let fmt ← Meta.ppExpr bt
+      rows := rows.push
+        { thm := name
+          binderIdx := i
+          binderName := localDecl.userName
+          binderType := fmt.pretty }
+    return rows
 
 end TrustGate.TypeWalk

--- a/trust/README.md
+++ b/trust/README.md
@@ -45,6 +45,7 @@ when they are not trust policy or trust evidence.
 | ---                                            | ---                                                           | ---                                                            |
 | `generated/baseline-axioms.txt`                | `trust/scripts/regenerate.py`                                 | Hash-pinned source ledger for allowed Lean trust declarations. |
 | `generated/baseline-zisk-riscv-compliant.txt`  | `lake exe trust-gate print-axiom-closure` via `regenerate.sh` | Active project-axiom closure of the global compliance theorem. |
+| `generated/baseline-global-theorem-binders.txt` | `lake exe trust-gate print-global-binders` via `regenerate.sh` | Elaborated binder list for the global compliance theorem.      |
 | `generated/baseline-equiv-axiom-deps.txt`      | `lake exe trust-gate regenerate-deps`                         | Per-canonical-theorem axiom closures.                          |
 | `generated/baseline-hypothesis-count.txt`      | `trust/scripts/count-hypotheses.py`                           | Anti-laundering metric for canonical theorem binder counts.    |
 | `generated/baseline-caller-burden.txt`         | `trust/scripts/regenerate-caller-burden.py`                   | Caller-burden ledger for canonical theorem binders.            |

--- a/trust/generated/baseline-global-theorem-binders.txt
+++ b/trust/generated/baseline-global-theorem-binders.txt
@@ -1,0 +1,7 @@
+0 :: state :: PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+1 :: m :: ZiskFv.Airs.Main.Valid_Main (Fin 18446744069414584321) (Fin 18446744069414584321)
+2 :: r_main :: Nat
+3 :: env :: ZiskFv.Compliance.OpEnvelope state m r_main
+4 :: h_bridge :: env.aeneasBridgeTrust
+5 :: h_memory_timeline :: env.memoryTimelineEvidence
+6 :: h_known_bugs :: ZiskFv.Compliance.Defects.NoKnownDefect env

--- a/trust/memory-argument-obligation-map.md
+++ b/trust/memory-argument-obligation-map.md
@@ -1,0 +1,78 @@
+# Memory Argument Obligation Map
+
+This map is the P3 close-out hand-off to P4. P3 does not reduce the memory trust
+surface: it leaves the global theorem's memory premise visible and auditable,
+then names the residual obligations P4 must remove.
+
+## Current Public Boundary
+
+The global theorem still takes
+`h_memory_timeline : env.memoryTimelineEvidence`
+([ZiskFv/Compliance.lean:94](../ZiskFv/Compliance.lean#L94),
+[ZiskFv/Compliance.lean:97](../ZiskFv/Compliance.lean#L97)) and threads it to
+the load and memory-touching dispatchers
+([ZiskFv/Compliance.lean:109](../ZiskFv/Compliance.lean#L109),
+[ZiskFv/Compliance.lean:111](../ZiskFv/Compliance.lean#L111),
+[ZiskFv/Compliance.lean:112](../ZiskFv/Compliance.lean#L112)).
+`OpEnvelope.memoryTimelineEvidence` is the current opaque load-family promise:
+each load arm requires `Nonempty (MemoryTimelineEvidence state bus.e1)`, while
+non-load arms are `True`
+([ZiskFv/Compliance/OpEnvelope.lean:2234](../ZiskFv/Compliance/OpEnvelope.lean#L2234),
+[ZiskFv/Compliance/OpEnvelope.lean:2239](../ZiskFv/Compliance/OpEnvelope.lean#L2239),
+[ZiskFv/Compliance/OpEnvelope.lean:2260](../ZiskFv/Compliance/OpEnvelope.lean#L2260)).
+
+`MemoryTimelineEvidence` decomposes the load promise into an accepted replay
+object, a selected row split, a read-tag fact, and byte agreement between the
+load Sail state and the replayed accepted prefix
+([ZiskFv/ZiskCircuit/MemTrace.lean:1266](../ZiskFv/ZiskCircuit/MemTrace.lean#L1266),
+[ZiskFv/ZiskCircuit/MemTrace.lean:1277](../ZiskFv/ZiskCircuit/MemTrace.lean#L1277),
+[ZiskFv/ZiskCircuit/MemTrace.lean:1280](../ZiskFv/ZiskCircuit/MemTrace.lean#L1280),
+[ZiskFv/ZiskCircuit/MemTrace.lean:1283](../ZiskFv/ZiskCircuit/MemTrace.lean#L1283),
+[ZiskFv/ZiskCircuit/MemTrace.lean:1284](../ZiskFv/ZiskCircuit/MemTrace.lean#L1284),
+[ZiskFv/ZiskCircuit/MemTrace.lean:1286](../ZiskFv/ZiskCircuit/MemTrace.lean#L1286)).
+
+## Ledger
+
+| Component | Status after P3 | Who removes it | Asset for the remover |
+| --- | --- | --- | --- |
+| `selectedRead` | Derived from load structural promises. | Done in P3. | `selectedRead_of_load_structural_promises` packages the `e1` read tag from `LoadStructuralPromises` ([ZiskFv/ZiskCircuit/MemTimeline/Linkage.lean:155](../ZiskFv/ZiskCircuit/MemTimeline/Linkage.lean#L155), [ZiskFv/ZiskCircuit/MemTimeline/Linkage.lean:169](../ZiskFv/ZiskCircuit/MemTimeline/Linkage.lean#L169)); the constructor consumes that derived fact directly ([ZiskFv/ZiskCircuit/MemTimeline/Construction.lean:99](../ZiskFv/ZiskCircuit/MemTimeline/Construction.lean#L99), [ZiskFv/ZiskCircuit/MemTimeline/Construction.lean:101](../ZiskFv/ZiskCircuit/MemTimeline/Construction.lean#L101)). |
+| `stateBytesAtPrefix` | Derived from `MemoryPrefixStateAlignment` plus generated replay `initialAgreement`. | Done in P3 once those residuals are supplied. | `stateBytesAtPrefix_of_memoryPrefixStateAlignment` rewrites the state through the alignment and applies `replayAgreement_after_memoryBusRows` using `facts.initialAgreement` ([ZiskFv/ZiskCircuit/MemTimeline/Construction.lean:36](../ZiskFv/ZiskCircuit/MemTimeline/Construction.lean#L36), [ZiskFv/ZiskCircuit/MemTimeline/Construction.lean:45](../ZiskFv/ZiskCircuit/MemTimeline/Construction.lean#L45), [ZiskFv/ZiskCircuit/MemTimeline/Construction.lean:49](../ZiskFv/ZiskCircuit/MemTimeline/Construction.lean#L49)). |
+| `prefixReadSound` | Named P4-bound residual. The single-segment circuit-side chain exists, but the whole-trace cross-segment assembly does not. | P4. | `GeneratedMemReplayFacts` currently carries `prefixReadSound` as a field ([ZiskFv/AirsClean/Mem/TraceSpec.lean:52](../ZiskFv/AirsClean/Mem/TraceSpec.lean#L52), [ZiskFv/AirsClean/Mem/TraceSpec.lean:56](../ZiskFv/AirsClean/Mem/TraceSpec.lean#L56)). The concrete single-segment asset derives active-table prefix soundness and packages `AcceptedMemoryReplayEvidence` from generated Mem AIR facts ([ZiskFv/AirsClean/FullEnsemble/Balance.lean:6172](../ZiskFv/AirsClean/FullEnsemble/Balance.lean#L6172), [ZiskFv/AirsClean/FullEnsemble/Balance.lean:6325](../ZiskFv/AirsClean/FullEnsemble/Balance.lean#L6325), [ZiskFv/AirsClean/FullEnsemble/Balance.lean:6474](../ZiskFv/AirsClean/FullEnsemble/Balance.lean#L6474)). P4 must assemble this across the accepted whole trace before it can remove the public memory premise. |
+| `initialAgreement` | Named P4/boot residual. | P4 / program binding. | `GeneratedMemReplayFacts` carries `initialAgreement` ([ZiskFv/AirsClean/Mem/TraceSpec.lean:58](../ZiskFv/AirsClean/Mem/TraceSpec.lean#L58)); it is consumed to derive `stateBytesAtPrefix` ([ZiskFv/ZiskCircuit/MemTimeline/Construction.lean:49](../ZiskFv/ZiskCircuit/MemTimeline/Construction.lean#L49), [ZiskFv/ZiskCircuit/MemTimeline/Construction.lean:50](../ZiskFv/ZiskCircuit/MemTimeline/Construction.lean#L50)). It ties Sail `initialState.mem` to circuit `initialMemory`, so it belongs to the trace/program-binding construction rather than `Valid_Mem`. |
+| `MemoryPrefixStateAlignment` | Named P4-bound residual. | P4. | The alignment identifies the selected load Sail state with replaying the accepted memory-bus prefix from the initial state ([ZiskFv/ZiskCircuit/MemTimeline/Construction.lean:21](../ZiskFv/ZiskCircuit/MemTimeline/Construction.lean#L21), [ZiskFv/ZiskCircuit/MemTimeline/Construction.lean:28](../ZiskFv/ZiskCircuit/MemTimeline/Construction.lean#L28), [ZiskFv/ZiskCircuit/MemTimeline/Construction.lean:31](../ZiskFv/ZiskCircuit/MemTimeline/Construction.lean#L31)). The nonempty constructors still take this split-indexed alignment as an input ([ZiskFv/ZiskCircuit/MemTimeline/Construction.lean:121](../ZiskFv/ZiskCircuit/MemTimeline/Construction.lean#L121), [ZiskFv/ZiskCircuit/MemTimeline/Construction.lean:125](../ZiskFv/ZiskCircuit/MemTimeline/Construction.lean#L125), [ZiskFv/ZiskCircuit/MemTimeline/Construction.lean:162](../ZiskFv/ZiskCircuit/MemTimeline/Construction.lean#L162)). |
+| store RMW preserved bytes (`sb`/`sh`/`sw` `h_m*`) | Bucket-(c), outside P3's load-only scope. | P4. | The envelope audit identifies the preserved-byte facts and explains that they should move into the memory replay construction or a store-event extension of the memory timeline ([trust/envelope-burden-audit.md:99](envelope-burden-audit.md#L99), [trust/envelope-burden-audit.md:120](envelope-burden-audit.md#L120), [trust/envelope-burden-audit.md:125](envelope-burden-audit.md#L125)). |
+
+## P4 Assets That Are Not Yet a Discharge
+
+The ordering lemmas in `ZiskFv/ZiskCircuit/MemTimeline/Ordering.lean` are useful
+P4 assets for same-address ordering and read-carry reasoning. They expose
+same-address read facts, adjacent read-chain facts, and primary/dual timestamp
+monotonicity
+([ZiskFv/ZiskCircuit/MemTimeline/Ordering.lean:21](../ZiskFv/ZiskCircuit/MemTimeline/Ordering.lean#L21),
+[ZiskFv/ZiskCircuit/MemTimeline/Ordering.lean:72](../ZiskFv/ZiskCircuit/MemTimeline/Ordering.lean#L72),
+[ZiskFv/ZiskCircuit/MemTimeline/Ordering.lean:121](../ZiskFv/ZiskCircuit/MemTimeline/Ordering.lean#L121),
+[ZiskFv/ZiskCircuit/MemTimeline/Ordering.lean:139](../ZiskFv/ZiskCircuit/MemTimeline/Ordering.lean#L139),
+[ZiskFv/ZiskCircuit/MemTimeline/Ordering.lean:157](../ZiskFv/ZiskCircuit/MemTimeline/Ordering.lean#L157)).
+They are intentionally not wired into the current construction: using them well
+requires P4's whole-trace accepted-row assembly.
+
+The full-witness sidecar path likewise remains an asset, not a public-theorem
+discharge. It can construct `MemoryTimelineEvidence` from generated Mem facts
+only after being given the selected trace split, read tag, and state/prefix byte
+agreement
+([ZiskFv/AirsClean/FullEnsemble/Balance.lean:6495](../ZiskFv/AirsClean/FullEnsemble/Balance.lean#L6495),
+[ZiskFv/AirsClean/FullEnsemble/Balance.lean:6501](../ZiskFv/AirsClean/FullEnsemble/Balance.lean#L6501),
+[ZiskFv/AirsClean/FullEnsemble/Balance.lean:6503](../ZiskFv/AirsClean/FullEnsemble/Balance.lean#L6503),
+[ZiskFv/AirsClean/FullEnsemble/Balance.lean:6504](../ZiskFv/AirsClean/FullEnsemble/Balance.lean#L6504),
+[ZiskFv/AirsClean/FullEnsemble/Balance.lean:6507](../ZiskFv/AirsClean/FullEnsemble/Balance.lean#L6507),
+[ZiskFv/AirsClean/FullEnsemble/Balance.lean:6514](../ZiskFv/AirsClean/FullEnsemble/Balance.lean#L6514)).
+Generated-artifact wrappers preserve the sidecar provenance
+([ZiskFv/AirsClean/FullEnsemble/Balance.lean:6758](../ZiskFv/AirsClean/FullEnsemble/Balance.lean#L6758),
+[ZiskFv/AirsClean/FullEnsemble/Balance.lean:6807](../ZiskFv/AirsClean/FullEnsemble/Balance.lean#L6807)).
+
+## Close-Out Rule
+
+P3 done does not mean memory trust is reduced. P3 done means the memory premise is
+auditable and the remaining work is named: whole-trace `prefixReadSound`,
+`initialAgreement`, `MemoryPrefixStateAlignment`, and store preserved-byte replay
+belong to P4.

--- a/trust/scripts/check-all-semantic.sh
+++ b/trust/scripts/check-all-semantic.sh
@@ -54,17 +54,18 @@ run_witnesses() {
   return $ok
 }
 
-run "1/8 axiom-deps baseline (V2)"        "$dir/check-axiom-deps.sh"
-run "2/8 forbidden types (V2)"            "$dir/check-no-output-eq-v2.sh"
-run "3/8 closure vs baseline-axioms (V2)" "$dir/check-closure-vs-baseline.sh"
-run "4/8 consistency false probe rejected" reject_false_probe
-run "5/8 Sail memory timeline witness" \
+run "1/9 axiom-deps baseline (V2)"        "$dir/check-axiom-deps.sh"
+run "2/9 forbidden types (V2)"            "$dir/check-no-output-eq-v2.sh"
+run "3/9 closure vs baseline-axioms (V2)" "$dir/check-closure-vs-baseline.sh"
+run "4/9 global theorem binders (V2)"     "$dir/check-global-theorem-binders.sh"
+run "5/9 consistency false probe rejected" reject_false_probe
+run "6/9 Sail memory timeline witness" \
   run_lean_no_sorry trust/consistency/load_byte_agreement_witness.lean
-run "6/8 memory timeline construction witness" \
+run "7/9 memory timeline construction witness" \
   run_lean_no_sorry trust/consistency/memory_timeline_construction_witness.lean
-run "7/8 global ADD theorem instantiation" \
+run "8/9 global ADD theorem instantiation" \
   run_lean_no_sorry trust/consistency/global_theorem_instantiation_add.lean
-run "8/8 Clean completeness witnesses" run_witnesses
+run "9/9 Clean completeness witnesses" run_witnesses
 
 if [ $overall -eq 0 ]; then
   echo "trust-gate (V2 semantic): ALL CHECKS PASSED."

--- a/trust/scripts/check-global-theorem-binders.sh
+++ b/trust/scripts/check-global-theorem-binders.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# check-global-theorem-binders.sh - V2: assert that the global compliance
+# theorem's elaborated binder list matches the committed baseline.
+#
+# This catches trust-surface reshapes that do not affect the 63 canonical
+# `equiv_<OP>` signatures or the project-axiom closure.
+#
+# Requires `lake build` to have run (consumes oleans).
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+baseline=trust/generated/baseline-global-theorem-binders.txt
+if [ ! -f "$baseline" ]; then
+  echo "trust-gate (V2): missing $baseline."
+  exit 1
+fi
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+lake exe trust-gate print-global-binders > "$tmp"
+
+if diff -u "$baseline" "$tmp"; then
+  echo "trust-gate (V2): global theorem binder baseline matches."
+else
+  echo "trust-gate (V2): global theorem binder baseline DIFFERS."
+  echo "  Run:"
+  echo "    lake exe trust-gate print-global-binders > $baseline"
+  echo "  and review the diff before committing."
+  exit 1
+fi

--- a/trust/scripts/regenerate.sh
+++ b/trust/scripts/regenerate.sh
@@ -2,10 +2,11 @@
 # Refresh the trust baseline files. Run this after a legitimate
 # trust-surface change, commit the updated baseline files alongside.
 #
-# Six baselines:
+# Seven baselines:
 #   trust/generated/baseline-axioms.txt                  — V1: source-text-hash per axiom
 #   trust/generated/baseline-equiv-axiom-deps.txt        — V2: per-theorem axiom closure
 #   trust/generated/baseline-zisk-riscv-compliant.txt    — V2: uber-theorem project-axiom closure
+#   trust/generated/baseline-global-theorem-binders.txt  — V2: uber-theorem binder list
 #   trust/generated/baseline-hypothesis-count.txt        — anti-laundering: per-theorem binder counts
 #   trust/generated/baseline-caller-burden.txt           — anti-laundering: per-binder ledger (canonical)
 #   trust/generated/baseline-wrapper-caller-burden.txt   — anti-laundering: per-binder ledger (wrappers)
@@ -38,6 +39,10 @@ if [ -d .lake/build ]; then
   echo "Refreshing V2 per-theorem axiom-dep baseline..."
   lake exe trust-gate regenerate-deps > trust/generated/baseline-equiv-axiom-deps.txt
   echo "  → trust/generated/baseline-equiv-axiom-deps.txt"
+
+  echo "Refreshing global theorem binder baseline..."
+  lake exe trust-gate print-global-binders > trust/generated/baseline-global-theorem-binders.txt
+  echo "  → trust/generated/baseline-global-theorem-binders.txt"
 
   echo "Refreshing uber-theorem axiom-closure baseline..."
   {
@@ -86,5 +91,6 @@ if [ -d .lake/build ]; then
   echo "  → trust/generated/baseline-zisk-riscv-compliant.txt"
 else
   echo "Skipping V2 axiom-dep regeneration (no .lake/build/ — run \`lake build\` first)."
+  echo "Skipping global theorem binder baseline (no .lake/build/ — run \`lake build\` first)."
   echo "Skipping uber-theorem closure baseline (no .lake/build/ — run \`lake build\` first)."
 fi


### PR DESCRIPTION
Queued for Claude review — do not merge.

Summary
- Adds TrustGate `print-global-binders` for `ZiskFv.Compliance.zisk_riscv_compliant_program_bus`.
- Adds `trust/generated/baseline-global-theorem-binders.txt` and an exact-diff semantic gate.
- Adds `trust/memory-argument-obligation-map.md` documenting that P3 reshapes/audits the memory premise but does not reduce memory trust; P4 owns the named residuals.

Scope
- No theorem statements changed.
- No new assumptions, axioms, sorries, unsafe/opaque/partial declarations, or forbidden policy edits.
- Canonical `equiv_<OP>` baselines remain byte-identical.

Verification
- `lake build`
- `trust/scripts/check-all.sh`
- `trust/scripts/check-all-semantic.sh`
- `lake build LeanRV64D Clean` (fresh-worktree dependency oleans for semantic scripts)
- `nix run .#test`
- `lake exe trust-gate print-axiom-closure ZiskFv.Compliance.zisk_riscv_compliant_program_bus` (prints no project axioms)
- `git diff origin/main -- trust/`

Notes
- This PR is Rework-PR-A only: auditability apparatus plus obligation map.
- The current baseline intentionally records `h_memory_timeline :: env.memoryTimelineEvidence`; PR-B should make the single reviewable binder-line reshape visible.
- The remaining memory obligations are P4-bound: whole-trace `prefixReadSound`, `initialAgreement`, `MemoryPrefixStateAlignment`, and store preserved-byte replay.