### PR TITLE
P4: LUI + AUIPC sound construction families (28 -> 30)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,34 @@
-Active plan: docs/ai/plan/PLAN_ENDGAME_P4_SWEEP.md (PR5 W-ALU, NEEDS-WORK Wave 6).
+Active plan: docs/ai/plan/PLAN_ENDGAME_P4_SWEEP.md (Wave A LUI/AUIPC DONE).
 
-DONE (SWEEP Wave 6 — W-ALU ADDW/SUBW/ADDIW, the NEEDS-WORK m32=1 binary
-families): AUTHORED the missing m32=1 32-bit lane-binding lemmas
+DONE (SWEEP Wave A — LUI/AUIPC, the FIRST provider-free is_external_op=0
+families): added ConstructionLui.lean (construction_lui_sound, 15 + execRow
+honest binders) and ConstructionAuipc.lean (construction_auipc_sound, 18 +
+execRow honest binders), the AUIPC clone of LUI. No op-bus provider block (LUI
+is internal OP_COPYB, AUIPC internal OP_FLAG) — STRICTLY MORE derivable than the
+28. Body: derive Main per-row Spec from trace.spec (mainSpec_at helper) ⇒
+add_subset_holds ⇒ lui/auipc_subset_holds (6 derived fields + DEFINITIONAL
+pc_handshake — next_pc chosen as the handshake RHS, holds by rfl, so it is NOT a
+residual); StorePcMemoryWitness via matches_memory_entry_refl off the real Clean
+cMemMessage row; rd-write MemBus shape + pure-spec nextPC_eq by rfl; h_circuit
+via lui/auipc_h_circuit_of_main_constraints (FLAT facts, NOT _of_row_provenance);
+conclude through EquivCore.Lui.equiv_LUI / EquivCore.Auipc.equiv_AUIPC (rd value
+DERIVED inside equiv_*: LUI rd = signExtend(imm<<12) from internal_op1_copies;
+AUIPC rd = pc+imm from internal_op0_* + h_pc_bridge/h_offset_bridge). Residuals
+are the standard named pins: decode pins, Sail-value bridges (incl. AUIPC's
+intra-row h_pc_bridge = the m.pc column, a bucket-b bridge NOT #100), the lone
+sequential pc+4 h_nextPC_matches (NOT #100 jump-target), exec artifacts + execRow
+∀-binder, AUIPC's 2 RANGE pins. Appended both to soundConstructionTheorems
+(28 → 30); deep construction-binder baseline grew +68 lines (2 honest flat
+blocks, prior 28 byte-identical, ZERO RowProvenance/RowBinding leaves). Whole
+project lake build green (8690 jobs); check-all.sh 18/18; check-all-semantic.sh
+12/12 (incl. 5/12 deep construction binder); 0 PROJECT (ZiskFv.*) axioms per new
+theorem (closure = Sail FP primitives + kernel only); baseline-axioms /
+hypothesis-count / caller-burden / equiv-axiom-deps UNCHANGED (constructions
+don't touch canonical equiv_<OP>). P4 sound construction count: 28 → 30.
+
+--- prior (SWEEP Wave 6 — W-ALU ADDW/SUBW/ADDIW) ---
+
+AUTHORED the missing m32=1 32-bit lane-binding lemmas
 `input_r1_packed_a32_row` / `input_r2_packed_b32_row` in
 ZiskFv/EquivCore/Bridge/Binary.lean (the binary analog of the BinaryExtension
 shift bridge's packed_a_lo32_eq_of_shift_match_m32_1_of_a_range). KEY FINDING:

--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -140,6 +140,8 @@ import ZiskFv.Compliance.ConstructionIType
 import ZiskFv.Compliance.ConstructionShift
 import ZiskFv.Compliance.ConstructionAdd
 import ZiskFv.Compliance.ConstructionWAlu
+import ZiskFv.Compliance.ConstructionLui
+import ZiskFv.Compliance.ConstructionAuipc
 import ZiskFv.Compliance
 import ZiskFv.Completeness.Rv
 import ZiskFv.Completeness.Rv64im

--- a/ZiskFv/Compliance/ConstructionAuipc.lean
+++ b/ZiskFv/Compliance/ConstructionAuipc.lean
@@ -1,0 +1,194 @@
+import ZiskFv.Compliance.ConstructionLui
+import ZiskFv.Compliance.Wrappers.Auipc
+
+/-!
+# Sound AUIPC construction (`construction_auipc_sound`)
+
+The second **provider-free** (`is_external_op = 0`) honest sound construction in
+the P4 sweep — the AUIPC clone of `ConstructionLui.construction_lui_sound`.
+AUIPC is realized by a single *internal* `OP_FLAG` microinstruction with
+`store_pc = 1`: it emits **no** operation-bus entry, so there is no op-bus
+provider block. The rd-value is `pc + signExtend(imm << 12)`, derived inside
+`equiv_AUIPC` from the `internal_op0_*` constraints + the PC/offset bridges.
+
+## The honest decomposition
+
+* **(a) derived** — proven inside the body, NOT a binder:
+  - the Main per-row `Spec` and from it the full AUIPC constraint subset
+    (`auipc_subset_holds`, including the *definitional* `pc_handshake_with_next_pc`
+    field — `next_pc` is chosen as the handshake RHS, so it holds by `rfl`),
+  - the `StorePcMemoryWitness` (`row_eq` by `rowAt_mainOfTable`, `rd_write_match`
+    by `matches_memory_entry_refl` off the real Clean Main `cMemMessage` row),
+  - the rd-write memory-bus shape (`rd_mult`, `rd_as` by `rfl`),
+  - the pure-spec `nextPC_eq` (`rfl`),
+  - the circuit-internal rd arithmetic (`pc + imm`), discharged inside
+    `equiv_AUIPC` from `internal_op0_*` + the PC/offset bridges + the range pins.
+
+* **(b) named residual** — explicit top-level binders (program/ROM/Sail facts):
+  - decode pins (5): `h_main_op` (`OP_FLAG`), `h_main_active` (`= 0`),
+    `h_m32` (`= 0`), `h_set_pc` (`= 0`), `h_store_pc` (`= 1`)
+  - Sail-value bridges (5): `h_input_imm`, `h_input_rd`, `h_input_pc`,
+    `h_rd_idx`, plus the intra-row current-PC bridge `h_pc_bridge`
+    (the `m.pc` r_main column ⟷ Sail PC — a bucket-(b) Sail-value bridge,
+    NOT the cross-row #100 term) and the offset bridge `h_offset_bridge`
+  - control-flow next-PC (1): `h_nextPC_matches` — the ORDINARY sequential
+    `pc + 4` handshake every one of the 28 already carries.
+  - RANGE pins (2): `h_no_wrap`, `h_pc_offset_lt_2_32`.
+
+* **(c) artifact** — pure `bus_effect`/`ExecutionBusEntry` bookkeeping:
+  - exec artifacts (3): `h_exec_len`, `h_e0_mult`, `h_e1_mult`, PLUS the genuine
+    `execRow : List (ExecutionBusEntry FGL)` ∀-binder.
+
+## Residual budget: EXACTLY 18 + execRow
+
+`5 + 6 + 1 + 3 + 2 + 1 = 18` hypothesis binders (the LUI 15, minus the two
+imm-lane Nat pins, plus `h_offset_bridge` + `h_pc_bridge` + the two RANGE pins),
+plus the genuine `execRow` ∀-binder. No `MainRowProvenance` / `*RowBinding` leaf
+appears anywhere.
+
+## Axioms
+
+`construction_auipc_sound` introduces **0 PROJECT (`ZiskFv.*`) axioms**.
+-/
+
+namespace ZiskFv.Compliance
+
+open ZiskFv.Trusted
+open ZiskFv.Airs.Main
+open ZiskFv.EquivCore.Promises
+open Interaction
+
+set_option maxHeartbeats 2000000
+
+/-- Sound AUIPC construction: from the accepted trace + honest residual binders,
+    conclude the canonical bare `execute (UTYPE AUIPC) = (bus_effect …).2`.
+
+    Honest top-level residual binders (the validated 18 + `execRow` budget):
+    * (b) decode pins (5): `h_main_op`, `h_main_active`, `h_m32`, `h_set_pc`,
+      `h_store_pc`
+    * (b) Sail-value bridges (6): `h_input_imm`, `h_input_rd`, `h_input_pc`,
+      `h_rd_idx`, `h_offset_bridge`, `h_pc_bridge`
+    * (b) next-PC (1): `h_nextPC_matches` (ordinary sequential `pc+4` handshake)
+    * (b) RANGE (2): `h_no_wrap`, `h_pc_offset_lt_2_32`
+    * (c) exec artifacts (3): `h_exec_len`, `h_e0_mult`, `h_e1_mult`, PLUS the
+      genuine `execRow` ∀-binder.
+
+    Derived inside the body (NOT binders): the Main per-row `Spec` and the full
+    AUIPC constraint subset, the `StorePcMemoryWitness`, the rd-write MemBus
+    shape, the pure-spec `nextPC_eq`, and the circuit-internal rd arithmetic. -/
+theorem construction_auipc_sound
+    (trace : AcceptedTrace)
+    (binding : ProgramBinding trace)
+    (i : Fin trace.length)
+    (auipc_input : PureSpec.AuipcInput)
+    (imm : BitVec 20)
+    (rd : regidx)
+    -- (b) decode pins
+    (h_main_op :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).op
+        i.val = ZiskFv.Trusted.OP_FLAG)
+    (h_main_active :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).is_external_op
+        i.val = 0)
+    (h_m32 :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).m32
+        i.val = 0)
+    (h_set_pc :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).set_pc
+        i.val = 0)
+    (h_store_pc :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).store_pc
+        i.val = 1)
+    -- (b) Sail-value bridges
+    (h_input_imm : auipc_input.imm = imm)
+    (h_input_rd : auipc_input.rd = regidx_to_fin rd)
+    (h_input_pc : (binding.stateAt i).regs.get? Register.PC = .some auipc_input.PC)
+    (h_offset_bridge :
+      ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).jmp_offset2
+          i.val).val
+        = (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat)
+    (h_pc_bridge :
+      ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).pc i.val).val
+        = auipc_input.PC.toNat)
+    -- (c) exec artifacts: the exec row is a genuine top-level binder.
+    (execRow : List (Interaction.ExecutionBusEntry FGL))
+    (h_exec_len : execRow.length = 2)
+    (h_e0_mult : execRow[0]!.multiplicity = -1)
+    (h_e1_mult : execRow[1]!.multiplicity = 1)
+    -- (b) next-PC residual (ordinary sequential pc+4 handshake)
+    (h_nextPC_matches :
+      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (execRow[1]!.pc).val))
+        = (PureSpec.execute_AUIPC_pure auipc_input).nextPC)
+    -- (b) rd-write entry ↔ register-index alignment
+    (h_rd_idx :
+      auipc_input.rd =
+        Transpiler.wrap_to_regidx (eRdLui trace binding i).ptr)
+    -- (b) RANGE pins
+    (h_no_wrap : auipc_input.PC.toNat
+      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
+        < GL_prime)
+    (h_pc_offset_lt_2_32 :
+      (auipc_input.PC + BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
+        < 4294967296) :
+    execute_instruction (instruction.UTYPE (imm, rd, uop.AUIPC)) (binding.stateAt i)
+      = (bus_effect execRow [eRdLui trace binding i] (binding.stateAt i)).2 := by
+  set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable with hm
+  set state := binding.stateAt i with hstate
+  let e_rd := eRdLui trace binding i
+  -- (a) Main per-row Spec ⇒ the AUIPC Main constraint subset.
+  have h_spec := mainSpec_at trace binding i
+  have h_add_subset : ZiskFv.Airs.Main.add_subset_holds m i.val :=
+    ZiskFv.AirsClean.Main.add_subset_holds_of_spec_rowAt m i.val h_spec
+  obtain ⟨h_c0, _h_b0, h_c1, _h_b1, h_set_flag, _h_clear_flag, h_disjoint,
+      h_flag_bool, h_ext_bool⟩ := h_add_subset
+  -- (a) the handshake is definitional: pick `next_pc` as its RHS.
+  let next_pc : FGL :=
+    m.set_pc i.val * (m.c_0 i.val + m.jmp_offset1 i.val)
+      + (1 - m.set_pc i.val) * (m.pc i.val + m.jmp_offset2 i.val)
+      + m.flag i.val * (m.jmp_offset1 i.val - m.jmp_offset2 i.val)
+  have h_handshake :
+      ZiskFv.Airs.Main.pc_handshake_with_next_pc m i.val next_pc := rfl
+  have h_auipc_subset :
+      ZiskFv.Tactics.UTypeArchetype.auipc_subset_holds m i.val next_pc :=
+    ⟨h_flag_bool, h_ext_bool, h_disjoint, h_c0, h_c1, h_set_flag, h_handshake⟩
+  -- (a) assemble `h_circuit` from FLAT top-level facts.
+  have h_circuit :
+      ZiskFv.Tactics.UTypeArchetype.auipc_archetype_circuit_holds m i.val next_pc :=
+    ZiskFv.EquivCore.Promises.auipc_h_circuit_of_main_constraints
+      m i.val next_pc h_main_active h_main_op h_m32 h_set_pc h_store_pc
+      h_auipc_subset
+  -- (a) `StorePcMemoryWitness` from the real Clean Main `c` message row.
+  have h_row_core :
+      (mainRowWithRomLui trace binding i).core =
+        ZiskFv.AirsClean.Main.rowAt m i.val := by
+    have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+      trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+    simpa [mainRowWithRomLui, m,
+      ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+  let store_pc_mem : ZiskFv.Compliance.StorePcMemoryWitness m i.val e_rd :=
+    { row := mainRowWithRomLui trace binding i
+      row_eq := h_row_core
+      rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
+  -- (a) the rd-write MemBus shape (`rd_mult`, `rd_as`) is `rfl`; the pure-spec
+  -- `nextPC_eq` is `rfl` since `nextPC_val` is the pure-spec nextPC.
+  let promises : ZiskFv.EquivCore.Promises.UTypePromises
+      state auipc_input.imm auipc_input.rd auipc_input.PC
+      (PureSpec.execute_AUIPC_pure auipc_input).nextPC
+      imm rd execRow e_rd (PureSpec.execute_AUIPC_pure auipc_input).nextPC :=
+    { input_imm_eq := h_input_imm
+      input_rd_eq := h_input_rd
+      input_pc_eq := h_input_pc
+      exec_len := h_exec_len
+      e0_mult := h_e0_mult
+      e1_mult := h_e1_mult
+      nextPC_matches := h_nextPC_matches
+      rd_mult := by rfl
+      rd_as := by rfl
+      nextPC_eq := rfl
+      rd_idx := h_rd_idx }
+  exact ZiskFv.EquivCore.Auipc.equiv_AUIPC state auipc_input imm rd
+    execRow e_rd m i.val next_pc store_pc_mem
+    (PureSpec.execute_AUIPC_pure auipc_input).nextPC
+    promises h_circuit h_offset_bridge h_pc_bridge h_no_wrap h_pc_offset_lt_2_32
+
+end ZiskFv.Compliance

--- a/ZiskFv/Compliance/ConstructionLui.lean
+++ b/ZiskFv/Compliance/ConstructionLui.lean
@@ -1,0 +1,226 @@
+import ZiskFv.Compliance.AcceptedTrace
+import ZiskFv.Compliance.Wrappers.Lui
+
+/-!
+# Sound LUI construction (`construction_lui_sound`)
+
+The first **provider-free** (`is_external_op = 0`) honest sound construction in
+the P4 sweep. LUI is realized by a single *internal* Zisk microinstruction
+(`OP_COPYB`), so it emits **no** operation-bus entry: there is no op-bus provider
+block at all (in contrast to `ConstructionSub.lean`, which derives the staticBinary
+op-bus provider match from `trace.balanced`). LUI is therefore STRICTLY MORE
+derivable than the 28 provider-backed families — the entire LUI Main constraint
+subset comes straight out of the per-row `Main.Spec`, and the rd-value is the
+identity copy `c_0/c_1 = b_0/b_1 = imm`.
+
+## The honest decomposition
+
+* **(a) derived** — proven inside the body, NOT a binder:
+  - the Main per-row `Spec` and from it the full LUI constraint subset
+    (`lui_subset_holds`, including the `pc_handshake_with_next_pc` field, which
+    is *definitional* — `next_pc` is chosen as the handshake RHS, so the field
+    holds by `rfl` and contributes no residual),
+  - the `StorePcMemoryWitness` (`row_eq` by `rowAt_mainOfTable`, `rd_write_match`
+    by `matches_memory_entry_refl` off the real Clean Main `cMemMessage` row),
+  - the rd-write memory-bus shape (`rd_mult`, `rd_as` by `rfl`),
+  - the pure-spec `nextPC_eq` (`rfl`, since `nextPC_val` is chosen to be the
+    pure-spec nextPC),
+  - the circuit-internal rd arithmetic (`c_0/c_1 = b_0/b_1 = imm`), discharged
+    inside `equiv_LUI` from `internal_op1_copies_*` + the imm-lane Nat pins.
+
+* **(b) named residual** — explicit top-level binders (program/ROM/Sail facts):
+  - decode pins (5): `h_main_op` (`OP_COPYB`), `h_main_active` (`= 0`),
+    `h_m32` (`= 0`), `h_set_pc` (`= 0`), `h_store_pc` (`= 0`)
+  - Sail-value bridges (6): `h_input_imm`, `h_input_rd`, `h_input_pc`,
+    `h_rd_idx`, `h_imm_lo_nat`, `h_imm_hi_nat`
+  - control-flow next-PC (1): `h_nextPC_matches` — the ORDINARY sequential
+    `pc + 4` handshake every one of the 28 already carries; NOT the cross-row
+    jump-target term.
+
+* **(c) artifact** — pure `bus_effect`/`ExecutionBusEntry` bookkeeping:
+  - exec artifacts (3): `h_exec_len`, `h_e0_mult`, `h_e1_mult`, PLUS the genuine
+    `execRow : List (ExecutionBusEntry FGL)` ∀-binder.
+
+## Residual budget: EXACTLY 15 + execRow
+
+`5 + 6 + 1 + 3 = 15` hypothesis binders, plus the genuine `execRow` ∀-binder.
+No `MainRowProvenance` / `*RowBinding` leaf appears anywhere in the binder set.
+
+## Axioms
+
+`construction_lui_sound` introduces **0 PROJECT (`ZiskFv.*`) axioms**.
+-/
+
+namespace ZiskFv.Compliance
+
+open ZiskFv.Trusted
+open ZiskFv.Airs.Main
+open ZiskFv.EquivCore.Promises
+open Interaction
+
+set_option maxHeartbeats 2000000
+
+/-- The honest unified Main+ROM row at trace index `i`, drawn from the real Main
+    table.  Its `.core` equals `rowAt (mainOfTable …) i`. -/
+@[reducible]
+def mainRowWithRomLui
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) :
+    ZiskFv.AirsClean.Main.MainRowWithRom FGL :=
+  ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+    trace.program binding.mainTable i.val
+
+/-- Construction-chosen rd-write entry: the real Clean Main `c` memory-bus
+    emission (rd write) of the honest unified row.  The `StorePcMemoryWitness`
+    match is then `matches_memory_entry_refl`. -/
+@[reducible]
+def eRdLui
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) :
+    Interaction.MemoryBusEntry FGL :=
+  ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+    (ZiskFv.AirsClean.Main.cMemMessage (mainRowWithRomLui trace binding i)) 1 1
+
+/-- The Main per-row `Spec` at trace index `i`, derived from `trace.spec`.
+    (Standalone version of the in-wrapper `h_main_spec` derivation.) -/
+theorem mainSpec_at
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) :
+    ZiskFv.AirsClean.Main.Spec
+      (ZiskFv.AirsClean.Main.rowAt
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+        i.val) := by
+  let mainIdx : Fin binding.mainTable.table.length := ⟨i.val, binding.mainTable_index i⟩
+  let mainRow := binding.mainTable.table.get mainIdx
+  have h_mainRow_mem : mainRow ∈ binding.mainTable.table := by simp [mainRow]
+  have h_main_component_spec :
+      binding.mainTable.component.Spec
+        (binding.mainTable.environment (binding.mainTable.table.get mainIdx)) := by
+    simpa [mainRow] using
+      trace.spec binding.mainTable binding.mainTable_mem mainRow h_mainRow_mem
+  simpa [mainIdx] using
+    ZiskFv.AirsClean.FullEnsemble.mainSpec_rowAt_mainOfTable_of_component_spec
+      trace.program binding.mainTable mainIdx binding.mainTable_component
+      h_main_component_spec
+
+/-- Sound LUI construction: from the accepted trace + honest residual binders,
+    conclude the canonical
+    `(writeReg nextPC (pc+4); execute (UTYPE LUI)) = (bus_effect …).2`.
+
+    Honest top-level residual binders (the validated 15 + `execRow` budget):
+    * (b) decode pins (5): `h_main_op`, `h_main_active`, `h_m32`, `h_set_pc`,
+      `h_store_pc`
+    * (b) Sail-value bridges (6): `h_input_imm`, `h_input_rd`, `h_input_pc`,
+      `h_rd_idx`, `h_imm_lo_nat`, `h_imm_hi_nat`
+    * (b) next-PC (1): `h_nextPC_matches` (ordinary sequential `pc+4` handshake)
+    * (c) exec artifacts (3): `h_exec_len`, `h_e0_mult`, `h_e1_mult`, PLUS the
+      genuine `execRow` ∀-binder.
+
+    Derived inside the body (NOT binders): the Main per-row `Spec` and the full
+    LUI constraint subset, the `StorePcMemoryWitness`, the rd-write MemBus shape,
+    the pure-spec `nextPC_eq`, and the circuit-internal rd arithmetic. -/
+theorem construction_lui_sound
+    (trace : AcceptedTrace)
+    (binding : ProgramBinding trace)
+    (i : Fin trace.length)
+    (lui_input : PureSpec.LuiInput)
+    (imm : BitVec 20)
+    (rd : regidx)
+    -- (b) decode pins
+    (h_main_op :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).op
+        i.val = ZiskFv.Trusted.OP_COPYB)
+    (h_main_active :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).is_external_op
+        i.val = 0)
+    (h_m32 :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).m32
+        i.val = 0)
+    (h_set_pc :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).set_pc
+        i.val = 0)
+    (h_store_pc :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).store_pc
+        i.val = 0)
+    -- (b) Sail-value bridges
+    (h_input_imm : lui_input.imm = imm)
+    (h_input_rd : lui_input.rd = regidx_to_fin rd)
+    (h_input_pc : (binding.stateAt i).regs.get? Register.PC = .some lui_input.PC)
+    (h_imm_lo_nat :
+      ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).b_0 i.val).val
+        = (imm ++ (0 : BitVec 12)).toNat)
+    (h_imm_hi_nat :
+      ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).b_1 i.val).val
+        = (BitVec.signExtend 64 (imm ++ (0 : BitVec 12))).toNat / 4294967296)
+    -- (c) exec artifacts: the exec row is a genuine top-level binder.
+    (execRow : List (Interaction.ExecutionBusEntry FGL))
+    (h_exec_len : execRow.length = 2)
+    (h_e0_mult : execRow[0]!.multiplicity = -1)
+    (h_e1_mult : execRow[1]!.multiplicity = 1)
+    -- (b) next-PC residual (ordinary sequential pc+4 handshake)
+    (h_nextPC_matches :
+      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (execRow[1]!.pc).val))
+        = (PureSpec.execute_LUI_pure lui_input).nextPC)
+    -- (b) rd-write entry ↔ register-index alignment
+    (h_rd_idx :
+      lui_input.rd =
+        Transpiler.wrap_to_regidx (eRdLui trace binding i).ptr) :
+    execute_instruction (instruction.UTYPE (imm, rd, uop.LUI)) (binding.stateAt i)
+      = (bus_effect execRow [eRdLui trace binding i] (binding.stateAt i)).2 := by
+  set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable with hm
+  set state := binding.stateAt i with hstate
+  let e_rd := eRdLui trace binding i
+  -- (a) Main per-row Spec ⇒ the LUI Main constraint subset.
+  have h_spec := mainSpec_at trace binding i
+  have h_add_subset : ZiskFv.Airs.Main.add_subset_holds m i.val :=
+    ZiskFv.AirsClean.Main.add_subset_holds_of_spec_rowAt m i.val h_spec
+  obtain ⟨_h_c0, h_b0, _h_c1, h_b1, _h_set_flag, h_clear_flag, h_disjoint,
+      h_flag_bool, h_ext_bool⟩ := h_add_subset
+  -- (a) the handshake is definitional: pick `next_pc` as its RHS.
+  let next_pc : FGL :=
+    m.set_pc i.val * (m.c_0 i.val + m.jmp_offset1 i.val)
+      + (1 - m.set_pc i.val) * (m.pc i.val + m.jmp_offset2 i.val)
+      + m.flag i.val * (m.jmp_offset1 i.val - m.jmp_offset2 i.val)
+  have h_handshake :
+      ZiskFv.Airs.Main.pc_handshake_with_next_pc m i.val next_pc := rfl
+  have h_lui_subset :
+      ZiskFv.Tactics.UTypeArchetype.lui_subset_holds m i.val next_pc :=
+    ⟨h_flag_bool, h_ext_bool, h_disjoint, h_b0, h_b1, h_clear_flag, h_handshake⟩
+  -- (a) assemble `h_circuit` from FLAT top-level facts.
+  have h_circuit :
+      ZiskFv.Tactics.UTypeArchetype.lui_archetype_circuit_holds m i.val next_pc :=
+    ZiskFv.EquivCore.Promises.lui_h_circuit_of_main_constraints
+      m i.val next_pc h_main_active h_main_op h_m32 h_set_pc h_store_pc
+      h_lui_subset
+  -- (a) `StorePcMemoryWitness` from the real Clean Main `c` message row.
+  have h_row_core :
+      (mainRowWithRomLui trace binding i).core =
+        ZiskFv.AirsClean.Main.rowAt m i.val := by
+    have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+      trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+    simpa [mainRowWithRomLui, m,
+      ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+  let store_pc_mem : ZiskFv.Compliance.StorePcMemoryWitness m i.val e_rd :=
+    { row := mainRowWithRomLui trace binding i
+      row_eq := h_row_core
+      rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
+  -- (a) the rd-write MemBus shape (`rd_mult`, `rd_as`) is `rfl`; the pure-spec
+  -- `nextPC_eq` is `rfl` since `nextPC_val` is the pure-spec nextPC.
+  let promises : ZiskFv.EquivCore.Promises.UTypePromises
+      state lui_input.imm lui_input.rd lui_input.PC
+      (PureSpec.execute_LUI_pure lui_input).nextPC
+      imm rd execRow e_rd (PureSpec.execute_LUI_pure lui_input).nextPC :=
+    { input_imm_eq := h_input_imm
+      input_rd_eq := h_input_rd
+      input_pc_eq := h_input_pc
+      exec_len := h_exec_len
+      e0_mult := h_e0_mult
+      e1_mult := h_e1_mult
+      nextPC_matches := h_nextPC_matches
+      rd_mult := by rfl
+      rd_as := by rfl
+      nextPC_eq := rfl
+      rd_idx := h_rd_idx }
+  exact ZiskFv.EquivCore.Lui.equiv_LUI state lui_input imm rd
+    m i.val next_pc execRow e_rd store_pc_mem
+    (PureSpec.execute_LUI_pure lui_input).nextPC
+    promises h_imm_lo_nat h_imm_hi_nat h_circuit
+
+end ZiskFv.Compliance

--- a/bin/TrustGate/Main.lean
+++ b/bin/TrustGate/Main.lean
@@ -270,7 +270,9 @@ def soundConstructionTheorems : List Name :=
   , `ZiskFv.Compliance.construction_addi_sound
   , `ZiskFv.Compliance.construction_subw_sound
   , `ZiskFv.Compliance.construction_addw_sound
-  , `ZiskFv.Compliance.construction_addiw_sound ]
+  , `ZiskFv.Compliance.construction_addiw_sound
+  , `ZiskFv.Compliance.construction_lui_sound
+  , `ZiskFv.Compliance.construction_auipc_sound ]
 
 /-- Subcommand: render the DEEP (recursive) construction-theorem binder list,
 for EVERY sound construction theorem in `soundConstructionTheorems`.

--- a/trust/generated/baseline-construction-theorem-binders.txt
+++ b/trust/generated/baseline-construction-theorem-binders.txt
@@ -987,3 +987,71 @@ h_e0_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub
 h_e1_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).multiplicity 1
 h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).pc.val) register_type_pc_equiv) (PureSpec.execute_ITYPE_addiw_pure addiw_input).nextPC
 h_rd_idx :: Eq addiw_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
+
+# ZiskFv.Compliance.construction_lui_sound
+trace.length :: Nat
+trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
+trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
+trace.constraints :: trace.3.Constraints
+trace.spec :: trace.3.Spec
+trace.balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
+binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.length
+lui_input :: PureSpec.LuiInput
+imm :: BitVec 20
+rd :: regidx
+h_main_op :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).op i.val) ZiskFv.Trusted.OP_COPYB
+h_main_active :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).is_external_op i.val) 0
+h_m32 :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).m32 i.val) 0
+h_set_pc :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).set_pc i.val) 0
+h_store_pc :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).store_pc i.val) 0
+h_input_imm :: Eq lui_input.imm imm
+h_input_rd :: Eq lui_input.rd (regidx_to_fin rd)
+h_input_pc :: Eq ((binding.stateAt i).regs.get? Register.PC) (Option.some lui_input.PC)
+h_imm_lo_nat :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).b_0 i.val).val (BitVec.instHAppendHAddNat.hAppend imm 0).toNat
+h_imm_hi_nat :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).b_1 i.val).val (instHDiv.hDiv (BitVec.signExtend 64 (BitVec.instHAppendHAddNat.hAppend imm 0)).toNat 4294967296)
+execRow :: List (Interaction.ExecutionBusEntry (Fin 18446744069414584321))
+h_exec_len :: Eq execRow.length 2
+h_e0_mult :: Eq (List.instGetElem?NatLtLength.getElem! execRow 0).multiplicity (-1)
+h_e1_mult :: Eq (List.instGetElem?NatLtLength.getElem! execRow 1).multiplicity 1
+h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.getElem! execRow 1).pc.val) register_type_pc_equiv) (PureSpec.execute_LUI_pure lui_input).nextPC
+h_rd_idx :: Eq lui_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.eRdLui trace binding i).ptr)
+
+# ZiskFv.Compliance.construction_auipc_sound
+trace.length :: Nat
+trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
+trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
+trace.constraints :: trace.3.Constraints
+trace.spec :: trace.3.Spec
+trace.balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
+binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.length
+auipc_input :: PureSpec.AuipcInput
+imm :: BitVec 20
+rd :: regidx
+h_main_op :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).op i.val) ZiskFv.Trusted.OP_FLAG
+h_main_active :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).is_external_op i.val) 0
+h_m32 :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).m32 i.val) 0
+h_set_pc :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).set_pc i.val) 0
+h_store_pc :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).store_pc i.val) 1
+h_input_imm :: Eq auipc_input.imm imm
+h_input_rd :: Eq auipc_input.rd (regidx_to_fin rd)
+h_input_pc :: Eq ((binding.stateAt i).regs.get? Register.PC) (Option.some auipc_input.PC)
+h_offset_bridge :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).jmp_offset2 i.val).val (BitVec.signExtend 64 (BitVec.instHAppendHAddNat.hAppend auipc_input.imm 0)).toNat
+h_pc_bridge :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).pc i.val).val auipc_input.PC.toNat
+execRow :: List (Interaction.ExecutionBusEntry (Fin 18446744069414584321))
+h_exec_len :: Eq execRow.length 2
+h_e0_mult :: Eq (List.instGetElem?NatLtLength.getElem! execRow 0).multiplicity (-1)
+h_e1_mult :: Eq (List.instGetElem?NatLtLength.getElem! execRow 1).multiplicity 1
+h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.getElem! execRow 1).pc.val) register_type_pc_equiv) (PureSpec.execute_AUIPC_pure auipc_input).nextPC
+h_rd_idx :: Eq auipc_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.eRdLui trace binding i).ptr)
+h_no_wrap :: instLTNat.lt (instHAdd.hAdd auipc_input.PC.toNat (BitVec.signExtend 64 (BitVec.instHAppendHAddNat.hAppend auipc_input.imm 0)).toNat) 18446744069414584321
+h_pc_offset_lt_2_32 :: instLTNat.lt (instHAdd.hAdd auipc_input.PC (BitVec.signExtend 64 (BitVec.instHAppendHAddNat.hAppend auipc_input.imm 0))).toNat 4294967296


### PR DESCRIPTION
The first provider-free (is_external_op=0) sound construction families, in the established 28-family mold.

- construction_lui_sound / construction_auipc_sound (new ZiskFv/Compliance/Construction{Lui,Auipc}.lean).
- Data effect DERIVED (LUI rd = signExtend(imm<<12); AUIPC rd = pc+imm) from Main.Spec <- trace.constraints via the flat {lui,auipc}_h_circuit_of_main_constraints assemblers -- no op-bus provider, no RowProvenance/RowBinding deep record.
- Residuals are the standard named pins only (decode, Sail-value bridges, next-PC h_nextPC_matches = ordinary pc+4, exec artifacts + execRow forall-binder). AUIPC current-PC is the intra-row m.pc column (bucket-b), not the #100 cross-row term.
- 0 PROJECT (ZiskFv.*) axioms (kernel + Sail externs only); whole project green (8690 jobs); trust gate 18/18 (V1) + 12/12 (V2).
- Only baseline-construction-theorem-binders.txt changed (+68, additive -- the 28 prior families byte-identical); canonical/global baselines untouched.

P4 sound construction count: 28 -> 30. Adversarially verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)