### PR TITLE
Endgame P4-1: AcceptedTrace construction spine

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,19 +1,23 @@
-Active plan: docs/ai/plan/ENDGAME_ROADMAP.md (metaplan) →
-docs/ai/plan/PLAN_ENDGAME_P1.md (first phase, ready for execution)
+Active plan: docs/ai/plan/PLAN_ENDGAME_P4.md.
 
-Current focus: Clean Completeness Proofs stream is COMPLETE — all five wave
-PRs (#69–#73) merged 2026-06-12. The Endgame campaign is set up: six phases
-from the envelope-conditional global theorem to a trace-level public
-statement, anchored to issues #61/#74–#78. Plan sizing convention: ~5 PRs
-per phase plan, written only when the phase is staffed.
+P1: COMPLETE on main (#79-#83 via #89). P3: COMPLETE on main (#90/#91).
+This worktree is rebased onto current `origin/main` at `1781edeb`.
 
-Blocking: none. P1 can be staffed now (two agents: A = PRs 1→2→3
-finalization + kernel-only closure; B = PRs 4→5 ADD instantiation + bucket
-audit). P3 (#76 memory argument) can be staffed in parallel once an agent
-frees up; its plan is written at that point.
+P4 is the first genuinely trust-reducing phase: build `AcceptedTrace ->
+OpEnvelope`, discharge derivable bucket-(a) evidence from accepted trace data,
+and leave only the named bucket-(b) residuals (`aeneasBridgeTrust`,
+`ProgramBinding`/boot, `NoKnownDefect`). Balance is assumed via
+`trace.balanced`, never proven.
 
-Open follow-ups carried from the completeness stream (recorded in P1-PR1):
-signed Arith completeness disjuncts; table-op scope extensions; wave
-worktree/branch cleanup pending Cody's deletion approval.
+Current focus: P4 PR1 in this worktree (`.worktrees/endgame-p4-pr1` on branch
+`endgame-p4-pr1`). PR1 implementation is in place: `AcceptedTrace`,
+`ProgramBinding`, `mainOfTable`, one BEQ construction template, and the
+construction-binder audit gate.
 
-Next step: hand PLAN_ENDGAME_P1.md to the P1 agent(s).
+Blocking: none. REPL is already configured for Lean v4.28.0. Final post-rebase
+verification is green: `lake build`, `trust/scripts/check-all.sh`,
+`trust/scripts/check-all-semantic.sh`, `nix run .#test`, axiom-closure print,
+and `git diff origin/main -- trust/`.
+
+Next step: stage the PR1 files, commit, push `endgame-p4-pr1`, and open the
+queued review PR.

--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -131,6 +131,7 @@ import ZiskFv.AirsClean.FullEnsemble.Balance
 import ZiskFv.ZiskCircuit.MemTimeline.Construction
 import ZiskFv.ZiskCircuit.MemTimeline.Linkage
 import ZiskFv.Compliance.RowProvenance
+import ZiskFv.Compliance.AcceptedTrace
 import ZiskFv.Compliance
 import ZiskFv.Completeness.Rv
 import ZiskFv.Completeness.Rv64im

--- a/ZiskFv/AirsClean/FullEnsemble/Balance.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance.lean
@@ -84,6 +84,28 @@ theorem exists_mem_table_of_fullRv64im_witness
   rcases List.mem_map.mp h_in_map with ⟨table, h_table, h_component⟩
   exact ⟨table, h_table, h_component⟩
 
+/-- Every concrete witness for the full RV64IM ensemble contains the unified
+    Main table. This is only table selection; row-level decode/provenance is
+    supplied separately by `ProgramBinding`. -/
+theorem exists_main_table_of_fullRv64im_witness
+    {length : ℕ} {program : Program length}
+    (witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble) :
+    ∃ table ∈ witness.allTables,
+      table.component =
+        ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program := by
+  have h_component_mem :
+      ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program ∈
+        (fullRv64imEnsemble length program).ensemble.allTables := by
+    simp [fullRv64imEnsemble, SoundEnsemble.toFormal, Ensemble.allTables,
+      SoundEnsemble.addTable_tables, SoundEnsemble.addFinishedChannel_tables]
+  have h_in_map :
+      ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program ∈
+        witness.allTables.map (·.component) := by
+    rw [witness.allTables_map_component]
+    exact h_component_mem
+  rcases List.mem_map.mp h_in_map with ⟨table, h_table, h_component⟩
+  exact ⟨table, h_table, h_component⟩
+
 /-- The full ensemble verifier table is the empty verifier component, so it
     cannot contribute operation-bus interactions. -/
 theorem verifierTable_interactionsWith_opBus_nil
@@ -1833,6 +1855,138 @@ theorem activeMemReplayRowsOfTable_nonempty_of_split
     0 < (activeMemReplayRowsOfTable table).length := by
   rw [h_split]
   simp
+
+/-- Zero row for totalizing concrete Main table projections. -/
+def zeroMainRowWithRom : ZiskFv.AirsClean.Main.MainRowWithRom FGL where
+  core := {
+    a_0 := 0
+    a_1 := 0
+    b_0 := 0
+    b_1 := 0
+    c_0 := 0
+    c_1 := 0
+    flag := 0
+    pc := 0
+    is_external_op := 0
+    op := 0
+    m32 := 0
+    ind_width := 0
+    set_pc := 0
+    jmp_offset1 := 0
+    jmp_offset2 := 0
+    store_pc := 0
+    im_high_degree_2 := 0
+    segment_l1 := 0 }
+  rom := {
+    a_offset_imm0 := 0
+    a_imm1 := 0
+    b_offset_imm0 := 0
+    b_imm1 := 0
+    store_offset := 0
+    a_src_imm := 0
+    a_src_mem := 0
+    is_precompiled := 0
+    b_src_imm := 0
+    b_src_mem := 0
+    store_mem := 0
+    store_ind := 0
+    b_src_ind := 0
+    a_src_reg := 0
+    b_src_reg := 0
+    store_reg := 0
+    addr0 := 0
+    addr1 := 0
+    addr2 := 0
+    main_step := 0 }
+
+/-- Project row `row` of a concrete Clean Main table to its unified Main+ROM
+    row input. Out-of-range rows use `zeroMainRowWithRom` only to keep the
+    named-column view total. -/
+@[reducible]
+def mainTableRowAtOrZero
+    {length : ℕ}
+    (program : Program length)
+    (table : Table FGL)
+    (row : ℕ) : ZiskFv.AirsClean.Main.MainRowWithRom FGL :=
+  if h_row : row < table.table.length then
+    eval (table.environment (table.table.get ⟨row, h_row⟩))
+      (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program).rowInputVar
+  else
+    zeroMainRowWithRom
+
+/-- Named-column Main view obtained from the concrete Clean unified Main table. -/
+@[reducible]
+def mainOfTable
+    {length : ℕ}
+    (program : Program length)
+    (table : Table FGL) :
+    ZiskFv.Airs.Main.Valid_Main FGL FGL where
+  a_0 := fun row => (mainTableRowAtOrZero program table row).core.a_0
+  a_1 := fun row => (mainTableRowAtOrZero program table row).core.a_1
+  b_0 := fun row => (mainTableRowAtOrZero program table row).core.b_0
+  b_1 := fun row => (mainTableRowAtOrZero program table row).core.b_1
+  c_0 := fun row => (mainTableRowAtOrZero program table row).core.c_0
+  c_1 := fun row => (mainTableRowAtOrZero program table row).core.c_1
+  flag := fun row => (mainTableRowAtOrZero program table row).core.flag
+  pc := fun row => (mainTableRowAtOrZero program table row).core.pc
+  is_external_op := fun row => (mainTableRowAtOrZero program table row).core.is_external_op
+  op := fun row => (mainTableRowAtOrZero program table row).core.op
+  b_src_imm := fun row => (mainTableRowAtOrZero program table row).rom.b_src_imm
+  b_src_mem := fun row => (mainTableRowAtOrZero program table row).rom.b_src_mem
+  b_src_ind := fun row => (mainTableRowAtOrZero program table row).rom.b_src_ind
+  b_src_reg := fun row => (mainTableRowAtOrZero program table row).rom.b_src_reg
+  m32 := fun row => (mainTableRowAtOrZero program table row).core.m32
+  ind_width := fun row => (mainTableRowAtOrZero program table row).core.ind_width
+  set_pc := fun row => (mainTableRowAtOrZero program table row).core.set_pc
+  jmp_offset1 := fun row => (mainTableRowAtOrZero program table row).core.jmp_offset1
+  jmp_offset2 := fun row => (mainTableRowAtOrZero program table row).core.jmp_offset2
+  store_pc := fun row => (mainTableRowAtOrZero program table row).core.store_pc
+  im_high_degree_2 := fun row => (mainTableRowAtOrZero program table row).core.im_high_degree_2
+  segment_l1 := fun row => (mainTableRowAtOrZero program table row).core.segment_l1
+
+/-- In-range concrete table projection agrees with `List.get`. -/
+theorem mainTableRowAtOrZero_get
+    {length : ℕ}
+    (program : Program length)
+    (table : Table FGL)
+    (idx : Fin table.table.length) :
+    mainTableRowAtOrZero program table idx.val =
+      eval (table.environment (table.table.get idx))
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program).rowInputVar := by
+  unfold mainTableRowAtOrZero
+  rw [dif_pos idx.isLt]
+
+/-- The named-column projection of a concrete unified Main table has the
+    expected core `rowAt` view at every in-range index. -/
+theorem rowAt_mainOfTable
+    {length : ℕ}
+    (program : Program length)
+    (table : Table FGL)
+    (idx : Fin table.table.length) :
+    ZiskFv.AirsClean.Main.rowAt (mainOfTable program table) idx.val =
+      (eval (table.environment (table.table.get idx))
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program).rowInputVar).core := by
+  simp [ZiskFv.AirsClean.Main.rowAt, mainTableRowAtOrZero_get program table idx]
+
+/-- The legacy `opBus_row_Main` view of `mainOfTable` is the Clean Main
+    operation-bus message evaluated on the same concrete row. -/
+theorem opBus_row_Main_mainOfTable
+    {length : ℕ}
+    (program : Program length)
+    (table : Table FGL)
+    (idx : Fin table.table.length) :
+    ZiskFv.Airs.OperationBus.opBus_row_Main (mainOfTable program table) idx.val =
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+        (ZiskFv.AirsClean.Main.opBusMessage
+          (eval (table.environment (table.table.get idx))
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar).core)
+        (eval (table.environment (table.table.get idx))
+          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar).core.is_external_op := by
+  rw [← ZiskFv.AirsClean.Main.opBusMessage_toEntry_rowAt_eq_opBus_row]
+  rw [rowAt_mainOfTable program table idx]
+  simp [mainTableRowAtOrZero_get program table idx]
 
 /-- Zero fallback for out-of-range projections from a concrete Mem table.
     In-range rows are the only rows consumed by the table bridge below. -/

--- a/ZiskFv/Compliance/AcceptedTrace.lean
+++ b/ZiskFv/Compliance/AcceptedTrace.lean
@@ -1,0 +1,187 @@
+import ZiskFv.AirsClean.FullEnsemble.Balance
+import ZiskFv.Compliance.AeneasBridgeTrust
+import ZiskFv.EquivCore.Promises.BranchHelpers
+
+/-!
+# Accepted trace construction spine
+
+P4 starts replacing caller-supplied `OpEnvelope` packages with envelopes
+constructed from an accepted full-ensemble trace plus one named program-binding
+premise. This PR1 module introduces the input record and the first construction
+template, for BEQ.
+
+`ProgramBinding` is intentionally the only bucket-(b) premise here. It carries
+the Sail/decode row facts that P4 does not prove from circuit constraints. The
+BEQ constructor below still packages the branch operands and promise bundle
+locally from those binding projections.
+-/
+
+namespace ZiskFv.Compliance
+
+open Goldilocks
+
+/-- Accepted committed trace for the full RV64IM Clean ensemble. -/
+structure AcceptedTrace where
+  length : Nat
+  program : ZiskFv.AirsClean.ZiskInstructionRom.Program length
+  witness :
+    Air.Flat.EnsembleWitness
+      (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble length program).ensemble
+  constraints : witness.Constraints
+  balanced : witness.BalancedChannels
+
+/-- Opcode-family selector exposed by the program binding. PR1 only consumes
+    `beq`; later P4 PRs extend the construction dispatcher over all tags. -/
+inductive ArmTag where
+  | beq
+  | other
+deriving DecidableEq, Repr
+
+/-- BEQ-specific projection of the named `ProgramBinding` premise.
+
+The fields are the raw Sail/decode/provenance facts. `ops` and `promises` below
+package these facts into the existing compliance API without adding a second
+caller-facing premise. -/
+structure BeqRowBinding
+    (main : ZiskFv.Airs.Main.Valid_Main FGL FGL) (r_main : Nat)
+    (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource) where
+  input : PureSpec.BeqInput
+  imm : BitVec 13
+  r1 : regidx
+  r2 : regidx
+  misaVal : RegisterType Register.misa
+  execRow : List (Interaction.ExecutionBusEntry FGL)
+  provenance : MainRowProvenance main r_main
+  h_op : provenance.extractedRow.op = ExtractedConst.opEq
+  h_external : provenance.extractedRow.isExternalOp = true
+  h_m32 : provenance.extractedRow.m32 = false
+  h_set_pc : provenance.extractedRow.setPc = false
+  h_store_pc : provenance.extractedRow.storePc = false
+  h_jmp_offset2 : provenance.extractedRow.jmpOffset2 = 4
+  h_input_imm : input.imm = imm
+  h_input_r1 :
+    read_xreg (regidx_to_fin r1) state = EStateM.Result.ok input.r1_val state
+  h_input_r2 :
+    read_xreg (regidx_to_fin r2) state = EStateM.Result.ok input.r2_val state
+  h_input_pc : state.regs.get? Register.PC = .some input.PC
+  h_input_misa : state.regs.get? Register.misa = .some misaVal
+  h_misa_c : Sail.BitVec.extractLsb misaVal 2 2 = 0#1
+  h_target_aligned : (input.PC + BitVec.signExtend 64 input.imm).toNat % 4 = 0
+  h_exec_len : execRow.length = 2
+  h_e0_mult : execRow[0]!.multiplicity = -1
+  h_e1_mult : execRow[1]!.multiplicity = 1
+  h_nextPC_matches :
+    (register_type_pc_equiv ▸ (BitVec.ofNat 64 (execRow[1]!.pc).val))
+      = (PureSpec.execute_BEQ_pure input).nextPC
+
+namespace BeqRowBinding
+
+/-- Branch operand bundle constructed from the named binding projection. -/
+@[reducible]
+def ops {main : ZiskFv.Airs.Main.Valid_Main FGL FGL} {r_main : Nat}
+    {state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource}
+    (b : BeqRowBinding main r_main state) : BranchInstrOperands where
+  imm := b.imm
+  r1 := b.r1
+  r2 := b.r2
+  misa_val := b.misaVal
+  exec_row := b.execRow
+
+/-- Branch promise bundle constructed from the named binding projection. -/
+@[reducible]
+def promises {main : ZiskFv.Airs.Main.Valid_Main FGL FGL} {r_main : Nat}
+    {state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource}
+    (b : BeqRowBinding main r_main state) :
+    ZiskFv.EquivCore.Promises.BranchPromises
+      state b.input.imm b.input.r1_val b.input.r2_val b.input.PC
+      (b.ops).misa_val
+      (PureSpec.execute_BEQ_pure b.input).nextPC
+      (PureSpec.execute_BEQ_pure b.input).throws
+      (PureSpec.execute_BEQ_pure b.input).success
+      (b.ops).imm (b.ops).r1 (b.ops).r2 (b.ops).exec_row :=
+  ZiskFv.EquivCore.Promises.BranchPromises.of_aligned_BEQ
+    b.input
+    b.h_input_imm
+    b.h_input_r1
+    b.h_input_r2
+    b.h_input_pc
+    b.h_input_misa
+    b.h_misa_c
+    b.h_target_aligned
+    b.h_exec_len
+    b.h_e0_mult
+    b.h_e1_mult
+    b.h_nextPC_matches
+
+end BeqRowBinding
+
+/-- The single named program-binding premise for P4 construction.
+
+It supplies the Sail state sequence, the selected Main table, and per-row
+decode/provenance projections. Later PRs add projections for the remaining
+`ArmTag`s while keeping this as one named premise. -/
+structure ProgramBinding (trace : AcceptedTrace) where
+  stateAt :
+    Fin trace.length →
+      PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+  mainTable : Air.Flat.Table FGL
+  mainTable_mem : mainTable ∈ trace.witness.allTables
+  mainTable_component :
+    mainTable.component =
+      ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+        trace.length trace.program
+  armTag : Fin trace.length → ArmTag
+  beq :
+    ∀ i : Fin trace.length, armTag i = ArmTag.beq →
+      BeqRowBinding
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program mainTable)
+        i.val
+        (stateAt i)
+
+/-- Construct the BEQ envelope arm from an accepted trace plus the named
+    program-binding projection for a BEQ row. -/
+def construction_beq
+    (trace : AcceptedTrace)
+    (binding : ProgramBinding trace)
+    (i : Fin trace.length)
+    (h_tag : binding.armTag i = ArmTag.beq) :
+    OpEnvelope
+      (binding.stateAt i)
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+      i.val :=
+  let b := binding.beq i h_tag
+  OpEnvelope.beqOfExtractedShape
+    b.input
+    b.ops
+    b.provenance
+    b.h_op
+    b.h_external
+    b.h_m32
+    b.h_set_pc
+    b.h_store_pc
+    b.h_jmp_offset2
+    b.promises
+
+/-- BEQ's Aeneas bridge predicate is derived from the named program-binding
+    provenance facts, not supplied as a separate premise. -/
+theorem construction_beq_aeneasBridgeTrust
+    (trace : AcceptedTrace)
+    (binding : ProgramBinding trace)
+    (i : Fin trace.length)
+    (h_tag : binding.armTag i = ArmTag.beq) :
+    (construction_beq trace binding i h_tag).aeneasBridgeTrust := by
+  let b := binding.beq i h_tag
+  exact
+    OpEnvelope.aeneasBridgeTrust_beqOfExtractedShape
+      b.input
+      b.ops
+      b.provenance
+      b.h_op
+      b.h_external
+      b.h_m32
+      b.h_set_pc
+      b.h_store_pc
+      b.h_jmp_offset2
+      b.promises
+
+end ZiskFv.Compliance

--- a/bin/TrustGate/Main.lean
+++ b/bin/TrustGate/Main.lean
@@ -298,6 +298,7 @@ def usage : IO Unit := do
   IO.println "  find-unused PATH               enumerate ZiskFv.* consts not reachable from PATH entry points"
   IO.println "  check-closure-vs-baseline PATH check zisk_riscv_compliant_program_bus axiom closure == generated/baseline-axioms.txt"
   IO.println "  print-global-binders           print zisk_riscv_compliant_program_bus binder baseline rows"
+  IO.println "  print-construction-binders     print P4 construction theorem binder baseline rows"
   IO.println "  print-tree-edges NAME          emit TSV edge list (parent→child) for proof-tree visualizer"
 
 def dispatch (env : Environment) (args : List String) : IO UInt32 := do
@@ -328,6 +329,9 @@ def dispatch (env : Environment) (args : List String) : IO UInt32 := do
   | ["print-global-binders"] =>
     cmdPrintGlobalBinders env
       `ZiskFv.Compliance.zisk_riscv_compliant_program_bus
+  | ["print-construction-binders"] =>
+    cmdPrintGlobalBinders env
+      `ZiskFv.Compliance.construction_beq
   | ["all"] =>
     let baseline ← IO.FS.readFile "trust/generated/baseline-equiv-axiom-deps.txt"
     let r1 ← diffStrings (renderDepsBaseline env) baseline

--- a/docs/ai/PROJECTS.md
+++ b/docs/ai/PROJECTS.md
@@ -2,7 +2,7 @@
 
 ## Endgame
 
-Metaplan: `docs/ai/plan/ENDGAME_ROADMAP.md` — the campaign from the current envelope-conditional global theorem to a trace-level public statement, in six phases (P1 foundations & bucket-audit verdict; P2 validation tooling; P3 memory argument; P4 construction theorem; P5 trace-level export; P6 OpEnvelope retirement), anchored to issues #61/#74–#78. Plans are written per-phase at ~5 PRs each, only when the phase is staffed. P1 is ready for execution: `docs/ai/plan/PLAN_ENDGAME_P1.md` (finalization sweep + kernel-only axiom closure + ADD instantiation + envelope burden audit + lean4lean scouting).
+Metaplan: `docs/ai/plan/ENDGAME_ROADMAP.md` — the campaign from the current envelope-conditional global theorem to a trace-level public statement, in six phases anchored to issues #61/#74-#78. P1 is complete on main via #89 (`cf2a4aa6`), and P3 is complete on main via #90/#91 (`4456a9e5`) as an auditable reshape rather than a memory-trust reduction. Active stream: `docs/ai/plan/PLAN_ENDGAME_P4.md`, the first trust-reducing phase: build `AcceptedTrace -> OpEnvelope`, discharge derivable bucket-(a) evidence from accepted trace data, and leave only the named bucket-(b) residuals (`aeneasBridgeTrust`, `ProgramBinding`/boot, `NoKnownDefect`). Current focus is P4 PR1 in `.worktrees/endgame-p4-pr1`: `AcceptedTrace`, `ProgramBinding`, `mainOfTable`, one BEQ construction template, and the construction-binder audit gate.
 
 ## Clean Completeness Proofs
 

--- a/trust/README.md
+++ b/trust/README.md
@@ -46,6 +46,7 @@ when they are not trust policy or trust evidence.
 | `generated/baseline-axioms.txt`                | `trust/scripts/regenerate.py`                                 | Hash-pinned source ledger for allowed Lean trust declarations. |
 | `generated/baseline-zisk-riscv-compliant.txt`  | `lake exe trust-gate print-axiom-closure` via `regenerate.sh` | Active project-axiom closure of the global compliance theorem. |
 | `generated/baseline-global-theorem-binders.txt` | `lake exe trust-gate print-global-binders` via `regenerate.sh` | Elaborated binder list for the global compliance theorem.      |
+| `generated/baseline-construction-theorem-binders.txt` | `lake exe trust-gate print-construction-binders` via `regenerate.sh` | Elaborated binder list for the P4 construction theorem.        |
 | `generated/baseline-equiv-axiom-deps.txt`      | `lake exe trust-gate regenerate-deps`                         | Per-canonical-theorem axiom closures.                          |
 | `generated/baseline-hypothesis-count.txt`      | `trust/scripts/count-hypotheses.py`                           | Anti-laundering metric for canonical theorem binder counts.    |
 | `generated/baseline-caller-burden.txt`         | `trust/scripts/regenerate-caller-burden.py`                   | Caller-burden ledger for canonical theorem binders.            |

--- a/trust/generated/baseline-construction-theorem-binders.txt
+++ b/trust/generated/baseline-construction-theorem-binders.txt
@@ -1,0 +1,4 @@
+0 :: trace :: ZiskFv.Compliance.AcceptedTrace
+1 :: binding :: ZiskFv.Compliance.ProgramBinding trace
+2 :: i :: Fin trace.length
+3 :: h_tag :: Eq (binding.armTag i) ZiskFv.Compliance.ArmTag.beq

--- a/trust/scripts/check-all-semantic.sh
+++ b/trust/scripts/check-all-semantic.sh
@@ -54,22 +54,23 @@ run_witnesses() {
   return $ok
 }
 
-run "1/11 axiom-deps baseline (V2)"        "$dir/check-axiom-deps.sh"
-run "2/11 forbidden types (V2)"            "$dir/check-no-output-eq-v2.sh"
-run "3/11 closure vs baseline-axioms (V2)" "$dir/check-closure-vs-baseline.sh"
-run "4/11 global theorem binders (V2)"     "$dir/check-global-theorem-binders.sh"
-run "5/11 consistency false probe rejected" reject_false_probe
-run "6/11 Sail memory timeline witness" \
+run "1/12 axiom-deps baseline (V2)"        "$dir/check-axiom-deps.sh"
+run "2/12 forbidden types (V2)"            "$dir/check-no-output-eq-v2.sh"
+run "3/12 closure vs baseline-axioms (V2)" "$dir/check-closure-vs-baseline.sh"
+run "4/12 global theorem binders (V2)"     "$dir/check-global-theorem-binders.sh"
+run "5/12 construction theorem binders (V2)" "$dir/check-construction-theorem-binders.sh"
+run "6/12 consistency false probe rejected" reject_false_probe
+run "7/12 Sail memory timeline witness" \
   run_lean_no_sorry trust/consistency/load_byte_agreement_witness.lean
-run "7/11 memory timeline construction witness" \
+run "8/12 memory timeline construction witness" \
   run_lean_no_sorry trust/consistency/memory_timeline_construction_witness.lean
-run "8/11 memory prefix alignment witness" \
+run "9/12 memory prefix alignment witness" \
   run_lean_no_sorry trust/consistency/memory_prefix_alignment_witness.lean
-run "9/11 global ADD theorem instantiation" \
+run "10/12 global ADD theorem instantiation" \
   run_lean_no_sorry trust/consistency/global_theorem_instantiation_add.lean
-run "10/11 global LD theorem instantiation" \
+run "11/12 global LD theorem instantiation" \
   run_lean_no_sorry trust/consistency/global_theorem_instantiation_ld.lean
-run "11/11 Clean completeness witnesses" run_witnesses
+run "12/12 Clean completeness witnesses" run_witnesses
 
 if [ $overall -eq 0 ]; then
   echo "trust-gate (V2 semantic): ALL CHECKS PASSED."

--- a/trust/scripts/check-construction-theorem-binders.sh
+++ b/trust/scripts/check-construction-theorem-binders.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# check-construction-theorem-binders.sh - V2: assert that the P4
+# construction theorem's elaborated binder list matches the committed
+# baseline.
+#
+# Requires `lake build` to have run (consumes oleans).
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+baseline=trust/generated/baseline-construction-theorem-binders.txt
+if [ ! -f "$baseline" ]; then
+  echo "trust-gate (V2): missing $baseline."
+  exit 1
+fi
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+lake exe trust-gate print-construction-binders > "$tmp"
+
+if diff -u "$baseline" "$tmp"; then
+  echo "trust-gate (V2): construction theorem binder baseline matches."
+else
+  echo "trust-gate (V2): construction theorem binder baseline DIFFERS."
+  echo "  Run:"
+  echo "    lake exe trust-gate print-construction-binders > $baseline"
+  echo "  and review the diff before committing."
+  exit 1
+fi

--- a/trust/scripts/regenerate.sh
+++ b/trust/scripts/regenerate.sh
@@ -2,11 +2,12 @@
 # Refresh the trust baseline files. Run this after a legitimate
 # trust-surface change, commit the updated baseline files alongside.
 #
-# Seven baselines:
+# Eight baselines:
 #   trust/generated/baseline-axioms.txt                  — V1: source-text-hash per axiom
 #   trust/generated/baseline-equiv-axiom-deps.txt        — V2: per-theorem axiom closure
 #   trust/generated/baseline-zisk-riscv-compliant.txt    — V2: uber-theorem project-axiom closure
 #   trust/generated/baseline-global-theorem-binders.txt  — V2: uber-theorem binder list
+#   trust/generated/baseline-construction-theorem-binders.txt — V2: P4 construction binder list
 #   trust/generated/baseline-hypothesis-count.txt        — anti-laundering: per-theorem binder counts
 #   trust/generated/baseline-caller-burden.txt           — anti-laundering: per-binder ledger (canonical)
 #   trust/generated/baseline-wrapper-caller-burden.txt   — anti-laundering: per-binder ledger (wrappers)
@@ -43,6 +44,10 @@ if [ -d .lake/build ]; then
   echo "Refreshing global theorem binder baseline..."
   lake exe trust-gate print-global-binders > trust/generated/baseline-global-theorem-binders.txt
   echo "  → trust/generated/baseline-global-theorem-binders.txt"
+
+  echo "Refreshing construction theorem binder baseline..."
+  lake exe trust-gate print-construction-binders > trust/generated/baseline-construction-theorem-binders.txt
+  echo "  → trust/generated/baseline-construction-theorem-binders.txt"
 
   echo "Refreshing uber-theorem axiom-closure baseline..."
   {


### PR DESCRIPTION
Queued for Claude review — do not merge.

## Summary
- Add `AcceptedTrace`, the named `ProgramBinding` premise, and a BEQ construction template from trace/binding data to `OpEnvelope`.
- Add `mainOfTable` plus row/op-bus correctness lemmas beside the existing full-ensemble table extraction machinery.
- Add the P4 construction-theorem binder audit baseline and wire it into the semantic trust gate.

## Scope
- PR1 template only: BEQ has no provider AIR and no memory timeline obligations.
- `ProgramBinding` remains the single named bucket-(b) input for Sail state/decode/provenance facts.
- No canonical `equiv_<OP>` signatures or existing caller-burden ledgers are changed.

## Verification
- `lake build`
- `trust/scripts/check-all.sh`
- `trust/scripts/check-all-semantic.sh`
- `nix run .#test`
- `lake exe trust-gate print-axiom-closure ZiskFv.Compliance.zisk_riscv_compliant_program_bus` (no closure entries; only existing `String.trim` warnings)
- `git diff origin/main -- trust/`
- `lean_verify` on `ZiskFv.Compliance.construction_beq_aeneasBridgeTrust`: only standard axioms (`propext`, `Classical.choice`, `Quot.sound`), no source warnings

## Notes
- Rebased onto `origin/main` at `1781edeb` after the tracked Aeneas extraction PR landed.
- The new construction baseline currently records the BEQ-template binders: `trace`, `binding`, `i`, and the BEQ tag proof `h_tag`. The tag proof is the row-family selector consumed by the future total dispatcher, not a per-field bucket-(a) obligation.
- `trust/README.md` anti-laundering terms were read before opening this PR.

## §7 Self-Check
1. Metrics: a new construction binder baseline makes the construction surface auditable; canonical hypothesis/caller-burden baselines are unchanged.
2. No bucket-(a) field was faked: BEQ operands, promises, and provenance-derived bridge facts are packaged from `ProgramBinding`; no extra per-field caller premise was added.
3. No new axioms, `sorry`, `opaque`, `unsafe`, `partial def`, or `native_decide`; global closure remains 0. New helper projections are `@[reducible]` where appropriate.
4. Balance is assumed only as `trace.balanced` in `AcceptedTrace`; PR1 does not try to prove balance.
5. Canonical glossary terms used; `trust/README.md#anti-laundering-terms` read.
