### PR TITLE
Endgame P3 closeout: reshape memory residual

### DIFF
--- a/ZiskFv/Compliance.lean
+++ b/ZiskFv/Compliance.lean
@@ -50,9 +50,10 @@ boundary for Aeneas-backed row-lowering facts that are still carried as
 `OpEnvelope` fields while generated Aeneas Lean is not imported by the main
 proof.
 
-It also assumes `env.memoryTimelineEvidence`, the single visible residual
-memory boundary for load arms: the selected load entry agrees with the Sail
-memory timeline. Non-load arms impose no memory-timeline obligation.
+It also assumes `env.memoryTimelineConstructionEvidence`, the single visible
+construction residual for load arms: the generated replay trace contains the
+selected load row, and the load Sail state aligns with the selected replay
+prefix. Non-load arms impose no memory-timeline obligation.
 
 `zisk_riscv_compliant_program_bus` is the single public global theorem. It is
 defect-aware while `trust/defects.md` contains open claim-weakening defects:
@@ -74,7 +75,7 @@ variable {m : Valid_Main FGL FGL} {r_main : ℕ}
     non-trivially for any given arm; the others are `True`. -/
 def OpEnvelope.exec_eq (env : OpEnvelope state m r_main) : Prop :=
   env.aeneasBridgeTrust
-    ∧ env.memoryTimelineEvidence
+    ∧ env.memoryTimelineConstructionEvidence
     ∧ env.exec_eq_branch
     ∧ env.exec_eq_nomem
     ∧ env.exec_eq_rtype_binary
@@ -94,21 +95,21 @@ def OpEnvelope.exec_eq (env : OpEnvelope state m r_main) : Prop :=
 theorem zisk_riscv_compliant_program_bus
     (env : OpEnvelope state m r_main)
     (h_bridge : env.aeneasBridgeTrust)
-    (h_memory_timeline : env.memoryTimelineEvidence)
+    (h_memory_construction : env.memoryTimelineConstructionEvidence)
     (h_known_bugs : Defects.NoKnownDefect env) :
     env.exec_eq := by
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · exact h_bridge
-  · exact h_memory_timeline
+  · exact h_memory_construction
   · exact zisk_riscv_compliant_program_bus_branch env
   · exact zisk_riscv_compliant_program_bus_nomem env
   · exact zisk_riscv_compliant_program_bus_rtype_binary env
   · exact zisk_riscv_compliant_program_bus_itype_binary env
   · exact zisk_riscv_compliant_program_bus_shift env
   · exact zisk_riscv_compliant_program_bus_add_rtypew env
-  · exact zisk_riscv_compliant_program_bus_ldsd env h_memory_timeline
+  · exact zisk_riscv_compliant_program_bus_ldsd env h_memory_construction
   · exact zisk_riscv_compliant_program_bus_divu_except_known_defects env h_known_bugs
-  · exact zisk_riscv_compliant_program_bus_misc env h_memory_timeline
-  · exact zisk_riscv_compliant_program_bus_remaining env h_memory_timeline h_known_bugs
+  · exact zisk_riscv_compliant_program_bus_misc env h_memory_construction
+  · exact zisk_riscv_compliant_program_bus_remaining env h_memory_construction h_known_bugs
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/Dispatch/LDSD.lean
+++ b/ZiskFv/Compliance/Dispatch/LDSD.lean
@@ -47,15 +47,16 @@ def OpEnvelope.exec_eq_ldsd
 
 theorem zisk_riscv_compliant_program_bus_ldsd
     (env : OpEnvelope state m r_main)
-    (h_memory_timeline : env.memoryTimelineEvidence) :
+    (h_memory_construction : env.memoryTimelineConstructionEvidence) :
     env.exec_eq_ldsd := by
   cases env with
   | ld ld_input regs mem bus pins promises r_mem h_mainEval h_providerEval
       h_msg h_main_row h_mem_row h_main_spec h_store_pc h_main_b_match
       h_main_c_match h_addr1 h_addr2_zero_iff h_addr2_idx h_mem_sel h_mem_wr =>
     simp only [OpEnvelope.exec_eq_ldsd]
-    simp only [OpEnvelope.memoryTimelineEvidence] at h_memory_timeline
-    rcases h_memory_timeline with ⟨timeline⟩
+    simp only [OpEnvelope.memoryTimelineConstructionEvidence] at h_memory_construction
+    rcases loadMemoryTimelineEvidence_of_constructionEvidence promises h_memory_construction with
+      ⟨timeline⟩
     let promises' :=
       ZiskFv.EquivCore.Promises.LoadStructuralPromises.withMemoryTimelineEvidence
         promises timeline

--- a/ZiskFv/Compliance/Dispatch/Misc.lean
+++ b/ZiskFv/Compliance/Dispatch/Misc.lean
@@ -67,7 +67,7 @@ def OpEnvelope.exec_eq_misc
 set_option maxHeartbeats 800000
 theorem zisk_riscv_compliant_program_bus_misc
     (env : OpEnvelope state m r_main)
-    (h_memory_timeline : env.memoryTimelineEvidence) :
+    (h_memory_construction : env.memoryTimelineConstructionEvidence) :
     env.exec_eq_misc := by
   cases env with
   | lb_via_static_match lb_input regs mem v r_binary offset env h_static h_match
@@ -81,8 +81,9 @@ theorem zisk_riscv_compliant_program_bus_misc
             lb_input.imm, regidx.Regidx lb_input.r1, regidx.Regidx lb_input.rd, false, 1
           ))) state
           = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
-    simp only [OpEnvelope.memoryTimelineEvidence] at h_memory_timeline
-    rcases h_memory_timeline with ⟨timeline⟩
+    simp only [OpEnvelope.memoryTimelineConstructionEvidence] at h_memory_construction
+    rcases loadMemoryTimelineEvidence_of_constructionEvidence promises h_memory_construction with
+      ⟨timeline⟩
     let promises' :=
       ZiskFv.EquivCore.Promises.LoadStructuralPromises.withMemoryTimelineEvidence
         promises timeline
@@ -106,8 +107,9 @@ theorem zisk_riscv_compliant_program_bus_misc
             lh_input.imm, regidx.Regidx lh_input.r1, regidx.Regidx lh_input.rd, false, 2
           ))) state
           = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
-    simp only [OpEnvelope.memoryTimelineEvidence] at h_memory_timeline
-    rcases h_memory_timeline with ⟨timeline⟩
+    simp only [OpEnvelope.memoryTimelineConstructionEvidence] at h_memory_construction
+    rcases loadMemoryTimelineEvidence_of_constructionEvidence promises h_memory_construction with
+      ⟨timeline⟩
     let promises' :=
       ZiskFv.EquivCore.Promises.LoadStructuralPromises.withMemoryTimelineEvidence
         promises timeline
@@ -131,8 +133,9 @@ theorem zisk_riscv_compliant_program_bus_misc
             lw_input.imm, regidx.Regidx lw_input.r1, regidx.Regidx lw_input.rd, false, 4
           ))) state
           = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
-    simp only [OpEnvelope.memoryTimelineEvidence] at h_memory_timeline
-    rcases h_memory_timeline with ⟨timeline⟩
+    simp only [OpEnvelope.memoryTimelineConstructionEvidence] at h_memory_construction
+    rcases loadMemoryTimelineEvidence_of_constructionEvidence promises h_memory_construction with
+      ⟨timeline⟩
     let promises' :=
       ZiskFv.EquivCore.Promises.LoadStructuralPromises.withMemoryTimelineEvidence
         promises timeline

--- a/ZiskFv/Compliance/Dispatch/Remaining.lean
+++ b/ZiskFv/Compliance/Dispatch/Remaining.lean
@@ -183,7 +183,7 @@ def OpEnvelope.exec_eq_remaining
 
 theorem zisk_riscv_compliant_program_bus_remaining
     (env : OpEnvelope state m r_main)
-    (h_memory_timeline : env.memoryTimelineEvidence)
+    (h_memory_construction : env.memoryTimelineConstructionEvidence)
     (h_known_bugs : Defects.NoKnownDefect env) :
     env.exec_eq_remaining := by
   cases env with
@@ -194,8 +194,9 @@ theorem zisk_riscv_compliant_program_bus_remaining
     change execute_instruction (instruction.LOAD (
         lbu_input.imm, regidx.Regidx lbu_input.r1, regidx.Regidx lbu_input.rd, true, 1
       )) state = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
-    simp only [OpEnvelope.memoryTimelineEvidence] at h_memory_timeline
-    rcases h_memory_timeline with ⟨timeline⟩
+    simp only [OpEnvelope.memoryTimelineConstructionEvidence] at h_memory_construction
+    rcases loadMemoryTimelineEvidence_of_constructionEvidence promises h_memory_construction with
+      ⟨timeline⟩
     let promises' :=
       ZiskFv.EquivCore.Promises.LoadStructuralPromises.withMemoryTimelineEvidence
         promises timeline
@@ -214,8 +215,9 @@ theorem zisk_riscv_compliant_program_bus_remaining
     change execute_instruction (instruction.LOAD (
         lhu_input.imm, regidx.Regidx lhu_input.r1, regidx.Regidx lhu_input.rd, true, 2
       )) state = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
-    simp only [OpEnvelope.memoryTimelineEvidence] at h_memory_timeline
-    rcases h_memory_timeline with ⟨timeline⟩
+    simp only [OpEnvelope.memoryTimelineConstructionEvidence] at h_memory_construction
+    rcases loadMemoryTimelineEvidence_of_constructionEvidence promises h_memory_construction with
+      ⟨timeline⟩
     let promises' :=
       ZiskFv.EquivCore.Promises.LoadStructuralPromises.withMemoryTimelineEvidence
         promises timeline
@@ -234,8 +236,9 @@ theorem zisk_riscv_compliant_program_bus_remaining
     change execute_instruction (instruction.LOAD (
         lwu_input.imm, regidx.Regidx lwu_input.r1, regidx.Regidx lwu_input.rd, true, 4
       )) state = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
-    simp only [OpEnvelope.memoryTimelineEvidence] at h_memory_timeline
-    rcases h_memory_timeline with ⟨timeline⟩
+    simp only [OpEnvelope.memoryTimelineConstructionEvidence] at h_memory_construction
+    rcases loadMemoryTimelineEvidence_of_constructionEvidence promises h_memory_construction with
+      ⟨timeline⟩
     let promises' :=
       ZiskFv.EquivCore.Promises.LoadStructuralPromises.withMemoryTimelineEvidence
         promises timeline
@@ -596,7 +599,7 @@ theorem zisk_riscv_compliant_program_bus_remaining
     closures. -/
 theorem zisk_riscv_compliant_program_bus_remaining_except_known_defects
     (env : OpEnvelope state m r_main)
-    (h_memory_timeline : env.memoryTimelineEvidence)
+    (h_memory_construction : env.memoryTimelineConstructionEvidence)
     (h_known_bugs : Defects.NoKnownDefect env) :
     env.exec_eq_remaining := by
   cases env with
@@ -607,8 +610,9 @@ theorem zisk_riscv_compliant_program_bus_remaining_except_known_defects
     change execute_instruction (instruction.LOAD (
         lbu_input.imm, regidx.Regidx lbu_input.r1, regidx.Regidx lbu_input.rd, true, 1
       )) state = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
-    simp only [OpEnvelope.memoryTimelineEvidence] at h_memory_timeline
-    rcases h_memory_timeline with ⟨timeline⟩
+    simp only [OpEnvelope.memoryTimelineConstructionEvidence] at h_memory_construction
+    rcases loadMemoryTimelineEvidence_of_constructionEvidence promises h_memory_construction with
+      ⟨timeline⟩
     let promises' :=
       ZiskFv.EquivCore.Promises.LoadStructuralPromises.withMemoryTimelineEvidence
         promises timeline
@@ -624,8 +628,9 @@ theorem zisk_riscv_compliant_program_bus_remaining_except_known_defects
     change execute_instruction (instruction.LOAD (
         lhu_input.imm, regidx.Regidx lhu_input.r1, regidx.Regidx lhu_input.rd, true, 2
       )) state = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
-    simp only [OpEnvelope.memoryTimelineEvidence] at h_memory_timeline
-    rcases h_memory_timeline with ⟨timeline⟩
+    simp only [OpEnvelope.memoryTimelineConstructionEvidence] at h_memory_construction
+    rcases loadMemoryTimelineEvidence_of_constructionEvidence promises h_memory_construction with
+      ⟨timeline⟩
     let promises' :=
       ZiskFv.EquivCore.Promises.LoadStructuralPromises.withMemoryTimelineEvidence
         promises timeline
@@ -641,8 +646,9 @@ theorem zisk_riscv_compliant_program_bus_remaining_except_known_defects
     change execute_instruction (instruction.LOAD (
         lwu_input.imm, regidx.Regidx lwu_input.r1, regidx.Regidx lwu_input.rd, true, 4
       )) state = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
-    simp only [OpEnvelope.memoryTimelineEvidence] at h_memory_timeline
-    rcases h_memory_timeline with ⟨timeline⟩
+    simp only [OpEnvelope.memoryTimelineConstructionEvidence] at h_memory_construction
+    rcases loadMemoryTimelineEvidence_of_constructionEvidence promises h_memory_construction with
+      ⟨timeline⟩
     let promises' :=
       ZiskFv.EquivCore.Promises.LoadStructuralPromises.withMemoryTimelineEvidence
         promises timeline

--- a/ZiskFv/Compliance/OpEnvelope.lean
+++ b/ZiskFv/Compliance/OpEnvelope.lean
@@ -6,6 +6,7 @@ import ZiskFv.Channels.MemoryBusBytes
 import ZiskFv.Field.Goldilocks
 import ZiskFv.RowShape.Contract
 import ZiskFv.ZiskCircuit.MemTrace
+import ZiskFv.ZiskCircuit.MemTimeline.Construction
 import ZiskFv.Compliance.Wrappers.Lui
 import ZiskFv.Compliance.Wrappers.Auipc
 import ZiskFv.Compliance.Wrappers.Jal
@@ -2258,5 +2259,126 @@ def OpEnvelope.memoryTimelineEvidence
       Nonempty
         (ZiskFv.ZiskCircuit.MemTrace.MemoryTimelineEvidence state bus.e1)
   | _ => True
+
+/-- Construction-shaped residual needed to build timeline evidence for one load
+    read entry.
+
+    This names the remaining P4 boundary explicitly: a generated replay trace
+    contains the selected read row, and the load Sail state is the state obtained
+    by replaying the selected chronological prefix from the trace's initial
+    state. It deliberately does not mention `MemoryTimelineEvidence`, so callers
+    cannot satisfy it by repackaging the old residual boundary. -/
+@[reducible]
+def LoadMemoryTimelineConstructionEvidence
+    (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
+    (entry : Interaction.MemoryBusEntry FGL) : Prop :=
+  ∃ (initialState : ZiskFv.ZiskCircuit.MemTrace.SailState)
+    (rows : List (Interaction.MemoryBusEntry FGL))
+    (_facts : ZiskFv.AirsClean.Mem.GeneratedMemReplayFacts initialState rows)
+    (priorRows laterRows : List (Interaction.MemoryBusEntry FGL)),
+      rows = priorRows ++ entry :: laterRows
+        ∧ ZiskFv.ZiskCircuit.MemTimeline.MemoryPrefixStateAlignment
+            initialState state priorRows
+
+/-- The construction-shaped load residual produces the legacy timeline evidence
+    needed by existing load equivalence cores. -/
+theorem loadMemoryTimelineEvidence_of_constructionEvidence
+    {state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource}
+    {mstatus : RegisterType Register.mstatus}
+    {pmaRegion : PMA_Region}
+    {misa : RegisterType Register.misa}
+    {mseccfg : RegisterType Register.mseccfg}
+    {opcode_assumptions : Prop}
+    {pure_nextPC : BitVec 64}
+    {exec_row : List (Interaction.ExecutionBusEntry FGL)}
+    {e0 e1 e2 : Interaction.MemoryBusEntry FGL}
+    (promises :
+      ZiskFv.EquivCore.Promises.LoadStructuralPromises state mstatus pmaRegion
+        misa mseccfg opcode_assumptions pure_nextPC exec_row e0 e1 e2)
+    (h_construction : LoadMemoryTimelineConstructionEvidence state e1) :
+    Nonempty (ZiskFv.ZiskCircuit.MemTrace.MemoryTimelineEvidence state e1) := by
+  rcases h_construction with
+    ⟨initialState, rows, facts, priorRows, laterRows, h_traceSplit, h_alignment⟩
+  exact
+    ⟨ZiskFv.ZiskCircuit.MemTimeline.memoryTimelineEvidence_of_load_structural_promises
+      facts promises priorRows laterRows h_traceSplit h_alignment⟩
+
+/-- Single global construction boundary for memory-timeline evidence. Load arms
+    require construction data for `state` and `bus.e1`; non-load arms impose no
+    obligation. -/
+@[reducible]
+def OpEnvelope.memoryTimelineConstructionEvidence
+    {state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource}
+    {m : Valid_Main FGL FGL}
+    {r_main : ℕ} :
+    OpEnvelope state m r_main → Prop
+  | .ld _ _ _ bus .. =>
+      LoadMemoryTimelineConstructionEvidence state bus.e1
+  | .lbu _ _ _ bus .. =>
+      LoadMemoryTimelineConstructionEvidence state bus.e1
+  | .lhu _ _ _ bus .. =>
+      LoadMemoryTimelineConstructionEvidence state bus.e1
+  | .lwu _ _ _ bus .. =>
+      LoadMemoryTimelineConstructionEvidence state bus.e1
+  | .lb_via_static_match _ _ _ _ _ _ _ _ _ bus .. =>
+      LoadMemoryTimelineConstructionEvidence state bus.e1
+  | .lh_via_static_match _ _ _ _ _ _ _ _ _ bus .. =>
+      LoadMemoryTimelineConstructionEvidence state bus.e1
+  | .lw_via_static_match _ _ _ _ _ _ _ _ _ bus .. =>
+      LoadMemoryTimelineConstructionEvidence state bus.e1
+  | _ => True
+
+/-- The construction boundary is the only public residual; this adapter is
+    internal glue for dispatchers that still consume the older timeline API. -/
+theorem OpEnvelope.memoryTimelineEvidence_of_constructionEvidence
+    {state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource}
+    {m : Valid_Main FGL FGL}
+    {r_main : ℕ}
+    (env : OpEnvelope state m r_main)
+    (h_construction : env.memoryTimelineConstructionEvidence) :
+    env.memoryTimelineEvidence := by
+  cases env with
+  | ld ld_input regs mem bus pins promises r_mem h_mainEval h_providerEval
+      h_msg h_main_row h_mem_row h_main_spec h_store_pc h_main_b_match
+      h_main_c_match h_addr1 h_addr2_zero_iff h_addr2_idx h_mem_sel h_mem_wr =>
+      exact loadMemoryTimelineEvidence_of_constructionEvidence
+        promises h_construction
+  | lbu lbu_input regs mem bus align pins h_width promises r_mem
+      h_mainEval h_providerEval h_msg h_main_row h_mem_row h_main_spec
+      h_store_pc h_main_b_match h_main_c_match h_addr1 h_addr2_zero_iff
+      h_addr2_idx h_mem_sel h_mem_wr =>
+      exact loadMemoryTimelineEvidence_of_constructionEvidence
+        promises h_construction
+  | lhu lhu_input regs mem bus align pins h_width promises r_mem
+      h_mainEval h_providerEval h_msg h_main_row h_mem_row h_main_spec
+      h_store_pc h_main_b_match h_main_c_match h_addr1 h_addr2_zero_iff
+      h_addr2_idx h_mem_sel h_mem_wr =>
+      exact loadMemoryTimelineEvidence_of_constructionEvidence
+        promises h_construction
+  | lwu lwu_input regs mem bus align pins h_width promises r_mem
+      h_mainEval h_providerEval h_msg h_main_row h_mem_row h_main_spec
+      h_store_pc h_main_b_match h_main_c_match h_addr1 h_addr2_zero_iff
+      h_addr2_idx h_mem_sel h_mem_wr =>
+      exact loadMemoryTimelineEvidence_of_constructionEvidence
+        promises h_construction
+  | lb_via_static_match lb_input regs mem v r_binary offset env h_static h_match
+      bus pins promises r_mem h_mainEval h_providerEval h_msg h_main_row
+      h_mem_row h_main_spec h_store_pc h_main_b_match h_main_c_match h_addr1
+      h_addr2_zero_iff h_addr2_idx h_mem_sel h_mem_wr =>
+      exact loadMemoryTimelineEvidence_of_constructionEvidence
+        promises h_construction
+  | lh_via_static_match lh_input regs mem v r_binary offset env h_static h_match
+      bus pins promises r_mem h_mainEval h_providerEval h_msg h_main_row
+      h_mem_row h_main_spec h_store_pc h_main_b_match h_main_c_match h_addr1
+      h_addr2_zero_iff h_addr2_idx h_mem_sel h_mem_wr =>
+      exact loadMemoryTimelineEvidence_of_constructionEvidence
+        promises h_construction
+  | lw_via_static_match lw_input regs mem v r_binary offset env h_static h_match
+      bus pins promises r_mem h_mainEval h_providerEval h_msg h_main_row
+      h_mem_row h_main_spec h_store_pc h_main_b_match h_main_c_match h_addr1
+      h_addr2_zero_iff h_addr2_idx h_mem_sel h_mem_wr =>
+      exact loadMemoryTimelineEvidence_of_constructionEvidence
+        promises h_construction
+  | _ => trivial
 
 end ZiskFv.Compliance

--- a/trust/consistency/global_theorem_instantiation_add.lean
+++ b/trust/consistency/global_theorem_instantiation_add.lean
@@ -208,7 +208,8 @@ private def addZeroEnv : ZiskFv.Compliance.OpEnvelope witnessState witnessMain 0
 private theorem addZeroBridge : addZeroEnv.aeneasBridgeTrust := by
   exact ⟨inputR1Row, inputR2Row⟩
 
-private theorem addZeroMemoryTimeline : addZeroEnv.memoryTimelineEvidence := by
+private theorem addZeroMemoryConstruction :
+    addZeroEnv.memoryTimelineConstructionEvidence := by
   trivial
 
 private theorem addZeroNoKnownDefect :
@@ -223,7 +224,7 @@ private theorem addZeroNoKnownDefect :
 theorem global_theorem_instantiation_add :
     addZeroEnv.exec_eq :=
   ZiskFv.Compliance.zisk_riscv_compliant_program_bus
-    addZeroEnv addZeroBridge addZeroMemoryTimeline addZeroNoKnownDefect
+    addZeroEnv addZeroBridge addZeroMemoryConstruction addZeroNoKnownDefect
 
 #print axioms global_theorem_instantiation_add
 

--- a/trust/consistency/global_theorem_instantiation_ld.lean
+++ b/trust/consistency/global_theorem_instantiation_ld.lean
@@ -1,0 +1,461 @@
+import ZiskFv.Compliance
+import ZiskFv.AirsClean.Main.Circuit
+
+/-!
+Concrete LD instantiation of the global theorem.
+
+This witness intentionally has the selected memory read as the first accepted
+memory row, so its construction evidence uses `priorRows = []`.  The separate
+`memory_prefix_alignment_witness.lean` consistency check covers a concrete
+non-empty store prefix for `MemoryPrefixStateAlignment`.
+-/
+
+namespace ZiskFv.TrustConsistency
+
+open Goldilocks
+open Interaction
+open ZiskFv.AirsClean.Main
+open ZiskFv.EquivCore.Promises
+
+private def ldPmaAttrs : PMA :=
+  { cacheable := false
+    coherent := false
+    executable := true
+    readable := true
+    writable := true
+    read_idempotent := true
+    write_idempotent := true
+    misaligned_fault := misaligned_fault.AlignmentFault
+    reservability := default
+    supports_cbo_zero := false }
+
+private def ldPmaRegion : PMA_Region :=
+  { base := 0#64
+    size := BitVec.ofNat 64 (2 ^ 32)
+    attributes := ldPmaAttrs
+    include_in_device_tree := false }
+
+private def ldModeRegs : ZiskFv.Compliance.ModeRegsFull :=
+  { mstatus := 0#64
+    pmaRegion := ldPmaRegion
+    misa := 0#64
+    mseccfg := 0#64 }
+
+private def ldByteMemory : Std.ExtHashMap Nat (BitVec 8) :=
+  let mem0 :=
+    (default : PreSail.SequentialState RegisterType Sail.trivialChoiceSource).mem
+  let mem1 := mem0.insert 0 (0#8)
+  let mem2 := mem1.insert 1 (0#8)
+  let mem3 := mem2.insert 2 (0#8)
+  let mem4 := mem3.insert 3 (0#8)
+  let mem5 := mem4.insert 4 (0#8)
+  let mem6 := mem5.insert 5 (0#8)
+  let mem7 := mem6.insert 6 (0#8)
+  mem7.insert 7 (0#8)
+
+private def ldRegs :=
+  let regs0 :=
+    (default : PreSail.SequentialState RegisterType Sail.trivialChoiceSource).regs
+  let regs1 := regs0.insert Register.PC (0#64)
+  let regs2 := regs1.insert Register.cur_privilege Privilege.Machine
+  let regs3 := regs2.insert Register.mstatus ldModeRegs.mstatus
+  let regs4 := regs3.insert Register.pma_regions [ldModeRegs.pmaRegion]
+  let regs5 := regs4.insert Register.htif_tohost_base (none : Option (BitVec 64))
+  let regs6 := regs5.insert Register.misa ldModeRegs.misa
+  regs6.insert Register.mseccfg ldModeRegs.mseccfg
+
+private def ldState :
+    PreSail.SequentialState RegisterType Sail.trivialChoiceSource :=
+  { (default : PreSail.SequentialState RegisterType Sail.trivialChoiceSource) with
+    regs := ldRegs
+    mem := ldByteMemory }
+
+private def ldInput : PureSpec.LdInput :=
+  { r1 := 0#5
+    imm := 0#12
+    rd := 0#5
+    r1_val := 0#64
+    PC := 0#64
+    data0 := 0#8
+    data1 := 0#8
+    data2 := 0#8
+    data3 := 0#8
+    data4 := 0#8
+    data5 := 0#8
+    data6 := 0#8
+    data7 := 0#8 }
+
+private def ldExecRow : List (Interaction.ExecutionBusEntry FGL) :=
+  [ { multiplicity := -1, pc := 0, timestamp := 0 },
+    { multiplicity := 1, pc := 4, timestamp := 1 } ]
+
+private def ldRegRead : Interaction.MemoryBusEntry FGL :=
+  { multiplicity := -1
+    as := 1
+    ptr := 0
+    value_0 := 0
+    value_1 := 0
+    timestamp := 1 }
+
+private def ldMemRead : Interaction.MemoryBusEntry FGL :=
+  { multiplicity := -1
+    as := 2
+    ptr := 0
+    value_0 := 0
+    value_1 := 0
+    timestamp := 2 }
+
+private def ldRegWrite : Interaction.MemoryBusEntry FGL :=
+  { multiplicity := 1
+    as := 1
+    ptr := 0
+    value_0 := 0
+    value_1 := 0
+    timestamp := 3 }
+
+private def ldBus : ZiskFv.Compliance.BusRows :=
+  { exec_row := ldExecRow
+    e0 := ldRegRead
+    e1 := ldMemRead
+    e2 := ldRegWrite }
+
+private def ldRomBits : RomFlagBits :=
+  { a_src_imm := false
+    a_src_mem := false
+    is_precompiled := false
+    b_src_imm := false
+    b_src_mem := true
+    is_external_op := false
+    store_pc := false
+    store_mem := false
+    store_ind := false
+    set_pc := false
+    m32 := false
+    b_src_ind := false
+    a_src_reg := true
+    b_src_reg := false
+    store_reg := true }
+
+private def ldRomMessage : ZiskFv.Channels.ZiskRomBus.ZiskRomMessage FGL :=
+  { line := 0
+    a_offset_imm0 := 0
+    a_imm1 := 0
+    b_offset_imm0 := 0
+    b_imm1 := 0
+    ind_width := 8
+    op := ZiskFv.Trusted.OP_COPYB
+    store_offset := 0
+    jmp_offset1 := 4
+    jmp_offset2 := 4
+    flags := packFlags ldRomBits }
+
+private def ldMainFree : MainRomFreeCols :=
+  { a_0 := 0
+    a_1 := 0
+    b_0 := 0
+    b_1 := 0
+    im_high_degree_2 := 0
+    segment_l1 := 0
+    addr0 := 0
+    addr1 := 0
+    addr2 := 0
+    main_step := 0 }
+
+private def ldMainRow : MainRowWithRom FGL :=
+  mainRomRowOf ldRomMessage ldRomBits .internalCopyB ldMainFree
+
+private def ldMain : ZiskFv.Airs.Main.Valid_Main FGL FGL :=
+  ZiskFv.AirsClean.Main.validOfRow ldMainRow.core
+
+private def ldMemRow : ZiskFv.AirsClean.Mem.MemRow FGL :=
+  { addr := 0
+    step := 2
+    sel := 1
+    addr_changes := 1
+    step_dual := 0
+    sel_dual := 0
+    value_0 := 0
+    value_1 := 0
+    wr := 0
+    previous_step := 0
+    increment_0 := 0
+    increment_1 := 0
+    read_same_addr := 0 }
+
+private def ldMem : ZiskFv.Airs.Mem.Valid_Mem FGL FGL :=
+  ZiskFv.AirsClean.Mem.validOfRow ldMemRow
+
+private def emptyEnv : Environment FGL :=
+  { get := fun _ => 0
+    data := fun _ _ => #[] }
+
+private def ldMainRowVar : Var ZiskFv.AirsClean.Main.MainRowWithRom FGL :=
+  { core :=
+      { a_0 := .const ldMainRow.core.a_0
+        a_1 := .const ldMainRow.core.a_1
+        b_0 := .const ldMainRow.core.b_0
+        b_1 := .const ldMainRow.core.b_1
+        c_0 := .const ldMainRow.core.c_0
+        c_1 := .const ldMainRow.core.c_1
+        flag := .const ldMainRow.core.flag
+        pc := .const ldMainRow.core.pc
+        is_external_op := .const ldMainRow.core.is_external_op
+        op := .const ldMainRow.core.op
+        m32 := .const ldMainRow.core.m32
+        ind_width := .const ldMainRow.core.ind_width
+        set_pc := .const ldMainRow.core.set_pc
+        jmp_offset1 := .const ldMainRow.core.jmp_offset1
+        jmp_offset2 := .const ldMainRow.core.jmp_offset2
+        store_pc := .const ldMainRow.core.store_pc
+        im_high_degree_2 := .const ldMainRow.core.im_high_degree_2
+        segment_l1 := .const ldMainRow.core.segment_l1 }
+    rom :=
+      { a_offset_imm0 := .const ldMainRow.rom.a_offset_imm0
+        a_imm1 := .const ldMainRow.rom.a_imm1
+        b_offset_imm0 := .const ldMainRow.rom.b_offset_imm0
+        b_imm1 := .const ldMainRow.rom.b_imm1
+        store_offset := .const ldMainRow.rom.store_offset
+        a_src_imm := .const ldMainRow.rom.a_src_imm
+        a_src_mem := .const ldMainRow.rom.a_src_mem
+        is_precompiled := .const ldMainRow.rom.is_precompiled
+        b_src_imm := .const ldMainRow.rom.b_src_imm
+        b_src_mem := .const ldMainRow.rom.b_src_mem
+        store_mem := .const ldMainRow.rom.store_mem
+        store_ind := .const ldMainRow.rom.store_ind
+        b_src_ind := .const ldMainRow.rom.b_src_ind
+        a_src_reg := .const ldMainRow.rom.a_src_reg
+        b_src_reg := .const ldMainRow.rom.b_src_reg
+        store_reg := .const ldMainRow.rom.store_reg
+        addr0 := .const ldMainRow.rom.addr0
+        addr1 := .const ldMainRow.rom.addr1
+        addr2 := .const ldMainRow.rom.addr2
+        main_step := .const ldMainRow.rom.main_step } }
+
+private def ldMemRowVar : Var ZiskFv.AirsClean.Mem.MemRow FGL :=
+  ZiskFv.AirsClean.Mem.constVar ldMemRow
+
+private theorem evalLdMainRowVar :
+    eval emptyEnv ldMainRowVar = ldMainRow := by
+  simp [ldMainRowVar, ldMainRow, ldRomMessage, ldRomBits, ldMainFree,
+    mainRomRowOf, packFlags, ZiskFv.AirsClean.boolF,
+    ProvableStruct.eval_eq_eval, ProvableStruct.eval,
+    ProvableStruct.fromComponents, ProvableStruct.components,
+    ProvableStruct.toComponents, ProvableStruct.eval.go,
+    CircuitType.eval_expr, Expression.eval]
+
+private theorem evalLdMemRowVar :
+    eval emptyEnv ldMemRowVar = ldMemRow := by
+  simp [ldMemRowVar, ldMemRow, ZiskFv.AirsClean.Mem.constVar,
+    ProvableStruct.eval_eq_eval, ProvableStruct.eval,
+    ProvableStruct.fromComponents, ProvableStruct.components,
+    ProvableStruct.toComponents, ProvableStruct.eval.go,
+    CircuitType.eval_expr, Expression.eval]
+
+private def ldMainMult : Expression FGL := .const (-1)
+
+private def ldProviderMult : Expression FGL := .const 1
+
+private def ldMainInteraction : Interaction FGL :=
+  ((ZiskFv.Channels.MemoryBus.MemBusChannel.emitted ldMainMult
+    (ZiskFv.AirsClean.Main.bMemMessageExpr ldMainRowVar)).toRaw).eval emptyEnv
+
+private def ldProviderInteraction : Interaction FGL :=
+  ((ZiskFv.Channels.MemoryBus.MemBusChannel.emitted ldProviderMult
+    (ZiskFv.AirsClean.Mem.memBusMessageExpr ldMemRowVar)).toRaw).eval emptyEnv
+
+private theorem ldMainEval :
+    ldMainInteraction =
+      ((ZiskFv.Channels.MemoryBus.MemBusChannel.emitted ldMainMult
+        (ZiskFv.AirsClean.Main.bMemMessageExpr ldMainRowVar)).toRaw).eval
+        emptyEnv := by
+  rfl
+
+private theorem ldProviderEval :
+    ldProviderInteraction =
+      ((ZiskFv.Channels.MemoryBus.MemBusChannel.emitted ldProviderMult
+        (ZiskFv.AirsClean.Mem.memBusMessageExpr ldMemRowVar)).toRaw).eval
+        emptyEnv := by
+  rfl
+
+private theorem ldMsg :
+    ldProviderInteraction.msg = ldMainInteraction.msg := by
+  unfold ldProviderInteraction ldMainInteraction
+  simp only [AbstractInteraction.eval, ChannelInteraction.toRaw,
+    Channel.emitted, emitted]
+  rw [← ProvableType.toElements_eval emptyEnv
+      (ZiskFv.AirsClean.Mem.memBusMessageExpr ldMemRowVar),
+    ← ProvableType.toElements_eval emptyEnv
+      (ZiskFv.AirsClean.Main.bMemMessageExpr ldMainRowVar)]
+  have h_eval_msg :
+      eval emptyEnv (ZiskFv.AirsClean.Mem.memBusMessageExpr ldMemRowVar) =
+        eval emptyEnv (ZiskFv.AirsClean.Main.bMemMessageExpr ldMainRowVar) := by
+    rw [ZiskFv.AirsClean.Mem.eval_memBusMessageExpr,
+      ZiskFv.AirsClean.Main.eval_bMemMessageExpr, evalLdMemRowVar,
+      evalLdMainRowVar]
+    norm_num [ldMemRow, ldMainRow, ldRomMessage, ldRomBits, ldMainFree,
+      ZiskFv.AirsClean.Mem.memBusMessage,
+      ZiskFv.AirsClean.Main.bMemMessage, mainRomRowOf,
+      ZiskFv.AirsClean.boolF]
+  rw [h_eval_msg]
+
+private theorem ldMainRowEq :
+    (eval emptyEnv ldMainRowVar).core =
+      ZiskFv.AirsClean.Main.rowAt ldMain 0 := by
+  rw [evalLdMainRowVar]
+  simp [ldMain, ZiskFv.AirsClean.Main.rowAt,
+    ZiskFv.AirsClean.Main.validOfRow]
+
+private theorem ldMemRowEq :
+    eval emptyEnv ldMemRowVar = ZiskFv.AirsClean.Mem.rowAt ldMem 0 := by
+  rw [evalLdMemRowVar]
+  simp [ldMem, ldMemRow,
+    ZiskFv.AirsClean.Mem.rowAt, ZiskFv.AirsClean.Mem.validOfRow]
+
+private theorem ldMainSpec :
+    ZiskFv.AirsClean.Main.Spec (eval emptyEnv ldMainRowVar).core := by
+  rw [evalLdMainRowVar]
+  norm_num [ldMainRow, ldRomMessage, ldRomBits, ldMainFree,
+    mainRomRowOf, ZiskFv.AirsClean.Main.Spec, ZiskFv.AirsClean.boolF,
+    ZiskFv.Trusted.OP_COPYB]
+
+private theorem ldStorePcZero :
+    (eval emptyEnv ldMainRowVar).core.store_pc = 0 := by
+  rw [evalLdMainRowVar]
+  rfl
+
+private theorem ldMainBMatch :
+    ZiskFv.Airs.MemoryBus.matches_memory_entry ldBus.e1
+      (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+        (ZiskFv.AirsClean.Main.bMemMessage (eval emptyEnv ldMainRowVar)) (-1) 2) := by
+  rw [evalLdMainRowVar]
+  norm_num [ZiskFv.Airs.MemoryBus.matches_memory_entry, ldBus, ldMemRead,
+    ldMainRow, ldRomMessage, ldRomBits, ldMainFree, mainRomRowOf,
+    ZiskFv.AirsClean.Main.bMemMessage, ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry,
+    ZiskFv.AirsClean.boolF]
+
+private theorem ldMainCMatch :
+    ZiskFv.Airs.MemoryBus.matches_memory_entry ldBus.e2
+      (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+        (ZiskFv.AirsClean.Main.cMemMessage (eval emptyEnv ldMainRowVar)) 1 1) := by
+  rw [evalLdMainRowVar]
+  norm_num [ZiskFv.Airs.MemoryBus.matches_memory_entry, ldBus, ldRegWrite,
+    ldMainRow, ldRomMessage, ldRomBits, ldMainFree, mainRomRowOf,
+    ZiskFv.AirsClean.Main.cMemMessage, ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry,
+    ZiskFv.AirsClean.boolF]
+
+private theorem ldAddr1 :
+    (eval emptyEnv ldMainRowVar).rom.addr1.toNat =
+      ldInput.r1_val.toNat + (BitVec.signExtend 64 ldInput.imm).toNat := by
+  rw [evalLdMainRowVar]
+  rfl
+
+private theorem ldAddr2ZeroIff :
+    Transpiler.wrap_to_regidx (eval emptyEnv ldMainRowVar).rom.addr2 = 0 ↔
+      ldInput.rd = 0 := by
+  rw [evalLdMainRowVar]
+  simp [ldMainRow, ldRomMessage, ldRomBits, ldMainFree,
+    mainRomRowOf, ldInput, Transpiler.wrap_to_regidx]
+
+private theorem ldAddr2Idx :
+    ldInput.rd.toNat =
+      (Transpiler.wrap_to_regidx (eval emptyEnv ldMainRowVar).rom.addr2).val := by
+  rw [evalLdMainRowVar]
+  rfl
+
+private theorem ldMemSel : ldMem.sel 0 = 1 := by
+  rfl
+
+private theorem ldMemWr : ldMem.wr 0 = 0 := by
+  rfl
+
+private theorem ldPromises :
+    LoadStructuralPromises ldState ldModeRegs.mstatus ldModeRegs.pmaRegion
+      ldModeRegs.misa ldModeRegs.mseccfg
+      (PureSpec.ld_state_assumptions ldInput ldState)
+      (PureSpec.execute_LOADD_pure ldInput).nextPC
+      ldBus.exec_row ldBus.e0 ldBus.e1 ldBus.e2 := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · unfold RISC_V_assumptions ldState ldRegs ldModeRegs ldPmaRegion ldPmaAttrs
+    simp [Sail.readReg, PreSail.readReg, Std.ExtDHashMap.get?_insert,
+      Std.ExtDHashMap.get?_insert_self]
+  · unfold PureSpec.ld_state_assumptions ldState ldRegs ldInput ldByteMemory
+    simp [LeanRV64D.Functions.rX_bits, LeanRV64D.Functions.rX,
+      Std.ExtDHashMap.get?_insert, Std.ExtDHashMap.get?_insert_self,
+      Std.ExtHashMap.getElem_insert, Std.ExtHashMap.getElem_insert_self]
+  · rfl
+  · rfl
+  · rfl
+  · rfl
+  · rfl
+  · rfl
+  · rfl
+  · rfl
+  · rfl
+  · rfl
+
+private def ldEnv : ZiskFv.Compliance.OpEnvelope ldState ldMain 0 :=
+  ZiskFv.Compliance.OpEnvelope.ld
+    ldInput ldModeRegs ldMem ldBus
+    ⟨rfl, rfl⟩ ldPromises 0
+    ldMainEval ldProviderEval ldMsg ldMainRowEq ldMemRowEq ldMainSpec
+    ldStorePcZero ldMainBMatch ldMainCMatch ldAddr1 ldAddr2ZeroIff
+    ldAddr2Idx ldMemSel ldMemWr
+
+private theorem ldBridge : ldEnv.aeneasBridgeTrust := by
+  rfl
+
+private theorem ldInitialAgreement :
+    ZiskFv.ZiskCircuit.MemTrace.ReplayMemoryAgreement ldState ldByteMemory := by
+  intro addr
+  rfl
+
+private theorem ldSelectedReadReplayAgreement :
+    ZiskFv.ZiskCircuit.MemTrace.ReadEventReplayAgreement ldByteMemory
+      (ZiskFv.ZiskCircuit.MemTrace.eventOfEntry ldMemRead) := by
+  unfold ZiskFv.ZiskCircuit.MemTrace.ReadEventReplayAgreement
+    ZiskFv.ZiskCircuit.MemTrace.eventOfEntry ldByteMemory ldMemRead
+  simp [Std.ExtHashMap.getElem_insert, Std.ExtHashMap.getElem_insert_self,
+    ZiskFv.ZiskCircuit.MemTrace.MemEvent.byteAt,
+    ZiskFv.Channels.MemoryBusBytes.byteAt,
+    ZiskFv.Channels.MemoryBusBytes.byteOf]
+
+private theorem ldPrefixReadSound :
+    ZiskFv.ZiskCircuit.MemTrace.MemoryBusRowsPrefixReadSound
+      ldByteMemory [ldMemRead] := by
+  intro priorRows row laterRows h_rows _h_as _h_mult
+  cases priorRows with
+  | nil =>
+      simp at h_rows
+      rcases h_rows with ⟨h_row, _h_laterRows⟩
+      subst row
+      exact ldSelectedReadReplayAgreement
+  | cons _priorHead priorTail =>
+      cases priorTail <;> simp at h_rows
+
+private def ldReplayFacts :
+    ZiskFv.AirsClean.Mem.GeneratedMemReplayFacts ldState [ldMemRead] :=
+  { initialMemory := ldByteMemory
+    prefixReadSound := ldPrefixReadSound
+    initialAgreement := ldInitialAgreement }
+
+private theorem ldMemoryConstruction :
+    ldEnv.memoryTimelineConstructionEvidence := by
+  exact ⟨ldState, [ldMemRead], ldReplayFacts, [], [], rfl, rfl⟩
+
+private theorem ldNoKnownDefect :
+    ZiskFv.Compliance.Defects.NoKnownDefect ldEnv := by
+  intro id h_block
+  cases id <;>
+    simp [ZiskFv.Compliance.Defects.Blocks,
+      ZiskFv.Compliance.Defects.MaliciousSignedMulWitnessShape,
+      ZiskFv.Compliance.Defects.ArithDivDynamicWitnessShape,
+      ZiskFv.Compliance.Defects.FenceKnownGoodShape, ldEnv] at h_block
+
+theorem global_theorem_instantiation_ld :
+    ldEnv.exec_eq :=
+  ZiskFv.Compliance.zisk_riscv_compliant_program_bus
+    ldEnv ldBridge ldMemoryConstruction ldNoKnownDefect
+
+#print axioms global_theorem_instantiation_ld
+
+end ZiskFv.TrustConsistency

--- a/trust/consistency/memory_prefix_alignment_witness.lean
+++ b/trust/consistency/memory_prefix_alignment_witness.lean
@@ -1,0 +1,40 @@
+import ZiskFv.ZiskCircuit.MemTimeline.Construction
+
+/-!
+Non-empty satisfiability witness for the P4-bound prefix-alignment residual.
+
+The LD global-theorem instantiation uses an empty prefix because the selected
+read is the first accepted memory row in that tiny witness.  This file keeps the
+alignment residual from being witnessed only by that degenerate prefix shape: a
+concrete store row gives a non-empty prefix whose aligned state is exactly the
+state obtained by replaying that one-row prefix.
+-/
+
+namespace ZiskFv.TrustConsistency
+
+open Goldilocks
+open Interaction
+open ZiskFv.ZiskCircuit.MemTrace
+open ZiskFv.ZiskCircuit.MemTimeline
+
+private def initialState :
+    PreSail.SequentialState RegisterType Sail.trivialChoiceSource :=
+  default
+
+private def storeRow : MemoryBusEntry FGL where
+  multiplicity := 1
+  as := 2
+  ptr := 32
+  value_0 := 1
+  value_1 := 0
+  timestamp := 1
+
+theorem memory_prefix_alignment_single_store_witness :
+    MemoryPrefixStateAlignment initialState
+      (stateAfterMemoryBusRows initialState [storeRow])
+      [storeRow] := by
+  rfl
+
+#print axioms memory_prefix_alignment_single_store_witness
+
+end ZiskFv.TrustConsistency

--- a/trust/generated/baseline-global-theorem-binders.txt
+++ b/trust/generated/baseline-global-theorem-binders.txt
@@ -3,5 +3,5 @@
 2 :: r_main :: Nat
 3 :: env :: ZiskFv.Compliance.OpEnvelope state m r_main
 4 :: h_bridge :: env.aeneasBridgeTrust
-5 :: h_memory_timeline :: env.memoryTimelineEvidence
+5 :: h_memory_construction :: env.memoryTimelineConstructionEvidence
 6 :: h_known_bugs :: ZiskFv.Compliance.Defects.NoKnownDefect env

--- a/trust/memory-argument-obligation-map.md
+++ b/trust/memory-argument-obligation-map.md
@@ -6,20 +6,22 @@ then names the residual obligations P4 must remove.
 
 ## Current Public Boundary
 
-The global theorem still takes
-`h_memory_timeline : env.memoryTimelineEvidence`
-([ZiskFv/Compliance.lean:94](../ZiskFv/Compliance.lean#L94),
-[ZiskFv/Compliance.lean:97](../ZiskFv/Compliance.lean#L97)) and threads it to
-the load and memory-touching dispatchers
-([ZiskFv/Compliance.lean:109](../ZiskFv/Compliance.lean#L109),
-[ZiskFv/Compliance.lean:111](../ZiskFv/Compliance.lean#L111),
-[ZiskFv/Compliance.lean:112](../ZiskFv/Compliance.lean#L112)).
-`OpEnvelope.memoryTimelineEvidence` is the current opaque load-family promise:
-each load arm requires `Nonempty (MemoryTimelineEvidence state bus.e1)`, while
-non-load arms are `True`
-([ZiskFv/Compliance/OpEnvelope.lean:2234](../ZiskFv/Compliance/OpEnvelope.lean#L2234),
-[ZiskFv/Compliance/OpEnvelope.lean:2239](../ZiskFv/Compliance/OpEnvelope.lean#L2239),
-[ZiskFv/Compliance/OpEnvelope.lean:2260](../ZiskFv/Compliance/OpEnvelope.lean#L2260)).
+The global theorem now takes
+`h_memory_construction : env.memoryTimelineConstructionEvidence`
+([ZiskFv/Compliance.lean:98](../ZiskFv/Compliance.lean#L98)) and threads it to
+the load and memory-touching dispatchers. This is a reshape to a named
+P4-bound residual, not a trust reduction.
+
+`OpEnvelope.memoryTimelineConstructionEvidence` is the visible load-family
+promise: each load arm requires `LoadMemoryTimelineConstructionEvidence state
+bus.e1`, while non-load arms are `True`
+([ZiskFv/Compliance/OpEnvelope.lean:2310](../ZiskFv/Compliance/OpEnvelope.lean#L2310),
+[ZiskFv/Compliance/OpEnvelope.lean:2315](../ZiskFv/Compliance/OpEnvelope.lean#L2315),
+[ZiskFv/Compliance/OpEnvelope.lean:2330](../ZiskFv/Compliance/OpEnvelope.lean#L2330)).
+The older `OpEnvelope.memoryTimelineEvidence` API remains only as internal
+adapter glue for existing load dispatchers
+([ZiskFv/Compliance/OpEnvelope.lean:2235](../ZiskFv/Compliance/OpEnvelope.lean#L2235),
+[ZiskFv/Compliance/OpEnvelope.lean:2333](../ZiskFv/Compliance/OpEnvelope.lean#L2333)).
 
 `MemoryTimelineEvidence` decomposes the load promise into an accepted replay
 object, a selected row split, a read-tag fact, and byte agreement between the
@@ -41,6 +43,17 @@ load Sail state and the replayed accepted prefix
 | `initialAgreement` | Named P4/boot residual. | P4 / program binding. | `GeneratedMemReplayFacts` carries `initialAgreement` ([ZiskFv/AirsClean/Mem/TraceSpec.lean:58](../ZiskFv/AirsClean/Mem/TraceSpec.lean#L58)); it is consumed to derive `stateBytesAtPrefix` ([ZiskFv/ZiskCircuit/MemTimeline/Construction.lean:49](../ZiskFv/ZiskCircuit/MemTimeline/Construction.lean#L49), [ZiskFv/ZiskCircuit/MemTimeline/Construction.lean:50](../ZiskFv/ZiskCircuit/MemTimeline/Construction.lean#L50)). It ties Sail `initialState.mem` to circuit `initialMemory`, so it belongs to the trace/program-binding construction rather than `Valid_Mem`. |
 | `MemoryPrefixStateAlignment` | Named P4-bound residual. | P4. | The alignment identifies the selected load Sail state with replaying the accepted memory-bus prefix from the initial state ([ZiskFv/ZiskCircuit/MemTimeline/Construction.lean:21](../ZiskFv/ZiskCircuit/MemTimeline/Construction.lean#L21), [ZiskFv/ZiskCircuit/MemTimeline/Construction.lean:28](../ZiskFv/ZiskCircuit/MemTimeline/Construction.lean#L28), [ZiskFv/ZiskCircuit/MemTimeline/Construction.lean:31](../ZiskFv/ZiskCircuit/MemTimeline/Construction.lean#L31)). The nonempty constructors still take this split-indexed alignment as an input ([ZiskFv/ZiskCircuit/MemTimeline/Construction.lean:121](../ZiskFv/ZiskCircuit/MemTimeline/Construction.lean#L121), [ZiskFv/ZiskCircuit/MemTimeline/Construction.lean:125](../ZiskFv/ZiskCircuit/MemTimeline/Construction.lean#L125), [ZiskFv/ZiskCircuit/MemTimeline/Construction.lean:162](../ZiskFv/ZiskCircuit/MemTimeline/Construction.lean#L162)). |
 | store RMW preserved bytes (`sb`/`sh`/`sw` `h_m*`) | Bucket-(c), outside P3's load-only scope. | P4. | The envelope audit identifies the preserved-byte facts and explains that they should move into the memory replay construction or a store-event extension of the memory timeline ([trust/envelope-burden-audit.md:99](envelope-burden-audit.md#L99), [trust/envelope-burden-audit.md:120](envelope-burden-audit.md#L120), [trust/envelope-burden-audit.md:125](envelope-burden-audit.md#L125)). |
+
+## Consistency Witnesses
+
+`trust/consistency/global_theorem_instantiation_ld.lean` is an empty-prefix
+satisfiability witness: the selected LD memory read is the first accepted memory
+row, so the construction evidence uses `priorRows = []`.
+`trust/consistency/memory_prefix_alignment_witness.lean` covers the non-empty
+case by proving `MemoryPrefixStateAlignment initialState
+(stateAfterMemoryBusRows initialState [storeRow]) [storeRow]` for one concrete
+store row. Neither witness removes a P4 residual; they only demonstrate the
+reshaped premise is satisfiable in both prefix shapes.
 
 ## P4 Assets That Are Not Yet a Discharge
 

--- a/trust/scripts/check-all-semantic.sh
+++ b/trust/scripts/check-all-semantic.sh
@@ -54,18 +54,22 @@ run_witnesses() {
   return $ok
 }
 
-run "1/9 axiom-deps baseline (V2)"        "$dir/check-axiom-deps.sh"
-run "2/9 forbidden types (V2)"            "$dir/check-no-output-eq-v2.sh"
-run "3/9 closure vs baseline-axioms (V2)" "$dir/check-closure-vs-baseline.sh"
-run "4/9 global theorem binders (V2)"     "$dir/check-global-theorem-binders.sh"
-run "5/9 consistency false probe rejected" reject_false_probe
-run "6/9 Sail memory timeline witness" \
+run "1/11 axiom-deps baseline (V2)"        "$dir/check-axiom-deps.sh"
+run "2/11 forbidden types (V2)"            "$dir/check-no-output-eq-v2.sh"
+run "3/11 closure vs baseline-axioms (V2)" "$dir/check-closure-vs-baseline.sh"
+run "4/11 global theorem binders (V2)"     "$dir/check-global-theorem-binders.sh"
+run "5/11 consistency false probe rejected" reject_false_probe
+run "6/11 Sail memory timeline witness" \
   run_lean_no_sorry trust/consistency/load_byte_agreement_witness.lean
-run "7/9 memory timeline construction witness" \
+run "7/11 memory timeline construction witness" \
   run_lean_no_sorry trust/consistency/memory_timeline_construction_witness.lean
-run "8/9 global ADD theorem instantiation" \
+run "8/11 memory prefix alignment witness" \
+  run_lean_no_sorry trust/consistency/memory_prefix_alignment_witness.lean
+run "9/11 global ADD theorem instantiation" \
   run_lean_no_sorry trust/consistency/global_theorem_instantiation_add.lean
-run "9/9 Clean completeness witnesses" run_witnesses
+run "10/11 global LD theorem instantiation" \
+  run_lean_no_sorry trust/consistency/global_theorem_instantiation_ld.lean
+run "11/11 Clean completeness witnesses" run_witnesses
 
 if [ $overall -eq 0 ]; then
   echo "trust-gate (V2 semantic): ALL CHECKS PASSED."


### PR DESCRIPTION
Queued for Claude review — do not merge.

## Summary
- Reshapes the global memory premise from `env.memoryTimelineEvidence` to `env.memoryTimelineConstructionEvidence`.
- Threads the construction evidence through the memory-touching dispatchers and keeps the legacy timeline API as internal adapter glue.
- Adds an LD global-theorem instantiation plus a separate non-empty prefix-alignment witness, both covered by the semantic gate.
- Updates the memory obligation map so P4 receives a precise ledger of remaining memory obligations.

## Scope
This is a reshape / reduce-to-named-P4-fact change, not a trust reduction. P4 remains responsible for removing the named memory residuals.

This PR does not wire `prefixReadSound`, does not add `OpEnvelope` or `Valid_Mem` fields, does not change canonical `equiv_<OP>` signatures, and does not claim that memory trust shrank.

## Audit Evidence
The global-binder baseline diff is exactly the visible reshape:

```diff
-5 :: h_memory_timeline :: env.memoryTimelineEvidence
+5 :: h_memory_construction :: env.memoryTimelineConstructionEvidence
```

The residual ledger handed to P4 is:
- `prefixReadSound`: P4-bound whole-trace cross-segment assembly; the single-segment `Balance.lean` chain remains only an asset.
- `initialAgreement`: P4 / program-binding boot premise tying Sail initial memory to circuit initial memory.
- `MemoryPrefixStateAlignment`: P4-bound running-state invariant for the selected accepted prefix.
- Store RMW preserved bytes (`sb`/`sh`/`sw` `h_m*`): P4 bucket-(c), outside this load-only P3 closeout.

## Notes
`trust/consistency/global_theorem_instantiation_ld.lean` is intentionally an empty-prefix satisfiability witness: the selected LD read is the first accepted memory row. `trust/consistency/memory_prefix_alignment_witness.lean` covers the non-empty case with one concrete store prefix. Neither witness removes a P4 residual.

## Verification
- `lake build` passed.
- `trust/scripts/check-all.sh` passed after initializing the pinned `zisk` submodule in the fresh worktree.
- `trust/scripts/check-all-semantic.sh` passed, including the global-binder check, LD instantiation, and non-empty prefix-alignment witness.
- `nix run .#test` passed all 8 stages.
- `lake exe trust-gate print-axiom-closure ZiskFv.Compliance.zisk_riscv_compliant_program_bus` emitted no closure entries, only existing TrustGate `String.trim` warnings.
- `git diff origin/main -- trust/` completed after commit and includes the PR-A audit apparatus plus PR-B witnesses.
- Canonical baselines `baseline-hypothesis-count.txt`, `baseline-caller-burden.txt`, `baseline-wrapper-caller-burden.txt`, and `baseline-equiv-axiom-deps.txt` are byte-identical vs PR-A and `origin/main`.

## §4 Self-Check
- No trust-reduction, shrink, removal, or discharge claim.
- No `prefixReadSound` wiring.
- No new `OpEnvelope` field, `Valid_Mem` field, or new global assumption.
- No canonical `equiv_<OP>` signature drift.
- No new `axiom`, `sorry`, `opaque`, `partial def`, `unsafe def`, or `native_decide` in the payload.
- No edits to trust allowlists or forbidden-policy files.
