### PR TITLE
P4 sweep (NEEDS-WORK, stacked on #99): ADD/ADDI + W-ALU sound constructions

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,3 +1,33 @@
+Active plan: docs/ai/plan/PLAN_ENDGAME_P4_SWEEP.md (PR5 W-ALU, NEEDS-WORK Wave 6).
+
+DONE (SWEEP Wave 6 — W-ALU ADDW/SUBW/ADDIW, the NEEDS-WORK m32=1 binary
+families): AUTHORED the missing m32=1 32-bit lane-binding lemmas
+`input_r1_packed_a32_row` / `input_r2_packed_b32_row` in
+ZiskFv/EquivCore/Bridge/Binary.lean (the binary analog of the BinaryExtension
+shift bridge's packed_a_lo32_eq_of_shift_match_m32_1_of_a_range). KEY FINDING:
+the m32=1 binary lane DOES close cleanly, and WITHOUT needing one_sub_one_mul on
+a_hi — for the staticBinary provider the a_lo conjunct of matches_entry is
+m32-independent, so the 32-bit operand binding (extractLsb r1_val 31 0).toNat =
+binaryRowA32 row % 2^32 derives from the low-4-byte a_lo equation alone (the
+a_hi=(1-m32)*a_1 collapses to 0 but is not consumed for the low half). Lane
+lemmas take 4 explicit a/b byte-range (<256) hyps, sourced in the constructions
+from h_facts (StaticBinaryTableWfFacts) — no byte_chain_discharge_64 (which
+requires mode32=0). Added ConstructionWAlu.lean with construction_subw_sound
+(unique OP_SUB_W, Or.inr), construction_addw_sound (OP_ADD_W, Or.inl), and
+construction_addiw_sound (ITYPE, OP_ADD_W; imm + h_addiw_subset named pin +
+ITypePromises; wrapper derives the immediate byte decomposition internally).
+W bus harness: m32=1, writeReg-nextPC prelude retained. Appended all three to
+soundConstructionTheorems (25 → 28); deep baseline grew +3 honest flat blocks
+(subw 34, addw 34, addiw 33 binders; ZERO RowBinding/MainRowProvenance leaves;
+prior 25 blocks byte-identical prefix). lake build green (8688 jobs);
+check-all.sh 18/18; check-all-semantic.sh 12/12; baseline-axioms.txt UNCHANGED
+(lane lemmas add NO axiom); 0 PROJECT (ZiskFv.*) axioms per new theorem and lane
+lemma (closure = [cancel_reservation, propext, Classical.choice, Quot.sound] for
+constructions; [propext, Classical.choice, Quot.sound] for the lane lemmas —
+Sail+kernel external only). NO sorry/admit/native_decide.
+
+--- prior (Wave 5, from base p4-closeout-construction) ---
+
 Active plan: docs/ai/plan/PLAN_ENDGAME_P4_CLOSEOUT.md (§5 PR2, rework-off-#97).
 
 Branch `p4-closeout-construction` off `origin/endgame-p4-pr2` (#97 @ 6c414ffa).

--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -139,6 +139,7 @@ import ZiskFv.Compliance.ConstructionCompare
 import ZiskFv.Compliance.ConstructionIType
 import ZiskFv.Compliance.ConstructionShift
 import ZiskFv.Compliance.ConstructionAdd
+import ZiskFv.Compliance.ConstructionWAlu
 import ZiskFv.Compliance
 import ZiskFv.Completeness.Rv
 import ZiskFv.Completeness.Rv64im

--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -138,6 +138,7 @@ import ZiskFv.Compliance.ConstructionLogic
 import ZiskFv.Compliance.ConstructionCompare
 import ZiskFv.Compliance.ConstructionIType
 import ZiskFv.Compliance.ConstructionShift
+import ZiskFv.Compliance.ConstructionAdd
 import ZiskFv.Compliance
 import ZiskFv.Completeness.Rv
 import ZiskFv.Completeness.Rv64im

--- a/ZiskFv/Compliance/ConstructionAdd.lean
+++ b/ZiskFv/Compliance/ConstructionAdd.lean
@@ -1,0 +1,507 @@
+import ZiskFv.Compliance.ConstructionSub
+import ZiskFv.Compliance.Wrappers.Add
+import ZiskFv.Compliance.Wrappers.Addi
+import ZiskFv.EquivCore.Promises.IType
+import ZiskFv.Tactics.ALUITypeArchetype
+
+/-!
+# Sound ADD / ADDI constructions (`construction_add_sound`, `construction_addi_sound`)
+
+The ADD / ADDI families of the P4 SWEEP Wave 5 (PLAN_ENDGAME_P4_SWEEP.md PR4).
+These are the NEEDS-WORK families: unlike SUB/AND/OR/XOR/… they are **not**
+clones of `construction_and_sound`, because `OP_ADD = 0x0A = 10` may be served by
+EITHER of two distinct providers with two distinct `opBusMessage` shapes:
+
+* the lookup-aware Binary provider (`staticLookupComponent`), or
+* the dedicated `BinaryAdd` provider (`BinaryAdd.component`).
+
+The salvaged Layer-A wrapper `exists_add_provider_row_matches_from_binding`
+(`AcceptedTrace.lean`) RESOLVES the op-bus from `trace.balanced` into the
+conjunction
+
+```
+add_subset_holds m i.val  ∧  (staticLookup-match ∨ BinaryAdd-match)
+```
+
+— a genuine provider DISJUNCTION, not a single unambiguous provider.
+
+## The chosen approach — (a) two-arm case-split (PR4 design decision)
+
+This construction takes **approach (a)** from the plan: it CASE-SPLITS the
+provider disjunction and discharges the **same** canonical goal on EACH arm,
+deriving the rd data effect independently per arm. No exclusion premise is
+carried — the conclusion holds regardless of which provider served the op.
+
+* **lookup arm** — mirrors `construction_sub_sound` / `construction_and_sound`:
+  derives the all-byte-matches fact via
+  `logic_row_mode_pins_of_emit_op_lt_16_of_static_spec` (`OP_ADD = 10 < 16`) +
+  `byte_chain_discharge_64_of_static_row`, then the lane→Sail binding
+  (`input_r1_packed_a_row` / `input_r2_packed_b_row`), then calls
+  `Compliance.equiv_ADD` (the lookup-arm wrapper).
+* **BinaryAdd arm** — calls `Compliance.equiv_ADD_via_binaryadd`, which consumes
+  the `add_subset_holds` conjunct (derived, NOT a binder), the r1/r2 lane bridges,
+  `m32 = 0`, and the BinaryAdd component facts (all derived from the provider's
+  Clean `Spec`). The data effect (`binary_add_chunks_eq_bv_add_via_component`)
+  bottoms inside `equiv_ADD_of_binaryadd_row`.
+
+Both arms share the SAME `bus` (`busSub`), `pins`, `promises`, `h_lane_rd`, and
+r1/r2 lane bridges — the rd write (`bus.e2`) is the Main row's emission regardless
+of which provider served the op. The disjunction only changes the op-bus
+provider-match block and how the operand→Sail binding is routed.
+
+## Residual budget: EXACTLY 17 + execRow (ADD), same as SUB/AND
+
+The disjunction is RESOLVED inside the body — both `add_subset_holds` and the
+provider match are DERIVED (bucket-(a)), not binders. So ADD's residual budget is
+identical to SUB's: the same 17 named top-level binders + `execRow`. (ADDI grows
+by the I-type immediate delta: it drops the r2 register lane bridges and gains the
+`imm` binder, the `h_input_imm` decode equality, the `h_addi_subset` immediate
+routing pin, and a `h_set_pc` pin consumed by the BinaryAdd arm.)
+
+## Anti-vacuity (PLAN §4.9)
+
+`execRow` is a genuine top-level ∀-binder in BOTH; the bus consumed by the exec
+hypotheses is built from the real trace row (`busSub`), NOT chosen to trivialize a
+hypothesis.
+
+## Axioms
+
+Both constructions introduce **0 PROJECT (`ZiskFv.*`) axioms**. As with every
+canonical theorem in this project, their closure still includes the
+Sail-translation axioms and the Lean-kernel postulates as documented external
+trust (`TrustGate.AxiomClosure.isProjectAxiom` filters those by design).
+-/
+
+namespace ZiskFv.Compliance
+
+open ZiskFv.Trusted
+open ZiskFv.Airs.Main
+open ZiskFv.Airs.OperationBus
+open ZiskFv.EquivCore.Promises
+
+set_option maxHeartbeats 2000000
+
+/-- Sound ADD construction (PR4, approach (a): two-arm provider case-split).
+
+    From the accepted trace + honest residual binders, conclude the canonical
+    `execute (RTYPE ADD) = (bus_effect …).2`. The op-bus provider is resolved from
+    `trace.balanced` into a `staticLookup ∨ BinaryAdd` disjunction; BOTH arms are
+    discharged, each deriving the rd data effect from the corresponding provider's
+    Clean `Spec`. The `add_subset_holds` conjunct and the provider match are
+    DERIVED (bucket-(a)), so the residual budget matches SUB: 17 + `execRow`.
+
+    Honest top-level residual binders (the validated §2 SUB budget, 17 +
+    `execRow`):
+    * (b) decode pins (4): `h_main_op`, `h_main_active`, `h_m32`, `h_store_pc`
+    * (b) Sail reads + operands (5): `h_input_r1`, `h_input_r2`, `h_input_pc`,
+      `h_input_rd`, `h_rd_idx`
+    * (b) lane bridges (4): `h_a_lo_t`, `h_a_hi_t`, `h_b_lo_t`, `h_b_hi_t`
+    * (b)-pending-infra (1): `h_nextPC_matches`
+    * (c) exec artifacts (3): `h_exec_len`, `h_e0_mult`, `h_e1_mult`, PLUS the
+      genuine `execRow` ∀-binder. -/
+theorem construction_add_sound
+    (trace : AcceptedTrace)
+    (binding : ProgramBinding trace)
+    (i : Fin trace.length)
+    (add_input : PureSpec.AddInput)
+    (r1 r2 rd : regidx)
+    -- (b) decode pins
+    (h_main_op :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).op
+        i.val = ZiskFv.Trusted.OP_ADD)
+    (h_main_active :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).is_external_op
+        i.val = 1)
+    (h_m32 :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).m32
+        i.val = 0)
+    (h_store_pc :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).store_pc
+        i.val = 0)
+    -- (b) Sail reads + operands
+    (h_input_r1 :
+      read_xreg (regidx_to_fin r1) (binding.stateAt i)
+        = EStateM.Result.ok add_input.r1_val (binding.stateAt i))
+    (h_input_r2 :
+      read_xreg (regidx_to_fin r2) (binding.stateAt i)
+        = EStateM.Result.ok add_input.r2_val (binding.stateAt i))
+    (h_input_pc : (binding.stateAt i).regs.get? Register.PC = .some add_input.PC)
+    (h_input_rd : add_input.rd = regidx_to_fin rd)
+    -- (b) lane bridges
+    (h_a_lo_t :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).a_0 i.val =
+        ZiskFv.Trusted.lane_lo
+          ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg
+            (regidx_to_fin r1)))
+    (h_a_hi_t :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).a_1 i.val =
+        ZiskFv.Trusted.lane_hi
+          ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg
+            (regidx_to_fin r1)))
+    (h_b_lo_t :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).b_0 i.val =
+        ZiskFv.Trusted.lane_lo
+          ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg
+            (regidx_to_fin r2)))
+    (h_b_hi_t :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).b_1 i.val =
+        ZiskFv.Trusted.lane_hi
+          ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg
+            (regidx_to_fin r2)))
+    -- (c) exec artifacts: the exec row is a genuine top-level binder.
+    (execRow : List (Interaction.ExecutionBusEntry FGL))
+    (h_exec_len : (busSub trace binding i execRow).exec_row.length = 2)
+    (h_e0_mult : (busSub trace binding i execRow).exec_row[0]!.multiplicity = -1)
+    (h_e1_mult : (busSub trace binding i execRow).exec_row[1]!.multiplicity = 1)
+    (h_nextPC_matches :
+      (register_type_pc_equiv ▸
+          (BitVec.ofNat 64 ((busSub trace binding i execRow).exec_row[1]!.pc).val))
+        = (PureSpec.execute_RTYPE_add_pure add_input).nextPC)
+    (h_rd_idx :
+      add_input.rd =
+        Transpiler.wrap_to_regidx (busSub trace binding i execRow).e2.ptr) :
+    (do
+      Sail.writeReg Register.nextPC
+        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
+      LeanRV64D.Functions.execute
+        (instruction.RTYPE (r2, r1, rd, rop.ADD))) (binding.stateAt i)
+      = (bus_effect (busSub trace binding i execRow).exec_row
+          [ (busSub trace binding i execRow).e0
+          , (busSub trace binding i execRow).e1
+          , (busSub trace binding i execRow).e2 ] (binding.stateAt i)).2 := by
+  -- abbreviations
+  set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable with hm
+  set state := binding.stateAt i with hstate
+  let bus := busSub trace binding i execRow
+  -- (a) op-bus provider RESOLUTION, derived from `trace.balanced`: the
+  -- `add_subset_holds` conjunct + a `staticLookup ∨ BinaryAdd` DISJUNCTION.
+  obtain ⟨h_add_subset, h_disj⟩ :=
+    exists_add_provider_row_matches_from_binding
+      trace binding i h_main_active h_main_op
+  -- decode pins bundle (shared by both arms)
+  let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD :=
+    ⟨h_main_active, h_main_op⟩
+  -- (a) lane-rd, derived from store_pc = 0 (shared by both arms; no record)
+  have h_core_store_pc :
+      (mainRowWithRomSub trace binding i).core.store_pc = 0 := by
+    have h_row :
+        (mainRowWithRomSub trace binding i).core =
+          ZiskFv.AirsClean.Main.rowAt m i.val := by
+      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+        trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+      simpa [mainRowWithRomSub, m,
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+    rw [h_row]
+    simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
+  have h_lane_rd :
+      ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
+    have h :=
+      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
+        (mainRowWithRomSub trace binding i) h_core_store_pc
+    have h_row :
+        (mainRowWithRomSub trace binding i).core =
+          ZiskFv.AirsClean.Main.rowAt m i.val := by
+      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+        trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+      simpa [mainRowWithRomSub, m,
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+    rw [h_row] at h
+    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
+      ZiskFv.AirsClean.Main.rowAt] using h
+  -- promises bundle: Sail reads + exec artifacts as binders; MemBus shape `rfl`.
+  -- (shared by both arms)
+  let promises : ZiskFv.EquivCore.Promises.RTypePromises
+      state add_input.r1_val add_input.r2_val add_input.rd add_input.PC
+      (PureSpec.execute_RTYPE_add_pure add_input).nextPC
+      r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2 :=
+    { input_r1_eq := h_input_r1
+      input_r2_eq := h_input_r2
+      input_rd_eq := h_input_rd
+      input_pc_eq := h_input_pc
+      exec_len := h_exec_len
+      e0_mult := h_e0_mult
+      e1_mult := h_e1_mult
+      nextPC_matches := h_nextPC_matches
+      m0_mult := by rfl
+      m0_as := by rfl
+      m1_mult := by rfl
+      m1_as := by rfl
+      m2_mult := by rfl
+      m2_as := by rfl
+      rd_idx := h_rd_idx }
+  have h_m32_zero : m.m32 i.val = 0 := h_m32
+  -- CASE-SPLIT the provider disjunction; discharge the SAME goal on each arm.
+  rcases h_disj with h_lookup | h_binaryadd
+  · -- lookup arm: mirror the SUB / AND construction body.
+    obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
+        h_component, h_table_spec, h_match⟩ := h_lookup
+    let providerInput :=
+      ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
+        (providerTable.environment providerRow)
+    obtain ⟨h_core, h_facts⟩ :=
+      ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
+        h_component h_table_spec h_provider_row
+    have h_static :
+        ZiskFv.AirsClean.Binary.StaticBinaryTableSpecFacts providerInput :=
+      ZiskFv.AirsClean.BinaryFamily.staticBinary_spec_facts_of_table_spec
+        h_component h_table_spec h_provider_row
+    have h_emit :
+        providerInput.chain.b_op + 16 * providerInput.mode.mode32 =
+          (ZiskFv.Airs.Tables.BinaryTable.OP_ADD : FGL) := by
+      have h_match_op := h_match
+      simp only [ZiskFv.Airs.OperationBus.matches_entry,
+        ZiskFv.Airs.OperationBus.opBus_row_Main] at h_match_op
+      have h_op_match :
+          m.op i.val = providerInput.chain.b_op + 16 * providerInput.mode.mode32 :=
+        h_match_op.2.1
+      rw [← h_op_match]
+      simpa [ZiskFv.Airs.Tables.BinaryTable.OP_ADD, ZiskFv.Trusted.OP_ADD] using
+        h_main_op
+    obtain ⟨h_row_m32, h_bop, _⟩ :=
+      ZiskFv.EquivCore.Bridge.Binary.logic_row_mode_pins_of_emit_op_lt_16_of_static_spec
+        providerInput h_static ZiskFv.Airs.Tables.BinaryTable.OP_ADD (by
+          simp [ZiskFv.Airs.Tables.BinaryTable.OP_ADD])
+        h_core h_emit
+    have h_out :=
+      ZiskFv.EquivCore.Bridge.Binary.byte_chain_discharge_64_of_static_row
+        providerInput h_facts
+        ZiskFv.Airs.Tables.BinaryTable.OP_ADD h_core h_row_m32 h_bop
+    have h_matches :
+        ZiskFv.EquivCore.Bridge.Binary.all_byte_matches_wf_at_row
+          providerInput ZiskFv.Airs.Tables.BinaryTable.OP_ADD :=
+      allByteMatchesOfStaticOut64_local h_out
+    have h_input_r1_row :
+        add_input.r1_val = ZiskFv.EquivCore.Add.binaryRowA64 providerInput := by
+      simpa [ZiskFv.EquivCore.Add.binaryRowA64] using
+        ZiskFv.EquivCore.Bridge.Binary.input_r1_packed_a_row
+          m providerInput i.val (regidx_to_fin r1) add_input.r1_val
+          h_matches h_m32_zero h_a_lo_t h_a_hi_t h_match h_input_r1
+    have h_input_r2_row :
+        add_input.r2_val = ZiskFv.EquivCore.Add.binaryRowB64 providerInput := by
+      simpa [ZiskFv.EquivCore.Add.binaryRowB64] using
+        ZiskFv.EquivCore.Bridge.Binary.input_r2_packed_b_row
+          m providerInput i.val (regidx_to_fin r2) add_input.r2_val
+          h_matches h_m32_zero h_b_lo_t h_b_hi_t h_match h_input_r2
+    exact ZiskFv.Compliance.equiv_ADD
+      state add_input r1 r2 rd m providerTable providerRow i.val bus pins
+      h_component h_table_spec h_provider_row h_match
+      h_input_r1_row h_input_r2_row h_lane_rd promises
+  · -- BinaryAdd arm: discharge via `equiv_ADD_via_binaryadd`.
+    obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
+        h_component, h_table_spec, h_match⟩ := h_binaryadd
+    exact ZiskFv.Compliance.equiv_ADD_via_binaryadd
+      state add_input r1 r2 rd m providerTable providerRow i.val bus pins
+      h_component h_table_spec h_provider_row h_match
+      h_add_subset h_a_lo_t h_a_hi_t h_b_lo_t h_b_hi_t h_m32_zero
+      h_lane_rd promises
+
+/-- Sound ADDI construction (PR4, approach (a): two-arm provider case-split).
+
+    = `construction_add_sound` + the PR3 I-type immediate delta. The op-bus is the
+    SAME `staticLookup ∨ BinaryAdd` disjunction (the op-bus match is
+    operand-source-agnostic); the second operand is the immediate, sourced via the
+    named `h_addi_subset` (`itype_imm_subset_holds_main`) decode pin instead of an
+    r2 register read. The r2 register lane bridges are dropped; `imm`, the decode
+    equality `h_input_imm`, the immediate routing pin `h_addi_subset`, and the
+    BinaryAdd-arm `h_set_pc` pin are added.
+
+    Residual budget = ADD's, minus the 2 r2 lane bridges (`h_b_lo_t`/`h_b_hi_t`)
+    and `h_input_r2`, plus `imm`, `h_input_imm`, `h_addi_subset`, `h_set_pc`. -/
+theorem construction_addi_sound
+    (trace : AcceptedTrace)
+    (binding : ProgramBinding trace)
+    (i : Fin trace.length)
+    (addi_input : PureSpec.AddiInput)
+    (r1 rd : regidx)
+    (imm : BitVec 12)
+    -- (b) decode pins
+    (h_main_op :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).op
+        i.val = ZiskFv.Trusted.OP_ADD)
+    (h_main_active :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).is_external_op
+        i.val = 1)
+    (h_m32 :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).m32
+        i.val = 0)
+    (h_store_pc :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).store_pc
+        i.val = 0)
+    (h_set_pc :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).set_pc
+        i.val = 0)
+    -- (b) Sail read + operands
+    (h_input_r1 :
+      read_xreg (regidx_to_fin r1) (binding.stateAt i)
+        = EStateM.Result.ok addi_input.r1_val (binding.stateAt i))
+    (h_input_imm : addi_input.imm = imm)
+    (h_input_pc : (binding.stateAt i).regs.get? Register.PC = .some addi_input.PC)
+    (h_input_rd : addi_input.rd = regidx_to_fin rd)
+    -- (b) r1 lane bridges
+    (h_a_lo_t :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).a_0 i.val =
+        ZiskFv.Trusted.lane_lo
+          ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg
+            (regidx_to_fin r1)))
+    (h_a_hi_t :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).a_1 i.val =
+        ZiskFv.Trusted.lane_hi
+          ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg
+            (regidx_to_fin r1)))
+    -- (b) immediate-routing pin (NAMED top-level binder, program/decode residual)
+    (h_addi_subset : ZiskFv.Tactics.ALUITypeArchetype.itype_imm_subset_holds_main
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+      i.val addi_input.imm)
+    -- (c) exec artifacts: the exec row is a genuine top-level binder.
+    (execRow : List (Interaction.ExecutionBusEntry FGL))
+    (h_exec_len : (busSub trace binding i execRow).exec_row.length = 2)
+    (h_e0_mult : (busSub trace binding i execRow).exec_row[0]!.multiplicity = -1)
+    (h_e1_mult : (busSub trace binding i execRow).exec_row[1]!.multiplicity = 1)
+    (h_nextPC_matches :
+      (register_type_pc_equiv ▸
+          (BitVec.ofNat 64 ((busSub trace binding i execRow).exec_row[1]!.pc).val))
+        = (PureSpec.execute_ITYPE_addi_pure addi_input).nextPC)
+    (h_rd_idx :
+      addi_input.rd =
+        Transpiler.wrap_to_regidx (busSub trace binding i execRow).e2.ptr) :
+    (do
+      Sail.writeReg Register.nextPC
+        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
+      LeanRV64D.Functions.execute
+        (instruction.ITYPE (imm, r1, rd, iop.ADDI))) (binding.stateAt i)
+      = (bus_effect (busSub trace binding i execRow).exec_row
+          [ (busSub trace binding i execRow).e0
+          , (busSub trace binding i execRow).e1
+          , (busSub trace binding i execRow).e2 ] (binding.stateAt i)).2 := by
+  -- abbreviations
+  set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable with hm
+  set state := binding.stateAt i with hstate
+  let bus := busSub trace binding i execRow
+  -- (a) op-bus provider RESOLUTION, derived from `trace.balanced`: the
+  -- `add_subset_holds` conjunct + a `staticLookup ∨ BinaryAdd` DISJUNCTION
+  -- (the op-bus match is operand-source-agnostic, so the SAME wrapper serves ADDI).
+  obtain ⟨h_add_subset, h_disj⟩ :=
+    exists_add_provider_row_matches_from_binding
+      trace binding i h_main_active h_main_op
+  -- decode pins bundle (shared by both arms)
+  let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD :=
+    ⟨h_main_active, h_main_op⟩
+  -- (a) lane-rd, derived from store_pc = 0 (shared by both arms; no record)
+  have h_core_store_pc :
+      (mainRowWithRomSub trace binding i).core.store_pc = 0 := by
+    have h_row :
+        (mainRowWithRomSub trace binding i).core =
+          ZiskFv.AirsClean.Main.rowAt m i.val := by
+      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+        trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+      simpa [mainRowWithRomSub, m,
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+    rw [h_row]
+    simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
+  have h_lane_rd :
+      ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
+    have h :=
+      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
+        (mainRowWithRomSub trace binding i) h_core_store_pc
+    have h_row :
+        (mainRowWithRomSub trace binding i).core =
+          ZiskFv.AirsClean.Main.rowAt m i.val := by
+      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+        trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+      simpa [mainRowWithRomSub, m,
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+    rw [h_row] at h
+    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
+      ZiskFv.AirsClean.Main.rowAt] using h
+  -- promises bundle: Sail read + immediate + exec artifacts as binders;
+  -- MemBus shape `rfl`. (shared by both arms)
+  let promises : ZiskFv.EquivCore.Promises.ITypePromises
+      state addi_input.r1_val addi_input.imm addi_input.rd addi_input.PC
+      (PureSpec.execute_ITYPE_addi_pure addi_input).nextPC
+      r1 rd imm bus.exec_row bus.e0 bus.e1 bus.e2 :=
+    { input_r1_eq := h_input_r1
+      input_imm_eq := h_input_imm
+      input_rd_eq := h_input_rd
+      input_pc_eq := h_input_pc
+      exec_len := h_exec_len
+      e0_mult := h_e0_mult
+      e1_mult := h_e1_mult
+      nextPC_matches := h_nextPC_matches
+      m0_mult := by rfl
+      m0_as := by rfl
+      m1_mult := by rfl
+      m1_as := by rfl
+      m2_mult := by rfl
+      m2_as := by rfl
+      rd_idx := h_rd_idx }
+  have h_m32_zero : m.m32 i.val = 0 := h_m32
+  have h_set_pc_zero : m.set_pc i.val = 0 := h_set_pc
+  -- CASE-SPLIT the provider disjunction; discharge the SAME goal on each arm.
+  rcases h_disj with h_lookup | h_binaryadd
+  · -- lookup arm: mirror the ANDI construction body (immediate routing).
+    obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
+        h_component, h_table_spec, h_match⟩ := h_lookup
+    let providerInput :=
+      ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
+        (providerTable.environment providerRow)
+    obtain ⟨h_core, h_facts⟩ :=
+      ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
+        h_component h_table_spec h_provider_row
+    have h_static :
+        ZiskFv.AirsClean.Binary.StaticBinaryTableSpecFacts providerInput :=
+      ZiskFv.AirsClean.BinaryFamily.staticBinary_spec_facts_of_table_spec
+        h_component h_table_spec h_provider_row
+    have h_emit :
+        providerInput.chain.b_op + 16 * providerInput.mode.mode32 =
+          (ZiskFv.Airs.Tables.BinaryTable.OP_ADD : FGL) := by
+      have h_match_op := h_match
+      simp only [ZiskFv.Airs.OperationBus.matches_entry,
+        ZiskFv.Airs.OperationBus.opBus_row_Main] at h_match_op
+      have h_op_match :
+          m.op i.val = providerInput.chain.b_op + 16 * providerInput.mode.mode32 :=
+        h_match_op.2.1
+      rw [← h_op_match]
+      simpa [ZiskFv.Airs.Tables.BinaryTable.OP_ADD, ZiskFv.Trusted.OP_ADD] using
+        h_main_op
+    obtain ⟨h_row_m32, h_bop, _⟩ :=
+      ZiskFv.EquivCore.Bridge.Binary.logic_row_mode_pins_of_emit_op_lt_16_of_static_spec
+        providerInput h_static ZiskFv.Airs.Tables.BinaryTable.OP_ADD (by
+          simp [ZiskFv.Airs.Tables.BinaryTable.OP_ADD])
+        h_core h_emit
+    have h_out :=
+      ZiskFv.EquivCore.Bridge.Binary.byte_chain_discharge_64_of_static_row
+        providerInput h_facts
+        ZiskFv.Airs.Tables.BinaryTable.OP_ADD h_core h_row_m32 h_bop
+    have h_matches :
+        ZiskFv.EquivCore.Bridge.Binary.all_byte_matches_wf_at_row
+          providerInput ZiskFv.Airs.Tables.BinaryTable.OP_ADD :=
+      allByteMatchesOfStaticOut64_local h_out
+    have h_input_r1_row :
+        addi_input.r1_val = ZiskFv.EquivCore.Add.binaryRowA64 providerInput := by
+      simpa [ZiskFv.EquivCore.Add.binaryRowA64] using
+        ZiskFv.EquivCore.Bridge.Binary.input_r1_packed_a_row
+          m providerInput i.val (regidx_to_fin r1) addi_input.r1_val
+          h_matches h_m32_zero h_a_lo_t h_a_hi_t h_match h_input_r1
+    -- Immediate routing: DERIVE the 8-byte Binary-row form from the named Main-form
+    -- pin + the in-body byte-match fact + `m32 = 0` + the provider match.
+    have h_input_imm_row :
+        BitVec.signExtend 64 addi_input.imm
+          = ZiskFv.EquivCore.Add.binaryRowB64 providerInput := by
+      simpa [ZiskFv.EquivCore.Add.binaryRowB64] using
+        ZiskFv.EquivCore.Bridge.Binary.itype_imm_subset_binary_row_of_main_row
+          m providerInput i.val addi_input.imm h_matches h_m32_zero h_match
+          h_addi_subset
+    exact ZiskFv.Compliance.equiv_ADDI
+      state addi_input r1 rd imm m providerTable providerRow i.val bus pins
+      h_component h_table_spec h_provider_row h_match
+      h_addi_subset h_input_r1_row h_input_imm_row h_lane_rd promises
+  · -- BinaryAdd arm: discharge via `equiv_ADDI_via_binaryadd`.
+    obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
+        h_component, h_table_spec, h_match⟩ := h_binaryadd
+    exact ZiskFv.Compliance.equiv_ADDI_via_binaryadd
+      state addi_input r1 rd imm m providerTable providerRow i.val bus pins
+      h_component h_table_spec h_provider_row h_match
+      h_add_subset h_addi_subset h_a_lo_t h_a_hi_t h_m32_zero h_set_pc_zero
+      h_lane_rd promises
+
+end ZiskFv.Compliance

--- a/ZiskFv/Compliance/ConstructionWAlu.lean
+++ b/ZiskFv/Compliance/ConstructionWAlu.lean
@@ -1,0 +1,583 @@
+import ZiskFv.Compliance.AcceptedTrace
+import ZiskFv.Compliance.ConstructionSub
+import ZiskFv.Compliance.Wrappers.Addw
+import ZiskFv.Compliance.Wrappers.Subw
+import ZiskFv.Compliance.Wrappers.Addiw
+import ZiskFv.EquivCore.Addw
+
+/-!
+# Sound W-ALU constructions (`construction_subw_sound`, `construction_addw_sound`,
+  `construction_addiw_sound`)
+
+PR5 / Wave 6 of the P4 SWEEP: the m32 = 1 word-ALU families. These were
+NEEDS-WORK because the prerequisite m32 = 1 32-bit lane-binding lemma did not
+exist; it is now authored as
+`ZiskFv.EquivCore.Bridge.Binary.input_r1_packed_a32_row` /
+`input_r2_packed_b32_row` (the binary analog of the BinaryExtension shift
+bridge's `packed_a_lo32_eq_of_shift_match_m32_1_of_a_range`). With that lemma in
+place these three constructions instantiate the honest §2 ALU template against the
+staticBinary provider in the **m32 = 1** path.
+
+## The W-mode DELTA from `construction_sub_sound`
+
+The W families differ from the 64-bit SUB construction on exactly these points:
+
+1. **m32 = 1** (not 0): `h_m32` pins `m.m32 i.val = 1`. The op-bus `a_hi`/`b_hi`
+   lanes collapse to `0` (provider high bytes pinned zero); the 32-bit operand is
+   sourced from the `a_lo`/`b_lo` conjunct only.
+2. **op-bus provider match** via the salvaged W Layer-A wrapper
+   `exists_staticBinary_provider_row_matches_w_from_binding` (op pin disjunction
+   `OP_ADD_W ∨ OP_SUB_W`).
+3. **lane → Sail binding** via the new m32 = 1 lane lemmas, producing the 32-bit
+   `extractLsb _ 31 0` form `binaryRowA32 row % 2^32` (NOT the 64-bit
+   `binaryRowA64`). The 4 low a/b byte ranges feeding the lemmas are projected
+   from `h_facts` (`StaticBinaryTableWfFacts`) — no `byte_chain_discharge_64`
+   (which requires `mode32 = 0`).
+4. **equiv wrapper** `equiv_SUBW` / `equiv_ADDW` / `equiv_ADDIW`; Sail pure spec
+   `execute_RTYPE_subw_pure` / `..._addw_pure` / `execute_ITYPE_addiw_pure`;
+   conclusion `ropw.SUBW` / `ropw.ADDW` / `instruction.ADDIW`. All three KEEP the
+   `writeReg Register.nextPC` prelude (the W-ALU wrappers carry it, unlike the
+   bare-execute W-shifts).
+5. **ADDIW** is ITYPE: immediate `imm : BitVec 12`, the named decode pin
+   `h_addiw_subset : itype_imm_subset_holds_main`, `ITypePromises`. The wrapper
+   derives the immediate byte decomposition `h_input_imm_extract` internally from
+   `h_addiw_subset` + the `b_lo` field of `h_match`, so the construction supplies
+   only the r1 lane extract.
+
+## Residual budget
+
+ADDW / SUBW: same flat top-level budget as `construction_sub_sound` — the 17
+named residuals + `execRow` ∀-binder (`h_m32` value 1 instead of 0; otherwise the
+identical decode pins / Sail reads / lane bridges / next-PC / exec artifacts).
+ADDIW swaps the r2 lane bridges + r2 read for the immediate `imm` binder +
+`h_input_imm` + `h_addiw_subset` (the I-type delta of PR3), `RTypePromises →
+ITypePromises`.
+
+## Anti-vacuity (PLAN §4.9)
+
+`execRow` is a genuine top-level ∀-binder in all three; the bus is `busSub`
+(built from the real trace row), so the exec hypotheses are jointly satisfiable.
+
+## Axioms
+
+Each of the three constructions, and the new lane lemmas they consume, introduce
+**0 PROJECT (`ZiskFv.*`) axioms**; the closure includes only the Sail-translation
+axioms and Lean-kernel postulates as documented external trust.
+-/
+
+namespace ZiskFv.Compliance
+
+open ZiskFv.Trusted
+open ZiskFv.Airs.Main
+open ZiskFv.Airs.OperationBus
+open ZiskFv.EquivCore.Promises
+open ZiskFv.Tactics.ALUITypeArchetype
+
+set_option maxHeartbeats 2000000
+
+/-- Sound SUBW construction (m32 = 1 word ALU). Unique opcode `OP_SUB_W`
+    (`Or.inr` of the shared W Layer-A wrapper). -/
+theorem construction_subw_sound
+    (trace : AcceptedTrace)
+    (binding : ProgramBinding trace)
+    (i : Fin trace.length)
+    (subw_input : PureSpec.SubwInput)
+    (r1 r2 rd : regidx)
+    -- (b) decode pins
+    (h_main_op :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).op
+        i.val = ZiskFv.Trusted.OP_SUB_W)
+    (h_main_active :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).is_external_op
+        i.val = 1)
+    (h_m32 :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).m32
+        i.val = 1)
+    (h_store_pc :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).store_pc
+        i.val = 0)
+    -- (b) Sail reads + operands
+    (h_input_r1 :
+      read_xreg (regidx_to_fin r1) (binding.stateAt i)
+        = EStateM.Result.ok subw_input.r1_val (binding.stateAt i))
+    (h_input_r2 :
+      read_xreg (regidx_to_fin r2) (binding.stateAt i)
+        = EStateM.Result.ok subw_input.r2_val (binding.stateAt i))
+    (h_input_pc : (binding.stateAt i).regs.get? Register.PC = .some subw_input.PC)
+    (h_input_rd : subw_input.rd = regidx_to_fin rd)
+    -- (b) lane bridges
+    (h_a_lo_t :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).a_0 i.val =
+        ZiskFv.Trusted.lane_lo
+          ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg
+            (regidx_to_fin r1)))
+    (h_a_hi_t :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).a_1 i.val =
+        ZiskFv.Trusted.lane_hi
+          ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg
+            (regidx_to_fin r1)))
+    (h_b_lo_t :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).b_0 i.val =
+        ZiskFv.Trusted.lane_lo
+          ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg
+            (regidx_to_fin r2)))
+    (h_b_hi_t :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).b_1 i.val =
+        ZiskFv.Trusted.lane_hi
+          ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg
+            (regidx_to_fin r2)))
+    -- (c) exec artifacts: the exec row is a genuine top-level binder.
+    (execRow : List (Interaction.ExecutionBusEntry FGL))
+    (h_exec_len : (busSub trace binding i execRow).exec_row.length = 2)
+    (h_e0_mult : (busSub trace binding i execRow).exec_row[0]!.multiplicity = -1)
+    (h_e1_mult : (busSub trace binding i execRow).exec_row[1]!.multiplicity = 1)
+    (h_nextPC_matches :
+      (register_type_pc_equiv ▸
+          (BitVec.ofNat 64 ((busSub trace binding i execRow).exec_row[1]!.pc).val))
+        = (PureSpec.execute_RTYPE_subw_pure subw_input).nextPC)
+    (h_rd_idx :
+      subw_input.rd =
+        Transpiler.wrap_to_regidx (busSub trace binding i execRow).e2.ptr) :
+    (do
+      Sail.writeReg Register.nextPC
+        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
+      LeanRV64D.Functions.execute
+        (instruction.RTYPEW (r2, r1, rd, ropw.SUBW))) (binding.stateAt i)
+      = (bus_effect (busSub trace binding i execRow).exec_row
+          [ (busSub trace binding i execRow).e0
+          , (busSub trace binding i execRow).e1
+          , (busSub trace binding i execRow).e2 ] (binding.stateAt i)).2 := by
+  set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable with hm
+  set state := binding.stateAt i with hstate
+  let bus := busSub trace binding i execRow
+  -- (a) op-bus provider match, derived from `trace.balanced`. SUBW = `Or.inr`.
+  obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
+      h_component, h_table_spec, h_match⟩ :=
+    exists_staticBinary_provider_row_matches_w_from_binding
+      trace binding i h_main_active (Or.inr h_main_op)
+  let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SUB_W :=
+    ⟨h_main_active, h_main_op⟩
+  have h_core_store_pc :
+      (mainRowWithRomSub trace binding i).core.store_pc = 0 := by
+    have h_row :
+        (mainRowWithRomSub trace binding i).core =
+          ZiskFv.AirsClean.Main.rowAt m i.val := by
+      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+        trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+      simpa [mainRowWithRomSub, m,
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+    rw [h_row]
+    simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
+  have h_lane_rd :
+      ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
+    have h :=
+      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
+        (mainRowWithRomSub trace binding i) h_core_store_pc
+    have h_row :
+        (mainRowWithRomSub trace binding i).core =
+          ZiskFv.AirsClean.Main.rowAt m i.val := by
+      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+        trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+      simpa [mainRowWithRomSub, m,
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+    rw [h_row] at h
+    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
+      ZiskFv.AirsClean.Main.rowAt] using h
+  let promises : ZiskFv.EquivCore.Promises.RTypePromises
+      state subw_input.r1_val subw_input.r2_val subw_input.rd subw_input.PC
+      (PureSpec.execute_RTYPE_subw_pure subw_input).nextPC
+      r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2 :=
+    { input_r1_eq := h_input_r1
+      input_r2_eq := h_input_r2
+      input_rd_eq := h_input_rd
+      input_pc_eq := h_input_pc
+      exec_len := h_exec_len
+      e0_mult := h_e0_mult
+      e1_mult := h_e1_mult
+      nextPC_matches := h_nextPC_matches
+      m0_mult := by rfl
+      m0_as := by rfl
+      m1_mult := by rfl
+      m1_as := by rfl
+      m2_mult := by rfl
+      m2_as := by rfl
+      rd_idx := h_rd_idx }
+  -- (a) provider correctness facts; byte ranges (a/b low 4) from `h_facts`.
+  let providerInput :=
+    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
+      (providerTable.environment providerRow)
+  obtain ⟨h_core, h_facts⟩ :=
+    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
+      h_component h_table_spec h_provider_row
+  have h_m32_one : m.m32 i.val = 1 := h_m32
+  have ha0 : (providerInput.aBytes.free_in_a_0).val < 256 := by
+    simpa [ZiskFv.Channels.BinaryTable.BinaryTableMessage.toEntry,
+      ZiskFv.Airs.Tables.BinaryTable.range_conditions] using h_facts.1.1.1
+  have ha1 : (providerInput.aBytes.free_in_a_1).val < 256 := by
+    simpa [ZiskFv.Channels.BinaryTable.BinaryTableMessage.toEntry,
+      ZiskFv.Airs.Tables.BinaryTable.range_conditions] using h_facts.2.1.1.1
+  have ha2 : (providerInput.aBytes.free_in_a_2).val < 256 := by
+    simpa [ZiskFv.Channels.BinaryTable.BinaryTableMessage.toEntry,
+      ZiskFv.Airs.Tables.BinaryTable.range_conditions] using h_facts.2.2.1.1.1
+  have ha3 : (providerInput.aBytes.free_in_a_3).val < 256 := by
+    simpa [ZiskFv.Channels.BinaryTable.BinaryTableMessage.toEntry,
+      ZiskFv.Airs.Tables.BinaryTable.range_conditions] using h_facts.2.2.2.1.1.1
+  have hb0 : (providerInput.bBytes.free_in_b_0).val < 256 := by
+    simpa [ZiskFv.Channels.BinaryTable.BinaryTableMessage.toEntry,
+      ZiskFv.Airs.Tables.BinaryTable.range_conditions] using h_facts.1.1.2.1
+  have hb1 : (providerInput.bBytes.free_in_b_1).val < 256 := by
+    simpa [ZiskFv.Channels.BinaryTable.BinaryTableMessage.toEntry,
+      ZiskFv.Airs.Tables.BinaryTable.range_conditions] using h_facts.2.1.1.2.1
+  have hb2 : (providerInput.bBytes.free_in_b_2).val < 256 := by
+    simpa [ZiskFv.Channels.BinaryTable.BinaryTableMessage.toEntry,
+      ZiskFv.Airs.Tables.BinaryTable.range_conditions] using h_facts.2.2.1.1.2.1
+  have hb3 : (providerInput.bBytes.free_in_b_3).val < 256 := by
+    simpa [ZiskFv.Channels.BinaryTable.BinaryTableMessage.toEntry,
+      ZiskFv.Airs.Tables.BinaryTable.range_conditions] using h_facts.2.2.2.1.1.2.1
+  -- Lane → Sail binding (m32 = 1, 32-bit extract) via the new lane lemmas.
+  have h_input_r1_extract :
+      (Sail.BitVec.extractLsb subw_input.r1_val 31 0 : BitVec (31 - 0 + 1)).toNat
+        = ZiskFv.EquivCore.Addw.binaryRowA32 providerInput % 2^32 := by
+    simpa [ZiskFv.EquivCore.Addw.binaryRowA32] using
+      ZiskFv.EquivCore.Bridge.Binary.input_r1_packed_a32_row
+        m providerInput i.val (regidx_to_fin r1) subw_input.r1_val
+        ha0 ha1 ha2 ha3 h_m32_one h_a_lo_t h_a_hi_t h_match h_input_r1
+  have h_input_r2_extract :
+      (Sail.BitVec.extractLsb subw_input.r2_val 31 0 : BitVec (31 - 0 + 1)).toNat
+        = ZiskFv.EquivCore.Addw.binaryRowB32 providerInput % 2^32 := by
+    simpa [ZiskFv.EquivCore.Addw.binaryRowB32] using
+      ZiskFv.EquivCore.Bridge.Binary.input_r2_packed_b32_row
+        m providerInput i.val (regidx_to_fin r2) subw_input.r2_val
+        hb0 hb1 hb2 hb3 h_m32_one h_b_lo_t h_b_hi_t h_match h_input_r2
+  exact ZiskFv.Compliance.equiv_SUBW
+    state subw_input r1 r2 rd m providerTable providerRow i.val bus pins
+    h_component h_table_spec h_provider_row h_match
+    h_input_r1_extract h_input_r2_extract h_lane_rd promises
+
+/-- Sound ADDW construction (m32 = 1 word ALU). DELTA from
+    `construction_subw_sound`: op pin `OP_ADD_W` (`Or.inl` of the shared W
+    Layer-A wrapper), `ropw.ADDW`, `execute_RTYPE_addw_pure`, `equiv_ADDW`. -/
+theorem construction_addw_sound
+    (trace : AcceptedTrace)
+    (binding : ProgramBinding trace)
+    (i : Fin trace.length)
+    (addw_input : PureSpec.AddwInput)
+    (r1 r2 rd : regidx)
+    (h_main_op :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).op
+        i.val = ZiskFv.Trusted.OP_ADD_W)
+    (h_main_active :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).is_external_op
+        i.val = 1)
+    (h_m32 :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).m32
+        i.val = 1)
+    (h_store_pc :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).store_pc
+        i.val = 0)
+    (h_input_r1 :
+      read_xreg (regidx_to_fin r1) (binding.stateAt i)
+        = EStateM.Result.ok addw_input.r1_val (binding.stateAt i))
+    (h_input_r2 :
+      read_xreg (regidx_to_fin r2) (binding.stateAt i)
+        = EStateM.Result.ok addw_input.r2_val (binding.stateAt i))
+    (h_input_pc : (binding.stateAt i).regs.get? Register.PC = .some addw_input.PC)
+    (h_input_rd : addw_input.rd = regidx_to_fin rd)
+    (h_a_lo_t :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).a_0 i.val =
+        ZiskFv.Trusted.lane_lo
+          ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg
+            (regidx_to_fin r1)))
+    (h_a_hi_t :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).a_1 i.val =
+        ZiskFv.Trusted.lane_hi
+          ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg
+            (regidx_to_fin r1)))
+    (h_b_lo_t :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).b_0 i.val =
+        ZiskFv.Trusted.lane_lo
+          ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg
+            (regidx_to_fin r2)))
+    (h_b_hi_t :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).b_1 i.val =
+        ZiskFv.Trusted.lane_hi
+          ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg
+            (regidx_to_fin r2)))
+    (execRow : List (Interaction.ExecutionBusEntry FGL))
+    (h_exec_len : (busSub trace binding i execRow).exec_row.length = 2)
+    (h_e0_mult : (busSub trace binding i execRow).exec_row[0]!.multiplicity = -1)
+    (h_e1_mult : (busSub trace binding i execRow).exec_row[1]!.multiplicity = 1)
+    (h_nextPC_matches :
+      (register_type_pc_equiv ▸
+          (BitVec.ofNat 64 ((busSub trace binding i execRow).exec_row[1]!.pc).val))
+        = (PureSpec.execute_RTYPE_addw_pure addw_input).nextPC)
+    (h_rd_idx :
+      addw_input.rd =
+        Transpiler.wrap_to_regidx (busSub trace binding i execRow).e2.ptr) :
+    (do
+      Sail.writeReg Register.nextPC
+        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
+      LeanRV64D.Functions.execute
+        (instruction.RTYPEW (r2, r1, rd, ropw.ADDW))) (binding.stateAt i)
+      = (bus_effect (busSub trace binding i execRow).exec_row
+          [ (busSub trace binding i execRow).e0
+          , (busSub trace binding i execRow).e1
+          , (busSub trace binding i execRow).e2 ] (binding.stateAt i)).2 := by
+  set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable with hm
+  set state := binding.stateAt i with hstate
+  let bus := busSub trace binding i execRow
+  obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
+      h_component, h_table_spec, h_match⟩ :=
+    exists_staticBinary_provider_row_matches_w_from_binding
+      trace binding i h_main_active (Or.inl h_main_op)
+  let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD_W :=
+    ⟨h_main_active, h_main_op⟩
+  have h_core_store_pc :
+      (mainRowWithRomSub trace binding i).core.store_pc = 0 := by
+    have h_row :
+        (mainRowWithRomSub trace binding i).core =
+          ZiskFv.AirsClean.Main.rowAt m i.val := by
+      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+        trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+      simpa [mainRowWithRomSub, m,
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+    rw [h_row]
+    simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
+  have h_lane_rd :
+      ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
+    have h :=
+      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
+        (mainRowWithRomSub trace binding i) h_core_store_pc
+    have h_row :
+        (mainRowWithRomSub trace binding i).core =
+          ZiskFv.AirsClean.Main.rowAt m i.val := by
+      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+        trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+      simpa [mainRowWithRomSub, m,
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+    rw [h_row] at h
+    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
+      ZiskFv.AirsClean.Main.rowAt] using h
+  let promises : ZiskFv.EquivCore.Promises.RTypePromises
+      state addw_input.r1_val addw_input.r2_val addw_input.rd addw_input.PC
+      (PureSpec.execute_RTYPE_addw_pure addw_input).nextPC
+      r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2 :=
+    { input_r1_eq := h_input_r1
+      input_r2_eq := h_input_r2
+      input_rd_eq := h_input_rd
+      input_pc_eq := h_input_pc
+      exec_len := h_exec_len
+      e0_mult := h_e0_mult
+      e1_mult := h_e1_mult
+      nextPC_matches := h_nextPC_matches
+      m0_mult := by rfl
+      m0_as := by rfl
+      m1_mult := by rfl
+      m1_as := by rfl
+      m2_mult := by rfl
+      m2_as := by rfl
+      rd_idx := h_rd_idx }
+  let providerInput :=
+    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
+      (providerTable.environment providerRow)
+  obtain ⟨h_core, h_facts⟩ :=
+    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
+      h_component h_table_spec h_provider_row
+  have h_m32_one : m.m32 i.val = 1 := h_m32
+  have ha0 : (providerInput.aBytes.free_in_a_0).val < 256 := by
+    simpa [ZiskFv.Channels.BinaryTable.BinaryTableMessage.toEntry,
+      ZiskFv.Airs.Tables.BinaryTable.range_conditions] using h_facts.1.1.1
+  have ha1 : (providerInput.aBytes.free_in_a_1).val < 256 := by
+    simpa [ZiskFv.Channels.BinaryTable.BinaryTableMessage.toEntry,
+      ZiskFv.Airs.Tables.BinaryTable.range_conditions] using h_facts.2.1.1.1
+  have ha2 : (providerInput.aBytes.free_in_a_2).val < 256 := by
+    simpa [ZiskFv.Channels.BinaryTable.BinaryTableMessage.toEntry,
+      ZiskFv.Airs.Tables.BinaryTable.range_conditions] using h_facts.2.2.1.1.1
+  have ha3 : (providerInput.aBytes.free_in_a_3).val < 256 := by
+    simpa [ZiskFv.Channels.BinaryTable.BinaryTableMessage.toEntry,
+      ZiskFv.Airs.Tables.BinaryTable.range_conditions] using h_facts.2.2.2.1.1.1
+  have hb0 : (providerInput.bBytes.free_in_b_0).val < 256 := by
+    simpa [ZiskFv.Channels.BinaryTable.BinaryTableMessage.toEntry,
+      ZiskFv.Airs.Tables.BinaryTable.range_conditions] using h_facts.1.1.2.1
+  have hb1 : (providerInput.bBytes.free_in_b_1).val < 256 := by
+    simpa [ZiskFv.Channels.BinaryTable.BinaryTableMessage.toEntry,
+      ZiskFv.Airs.Tables.BinaryTable.range_conditions] using h_facts.2.1.1.2.1
+  have hb2 : (providerInput.bBytes.free_in_b_2).val < 256 := by
+    simpa [ZiskFv.Channels.BinaryTable.BinaryTableMessage.toEntry,
+      ZiskFv.Airs.Tables.BinaryTable.range_conditions] using h_facts.2.2.1.1.2.1
+  have hb3 : (providerInput.bBytes.free_in_b_3).val < 256 := by
+    simpa [ZiskFv.Channels.BinaryTable.BinaryTableMessage.toEntry,
+      ZiskFv.Airs.Tables.BinaryTable.range_conditions] using h_facts.2.2.2.1.1.2.1
+  have h_input_r1_extract :
+      (Sail.BitVec.extractLsb addw_input.r1_val 31 0 : BitVec (31 - 0 + 1)).toNat
+        = ZiskFv.EquivCore.Addw.binaryRowA32 providerInput % 2^32 := by
+    simpa [ZiskFv.EquivCore.Addw.binaryRowA32] using
+      ZiskFv.EquivCore.Bridge.Binary.input_r1_packed_a32_row
+        m providerInput i.val (regidx_to_fin r1) addw_input.r1_val
+        ha0 ha1 ha2 ha3 h_m32_one h_a_lo_t h_a_hi_t h_match h_input_r1
+  have h_input_r2_extract :
+      (Sail.BitVec.extractLsb addw_input.r2_val 31 0 : BitVec (31 - 0 + 1)).toNat
+        = ZiskFv.EquivCore.Addw.binaryRowB32 providerInput % 2^32 := by
+    simpa [ZiskFv.EquivCore.Addw.binaryRowB32] using
+      ZiskFv.EquivCore.Bridge.Binary.input_r2_packed_b32_row
+        m providerInput i.val (regidx_to_fin r2) addw_input.r2_val
+        hb0 hb1 hb2 hb3 h_m32_one h_b_lo_t h_b_hi_t h_match h_input_r2
+  exact ZiskFv.Compliance.equiv_ADDW
+    state addw_input r1 r2 rd m providerTable providerRow i.val bus pins
+    h_component h_table_spec h_provider_row h_match
+    h_input_r1_extract h_input_r2_extract h_lane_rd promises
+
+/-- Sound ADDIW construction (m32 = 1 word ALU, ITYPE immediate). DELTA from
+    `construction_addw_sound`: drops the r2 read + r2 lane bridges; adds the
+    immediate binder `imm : BitVec 12`, the immediate-decode equality
+    `h_input_imm : addiw_input.imm = imm`, and the NAMED top-level decode pin
+    `h_addiw_subset : itype_imm_subset_holds_main`; swaps `RTypePromises →
+    ITypePromises`; routes via `equiv_ADDIW` (`execute_ITYPE_addiw_pure`,
+    `instruction.ADDIW`). Shares `OP_ADD_W` with ADDW (`Or.inl`); the wrapper
+    derives the immediate byte decomposition internally from `h_addiw_subset` +
+    `h_match`, so the construction supplies only the r1 lane extract. -/
+theorem construction_addiw_sound
+    (trace : AcceptedTrace)
+    (binding : ProgramBinding trace)
+    (i : Fin trace.length)
+    (addiw_input : PureSpec.AddiwInput)
+    (r1 rd : regidx)
+    (imm : BitVec 12)
+    (h_main_op :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).op
+        i.val = ZiskFv.Trusted.OP_ADD_W)
+    (h_main_active :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).is_external_op
+        i.val = 1)
+    (h_m32 :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).m32
+        i.val = 1)
+    (h_store_pc :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).store_pc
+        i.val = 0)
+    (h_input_r1 :
+      read_xreg (regidx_to_fin r1) (binding.stateAt i)
+        = EStateM.Result.ok addiw_input.r1_val (binding.stateAt i))
+    (h_input_imm : addiw_input.imm = imm)
+    (h_input_pc : (binding.stateAt i).regs.get? Register.PC = .some addiw_input.PC)
+    (h_input_rd : addiw_input.rd = regidx_to_fin rd)
+    (h_a_lo_t :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).a_0 i.val =
+        ZiskFv.Trusted.lane_lo
+          ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg
+            (regidx_to_fin r1)))
+    (h_a_hi_t :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).a_1 i.val =
+        ZiskFv.Trusted.lane_hi
+          ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg
+            (regidx_to_fin r1)))
+    -- (b) immediate-routing pin (NAMED top-level binder, program/decode residual)
+    (h_addiw_subset : itype_imm_subset_holds_main
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+      i.val addiw_input.imm)
+    (execRow : List (Interaction.ExecutionBusEntry FGL))
+    (h_exec_len : (busSub trace binding i execRow).exec_row.length = 2)
+    (h_e0_mult : (busSub trace binding i execRow).exec_row[0]!.multiplicity = -1)
+    (h_e1_mult : (busSub trace binding i execRow).exec_row[1]!.multiplicity = 1)
+    (h_nextPC_matches :
+      (register_type_pc_equiv ▸
+          (BitVec.ofNat 64 ((busSub trace binding i execRow).exec_row[1]!.pc).val))
+        = (PureSpec.execute_ITYPE_addiw_pure addiw_input).nextPC)
+    (h_rd_idx :
+      addiw_input.rd =
+        Transpiler.wrap_to_regidx (busSub trace binding i execRow).e2.ptr) :
+    (do
+      Sail.writeReg Register.nextPC
+        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
+      LeanRV64D.Functions.execute
+        (instruction.ADDIW (imm, r1, rd))) (binding.stateAt i)
+      = (bus_effect (busSub trace binding i execRow).exec_row
+          [ (busSub trace binding i execRow).e0
+          , (busSub trace binding i execRow).e1
+          , (busSub trace binding i execRow).e2 ] (binding.stateAt i)).2 := by
+  set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable with hm
+  set state := binding.stateAt i with hstate
+  let bus := busSub trace binding i execRow
+  obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
+      h_component, h_table_spec, h_match⟩ :=
+    exists_staticBinary_provider_row_matches_w_from_binding
+      trace binding i h_main_active (Or.inl h_main_op)
+  let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD_W :=
+    ⟨h_main_active, h_main_op⟩
+  have h_core_store_pc :
+      (mainRowWithRomSub trace binding i).core.store_pc = 0 := by
+    have h_row :
+        (mainRowWithRomSub trace binding i).core =
+          ZiskFv.AirsClean.Main.rowAt m i.val := by
+      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+        trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+      simpa [mainRowWithRomSub, m,
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+    rw [h_row]
+    simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
+  have h_lane_rd :
+      ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
+    have h :=
+      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
+        (mainRowWithRomSub trace binding i) h_core_store_pc
+    have h_row :
+        (mainRowWithRomSub trace binding i).core =
+          ZiskFv.AirsClean.Main.rowAt m i.val := by
+      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+        trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+      simpa [mainRowWithRomSub, m,
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+    rw [h_row] at h
+    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
+      ZiskFv.AirsClean.Main.rowAt] using h
+  let promises : ZiskFv.EquivCore.Promises.ITypePromises
+      state addiw_input.r1_val addiw_input.imm addiw_input.rd addiw_input.PC
+      (PureSpec.execute_ITYPE_addiw_pure addiw_input).nextPC
+      r1 rd imm bus.exec_row bus.e0 bus.e1 bus.e2 :=
+    { input_r1_eq := h_input_r1
+      input_imm_eq := h_input_imm
+      input_rd_eq := h_input_rd
+      input_pc_eq := h_input_pc
+      exec_len := h_exec_len
+      e0_mult := h_e0_mult
+      e1_mult := h_e1_mult
+      nextPC_matches := h_nextPC_matches
+      m0_mult := by rfl
+      m0_as := by rfl
+      m1_mult := by rfl
+      m1_as := by rfl
+      m2_mult := by rfl
+      m2_as := by rfl
+      rd_idx := h_rd_idx }
+  let providerInput :=
+    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
+      (providerTable.environment providerRow)
+  obtain ⟨h_core, h_facts⟩ :=
+    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
+      h_component h_table_spec h_provider_row
+  have h_m32_one : m.m32 i.val = 1 := h_m32
+  have ha0 : (providerInput.aBytes.free_in_a_0).val < 256 := by
+    simpa [ZiskFv.Channels.BinaryTable.BinaryTableMessage.toEntry,
+      ZiskFv.Airs.Tables.BinaryTable.range_conditions] using h_facts.1.1.1
+  have ha1 : (providerInput.aBytes.free_in_a_1).val < 256 := by
+    simpa [ZiskFv.Channels.BinaryTable.BinaryTableMessage.toEntry,
+      ZiskFv.Airs.Tables.BinaryTable.range_conditions] using h_facts.2.1.1.1
+  have ha2 : (providerInput.aBytes.free_in_a_2).val < 256 := by
+    simpa [ZiskFv.Channels.BinaryTable.BinaryTableMessage.toEntry,
+      ZiskFv.Airs.Tables.BinaryTable.range_conditions] using h_facts.2.2.1.1.1
+  have ha3 : (providerInput.aBytes.free_in_a_3).val < 256 := by
+    simpa [ZiskFv.Channels.BinaryTable.BinaryTableMessage.toEntry,
+      ZiskFv.Airs.Tables.BinaryTable.range_conditions] using h_facts.2.2.2.1.1.1
+  have h_input_r1_extract :
+      (Sail.BitVec.extractLsb addiw_input.r1_val 31 0 : BitVec (31 - 0 + 1)).toNat
+        = ZiskFv.EquivCore.Addw.binaryRowA32 providerInput % 2^32 := by
+    simpa [ZiskFv.EquivCore.Addw.binaryRowA32] using
+      ZiskFv.EquivCore.Bridge.Binary.input_r1_packed_a32_row
+        m providerInput i.val (regidx_to_fin r1) addiw_input.r1_val
+        ha0 ha1 ha2 ha3 h_m32_one h_a_lo_t h_a_hi_t h_match h_input_r1
+  exact ZiskFv.Compliance.equiv_ADDIW
+    state addiw_input r1 rd imm m providerTable providerRow i.val bus pins
+    h_addiw_subset h_component h_table_spec h_provider_row h_match
+    h_input_r1_extract h_lane_rd promises
+
+end ZiskFv.Compliance

--- a/ZiskFv/EquivCore/Bridge/Binary.lean
+++ b/ZiskFv/EquivCore/Bridge/Binary.lean
@@ -2970,6 +2970,149 @@ lemma input_r2_packed_b_row
   rw [h_b0_val, h_b1_val]
   ring
 
+open ZiskFv.EquivCore.Bridge.SailStateBridge in
+/-- Row-native 32-bit (W-mode) `input_r1` binding for the **m32 = 1** case.
+
+    The binary analog of the shift bridge's
+    `packed_a_lo32_eq_of_shift_match_m32_1_of_a_range`
+    (`Bridge/BinaryExtension.lean:402`). For the staticBinary provider, the
+    op-bus `a_hi` lane is `b.free_in_a_4 + … + 16777216 * b.free_in_a_7` with no
+    `op_is_shift` factor, while the Main side carries the PIL factor
+    `(1 - m32) * a_1`. With `m32 = 1`, `one_sub_one_mul` collapses the Main
+    `a_hi` lane to `0`, so the provider's high a-bytes are pinned to zero and the
+    32-bit operand is sourced solely from the `a_lo` conjunct (`m.a_0`). Since
+    `m.a_0` packs the 4 low bytes (each `< 256`, sum `< 2^32`), taking the low
+    32 bits of `r1_val = a_0 + a_1 * 2^32` yields exactly `binaryRowA32 row`.
+
+    Unlike the m32 = 0 sibling `input_r1_packed_a_row` this does NOT use
+    `one_sub_zero_mul` (CLAUDE.md trap #3); the `(1 - 1) * a_hi` term collapses
+    via `one_sub_one_mul` after `rw [h_m32]`, and the low-half binding closes by
+    `omega` on the byte bounds. No `simp`/`decide` papers over the field term. -/
+lemma input_r1_packed_a32_row
+    {state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource}
+    (m : Valid_Main FGL FGL)
+    (row : ZiskFv.AirsClean.Binary.BinaryRow FGL)
+    (r_main : ℕ) (rs1 : Fin 32) (r1_val : BitVec 64)
+    (ha0 : (row.aBytes.free_in_a_0).val < 256)
+    (ha1 : (row.aBytes.free_in_a_1).val < 256)
+    (ha2 : (row.aBytes.free_in_a_2).val < 256)
+    (ha3 : (row.aBytes.free_in_a_3).val < 256)
+    (_h_m32 : m.m32 r_main = 1)
+    (h_a_lo_t : m.a_0 r_main = lane_lo ((sail_to_rv64 state).xreg rs1))
+    (h_a_hi_t : m.a_1 r_main = lane_hi ((sail_to_rv64 state).xreg rs1))
+    (h_match : matches_entry (opBus_row_Main m r_main)
+      (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+        (ZiskFv.AirsClean.Binary.opBusMessage row) 1))
+    (h_input_r1 : read_xreg rs1 state = EStateM.Result.ok r1_val state) :
+    (Sail.BitVec.extractLsb r1_val 31 0 : BitVec (31 - 0 + 1)).toNat
+      = (row.aBytes.free_in_a_0.val + row.aBytes.free_in_a_1.val * 256
+          + row.aBytes.free_in_a_2.val * 65536
+          + row.aBytes.free_in_a_3.val * 16777216) % 2^32 := by
+  have h_match' : matches_entry (opBus_row_Main m r_main)
+      (opBus_row_Binary (ZiskFv.AirsClean.Binary.validOfRow row) 0) := by
+    simpa [ZiskFv.AirsClean.Binary.validOfRow,
+      ZiskFv.AirsClean.Binary.opBusMessage] using h_match
+  have h_r1_main :=
+    packed_lane_eq_of_read_xreg state rs1 r1_val (m.a_0 r_main) (m.a_1 r_main)
+      h_a_lo_t h_a_hi_t h_input_r1
+  simp only [matches_entry, opBus_row_Main, opBus_row_Binary] at h_match'
+  obtain ⟨_, _, h_a_lo_m, _, _, _, _, _, _, _, _, _⟩ := h_match'
+  -- low-half binding: `m.a_0` packs the 4 low a-bytes (m32 does not enter `a_lo`)
+  have h_a0_val : (m.a_0 r_main).val =
+      row.aBytes.free_in_a_0.val + row.aBytes.free_in_a_1.val * 256
+      + row.aBytes.free_in_a_2.val * 65536
+      + row.aBytes.free_in_a_3.val * 16777216 := by
+    rw [h_a_lo_m]
+    have h_cast :
+        row.aBytes.free_in_a_0 + 256 * row.aBytes.free_in_a_1
+          + 65536 * row.aBytes.free_in_a_2 + 16777216 * row.aBytes.free_in_a_3
+        = (((row.aBytes.free_in_a_0.val + row.aBytes.free_in_a_1.val * 256
+              + row.aBytes.free_in_a_2.val * 65536
+              + row.aBytes.free_in_a_3.val * 16777216 : ℕ) : FGL)) := by
+      push_cast; ring
+    rw [h_cast, Fin.val_natCast]
+    apply Nat.mod_eq_of_lt
+    omega
+  rw [h_r1_main]
+  -- extract the low 32 bits of `ofNat 64 (a0 + a1 * 2^32)`
+  have h_extract_eq :
+      (Sail.BitVec.extractLsb
+        (BitVec.ofNat 64
+          ((m.a_0 r_main).val + (m.a_1 r_main).val * 4294967296)) 31 0
+        : BitVec (31 - 0 + 1)).toNat
+      = ((m.a_0 r_main).val + (m.a_1 r_main).val * 4294967296) % 2^32 := by
+    simp [Sail.BitVec.extractLsb, BitVec.extractLsb, BitVec.extractLsb',
+          BitVec.toNat_ofNat]
+  rw [h_extract_eq, h_a0_val]
+  -- the `a_1 * 2^32` summand contributes only to bits ≥ 32; the low-half sum
+  -- is `< 2^32`, so the two `% 2^32` reductions agree.
+  have h_a0_lt : row.aBytes.free_in_a_0.val + row.aBytes.free_in_a_1.val * 256
+        + row.aBytes.free_in_a_2.val * 65536 + row.aBytes.free_in_a_3.val * 16777216
+        < 4294967296 := by omega
+  omega
+
+open ZiskFv.EquivCore.Bridge.SailStateBridge in
+/-- Row-native 32-bit (W-mode) `input_r2` binding for the **m32 = 1** case.
+    Mirror of `input_r1_packed_a32_row` on the `b` lanes. -/
+lemma input_r2_packed_b32_row
+    {state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource}
+    (m : Valid_Main FGL FGL)
+    (row : ZiskFv.AirsClean.Binary.BinaryRow FGL)
+    (r_main : ℕ) (rs2 : Fin 32) (r2_val : BitVec 64)
+    (hb0 : (row.bBytes.free_in_b_0).val < 256)
+    (hb1 : (row.bBytes.free_in_b_1).val < 256)
+    (hb2 : (row.bBytes.free_in_b_2).val < 256)
+    (hb3 : (row.bBytes.free_in_b_3).val < 256)
+    (_h_m32 : m.m32 r_main = 1)
+    (h_b_lo_t : m.b_0 r_main = lane_lo ((sail_to_rv64 state).xreg rs2))
+    (h_b_hi_t : m.b_1 r_main = lane_hi ((sail_to_rv64 state).xreg rs2))
+    (h_match : matches_entry (opBus_row_Main m r_main)
+      (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+        (ZiskFv.AirsClean.Binary.opBusMessage row) 1))
+    (h_input_r2 : read_xreg rs2 state = EStateM.Result.ok r2_val state) :
+    (Sail.BitVec.extractLsb r2_val 31 0 : BitVec (31 - 0 + 1)).toNat
+      = (row.bBytes.free_in_b_0.val + row.bBytes.free_in_b_1.val * 256
+          + row.bBytes.free_in_b_2.val * 65536
+          + row.bBytes.free_in_b_3.val * 16777216) % 2^32 := by
+  have h_match' : matches_entry (opBus_row_Main m r_main)
+      (opBus_row_Binary (ZiskFv.AirsClean.Binary.validOfRow row) 0) := by
+    simpa [ZiskFv.AirsClean.Binary.validOfRow,
+      ZiskFv.AirsClean.Binary.opBusMessage] using h_match
+  have h_r2_main :=
+    packed_lane_eq_of_read_xreg state rs2 r2_val (m.b_0 r_main) (m.b_1 r_main)
+      h_b_lo_t h_b_hi_t h_input_r2
+  simp only [matches_entry, opBus_row_Main, opBus_row_Binary] at h_match'
+  obtain ⟨_, _, _, _, h_b_lo_m, _, _, _, _, _, _, _⟩ := h_match'
+  have h_b0_val : (m.b_0 r_main).val =
+      row.bBytes.free_in_b_0.val + row.bBytes.free_in_b_1.val * 256
+      + row.bBytes.free_in_b_2.val * 65536
+      + row.bBytes.free_in_b_3.val * 16777216 := by
+    rw [h_b_lo_m]
+    have h_cast :
+        row.bBytes.free_in_b_0 + 256 * row.bBytes.free_in_b_1
+          + 65536 * row.bBytes.free_in_b_2 + 16777216 * row.bBytes.free_in_b_3
+        = (((row.bBytes.free_in_b_0.val + row.bBytes.free_in_b_1.val * 256
+              + row.bBytes.free_in_b_2.val * 65536
+              + row.bBytes.free_in_b_3.val * 16777216 : ℕ) : FGL)) := by
+      push_cast; ring
+    rw [h_cast, Fin.val_natCast]
+    apply Nat.mod_eq_of_lt
+    omega
+  rw [h_r2_main]
+  have h_extract_eq :
+      (Sail.BitVec.extractLsb
+        (BitVec.ofNat 64
+          ((m.b_0 r_main).val + (m.b_1 r_main).val * 4294967296)) 31 0
+        : BitVec (31 - 0 + 1)).toNat
+      = ((m.b_0 r_main).val + (m.b_1 r_main).val * 4294967296) % 2^32 := by
+    simp [Sail.BitVec.extractLsb, BitVec.extractLsb, BitVec.extractLsb',
+          BitVec.toNat_ofNat]
+  rw [h_extract_eq, h_b0_val]
+  have h_b0_lt : row.bBytes.free_in_b_0.val + row.bBytes.free_in_b_1.val * 256
+        + row.bBytes.free_in_b_2.val * 65536 + row.bBytes.free_in_b_3.val * 16777216
+        < 4294967296 := by omega
+  omega
+
 /-! ## c-lane match discharge for AND / OR / XOR rows (Round-3 lift)
 
 Combines the existing `carry_7_zero_<X>_pure` helpers with

--- a/bin/TrustGate/Main.lean
+++ b/bin/TrustGate/Main.lean
@@ -265,7 +265,9 @@ def soundConstructionTheorems : List Name :=
   , `ZiskFv.Compliance.construction_sraw_sound
   , `ZiskFv.Compliance.construction_slliw_sound
   , `ZiskFv.Compliance.construction_srliw_sound
-  , `ZiskFv.Compliance.construction_sraiw_sound ]
+  , `ZiskFv.Compliance.construction_sraiw_sound
+  , `ZiskFv.Compliance.construction_add_sound
+  , `ZiskFv.Compliance.construction_addi_sound ]
 
 /-- Subcommand: render the DEEP (recursive) construction-theorem binder list,
 for EVERY sound construction theorem in `soundConstructionTheorems`.

--- a/bin/TrustGate/Main.lean
+++ b/bin/TrustGate/Main.lean
@@ -267,7 +267,10 @@ def soundConstructionTheorems : List Name :=
   , `ZiskFv.Compliance.construction_srliw_sound
   , `ZiskFv.Compliance.construction_sraiw_sound
   , `ZiskFv.Compliance.construction_add_sound
-  , `ZiskFv.Compliance.construction_addi_sound ]
+  , `ZiskFv.Compliance.construction_addi_sound
+  , `ZiskFv.Compliance.construction_subw_sound
+  , `ZiskFv.Compliance.construction_addw_sound
+  , `ZiskFv.Compliance.construction_addiw_sound ]
 
 /-- Subcommand: render the DEEP (recursive) construction-theorem binder list,
 for EVERY sound construction theorem in `soundConstructionTheorems`.

--- a/trust/generated/baseline-construction-theorem-binders.txt
+++ b/trust/generated/baseline-construction-theorem-binders.txt
@@ -808,3 +808,75 @@ h_e0_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub
 h_e1_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).multiplicity 1
 h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).pc.val) register_type_pc_equiv) (PureSpec.execute_SHIFTIWOP_sraiw_pure sraiw_input).nextPC
 h_rd_idx :: Eq sraiw_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
+
+# ZiskFv.Compliance.construction_add_sound
+trace.length :: Nat
+trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
+trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
+trace.constraints :: trace.3.Constraints
+trace.spec :: trace.3.Spec
+trace.balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
+binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.length
+add_input :: PureSpec.AddInput
+r1 :: regidx
+r2 :: regidx
+rd :: regidx
+h_main_op :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).op i.val) ZiskFv.Trusted.OP_ADD
+h_main_active :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).is_external_op i.val) 1
+h_m32 :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).m32 i.val) 0
+h_store_pc :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).store_pc i.val) 0
+h_input_r1 :: Eq (read_xreg (regidx_to_fin r1) (binding.stateAt i)) (EStateM.Result.ok add_input.r1_val (binding.stateAt i))
+h_input_r2 :: Eq (read_xreg (regidx_to_fin r2) (binding.stateAt i)) (EStateM.Result.ok add_input.r2_val (binding.stateAt i))
+h_input_pc :: Eq ((binding.stateAt i).regs.get? Register.PC) (Option.some add_input.PC)
+h_input_rd :: Eq add_input.rd (regidx_to_fin rd)
+h_a_lo_t :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).a_0 i.val) (ZiskFv.Trusted.lane_lo ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg (regidx_to_fin r1)))
+h_a_hi_t :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).a_1 i.val) (ZiskFv.Trusted.lane_hi ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg (regidx_to_fin r1)))
+h_b_lo_t :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).b_0 i.val) (ZiskFv.Trusted.lane_lo ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg (regidx_to_fin r2)))
+h_b_hi_t :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).b_1 i.val) (ZiskFv.Trusted.lane_hi ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg (regidx_to_fin r2)))
+execRow :: List (Interaction.ExecutionBusEntry (Fin 18446744069414584321))
+h_exec_len :: Eq (ZiskFv.Compliance.busSub trace binding i execRow).exec_row.length 2
+h_e0_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 0).multiplicity (-1)
+h_e1_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).multiplicity 1
+h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).pc.val) register_type_pc_equiv) (PureSpec.execute_RTYPE_add_pure add_input).nextPC
+h_rd_idx :: Eq add_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
+
+# ZiskFv.Compliance.construction_addi_sound
+trace.length :: Nat
+trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
+trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
+trace.constraints :: trace.3.Constraints
+trace.spec :: trace.3.Spec
+trace.balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
+binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.length
+addi_input :: PureSpec.AddiInput
+r1 :: regidx
+rd :: regidx
+imm :: BitVec 12
+h_main_op :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).op i.val) ZiskFv.Trusted.OP_ADD
+h_main_active :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).is_external_op i.val) 1
+h_m32 :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).m32 i.val) 0
+h_store_pc :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).store_pc i.val) 0
+h_set_pc :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).set_pc i.val) 0
+h_input_r1 :: Eq (read_xreg (regidx_to_fin r1) (binding.stateAt i)) (EStateM.Result.ok addi_input.r1_val (binding.stateAt i))
+h_input_imm :: Eq addi_input.imm imm
+h_input_pc :: Eq ((binding.stateAt i).regs.get? Register.PC) (Option.some addi_input.PC)
+h_input_rd :: Eq addi_input.rd (regidx_to_fin rd)
+h_a_lo_t :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).a_0 i.val) (ZiskFv.Trusted.lane_lo ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg (regidx_to_fin r1)))
+h_a_hi_t :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).a_1 i.val) (ZiskFv.Trusted.lane_hi ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg (regidx_to_fin r1)))
+h_addi_subset :: ZiskFv.Tactics.ALUITypeArchetype.itype_imm_subset_holds_main (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable) i.val addi_input.imm
+execRow :: List (Interaction.ExecutionBusEntry (Fin 18446744069414584321))
+h_exec_len :: Eq (ZiskFv.Compliance.busSub trace binding i execRow).exec_row.length 2
+h_e0_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 0).multiplicity (-1)
+h_e1_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).multiplicity 1
+h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).pc.val) register_type_pc_equiv) (PureSpec.execute_ITYPE_addi_pure addi_input).nextPC
+h_rd_idx :: Eq addi_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)

--- a/trust/generated/baseline-construction-theorem-binders.txt
+++ b/trust/generated/baseline-construction-theorem-binders.txt
@@ -880,3 +880,110 @@ h_e0_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub
 h_e1_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).multiplicity 1
 h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).pc.val) register_type_pc_equiv) (PureSpec.execute_ITYPE_addi_pure addi_input).nextPC
 h_rd_idx :: Eq addi_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
+
+# ZiskFv.Compliance.construction_subw_sound
+trace.length :: Nat
+trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
+trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
+trace.constraints :: trace.3.Constraints
+trace.spec :: trace.3.Spec
+trace.balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
+binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.length
+subw_input :: PureSpec.SubwInput
+r1 :: regidx
+r2 :: regidx
+rd :: regidx
+h_main_op :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).op i.val) ZiskFv.Trusted.OP_SUB_W
+h_main_active :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).is_external_op i.val) 1
+h_m32 :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).m32 i.val) 1
+h_store_pc :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).store_pc i.val) 0
+h_input_r1 :: Eq (read_xreg (regidx_to_fin r1) (binding.stateAt i)) (EStateM.Result.ok subw_input.r1_val (binding.stateAt i))
+h_input_r2 :: Eq (read_xreg (regidx_to_fin r2) (binding.stateAt i)) (EStateM.Result.ok subw_input.r2_val (binding.stateAt i))
+h_input_pc :: Eq ((binding.stateAt i).regs.get? Register.PC) (Option.some subw_input.PC)
+h_input_rd :: Eq subw_input.rd (regidx_to_fin rd)
+h_a_lo_t :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).a_0 i.val) (ZiskFv.Trusted.lane_lo ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg (regidx_to_fin r1)))
+h_a_hi_t :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).a_1 i.val) (ZiskFv.Trusted.lane_hi ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg (regidx_to_fin r1)))
+h_b_lo_t :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).b_0 i.val) (ZiskFv.Trusted.lane_lo ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg (regidx_to_fin r2)))
+h_b_hi_t :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).b_1 i.val) (ZiskFv.Trusted.lane_hi ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg (regidx_to_fin r2)))
+execRow :: List (Interaction.ExecutionBusEntry (Fin 18446744069414584321))
+h_exec_len :: Eq (ZiskFv.Compliance.busSub trace binding i execRow).exec_row.length 2
+h_e0_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 0).multiplicity (-1)
+h_e1_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).multiplicity 1
+h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).pc.val) register_type_pc_equiv) (PureSpec.execute_RTYPE_subw_pure subw_input).nextPC
+h_rd_idx :: Eq subw_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
+
+# ZiskFv.Compliance.construction_addw_sound
+trace.length :: Nat
+trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
+trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
+trace.constraints :: trace.3.Constraints
+trace.spec :: trace.3.Spec
+trace.balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
+binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.length
+addw_input :: PureSpec.AddwInput
+r1 :: regidx
+r2 :: regidx
+rd :: regidx
+h_main_op :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).op i.val) ZiskFv.Trusted.OP_ADD_W
+h_main_active :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).is_external_op i.val) 1
+h_m32 :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).m32 i.val) 1
+h_store_pc :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).store_pc i.val) 0
+h_input_r1 :: Eq (read_xreg (regidx_to_fin r1) (binding.stateAt i)) (EStateM.Result.ok addw_input.r1_val (binding.stateAt i))
+h_input_r2 :: Eq (read_xreg (regidx_to_fin r2) (binding.stateAt i)) (EStateM.Result.ok addw_input.r2_val (binding.stateAt i))
+h_input_pc :: Eq ((binding.stateAt i).regs.get? Register.PC) (Option.some addw_input.PC)
+h_input_rd :: Eq addw_input.rd (regidx_to_fin rd)
+h_a_lo_t :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).a_0 i.val) (ZiskFv.Trusted.lane_lo ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg (regidx_to_fin r1)))
+h_a_hi_t :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).a_1 i.val) (ZiskFv.Trusted.lane_hi ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg (regidx_to_fin r1)))
+h_b_lo_t :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).b_0 i.val) (ZiskFv.Trusted.lane_lo ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg (regidx_to_fin r2)))
+h_b_hi_t :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).b_1 i.val) (ZiskFv.Trusted.lane_hi ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg (regidx_to_fin r2)))
+execRow :: List (Interaction.ExecutionBusEntry (Fin 18446744069414584321))
+h_exec_len :: Eq (ZiskFv.Compliance.busSub trace binding i execRow).exec_row.length 2
+h_e0_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 0).multiplicity (-1)
+h_e1_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).multiplicity 1
+h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).pc.val) register_type_pc_equiv) (PureSpec.execute_RTYPE_addw_pure addw_input).nextPC
+h_rd_idx :: Eq addw_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
+
+# ZiskFv.Compliance.construction_addiw_sound
+trace.length :: Nat
+trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
+trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
+trace.constraints :: trace.3.Constraints
+trace.spec :: trace.3.Spec
+trace.balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
+binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.length
+addiw_input :: PureSpec.AddiwInput
+r1 :: regidx
+rd :: regidx
+imm :: BitVec 12
+h_main_op :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).op i.val) ZiskFv.Trusted.OP_ADD_W
+h_main_active :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).is_external_op i.val) 1
+h_m32 :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).m32 i.val) 1
+h_store_pc :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).store_pc i.val) 0
+h_input_r1 :: Eq (read_xreg (regidx_to_fin r1) (binding.stateAt i)) (EStateM.Result.ok addiw_input.r1_val (binding.stateAt i))
+h_input_imm :: Eq addiw_input.imm imm
+h_input_pc :: Eq ((binding.stateAt i).regs.get? Register.PC) (Option.some addiw_input.PC)
+h_input_rd :: Eq addiw_input.rd (regidx_to_fin rd)
+h_a_lo_t :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).a_0 i.val) (ZiskFv.Trusted.lane_lo ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg (regidx_to_fin r1)))
+h_a_hi_t :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).a_1 i.val) (ZiskFv.Trusted.lane_hi ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding.stateAt i)).xreg (regidx_to_fin r1)))
+h_addiw_subset :: ZiskFv.Tactics.ALUITypeArchetype.itype_imm_subset_holds_main (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable) i.val addiw_input.imm
+execRow :: List (Interaction.ExecutionBusEntry (Fin 18446744069414584321))
+h_exec_len :: Eq (ZiskFv.Compliance.busSub trace binding i execRow).exec_row.length 2
+h_e0_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 0).multiplicity (-1)
+h_e1_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).multiplicity 1
+h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).pc.val) register_type_pc_equiv) (PureSpec.execute_ITYPE_addiw_pure addiw_input).nextPC
+h_rd_idx :: Eq addiw_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)


### PR DESCRIPTION
## P4 sweep — NEEDS-WORK families (stacked on #99)

Stacks on **#99** (the sound spine + 23-family READY front). Base = `p4-closeout-construction`. This PR adds the 5 families that required real new work beyond template cloning.

### Families (all sound, 0 PROJECT axioms, adversarially verified `pass`)
- **ADD, ADDI** — the op-bus provider is a `staticLookup-Binary ∨ BinaryAdd` **disjunction**. The construction derives the disjunction from `trace.balanced`, **case-splits it, and discharges BOTH arms** (staticLookup arm via the binary-lookup byte-chain; BinaryAdd arm via `equiv_ADD_via_binaryadd`). Neither arm is assumed away; no exclusion premise — the conclusion holds regardless of which provider served the op.
- **ADDW, SUBW, ADDIW** — required **authoring** the missing m32=1 binary lane lemma `input_r1_packed_a32_row` / `input_r2_packed_b32_row` (the m32=0 version existed; the W-ALU runs m32=1). Both genuinely proven (kernel-only axioms, no `sorry`/`axiom`). Key finding: the m32=1 high-lane `(1-1)*a_hi` term needs **no** discharge — the 32-bit operand binding comes from the m32-independent `a_lo` conjunct alone (so `_h_m32` is honestly unused). 32→64 sign-extension is handled inside the `equiv_<OP>_of_static_row` chain.

### Same invariants as #99
Data effect derived from `trace.balanced`/`trace.constraints`; residuals are explicit named top-level binders (no `*RowBinding`/`MainRowProvenance` record); `execRow` a genuine ∀-binder; the deep audit gate grows by honest flat binders only (now **28** construction blocks). **0 PROJECT (`ZiskFv.*`) axioms** (Sail-translation + Lean-kernel axioms external as documented); `baseline-axioms.txt` byte-unchanged by the new lane lemmas. Full `nix run .#test` green.

### Cumulative (with #99): 28 of 63 RV64IM opcodes have sound constructions
The full RV64I R-type + I-type ALU + all 12 shifts (#99) + ADD/ADDI + the W-ALU (this PR). Remaining: M-extension (separate sub-stream — new ArithMul/ArithDiv extractors), branches → #100/#101, loads/stores → #76, JAL/JALR → #100, FENCE → defect. All next-PC discharge is a named residual pending #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
