### PR TITLE
ci: run Aeneas extraction harness in parallel, off the FV-gate critical path

### DIFF
--- a/.github/workflows/proofs.yml
+++ b/.github/workflows/proofs.yml
@@ -160,6 +160,12 @@ jobs:
           # That fits the 16 GiB L runner with headroom after the sd
           # proof-memory fix, and matches nix/test.nix's default.
           LEAN_NUM_THREADS: "4"
+          # The independent Aeneas production-extraction completeness check
+          # (step 3/8) is the single largest cost (~1.5h) and is unrelated to
+          # the Lake proof graph. Run it in the parallel
+          # aeneas-production-extraction job below instead of serializing it
+          # ahead of `lake build`. Plain local `nix run .#test` is unaffected.
+          ZISK_FV_TEST_SKIP_AENEAS: "1"
         run: |
           # Memory + lean-process sidecar. Run 25230110804 died with no
           # step log content preserved → strong signal the runner host
@@ -218,3 +224,58 @@ jobs:
           echo "  - CLAUDE.md  (working conventions for agents)"
           echo "  - trust/README.md  (overview of the trust gate)"
           echo "  - flake.lock  (the audit surface for build-input changes)"
+
+  # ------------------------------------------------------------------
+  # Aeneas RV-completeness extraction harness, run in PARALLEL with the
+  # Lake FV gate above. Previously this ran as step 3/8 of `nix run .#test`
+  # inside the lake-build job, serializing ~1.5h of generated-extraction
+  # work ahead of the proof build. It is independent of the Lake proof
+  # graph (the `aeneas-extraction-diff` job already guards the tracked
+  # ProductionM2 artifact), so it belongs off the critical path.
+  #
+  # The temporary `build/aeneas-production-extraction/lean-check/.lake` is
+  # cached across runs: the generated completeness files are deterministic
+  # given the extraction inputs, so an unchanged harness is a near no-op
+  # lake build instead of recompiling ~26 RvDecode* files (~580-820s each)
+  # from scratch every push.
+  # ------------------------------------------------------------------
+  aeneas-production-extraction:
+    name: Aeneas production extraction
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - uses: cachix/cachix-action@v15
+        with:
+          name: zisk-fv
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - name: Cache Aeneas lean-check .lake
+        uses: actions/cache@v4
+        with:
+          path: build/aeneas-production-extraction/lean-check/.lake
+          key: aeneas-lean-check-${{ runner.os }}-${{ hashFiles('flake.lock', 'lean-toolchain', 'scripts/aeneas-production-extract.sh', 'zisk/core/src/aeneas_extract.rs', 'ZiskFv/Compliance/RowProvenance.lean', 'trust/aeneas/ProductionM2.lean') }}
+          restore-keys: |
+            aeneas-lean-check-${{ runner.os }}-
+
+      - name: Run full Aeneas production extraction completeness check
+        env:
+          AENEAS_CHECK_RV_COMPLETENESS: "1"
+          LEAN_NUM_THREADS: "4"
+        run: nix run .#aeneas-production-extract
+
+      - name: On failure — show next-step pointers
+        if: failure()
+        run: |
+          echo "::error::Aeneas production extraction failed. Documentation:"
+          echo "  - scripts/aeneas-production-extract.sh"
+          echo "  - trust/aeneas/README.md"
+          echo "  - flake.lock  (the audit surface for Aeneas/build-input changes)"

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -61,6 +61,25 @@ writeShellApplication {
       echo
     }
 
+    # Like `run`, but skipped when the named env var is set truthy. Used so
+    # the independent Aeneas production-extraction harness can be run in a
+    # parallel CI job (see .github/workflows/proofs.yml) instead of
+    # serializing the ~1.5h generated-extraction gate ahead of `lake build`.
+    # Local `nix run .#test` keeps running every step by default.
+    run_unless_skipped() {
+      local skip_var=$1
+      local name=$2
+      shift 2
+      local skip_value="''${!skip_var:-0}"
+      if [[ "$skip_value" != 0 && "$skip_value" != false && "$skip_value" != FALSE ]]; then
+        echo "::: $name :::"
+        echo "skipped because $skip_var=$skip_value"
+        echo
+        return 0
+      fi
+      run "$name" "$@"
+    }
+
     # shellcheck disable=SC2329
     mem_generated_artifact_wrapper() {
       test -f build/extraction/Extraction/Circuit.lean
@@ -99,7 +118,7 @@ writeShellApplication {
     # build and checks the production-backed extraction boundary. The canonical
     # ProductionM2 extraction is tracked under trust/aeneas/ and diff-checked by
     # CI; temporary generated harness files remain under build/.
-    run "3/8 Aeneas production extraction harness" bash -c '
+    run_unless_skipped ZISK_FV_TEST_SKIP_AENEAS "3/8 Aeneas production extraction harness" bash -c '
       AENEAS_FLAKE="${aeneas}" AENEAS_CHECK_RV_COMPLETENESS=1 scripts/aeneas-production-extract.sh
     '
 


### PR DESCRIPTION
## Problem

The `proofs` workflow has climbed to ~2.5h ([run 27594292349](https://github.com/eth-act/zisk-fv/actions/runs/27594292349) = 2h31m). The recent "CI speedup" PRs did not move runtime: #96/#95 just added `nasm` to fix a missing-dependency crash, and #93 *tracked* the extraction but left the heavy work on the critical path. The actual load-split (#92) was abandoned.

## Diagnosis (per-step timing of the critical-path `lake-build` job)

Inside `nix run .#test`, from the `::: N/8 :::` markers:

| Step | Time |
|---|---|
| **3/8 Aeneas RV-completeness extraction harness** | **~1h31m** ⬅ #1 |
| **4/8 lake build (the real FV check)** | **~40m** ⬅ #2 |
| 7/8 trust gate V2 semantic | ~5.5m |
| all other steps | ~3m |

Step 3 is **bigger than the proof build itself**, and it is *not* part of the FV proof graph — it's an acceptance/coverage harness. It runs serially *ahead* of `lake build` in the single `lake-build` job, and its temporary `build/aeneas-production-extraction/lean-check/.lake` is discarded every run, so ~26 generated `RvDecode*` completeness files (580–820s **each**) recompile from scratch on every push.

## Change

Re-applies #92's split on top of #93's tracked artifact:

- **`nix/test.nix`** — gate step 3 behind `ZISK_FV_TEST_SKIP_AENEAS` (off by default; plain local `nix run .#test` still runs every step).
- **`.github/workflows/proofs.yml`** —
  - set `ZISK_FV_TEST_SKIP_AENEAS=1` on the `lake-build` test step, so the FV gate stops waiting behind the harness;
  - add a parallel `aeneas-production-extraction` job that runs the full `AENEAS_CHECK_RV_COMPLETENESS=1` harness, with an `actions/cache` for `build/aeneas-production-extraction/lean-check/.lake` keyed on the extraction inputs. The generated files are deterministic, so an unchanged harness is a near no-op build instead of recompiling all `RvDecode*` files.

This gives the two-job shape: the existing `aeneas-extraction-diff` job *validates the tracked extraction*; the new job *runs the lake build on the extraction* — both off the critical path.

## Effect

- `lake-build` (the load-bearing FV claim) returns in ~50m instead of ~2.5h.
- The completeness harness runs concurrently and, once the `.lake` cache is warm, finishes fast.

## Verification

- `python3` YAML parse + `git diff --check`.
- `nix flake check --no-build` — flake + `test.nix` evaluate cleanly.
- Unit-tested the `run_unless_skipped` skip semantics in bash (unset/0/false → run; 1 → skip).
- `act -l` confirms `aeneas-production-extraction` is **Stage 0 (parallel)**, `lake-build` Stage 1.
- `act -n push` dry-runs the whole workflow + the new job's step plan (incl. cache save) without error.

Note: `proofs.yml` triggers on push-to-`main` + `workflow_dispatch` only, so this PR won't auto-run CI. To measure the real wall-clock delta, trigger `workflow_dispatch` on this branch or merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)