### PR TITLE
XCAP #103 XS-PR1 Step 1: structural segment-continuation channel exposure (framework, stacked work to follow)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,136 +1,46 @@
-Active plan: docs/ai/plan/PLAN_ENDGAME_P4_SWEEP.md (PR5 W-ALU, NEEDS-WORK Wave 6).
+Active plan: docs/ai/plan/PLAN_ENDGAME_XCAP.md §4.B (XS-PR1, framework — cross-segment Mem seam).
+Branch: xcap-xseg (off origin/main eb19cc8f). Worktree: .worktrees/xcap-xseg.
 
-DONE (SWEEP Wave 6 — W-ALU ADDW/SUBW/ADDIW, the NEEDS-WORK m32=1 binary
-families): AUTHORED the missing m32=1 32-bit lane-binding lemmas
-`input_r1_packed_a32_row` / `input_r2_packed_b32_row` in
-ZiskFv/EquivCore/Bridge/Binary.lean (the binary analog of the BinaryExtension
-shift bridge's packed_a_lo32_eq_of_shift_match_m32_1_of_a_range). KEY FINDING:
-the m32=1 binary lane DOES close cleanly, and WITHOUT needing one_sub_one_mul on
-a_hi — for the staticBinary provider the a_lo conjunct of matches_entry is
-m32-independent, so the 32-bit operand binding (extractLsb r1_val 31 0).toNat =
-binaryRowA32 row % 2^32 derives from the low-4-byte a_lo equation alone (the
-a_hi=(1-m32)*a_1 collapses to 0 but is not consumed for the low half). Lane
-lemmas take 4 explicit a/b byte-range (<256) hyps, sourced in the constructions
-from h_facts (StaticBinaryTableWfFacts) — no byte_chain_discharge_64 (which
-requires mode32=0). Added ConstructionWAlu.lean with construction_subw_sound
-(unique OP_SUB_W, Or.inr), construction_addw_sound (OP_ADD_W, Or.inl), and
-construction_addiw_sound (ITYPE, OP_ADD_W; imm + h_addiw_subset named pin +
-ITypePromises; wrapper derives the immediate byte decomposition internally).
-W bus harness: m32=1, writeReg-nextPC prelude retained. Appended all three to
-soundConstructionTheorems (25 → 28); deep baseline grew +3 honest flat blocks
-(subw 34, addw 34, addiw 33 binders; ZERO RowBinding/MainRowProvenance leaves;
-prior 25 blocks byte-identical prefix). lake build green (8688 jobs);
-check-all.sh 18/18; check-all-semantic.sh 12/12; baseline-axioms.txt UNCHANGED
-(lane lemmas add NO axiom); 0 PROJECT (ZiskFv.*) axioms per new theorem and lane
-lemma (closure = [cancel_reservation, propext, Classical.choice, Quot.sound] for
-constructions; [propext, Classical.choice, Quot.sound] for the lane lemmas —
-Sail+kernel external only). NO sorry/admit/native_decide.
+## Current focus: XS-PR1 Step 1 (structural seam-channel exposure) — DONE, green.
 
---- prior (Wave 5, from base p4-closeout-construction) ---
+Landed the MINIMAL first green increment of XS-PR1: the live Clean Mem layer can
+now EXPOSE a segment-continuation channel from row-local columns — the capability
+the per-row component "structurally cannot" do today (PLAN §1 TL;DR).
 
-Active plan: docs/ai/plan/PLAN_ENDGAME_P4_CLOSEOUT.md (§5 PR2, rework-off-#97).
+New files (additive; nothing in the live ensemble imports them — 28 families
+byte-identical green):
+- ZiskFv/Channels/SegmentContinuation.lean — SeamMessage (raw 5-tuple
+  [value_0,value_1,addr,step,segment_id]) + SeamContChannel (Guarantees := True,
+  mirroring MemBusChannel).
+- ZiskFv/AirsClean/Mem/SeamCircuit.lean — MemSeamRow (MemRow + 9 segment-boundary
+  Var fields) + circuitWithSeamAndMemBus / componentWithSeamAndMemBus: emits dual
+  MemBus + pull(previous_segment_*) + push(segment_last_*). Soundness/completeness
+  closed; 0 PROJECT axioms (kernel-only).
+- ZiskFv.lean: + import of SeamCircuit (build coverage only).
 
-Branch `p4-closeout-construction` off `origin/endgame-p4-pr2` (#97 @ 6c414ffa).
+Gates: full lake build green (8690 jobs); check-all.sh (V1) ALL PASS;
+check-all-semantic.sh (V2) ALL PASS. 63-theorem baselines unchanged (additive).
 
-Focus: EXECUTE PR2 — strip the P4 relabel, keep the salvage + via_binaryadd
-route, add the first honest sound construction (`construction_sub_sound`, 17 +
-execRow residual binders). End in a CLEAN do-not-merge PR superseding #94/#97.
+## Blocking / reported residual (CRITICAL — see PR body)
 
-Done:
-- Stripped AcceptedTrace.lean to the salvage (AcceptedTrace + ProgramBinding
-  skeleton + Layer-A provider-match wrappers). Removed ArmTag, 37 *RowBinding
-  structs, per-op ProgramBinding projections, all construction_<op> defs +
-  aeneasBridgeTrust theorems, the 28 exists_construction_*_from_balance wrappers.
-- Stripped the 4 addViaBinaryAdd*OfExtractedShape decls (AeneasBridgeTrust.lean).
-- Stripped the print-construction-binders subcommand (TrustGate/Main.lean), the
-  blind check-construction-theorem-binders.sh + its baseline + its wiring in
-  check-all-semantic.sh / regenerate.sh / README.md.
-- KEPT the via_binaryadd salvage route (OpEnvelope arms, Dispatch, EquivCore/Add,
-  BinaryAdd circuit, route ledger).
-- Added ConstructionSub.lean (sound construction_sub_sound).
+The firstGreenIncrement asked the seam emission's Requirements/Guarantees be
+PROVEN from permutation_every_row. That half is NOT delivered, and is a genuine
+reportable obstacle (NOT faked / NOT axiomatized):
+- permutation_every_row is ABSENT from the live Clean Mem component (it + the
+  SegmentColumns/PermutationColumns live only as Valid_Mem-parameterized defs in
+  Airs/Mem.lean + dead defs in Mem/Constraints.lean — grep confirms 0 refs under
+  AirsClean/ outside Constraints.lean).
+- permutation_every_row is a NON-VANISHING constraint on a Horner HASH
+  (im_direct_i * direct_gsum_i + 1 = 0); it carries NO raw-tuple statement, so the
+  raw-tuple seam emission cannot be derived from it row-locally (Risk #1).
+- The seam fact is a BALANCE fact (exists_push_of_pull over SoundVmEnsemble), per
+  the validated route — Channel.Guarantees := True deliberately carries nothing.
 
-DONE: lake build green (8681 jobs); check-all.sh 18/18; check-all-semantic.sh
-12/12; 0 PROJECT axioms (construction_sub_sound closure empty); 17 + execRow
-honest binders; net diff vs main has 0 relabel decls. Committed 9b55bcdb, pushed,
-opened do-not-merge PR #99 (eth-act/zisk-fv, base main) superseding #94/#97.
+## Next step (XS-PR1 Step 2, separate later PR — DISRUPTIVE)
 
-DONE (recursive gate, Option X): re-added the DEEP construction-binder gate.
-TypeWalk.lean renderTheoremBindersDeep + renderDeep (descend only into ZiskFv.*
-project structures; library structures are leaves; visited-set cycle guard).
-Main.lean print-construction-binders-deep targeting construction_sub_sound.
-check-construction-theorem-binders.sh re-added (points at -deep), re-wired into
-check-all-semantic.sh (5/12) + regenerate.sh + README. Deep baseline = 17 flat
-h_ residual lines + execRow; ZERO RowBinding/MainRowProvenance substrings; setup
-binders (trace/binding) descend into honest trace structure only. nix run .#test
-green. Committed 0e25550d, pushed to update PR #99.
-
-DONE (PR3 — second sound family, AND, logic route): added
-ConstructionAnd.lean (`construction_and_sound`), the mechanical mirror of
-`construction_sub_sound` for the logic family. Op-bus match via the salvaged
-logic Layer-A wrapper `exists_staticBinary_provider_row_matches_logic_from_binding`
-(op pin via `Or.inl h_main_op`); OP_AND (=14, <16) byte-chain path
-(`logic_row_mode_pins_of_emit_op_lt_16_of_static_spec` + `BinaryTable.OP_AND`);
-data effect concluded via `equiv_AND` (`execute_RTYPE_and_pure`, bottoms in
-`binary_and_chunks_eq_bv_and_of_wf`). Same 17 + execRow residual budget, flat
-top-level binders, no `*RowBinding`/`MainRowProvenance` leaf. Generalized the
-recursive gate: `soundConstructionTheorems` list + labelled-block deep render
-in TrustGate/Main.lean (adding a family = append to the list + regen). Deep
-baseline grew 34→71 lines = +2 headers + 1 blank + 34 honest AND binders; SUB
-block byte-identical. lake build green (8682 jobs); check-all.sh 18/18;
-check-all-semantic.sh 12/12 (deep check now covers both); 0 PROJECT
-(ZiskFv.*) axioms (construction_and_sound closure empty of ZiskFv.* names);
-nix run .#test green.
-
-DONE (SWEEP Wave 2 — I-type logic + compare, ANDI/ORI/XORI/SLTI/SLTIU): added
-ConstructionIType.lean with five sound constructions, each the mechanical mirror
-of its R-type sibling (AND/OR/XOR/SLT/SLTU) through the uniform I-type immediate
-DELTA. The second operand is the immediate (NOT a register read): drop r2's Sail
-read + `h_b_lo_t`/`h_b_hi_t` lane bridges; add the `imm : BitVec 12` binder, the
-immediate-decode equality `h_input_imm : input.imm = imm`, and the NAMED
-top-level `itype_imm_subset_holds_main` pin (`h_<op>_subset`); swap
-RTypePromises→ITypePromises (carries `input_imm_eq`); route via `equiv_<OP>I`.
-Logic ops (ANDI/ORI/XORI) DERIVE the 8-byte Binary-row imm form `h_input_imm_row`
-in-body via `itype_imm_subset_binary_row_of_main_row` (NOT a binder); compare ops
-(SLTI/SLTIU) pass `m32=0`+`h_<op>_subset` directly and the wrapper re-derives it.
-XORI inherits XOR's OP_XOR=16 wrinkle (static_table_logic_mode_pins_of_emit +
-byte_chain_discharge_logic). Per-family budget: 16 hyp binders + `imm` + execRow
-(33 deep leaves vs R-type's 34; net -1, fully honest: -r2/-h_input_r2/-h_b_lo_t/
--h_b_hi_t = -4, +imm/+h_input_imm/+h_<op>_subset = +3). Appended all five to
-`soundConstructionTheorems`; deep baseline grew +175 lines (5 honest blocks);
-prior 6 blocks byte-identical; ZERO RowBinding/MainRowProvenance leaves;
-itype_imm_subset_holds_main is a flat binder line in all 5. lake build green
-(8685 jobs); check-all.sh 18/18; check-all-semantic.sh 12/12; 0 PROJECT
-(ZiskFv.*) axioms per new theorem (Sail+kernel external).
-
-DONE (SWEEP Wave 3 — m32 = 0 shifts SLL/SRL/SRA/SLLI/SRLI/SRAI): added
-ConstructionShift.lean with six sound constructions on the BinaryExtension
-template (NOT the busSub/staticBinary path). SLL was the exemplar that solved
-the three shift novelties: (1) op-bus match via the salvaged shift Layer-A
-wrapper exists_binaryExtension_provider_row_matches_shift_from_binding (6-way op
-disjunction; SLL/SLLI Or.inl, SRL/SRLI Or.inr (Or.inl ·), SRA/SRAI
-Or.inr (Or.inr (Or.inl ·))); (2) BARE-execute conclusion (no writeReg-nextPC
-prelude) — the construction concludes equiv_<OP>'s conclusion verbatim, so the
-exec-bus bookkeeping (h_exec_len/h_e0_mult/h_e1_mult/busSub/h_nextPC_matches)
-rides inside the RTypePromises / ShiftImmPromises bundle against the bare-execute
-pure spec; (3) the m32 = 0 lane route — packed_a_eq_of_shift_match_m32_0_of_a_range
-(one_sub_zero_mul, Bridge/BinaryExtension.lean:240/269) + shift-pin lemmas.
-To keep the giant shiftStaticLookupComponent.rowInput term opaque (a `set row`
-inline derivation timed out at whnf), the lane/op-is-shift derivations are
-factored into five opaque-`row` helper theorems in ConstructionShift.lean
-(shift_op_pin_eq_of_match, shift_op_is_shift_of_facts,
-shift_m32_0_input_r1_row_of_facts, shift_m32_0_shift_pin_row_of_facts,
-shift_imm_shift_pin_row_of_facts) which mirror equiv_SLL_of_static_row's internal
-block. Register variants carry SUB's 17 + execRow budget; immediate variants drop
-r2's read + hi-lane, add shamt + h_input_shamt + the b_0 shamt_b_lo decode pin
-(16 hyp + shamt + execRow). Appended all six to soundConstructionTheorems
-(11 → 17); deep baseline grew +201 lines = 6 honest flat blocks; prior 11 blocks
-byte-identical; ZERO RowBinding/MainRowProvenance leaves. lake build green
-(8686 jobs); check-all.sh 18/18; check-all-semantic.sh 12/12; 0 PROJECT (ZiskFv.*)
-axioms per new theorem (closure = [cancel_reservation, propext, Classical.choice,
-Quot.sound], i.e. Sail+kernel external only).
-
-Next (follow-up increments, NOT this PR): the remaining ALU/sweep families
-(ADD/ADDI provider-disjunction PR4; W-types PR5 incl. m32 = 1 W-shifts;
-M-ext; branches; loads/stores); close stale #94/#97 on merge (Cody's call).
-
-Blocking: none.
+Build memSegVm : VmTables over componentWithSeamAndMemBus; migrate
+fullRv64imEnsemble SoundEnsemble→SoundVmEnsemble + non-empty verifier; absorb the
+Balance.lean re-proves (shifted channel list, prepended tables, non-empty
+verifier); derive SeamColumnEquality from balance + the tag pins. The tag-pin
+derivation from segment_every_row + boot saturation (Risk #3) and the
+verifier-endpoint discharge (PLAN §7.5) are the Step-2 make-or-break.

--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -128,6 +128,7 @@ import ZiskFv.AirsClean.ArithTableProjections
 import ZiskFv.AirsClean.BinaryFamily.Balance
 import ZiskFv.AirsClean.FullEnsemble
 import ZiskFv.AirsClean.FullEnsemble.Balance
+import ZiskFv.AirsClean.Mem.SeamCircuit
 import ZiskFv.ZiskCircuit.MemTimeline.Construction
 import ZiskFv.ZiskCircuit.MemTimeline.Linkage
 import ZiskFv.Compliance.RowProvenance

--- a/ZiskFv/AirsClean/Mem/SeamCircuit.lean
+++ b/ZiskFv/AirsClean/Mem/SeamCircuit.lean
@@ -1,0 +1,201 @@
+import ZiskFv.AirsClean.Mem.Circuit
+import ZiskFv.Channels.SegmentContinuation
+import Clean.Air.FlatComponent
+import Clean.Utils.Tactics
+
+/-!
+# Mem-with-segment-continuation Clean component (XCAP #103 / XS-PR1, Step 1)
+
+This is the **structural seam-channel-exposure** half of XS-PR1 (the framework
+PR for the cross-segment Mem seam). It adds a NEW, self-contained Clean
+component variant that — in addition to the dual MemBus emission of
+`componentWithDualMemBus` — exposes the **segment-continuation channel**
+(`ZiskFv/Channels/SegmentContinuation.lean`) by PULLing `previous_segment_*` and
+PUSHing `segment_last_*` as RAW boundary tuples read off the row.
+
+It is built on a NEW row type `MemSeamRow` that carries the 9 segment-boundary
+columns as `Var` fields, so the seam tuple is reachable through the component's
+`rowInputVar` (the precondition `VmTables.tables_channel`,
+`build/clean-lean/Clean/Air/Vm.lean:51-53`, imposes). `MemRow` and
+`componentWithDualMemBus` are LEFT UNTOUCHED, so the 28 merged ALU/shift
+families and every `FullEnsemble/Balance.lean` projection stay byte-identical:
+nothing in the live ensemble imports this module.
+
+## What this module IS and IS NOT (XS-PR1 Step 1 / Step 2 boundary)
+
+**IS:** the live Clean Mem layer's first ability to EXPOSE a
+segment-continuation channel from row-local columns — the capability the plan
+(PLAN_ENDGAME_XCAP §1, TL;DR) says the per-row component "structurally cannot"
+do today. Additive, green, **0 PROJECT (`ZiskFv.*`) axioms** (kernel-only:
+`propext`, `Classical.choice`, `Quot.sound`).
+
+**IS NOT:** a derivation of the seam. The channel `Guarantees` is `True`
+(matching `MemBusChannel`); the cross-segment fact
+`seg.segment_last_* = next_seg.previous_segment_*` is a GLOBAL balance fact of
+the migrated `SoundVmEnsemble`, derived via `exists_push_of_pull` (XCAP #103
+validated go/no-go PoC). It is NOT, and at the row-emission layer cannot be,
+derived from `permutation_every_row`: that constraint is a non-vanishing
+condition on a Horner HASH (`im_direct_i * direct_gsum_i + 1 = 0`), carrying no
+raw-tuple statement. The seam derivation + driver migration + verifier endpoints
+are XS-PR1 Step 2, NOT this increment.
+
+## Trust note
+
+No axioms. The seam emission adds only the trivially-true channel guarantee
+(`SeamContChannel.Guarantees := True`), exactly as the MemBus emission does.
+-/
+
+namespace ZiskFv.AirsClean.Mem
+
+open Goldilocks
+open ZiskFv.Channels.MemoryBus (MemBusChannel)
+open ZiskFv.Channels.SegmentContinuation (SeamContChannel SeamMessage)
+open Air.Flat
+
+/-- Mem row extended with the 9 segment-boundary columns needed to expose the
+    raw segment-continuation seam tuple from `rowInputVar`. The first 13 fields
+    mirror `MemRow`; the remaining 9 are `SegmentColumns`'s boundary/tag fields
+    (`ZiskFv/Airs/Mem.lean:162-173`) that the seam channel carries RAW. -/
+structure MemSeamRow (F : Type) where
+  -- base MemRow columns
+  addr : F
+  step : F
+  sel : F
+  addr_changes : F
+  step_dual : F
+  sel_dual : F
+  value_0 : F
+  value_1 : F
+  wr : F
+  previous_step : F
+  increment_0 : F
+  increment_1 : F
+  read_same_addr : F
+  -- segment-boundary columns (the raw seam tuple components + tag)
+  segment_id : F
+  previous_segment_value_0 : F
+  previous_segment_value_1 : F
+  previous_segment_addr : F
+  previous_segment_step : F
+  segment_last_value_0 : F
+  segment_last_value_1 : F
+  segment_last_addr : F
+  segment_last_step : F
+deriving ProvableStruct
+
+/-- The base MemBus provider message read off a `MemSeamRow`
+    (`mem_op = wr + 1`, `ptr = addr * 8`, `width = 8`, `timestamp = step`). -/
+@[reducible]
+def seamRowMemBusMessageExpr (row : Var MemSeamRow FGL) :
+    ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL) :=
+  { mem_op := row.wr + 1
+    ptr := row.addr * 8
+    timestamp := row.step
+    width := 8
+    value_0 := row.value_0
+    value_1 := row.value_1 }
+
+/-- The dual MemBus provider message read off a `MemSeamRow`. -/
+@[reducible]
+def seamRowMemBusDualMessageExpr (row : Var MemSeamRow FGL) :
+    ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL) :=
+  { mem_op := 1
+    ptr := row.addr * 8
+    timestamp := row.step_dual
+    width := 8
+    value_0 := row.value_0
+    value_1 := row.value_1 }
+
+/-- The incoming-boundary seam message PULLed by a segment (the raw
+    `previous_segment_*` tuple, tagged with `segment_id`). Mirrors the
+    `direct_gsum_0` tag (`ZiskFv/Airs/Mem.lean:1351-1358`). -/
+@[reducible]
+def prevSeamMessageExpr (row : Var MemSeamRow FGL) : SeamMessage (Expression FGL) :=
+  { value_0 := row.previous_segment_value_0
+    value_1 := row.previous_segment_value_1
+    addr := row.previous_segment_addr
+    step := row.previous_segment_step
+    segment_id := row.segment_id }
+
+/-- The outgoing-boundary seam message PUSHed by a segment (the raw
+    `segment_last_*` tuple, tagged with `segment_id + 1`). Mirrors the
+    `direct_gsum_1` tag (`ZiskFv/Airs/Mem.lean:1361-1368`). -/
+@[reducible]
+def lastSeamMessageExpr (row : Var MemSeamRow FGL) : SeamMessage (Expression FGL) :=
+  { value_0 := row.segment_last_value_0
+    value_1 := row.segment_last_value_1
+    addr := row.segment_last_addr
+    step := row.segment_last_step
+    segment_id := row.segment_id + 1 }
+
+/-- Mem constraints + dual MemBus emission + segment-continuation seam
+    pull/push. The seam channel PULLs the incoming boundary and PUSHes the
+    outgoing boundary — one VM transition. -/
+@[circuit_norm]
+def memWithSeamAndMemBus (row : Var MemSeamRow FGL) : Circuit FGL Unit := do
+  MemBusChannel.emit row.sel (seamRowMemBusMessageExpr row)
+  MemBusChannel.emit row.sel_dual (seamRowMemBusDualMessageExpr row)
+  SeamContChannel.pull (prevSeamMessageExpr row)
+  SeamContChannel.push (lastSeamMessageExpr row)
+
+/-- Elaborated `memWithSeamAndMemBus` circuit. Exposes both the MemBus
+    provider emissions and the segment-continuation pull/push. -/
+@[reducible] def memWithSeamAndMemBusElaborated :
+    ElaboratedCircuit FGL MemSeamRow unit where
+  name := "MemWithSeamAndMemBus"
+  main := memWithSeamAndMemBus
+  localLength _ := 0
+  output _ _ := ()
+  channelsWithRequirements := [MemBusChannel.toRaw, SeamContChannel.toRaw]
+  -- Expose the SEAM interactions in detail (the new Step-1 capability); the
+  -- MemBus interactions are covered by the requirements/guarantees lists, as in
+  -- `Main.mainWithRomMemAndOpBus` (which exposes only its OpBus in detail).
+  exposedChannels row _ :=
+    expose SeamContChannel
+      [ pulled (prevSeamMessageExpr row), pushed (lastSeamMessageExpr row) ]
+  channelsLawful := by
+    simp [circuit_norm, memWithSeamAndMemBus, seamRowMemBusMessageExpr,
+      seamRowMemBusDualMessageExpr, prevSeamMessageExpr, lastSeamMessageExpr,
+      MemBusChannel, SeamContChannel]
+
+/-- Mem (with dual MemBus + segment-continuation seam) as a Clean
+    `GeneralFormalCircuit`. The Spec is trivial here (`True`): this Step-1
+    increment delivers seam-channel exposure only — the per-row Mem Spec and the
+    seam derivation are out of scope (Step 2). -/
+def circuitWithSeamAndMemBus : GeneralFormalCircuit FGL MemSeamRow unit where
+  main := memWithSeamAndMemBus
+  localLength _ := 0
+  output _ _ := ()
+  Assumptions _ _ := True
+  Spec _ _ _ := True
+  ProverAssumptions _ _ _ := True
+  ProverSpec _ _ _ := True
+  channelsWithGuarantees := [MemBusChannel.toRaw, SeamContChannel.toRaw]
+  channelsWithRequirements := [MemBusChannel.toRaw, SeamContChannel.toRaw]
+  exposedChannels row _ :=
+    expose SeamContChannel
+      [ pulled (prevSeamMessageExpr row), pushed (lastSeamMessageExpr row) ]
+  channelsLawful := by
+    simp [circuit_norm, memWithSeamAndMemBus, seamRowMemBusMessageExpr,
+      seamRowMemBusDualMessageExpr, prevSeamMessageExpr, lastSeamMessageExpr,
+      MemBusChannel, SeamContChannel]
+  soundness := by
+    circuit_proof_start [MemBusChannel, SeamContChannel]
+  completeness := by
+    circuit_proof_start [MemBusChannel, SeamContChannel]
+
+/-- Mem (with dual MemBus + segment-continuation seam) as a Clean
+    `Air.Flat.Component`. NOT wired into `fullRv64imEnsemble` — that driver
+    migration is XS-PR1 Step 2.
+
+    NOTE (Step-2 handoff): the companion
+    `componentWithSeamAndMemBus_interactionsWith_seam` lemma — the analogue of
+    `componentWithDualMemBus_interactionsWith_memBus` projecting this
+    component's `interactionsWith SeamContChannel.toRaw` to the raw pull/push
+    pair — is deferred to Step 2, where the `SoundVmEnsemble` balance proof
+    actually consumes it (and supplies the multi-channel `expose ++ expose`
+    normalization context that keeps the `interactionsWith` computation
+    tractable). It is NOT needed by this Step-1 capability increment. -/
+def componentWithSeamAndMemBus : Air.Flat.Component FGL := ⟨ circuitWithSeamAndMemBus ⟩
+
+end ZiskFv.AirsClean.Mem

--- a/ZiskFv/Channels/SegmentContinuation.lean
+++ b/ZiskFv/Channels/SegmentContinuation.lean
@@ -1,0 +1,81 @@
+import Clean.Circuit.Channel
+import Clean.Circuit.Provable
+import Clean.Utils.Tactics.ProvableStructDeriving
+import ZiskFv.Field.Goldilocks
+
+/-!
+# SegmentContinuation typed channel (XCAP #103 / XS-PR1 framework, Step 1)
+
+ZisK's Mem AIR proves a per-segment permutation accumulator
+(`ZiskFv/Airs/Mem.lean:1351/1361` `direct_gsum_0/1`, summed by
+`permutation_every_row :1398`) whose GLOBAL cancellation across segments is
+what forces the cross-segment seam
+`seg.segment_last_* = next_seg.previous_segment_*`. The live single-table /
+per-row Clean Mem component (`ZiskFv/AirsClean/Mem/Circuit.lean`) cannot today
+EXPRESS that cross-segment fact: it emits only the (row-local) MemBus channel,
+and the segment-boundary columns are not even reachable through its row.
+
+This file introduces the **segment-continuation channel** as a
+`Clean.Channel FGL SeamMessage` carrying the RAW boundary tuple
+
+```
+[value_0, value_1, addr, step, segment_id]
+```
+
+so that — once the ensemble is migrated to the `SoundVmEnsemble` driver
+(XS-PR1 Step 2) — global balance forces element-wise equality of the matched
+pulled/pushed message via `exists_push_of_pull` (validated go/no-go PoC
+`tagged_seam_forced`, branch `xseg`), with NO hash-injectivity /
+Schwartz-Zippel step. Carrying the tuple RAW is the validated route-(a) relief
+the plan (PLAN_ENDGAME_XCAP §2.2 / Risk #4) names (issue #103).
+
+## Trust note
+
+Same pattern as `Channels/MemoryBus.lean` and `Channels/OperationBus.lean` —
+**no new axioms**. The channel `Guarantees` is `True`: the cross-segment seam is
+NOT bundled into a per-row channel guarantee. It is a GLOBAL balance fact,
+discharged by `Air.Balance` once the seam is hosted as a VM channel of a
+`SoundVmEnsemble`. This mirrors `MemBusChannel`'s documented `Guarantees := True`
+(`Channels/MemoryBus.lean:99-105`): cross-AIR/cross-segment consistency lives in
+balance, not in the channel guarantee.
+
+**Scope honesty (XS-PR1 Step 1 boundary).** `permutation_every_row` is a
+NON-VANISHING constraint on a Horner HASH (`im_direct_i * direct_gsum_i + 1 = 0`,
+i.e. `direct_gsum_i ≠ 0`); it carries NO raw-tuple statement. The raw-tuple seam
+fact this channel carries is therefore NOT derivable as a row-local guarantee
+from `permutation_every_row` — it is a balance fact of the migrated ensemble
+(Step 2). This module delivers only the structural CAPABILITY to expose the
+segment-continuation channel from row-local columns; it does not, and cannot at
+the row-emission layer, derive the seam.
+-/
+
+namespace ZiskFv.Channels.SegmentContinuation
+
+open Goldilocks
+
+/-- The 5-slot segment-boundary message carried on the segment-continuation
+    channel: `[value_0, value_1, addr, step, segment_id]`.
+
+    `segment_id` is the per-segment TAG. The ZisK accumulator tags the PULL of
+    `previous_segment_*` with `segment_id` (`direct_gsum_0`) and the PUSH of
+    `segment_last_*` with `segment_id + 1` (`direct_gsum_1`); carrying the tag
+    RAW is what lets balance select the unique matching push per segment
+    (validated go/no-go PoC `tagged_seam_forced`). -/
+structure SeamMessage (F : Type) where
+  value_0 : F
+  value_1 : F
+  addr : F
+  step : F
+  segment_id : F
+deriving ProvableStruct
+
+/-- The segment-continuation channel. As with `MemBusChannel`/`OpBusChannel`,
+    the guarantee is `True`: the cross-segment seam is enforced by `Air.Balance`
+    over a `SoundVmEnsemble` (XS-PR1 Step 2), not bundled into the channel
+    guarantee. A segment row PULLs its `previous_segment_*` boundary and PUSHes
+    its `segment_last_*` boundary — a VM transition. -/
+instance SeamContChannel : Channel FGL SeamMessage where
+  name := "SegmentContinuation"
+  Guarantees _msg _data := True
+
+end ZiskFv.Channels.SegmentContinuation


### PR DESCRIPTION
Queued for Claude review — do not merge.

This is **XCAP #103 XS-PR1** (the cross-segment Mem seam framework PR,
PLAN_ENDGAME_XCAP §4.B), **Step 1 of 2** — the additive, low-risk half. **Stacked
work to follow** (Step 2 = the disruptive `SoundVmEnsemble` driver migration).

## What this PR delivers (the minimal first green increment)

The live single-table / per-row Clean Mem component (`ZiskFv/AirsClean/Mem/`)
**structurally cannot** express a cross-segment balance fact today: it emits only
the row-local MemBus channel, and the segment-boundary columns are not even
reachable through its row. This PR gives it that structural capability, additively:

- **`ZiskFv/Channels/SegmentContinuation.lean`** — `SeamMessage` (the RAW
  boundary 5-tuple `[value_0, value_1, addr, step, segment_id]`) +
  `SeamContChannel` with `Guarantees := True`, mirroring `MemBusChannel`
  (`Channels/MemoryBus.lean:99-105`): cross-segment consistency lives in
  `Air.Balance`, not in the channel guarantee. Carrying the tuple RAW is the
  validated route-(a) relief (no hash-injectivity / Schwartz-Zippel).
- **`ZiskFv/AirsClean/Mem/SeamCircuit.lean`** — `MemSeamRow` (the 13 `MemRow`
  columns + the 9 `SegmentColumns` boundary/tag columns as `Var` fields, so the
  seam tuple is reachable through `rowInputVar`, as `VmTables.tables_channel`
  requires, `build/clean-lean/Clean/Air/Vm.lean:51-53`) +
  `circuitWithSeamAndMemBus` / `componentWithSeamAndMemBus`, which emit dual
  MemBus + `pull(previous_segment_*)` + `push(segment_last_*)`.
  Soundness/completeness closed.
- **`ZiskFv.lean`** — import for build coverage.

`MemRow` and `componentWithDualMemBus` are **untouched**; nothing in
`fullRv64imEnsemble` imports the new module, so the **28 merged ALU/shift
families and every `FullEnsemble/Balance.lean` projection stay byte-identical**.

## Invariants

- **0 PROJECT (`ZiskFv.*`) axioms; Sail-translation + Lean-kernel axioms present
  as documented external trust.** The seam declarations
  (`circuitWithSeamAndMemBus`, `componentWithSeamAndMemBus`, `SeamContChannel`)
  close on kernel axioms only (`[propext, Classical.choice, Quot.sound]`); no
  `sorryAx`.
- **Gates:** full `lake build` green (8690 jobs = baseline 8688 + 2 new modules);
  `check-all.sh` (V1) ALL PASS; `check-all-semantic.sh` (V2) ALL PASS. The
  63-theorem hypothesis-count / caller-burden / per-theorem axiom-dep baselines
  are **unchanged** (the increment is purely additive — it touches no canonical
  `equiv_<OP>` theorem). The deep construction-binder snapshot is unchanged.

## REPORTED RESIDUAL (CRITICAL — not faked, not axiomatized)

The plan's `firstGreenIncrement` framing asked Step 1 to **PROVE the seam
emission's Requirements/Guarantees from the existing `permutation_every_row`
facts.** That half is **not delivered**, and per the SPINE §4.3 CRITICAL
REPORTING RULE it is reported here as a genuine finding rather than faked:

1. **`permutation_every_row` is absent from the live Clean Mem component.** The
   permutation accumulator (`PermutationColumns`: `std_alpha`, `std_gamma`,
   `im_direct_0..5`), the segment-boundary columns (`SegmentColumns`), and
   `permutation_every_row` (`direct_gsum_0/1`) live ONLY as
   `Valid_Mem`-parameterized defs in `ZiskFv/Airs/Mem.lean` plus dead defs in
   `ZiskFv/AirsClean/Mem/Constraints.lean`. They are never lifted into
   `memElaborated` / `memWithDualMemBusElaborated`; grep for
   `permutation_every_row|SegmentColumns|PermutationColumns` under `AirsClean/`
   returns nothing outside `Constraints.lean`. The Clean component's `Spec` is
   only the 9 row-local boolean/zeroing clauses (`Mem/Soundness.lean`).
2. **`permutation_every_row` carries no raw-tuple statement.** Its
   segment-boundary arm is `im_direct_i * direct_gsum_i + 1 = 0`, i.e.
   `direct_gsum_i != 0` — a NON-VANISHING condition on a Horner HASH over
   `std_alpha`/`std_gamma`. Bridging that to "the row pushes the raw tuple" would
   need a hash-injectivity / Schwartz-Zippel step the Lean model deliberately
   avoids (Risk #1).
3. **The seam is a BALANCE fact, not a row-local guarantee.** Per the validated
   go/no-go route, `SeamColumnEquality` follows from global balance via
   `exists_push_of_pull` over a RAW-tuple VM channel; `Channel.Guarantees := True`
   deliberately carries nothing. So there is no honest row-local
   "guarantee-from-`permutation_every_row`" to construct at Step 1 — the
   derivation is intrinsically a Step-2 balance fact.

## Proposed XS-PR1 split (Step 2 = separate later PR, DISRUPTIVE)

Build `memSegVm : VmTables` over `componentWithSeamAndMemBus`; migrate
`fullRv64imEnsemble` from `SoundEnsemble`/`OrderedChannel` to
`SoundVmEnsemble`/`Vm.lean` with a non-empty verifier; absorb the
`FullEnsemble/Balance.lean` re-proves (shifted channel list, prepended segment
tables, non-empty-verifier sites); derive `SeamColumnEquality` from balance +
the tag pins. The make-or-break for Step 2 is the **verifier-endpoint /
tag-pin discharge** — whether the per-segment tag chain is forced by
`segment_every_row` + boot saturation (Risk #3 / PLAN §7.5) rather than
relocated to a caller-supplied verifier premise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)