### PR TITLE
ci: add nasm to Aeneas extraction diff app

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -119,6 +119,7 @@
               gnumake
               jq
               libclang.lib
+              nasm
               nix
               rustc
               pkgsCross.riscv64-embedded.stdenv.cc


### PR DESCRIPTION
## Summary
- add `nasm` to the `aeneas-production-extract-check-tracked` app runtime inputs
- match the existing `aeneas-production-extract` app dependency set for the `zisk/lib-c` build script

## Verification
- `act push -j aeneas-extraction-diff --container-architecture linux/amd64` reached the Nix extraction app and no longer failed with `make: nasm: No such file or directory`; full local `act` completion was blocked by local Docker/Nix DNS and `/homeless-shelter` artifacts after the original failure point
- `nix run .#aeneas-production-extract-check-tracked` passed after initializing the `zisk` submodule, ending with `Tracked Aeneas extraction matches regenerated ProductionM2.lean.`

Fixes failed job https://github.com/eth-act/zisk-fv/actions/runs/27488638128/job/81249525877