### PR TITLE
ci: add nasm to checked Aeneas extraction app

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -148,6 +148,7 @@
               gnumake
               jq
               libclang.lib
+              nasm
               nix
               rustc
               pkgsCross.riscv64-embedded.stdenv.cc


### PR DESCRIPTION
## Summary
- add nasm to the runtime inputs for aeneas-production-extract-check-tracked
- fixes the Aeneas extraction diff job, which runs the checked app rather than aeneas-production-extract

## Verification
- nix run .#aeneas-production-extract-check-tracked
- act push -j aeneas-extraction-diff --container-architecture linux/amd64 --privileged --container-options "--add-host static.crates.io:151.101.18.137 --add-host static.rust-lang.org:151.101.18.137" got past the original missing-nasm failure, fetched nasm, compiled zisk/lib-c, then was canceled during later Aeneas/OCaml dependency builds