### PR TITLE
P4 M-ext: unsigned RV64M sound constructions (30→36) + arith extraction foundation

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,163 +1,24 @@
-Active plan: docs/ai/plan/PLAN_ENDGAME_P4_SWEEP.md (Wave A LUI/AUIPC DONE).
+Active stream: P4 M-ext constructions — add the 6 unsigned RV64M
+`construction_<op>_sound` theorems (MULW, MULHU, DIVU, DIVUW, REMU, REMUW) to the
+P4 construction set (30 → 36). Feeds the P5 env-removal assembly.
 
-DONE (SWEEP Wave A — LUI/AUIPC, the FIRST provider-free is_external_op=0
-families): added ConstructionLui.lean (construction_lui_sound, 15 + execRow
-honest binders) and ConstructionAuipc.lean (construction_auipc_sound, 18 +
-execRow honest binders), the AUIPC clone of LUI. No op-bus provider block (LUI
-is internal OP_COPYB, AUIPC internal OP_FLAG) — STRICTLY MORE derivable than the
-28. Body: derive Main per-row Spec from trace.spec (mainSpec_at helper) ⇒
-add_subset_holds ⇒ lui/auipc_subset_holds (6 derived fields + DEFINITIONAL
-pc_handshake — next_pc chosen as the handshake RHS, holds by rfl, so it is NOT a
-residual); StorePcMemoryWitness via matches_memory_entry_refl off the real Clean
-cMemMessage row; rd-write MemBus shape + pure-spec nextPC_eq by rfl; h_circuit
-via lui/auipc_h_circuit_of_main_constraints (FLAT facts, NOT _of_row_provenance);
-conclude through EquivCore.Lui.equiv_LUI / EquivCore.Auipc.equiv_AUIPC (rd value
-DERIVED inside equiv_*: LUI rd = signExtend(imm<<12) from internal_op1_copies;
-AUIPC rd = pc+imm from internal_op0_* + h_pc_bridge/h_offset_bridge). Residuals
-are the standard named pins: decode pins, Sail-value bridges (incl. AUIPC's
-intra-row h_pc_bridge = the m.pc column, a bucket-b bridge NOT #100), the lone
-sequential pc+4 h_nextPC_matches (NOT #100 jump-target), exec artifacts + execRow
-∀-binder, AUIPC's 2 RANGE pins. Appended both to soundConstructionTheorems
-(28 → 30); deep construction-binder baseline grew +68 lines (2 honest flat
-blocks, prior 28 byte-identical, ZERO RowProvenance/RowBinding leaves). Whole
-project lake build green (8690 jobs); check-all.sh 18/18; check-all-semantic.sh
-12/12 (incl. 5/12 deep construction binder); 0 PROJECT (ZiskFv.*) axioms per new
-theorem (closure = Sail FP primitives + kernel only); baseline-axioms /
-hypothesis-count / caller-burden / equiv-axiom-deps UNCHANGED (constructions
-don't touch canonical equiv_<OP>). P4 sound construction count: 28 → 30.
+Worktree `.worktrees/p4-mext`, branch `p4-mext` off `origin/main` (a5679e5b).
+build/ symlinked to main checkout; `lake exe cache get` done.
 
---- prior (SWEEP Wave 6 — W-ALU ADDW/SUBW/ADDIW) ---
+Plan: docs/ai/plan/PLAN_ENDGAME_P4_MEXT.md (navigable spine + checklist).
 
-AUTHORED the missing m32=1 32-bit lane-binding lemmas
-`input_r1_packed_a32_row` / `input_r2_packed_b32_row` in
-ZiskFv/EquivCore/Bridge/Binary.lean (the binary analog of the BinaryExtension
-shift bridge's packed_a_lo32_eq_of_shift_match_m32_1_of_a_range). KEY FINDING:
-the m32=1 binary lane DOES close cleanly, and WITHOUT needing one_sub_one_mul on
-a_hi — for the staticBinary provider the a_lo conjunct of matches_entry is
-m32-independent, so the 32-bit operand binding (extractLsb r1_val 31 0).toNat =
-binaryRowA32 row % 2^32 derives from the low-4-byte a_lo equation alone (the
-a_hi=(1-m32)*a_1 collapses to 0 but is not consumed for the low half). Lane
-lemmas take 4 explicit a/b byte-range (<256) hyps, sourced in the constructions
-from h_facts (StaticBinaryTableWfFacts) — no byte_chain_discharge_64 (which
-requires mode32=0). Added ConstructionWAlu.lean with construction_subw_sound
-(unique OP_SUB_W, Or.inr), construction_addw_sound (OP_ADD_W, Or.inl), and
-construction_addiw_sound (ITYPE, OP_ADD_W; imm + h_addiw_subset named pin +
-ITypePromises; wrapper derives the immediate byte decomposition internally).
-W bus harness: m32=1, writeReg-nextPC prelude retained. Appended all three to
-soundConstructionTheorems (25 → 28); deep baseline grew +3 honest flat blocks
-(subw 34, addw 34, addiw 33 binders; ZERO RowBinding/MainRowProvenance leaves;
-prior 25 blocks byte-identical prefix). lake build green (8688 jobs);
-check-all.sh 18/18; check-all-semantic.sh 12/12; baseline-axioms.txt UNCHANGED
-(lane lemmas add NO axiom); 0 PROJECT (ZiskFv.*) axioms per new theorem and lane
-lemma (closure = [cancel_reservation, propext, Classical.choice, Quot.sound] for
-constructions; [propext, Classical.choice, Quot.sound] for the lane lemmas —
-Sail+kernel external only). NO sorry/admit/native_decide.
+Scope (verified 2026-06-18): equiv_<OP> layer DONE + axiom-free for all 6;
+MISSING = the P4 construction layer. M-ext is the FIRST construction-layer touch
+of the Arith family — needs NEW Arith provider-match-from-balance + witness
+packaging (the 30 ALU constructions reused pre-existing Binary packaging). The
+core balance enumeration (Balance.lean:1732) already surfaces an arithMul branch
+the ALU theorems refute; M-ext keeps it. 0 PROJECT axioms required.
 
---- prior (Wave 5, from base p4-closeout-construction) ---
+Current focus: PR-MEXT.1 — MULW spike (primary op-bus, op=182). This is the
+make-or-break Arith balance+witness foundation; once it lands, MULHU (secondary)
+and the DIV family follow incrementally.
 
-Active plan: docs/ai/plan/PLAN_ENDGAME_P4_CLOSEOUT.md (§5 PR2, rework-off-#97).
+Next step: build `exists_arithMul_provider_row_matches_primary_from_binding`
+(mirror the Binary `_logic_` theorem, keep arithMul branch, refute the other 3).
 
-Branch `p4-closeout-construction` off `origin/endgame-p4-pr2` (#97 @ 6c414ffa).
-
-Focus: EXECUTE PR2 — strip the P4 relabel, keep the salvage + via_binaryadd
-route, add the first honest sound construction (`construction_sub_sound`, 17 +
-execRow residual binders). End in a CLEAN do-not-merge PR superseding #94/#97.
-
-Done:
-- Stripped AcceptedTrace.lean to the salvage (AcceptedTrace + ProgramBinding
-  skeleton + Layer-A provider-match wrappers). Removed ArmTag, 37 *RowBinding
-  structs, per-op ProgramBinding projections, all construction_<op> defs +
-  aeneasBridgeTrust theorems, the 28 exists_construction_*_from_balance wrappers.
-- Stripped the 4 addViaBinaryAdd*OfExtractedShape decls (AeneasBridgeTrust.lean).
-- Stripped the print-construction-binders subcommand (TrustGate/Main.lean), the
-  blind check-construction-theorem-binders.sh + its baseline + its wiring in
-  check-all-semantic.sh / regenerate.sh / README.md.
-- KEPT the via_binaryadd salvage route (OpEnvelope arms, Dispatch, EquivCore/Add,
-  BinaryAdd circuit, route ledger).
-- Added ConstructionSub.lean (sound construction_sub_sound).
-
-DONE: lake build green (8681 jobs); check-all.sh 18/18; check-all-semantic.sh
-12/12; 0 PROJECT axioms (construction_sub_sound closure empty); 17 + execRow
-honest binders; net diff vs main has 0 relabel decls. Committed 9b55bcdb, pushed,
-opened do-not-merge PR #99 (eth-act/zisk-fv, base main) superseding #94/#97.
-
-DONE (recursive gate, Option X): re-added the DEEP construction-binder gate.
-TypeWalk.lean renderTheoremBindersDeep + renderDeep (descend only into ZiskFv.*
-project structures; library structures are leaves; visited-set cycle guard).
-Main.lean print-construction-binders-deep targeting construction_sub_sound.
-check-construction-theorem-binders.sh re-added (points at -deep), re-wired into
-check-all-semantic.sh (5/12) + regenerate.sh + README. Deep baseline = 17 flat
-h_ residual lines + execRow; ZERO RowBinding/MainRowProvenance substrings; setup
-binders (trace/binding) descend into honest trace structure only. nix run .#test
-green. Committed 0e25550d, pushed to update PR #99.
-
-DONE (PR3 — second sound family, AND, logic route): added
-ConstructionAnd.lean (`construction_and_sound`), the mechanical mirror of
-`construction_sub_sound` for the logic family. Op-bus match via the salvaged
-logic Layer-A wrapper `exists_staticBinary_provider_row_matches_logic_from_binding`
-(op pin via `Or.inl h_main_op`); OP_AND (=14, <16) byte-chain path
-(`logic_row_mode_pins_of_emit_op_lt_16_of_static_spec` + `BinaryTable.OP_AND`);
-data effect concluded via `equiv_AND` (`execute_RTYPE_and_pure`, bottoms in
-`binary_and_chunks_eq_bv_and_of_wf`). Same 17 + execRow residual budget, flat
-top-level binders, no `*RowBinding`/`MainRowProvenance` leaf. Generalized the
-recursive gate: `soundConstructionTheorems` list + labelled-block deep render
-in TrustGate/Main.lean (adding a family = append to the list + regen). Deep
-baseline grew 34→71 lines = +2 headers + 1 blank + 34 honest AND binders; SUB
-block byte-identical. lake build green (8682 jobs); check-all.sh 18/18;
-check-all-semantic.sh 12/12 (deep check now covers both); 0 PROJECT
-(ZiskFv.*) axioms (construction_and_sound closure empty of ZiskFv.* names);
-nix run .#test green.
-
-DONE (SWEEP Wave 2 — I-type logic + compare, ANDI/ORI/XORI/SLTI/SLTIU): added
-ConstructionIType.lean with five sound constructions, each the mechanical mirror
-of its R-type sibling (AND/OR/XOR/SLT/SLTU) through the uniform I-type immediate
-DELTA. The second operand is the immediate (NOT a register read): drop r2's Sail
-read + `h_b_lo_t`/`h_b_hi_t` lane bridges; add the `imm : BitVec 12` binder, the
-immediate-decode equality `h_input_imm : input.imm = imm`, and the NAMED
-top-level `itype_imm_subset_holds_main` pin (`h_<op>_subset`); swap
-RTypePromises→ITypePromises (carries `input_imm_eq`); route via `equiv_<OP>I`.
-Logic ops (ANDI/ORI/XORI) DERIVE the 8-byte Binary-row imm form `h_input_imm_row`
-in-body via `itype_imm_subset_binary_row_of_main_row` (NOT a binder); compare ops
-(SLTI/SLTIU) pass `m32=0`+`h_<op>_subset` directly and the wrapper re-derives it.
-XORI inherits XOR's OP_XOR=16 wrinkle (static_table_logic_mode_pins_of_emit +
-byte_chain_discharge_logic). Per-family budget: 16 hyp binders + `imm` + execRow
-(33 deep leaves vs R-type's 34; net -1, fully honest: -r2/-h_input_r2/-h_b_lo_t/
--h_b_hi_t = -4, +imm/+h_input_imm/+h_<op>_subset = +3). Appended all five to
-`soundConstructionTheorems`; deep baseline grew +175 lines (5 honest blocks);
-prior 6 blocks byte-identical; ZERO RowBinding/MainRowProvenance leaves;
-itype_imm_subset_holds_main is a flat binder line in all 5. lake build green
-(8685 jobs); check-all.sh 18/18; check-all-semantic.sh 12/12; 0 PROJECT
-(ZiskFv.*) axioms per new theorem (Sail+kernel external).
-
-DONE (SWEEP Wave 3 — m32 = 0 shifts SLL/SRL/SRA/SLLI/SRLI/SRAI): added
-ConstructionShift.lean with six sound constructions on the BinaryExtension
-template (NOT the busSub/staticBinary path). SLL was the exemplar that solved
-the three shift novelties: (1) op-bus match via the salvaged shift Layer-A
-wrapper exists_binaryExtension_provider_row_matches_shift_from_binding (6-way op
-disjunction; SLL/SLLI Or.inl, SRL/SRLI Or.inr (Or.inl ·), SRA/SRAI
-Or.inr (Or.inr (Or.inl ·))); (2) BARE-execute conclusion (no writeReg-nextPC
-prelude) — the construction concludes equiv_<OP>'s conclusion verbatim, so the
-exec-bus bookkeeping (h_exec_len/h_e0_mult/h_e1_mult/busSub/h_nextPC_matches)
-rides inside the RTypePromises / ShiftImmPromises bundle against the bare-execute
-pure spec; (3) the m32 = 0 lane route — packed_a_eq_of_shift_match_m32_0_of_a_range
-(one_sub_zero_mul, Bridge/BinaryExtension.lean:240/269) + shift-pin lemmas.
-To keep the giant shiftStaticLookupComponent.rowInput term opaque (a `set row`
-inline derivation timed out at whnf), the lane/op-is-shift derivations are
-factored into five opaque-`row` helper theorems in ConstructionShift.lean
-(shift_op_pin_eq_of_match, shift_op_is_shift_of_facts,
-shift_m32_0_input_r1_row_of_facts, shift_m32_0_shift_pin_row_of_facts,
-shift_imm_shift_pin_row_of_facts) which mirror equiv_SLL_of_static_row's internal
-block. Register variants carry SUB's 17 + execRow budget; immediate variants drop
-r2's read + hi-lane, add shamt + h_input_shamt + the b_0 shamt_b_lo decode pin
-(16 hyp + shamt + execRow). Appended all six to soundConstructionTheorems
-(11 → 17); deep baseline grew +201 lines = 6 honest flat blocks; prior 11 blocks
-byte-identical; ZERO RowBinding/MainRowProvenance leaves. lake build green
-(8686 jobs); check-all.sh 18/18; check-all-semantic.sh 12/12; 0 PROJECT (ZiskFv.*)
-axioms per new theorem (closure = [cancel_reservation, propext, Classical.choice,
-Quot.sound], i.e. Sail+kernel external only).
-
-Next (follow-up increments, NOT this PR): the remaining ALU/sweep families
-(ADD/ADDI provider-disjunction PR4; W-types PR5 incl. m32 = 1 W-shifts;
-M-ext; branches; loads/stores); close stale #94/#97 on merge (Cody's call).
-
-Blocking: none.
+No blockers. Goal hook active: "land the M-ext part."

--- a/STATUS.md
+++ b/STATUS.md
@@ -97,5 +97,28 @@ divu_mode_pins_of_row + MulDivRemUnsigned loose divu path; registered in ZiskFv.
 + bin/TrustGate/Main.lean; construction-binder baseline refreshed. NOT committed
 (parent commits).
 
-NEXT after Stage 3: DIVUW/REMU/REMUW. Then P5 assembly over the 36 constructions,
+DONE (Stage 4 — construction_divuw_sound, unsigned W-mode DIVUW op-188 a-lane, 34/63):
+mirrors DIVU. Provider = SHARED ArithMul componentWithArithTable; reuses DIVU's
+vOfDivuRow + DIVU-mode op-bus bridge (the div=1∧main_div=1∧main_mul=0 mux selectors
+are m32-agnostic, so the SAME bridge reduces the muxed primaryOpBusMessage to
+opBus_row_ArithDiv). Arith witnesses (ArithTable/chunk/signed-carry/c46/carry-chain)
+ALL DERIVED from FullSpec; the W-mode chain (m32=1) is m32-independent so divuw_chain_eqs
+= divu_chain_eqs. CARRY BOUND: same blocker — loose <983041 derived + NEW loose
+W-mode write-value path h_rd_val_mdru_divuw_loose (in MulDivRemUnsigned.lean) routed
+through a custom equiv_DIVUW_of_fullSpec (NOT equiv_DIVUW). h_byte_lo DERIVED from the
+op-bus c-lane projection. RESIDUALS = DIVU shape (decode/Sail/operand/exec/nextPC) +
+remainder_bound (the ArithDiv LTU self-edge, NOT balance-derivable) + the THREE W-mode
+residuals the canonical equiv_DIVUW also carries: h_b23, h_c23 (high-lane zeros — m32 is
+NOT an op-bus field, so not balance-derivable), h_sext_choice (SEXT_00/SEXT_FF bus
+encoding on bytes 4..7, class #4). NO arith-witness binders. Full lake build GREEN (8695);
+0 sorry; 0 PROJECT ZiskFv.* axioms (closure carries Classical.choice + Quot.sound + Sail
++ Lean.ofReduceBool/trustCompiler native_decide INHERITED from canonical equiv_DIVUW path
+— NOT new; #75). V1 18/18 + V2 12/12 ALL PASS. Files: NEW Compliance/ConstructionDivuw.lean;
++op-188/offset-172 exclusions (BinaryTable, BinaryExtensionTable, Binary/Bridge,
+BinaryExtension/StaticCircuit) + ArithBalance keep/refute + AcceptedTrace from_binding
+wrapper + ArithTableProjections divuw_mode_pins_of_row + MulDivRemUnsigned loose divuw path;
+registered in ZiskFv.lean + bin/TrustGate/Main.lean; construction-binder baseline refreshed
+(purely additive +123). NOT committed (parent commits).
+
+NEXT after Stage 4: REMU/REMUW. Then P5 assembly over the 36 constructions,
 carrying the non-extraction residuals.

--- a/STATUS.md
+++ b/STATUS.md
@@ -30,7 +30,13 @@ construction_mulw_sound cannot derive c46+ranges from balance today. See memory
 `project_extraction_fidelity_scope` + PLAN FIDELITY CEILING (audited verdict +
 5-step path).
 
-AWAITING USER DECISION: fund the ensemble-extension (model c46 + compose range
-lookups, ~Step1-2 of the path) for true full fidelity, vs accept c46+ranges as
-named residuals, vs redirect. /goal "land the M-ext part" was cleared by user
-after the audit re-scoped it.
+CURRENT FOCUS (2026-06-18): EXECUTING the extraction expansion — RANK 1 (c46
+re-compose) then RANK 2 (range providers). User directed: expand extraction +
+solve c46 + ranges. This is the ONLY extraction lever for P4/P5 (unblocks
+full-fidelity M-ext → 36/63); rest of P4/P5 is non-extraction (see plan P4/P5 PATH).
+
+RANK 1 c46: add the bus_res1 mux equation (mul_constraint_46_named, arith.pil:262,
+extracted Arith.lean:165 but dropped at AirsClean) into circuitWithArithTable so
+componentWithArithTable.Spec conjoins it. Anti-laundering POSITIVE (discharges the
+c46 caller promise by composing the real PIL constraint). Must stay green + 0
+ZiskFv axioms + ensemble balance intact.

--- a/STATUS.md
+++ b/STATUS.md
@@ -149,3 +149,21 @@ construction-binder baseline refreshed (purely additive +120). NOT committed (pa
 
 NEXT after Stage 5: REMUW. Then P5 assembly over the 36 constructions,
 carrying the non-extraction residuals.
+
+DONE (Stage 6 — construction_remuw_sound, secondary remainder lane + W-mode, → 36/63):
+mirrors REMU (secondary lane: main_div=0, main_mul=0, c_lo→d_0+d_1*65536 via
+opBus_row_ArithDivSecondary; reuses REMU's match_opBus_row_ArithDivSecondary_vOfDivuRow
+verbatim — m32 not a mux selector) PLUS DIVUW W-mode (m32=1, h_b23/h_c23/h_sext_choice
+W residuals, h_d23 derived via arith_div_remainder_bound_unsigned_w, loose <983041
+carry route). Built full op-189 stack: spec_op_val_ne_arith_remuw (BinaryTable +
+BinaryExtensionTable), static_table_op_val_ne_arith_remuw_of_emit (Binary/Bridge),
+_of_spec_facts + shiftStaticLookupComponent_op_val_ne_arith_remuw_of_spec
+(BinaryExtension/StaticCircuit), 3 refute lemmas + keep theorem
+exists_arithMul_provider_row_matches_primary_of_remuw_active_main_row_interaction
+(ArithBalance), _from_binding wrapper (AcceptedTrace), remuw_mode_pins_of_row
+(ArithTableProjections: na=nb=np=nr=0, m32=1, div=1, main_div=0, main_mul=0),
+h_rd_val_mdru_remuw_loose (MulDivRemUnsigned), ConstructionRemuw.lean (F4 bridge
+equiv_REMUW_of_fullSpec + construction_remuw_sound). REMUW = OP_REMU_W = 189 (m32=0
+decomp = 173). Sail conclusion: instruction.REMW (r2,r1,rd,true) /
+execute_DIVREM_remuw_pure. ONE remainder_bound residual + W-mode (h_b23,h_c23,
+h_sext_choice) + operand bridges. Completes the 6 unsigned M-ext constructions.

--- a/STATUS.md
+++ b/STATUS.md
@@ -14,11 +14,23 @@ packaging (the 30 ALU constructions reused pre-existing Binary packaging). The
 core balance enumeration (Balance.lean:1732) already surfaces an arithMul branch
 the ALU theorems refute; M-ext keeps it. 0 PROJECT axioms required.
 
-Current focus: PR-MEXT.1 — MULW spike (primary op-bus, op=182). This is the
-make-or-break Arith balance+witness foundation; once it lands, MULHU (secondary)
-and the DIV family follow incrementally.
+DONE: MULW provider-match foundation (F1 table-exclusion + F2 refutations + F3
+`exists_arithMul_provider_row_matches_primary_of_mulw_active_main_row_interaction`
+in ZiskFv/AirsClean/FullEnsemble/ArithBalance.lean). Full `lake build` green, 0
+sorry, 0 new ZiskFv.* axioms. (Committed: foundation files are uncommitted working
+changes — commit before switching context.)
 
-Next step: build `exists_arithMul_provider_row_matches_primary_from_binding`
-(mirror the Binary `_logic_` theorem, keep arithMul branch, refute the other 3).
+BLOCKER (AUDITED 2026-06-18, workflow wmd3batug, adversarially confirmed): full-
+fidelity arith is blocked by an EXTRACTION-SCOPE reality, not just proof effort.
+The extracted ensemble = F-only polynomial slice. Arith carry-chain is balance-
+derivable (✓), but **c46 (bus_res1 mux) and chunk/carry range checks are NOT
+composed into the ensemble** (c46 = modeling drop; ranges = extraction-skip +
+deliberate non-composition; SpecifiedRanges AIR #19 not extracted at all). So
+construction_mulw_sound cannot derive c46+ranges from balance today. See memory
+`project_extraction_fidelity_scope` + PLAN FIDELITY CEILING (audited verdict +
+5-step path).
 
-No blockers. Goal hook active: "land the M-ext part."
+AWAITING USER DECISION: fund the ensemble-extension (model c46 + compose range
+lookups, ~Step1-2 of the path) for true full fidelity, vs accept c46+ranges as
+named residuals, vs redirect. /goal "land the M-ext part" was cleared by user
+after the audit re-scoped it.

--- a/STATUS.md
+++ b/STATUS.md
@@ -50,6 +50,25 @@ Ripples to the core op-bus enumeration (Balance.lean) + the per-mode bridge
 (opBus_row_ArithMul at MULW mode) + MULW re-derivation. Anti-laundering positive
 (faithful mux replaces unfaithful hardcoding; no new trust).
 
-NEXT after Stage 1: construction_mulhu_sound (d-lane via mode pins), then the
-div-family (DIVU/DIVUW/REMU/REMUW — ArithDiv view + the remainder-bound self-edge).
-Then P5 assembly over the 36 constructions, carrying the non-extraction residuals.
+DONE (Stage 2 — construction_mulhu_sound, d-lane secondary, 32/63): mirrors MULW.
+KEY BLOCKER FOUND + RESOLVED: EquivCore.MulHU.equiv_MULHU wants carry ranges < 131072
+(2^17) but balance (FullSpec.CarryRangeSpec) only gives the SIGNED disjunction
+(< 983041 ∨ ≥ p-983040). Genuine 4×4 unsigned-mul carries reach ~3·2^16 > 2^17, so
+< 131072 is UNSATISFIABLE from real balance data (the shared MulNoWrap < 131072 bound
+is documented-conservative). Resolution: derive < 983041 from balance
+(unsigned_carry_step_nat = signed disjunction + chain step + chunk ranges ⟹ < 983041)
+and route construction_mulhu_sound through a NEW equiv_MULHU_of_fullSpec that
+reconstructs rd via a LOOSE-bound (< 983041) chunk→ℕ→high-half write-value path in
+ConstructionMulhu.lean (NOT modifying shared MulNoWrap / equiv_MULHU). Arith witnesses
+all DERIVED from FullSpec; 0 PROJECT ZiskFv.* axioms. Closure carries
+Lean.ofReduceBool/trustCompiler (native_decide) INHERITED from the canonical
+equiv_MULHU path (already has it; NOT new — MULW is native_decide-free); tracked by #75.
+Full lake build GREEN (8693). V1 17/18 + V2 ALL PASS (only the pre-existing
+zisk-submodule-absent Aeneas 16/18 fails). Files: NEW Compliance/ConstructionMulhu.lean;
++op-177 keep/refute in ArithBalance + table-exclusions (Binary/BinaryExtension Table +
+StaticCircuit + Binary Bridge) + AcceptedTrace binding wrapper + ArithMul/Bridge
+MULHU-mode bridge + ArithTableProjections mulhu_mode_pins_of_row; registered in
+ZiskFv.lean + bin/TrustGate/Main.lean; construction-binder baseline appended.
+
+NEXT after Stage 2: div-family (DIVU/DIVUW/REMU/REMUW). Then P5 assembly over the
+36 constructions, carrying the non-extraction residuals.

--- a/STATUS.md
+++ b/STATUS.md
@@ -70,5 +70,32 @@ StaticCircuit + Binary Bridge) + AcceptedTrace binding wrapper + ArithMul/Bridge
 MULHU-mode bridge + ArithTableProjections mulhu_mode_pins_of_row; registered in
 ZiskFv.lean + bin/TrustGate/Main.lean; construction-binder baseline appended.
 
-NEXT after Stage 2: div-family (DIVU/DIVUW/REMU/REMUW). Then P5 assembly over the
-36 constructions, carrying the non-extraction residuals.
+DONE (Stage 3 — construction_divu_sound, unsigned DIVU primary a-lane, 33/63):
+mirrors MULW/MULHU. Provider = SHARED ArithMul componentWithArithTable (ArithDiv
+emits NO op-bus in the ensemble: arithDiv_table_interactionsWith_opBus_nil →
+circuit.channels=[]). DIVU Main op-bus matches the muxed primaryOpBusMessage; new
+DIVU-mode bridge primaryOpBusMessage_toEntry_eq_opBus_row_ArithDiv reduces it (at
+div=1 ∧ main_div=1 ∧ main_mul=0) to opBus_row_ArithDiv. Arith witnesses
+(ArithTable/chunk/signed-carry/c46/carry-chain) ALL DERIVED from FullSpec.
+CARRY BOUND: same MULHU blocker — equiv_DIVU wants <131072 (2^17), balance only
+gives signed disjunction; genuine Euclidean carries >2^17 ⟹ loose <983041 derived
+(divu_carry_bounds via unsigned_carry_step_nat) + NEW loose write-value path
+h_rd_val_mdru_divu_loose (in MulDivRemUnsigned.lean) routed through a custom
+equiv_DIVU_of_fullSpec (NOT equiv_DIVU). REMAINDER BOUND = RESIDUAL (not
+balance-derivable): ArithDivRemainderBoundWitness is the arith.pil:274
+assumes_operation LTU consumer edge matched vs a Binary provider — a
+finished-channel SELF-EDGE absent from the ensemble (ArithDiv emits no op-bus), so
+it CANNOT come from balance. Carried as the ONE explicit residual binder, exactly
+as the canonical equiv_DIVU carries it. Full lake build GREEN (8694); 0 sorry;
+0 PROJECT ZiskFv.* axioms (closure carries Classical.choice + Quot.sound + Sail +
+Lean.ofReduceBool/trustCompiler native_decide INHERITED from canonical equiv_DIVU
+path — NOT new; #75). V1 18/18 + V2 12/12 ALL PASS. Files: NEW
+Compliance/ConstructionDivu.lean; +op-184/offset-168 exclusions (BinaryTable,
+BinaryExtensionTable, Binary/Bridge, BinaryExtension/StaticCircuit) + ArithBalance
+keep/refute + AcceptedTrace from_binding wrapper + ArithTableProjections
+divu_mode_pins_of_row + MulDivRemUnsigned loose divu path; registered in ZiskFv.lean
++ bin/TrustGate/Main.lean; construction-binder baseline refreshed. NOT committed
+(parent commits).
+
+NEXT after Stage 3: DIVUW/REMU/REMUW. Then P5 assembly over the 36 constructions,
+carrying the non-extraction residuals.

--- a/STATUS.md
+++ b/STATUS.md
@@ -42,8 +42,19 @@ lookups. ArithMulTableWitness.chunk_ranges derivation added. ArithMulChunkRangeW
 kept as deprecated alias. Full lake build green, 0 sorry, 0 new ZiskFv.* axioms,
 trust gate checks #3/#5/#7/#8 pass.
 
-NEXT: RANK 2b carry ranges (signed carry range lookups into shared component?
-NOTE: carry ranges are mode-dependent — unsigned=rangeTable17, signed uses
-signedCarryRangeTable. Cannot add unsigned carry to SHARED component without
-vacuity. Evaluate separately. RANK 3 = use FullSpec to discharge ArithMulChunkRangeWitness
-from equiv_MUL/MULH/MULW canonical signatures (requires updating Equivalence/Wrappers).
+RANK 2b carry ranges: IN PROGRESS. CORRECTION (verified arith.pil:17,280): carry
+ranges are NOT mode-dependent. The PIL carries are `bits(64, signed)` range-checked
+with the single ARITH_RANGE_CARRY type = signedCarryRangeTable
+(val < 983041 ∨ GL_prime−983040 ≤ val), which holds for ALL arith rows (unsigned
+carries < 2^17 < 983041, first disjunct). So composing signedCarryRangeTable into
+the SHARED component is faithful + sound (no vacuity). The earlier "mode-dependent /
+cannot add" note was wrong (conflated the real PIL range with the tight unsigned
+rangeTable17 hand-specialization). 2b composes signedCarryRangeTable ×7 →
+FullSpec += CarryRangeSpec. The unsigned arms' tight < 2^17 bound is a
+construction-layer derivation (not an extraction blocker).
+
+NEXT after 2b: RANK 3 = use the now-fuller FullSpec to DISCHARGE the chunk/carry/c46
+witnesses from the M-ext construction theorems (the construction-layer plumbing,
+the active P4 M-ext stream) — derive them from the provider match instead of
+caller witnesses. Then RANK 3 (ArithDiv table-component) + RANK 4 (remainder
+self-edge) for the div/rem arms.

--- a/STATUS.md
+++ b/STATUS.md
@@ -35,8 +35,15 @@ re-compose) then RANK 2 (range providers). User directed: expand extraction +
 solve c46 + ranges. This is the ONLY extraction lever for P4/P5 (unblocks
 full-fidelity M-ext → 36/63); rest of P4/P5 is non-extraction (see plan P4/P5 PATH).
 
-RANK 1 c46: add the bus_res1 mux equation (mul_constraint_46_named, arith.pil:262,
-extracted Arith.lean:165 but dropped at AirsClean) into circuitWithArithTable so
-componentWithArithTable.Spec conjoins it. Anti-laundering POSITIVE (discharges the
-c46 caller promise by composing the real PIL constraint). Must stay green + 0
-ZiskFv axioms + ensemble balance intact.
+RANK 1 c46: DONE (committed cd26a331). FullSpec = Spec ∧ ArithTableSpec ∧ C46Spec.
+RANK 2a chunk ranges: DONE (committed d9e59667). FullSpec = Spec ∧ ArithTableSpec
+∧ C46Spec ∧ ChunkRangeSpec. mainWithArithTable now includes 16 bits(16) chunk
+lookups. ArithMulTableWitness.chunk_ranges derivation added. ArithMulChunkRangeWitness
+kept as deprecated alias. Full lake build green, 0 sorry, 0 new ZiskFv.* axioms,
+trust gate checks #3/#5/#7/#8 pass.
+
+NEXT: RANK 2b carry ranges (signed carry range lookups into shared component?
+NOTE: carry ranges are mode-dependent — unsigned=rangeTable17, signed uses
+signedCarryRangeTable. Cannot add unsigned carry to SHARED component without
+vacuity. Evaluate separately. RANK 3 = use FullSpec to discharge ArithMulChunkRangeWitness
+from equiv_MUL/MULH/MULW canonical signatures (requires updating Equivalence/Wrappers).

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,169 +1,25 @@
-Active stream: P4 M-ext constructions — add the 6 unsigned RV64M
-`construction_<op>_sound` theorems (MULW, MULHU, DIVU, DIVUW, REMU, REMUW), 31 → 36.
-Feeds the P5 OpEnvelope-removal assembly.
+Stream: P4 M-ext constructions (p4-mext worktree, off origin/main). build/ symlinked,
+submodule populated, gate 18/18 (V1) + 12/12 (V2). Plan: docs/ai/plan/PLAN_ENDGAME_P4_MEXT.md.
 
-Worktree `.worktrees/p4-mext`, branch `p4-mext` off `origin/main`. build/ symlinked.
-Plan: docs/ai/plan/PLAN_ENDGAME_P4_MEXT.md (P4/P5 PATH + extraction-expansion checklist).
+=== UNSIGNED M-EXT COMPLETE: 36/63 ===
+All 6 unsigned RV64M construction_<op>_sound landed, full-fidelity (arith witnesses
+DERIVED from componentWithArithTable.FullSpec, not caller-supplied), green, 0 PROJECT
+ZiskFv.* axioms each, committed:
+- MULW e86b7c05, MULHU 94b09482, DIVU 266e7a98, DIVUW a297ef86, REMU 8e2f084c, REMUW e7ffae17.
+Signed M-ext (MUL/MULH/MULHSU/DIV/DIVW/REM/REMW) stay defect-gated (NoKnownDefect /
+the codygunton/zisk#5 LT_ABS_NP bug). FENCE defect-gated.
 
-PATH (verified): expanding the PIL extraction is the ONLY lever for the M-ext arith
-constructions; rest of P4/P5 is non-extraction (constructions plumbing / #76 / #100 /
-bus_effect retirement / Aeneas / defect gates). Full fidelity throughout (user choice).
+EXTRACTION FOUNDATION (committed, the lever that unblocked full-fidelity M-ext):
+- c46 re-compose (cd26a331), chunk ranges (d9e59667), carry ranges (8660312f),
+  faithful op-bus mux (af16b990) → componentWithArithTable now faithfully constrains
+  carry-chain + ArithTable + c46 + chunk ranges + carry ranges + the muxed message
+  (all modes), all balance-derivable.
 
-DONE (faithful-mux foundation, uncommitted): the Clean ArithMul provider op-bus
-message is now FAITHFUL to the real PIL emission (arith.pil:247-258 /
-build/extraction/Extraction/Buses.lean bus_emission_Arith_0). `primaryOpBusMessageExpr`
-+ concrete `primaryOpBusMessage` carry the real MUXED a_lo/a_hi/c_lo lanes
-(div / main_mul / main_div selectors) covering all arith modes via one message.
-The hardcoded `main_mul` branch is GONE. Anti-laundering positive: replaces an
-unfaithful hardcoding with the real PIL mux; NO new trust (the emission was already
-in the ensemble — now correct). MULW PRESERVED: `construction_mulw_sound` re-derived
-through the new muxed message + a MODE-GATED bridge
-(`primaryOpBusMessage_toEntry_rowAt_eq_opBus_row` now takes div=0 ∧ main_mul=1 ∧
-main_div=0; reduces the mux to the plain c-lanes). Mode pins DERIVED inside the
-construction from the balance-derived FullSpec's ArithTableSpec + op=182 via the new
-bare-row `mulw_mode_pins_of_row` (ArithTableProjections). construction_mulw_sound
-binders UNCHANGED. Full `lake build` GREEN (8692 jobs); 0 sorry; 0 new ZiskFv.* axioms
-(construction_mulw_sound closure = Sail+kernel external only); V1 17/18 (only the
-pre-existing zisk-submodule-absent Aeneas 16/18 fails) + V2 ALL PASS; no trust baseline
-files changed. 4 files touched: AirsClean/ArithMul/{Constraints,Bridge}.lean,
-AirsClean/ArithTableProjections.lean, Compliance/ConstructionMulw.lean.
-NEXT (separate task): build MULHU + div/rem op-bus matches off the muxed message
-(secondary/div-mode bridges) — NOT in this foundation task.
+RESIDUALS carried per div/rem construction (honest, == canonical equiv): the ONE
+`remainder_bound` (LTU |d|<b self-edge — a finished-channel self-edge NOT in the
+ensemble; full-fidelity needs composing it, deferred) + W-mode bus-encoding residuals
+(h_b23/h_c23/h_sext_choice for the W ops) + operand bridges + decode/Sail/exec/nextPC.
 
-DONE (committed, green, 0 ZiskFv.* axioms):
-- c46 re-compose (cd26a331), chunk ranges (d9e59667), carry ranges (8660312f) →
-  `componentWithArithTable.Spec = FullSpec = Spec ∧ ArithTableSpec ∧ C46Spec ∧
-  ChunkRangeSpec ∧ CarryRangeSpec`, all balance-derivable.
-- construction_mulw_sound (e86b7c05) — FIRST M-ext construction, full-fidelity (31/63).
-  F4 bridge `equiv_MULW_of_fullSpec` derives the arith witnesses from balance;
-  residual binders are honest decode/Sail/operand/exec/nextPC only.
-
-KEY FINDING: the other 5 M-ext were blocked — the Clean ArithMul provider's op-bus
-message HARDCODES the main_mul (c-chunk) lane; the real PIL emission (arith.pil:247-258
-/ bus_emission_Arith_0) MUXES the a/c lanes (bus_a0 div-mux, bus_res0 3-way mux). So
-MULW (c-lane) matched; MULHU (d-lane) + div/rem (a-lane) could not. User chose FULL
-FIDELITY (core extraction) over carrying the match as a residual.
-
-IN PROGRESS: Stage 1 — make `primaryOpBusMessageExpr` the faithful bus_a/bus_res0 mux
-(one message covers all modes; each op's mode pins select its lane). MULW-preserving.
-Ripples to the core op-bus enumeration (Balance.lean) + the per-mode bridge
-(opBus_row_ArithMul at MULW mode) + MULW re-derivation. Anti-laundering positive
-(faithful mux replaces unfaithful hardcoding; no new trust).
-
-DONE (Stage 2 — construction_mulhu_sound, d-lane secondary, 32/63): mirrors MULW.
-KEY BLOCKER FOUND + RESOLVED: EquivCore.MulHU.equiv_MULHU wants carry ranges < 131072
-(2^17) but balance (FullSpec.CarryRangeSpec) only gives the SIGNED disjunction
-(< 983041 ∨ ≥ p-983040). Genuine 4×4 unsigned-mul carries reach ~3·2^16 > 2^17, so
-< 131072 is UNSATISFIABLE from real balance data (the shared MulNoWrap < 131072 bound
-is documented-conservative). Resolution: derive < 983041 from balance
-(unsigned_carry_step_nat = signed disjunction + chain step + chunk ranges ⟹ < 983041)
-and route construction_mulhu_sound through a NEW equiv_MULHU_of_fullSpec that
-reconstructs rd via a LOOSE-bound (< 983041) chunk→ℕ→high-half write-value path in
-ConstructionMulhu.lean (NOT modifying shared MulNoWrap / equiv_MULHU). Arith witnesses
-all DERIVED from FullSpec; 0 PROJECT ZiskFv.* axioms. Closure carries
-Lean.ofReduceBool/trustCompiler (native_decide) INHERITED from the canonical
-equiv_MULHU path (already has it; NOT new — MULW is native_decide-free); tracked by #75.
-Full lake build GREEN (8693). V1 17/18 + V2 ALL PASS (only the pre-existing
-zisk-submodule-absent Aeneas 16/18 fails). Files: NEW Compliance/ConstructionMulhu.lean;
-+op-177 keep/refute in ArithBalance + table-exclusions (Binary/BinaryExtension Table +
-StaticCircuit + Binary Bridge) + AcceptedTrace binding wrapper + ArithMul/Bridge
-MULHU-mode bridge + ArithTableProjections mulhu_mode_pins_of_row; registered in
-ZiskFv.lean + bin/TrustGate/Main.lean; construction-binder baseline appended.
-
-DONE (Stage 3 — construction_divu_sound, unsigned DIVU primary a-lane, 33/63):
-mirrors MULW/MULHU. Provider = SHARED ArithMul componentWithArithTable (ArithDiv
-emits NO op-bus in the ensemble: arithDiv_table_interactionsWith_opBus_nil →
-circuit.channels=[]). DIVU Main op-bus matches the muxed primaryOpBusMessage; new
-DIVU-mode bridge primaryOpBusMessage_toEntry_eq_opBus_row_ArithDiv reduces it (at
-div=1 ∧ main_div=1 ∧ main_mul=0) to opBus_row_ArithDiv. Arith witnesses
-(ArithTable/chunk/signed-carry/c46/carry-chain) ALL DERIVED from FullSpec.
-CARRY BOUND: same MULHU blocker — equiv_DIVU wants <131072 (2^17), balance only
-gives signed disjunction; genuine Euclidean carries >2^17 ⟹ loose <983041 derived
-(divu_carry_bounds via unsigned_carry_step_nat) + NEW loose write-value path
-h_rd_val_mdru_divu_loose (in MulDivRemUnsigned.lean) routed through a custom
-equiv_DIVU_of_fullSpec (NOT equiv_DIVU). REMAINDER BOUND = RESIDUAL (not
-balance-derivable): ArithDivRemainderBoundWitness is the arith.pil:274
-assumes_operation LTU consumer edge matched vs a Binary provider — a
-finished-channel SELF-EDGE absent from the ensemble (ArithDiv emits no op-bus), so
-it CANNOT come from balance. Carried as the ONE explicit residual binder, exactly
-as the canonical equiv_DIVU carries it. Full lake build GREEN (8694); 0 sorry;
-0 PROJECT ZiskFv.* axioms (closure carries Classical.choice + Quot.sound + Sail +
-Lean.ofReduceBool/trustCompiler native_decide INHERITED from canonical equiv_DIVU
-path — NOT new; #75). V1 18/18 + V2 12/12 ALL PASS. Files: NEW
-Compliance/ConstructionDivu.lean; +op-184/offset-168 exclusions (BinaryTable,
-BinaryExtensionTable, Binary/Bridge, BinaryExtension/StaticCircuit) + ArithBalance
-keep/refute + AcceptedTrace from_binding wrapper + ArithTableProjections
-divu_mode_pins_of_row + MulDivRemUnsigned loose divu path; registered in ZiskFv.lean
-+ bin/TrustGate/Main.lean; construction-binder baseline refreshed. NOT committed
-(parent commits).
-
-DONE (Stage 4 — construction_divuw_sound, unsigned W-mode DIVUW op-188 a-lane, 34/63):
-mirrors DIVU. Provider = SHARED ArithMul componentWithArithTable; reuses DIVU's
-vOfDivuRow + DIVU-mode op-bus bridge (the div=1∧main_div=1∧main_mul=0 mux selectors
-are m32-agnostic, so the SAME bridge reduces the muxed primaryOpBusMessage to
-opBus_row_ArithDiv). Arith witnesses (ArithTable/chunk/signed-carry/c46/carry-chain)
-ALL DERIVED from FullSpec; the W-mode chain (m32=1) is m32-independent so divuw_chain_eqs
-= divu_chain_eqs. CARRY BOUND: same blocker — loose <983041 derived + NEW loose
-W-mode write-value path h_rd_val_mdru_divuw_loose (in MulDivRemUnsigned.lean) routed
-through a custom equiv_DIVUW_of_fullSpec (NOT equiv_DIVUW). h_byte_lo DERIVED from the
-op-bus c-lane projection. RESIDUALS = DIVU shape (decode/Sail/operand/exec/nextPC) +
-remainder_bound (the ArithDiv LTU self-edge, NOT balance-derivable) + the THREE W-mode
-residuals the canonical equiv_DIVUW also carries: h_b23, h_c23 (high-lane zeros — m32 is
-NOT an op-bus field, so not balance-derivable), h_sext_choice (SEXT_00/SEXT_FF bus
-encoding on bytes 4..7, class #4). NO arith-witness binders. Full lake build GREEN (8695);
-0 sorry; 0 PROJECT ZiskFv.* axioms (closure carries Classical.choice + Quot.sound + Sail
-+ Lean.ofReduceBool/trustCompiler native_decide INHERITED from canonical equiv_DIVUW path
-— NOT new; #75). V1 18/18 + V2 12/12 ALL PASS. Files: NEW Compliance/ConstructionDivuw.lean;
-+op-188/offset-172 exclusions (BinaryTable, BinaryExtensionTable, Binary/Bridge,
-BinaryExtension/StaticCircuit) + ArithBalance keep/refute + AcceptedTrace from_binding
-wrapper + ArithTableProjections divuw_mode_pins_of_row + MulDivRemUnsigned loose divuw path;
-registered in ZiskFv.lean + bin/TrustGate/Main.lean; construction-binder baseline refreshed
-(purely additive +123). NOT committed (parent commits).
-
-DONE (Stage 5 — construction_remu_sound, unsigned REMU op-185 SECONDARY d-lane, 35/63):
-mirrors DIVU but on the REMAINDER (secondary) lane. KEY LANE FINDING: REMU's result is
-the remainder in d[]; REMU consumes the SECONDARY Arith lane (main_div=0, main_mul=0, so
-secondary=1). At those mode pins the muxed primaryOpBusMessage c_lo lane collapses to
-d_0+d_1·2^16 and reduces to opBus_row_ArithDivSecondary (NOT opBus_row_ArithDiv that DIVU
-uses). So the DIVU-mode bridge was NOT reusable — built a REMU variant
-primaryOpBusMessage_toEntry_eq_opBus_row_ArithDivSecondary pinning main_div=0 (vs DIVU's
-main_div=1) targeting the secondary row; high half from bus_res1=d_2+d_3·2^16 via
-rem_bus_res1_eq_d_hi (already existed). Reused arith_div_secondary_op_eq /
-arith_div_secondary_projections (already existed) + vOfDivuRow. Arith witnesses
-(ArithTable/chunk/signed-carry/c46/carry-chain) ALL DERIVED from FullSpec via op-185
-remu_mode_pins_of_row (NEW). CARRY BOUND: same blocker — loose <983041 derived (local
-remu_chain_eqs/remu_carry_bounds copies, since DIVU's are private — same pattern as DIVUW) +
-NEW loose write-value path h_rd_val_mdru_remu_loose (in MulDivRemUnsigned; mirrors
-h_rd_val_mdru_divu_loose but extracts remainder via fgl_rem_unsigned_to_bv64) routed through
-custom equiv_REMU_of_fullSpec (NOT equiv_REMU). RESIDUALS = DIVU shape
-(decode/Sail/operand/exec/nextPC) + remainder_bound (the ArithDiv LTU self-edge, NOT
-balance-derivable). NO arith-witness binders. Full lake build GREEN (8696); 0 sorry;
-0 PROJECT ZiskFv.* axioms (closure carries Classical.choice + Quot.sound + Sail +
-Lean.ofReduceBool/trustCompiler native_decide INHERITED from canonical equiv_REMU path
-— NOT new; #75). V1 18/18 + V2 12/12 ALL PASS. Files: NEW Compliance/ConstructionRemu.lean;
-+op-185/offset-169 exclusions (BinaryTable, BinaryExtensionTable, Binary/Bridge,
-BinaryExtension/StaticCircuit) + ArithBalance keep/refute (*_ne_arithRemuPrimary) +
-AcceptedTrace from_binding wrapper + ArithTableProjections remu_mode_pins_of_row +
-MulDivRemUnsigned loose remu path; registered in ZiskFv.lean + bin/TrustGate/Main.lean;
-construction-binder baseline refreshed (purely additive +120). NOT committed (parent commits).
-
-NEXT after Stage 5: REMUW. Then P5 assembly over the 36 constructions,
-carrying the non-extraction residuals.
-
-DONE (Stage 6 — construction_remuw_sound, secondary remainder lane + W-mode, → 36/63):
-mirrors REMU (secondary lane: main_div=0, main_mul=0, c_lo→d_0+d_1*65536 via
-opBus_row_ArithDivSecondary; reuses REMU's match_opBus_row_ArithDivSecondary_vOfDivuRow
-verbatim — m32 not a mux selector) PLUS DIVUW W-mode (m32=1, h_b23/h_c23/h_sext_choice
-W residuals, h_d23 derived via arith_div_remainder_bound_unsigned_w, loose <983041
-carry route). Built full op-189 stack: spec_op_val_ne_arith_remuw (BinaryTable +
-BinaryExtensionTable), static_table_op_val_ne_arith_remuw_of_emit (Binary/Bridge),
-_of_spec_facts + shiftStaticLookupComponent_op_val_ne_arith_remuw_of_spec
-(BinaryExtension/StaticCircuit), 3 refute lemmas + keep theorem
-exists_arithMul_provider_row_matches_primary_of_remuw_active_main_row_interaction
-(ArithBalance), _from_binding wrapper (AcceptedTrace), remuw_mode_pins_of_row
-(ArithTableProjections: na=nb=np=nr=0, m32=1, div=1, main_div=0, main_mul=0),
-h_rd_val_mdru_remuw_loose (MulDivRemUnsigned), ConstructionRemuw.lean (F4 bridge
-equiv_REMUW_of_fullSpec + construction_remuw_sound). REMUW = OP_REMU_W = 189 (m32=0
-decomp = 173). Sail conclusion: instruction.REMW (r2,r1,rd,true) /
-execute_DIVREM_remuw_pure. ONE remainder_bound residual + W-mode (h_b23,h_c23,
-h_sext_choice) + operand bridges. Completes the 6 unsigned M-ext constructions.
+NEXT (p4-mext thread now FREE): either P5 assembly (compose the 36 constructions → env
+removal) or merge/PR p4-mext. Sibling threads: #76 (p76-memory, spike GO/committed,
+PR-76.5 production wiring not started) + Aeneas downgrade (aeneas-discharge, running).

--- a/STATUS.md
+++ b/STATUS.md
@@ -120,5 +120,32 @@ wrapper + ArithTableProjections divuw_mode_pins_of_row + MulDivRemUnsigned loose
 registered in ZiskFv.lean + bin/TrustGate/Main.lean; construction-binder baseline refreshed
 (purely additive +123). NOT committed (parent commits).
 
-NEXT after Stage 4: REMU/REMUW. Then P5 assembly over the 36 constructions,
+DONE (Stage 5 — construction_remu_sound, unsigned REMU op-185 SECONDARY d-lane, 35/63):
+mirrors DIVU but on the REMAINDER (secondary) lane. KEY LANE FINDING: REMU's result is
+the remainder in d[]; REMU consumes the SECONDARY Arith lane (main_div=0, main_mul=0, so
+secondary=1). At those mode pins the muxed primaryOpBusMessage c_lo lane collapses to
+d_0+d_1·2^16 and reduces to opBus_row_ArithDivSecondary (NOT opBus_row_ArithDiv that DIVU
+uses). So the DIVU-mode bridge was NOT reusable — built a REMU variant
+primaryOpBusMessage_toEntry_eq_opBus_row_ArithDivSecondary pinning main_div=0 (vs DIVU's
+main_div=1) targeting the secondary row; high half from bus_res1=d_2+d_3·2^16 via
+rem_bus_res1_eq_d_hi (already existed). Reused arith_div_secondary_op_eq /
+arith_div_secondary_projections (already existed) + vOfDivuRow. Arith witnesses
+(ArithTable/chunk/signed-carry/c46/carry-chain) ALL DERIVED from FullSpec via op-185
+remu_mode_pins_of_row (NEW). CARRY BOUND: same blocker — loose <983041 derived (local
+remu_chain_eqs/remu_carry_bounds copies, since DIVU's are private — same pattern as DIVUW) +
+NEW loose write-value path h_rd_val_mdru_remu_loose (in MulDivRemUnsigned; mirrors
+h_rd_val_mdru_divu_loose but extracts remainder via fgl_rem_unsigned_to_bv64) routed through
+custom equiv_REMU_of_fullSpec (NOT equiv_REMU). RESIDUALS = DIVU shape
+(decode/Sail/operand/exec/nextPC) + remainder_bound (the ArithDiv LTU self-edge, NOT
+balance-derivable). NO arith-witness binders. Full lake build GREEN (8696); 0 sorry;
+0 PROJECT ZiskFv.* axioms (closure carries Classical.choice + Quot.sound + Sail +
+Lean.ofReduceBool/trustCompiler native_decide INHERITED from canonical equiv_REMU path
+— NOT new; #75). V1 18/18 + V2 12/12 ALL PASS. Files: NEW Compliance/ConstructionRemu.lean;
++op-185/offset-169 exclusions (BinaryTable, BinaryExtensionTable, Binary/Bridge,
+BinaryExtension/StaticCircuit) + ArithBalance keep/refute (*_ne_arithRemuPrimary) +
+AcceptedTrace from_binding wrapper + ArithTableProjections remu_mode_pins_of_row +
+MulDivRemUnsigned loose remu path; registered in ZiskFv.lean + bin/TrustGate/Main.lean;
+construction-binder baseline refreshed (purely additive +120). NOT committed (parent commits).
+
+NEXT after Stage 5: REMUW. Then P5 assembly over the 36 constructions,
 carrying the non-extraction residuals.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,60 +1,55 @@
 Active stream: P4 M-ext constructions — add the 6 unsigned RV64M
-`construction_<op>_sound` theorems (MULW, MULHU, DIVU, DIVUW, REMU, REMUW) to the
-P4 construction set (30 → 36). Feeds the P5 env-removal assembly.
+`construction_<op>_sound` theorems (MULW, MULHU, DIVU, DIVUW, REMU, REMUW), 31 → 36.
+Feeds the P5 OpEnvelope-removal assembly.
 
-Worktree `.worktrees/p4-mext`, branch `p4-mext` off `origin/main` (a5679e5b).
-build/ symlinked to main checkout; `lake exe cache get` done.
+Worktree `.worktrees/p4-mext`, branch `p4-mext` off `origin/main`. build/ symlinked.
+Plan: docs/ai/plan/PLAN_ENDGAME_P4_MEXT.md (P4/P5 PATH + extraction-expansion checklist).
 
-Plan: docs/ai/plan/PLAN_ENDGAME_P4_MEXT.md (navigable spine + checklist).
+PATH (verified): expanding the PIL extraction is the ONLY lever for the M-ext arith
+constructions; rest of P4/P5 is non-extraction (constructions plumbing / #76 / #100 /
+bus_effect retirement / Aeneas / defect gates). Full fidelity throughout (user choice).
 
-Scope (verified 2026-06-18): equiv_<OP> layer DONE + axiom-free for all 6;
-MISSING = the P4 construction layer. M-ext is the FIRST construction-layer touch
-of the Arith family — needs NEW Arith provider-match-from-balance + witness
-packaging (the 30 ALU constructions reused pre-existing Binary packaging). The
-core balance enumeration (Balance.lean:1732) already surfaces an arithMul branch
-the ALU theorems refute; M-ext keeps it. 0 PROJECT axioms required.
+DONE (faithful-mux foundation, uncommitted): the Clean ArithMul provider op-bus
+message is now FAITHFUL to the real PIL emission (arith.pil:247-258 /
+build/extraction/Extraction/Buses.lean bus_emission_Arith_0). `primaryOpBusMessageExpr`
++ concrete `primaryOpBusMessage` carry the real MUXED a_lo/a_hi/c_lo lanes
+(div / main_mul / main_div selectors) covering all arith modes via one message.
+The hardcoded `main_mul` branch is GONE. Anti-laundering positive: replaces an
+unfaithful hardcoding with the real PIL mux; NO new trust (the emission was already
+in the ensemble — now correct). MULW PRESERVED: `construction_mulw_sound` re-derived
+through the new muxed message + a MODE-GATED bridge
+(`primaryOpBusMessage_toEntry_rowAt_eq_opBus_row` now takes div=0 ∧ main_mul=1 ∧
+main_div=0; reduces the mux to the plain c-lanes). Mode pins DERIVED inside the
+construction from the balance-derived FullSpec's ArithTableSpec + op=182 via the new
+bare-row `mulw_mode_pins_of_row` (ArithTableProjections). construction_mulw_sound
+binders UNCHANGED. Full `lake build` GREEN (8692 jobs); 0 sorry; 0 new ZiskFv.* axioms
+(construction_mulw_sound closure = Sail+kernel external only); V1 17/18 (only the
+pre-existing zisk-submodule-absent Aeneas 16/18 fails) + V2 ALL PASS; no trust baseline
+files changed. 4 files touched: AirsClean/ArithMul/{Constraints,Bridge}.lean,
+AirsClean/ArithTableProjections.lean, Compliance/ConstructionMulw.lean.
+NEXT (separate task): build MULHU + div/rem op-bus matches off the muxed message
+(secondary/div-mode bridges) — NOT in this foundation task.
 
-DONE: MULW provider-match foundation (F1 table-exclusion + F2 refutations + F3
-`exists_arithMul_provider_row_matches_primary_of_mulw_active_main_row_interaction`
-in ZiskFv/AirsClean/FullEnsemble/ArithBalance.lean). Full `lake build` green, 0
-sorry, 0 new ZiskFv.* axioms. (Committed: foundation files are uncommitted working
-changes — commit before switching context.)
+DONE (committed, green, 0 ZiskFv.* axioms):
+- c46 re-compose (cd26a331), chunk ranges (d9e59667), carry ranges (8660312f) →
+  `componentWithArithTable.Spec = FullSpec = Spec ∧ ArithTableSpec ∧ C46Spec ∧
+  ChunkRangeSpec ∧ CarryRangeSpec`, all balance-derivable.
+- construction_mulw_sound (e86b7c05) — FIRST M-ext construction, full-fidelity (31/63).
+  F4 bridge `equiv_MULW_of_fullSpec` derives the arith witnesses from balance;
+  residual binders are honest decode/Sail/operand/exec/nextPC only.
 
-BLOCKER (AUDITED 2026-06-18, workflow wmd3batug, adversarially confirmed): full-
-fidelity arith is blocked by an EXTRACTION-SCOPE reality, not just proof effort.
-The extracted ensemble = F-only polynomial slice. Arith carry-chain is balance-
-derivable (✓), but **c46 (bus_res1 mux) and chunk/carry range checks are NOT
-composed into the ensemble** (c46 = modeling drop; ranges = extraction-skip +
-deliberate non-composition; SpecifiedRanges AIR #19 not extracted at all). So
-construction_mulw_sound cannot derive c46+ranges from balance today. See memory
-`project_extraction_fidelity_scope` + PLAN FIDELITY CEILING (audited verdict +
-5-step path).
+KEY FINDING: the other 5 M-ext were blocked — the Clean ArithMul provider's op-bus
+message HARDCODES the main_mul (c-chunk) lane; the real PIL emission (arith.pil:247-258
+/ bus_emission_Arith_0) MUXES the a/c lanes (bus_a0 div-mux, bus_res0 3-way mux). So
+MULW (c-lane) matched; MULHU (d-lane) + div/rem (a-lane) could not. User chose FULL
+FIDELITY (core extraction) over carrying the match as a residual.
 
-CURRENT FOCUS (2026-06-18): EXECUTING the extraction expansion — RANK 1 (c46
-re-compose) then RANK 2 (range providers). User directed: expand extraction +
-solve c46 + ranges. This is the ONLY extraction lever for P4/P5 (unblocks
-full-fidelity M-ext → 36/63); rest of P4/P5 is non-extraction (see plan P4/P5 PATH).
+IN PROGRESS: Stage 1 — make `primaryOpBusMessageExpr` the faithful bus_a/bus_res0 mux
+(one message covers all modes; each op's mode pins select its lane). MULW-preserving.
+Ripples to the core op-bus enumeration (Balance.lean) + the per-mode bridge
+(opBus_row_ArithMul at MULW mode) + MULW re-derivation. Anti-laundering positive
+(faithful mux replaces unfaithful hardcoding; no new trust).
 
-RANK 1 c46: DONE (committed cd26a331). FullSpec = Spec ∧ ArithTableSpec ∧ C46Spec.
-RANK 2a chunk ranges: DONE (committed d9e59667). FullSpec = Spec ∧ ArithTableSpec
-∧ C46Spec ∧ ChunkRangeSpec. mainWithArithTable now includes 16 bits(16) chunk
-lookups. ArithMulTableWitness.chunk_ranges derivation added. ArithMulChunkRangeWitness
-kept as deprecated alias. Full lake build green, 0 sorry, 0 new ZiskFv.* axioms,
-trust gate checks #3/#5/#7/#8 pass.
-
-RANK 2b carry ranges: IN PROGRESS. CORRECTION (verified arith.pil:17,280): carry
-ranges are NOT mode-dependent. The PIL carries are `bits(64, signed)` range-checked
-with the single ARITH_RANGE_CARRY type = signedCarryRangeTable
-(val < 983041 ∨ GL_prime−983040 ≤ val), which holds for ALL arith rows (unsigned
-carries < 2^17 < 983041, first disjunct). So composing signedCarryRangeTable into
-the SHARED component is faithful + sound (no vacuity). The earlier "mode-dependent /
-cannot add" note was wrong (conflated the real PIL range with the tight unsigned
-rangeTable17 hand-specialization). 2b composes signedCarryRangeTable ×7 →
-FullSpec += CarryRangeSpec. The unsigned arms' tight < 2^17 bound is a
-construction-layer derivation (not an extraction blocker).
-
-NEXT after 2b: RANK 3 = use the now-fuller FullSpec to DISCHARGE the chunk/carry/c46
-witnesses from the M-ext construction theorems (the construction-layer plumbing,
-the active P4 M-ext stream) — derive them from the provider match instead of
-caller witnesses. Then RANK 3 (ArithDiv table-component) + RANK 4 (remainder
-self-edge) for the div/rem arms.
+NEXT after Stage 1: construction_mulhu_sound (d-lane via mode pins), then the
+div-family (DIVU/DIVUW/REMU/REMUW — ArithDiv view + the remainder-bound self-edge).
+Then P5 assembly over the 36 constructions, carrying the non-extraction residuals.

--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -145,6 +145,7 @@ import ZiskFv.Compliance.ConstructionAuipc
 import ZiskFv.Compliance.ConstructionMulw
 import ZiskFv.Compliance.ConstructionMulhu
 import ZiskFv.Compliance.ConstructionDivu
+import ZiskFv.Compliance.ConstructionDivuw
 import ZiskFv.Compliance
 import ZiskFv.Completeness.Rv
 import ZiskFv.Completeness.Rv64im

--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -144,6 +144,7 @@ import ZiskFv.Compliance.ConstructionLui
 import ZiskFv.Compliance.ConstructionAuipc
 import ZiskFv.Compliance.ConstructionMulw
 import ZiskFv.Compliance.ConstructionMulhu
+import ZiskFv.Compliance.ConstructionDivu
 import ZiskFv.Compliance
 import ZiskFv.Completeness.Rv
 import ZiskFv.Completeness.Rv64im

--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -143,6 +143,7 @@ import ZiskFv.Compliance.ConstructionWAlu
 import ZiskFv.Compliance.ConstructionLui
 import ZiskFv.Compliance.ConstructionAuipc
 import ZiskFv.Compliance.ConstructionMulw
+import ZiskFv.Compliance.ConstructionMulhu
 import ZiskFv.Compliance
 import ZiskFv.Completeness.Rv
 import ZiskFv.Completeness.Rv64im

--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -142,6 +142,7 @@ import ZiskFv.Compliance.ConstructionAdd
 import ZiskFv.Compliance.ConstructionWAlu
 import ZiskFv.Compliance.ConstructionLui
 import ZiskFv.Compliance.ConstructionAuipc
+import ZiskFv.Compliance.ConstructionMulw
 import ZiskFv.Compliance
 import ZiskFv.Completeness.Rv
 import ZiskFv.Completeness.Rv64im

--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -146,6 +146,7 @@ import ZiskFv.Compliance.ConstructionMulw
 import ZiskFv.Compliance.ConstructionMulhu
 import ZiskFv.Compliance.ConstructionDivu
 import ZiskFv.Compliance.ConstructionDivuw
+import ZiskFv.Compliance.ConstructionRemu
 import ZiskFv.Compliance
 import ZiskFv.Completeness.Rv
 import ZiskFv.Completeness.Rv64im

--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -147,6 +147,7 @@ import ZiskFv.Compliance.ConstructionMulhu
 import ZiskFv.Compliance.ConstructionDivu
 import ZiskFv.Compliance.ConstructionDivuw
 import ZiskFv.Compliance.ConstructionRemu
+import ZiskFv.Compliance.ConstructionRemuw
 import ZiskFv.Compliance
 import ZiskFv.Completeness.Rv
 import ZiskFv.Completeness.Rv64im

--- a/ZiskFv/AirsClean/ArithMul/Bridge.lean
+++ b/ZiskFv/AirsClean/ArithMul/Bridge.lean
@@ -84,9 +84,73 @@ theorem arith_table_spec_of_lookup_aware_soundness
   simp only [mainWithArithTable, main, circuit_norm] at h_holds
   rcases h_holds with
     ⟨_h6, _h7, _h8, _h31, _h32, _h33, _h34, _h35, _h36, _h37, _h38,
-      _h46, h_lookup⟩
+      _h46, h_lookup, _ha0, _ha1, _ha2, _ha3, _hb0, _hb1, _hb2, _hb3,
+      _hc0, _hc1, _hc2, _hc3, _hd0, _hd1, _hd2, _hd3⟩
   simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable, Table.toRaw,
     ArithTableSpec, arithTableRow] using h_lookup
+
+/-- Extract the sixteen 16-bit chunk range bounds from a `mainWithArithTable`
+    soundness proof.  After RANK 2a, `mainWithArithTable` includes the chunk
+    range lookups, so the ArithTable witness alone supplies chunk ranges. -/
+theorem chunk_ranges_of_arith_table_soundness
+    (offset : ℕ) (env : Environment FGL)
+    (input_var : Var ArithMulRow FGL)
+    (h_holds :
+      ConstraintsHold.Soundness env
+        ((mainWithArithTable input_var).operations offset)) :
+    (Expression.eval env input_var.chunks.a_0).val < 2 ^ 16
+  ∧ (Expression.eval env input_var.chunks.a_1).val < 2 ^ 16
+  ∧ (Expression.eval env input_var.chunks.a_2).val < 2 ^ 16
+  ∧ (Expression.eval env input_var.chunks.a_3).val < 2 ^ 16
+  ∧ (Expression.eval env input_var.chunks.b_0).val < 2 ^ 16
+  ∧ (Expression.eval env input_var.chunks.b_1).val < 2 ^ 16
+  ∧ (Expression.eval env input_var.chunks.b_2).val < 2 ^ 16
+  ∧ (Expression.eval env input_var.chunks.b_3).val < 2 ^ 16
+  ∧ (Expression.eval env input_var.chunks.c_0).val < 2 ^ 16
+  ∧ (Expression.eval env input_var.chunks.c_1).val < 2 ^ 16
+  ∧ (Expression.eval env input_var.chunks.c_2).val < 2 ^ 16
+  ∧ (Expression.eval env input_var.chunks.c_3).val < 2 ^ 16
+  ∧ (Expression.eval env input_var.chunks.d_0).val < 2 ^ 16
+  ∧ (Expression.eval env input_var.chunks.d_1).val < 2 ^ 16
+  ∧ (Expression.eval env input_var.chunks.d_2).val < 2 ^ 16
+  ∧ (Expression.eval env input_var.chunks.d_3).val < 2 ^ 16 := by
+  simp only [mainWithArithTable, main, circuit_norm] at h_holds
+  rcases h_holds with
+    ⟨_h6, _h7, _h8, _h31, _h32, _h33, _h34, _h35, _h36, _h37, _h38,
+      _h46, _h_lookup, ha0, ha1, ha2, ha3, hb0, hb1, hb2, hb3,
+      hc0, hc1, hc2, hc3, hd0, hd1, hd2, hd3⟩
+  exact ⟨by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+              Table.toRaw] using ha0,
+         by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+              Table.toRaw] using ha1,
+         by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+              Table.toRaw] using ha2,
+         by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+              Table.toRaw] using ha3,
+         by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+              Table.toRaw] using hb0,
+         by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+              Table.toRaw] using hb1,
+         by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+              Table.toRaw] using hb2,
+         by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+              Table.toRaw] using hb3,
+         by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+              Table.toRaw] using hc0,
+         by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+              Table.toRaw] using hc1,
+         by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+              Table.toRaw] using hc2,
+         by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+              Table.toRaw] using hc3,
+         by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+              Table.toRaw] using hd0,
+         by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+              Table.toRaw] using hd1,
+         by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+              Table.toRaw] using hd2,
+         by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+              Table.toRaw] using hd3⟩
 
 /-- Constant-row specialization of
     `arith_table_spec_of_lookup_aware_soundness`.
@@ -103,6 +167,20 @@ theorem arith_table_spec_of_lookup_aware_const_soundness
   have h_table :=
     arith_table_spec_of_lookup_aware_soundness offset env (constVar row) h_holds
   simpa [ArithTableSpec, arithTableRow, constVar] using h_table
+
+/-- Constant-row specialization of `chunk_ranges_of_arith_table_soundness`.
+
+    After RANK 2a the ArithTable witness (which holds `mainWithArithTable`
+    soundness) automatically supplies the chunk range bounds via the 16
+    newly-embedded chunk lookups. -/
+theorem chunk_ranges_of_arith_table_const_soundness
+    (offset : ℕ) (env : Environment FGL) (row : ArithMulRow FGL)
+    (h_holds :
+      ConstraintsHold.Soundness env
+        ((mainWithArithTable (constVar row)).operations offset)) :
+    ChunkRangeSpec row := by
+  have h := chunk_ranges_of_arith_table_soundness offset env (constVar row) h_holds
+  simpa [ChunkRangeSpec, constVar] using h
 
 /-- Project a `Valid_ArithMul` at row `r` into a Clean `ArithMulRow FGL`.
     The `Valid_ArithMul` record exposes all 28 chunk / flag / carry
@@ -396,8 +474,9 @@ theorem full_spec_of_carry_chain_and_arith_table
     (v : ZiskFv.Airs.ArithMul.Valid_ArithMul FGL FGL) (r : ℕ)
     (h_chain : ZiskFv.Airs.ArithMul.mul_carry_chain_holds v r)
     (h_table : ArithTableSpec (rowAt v r))
-    (h_c46 : C46Spec (rowAt v r)) :
+    (h_c46 : C46Spec (rowAt v r))
+    (h_chunk_ranges : ChunkRangeSpec (rowAt v r)) :
     FullSpec (rowAt v r) := by
-  exact ⟨spec_of_carry_chain_via_component v r h_chain, h_table, h_c46⟩
+  exact ⟨spec_of_carry_chain_via_component v r h_chain, h_table, h_c46, h_chunk_ranges⟩
 
 end ZiskFv.AirsClean.ArithMul

--- a/ZiskFv/AirsClean/ArithMul/Bridge.lean
+++ b/ZiskFv/AirsClean/ArithMul/Bridge.lean
@@ -322,15 +322,31 @@ theorem signed_carry_ranges_of_lookup_aware_const_soundness
     by simpa [rowAt, constVar] using h_cy5,
     by simpa [rowAt, constVar] using h_cy6⟩
 
-/-- Concrete primary MUL/MULW op-bus message for a Clean ArithMul row. -/
-@[reducible]
+/-- Concrete ArithMul op-bus message for a Clean ArithMul row — the
+    field-valued image of `primaryOpBusMessageExpr`, carrying the same real
+    PIL MUXED `a_lo` / `a_hi` / `c_lo` lanes (`arith.pil:247-258`).  Under the
+    MUL/MULW mode pins (`div=0`, `main_mul=1`, `main_div=0`) the muxes reduce
+    to the plain `a`/`c`-chunk lanes — see
+    `primaryOpBusMessage_toEntry_rowAt_eq_opBus_row`.
+
+    NOTE: deliberately NOT `@[reducible]`.  The faithful mux makes this message
+    large; leaving it reducible caused `exact`/`isDefEq` in the MULW construction
+    to eagerly unfold it and whnf the heavy balance-selected provider row while
+    comparing the per-lane field projections.  Every consumer unfolds it
+    explicitly (`simp only [primaryOpBusMessage]` or `eval_primaryOpBusMessageExpr`),
+    so non-reducibility is safe. -/
 def primaryOpBusMessage (row : ArithMulRow FGL) : OpBusMessage FGL :=
   { op := row.flags.op
-    a_lo := row.chunks.a_0 + row.chunks.a_1 * 65536
-    a_hi := row.chunks.a_2 + row.chunks.a_3 * 65536
+    a_lo := row.flags.div * (row.chunks.c_0 + row.chunks.c_1 * 65536)
+      + (1 - row.flags.div) * (row.chunks.a_0 + row.chunks.a_1 * 65536)
+    a_hi := row.flags.div * (row.chunks.c_2 + row.chunks.c_3 * 65536)
+      + (1 - row.flags.div) * (row.chunks.a_2 + row.chunks.a_3 * 65536)
     b_lo := row.chunks.b_0 + row.chunks.b_1 * 65536
     b_hi := row.chunks.b_2 + row.chunks.b_3 * 65536
-    c_lo := row.chunks.c_0 + row.chunks.c_1 * 65536
+    c_lo := (1 - row.flags.main_mul - row.flags.main_div)
+        * (row.chunks.d_0 + row.chunks.d_1 * 65536)
+      + row.flags.main_mul * (row.chunks.c_0 + row.chunks.c_1 * 65536)
+      + row.flags.main_div * (row.chunks.a_0 + row.chunks.a_1 * 65536)
     c_hi := row.flags.bus_res1
     flag := 0
     main_step := 0
@@ -355,12 +371,14 @@ def secondaryOpBusMessage (row : ArithMulRow FGL) : OpBusMessage FGL :=
 theorem eval_primaryOpBusMessageExpr
     (env : Environment FGL) (row : Var ArithMulRow FGL) :
     eval env (primaryOpBusMessageExpr row) = primaryOpBusMessage (eval env row) := by
-  rw [OpBusMessage.mk.injEq]
+  rw [primaryOpBusMessage, OpBusMessage.mk.injEq]
   simp only [primaryOpBusMessageExpr, ProvableStruct.eval_eq_eval,
     ProvableStruct.eval, ProvableStruct.fromComponents,
     ProvableStruct.components, ProvableStruct.toComponents,
     ProvableStruct.eval.go, ProvableType.eval_field, Expression.eval]
-  repeat constructor
+  -- `eval` normalizes `1 - x` to `1 + -1 * x`; the `a_lo`/`a_hi`/`c_lo` mux
+  -- lanes therefore need `ring`, not `rfl` (the other lanes are `True`/defeq).
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;> first | trivial | ring
 
 /-- Op-only projection of `eval_primaryOpBusMessageExpr`, used to avoid
     unfolding the entire operation-bus message in downstream provider
@@ -370,6 +388,18 @@ theorem eval_primaryOpBusMessageExpr_toEntry_op
     (OpBusMessage.toEntry (eval env (primaryOpBusMessageExpr row)) multiplicity).op =
       (eval env row).flags.op := by
   rw [eval_primaryOpBusMessageExpr]
+  -- `primaryOpBusMessage` is no longer reducible; project `.op` explicitly.
+  simp only [primaryOpBusMessage]
+
+/-- Cheap `op`-lane projection of the concrete primary message.  Stated over a
+    FREE `ArithMulRow` so the proof is `rfl` (a single structure-literal `.op`
+    pick that never touches the muxed `a_lo`/`a_hi`/`c_lo` lanes); applying it
+    to a balance-selected (heavy `Classical.choose`) provider row is then mere
+    substitution, avoiding the whnf blow-up of forcing the full message. -/
+@[simp]
+theorem primaryOpBusMessage_toEntry_op (row : ArithMulRow FGL) (multiplicity : FGL) :
+    (OpBusMessage.toEntry (primaryOpBusMessage row) multiplicity).op = row.flags.op :=
+  rfl
 
 theorem eval_secondaryOpBusMessageExpr
     (env : Environment FGL) (row : Var ArithMulRow FGL) :
@@ -382,11 +412,24 @@ theorem eval_secondaryOpBusMessageExpr
     ProvableStruct.eval.go, ProvableType.eval_field, Expression.eval]
   repeat constructor
 
+/-- Mode-conditional MUL/MULW bridge: the FAITHFUL muxed primary message
+    reduces to the plain MUL/MULW `opBus_row_Arith` entry exactly at the
+    MUL/MULW mode pins (`div=0`, `main_mul=1`, `main_div=0`).
+
+    With the muxed `primaryOpBusMessage`, the `a_lo`/`a_hi` lanes carry
+    `div·c + (1-div)·a` (→ `a` at `div=0`) and the `c_lo` lane carries
+    `(1-main_mul-main_div)·d + main_mul·c + main_div·a` (→ `c` at
+    `main_mul=1, main_div=0`).  This is no longer `rfl`; the mode pins are
+    discharged by the caller (e.g. `construction_mulw_sound`) from the
+    provider row's `ArithTableSpec` + opcode pin. -/
 theorem primaryOpBusMessage_toEntry_rowAt_eq_opBus_row
-    (v : ZiskFv.Airs.ArithMul.Valid_ArithMul FGL FGL) (r : ℕ) :
+    (v : ZiskFv.Airs.ArithMul.Valid_ArithMul FGL FGL) (r : ℕ)
+    (h_div : v.div r = 0) (h_main_mul : v.main_mul r = 1) (h_main_div : v.main_div r = 0) :
     OpBusMessage.toEntry (primaryOpBusMessage (rowAt v r)) (v.multiplicity r) =
       ZiskFv.Airs.ArithMul.opBus_row_Arith v r := by
-  rfl
+  simp only [OpBusMessage.toEntry, primaryOpBusMessage, rowAt,
+    ZiskFv.Airs.ArithMul.opBus_row_Arith, h_div, h_main_mul, h_main_div]
+  ring
 
 theorem secondaryOpBusMessage_toEntry_rowAt_eq_opBus_row
     (v : ZiskFv.Airs.ArithMul.Valid_ArithMul FGL FGL) (r : ℕ) :

--- a/ZiskFv/AirsClean/ArithMul/Bridge.lean
+++ b/ZiskFv/AirsClean/ArithMul/Bridge.lean
@@ -437,6 +437,27 @@ theorem secondaryOpBusMessage_toEntry_rowAt_eq_opBus_row
       ZiskFv.Airs.ArithMul.opBus_row_ArithMulSecondary v r := by
   rfl
 
+/-- Mode-conditional MULHU bridge: the FAITHFUL muxed primary message reduces
+    to the secondary high-half `opBus_row_ArithMulSecondary` entry (the d-lane
+    message) exactly at the MULHU secondary mode pins (`div = 0`,
+    `main_mul = 0`, `main_div = 0`).
+
+    At these pins the muxed `a_lo`/`a_hi` lanes (`div·c + (1-div)·a`) collapse to
+    the `a`-chunks, and the muxed `c_lo` lane
+    (`(1-main_mul-main_div)·d + main_mul·c + main_div·a`) collapses to the
+    `d`-chunks — i.e. the muxed primary message at MULHU mode IS the secondary
+    d-lane message.  The mode pins are discharged by the caller (e.g.
+    `construction_mulhu_sound`) from the provider row's `ArithTableSpec` +
+    opcode pin. -/
+theorem primaryOpBusMessage_toEntry_rowAt_eq_opBus_row_secondary
+    (v : ZiskFv.Airs.ArithMul.Valid_ArithMul FGL FGL) (r : ℕ)
+    (h_div : v.div r = 0) (h_main_mul : v.main_mul r = 0) (h_main_div : v.main_div r = 0) :
+    OpBusMessage.toEntry (primaryOpBusMessage (rowAt v r)) (v.multiplicity r) =
+      ZiskFv.Airs.ArithMul.opBus_row_ArithMulSecondary v r := by
+  simp only [OpBusMessage.toEntry, primaryOpBusMessage,
+    ZiskFv.Airs.ArithMul.opBus_row_ArithMulSecondary, h_div, h_main_mul, h_main_div]
+  ring
+
 /-- The Clean Component `Spec` projected at a `Valid_ArithMul` row,
     derived **through the Clean Component**. From the AIR's MUL-mode
     carry-chain constraints (`mul_carry_chain_holds v r` = named-form

--- a/ZiskFv/AirsClean/ArithMul/Bridge.lean
+++ b/ZiskFv/AirsClean/ArithMul/Bridge.lean
@@ -84,7 +84,7 @@ theorem arith_table_spec_of_lookup_aware_soundness
   simp only [mainWithArithTable, main, circuit_norm] at h_holds
   rcases h_holds with
     ⟨_h6, _h7, _h8, _h31, _h32, _h33, _h34, _h35, _h36, _h37, _h38,
-      h_lookup⟩
+      _h46, h_lookup⟩
   simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable, Table.toRaw,
     ArithTableSpec, arithTableRow] using h_lookup
 
@@ -383,18 +383,21 @@ theorem mul_carry_chain_holds_via_component
   · exact hs38
 
 /-- Combine the load-bearing Clean carry-chain route with a separately
-    sourced ArithTable lookup membership proof.
+    sourced ArithTable lookup membership proof and the `bus_res1` mux
+    equation (constraint 46, `arith.pil:262`).
 
-    This is the non-laundered C3/C4-b shape: `h_table` is explicit here
-    because the current global theorem does not yet provide lookup
-    membership. Compliance wrappers must not acquire this as a fresh
-    per-opcode promise; the proof becomes useful only once the shared
-    lookup/ensemble statement supplies `ArithTableSpec (rowAt v r)`. -/
+    This is the non-laundered C3/C4-b shape: `h_table` and `h_c46` are
+    explicit here because the current global theorem does not yet provide
+    lookup membership.  Compliance wrappers must not acquire these as
+    fresh per-opcode promises; the proof becomes useful only once the
+    shared lookup/ensemble statement supplies `ArithTableSpec (rowAt v r)`
+    and `C46Spec (rowAt v r)`. -/
 theorem full_spec_of_carry_chain_and_arith_table
     (v : ZiskFv.Airs.ArithMul.Valid_ArithMul FGL FGL) (r : ℕ)
     (h_chain : ZiskFv.Airs.ArithMul.mul_carry_chain_holds v r)
-    (h_table : ArithTableSpec (rowAt v r)) :
+    (h_table : ArithTableSpec (rowAt v r))
+    (h_c46 : C46Spec (rowAt v r)) :
     FullSpec (rowAt v r) := by
-  exact ⟨spec_of_carry_chain_via_component v r h_chain, h_table⟩
+  exact ⟨spec_of_carry_chain_via_component v r h_chain, h_table, h_c46⟩
 
 end ZiskFv.AirsClean.ArithMul

--- a/ZiskFv/AirsClean/ArithMul/Bridge.lean
+++ b/ZiskFv/AirsClean/ArithMul/Bridge.lean
@@ -85,7 +85,8 @@ theorem arith_table_spec_of_lookup_aware_soundness
   rcases h_holds with
     ⟨_h6, _h7, _h8, _h31, _h32, _h33, _h34, _h35, _h36, _h37, _h38,
       _h46, h_lookup, _ha0, _ha1, _ha2, _ha3, _hb0, _hb1, _hb2, _hb3,
-      _hc0, _hc1, _hc2, _hc3, _hd0, _hd1, _hd2, _hd3⟩
+      _hc0, _hc1, _hc2, _hc3, _hd0, _hd1, _hd2, _hd3,
+      _hcy0, _hcy1, _hcy2, _hcy3, _hcy4, _hcy5, _hcy6⟩
   simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable, Table.toRaw,
     ArithTableSpec, arithTableRow] using h_lookup
 
@@ -118,7 +119,8 @@ theorem chunk_ranges_of_arith_table_soundness
   rcases h_holds with
     ⟨_h6, _h7, _h8, _h31, _h32, _h33, _h34, _h35, _h36, _h37, _h38,
       _h46, _h_lookup, ha0, ha1, ha2, ha3, hb0, hb1, hb2, hb3,
-      hc0, hc1, hc2, hc3, hd0, hd1, hd2, hd3⟩
+      hc0, hc1, hc2, hc3, hd0, hd1, hd2, hd3,
+      _hcy0, _hcy1, _hcy2, _hcy3, _hcy4, _hcy5, _hcy6⟩
   exact ⟨by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
               Table.toRaw] using ha0,
          by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
@@ -475,8 +477,10 @@ theorem full_spec_of_carry_chain_and_arith_table
     (h_chain : ZiskFv.Airs.ArithMul.mul_carry_chain_holds v r)
     (h_table : ArithTableSpec (rowAt v r))
     (h_c46 : C46Spec (rowAt v r))
-    (h_chunk_ranges : ChunkRangeSpec (rowAt v r)) :
+    (h_chunk_ranges : ChunkRangeSpec (rowAt v r))
+    (h_carry_ranges : CarryRangeSpec (rowAt v r)) :
     FullSpec (rowAt v r) := by
-  exact ⟨spec_of_carry_chain_via_component v r h_chain, h_table, h_c46, h_chunk_ranges⟩
+  exact ⟨spec_of_carry_chain_via_component v r h_chain, h_table, h_c46, h_chunk_ranges,
+    h_carry_ranges⟩
 
 end ZiskFv.AirsClean.ArithMul

--- a/ZiskFv/AirsClean/ArithMul/Circuit.lean
+++ b/ZiskFv/AirsClean/ArithMul/Circuit.lean
@@ -273,8 +273,12 @@ def circuitWithArithTable : GeneralFormalCircuit FGL ArithMulRow unit :=
       circuit_proof_start
       refine ⟨?_, ?_⟩
       · obtain ⟨h_c6, h_c7, h_c8, h_c31, h_c32, h_c33, h_c34,
-                h_c35, h_c36, h_c37, h_c38, h_c46, h_lookup⟩ := h_holds
-        refine ⟨?_, ?_, ?_⟩
+                h_c35, h_c36, h_c37, h_c38, h_c46, h_lookup,
+                h_a0, h_a1, h_a2, h_a3,
+                h_b0, h_b1, h_b2, h_b3,
+                h_c0, h_c1, h_c2, h_c3,
+                h_d0, h_d1, h_d2, h_d3⟩ := h_holds
+        refine ⟨?_, ?_, ?_, ?_⟩
         · -- Carry-chain Spec (11 clauses).
           refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
           · linear_combination h_c6
@@ -299,6 +303,42 @@ def circuitWithArithTable : GeneralFormalCircuit FGL ArithMulRow unit :=
             h_signed, h_range_ab, h_range_cd] using h_lookup
         · -- C46Spec: bus_res1 mux equation (constraint 46, arith.pil:262).
           linear_combination h_c46
+        · -- ChunkRangeSpec: sixteen 16-bit chunk column range lookups.
+          obtain ⟨h_chunks, _, _⟩ := h_input
+          obtain ⟨h_ia0, h_ia1, h_ia2, h_ia3, h_ib0, h_ib1, h_ib2, h_ib3,
+                  h_ic0, h_ic1, h_ic2, h_ic3, h_id0, h_id1, h_id2, h_id3⟩ := h_chunks
+          exact ⟨by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, h_ia0] using h_a0,
+                 by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, h_ia1] using h_a1,
+                 by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, h_ia2] using h_a2,
+                 by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, h_ia3] using h_a3,
+                 by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, h_ib0] using h_b0,
+                 by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, h_ib1] using h_b1,
+                 by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, h_ib2] using h_b2,
+                 by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, h_ib3] using h_b3,
+                 by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, h_ic0] using h_c0,
+                 by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, h_ic1] using h_c1,
+                 by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, h_ic2] using h_c2,
+                 by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, h_ic3] using h_c3,
+                 by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, h_id0] using h_d0,
+                 by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, h_id1] using h_d1,
+                 by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, h_id2] using h_d2,
+                 by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, h_id3] using h_d3⟩
       · intro _
         trivial
     completeness := by

--- a/ZiskFv/AirsClean/ArithMul/Circuit.lean
+++ b/ZiskFv/AirsClean/ArithMul/Circuit.lean
@@ -39,6 +39,7 @@ open Goldilocks
 open ZiskFv.Channels.OperationBus (OpBusChannel)
 open Air.Flat
 open ZiskFv.Airs.ArithCarryChainCompleteness
+open ZiskFv.AirsClean.RangeTables (signedCarryRangeTable)
 
 /-- Columns not constrained by the unsigned carry-chain completeness slice. -/
 structure ArithMulFreeCols where
@@ -277,8 +278,9 @@ def circuitWithArithTable : GeneralFormalCircuit FGL ArithMulRow unit :=
                 h_a0, h_a1, h_a2, h_a3,
                 h_b0, h_b1, h_b2, h_b3,
                 h_c0, h_c1, h_c2, h_c3,
-                h_d0, h_d1, h_d2, h_d3⟩ := h_holds
-        refine ⟨?_, ?_, ?_, ?_⟩
+                h_d0, h_d1, h_d2, h_d3,
+                h_cy0, h_cy1, h_cy2, h_cy3, h_cy4, h_cy5, h_cy6⟩ := h_holds
+        refine ⟨?_, ?_, ?_, ?_, ?_⟩
         · -- Carry-chain Spec (11 clauses).
           refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
           · linear_combination h_c6
@@ -339,6 +341,24 @@ def circuitWithArithTable : GeneralFormalCircuit FGL ArithMulRow unit :=
                     Table.toRaw, h_id2] using h_d2,
                  by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
                     Table.toRaw, h_id3] using h_d3⟩
+        · -- CarryRangeSpec: seven signed-carry range lookups (arith.pil:17,280).
+          obtain ⟨_, _, h_carries⟩ := h_input
+          obtain ⟨h_icy0, h_icy1, h_icy2, h_icy3, h_icy4, h_icy5, h_icy6,
+                  _h_fab, _h_na_fb, _h_nb_fa⟩ := h_carries
+          exact ⟨by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, signedCarryRangeTable, h_icy0] using h_cy0,
+                 by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, signedCarryRangeTable, h_icy1] using h_cy1,
+                 by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, signedCarryRangeTable, h_icy2] using h_cy2,
+                 by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, signedCarryRangeTable, h_icy3] using h_cy3,
+                 by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, signedCarryRangeTable, h_icy4] using h_cy4,
+                 by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, signedCarryRangeTable, h_icy5] using h_cy5,
+                 by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
+                    Table.toRaw, signedCarryRangeTable, h_icy6] using h_cy6⟩
       · intro _
         trivial
     completeness := by

--- a/ZiskFv/AirsClean/ArithMul/Circuit.lean
+++ b/ZiskFv/AirsClean/ArithMul/Circuit.lean
@@ -273,9 +273,10 @@ def circuitWithArithTable : GeneralFormalCircuit FGL ArithMulRow unit :=
       circuit_proof_start
       refine ⟨?_, ?_⟩
       · obtain ⟨h_c6, h_c7, h_c8, h_c31, h_c32, h_c33, h_c34,
-                h_c35, h_c36, h_c37, h_c38, h_lookup⟩ := h_holds
-        refine ⟨?_, ?_⟩
-        · refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+                h_c35, h_c36, h_c37, h_c38, h_c46, h_lookup⟩ := h_holds
+        refine ⟨?_, ?_, ?_⟩
+        · -- Carry-chain Spec (11 clauses).
+          refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
           · linear_combination h_c6
           · linear_combination h_c7
           · linear_combination h_c8
@@ -287,7 +288,8 @@ def circuitWithArithTable : GeneralFormalCircuit FGL ArithMulRow unit :=
           · linear_combination h_c36
           · linear_combination h_c37
           · linear_combination h_c38
-        · obtain ⟨_, h_flags, _⟩ := h_input
+        · -- ArithTableSpec: from the ROM lookup.
+          obtain ⟨_, h_flags, _⟩ := h_input
           obtain ⟨h_na, h_nb, h_nr, h_np, h_sext, h_m32, h_div, h_div_by_zero,
             h_div_overflow, h_main_div, h_main_mul, h_signed, h_range_ab, h_range_cd,
             h_op, _h_bus_res1, _h_multiplicity⟩ := h_flags
@@ -295,6 +297,8 @@ def circuitWithArithTable : GeneralFormalCircuit FGL ArithMulRow unit :=
             StaticTable.toTable, Table.toRaw, h_op, h_m32, h_div, h_na, h_nb, h_np,
             h_nr, h_sext, h_div_by_zero, h_div_overflow, h_main_mul, h_main_div,
             h_signed, h_range_ab, h_range_cd] using h_lookup
+        · -- C46Spec: bus_res1 mux equation (constraint 46, arith.pil:262).
+          linear_combination h_c46
       · intro _
         trivial
     completeness := by

--- a/ZiskFv/AirsClean/ArithMul/Constraints.lean
+++ b/ZiskFv/AirsClean/ArithMul/Constraints.lean
@@ -192,6 +192,26 @@ def mainWithArithTable (row : Var ArithMulRow FGL) : Circuit FGL Unit := do
           + row.flags.main_div
               * (row.chunks.a_2 + row.chunks.a_3 * 65536))))
   lookup (Table.fromStatic ArithTable.arithTable) (arithTableRow row)
+  -- Sixteen `bits(16)` chunk column range lookups (`arith.pil:18-21`).
+  -- These are shared across signed and unsigned Arith rows, so they are
+  -- sound to include in the SHARED component: real arith rows always
+  -- have 16-bit a/b/c/d chunks.
+  lookup (Table.fromStatic rangeTable16) row.chunks.a_0
+  lookup (Table.fromStatic rangeTable16) row.chunks.a_1
+  lookup (Table.fromStatic rangeTable16) row.chunks.a_2
+  lookup (Table.fromStatic rangeTable16) row.chunks.a_3
+  lookup (Table.fromStatic rangeTable16) row.chunks.b_0
+  lookup (Table.fromStatic rangeTable16) row.chunks.b_1
+  lookup (Table.fromStatic rangeTable16) row.chunks.b_2
+  lookup (Table.fromStatic rangeTable16) row.chunks.b_3
+  lookup (Table.fromStatic rangeTable16) row.chunks.c_0
+  lookup (Table.fromStatic rangeTable16) row.chunks.c_1
+  lookup (Table.fromStatic rangeTable16) row.chunks.c_2
+  lookup (Table.fromStatic rangeTable16) row.chunks.c_3
+  lookup (Table.fromStatic rangeTable16) row.chunks.d_0
+  lookup (Table.fromStatic rangeTable16) row.chunks.d_1
+  lookup (Table.fromStatic rangeTable16) row.chunks.d_2
+  lookup (Table.fromStatic rangeTable16) row.chunks.d_3
 
 /-- Lookup-aware ArithMul path for the sixteen `bits(16)` chunk columns.
     This models the column-level PIL declarations at `arith.pil:18-21`.

--- a/ZiskFv/AirsClean/ArithMul/Constraints.lean
+++ b/ZiskFv/AirsClean/ArithMul/Constraints.lean
@@ -39,16 +39,35 @@ open Circuit (assertZero lookup)
 open ZiskFv.AirsClean.RangeTables
 open ZiskFv.Channels.OperationBus (OpBusChannel OpBusMessage)
 
-/-- Primary MUL/MULW op-bus message: low result in the `c[]` chunks. -/
+/-- ArithMul op-bus message — FAITHFUL to the real PIL `bus_emission_Arith_0`
+    (`arith.pil:247-258`, extracted verbatim in
+    `build/extraction/Extraction/Buses.lean`).  The `a_lo` / `a_hi` / `c_lo`
+    lanes are the real MUXED lanes covering every arith mode (mul-low /
+    mul-high / div / rem) via `div` / `main_mul` / `main_div`:
+
+    * `a_lo` (bus_a0)  = `div·(c_0+c_1·2^16) + (1-div)·(a_0+a_1·2^16)`
+    * `a_hi` (bus_a1)  = `div·(c_2+c_3·2^16) + (1-div)·(a_2+a_3·2^16)`
+    * `c_lo` (bus_res0)= `(1-main_mul-main_div)·(d_0+d_1·2^16)
+                         + main_mul·(c_0+c_1·2^16) + main_div·(a_0+a_1·2^16)`
+
+    `b_lo` / `b_hi` / `c_hi` (= bus_res1) are unchanged.  Under the MUL/MULW
+    mode pins (`div=0`, `main_mul=1`, `main_div=0`) these muxes reduce to the
+    plain `a`/`c`-chunk lanes (the previous hand-specialization); the per-mode
+    reduction is the bridge in `Bridge.lean`. -/
 @[reducible]
 def primaryOpBusMessageExpr (row : Var ArithMulRow FGL) :
     OpBusMessage (Expression FGL) :=
   { op := row.flags.op
-    a_lo := row.chunks.a_0 + row.chunks.a_1 * 65536
-    a_hi := row.chunks.a_2 + row.chunks.a_3 * 65536
+    a_lo := row.flags.div * (row.chunks.c_0 + row.chunks.c_1 * 65536)
+      + (1 - row.flags.div) * (row.chunks.a_0 + row.chunks.a_1 * 65536)
+    a_hi := row.flags.div * (row.chunks.c_2 + row.chunks.c_3 * 65536)
+      + (1 - row.flags.div) * (row.chunks.a_2 + row.chunks.a_3 * 65536)
     b_lo := row.chunks.b_0 + row.chunks.b_1 * 65536
     b_hi := row.chunks.b_2 + row.chunks.b_3 * 65536
-    c_lo := row.chunks.c_0 + row.chunks.c_1 * 65536
+    c_lo := (1 - row.flags.main_mul - row.flags.main_div)
+        * (row.chunks.d_0 + row.chunks.d_1 * 65536)
+      + row.flags.main_mul * (row.chunks.c_0 + row.chunks.c_1 * 65536)
+      + row.flags.main_div * (row.chunks.a_0 + row.chunks.a_1 * 65536)
     c_hi := row.flags.bus_res1
     flag := 0
     main_step := 0

--- a/ZiskFv/AirsClean/ArithMul/Constraints.lean
+++ b/ZiskFv/AirsClean/ArithMul/Constraints.lean
@@ -171,12 +171,26 @@ def main (row : Var ArithMulRow FGL) : Circuit FGL Unit := do
 
 
 /-- Lookup-aware ArithMul circuit path. This appends the full 15-column
-    `arith_table_assumes` ROM lookup after the existing carry-chain/op-bus
+    `arith_table_assumes` ROM lookup and the `bus_res1` mux constraint
+    (constraint 46, `arith.pil:262`) after the existing carry-chain/op-bus
     component body. The current load-bearing carry-chain component remains
     unchanged until Compliance supplies this lookup evidence globally. -/
 @[circuit_norm]
 def mainWithArithTable (row : Var ArithMulRow FGL) : Circuit FGL Unit := do
   main row
+  -- Constraint 46 (`arith.pil:262`): bus_res1 − (sext·4294967295 +
+  --   (1 − m32)·((1 − main_mul − main_div)·(d_2 + d_3·65536)
+  --              + main_mul·(c_2 + c_3·65536)
+  --              + main_div·(a_2 + a_3·65536))) = 0.
+  -- Mirror of `constraint_46_every_row` in `Extraction/Arith.lean:165`.
+  assertZero (row.flags.bus_res1
+    - (row.flags.sext * 4294967295
+      + (1 - row.flags.m32) * (
+          (1 - row.flags.main_mul - row.flags.main_div)
+              * (row.chunks.d_2 + row.chunks.d_3 * 65536)
+          + row.flags.main_mul * (row.chunks.c_2 + row.chunks.c_3 * 65536)
+          + row.flags.main_div
+              * (row.chunks.a_2 + row.chunks.a_3 * 65536))))
   lookup (Table.fromStatic ArithTable.arithTable) (arithTableRow row)
 
 /-- Lookup-aware ArithMul path for the sixteen `bits(16)` chunk columns.

--- a/ZiskFv/AirsClean/ArithMul/Constraints.lean
+++ b/ZiskFv/AirsClean/ArithMul/Constraints.lean
@@ -212,6 +212,20 @@ def mainWithArithTable (row : Var ArithMulRow FGL) : Circuit FGL Unit := do
   lookup (Table.fromStatic rangeTable16) row.chunks.d_1
   lookup (Table.fromStatic rangeTable16) row.chunks.d_2
   lookup (Table.fromStatic rangeTable16) row.chunks.d_3
+  -- Seven `ARITH_RANGE_CARRY` signed-carry range lookups (`arith.pil:17,280`).
+  -- `carry[]` is declared as `bits(64, signed)` and range-checked with the
+  -- single ARITH_RANGE_CARRY type = the signed-carry range. The
+  -- `signedCarryRangeTable.Spec t = (t.val < 983041 ∨ GL_prime − 983040 ≤ t.val)`
+  -- holds for EVERY Arith row: unsigned carries are < 2^17 < 983041 (first
+  -- disjunct) and signed carries satisfy the disjunction by construction.
+  -- Sound to include in the SHARED component — no vacuity.
+  lookup (Table.fromStatic signedCarryRangeTable) row.carries.carry_0
+  lookup (Table.fromStatic signedCarryRangeTable) row.carries.carry_1
+  lookup (Table.fromStatic signedCarryRangeTable) row.carries.carry_2
+  lookup (Table.fromStatic signedCarryRangeTable) row.carries.carry_3
+  lookup (Table.fromStatic signedCarryRangeTable) row.carries.carry_4
+  lookup (Table.fromStatic signedCarryRangeTable) row.carries.carry_5
+  lookup (Table.fromStatic signedCarryRangeTable) row.carries.carry_6
 
 /-- Lookup-aware ArithMul path for the sixteen `bits(16)` chunk columns.
     This models the column-level PIL declarations at `arith.pil:18-21`.

--- a/ZiskFv/AirsClean/ArithMul/Spec.lean
+++ b/ZiskFv/AirsClean/ArithMul/Spec.lean
@@ -150,11 +150,33 @@ def Spec (row : ArithMulRow FGL) : Prop :=
 def ArithTableSpec (row : ArithMulRow FGL) : Prop :=
   ArithTable.arithTable.Spec (arithTableRow row)
 
-/-- Full ArithMul row contract once the ArithTable lookup is plumbed into
-    Compliance: carry-chain algebra plus ROM membership for the full
-    `arith_table_assumes` tuple. -/
+/-- Constraint 46 (`arith.pil:262`): the `bus_res1` output mux.
+    Pins `bus_res1` to its mode-specialised value — sign-extension path
+    (`sext * 4294967295`) or the appropriate high-chunk pair depending
+    on `m32`, `main_mul`, and `main_div`.
+
+    This is a verbatim algebraic mirror of `constraint_46_every_row` in
+    `build/extraction/Extraction/Arith.lean:165`.  Constructibility:
+    real Arith rows satisfy this because `arith_full.rs` computes
+    `bus_res1` as exactly this mux (PIL `arith.pil:262`).  No axiom is
+    introduced — the constraint is discharged by the `assertZero` in
+    `mainWithArithTable`. -/
+@[reducible]
+def C46Spec (row : ArithMulRow FGL) : Prop :=
+  row.flags.bus_res1
+    - (row.flags.sext * 4294967295
+      + (1 - row.flags.m32) * (
+          (1 - row.flags.main_mul - row.flags.main_div)
+              * (row.chunks.d_2 + row.chunks.d_3 * 65536)
+          + row.flags.main_mul * (row.chunks.c_2 + row.chunks.c_3 * 65536)
+          + row.flags.main_div
+              * (row.chunks.a_2 + row.chunks.a_3 * 65536))) = 0
+
+/-- Full ArithMul row contract once the ArithTable lookup and the
+    `bus_res1` mux constraint (c46) are plumbed into Compliance:
+    carry-chain algebra + ROM membership + `bus_res1` pinning. -/
 @[reducible]
 def FullSpec (row : ArithMulRow FGL) : Prop :=
-  Spec row ∧ ArithTableSpec row
+  Spec row ∧ ArithTableSpec row ∧ C46Spec row
 
 end ZiskFv.AirsClean.ArithMul

--- a/ZiskFv/AirsClean/ArithMul/Spec.lean
+++ b/ZiskFv/AirsClean/ArithMul/Spec.lean
@@ -188,12 +188,33 @@ def ChunkRangeSpec (row : ArithMulRow FGL) : Prop :=
   ∧ (row.chunks.d_0).val < 2 ^ 16 ∧ (row.chunks.d_1).val < 2 ^ 16
   ∧ (row.chunks.d_2).val < 2 ^ 16 ∧ (row.chunks.d_3).val < 2 ^ 16
 
+/-- The seven signed-carry range constraints (`arith.pil:17, 280`):
+    each of the seven carry witnesses lies in the `ARITH_RANGE_CARRY`
+    range — `(val < 983041 ∨ GL_prime − 983040 ≤ val)`.  This holds for
+    every Arith row: unsigned carries are < 2^17 < 983041 (first
+    disjunct) and signed carries satisfy the disjunction by construction.
+    Constructibility: real ZisK Arith rows satisfy this because ZisK's
+    prover sets each `carry_i` as a field element in the signed-carry
+    range by PIL `arith.pil:280`.  No axiom is introduced — the constraint
+    is discharged by the `signedCarryRangeTable` lookups in
+    `mainWithArithTable`. -/
+@[reducible]
+def CarryRangeSpec (row : ArithMulRow FGL) : Prop :=
+  ((row.carries.carry_0).val < 983041 ∨ GL_prime - 983040 ≤ (row.carries.carry_0).val)
+  ∧ ((row.carries.carry_1).val < 983041 ∨ GL_prime - 983040 ≤ (row.carries.carry_1).val)
+  ∧ ((row.carries.carry_2).val < 983041 ∨ GL_prime - 983040 ≤ (row.carries.carry_2).val)
+  ∧ ((row.carries.carry_3).val < 983041 ∨ GL_prime - 983040 ≤ (row.carries.carry_3).val)
+  ∧ ((row.carries.carry_4).val < 983041 ∨ GL_prime - 983040 ≤ (row.carries.carry_4).val)
+  ∧ ((row.carries.carry_5).val < 983041 ∨ GL_prime - 983040 ≤ (row.carries.carry_5).val)
+  ∧ ((row.carries.carry_6).val < 983041 ∨ GL_prime - 983040 ≤ (row.carries.carry_6).val)
+
 /-- Full ArithMul row contract once the ArithTable lookup, the
-    `bus_res1` mux constraint (c46), and the sixteen 16-bit chunk range
-    lookups are plumbed into Compliance: carry-chain algebra + ROM
-    membership + `bus_res1` pinning + 16-bit chunk bounds. -/
+    `bus_res1` mux constraint (c46), the sixteen 16-bit chunk range
+    lookups, and the seven signed-carry range lookups are plumbed into
+    Compliance: carry-chain algebra + ROM membership + `bus_res1`
+    pinning + 16-bit chunk bounds + signed-carry bounds. -/
 @[reducible]
 def FullSpec (row : ArithMulRow FGL) : Prop :=
-  Spec row ∧ ArithTableSpec row ∧ C46Spec row ∧ ChunkRangeSpec row
+  Spec row ∧ ArithTableSpec row ∧ C46Spec row ∧ ChunkRangeSpec row ∧ CarryRangeSpec row
 
 end ZiskFv.AirsClean.ArithMul

--- a/ZiskFv/AirsClean/ArithMul/Spec.lean
+++ b/ZiskFv/AirsClean/ArithMul/Spec.lean
@@ -172,11 +172,28 @@ def C46Spec (row : ArithMulRow FGL) : Prop :=
           + row.flags.main_div
               * (row.chunks.a_2 + row.chunks.a_3 * 65536))) = 0
 
-/-- Full ArithMul row contract once the ArithTable lookup and the
-    `bus_res1` mux constraint (c46) are plumbed into Compliance:
-    carry-chain algebra + ROM membership + `bus_res1` pinning. -/
+/-- The sixteen 16-bit chunk column range constraints (`arith.pil:18-21`):
+    each of the a/b/c/d chunks is a 16-bit value.  These hold for every
+    Arith row (signed or unsigned), so they are part of the shared
+    component's contract.  Constructibility: real ZisK Arith rows have
+    16-bit chunks by construction in `arith_full.rs`. -/
+@[reducible]
+def ChunkRangeSpec (row : ArithMulRow FGL) : Prop :=
+  (row.chunks.a_0).val < 2 ^ 16 ∧ (row.chunks.a_1).val < 2 ^ 16
+  ∧ (row.chunks.a_2).val < 2 ^ 16 ∧ (row.chunks.a_3).val < 2 ^ 16
+  ∧ (row.chunks.b_0).val < 2 ^ 16 ∧ (row.chunks.b_1).val < 2 ^ 16
+  ∧ (row.chunks.b_2).val < 2 ^ 16 ∧ (row.chunks.b_3).val < 2 ^ 16
+  ∧ (row.chunks.c_0).val < 2 ^ 16 ∧ (row.chunks.c_1).val < 2 ^ 16
+  ∧ (row.chunks.c_2).val < 2 ^ 16 ∧ (row.chunks.c_3).val < 2 ^ 16
+  ∧ (row.chunks.d_0).val < 2 ^ 16 ∧ (row.chunks.d_1).val < 2 ^ 16
+  ∧ (row.chunks.d_2).val < 2 ^ 16 ∧ (row.chunks.d_3).val < 2 ^ 16
+
+/-- Full ArithMul row contract once the ArithTable lookup, the
+    `bus_res1` mux constraint (c46), and the sixteen 16-bit chunk range
+    lookups are plumbed into Compliance: carry-chain algebra + ROM
+    membership + `bus_res1` pinning + 16-bit chunk bounds. -/
 @[reducible]
 def FullSpec (row : ArithMulRow FGL) : Prop :=
-  Spec row ∧ ArithTableSpec row ∧ C46Spec row
+  Spec row ∧ ArithTableSpec row ∧ C46Spec row ∧ ChunkRangeSpec row
 
 end ZiskFv.AirsClean.ArithMul

--- a/ZiskFv/AirsClean/ArithTableProjections.lean
+++ b/ZiskFv/AirsClean/ArithTableProjections.lean
@@ -173,6 +173,35 @@ theorem divu_mode_pins_of_row
       have hval := congrArg Fin.val hop
       norm_num at hval
 
+/-- Bare-`ArithMulRow` REMU secondary mode pins (mirrors `divu_mode_pins_of_row`
+    but for `OP_REMU = 185`).  Reads the full unsigned-REMU mode flags off the
+    balance-selected provider `ArithMulRow` (the REMU provider is the SHARED
+    ArithMul component) WITHOUT routing through a `rowAt` view.  At op `185`
+    (`OP_REMU`) the shared 74-row ArithTable pins
+    `na = nb = np = nr = sext = m32 = 0`, `div = 1`, `main_div = 0`,
+    `main_mul = 0` (REMU consumes the **secondary** lane — the remainder in
+    `d[]` — so `main_div = 0`, unlike DIVU's `main_div = 1`). -/
+theorem remu_mode_pins_of_row
+    (row : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL)
+    (h_table : ZiskFv.AirsClean.ArithMul.ArithTableSpec row)
+    (h_op : row.flags.op = 185) :
+    row.flags.na = 0 ∧ row.flags.nb = 0 ∧ row.flags.np = 0 ∧ row.flags.nr = 0
+      ∧ row.flags.sext = 0 ∧ row.flags.m32 = 0 ∧ row.flags.div = 1
+      ∧ row.flags.main_div = 0 ∧ row.flags.main_mul = 0 := by
+  rcases h_table with ⟨i, hrow⟩
+  fin_cases i <;>
+    simp [ZiskFv.AirsClean.ArithMul.arithTableRow,
+      ZiskFv.AirsClean.ArithTable.rows] at hrow h_op ⊢
+  all_goals
+    rcases hrow with ⟨hop, hm32, hdiv, hna, hnb, hnp, hnr, hsext,
+      _hdiv_by_zero, _hdiv_overflow, hmain_mul, hmain_div, _hsigned, _hrange_ab,
+      _hrange_cd⟩
+    first
+    | exact ⟨hna, hnb, hnp, hnr, hsext, hm32, hdiv, hmain_div, hmain_mul⟩
+    | rw [h_op] at hop
+      have hval := congrArg Fin.val hop
+      norm_num at hval
+
 /-- Bare-`ArithMulRow` DIVUW (W-mode) mode pins (mirrors `divu_mode_pins_of_row`
     but for `OP_DIVU_W = 188`, `m32 = 1`).  Reads the unsigned-DIVUW mode flags
     off the balance-selected provider `ArithMulRow` (the DIVUW provider is the

--- a/ZiskFv/AirsClean/ArithTableProjections.lean
+++ b/ZiskFv/AirsClean/ArithTableProjections.lean
@@ -232,6 +232,38 @@ theorem divuw_mode_pins_of_row
       have hval := congrArg Fin.val hop
       norm_num at hval
 
+/-- Bare-`ArithMulRow` REMUW (W-mode secondary) mode pins (mirrors
+    `remu_mode_pins_of_row` but for `OP_REMU_W = 189`, `m32 = 1`).  Reads the
+    unsigned-REMUW mode flags off the balance-selected provider `ArithMulRow`
+    (the REMUW provider is the SHARED ArithMul component) WITHOUT routing through
+    a `rowAt` view.  At op `189` all four shared 74-row ArithTable rows pin
+    `na = nb = np = nr = 0`, `m32 = 1`, `div = 1`, `main_div = 0`,
+    `main_mul = 0` (REMUW consumes the **secondary** lane — the remainder in
+    `d[]` — so `main_div = 0`, unlike DIVUW's `main_div = 1`; and `m32 = 1` for
+    the W width, unlike REMU's `m32 = 0`).  Note `sext` is NOT uniform across the
+    op-189 rows (the W-mode sign-extension lives in the `h_sext_choice` bus
+    residual), so it is intentionally omitted. -/
+theorem remuw_mode_pins_of_row
+    (row : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL)
+    (h_table : ZiskFv.AirsClean.ArithMul.ArithTableSpec row)
+    (h_op : row.flags.op = 189) :
+    row.flags.na = 0 ∧ row.flags.nb = 0 ∧ row.flags.np = 0 ∧ row.flags.nr = 0
+      ∧ row.flags.m32 = 1 ∧ row.flags.div = 1
+      ∧ row.flags.main_div = 0 ∧ row.flags.main_mul = 0 := by
+  rcases h_table with ⟨i, hrow⟩
+  fin_cases i <;>
+    simp [ZiskFv.AirsClean.ArithMul.arithTableRow,
+      ZiskFv.AirsClean.ArithTable.rows] at hrow h_op ⊢
+  all_goals
+    rcases hrow with ⟨hop, hm32, hdiv, hna, hnb, hnp, hnr, _hsext,
+      _hdiv_by_zero, _hdiv_overflow, hmain_mul, hmain_div, _hsigned, _hrange_ab,
+      _hrange_cd⟩
+    first
+    | exact ⟨hna, hnb, hnp, hnr, hm32, hdiv, hmain_div, hmain_mul⟩
+    | rw [h_op] at hop
+      have hval := congrArg Fin.val hop
+      norm_num at hval
+
 theorem mul_main_selector_pin
     (v : ZiskFv.Airs.ArithMul.Valid_ArithMul FGL FGL) (r : ℕ)
     (h_table : ZiskFv.AirsClean.ArithMul.ArithTableSpec

--- a/ZiskFv/AirsClean/ArithTableProjections.lean
+++ b/ZiskFv/AirsClean/ArithTableProjections.lean
@@ -173,6 +173,36 @@ theorem divu_mode_pins_of_row
       have hval := congrArg Fin.val hop
       norm_num at hval
 
+/-- Bare-`ArithMulRow` DIVUW (W-mode) mode pins (mirrors `divu_mode_pins_of_row`
+    but for `OP_DIVU_W = 188`, `m32 = 1`).  Reads the unsigned-DIVUW mode flags
+    off the balance-selected provider `ArithMulRow` (the DIVUW provider is the
+    SHARED ArithMul component) WITHOUT routing through a `rowAt` view.  At op
+    `188` all three shared 74-row ArithTable rows pin
+    `na = nb = np = nr = 0`, `m32 = 1`, `div = 1`, `main_div = 1`,
+    `main_mul = 0`.  Note `sext` is NOT uniform across the op-188 rows
+    (the W-mode sign-extension lives in the `bus_res1` encoding / the
+    `h_sext_choice` bus residual), so it is intentionally omitted. -/
+theorem divuw_mode_pins_of_row
+    (row : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL)
+    (h_table : ZiskFv.AirsClean.ArithMul.ArithTableSpec row)
+    (h_op : row.flags.op = 188) :
+    row.flags.na = 0 ∧ row.flags.nb = 0 ∧ row.flags.np = 0 ∧ row.flags.nr = 0
+      ∧ row.flags.m32 = 1 ∧ row.flags.div = 1
+      ∧ row.flags.main_div = 1 ∧ row.flags.main_mul = 0 := by
+  rcases h_table with ⟨i, hrow⟩
+  fin_cases i <;>
+    simp [ZiskFv.AirsClean.ArithMul.arithTableRow,
+      ZiskFv.AirsClean.ArithTable.rows] at hrow h_op ⊢
+  all_goals
+    rcases hrow with ⟨hop, hm32, hdiv, hna, hnb, hnp, hnr, _hsext,
+      _hdiv_by_zero, _hdiv_overflow, hmain_mul, hmain_div, _hsigned, _hrange_ab,
+      _hrange_cd⟩
+    first
+    | exact ⟨hna, hnb, hnp, hnr, hm32, hdiv, hmain_div, hmain_mul⟩
+    | rw [h_op] at hop
+      have hval := congrArg Fin.val hop
+      norm_num at hval
+
 theorem mul_main_selector_pin
     (v : ZiskFv.Airs.ArithMul.Valid_ArithMul FGL FGL) (r : ℕ)
     (h_table : ZiskFv.AirsClean.ArithMul.ArithTableSpec

--- a/ZiskFv/AirsClean/ArithTableProjections.lean
+++ b/ZiskFv/AirsClean/ArithTableProjections.lean
@@ -121,6 +121,31 @@ theorem mulw_mode_pins_of_row
       have hval := congrArg Fin.val hop
       norm_num at hval
 
+/-- Bare-`ArithMulRow` MULHU secondary mode pins (mirrors `mulw_mode_pins_of_row`
+    — a bare row + `ArithTableSpec`, no `Valid_ArithMul`/`rowAt` wrapper).  Lets
+    the P4 MULHU construction read the secondary mode flags off the
+    balance-selected provider `ArithMulRow` WITHOUT routing through a `rowAt`
+    view (whose per-field closures force a costly whnf of the heavy
+    `Classical.choose` provider row). -/
+theorem mulhu_mode_pins_of_row
+    (row : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL)
+    (h_table : ZiskFv.AirsClean.ArithMul.ArithTableSpec row)
+    (h_op : row.flags.op = 177) :
+    row.flags.div = 0 ∧ row.flags.main_mul = 0 ∧ row.flags.main_div = 0 := by
+  rcases h_table with ⟨i, hrow⟩
+  fin_cases i <;>
+    simp [ZiskFv.AirsClean.ArithMul.arithTableRow,
+      ZiskFv.AirsClean.ArithTable.rows] at hrow h_op ⊢
+  all_goals
+    rcases hrow with ⟨hop, _hm32, hdiv, _hna, _hnb, _hnp, _hnr, _hsext,
+      _hdiv_by_zero, _hdiv_overflow, hmain_mul, hmain_div, _hsigned, _hrange_ab,
+      _hrange_cd⟩
+    first
+    | exact ⟨hdiv, hmain_mul, hmain_div⟩
+    | rw [h_op] at hop
+      have hval := congrArg Fin.val hop
+      norm_num at hval
+
 theorem mul_main_selector_pin
     (v : ZiskFv.Airs.ArithMul.Valid_ArithMul FGL FGL) (r : ℕ)
     (h_table : ZiskFv.AirsClean.ArithMul.ArithTableSpec

--- a/ZiskFv/AirsClean/ArithTableProjections.lean
+++ b/ZiskFv/AirsClean/ArithTableProjections.lean
@@ -146,6 +146,33 @@ theorem mulhu_mode_pins_of_row
       have hval := congrArg Fin.val hop
       norm_num at hval
 
+/-- Bare-`ArithMulRow` DIVU mode pins (mirrors `mulw_mode_pins_of_row`).  Reads
+    the full unsigned-DIVU mode flags off the balance-selected provider
+    `ArithMulRow` (the DIVU provider is the SHARED ArithMul component) WITHOUT
+    routing through a `rowAt` view.  At op `184` (`OP_DIVU`) the shared
+    74-row ArithTable pins `na = nb = np = nr = sext = m32 = 0`, `div = 1`,
+    `main_div = 1`, `main_mul = 0`. -/
+theorem divu_mode_pins_of_row
+    (row : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL)
+    (h_table : ZiskFv.AirsClean.ArithMul.ArithTableSpec row)
+    (h_op : row.flags.op = 184) :
+    row.flags.na = 0 ∧ row.flags.nb = 0 ∧ row.flags.np = 0 ∧ row.flags.nr = 0
+      ∧ row.flags.sext = 0 ∧ row.flags.m32 = 0 ∧ row.flags.div = 1
+      ∧ row.flags.main_div = 1 ∧ row.flags.main_mul = 0 := by
+  rcases h_table with ⟨i, hrow⟩
+  fin_cases i <;>
+    simp [ZiskFv.AirsClean.ArithMul.arithTableRow,
+      ZiskFv.AirsClean.ArithTable.rows] at hrow h_op ⊢
+  all_goals
+    rcases hrow with ⟨hop, hm32, hdiv, hna, hnb, hnp, hnr, hsext,
+      _hdiv_by_zero, _hdiv_overflow, hmain_mul, hmain_div, _hsigned, _hrange_ab,
+      _hrange_cd⟩
+    first
+    | exact ⟨hna, hnb, hnp, hnr, hsext, hm32, hdiv, hmain_div, hmain_mul⟩
+    | rw [h_op] at hop
+      have hval := congrArg Fin.val hop
+      norm_num at hval
+
 theorem mul_main_selector_pin
     (v : ZiskFv.Airs.ArithMul.Valid_ArithMul FGL FGL) (r : ℕ)
     (h_table : ZiskFv.AirsClean.ArithMul.ArithTableSpec

--- a/ZiskFv/AirsClean/ArithTableProjections.lean
+++ b/ZiskFv/AirsClean/ArithTableProjections.lean
@@ -97,6 +97,30 @@ theorem op_val_ge_176
     rw [hop]
     norm_num
 
+/-- Bare-`ArithMulRow` MULW mode pins (mirrors `op_val_ge_176`'s shape — a bare
+    row + `ArithTableSpec`, no `Valid_ArithMul`/`rowAt` wrapper).  This lets the
+    P4 MULW construction read the mode flags off the balance-selected provider
+    `ArithMulRow` WITHOUT routing through `vOfMulwRow`, whose per-field closures
+    force a costly whnf of the heavy `Classical.choose` provider row. -/
+theorem mulw_mode_pins_of_row
+    (row : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL)
+    (h_table : ZiskFv.AirsClean.ArithMul.ArithTableSpec row)
+    (h_op : row.flags.op = 182) :
+    row.flags.div = 0 ∧ row.flags.main_mul = 1 ∧ row.flags.main_div = 0 := by
+  rcases h_table with ⟨i, hrow⟩
+  fin_cases i <;>
+    simp [ZiskFv.AirsClean.ArithMul.arithTableRow,
+      ZiskFv.AirsClean.ArithTable.rows] at hrow h_op ⊢
+  all_goals
+    rcases hrow with ⟨hop, _hm32, hdiv, _hna, _hnb, _hnp, _hnr, _hsext,
+      _hdiv_by_zero, _hdiv_overflow, hmain_mul, hmain_div, _hsigned, _hrange_ab,
+      _hrange_cd⟩
+    first
+    | exact ⟨hdiv, hmain_mul, hmain_div⟩
+    | rw [h_op] at hop
+      have hval := congrArg Fin.val hop
+      norm_num at hval
+
 theorem mul_main_selector_pin
     (v : ZiskFv.Airs.ArithMul.Valid_ArithMul FGL FGL) (r : ℕ)
     (h_table : ZiskFv.AirsClean.ArithMul.ArithTableSpec

--- a/ZiskFv/AirsClean/Binary/Bridge.lean
+++ b/ZiskFv/AirsClean/Binary/Bridge.lean
@@ -750,6 +750,44 @@ theorem static_table_op_val_ne_arith_divu_of_emit
     exact h_ne.2 hoffset
 
 /-- A row accepted by the static Binary lookup component cannot emit the
+    Arith REMU operation-bus opcode `185` (`OP_REMU`). The emitted value is
+    `b_op + 16 * mode32`; with `mode32 ∈ {0, 1}` that forces `b_op = 185`
+    (excluded by the BinaryTable membership) or `b_op = 169` (also excluded),
+    so the static Binary provider can never be the REMU provider. -/
+theorem static_table_op_val_ne_arith_remu_of_emit
+    (row : BinaryRow FGL)
+    (h_spec : Spec row)
+    (h_static : StaticBinaryTableSpecFacts row)
+    (h_emit : row.chain.b_op + 16 * row.mode.mode32 = ((185 : ℕ) : FGL)) :
+    False := by
+  rcases h_spec with ⟨h_mode32, _, _, _, _, _, _⟩
+  rcases h_static with ⟨h0, _, _, _, _, _, _, _⟩
+  have h_ne_raw :=
+    ZiskFv.AirsClean.BinaryTable.spec_op_val_ne_arith_remu h0
+  have h_ne :
+      row.chain.b_op.val ≠ 185 ∧ row.chain.b_op.val ≠ 169 := by
+    simpa [lookupMessage0Row] using h_ne_raw
+  have h_mode : row.mode.mode32 = 0 ∨ row.mode.mode32 = 1 := by
+    rcases mul_eq_zero.mp h_mode32 with h_zero | h_one_sub
+    · exact Or.inl h_zero
+    · exact Or.inr ((sub_eq_zero.mp h_one_sub).symm)
+  rcases h_mode with h_zero | h_one
+  · have h_bop : row.chain.b_op = ((185 : ℕ) : FGL) := by
+      simpa [h_zero] using h_emit
+    have h_val := congrArg Fin.val h_bop
+    rw [Fin.val_natCast, Nat.mod_eq_of_lt (by omega : (185 : ℕ) < GL_prime)] at h_val
+    exact h_ne.1 h_val
+  · have hoffset : row.chain.b_op.val = 169 := by
+      have h_bop_lt : row.chain.b_op.val < 514 := by
+        have h := ZiskFv.AirsClean.BinaryTable.spec_op_val_lt_514 h0
+        simpa [lookupMessage0Row] using h
+      have hv := congrArg Fin.val h_emit
+      rw [h_one, Fin.val_add, Fin.val_mul, Fin.val_natCast,
+        Nat.mod_eq_of_lt (by omega : (185 : ℕ) < GL_prime)] at hv
+      omega
+    exact h_ne.2 hoffset
+
+/-- A row accepted by the static Binary lookup component cannot emit the
     Arith DIVUW operation-bus opcode `188` (`OP_DIVU_W`). The emitted value is
     `b_op + 16 * mode32`; with `mode32 ∈ {0, 1}` that forces `b_op = 188`
     (excluded by the BinaryTable membership) or `b_op = 172` (also excluded),

--- a/ZiskFv/AirsClean/Binary/Bridge.lean
+++ b/ZiskFv/AirsClean/Binary/Bridge.lean
@@ -825,6 +825,44 @@ theorem static_table_op_val_ne_arith_divuw_of_emit
       omega
     exact h_ne.2 hoffset
 
+/-- A row accepted by the static Binary lookup component cannot emit the
+    Arith REMUW operation-bus opcode `189` (`OP_REMU_W`). The emitted value is
+    `b_op + 16 * mode32`; with `mode32 ∈ {0, 1}` that forces `b_op = 189`
+    (excluded by the BinaryTable membership) or `b_op = 173` (also excluded),
+    so the static Binary provider can never be the REMUW provider. -/
+theorem static_table_op_val_ne_arith_remuw_of_emit
+    (row : BinaryRow FGL)
+    (h_spec : Spec row)
+    (h_static : StaticBinaryTableSpecFacts row)
+    (h_emit : row.chain.b_op + 16 * row.mode.mode32 = ((189 : ℕ) : FGL)) :
+    False := by
+  rcases h_spec with ⟨h_mode32, _, _, _, _, _, _⟩
+  rcases h_static with ⟨h0, _, _, _, _, _, _, _⟩
+  have h_ne_raw :=
+    ZiskFv.AirsClean.BinaryTable.spec_op_val_ne_arith_remuw h0
+  have h_ne :
+      row.chain.b_op.val ≠ 189 ∧ row.chain.b_op.val ≠ 173 := by
+    simpa [lookupMessage0Row] using h_ne_raw
+  have h_mode : row.mode.mode32 = 0 ∨ row.mode.mode32 = 1 := by
+    rcases mul_eq_zero.mp h_mode32 with h_zero | h_one_sub
+    · exact Or.inl h_zero
+    · exact Or.inr ((sub_eq_zero.mp h_one_sub).symm)
+  rcases h_mode with h_zero | h_one
+  · have h_bop : row.chain.b_op = ((189 : ℕ) : FGL) := by
+      simpa [h_zero] using h_emit
+    have h_val := congrArg Fin.val h_bop
+    rw [Fin.val_natCast, Nat.mod_eq_of_lt (by omega : (189 : ℕ) < GL_prime)] at h_val
+    exact h_ne.1 h_val
+  · have hoffset : row.chain.b_op.val = 173 := by
+      have h_bop_lt : row.chain.b_op.val < 514 := by
+        have h := ZiskFv.AirsClean.BinaryTable.spec_op_val_lt_514 h0
+        simpa [lookupMessage0Row] using h
+      have hv := congrArg Fin.val h_emit
+      rw [h_one, Fin.val_add, Fin.val_mul, Fin.val_natCast,
+        Nat.mod_eq_of_lt (by omega : (189 : ℕ) < GL_prime)] at hv
+      omega
+    exact h_ne.2 hoffset
+
 /-- Shared C7 witness surface for Binary's static-table lookup path.
     This is intentionally family-level and row-indexed; it is the shape a
     terminal Binary-family ensemble can provide once the static provider is

--- a/ZiskFv/AirsClean/Binary/Bridge.lean
+++ b/ZiskFv/AirsClean/Binary/Bridge.lean
@@ -711,6 +711,44 @@ theorem static_table_op_val_ne_arith_mul_uh_of_emit
       omega
     exact h_ne.2 hoffset
 
+/-- A row accepted by the static Binary lookup component cannot emit the
+    Arith DIVU operation-bus opcode `184` (`OP_DIVU`). The emitted value is
+    `b_op + 16 * mode32`; with `mode32 ∈ {0, 1}` that forces `b_op = 184`
+    (excluded by the BinaryTable membership) or `b_op = 168` (also excluded),
+    so the static Binary provider can never be the DIVU provider. -/
+theorem static_table_op_val_ne_arith_divu_of_emit
+    (row : BinaryRow FGL)
+    (h_spec : Spec row)
+    (h_static : StaticBinaryTableSpecFacts row)
+    (h_emit : row.chain.b_op + 16 * row.mode.mode32 = ((184 : ℕ) : FGL)) :
+    False := by
+  rcases h_spec with ⟨h_mode32, _, _, _, _, _, _⟩
+  rcases h_static with ⟨h0, _, _, _, _, _, _, _⟩
+  have h_ne_raw :=
+    ZiskFv.AirsClean.BinaryTable.spec_op_val_ne_arith_divu h0
+  have h_ne :
+      row.chain.b_op.val ≠ 184 ∧ row.chain.b_op.val ≠ 168 := by
+    simpa [lookupMessage0Row] using h_ne_raw
+  have h_mode : row.mode.mode32 = 0 ∨ row.mode.mode32 = 1 := by
+    rcases mul_eq_zero.mp h_mode32 with h_zero | h_one_sub
+    · exact Or.inl h_zero
+    · exact Or.inr ((sub_eq_zero.mp h_one_sub).symm)
+  rcases h_mode with h_zero | h_one
+  · have h_bop : row.chain.b_op = ((184 : ℕ) : FGL) := by
+      simpa [h_zero] using h_emit
+    have h_val := congrArg Fin.val h_bop
+    rw [Fin.val_natCast, Nat.mod_eq_of_lt (by omega : (184 : ℕ) < GL_prime)] at h_val
+    exact h_ne.1 h_val
+  · have hoffset : row.chain.b_op.val = 168 := by
+      have h_bop_lt : row.chain.b_op.val < 514 := by
+        have h := ZiskFv.AirsClean.BinaryTable.spec_op_val_lt_514 h0
+        simpa [lookupMessage0Row] using h
+      have hv := congrArg Fin.val h_emit
+      rw [h_one, Fin.val_add, Fin.val_mul, Fin.val_natCast,
+        Nat.mod_eq_of_lt (by omega : (184 : ℕ) < GL_prime)] at hv
+      omega
+    exact h_ne.2 hoffset
+
 /-- Shared C7 witness surface for Binary's static-table lookup path.
     This is intentionally family-level and row-indexed; it is the shape a
     terminal Binary-family ensemble can provide once the static provider is

--- a/ZiskFv/AirsClean/Binary/Bridge.lean
+++ b/ZiskFv/AirsClean/Binary/Bridge.lean
@@ -635,6 +635,44 @@ theorem static_table_op_val_ne_binaryExtension_shift_of_emit
     exact h_contra (by omega) (by omega) h_ne_shift.2.2.2.2.2
       h_ne_offset.2.2.2.2.2 (by simpa [OP_SRA_W] using h_emit)
 
+/-- A row accepted by the static Binary lookup component cannot emit the
+    Arith MULW operation-bus opcode `182` (`OP_MUL_W`). The emitted value is
+    `b_op + 16 * mode32`; with `mode32 ∈ {0, 1}` that forces `b_op = 182`
+    (excluded by the BinaryTable membership) or `b_op = 166` (also excluded),
+    so the static Binary provider can never be the MULW provider. -/
+theorem static_table_op_val_ne_arith_mul_w_of_emit
+    (row : BinaryRow FGL)
+    (h_spec : Spec row)
+    (h_static : StaticBinaryTableSpecFacts row)
+    (h_emit : row.chain.b_op + 16 * row.mode.mode32 = ((182 : ℕ) : FGL)) :
+    False := by
+  rcases h_spec with ⟨h_mode32, _, _, _, _, _, _⟩
+  rcases h_static with ⟨h0, _, _, _, _, _, _, _⟩
+  have h_ne_raw :=
+    ZiskFv.AirsClean.BinaryTable.spec_op_val_ne_arith_mul_w h0
+  have h_ne :
+      row.chain.b_op.val ≠ 182 ∧ row.chain.b_op.val ≠ 166 := by
+    simpa [lookupMessage0Row] using h_ne_raw
+  have h_mode : row.mode.mode32 = 0 ∨ row.mode.mode32 = 1 := by
+    rcases mul_eq_zero.mp h_mode32 with h_zero | h_one_sub
+    · exact Or.inl h_zero
+    · exact Or.inr ((sub_eq_zero.mp h_one_sub).symm)
+  rcases h_mode with h_zero | h_one
+  · have h_bop : row.chain.b_op = ((182 : ℕ) : FGL) := by
+      simpa [h_zero] using h_emit
+    have h_val := congrArg Fin.val h_bop
+    rw [Fin.val_natCast, Nat.mod_eq_of_lt (by omega : (182 : ℕ) < GL_prime)] at h_val
+    exact h_ne.1 h_val
+  · have hoffset : row.chain.b_op.val = 166 := by
+      have h_bop_lt : row.chain.b_op.val < 514 := by
+        have h := ZiskFv.AirsClean.BinaryTable.spec_op_val_lt_514 h0
+        simpa [lookupMessage0Row] using h
+      have hv := congrArg Fin.val h_emit
+      rw [h_one, Fin.val_add, Fin.val_mul, Fin.val_natCast,
+        Nat.mod_eq_of_lt (by omega : (182 : ℕ) < GL_prime)] at hv
+      omega
+    exact h_ne.2 hoffset
+
 /-- Shared C7 witness surface for Binary's static-table lookup path.
     This is intentionally family-level and row-indexed; it is the shape a
     terminal Binary-family ensemble can provide once the static provider is

--- a/ZiskFv/AirsClean/Binary/Bridge.lean
+++ b/ZiskFv/AirsClean/Binary/Bridge.lean
@@ -749,6 +749,44 @@ theorem static_table_op_val_ne_arith_divu_of_emit
       omega
     exact h_ne.2 hoffset
 
+/-- A row accepted by the static Binary lookup component cannot emit the
+    Arith DIVUW operation-bus opcode `188` (`OP_DIVU_W`). The emitted value is
+    `b_op + 16 * mode32`; with `mode32 ∈ {0, 1}` that forces `b_op = 188`
+    (excluded by the BinaryTable membership) or `b_op = 172` (also excluded),
+    so the static Binary provider can never be the DIVUW provider. -/
+theorem static_table_op_val_ne_arith_divuw_of_emit
+    (row : BinaryRow FGL)
+    (h_spec : Spec row)
+    (h_static : StaticBinaryTableSpecFacts row)
+    (h_emit : row.chain.b_op + 16 * row.mode.mode32 = ((188 : ℕ) : FGL)) :
+    False := by
+  rcases h_spec with ⟨h_mode32, _, _, _, _, _, _⟩
+  rcases h_static with ⟨h0, _, _, _, _, _, _, _⟩
+  have h_ne_raw :=
+    ZiskFv.AirsClean.BinaryTable.spec_op_val_ne_arith_divuw h0
+  have h_ne :
+      row.chain.b_op.val ≠ 188 ∧ row.chain.b_op.val ≠ 172 := by
+    simpa [lookupMessage0Row] using h_ne_raw
+  have h_mode : row.mode.mode32 = 0 ∨ row.mode.mode32 = 1 := by
+    rcases mul_eq_zero.mp h_mode32 with h_zero | h_one_sub
+    · exact Or.inl h_zero
+    · exact Or.inr ((sub_eq_zero.mp h_one_sub).symm)
+  rcases h_mode with h_zero | h_one
+  · have h_bop : row.chain.b_op = ((188 : ℕ) : FGL) := by
+      simpa [h_zero] using h_emit
+    have h_val := congrArg Fin.val h_bop
+    rw [Fin.val_natCast, Nat.mod_eq_of_lt (by omega : (188 : ℕ) < GL_prime)] at h_val
+    exact h_ne.1 h_val
+  · have hoffset : row.chain.b_op.val = 172 := by
+      have h_bop_lt : row.chain.b_op.val < 514 := by
+        have h := ZiskFv.AirsClean.BinaryTable.spec_op_val_lt_514 h0
+        simpa [lookupMessage0Row] using h
+      have hv := congrArg Fin.val h_emit
+      rw [h_one, Fin.val_add, Fin.val_mul, Fin.val_natCast,
+        Nat.mod_eq_of_lt (by omega : (188 : ℕ) < GL_prime)] at hv
+      omega
+    exact h_ne.2 hoffset
+
 /-- Shared C7 witness surface for Binary's static-table lookup path.
     This is intentionally family-level and row-indexed; it is the shape a
     terminal Binary-family ensemble can provide once the static provider is

--- a/ZiskFv/AirsClean/Binary/Bridge.lean
+++ b/ZiskFv/AirsClean/Binary/Bridge.lean
@@ -673,6 +673,44 @@ theorem static_table_op_val_ne_arith_mul_w_of_emit
       omega
     exact h_ne.2 hoffset
 
+/-- A row accepted by the static Binary lookup component cannot emit the
+    Arith MULHU operation-bus opcode `177` (`OP_MULUH`). The emitted value is
+    `b_op + 16 * mode32`; with `mode32 ∈ {0, 1}` that forces `b_op = 177`
+    (excluded by the BinaryTable membership) or `b_op = 161` (also excluded),
+    so the static Binary provider can never be the MULHU provider. -/
+theorem static_table_op_val_ne_arith_mul_uh_of_emit
+    (row : BinaryRow FGL)
+    (h_spec : Spec row)
+    (h_static : StaticBinaryTableSpecFacts row)
+    (h_emit : row.chain.b_op + 16 * row.mode.mode32 = ((177 : ℕ) : FGL)) :
+    False := by
+  rcases h_spec with ⟨h_mode32, _, _, _, _, _, _⟩
+  rcases h_static with ⟨h0, _, _, _, _, _, _, _⟩
+  have h_ne_raw :=
+    ZiskFv.AirsClean.BinaryTable.spec_op_val_ne_arith_mul_uh h0
+  have h_ne :
+      row.chain.b_op.val ≠ 177 ∧ row.chain.b_op.val ≠ 161 := by
+    simpa [lookupMessage0Row] using h_ne_raw
+  have h_mode : row.mode.mode32 = 0 ∨ row.mode.mode32 = 1 := by
+    rcases mul_eq_zero.mp h_mode32 with h_zero | h_one_sub
+    · exact Or.inl h_zero
+    · exact Or.inr ((sub_eq_zero.mp h_one_sub).symm)
+  rcases h_mode with h_zero | h_one
+  · have h_bop : row.chain.b_op = ((177 : ℕ) : FGL) := by
+      simpa [h_zero] using h_emit
+    have h_val := congrArg Fin.val h_bop
+    rw [Fin.val_natCast, Nat.mod_eq_of_lt (by omega : (177 : ℕ) < GL_prime)] at h_val
+    exact h_ne.1 h_val
+  · have hoffset : row.chain.b_op.val = 161 := by
+      have h_bop_lt : row.chain.b_op.val < 514 := by
+        have h := ZiskFv.AirsClean.BinaryTable.spec_op_val_lt_514 h0
+        simpa [lookupMessage0Row] using h
+      have hv := congrArg Fin.val h_emit
+      rw [h_one, Fin.val_add, Fin.val_mul, Fin.val_natCast,
+        Nat.mod_eq_of_lt (by omega : (177 : ℕ) < GL_prime)] at hv
+      omega
+    exact h_ne.2 hoffset
+
 /-- Shared C7 witness surface for Binary's static-table lookup path.
     This is intentionally family-level and row-indexed; it is the shape a
     terminal Binary-family ensemble can provide once the static provider is

--- a/ZiskFv/AirsClean/BinaryExtension/StaticCircuit.lean
+++ b/ZiskFv/AirsClean/BinaryExtension/StaticCircuit.lean
@@ -666,6 +666,12 @@ theorem static_table_op_val_ne_arith_mul_uh_of_spec_facts
     row.flags.op.val ≠ 177 ∧ row.flags.op.val ≠ 161 := by
   exact ZiskFv.AirsClean.BinaryExtensionTable.spec_op_val_ne_arith_mul_uh h_specs.1
 
+theorem static_table_op_val_ne_arith_divu_of_spec_facts
+    (row : BinaryExtensionRow FGL)
+    (h_specs : StaticBinaryExtensionTableSpecFacts row) :
+    row.flags.op.val ≠ 184 ∧ row.flags.op.val ≠ 168 := by
+  exact ZiskFv.AirsClean.BinaryExtensionTable.spec_op_val_ne_arith_divu h_specs.1
+
 /-- A row accepted by the lookup-aware BinaryExtension component cannot carry
     Binary-table bitwise opcodes (`AND`/`OR`/`XOR`, values 14/15/16). -/
 theorem staticLookupComponent_op_val_ne_bitwise_of_spec
@@ -778,6 +784,18 @@ theorem shiftStaticLookupComponent_op_val_ne_arith_mul_uh_of_spec
       ∧ (shiftStaticLookupComponent.rowInput env).flags.op.val ≠ 161 := by
   rw [shiftStaticLookupComponent_spec] at h_spec
   exact static_table_op_val_ne_arith_mul_uh_of_spec_facts
+    (shiftStaticLookupComponent.rowInput env) h_spec.2.1
+
+/-- A row accepted by the shift-aware lookup BinaryExtension component cannot
+    carry the Arith DIVU bus opcode `184` (`OP_DIVU`) nor the alternate
+    `m32 = 0` decomposition value `168`. -/
+theorem shiftStaticLookupComponent_op_val_ne_arith_divu_of_spec
+    (env : Environment FGL)
+    (h_spec : shiftStaticLookupComponent.Spec env) :
+    (shiftStaticLookupComponent.rowInput env).flags.op.val ≠ 184
+      ∧ (shiftStaticLookupComponent.rowInput env).flags.op.val ≠ 168 := by
+  rw [shiftStaticLookupComponent_spec] at h_spec
+  exact static_table_op_val_ne_arith_divu_of_spec_facts
     (shiftStaticLookupComponent.rowInput env) h_spec.2.1
 
 theorem aCols_eval_eq

--- a/ZiskFv/AirsClean/BinaryExtension/StaticCircuit.lean
+++ b/ZiskFv/AirsClean/BinaryExtension/StaticCircuit.lean
@@ -654,6 +654,12 @@ theorem static_table_op_val_ne_W_add_sub_of_spec_facts
     row.flags.op.val ≠ 0x1A ∧ row.flags.op.val ≠ 0x1B := by
   exact ZiskFv.AirsClean.BinaryExtensionTable.spec_op_val_ne_W_add_sub h_specs.1
 
+theorem static_table_op_val_ne_arith_mul_w_of_spec_facts
+    (row : BinaryExtensionRow FGL)
+    (h_specs : StaticBinaryExtensionTableSpecFacts row) :
+    row.flags.op.val ≠ 182 ∧ row.flags.op.val ≠ 166 := by
+  exact ZiskFv.AirsClean.BinaryExtensionTable.spec_op_val_ne_arith_mul_w h_specs.1
+
 /-- A row accepted by the lookup-aware BinaryExtension component cannot carry
     Binary-table bitwise opcodes (`AND`/`OR`/`XOR`, values 14/15/16). -/
 theorem staticLookupComponent_op_val_ne_bitwise_of_spec
@@ -742,6 +748,18 @@ theorem shiftStaticLookupComponent_op_val_ne_W_add_sub_of_spec
       ∧ (shiftStaticLookupComponent.rowInput env).flags.op.val ≠ 0x1B := by
   rw [shiftStaticLookupComponent_spec] at h_spec
   exact static_table_op_val_ne_W_add_sub_of_spec_facts
+    (shiftStaticLookupComponent.rowInput env) h_spec.2.1
+
+/-- A row accepted by the shift-aware lookup BinaryExtension component cannot
+    carry the Arith MULW bus opcode `182` (`OP_MUL_W`) nor the alternate
+    `m32 = 0` decomposition value `166`. -/
+theorem shiftStaticLookupComponent_op_val_ne_arith_mul_w_of_spec
+    (env : Environment FGL)
+    (h_spec : shiftStaticLookupComponent.Spec env) :
+    (shiftStaticLookupComponent.rowInput env).flags.op.val ≠ 182
+      ∧ (shiftStaticLookupComponent.rowInput env).flags.op.val ≠ 166 := by
+  rw [shiftStaticLookupComponent_spec] at h_spec
+  exact static_table_op_val_ne_arith_mul_w_of_spec_facts
     (shiftStaticLookupComponent.rowInput env) h_spec.2.1
 
 theorem aCols_eval_eq

--- a/ZiskFv/AirsClean/BinaryExtension/StaticCircuit.lean
+++ b/ZiskFv/AirsClean/BinaryExtension/StaticCircuit.lean
@@ -672,6 +672,12 @@ theorem static_table_op_val_ne_arith_divu_of_spec_facts
     row.flags.op.val ≠ 184 ∧ row.flags.op.val ≠ 168 := by
   exact ZiskFv.AirsClean.BinaryExtensionTable.spec_op_val_ne_arith_divu h_specs.1
 
+theorem static_table_op_val_ne_arith_divuw_of_spec_facts
+    (row : BinaryExtensionRow FGL)
+    (h_specs : StaticBinaryExtensionTableSpecFacts row) :
+    row.flags.op.val ≠ 188 ∧ row.flags.op.val ≠ 172 := by
+  exact ZiskFv.AirsClean.BinaryExtensionTable.spec_op_val_ne_arith_divuw h_specs.1
+
 /-- A row accepted by the lookup-aware BinaryExtension component cannot carry
     Binary-table bitwise opcodes (`AND`/`OR`/`XOR`, values 14/15/16). -/
 theorem staticLookupComponent_op_val_ne_bitwise_of_spec
@@ -796,6 +802,18 @@ theorem shiftStaticLookupComponent_op_val_ne_arith_divu_of_spec
       ∧ (shiftStaticLookupComponent.rowInput env).flags.op.val ≠ 168 := by
   rw [shiftStaticLookupComponent_spec] at h_spec
   exact static_table_op_val_ne_arith_divu_of_spec_facts
+    (shiftStaticLookupComponent.rowInput env) h_spec.2.1
+
+/-- A row accepted by the shift-aware lookup BinaryExtension component cannot
+    carry the Arith DIVUW bus opcode `188` (`OP_DIVU_W`) nor the alternate
+    `m32 = 0` decomposition value `172`. -/
+theorem shiftStaticLookupComponent_op_val_ne_arith_divuw_of_spec
+    (env : Environment FGL)
+    (h_spec : shiftStaticLookupComponent.Spec env) :
+    (shiftStaticLookupComponent.rowInput env).flags.op.val ≠ 188
+      ∧ (shiftStaticLookupComponent.rowInput env).flags.op.val ≠ 172 := by
+  rw [shiftStaticLookupComponent_spec] at h_spec
+  exact static_table_op_val_ne_arith_divuw_of_spec_facts
     (shiftStaticLookupComponent.rowInput env) h_spec.2.1
 
 theorem aCols_eval_eq

--- a/ZiskFv/AirsClean/BinaryExtension/StaticCircuit.lean
+++ b/ZiskFv/AirsClean/BinaryExtension/StaticCircuit.lean
@@ -672,6 +672,12 @@ theorem static_table_op_val_ne_arith_divu_of_spec_facts
     row.flags.op.val ≠ 184 ∧ row.flags.op.val ≠ 168 := by
   exact ZiskFv.AirsClean.BinaryExtensionTable.spec_op_val_ne_arith_divu h_specs.1
 
+theorem static_table_op_val_ne_arith_remu_of_spec_facts
+    (row : BinaryExtensionRow FGL)
+    (h_specs : StaticBinaryExtensionTableSpecFacts row) :
+    row.flags.op.val ≠ 185 ∧ row.flags.op.val ≠ 169 := by
+  exact ZiskFv.AirsClean.BinaryExtensionTable.spec_op_val_ne_arith_remu h_specs.1
+
 theorem static_table_op_val_ne_arith_divuw_of_spec_facts
     (row : BinaryExtensionRow FGL)
     (h_specs : StaticBinaryExtensionTableSpecFacts row) :
@@ -802,6 +808,18 @@ theorem shiftStaticLookupComponent_op_val_ne_arith_divu_of_spec
       ∧ (shiftStaticLookupComponent.rowInput env).flags.op.val ≠ 168 := by
   rw [shiftStaticLookupComponent_spec] at h_spec
   exact static_table_op_val_ne_arith_divu_of_spec_facts
+    (shiftStaticLookupComponent.rowInput env) h_spec.2.1
+
+/-- A row accepted by the shift-aware lookup BinaryExtension component cannot
+    carry the Arith REMU bus opcode `185` (`OP_REMU`) nor the alternate
+    `m32 = 0` decomposition value `169`. -/
+theorem shiftStaticLookupComponent_op_val_ne_arith_remu_of_spec
+    (env : Environment FGL)
+    (h_spec : shiftStaticLookupComponent.Spec env) :
+    (shiftStaticLookupComponent.rowInput env).flags.op.val ≠ 185
+      ∧ (shiftStaticLookupComponent.rowInput env).flags.op.val ≠ 169 := by
+  rw [shiftStaticLookupComponent_spec] at h_spec
+  exact static_table_op_val_ne_arith_remu_of_spec_facts
     (shiftStaticLookupComponent.rowInput env) h_spec.2.1
 
 /-- A row accepted by the shift-aware lookup BinaryExtension component cannot

--- a/ZiskFv/AirsClean/BinaryExtension/StaticCircuit.lean
+++ b/ZiskFv/AirsClean/BinaryExtension/StaticCircuit.lean
@@ -684,6 +684,12 @@ theorem static_table_op_val_ne_arith_divuw_of_spec_facts
     row.flags.op.val ≠ 188 ∧ row.flags.op.val ≠ 172 := by
   exact ZiskFv.AirsClean.BinaryExtensionTable.spec_op_val_ne_arith_divuw h_specs.1
 
+theorem static_table_op_val_ne_arith_remuw_of_spec_facts
+    (row : BinaryExtensionRow FGL)
+    (h_specs : StaticBinaryExtensionTableSpecFacts row) :
+    row.flags.op.val ≠ 189 ∧ row.flags.op.val ≠ 173 := by
+  exact ZiskFv.AirsClean.BinaryExtensionTable.spec_op_val_ne_arith_remuw h_specs.1
+
 /-- A row accepted by the lookup-aware BinaryExtension component cannot carry
     Binary-table bitwise opcodes (`AND`/`OR`/`XOR`, values 14/15/16). -/
 theorem staticLookupComponent_op_val_ne_bitwise_of_spec
@@ -832,6 +838,18 @@ theorem shiftStaticLookupComponent_op_val_ne_arith_divuw_of_spec
       ∧ (shiftStaticLookupComponent.rowInput env).flags.op.val ≠ 172 := by
   rw [shiftStaticLookupComponent_spec] at h_spec
   exact static_table_op_val_ne_arith_divuw_of_spec_facts
+    (shiftStaticLookupComponent.rowInput env) h_spec.2.1
+
+/-- A row accepted by the shift-aware lookup BinaryExtension component cannot
+    carry the Arith REMUW bus opcode `189` (`OP_REMU_W`) nor the alternate
+    `m32 = 0` decomposition value `173`. -/
+theorem shiftStaticLookupComponent_op_val_ne_arith_remuw_of_spec
+    (env : Environment FGL)
+    (h_spec : shiftStaticLookupComponent.Spec env) :
+    (shiftStaticLookupComponent.rowInput env).flags.op.val ≠ 189
+      ∧ (shiftStaticLookupComponent.rowInput env).flags.op.val ≠ 173 := by
+  rw [shiftStaticLookupComponent_spec] at h_spec
+  exact static_table_op_val_ne_arith_remuw_of_spec_facts
     (shiftStaticLookupComponent.rowInput env) h_spec.2.1
 
 theorem aCols_eval_eq

--- a/ZiskFv/AirsClean/BinaryExtension/StaticCircuit.lean
+++ b/ZiskFv/AirsClean/BinaryExtension/StaticCircuit.lean
@@ -660,6 +660,12 @@ theorem static_table_op_val_ne_arith_mul_w_of_spec_facts
     row.flags.op.val ≠ 182 ∧ row.flags.op.val ≠ 166 := by
   exact ZiskFv.AirsClean.BinaryExtensionTable.spec_op_val_ne_arith_mul_w h_specs.1
 
+theorem static_table_op_val_ne_arith_mul_uh_of_spec_facts
+    (row : BinaryExtensionRow FGL)
+    (h_specs : StaticBinaryExtensionTableSpecFacts row) :
+    row.flags.op.val ≠ 177 ∧ row.flags.op.val ≠ 161 := by
+  exact ZiskFv.AirsClean.BinaryExtensionTable.spec_op_val_ne_arith_mul_uh h_specs.1
+
 /-- A row accepted by the lookup-aware BinaryExtension component cannot carry
     Binary-table bitwise opcodes (`AND`/`OR`/`XOR`, values 14/15/16). -/
 theorem staticLookupComponent_op_val_ne_bitwise_of_spec
@@ -760,6 +766,18 @@ theorem shiftStaticLookupComponent_op_val_ne_arith_mul_w_of_spec
       ∧ (shiftStaticLookupComponent.rowInput env).flags.op.val ≠ 166 := by
   rw [shiftStaticLookupComponent_spec] at h_spec
   exact static_table_op_val_ne_arith_mul_w_of_spec_facts
+    (shiftStaticLookupComponent.rowInput env) h_spec.2.1
+
+/-- A row accepted by the shift-aware lookup BinaryExtension component cannot
+    carry the Arith MULHU bus opcode `177` (`OP_MULUH`) nor the alternate
+    `m32 = 1` decomposition value `161`. -/
+theorem shiftStaticLookupComponent_op_val_ne_arith_mul_uh_of_spec
+    (env : Environment FGL)
+    (h_spec : shiftStaticLookupComponent.Spec env) :
+    (shiftStaticLookupComponent.rowInput env).flags.op.val ≠ 177
+      ∧ (shiftStaticLookupComponent.rowInput env).flags.op.val ≠ 161 := by
+  rw [shiftStaticLookupComponent_spec] at h_spec
+  exact static_table_op_val_ne_arith_mul_uh_of_spec_facts
     (shiftStaticLookupComponent.rowInput env) h_spec.2.1
 
 theorem aCols_eval_eq

--- a/ZiskFv/AirsClean/BinaryExtensionTable.lean
+++ b/ZiskFv/AirsClean/BinaryExtensionTable.lean
@@ -418,6 +418,32 @@ theorem spec_op_val_ne_arith_divu {t : BinaryExtensionTableMessage FGL}
         OP_SEXT_B, OP_SEXT_H, OP_SEXT_W]
 
 open ZiskFv.Airs.Tables.BinaryExtensionTable in
+/-- BinaryExtensionTable rows cover shift and sign-extension opcodes only;
+    they cannot be the Arith DIVUW bus opcode `188` (`OP_DIVU_W`) nor the
+    alternate `m32 = 0` decomposition value `172` (`= 188 - 16`). -/
+theorem spec_op_val_ne_arith_divuw {t : BinaryExtensionTableMessage FGL}
+    (h : binaryExtensionTable.Spec t) :
+    t.op.val ≠ 188 ∧ t.op.val ≠ 172 := by
+  rcases h with ⟨i, rfl⟩
+  change (opOfIndex i.val : FGL).val ≠ 188
+    ∧ (opOfIndex i.val : FGL).val ≠ 172
+  have h_block_lt : blockOfIndex i.val < 9 := blockOfIndex_lt_9 i
+  unfold opOfIndex
+  generalize h_block : blockOfIndex i.val = block
+  have h_block_lt' : block < 9 := by
+    rw [← h_block]
+    exact h_block_lt
+  interval_cases block
+  all_goals
+    constructor
+    · unfold opOfBlock
+      norm_num [OP_SLL, OP_SRL, OP_SRA, OP_SLL_W, OP_SRL_W, OP_SRA_W,
+        OP_SEXT_B, OP_SEXT_H, OP_SEXT_W]
+    · unfold opOfBlock
+      norm_num [OP_SLL, OP_SRL, OP_SRA, OP_SLL_W, OP_SRL_W, OP_SRA_W,
+        OP_SEXT_B, OP_SEXT_H, OP_SEXT_W]
+
+open ZiskFv.Airs.Tables.BinaryExtensionTable in
 /-- The static decoder always produces the byte/range side of the legacy
     BinaryExtensionTable semantic predicate. This is the first reusable
     membership-to-semantics projection; the per-op output equations are

--- a/ZiskFv/AirsClean/BinaryExtensionTable.lean
+++ b/ZiskFv/AirsClean/BinaryExtensionTable.lean
@@ -470,6 +470,32 @@ theorem spec_op_val_ne_arith_divuw {t : BinaryExtensionTableMessage FGL}
         OP_SEXT_B, OP_SEXT_H, OP_SEXT_W]
 
 open ZiskFv.Airs.Tables.BinaryExtensionTable in
+/-- BinaryExtensionTable rows cover shift and sign-extension opcodes only;
+    they cannot be the Arith REMUW bus opcode `189` (`OP_REMU_W`) nor the
+    alternate `m32 = 0` decomposition value `173` (`= 189 - 16`). -/
+theorem spec_op_val_ne_arith_remuw {t : BinaryExtensionTableMessage FGL}
+    (h : binaryExtensionTable.Spec t) :
+    t.op.val ≠ 189 ∧ t.op.val ≠ 173 := by
+  rcases h with ⟨i, rfl⟩
+  change (opOfIndex i.val : FGL).val ≠ 189
+    ∧ (opOfIndex i.val : FGL).val ≠ 173
+  have h_block_lt : blockOfIndex i.val < 9 := blockOfIndex_lt_9 i
+  unfold opOfIndex
+  generalize h_block : blockOfIndex i.val = block
+  have h_block_lt' : block < 9 := by
+    rw [← h_block]
+    exact h_block_lt
+  interval_cases block
+  all_goals
+    constructor
+    · unfold opOfBlock
+      norm_num [OP_SLL, OP_SRL, OP_SRA, OP_SLL_W, OP_SRL_W, OP_SRA_W,
+        OP_SEXT_B, OP_SEXT_H, OP_SEXT_W]
+    · unfold opOfBlock
+      norm_num [OP_SLL, OP_SRL, OP_SRA, OP_SLL_W, OP_SRL_W, OP_SRA_W,
+        OP_SEXT_B, OP_SEXT_H, OP_SEXT_W]
+
+open ZiskFv.Airs.Tables.BinaryExtensionTable in
 /-- The static decoder always produces the byte/range side of the legacy
     BinaryExtensionTable semantic predicate. This is the first reusable
     membership-to-semantics projection; the per-op output equations are

--- a/ZiskFv/AirsClean/BinaryExtensionTable.lean
+++ b/ZiskFv/AirsClean/BinaryExtensionTable.lean
@@ -392,6 +392,32 @@ theorem spec_op_val_ne_arith_mul_w {t : BinaryExtensionTableMessage FGL}
         OP_SEXT_B, OP_SEXT_H, OP_SEXT_W]
 
 open ZiskFv.Airs.Tables.BinaryExtensionTable in
+/-- BinaryExtensionTable rows cover shift and sign-extension opcodes only;
+    they cannot be the Arith DIVU bus opcode `184` (`OP_DIVU`) nor the
+    alternate `m32 = 0` decomposition value `168` (`= 184 - 16`). -/
+theorem spec_op_val_ne_arith_divu {t : BinaryExtensionTableMessage FGL}
+    (h : binaryExtensionTable.Spec t) :
+    t.op.val ≠ 184 ∧ t.op.val ≠ 168 := by
+  rcases h with ⟨i, rfl⟩
+  change (opOfIndex i.val : FGL).val ≠ 184
+    ∧ (opOfIndex i.val : FGL).val ≠ 168
+  have h_block_lt : blockOfIndex i.val < 9 := blockOfIndex_lt_9 i
+  unfold opOfIndex
+  generalize h_block : blockOfIndex i.val = block
+  have h_block_lt' : block < 9 := by
+    rw [← h_block]
+    exact h_block_lt
+  interval_cases block
+  all_goals
+    constructor
+    · unfold opOfBlock
+      norm_num [OP_SLL, OP_SRL, OP_SRA, OP_SLL_W, OP_SRL_W, OP_SRA_W,
+        OP_SEXT_B, OP_SEXT_H, OP_SEXT_W]
+    · unfold opOfBlock
+      norm_num [OP_SLL, OP_SRL, OP_SRA, OP_SLL_W, OP_SRL_W, OP_SRA_W,
+        OP_SEXT_B, OP_SEXT_H, OP_SEXT_W]
+
+open ZiskFv.Airs.Tables.BinaryExtensionTable in
 /-- The static decoder always produces the byte/range side of the legacy
     BinaryExtensionTable semantic predicate. This is the first reusable
     membership-to-semantics projection; the per-op output equations are

--- a/ZiskFv/AirsClean/BinaryExtensionTable.lean
+++ b/ZiskFv/AirsClean/BinaryExtensionTable.lean
@@ -341,6 +341,32 @@ theorem spec_op_val_ne_W_add_sub {t : BinaryExtensionTableMessage FGL}
 
 open ZiskFv.Airs.Tables.BinaryExtensionTable in
 /-- BinaryExtensionTable rows cover shift and sign-extension opcodes only;
+    they cannot be the Arith MULHU bus opcode `177` (`OP_MULUH`) nor the
+    alternate `m32 = 1` decomposition value `161` (`= 177 - 16`). -/
+theorem spec_op_val_ne_arith_mul_uh {t : BinaryExtensionTableMessage FGL}
+    (h : binaryExtensionTable.Spec t) :
+    t.op.val ≠ 177 ∧ t.op.val ≠ 161 := by
+  rcases h with ⟨i, rfl⟩
+  change (opOfIndex i.val : FGL).val ≠ 177
+    ∧ (opOfIndex i.val : FGL).val ≠ 161
+  have h_block_lt : blockOfIndex i.val < 9 := blockOfIndex_lt_9 i
+  unfold opOfIndex
+  generalize h_block : blockOfIndex i.val = block
+  have h_block_lt' : block < 9 := by
+    rw [← h_block]
+    exact h_block_lt
+  interval_cases block
+  all_goals
+    constructor
+    · unfold opOfBlock
+      norm_num [OP_SLL, OP_SRL, OP_SRA, OP_SLL_W, OP_SRL_W, OP_SRA_W,
+        OP_SEXT_B, OP_SEXT_H, OP_SEXT_W]
+    · unfold opOfBlock
+      norm_num [OP_SLL, OP_SRL, OP_SRA, OP_SLL_W, OP_SRL_W, OP_SRA_W,
+        OP_SEXT_B, OP_SEXT_H, OP_SEXT_W]
+
+open ZiskFv.Airs.Tables.BinaryExtensionTable in
+/-- BinaryExtensionTable rows cover shift and sign-extension opcodes only;
     they cannot be the Arith MULW bus opcode `182` (`OP_MUL_W`) nor the
     alternate `m32 = 0` decomposition value `166` (`= 182 - 16`). -/
 theorem spec_op_val_ne_arith_mul_w {t : BinaryExtensionTableMessage FGL}

--- a/ZiskFv/AirsClean/BinaryExtensionTable.lean
+++ b/ZiskFv/AirsClean/BinaryExtensionTable.lean
@@ -419,6 +419,32 @@ theorem spec_op_val_ne_arith_divu {t : BinaryExtensionTableMessage FGL}
 
 open ZiskFv.Airs.Tables.BinaryExtensionTable in
 /-- BinaryExtensionTable rows cover shift and sign-extension opcodes only;
+    they cannot be the Arith REMU bus opcode `185` (`OP_REMU`) nor the
+    alternate `m32 = 0` decomposition value `169` (`= 185 - 16`). -/
+theorem spec_op_val_ne_arith_remu {t : BinaryExtensionTableMessage FGL}
+    (h : binaryExtensionTable.Spec t) :
+    t.op.val ≠ 185 ∧ t.op.val ≠ 169 := by
+  rcases h with ⟨i, rfl⟩
+  change (opOfIndex i.val : FGL).val ≠ 185
+    ∧ (opOfIndex i.val : FGL).val ≠ 169
+  have h_block_lt : blockOfIndex i.val < 9 := blockOfIndex_lt_9 i
+  unfold opOfIndex
+  generalize h_block : blockOfIndex i.val = block
+  have h_block_lt' : block < 9 := by
+    rw [← h_block]
+    exact h_block_lt
+  interval_cases block
+  all_goals
+    constructor
+    · unfold opOfBlock
+      norm_num [OP_SLL, OP_SRL, OP_SRA, OP_SLL_W, OP_SRL_W, OP_SRA_W,
+        OP_SEXT_B, OP_SEXT_H, OP_SEXT_W]
+    · unfold opOfBlock
+      norm_num [OP_SLL, OP_SRL, OP_SRA, OP_SLL_W, OP_SRL_W, OP_SRA_W,
+        OP_SEXT_B, OP_SEXT_H, OP_SEXT_W]
+
+open ZiskFv.Airs.Tables.BinaryExtensionTable in
+/-- BinaryExtensionTable rows cover shift and sign-extension opcodes only;
     they cannot be the Arith DIVUW bus opcode `188` (`OP_DIVU_W`) nor the
     alternate `m32 = 0` decomposition value `172` (`= 188 - 16`). -/
 theorem spec_op_val_ne_arith_divuw {t : BinaryExtensionTableMessage FGL}

--- a/ZiskFv/AirsClean/BinaryExtensionTable.lean
+++ b/ZiskFv/AirsClean/BinaryExtensionTable.lean
@@ -340,6 +340,32 @@ theorem spec_op_val_ne_W_add_sub {t : BinaryExtensionTableMessage FGL}
         OP_SEXT_B, OP_SEXT_H, OP_SEXT_W]
 
 open ZiskFv.Airs.Tables.BinaryExtensionTable in
+/-- BinaryExtensionTable rows cover shift and sign-extension opcodes only;
+    they cannot be the Arith MULW bus opcode `182` (`OP_MUL_W`) nor the
+    alternate `m32 = 0` decomposition value `166` (`= 182 - 16`). -/
+theorem spec_op_val_ne_arith_mul_w {t : BinaryExtensionTableMessage FGL}
+    (h : binaryExtensionTable.Spec t) :
+    t.op.val ≠ 182 ∧ t.op.val ≠ 166 := by
+  rcases h with ⟨i, rfl⟩
+  change (opOfIndex i.val : FGL).val ≠ 182
+    ∧ (opOfIndex i.val : FGL).val ≠ 166
+  have h_block_lt : blockOfIndex i.val < 9 := blockOfIndex_lt_9 i
+  unfold opOfIndex
+  generalize h_block : blockOfIndex i.val = block
+  have h_block_lt' : block < 9 := by
+    rw [← h_block]
+    exact h_block_lt
+  interval_cases block
+  all_goals
+    constructor
+    · unfold opOfBlock
+      norm_num [OP_SLL, OP_SRL, OP_SRA, OP_SLL_W, OP_SRL_W, OP_SRA_W,
+        OP_SEXT_B, OP_SEXT_H, OP_SEXT_W]
+    · unfold opOfBlock
+      norm_num [OP_SLL, OP_SRL, OP_SRA, OP_SLL_W, OP_SRL_W, OP_SRA_W,
+        OP_SEXT_B, OP_SEXT_H, OP_SEXT_W]
+
+open ZiskFv.Airs.Tables.BinaryExtensionTable in
 /-- The static decoder always produces the byte/range side of the legacy
     BinaryExtensionTable semantic predicate. This is the first reusable
     membership-to-semantics projection; the per-op output equations are

--- a/ZiskFv/AirsClean/BinaryTable.lean
+++ b/ZiskFv/AirsClean/BinaryTable.lean
@@ -807,6 +807,28 @@ theorem spec_op_val_ne_arith_divuw {t : BinaryTableMessage FGL}
   rcases h with ⟨i, rfl⟩
   exact rowOfIndex_op_val_ne_arith_divuw i
 
+theorem rowOfIndex_op_val_ne_arith_remuw (i : Fin tableSize) :
+    (rowOfIndex i.val).op.val ≠ 189
+      ∧ (rowOfIndex i.val).op.val ≠ 173 := by
+  have h_block_lt : blockOfIndex i.val < 19 := blockOfIndex_lt_19 i
+  unfold rowOfIndex opOfIndex
+  rw [Fin.val_natCast]
+  generalize h_block : blockOfIndex i.val = block
+  have h_block_lt' : block < 19 := by
+    rw [← h_block]
+    exact h_block_lt
+  refine ⟨?_, ?_⟩ <;>
+    interval_cases block <;> norm_num [opOfBlock, OP_AND, OP_OR, OP_XOR,
+      OP_LTU, OP_LT, OP_GT, OP_EQ, OP_ADD, OP_SUB, OP_LEU, OP_LE,
+      OP_SEXT_00, OP_SEXT_FF, OP_MINU, OP_MIN, OP_MAXU, OP_MAX,
+      OP_LT_ABS_NP, OP_LT_ABS_PN]
+
+theorem spec_op_val_ne_arith_remuw {t : BinaryTableMessage FGL}
+    (h : binaryTable.Spec t) :
+    t.op.val ≠ 189 ∧ t.op.val ≠ 173 := by
+  rcases h with ⟨i, rfl⟩
+  exact rowOfIndex_op_val_ne_arith_remuw i
+
 theorem signByte_eq_zero_iff_lt_128 {a : ℕ} (ha : a < 256) :
     signByte a = 0 ↔ a < 128 := by
   interval_cases a <;> decide

--- a/ZiskFv/AirsClean/BinaryTable.lean
+++ b/ZiskFv/AirsClean/BinaryTable.lean
@@ -741,6 +741,28 @@ theorem spec_op_val_ne_arith_mul_uh {t : BinaryTableMessage FGL}
   rcases h with ⟨i, rfl⟩
   exact rowOfIndex_op_val_ne_arith_mul_uh i
 
+theorem rowOfIndex_op_val_ne_arith_divu (i : Fin tableSize) :
+    (rowOfIndex i.val).op.val ≠ 184
+      ∧ (rowOfIndex i.val).op.val ≠ 168 := by
+  have h_block_lt : blockOfIndex i.val < 19 := blockOfIndex_lt_19 i
+  unfold rowOfIndex opOfIndex
+  rw [Fin.val_natCast]
+  generalize h_block : blockOfIndex i.val = block
+  have h_block_lt' : block < 19 := by
+    rw [← h_block]
+    exact h_block_lt
+  refine ⟨?_, ?_⟩ <;>
+    interval_cases block <;> norm_num [opOfBlock, OP_AND, OP_OR, OP_XOR,
+      OP_LTU, OP_LT, OP_GT, OP_EQ, OP_ADD, OP_SUB, OP_LEU, OP_LE,
+      OP_SEXT_00, OP_SEXT_FF, OP_MINU, OP_MIN, OP_MAXU, OP_MAX,
+      OP_LT_ABS_NP, OP_LT_ABS_PN]
+
+theorem spec_op_val_ne_arith_divu {t : BinaryTableMessage FGL}
+    (h : binaryTable.Spec t) :
+    t.op.val ≠ 184 ∧ t.op.val ≠ 168 := by
+  rcases h with ⟨i, rfl⟩
+  exact rowOfIndex_op_val_ne_arith_divu i
+
 theorem signByte_eq_zero_iff_lt_128 {a : ℕ} (ha : a < 256) :
     signByte a = 0 ↔ a < 128 := by
   interval_cases a <;> decide

--- a/ZiskFv/AirsClean/BinaryTable.lean
+++ b/ZiskFv/AirsClean/BinaryTable.lean
@@ -763,6 +763,28 @@ theorem spec_op_val_ne_arith_divu {t : BinaryTableMessage FGL}
   rcases h with ⟨i, rfl⟩
   exact rowOfIndex_op_val_ne_arith_divu i
 
+theorem rowOfIndex_op_val_ne_arith_divuw (i : Fin tableSize) :
+    (rowOfIndex i.val).op.val ≠ 188
+      ∧ (rowOfIndex i.val).op.val ≠ 172 := by
+  have h_block_lt : blockOfIndex i.val < 19 := blockOfIndex_lt_19 i
+  unfold rowOfIndex opOfIndex
+  rw [Fin.val_natCast]
+  generalize h_block : blockOfIndex i.val = block
+  have h_block_lt' : block < 19 := by
+    rw [← h_block]
+    exact h_block_lt
+  refine ⟨?_, ?_⟩ <;>
+    interval_cases block <;> norm_num [opOfBlock, OP_AND, OP_OR, OP_XOR,
+      OP_LTU, OP_LT, OP_GT, OP_EQ, OP_ADD, OP_SUB, OP_LEU, OP_LE,
+      OP_SEXT_00, OP_SEXT_FF, OP_MINU, OP_MIN, OP_MAXU, OP_MAX,
+      OP_LT_ABS_NP, OP_LT_ABS_PN]
+
+theorem spec_op_val_ne_arith_divuw {t : BinaryTableMessage FGL}
+    (h : binaryTable.Spec t) :
+    t.op.val ≠ 188 ∧ t.op.val ≠ 172 := by
+  rcases h with ⟨i, rfl⟩
+  exact rowOfIndex_op_val_ne_arith_divuw i
+
 theorem signByte_eq_zero_iff_lt_128 {a : ℕ} (ha : a < 256) :
     signByte a = 0 ↔ a < 128 := by
   interval_cases a <;> decide

--- a/ZiskFv/AirsClean/BinaryTable.lean
+++ b/ZiskFv/AirsClean/BinaryTable.lean
@@ -763,6 +763,28 @@ theorem spec_op_val_ne_arith_divu {t : BinaryTableMessage FGL}
   rcases h with ⟨i, rfl⟩
   exact rowOfIndex_op_val_ne_arith_divu i
 
+theorem rowOfIndex_op_val_ne_arith_remu (i : Fin tableSize) :
+    (rowOfIndex i.val).op.val ≠ 185
+      ∧ (rowOfIndex i.val).op.val ≠ 169 := by
+  have h_block_lt : blockOfIndex i.val < 19 := blockOfIndex_lt_19 i
+  unfold rowOfIndex opOfIndex
+  rw [Fin.val_natCast]
+  generalize h_block : blockOfIndex i.val = block
+  have h_block_lt' : block < 19 := by
+    rw [← h_block]
+    exact h_block_lt
+  refine ⟨?_, ?_⟩ <;>
+    interval_cases block <;> norm_num [opOfBlock, OP_AND, OP_OR, OP_XOR,
+      OP_LTU, OP_LT, OP_GT, OP_EQ, OP_ADD, OP_SUB, OP_LEU, OP_LE,
+      OP_SEXT_00, OP_SEXT_FF, OP_MINU, OP_MIN, OP_MAXU, OP_MAX,
+      OP_LT_ABS_NP, OP_LT_ABS_PN]
+
+theorem spec_op_val_ne_arith_remu {t : BinaryTableMessage FGL}
+    (h : binaryTable.Spec t) :
+    t.op.val ≠ 185 ∧ t.op.val ≠ 169 := by
+  rcases h with ⟨i, rfl⟩
+  exact rowOfIndex_op_val_ne_arith_remu i
+
 theorem rowOfIndex_op_val_ne_arith_divuw (i : Fin tableSize) :
     (rowOfIndex i.val).op.val ≠ 188
       ∧ (rowOfIndex i.val).op.val ≠ 172 := by

--- a/ZiskFv/AirsClean/BinaryTable.lean
+++ b/ZiskFv/AirsClean/BinaryTable.lean
@@ -693,6 +693,32 @@ theorem spec_op_val_ne_shift_ops {t : BinaryTableMessage FGL}
   rcases h with ⟨i, rfl⟩
   exact rowOfIndex_op_val_ne_shift_ops i
 
+/-- No static BinaryTable row carries the Arith MULW bus opcode `182`
+    (`OP_MUL_W`) nor the alternate `m32 = 0` decomposition value `166`
+    (`= 182 - 16`). Used by the MULW dispatch to exclude the static
+    Binary provider branch. -/
+theorem rowOfIndex_op_val_ne_arith_mul_w (i : Fin tableSize) :
+    (rowOfIndex i.val).op.val ≠ 182
+      ∧ (rowOfIndex i.val).op.val ≠ 166 := by
+  have h_block_lt : blockOfIndex i.val < 19 := blockOfIndex_lt_19 i
+  unfold rowOfIndex opOfIndex
+  rw [Fin.val_natCast]
+  generalize h_block : blockOfIndex i.val = block
+  have h_block_lt' : block < 19 := by
+    rw [← h_block]
+    exact h_block_lt
+  refine ⟨?_, ?_⟩ <;>
+    interval_cases block <;> norm_num [opOfBlock, OP_AND, OP_OR, OP_XOR,
+      OP_LTU, OP_LT, OP_GT, OP_EQ, OP_ADD, OP_SUB, OP_LEU, OP_LE,
+      OP_SEXT_00, OP_SEXT_FF, OP_MINU, OP_MIN, OP_MAXU, OP_MAX,
+      OP_LT_ABS_NP, OP_LT_ABS_PN]
+
+theorem spec_op_val_ne_arith_mul_w {t : BinaryTableMessage FGL}
+    (h : binaryTable.Spec t) :
+    t.op.val ≠ 182 ∧ t.op.val ≠ 166 := by
+  rcases h with ⟨i, rfl⟩
+  exact rowOfIndex_op_val_ne_arith_mul_w i
+
 theorem signByte_eq_zero_iff_lt_128 {a : ℕ} (ha : a < 256) :
     signByte a = 0 ↔ a < 128 := by
   interval_cases a <;> decide

--- a/ZiskFv/AirsClean/BinaryTable.lean
+++ b/ZiskFv/AirsClean/BinaryTable.lean
@@ -719,6 +719,28 @@ theorem spec_op_val_ne_arith_mul_w {t : BinaryTableMessage FGL}
   rcases h with ⟨i, rfl⟩
   exact rowOfIndex_op_val_ne_arith_mul_w i
 
+theorem rowOfIndex_op_val_ne_arith_mul_uh (i : Fin tableSize) :
+    (rowOfIndex i.val).op.val ≠ 177
+      ∧ (rowOfIndex i.val).op.val ≠ 161 := by
+  have h_block_lt : blockOfIndex i.val < 19 := blockOfIndex_lt_19 i
+  unfold rowOfIndex opOfIndex
+  rw [Fin.val_natCast]
+  generalize h_block : blockOfIndex i.val = block
+  have h_block_lt' : block < 19 := by
+    rw [← h_block]
+    exact h_block_lt
+  refine ⟨?_, ?_⟩ <;>
+    interval_cases block <;> norm_num [opOfBlock, OP_AND, OP_OR, OP_XOR,
+      OP_LTU, OP_LT, OP_GT, OP_EQ, OP_ADD, OP_SUB, OP_LEU, OP_LE,
+      OP_SEXT_00, OP_SEXT_FF, OP_MINU, OP_MIN, OP_MAXU, OP_MAX,
+      OP_LT_ABS_NP, OP_LT_ABS_PN]
+
+theorem spec_op_val_ne_arith_mul_uh {t : BinaryTableMessage FGL}
+    (h : binaryTable.Spec t) :
+    t.op.val ≠ 177 ∧ t.op.val ≠ 161 := by
+  rcases h with ⟨i, rfl⟩
+  exact rowOfIndex_op_val_ne_arith_mul_uh i
+
 theorem signByte_eq_zero_iff_lt_128 {a : ℕ} (ha : a < 256) :
     signByte a = 0 ↔ a < 128 := by
   interval_cases a <;> decide

--- a/ZiskFv/AirsClean/FullEnsemble/ArithBalance.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/ArithBalance.lean
@@ -541,4 +541,268 @@ theorem exists_arithMul_provider_row_matches_secondary_of_mulhu_active_main_row_
     exact False.elim
       (binaryAdd_provider_branch_ne_arithMulSecondary h_match h_main_op)
 
+/-! ## Arith DIVU keep/refute (`OP_DIVU = 184`)
+
+Mirror of the MULW keep/refute above, for the unsigned DIVU operation.  The
+provider is still the shared ArithMul `componentWithArithTable` (the ArithDiv
+component carries no op-bus interactions in the ensemble — see
+`arithDiv_table_interactionsWith_opBus_nil`).  The keep theorem produces the
+SAME muxed `primaryOpBusMessage` match; the DIVU-mode bridge in
+`ArithMul/Bridge.lean` reduces that muxed message — at `div = 1`,
+`main_div = 1`, `main_mul = 0` — to the div quotient-lane message
+`opBus_row_ArithDiv` the DIVU wrapper consumes.  The three non-arith provider
+branches are refuted via the op-184 static-table exclusions. -/
+
+/-- A lookup-aware static Binary provider branch cannot be the provider for a
+    Main Arith DIVU operation (`OP_DIVU = 184`). -/
+theorem staticBinary_provider_branch_ne_arithDivuPrimary
+    {m : ZiskFv.Airs.Main.Valid_Main FGL FGL} {r_main : ℕ}
+    {providerTable : Table FGL} {providerRow : Array FGL}
+    (h_component :
+      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
+    (h_providerSpec :
+      providerTable.component.Spec (providerTable.environment providerRow))
+    (h_match :
+      ZiskFv.Airs.OperationBus.matches_entry
+        (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+        (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+          (eval (providerTable.environment providerRow)
+            (ZiskFv.AirsClean.Binary.opBusMessageExpr
+              ZiskFv.AirsClean.Binary.staticLookupComponent.rowInputVar)) 1))
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_DIVU) :
+    False := by
+  let env := providerTable.environment providerRow
+  let row := ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput env
+  have h_componentSpec :
+      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec env := by
+    simpa [env, h_component] using h_providerSpec
+  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_componentSpec
+  have h_provider_op :
+      m.op r_main = row.chain.b_op + 16 * row.mode.mode32 := by
+    have h_op := h_match.2.1
+    simpa [env, row, ZiskFv.Airs.OperationBus.opBus_row_Main,
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
+      ZiskFv.AirsClean.Binary.staticLookupComponent_eval_opBusMessageExpr,
+      ZiskFv.AirsClean.Binary.opBusMessage] using h_op
+  exact ZiskFv.AirsClean.Binary.static_table_op_val_ne_arith_divu_of_emit
+    row h_componentSpec.1 h_componentSpec.2
+    (by
+      rw [← h_provider_op, h_main_op]
+      norm_num [ZiskFv.Trusted.OP_DIVU])
+
+/-- A lookup-aware BinaryExtension provider branch cannot be the provider for a
+    Main Arith DIVU operation (`OP_DIVU = 184`). -/
+theorem staticBinaryExtension_provider_branch_ne_arithDivuPrimary
+    {m : ZiskFv.Airs.Main.Valid_Main FGL FGL} {r_main : ℕ}
+    {providerTable : Table FGL} {providerRow : Array FGL}
+    (h_component :
+      providerTable.component = shiftStaticLookupComponent)
+    (h_providerSpec :
+      providerTable.component.Spec (providerTable.environment providerRow))
+    (h_match :
+      ZiskFv.Airs.OperationBus.matches_entry
+        (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+        (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+          (eval (providerTable.environment providerRow)
+            (ZiskFv.AirsClean.BinaryExtension.opBusMessageExpr
+              shiftStaticLookupComponent.rowInputVar)) 1))
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_DIVU) :
+    False := by
+  let env := providerTable.environment providerRow
+  have h_componentSpec :
+      shiftStaticLookupComponent.Spec env := by
+    simpa [env, h_component] using h_providerSpec
+  have h_ne :=
+    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent_op_val_ne_arith_divu_of_spec
+      env h_componentSpec
+  have h_provider_op :
+      (m.op r_main).val =
+        (shiftStaticLookupComponent.rowInput env).flags.op.val := by
+    have h_op := h_match.2.1
+    have h_op_val := congrArg Fin.val h_op
+    simpa [env, ZiskFv.Airs.OperationBus.opBus_row_Main,
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
+      ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent_eval_opBusMessageExpr_op]
+      using h_op_val
+  exact h_ne.1 (by
+    rw [← h_provider_op, h_main_op]
+    norm_num [ZiskFv.Trusted.OP_DIVU])
+
+/-- The BinaryAdd provider branch cannot be the provider for a Main Arith DIVU
+    operation (`OP_DIVU = 184`). -/
+theorem binaryAdd_provider_branch_ne_arithDivuPrimary
+    {m : ZiskFv.Airs.Main.Valid_Main FGL FGL} {r_main : ℕ}
+    {providerTable : Table FGL} {providerRow : Array FGL}
+    (h_match :
+      ZiskFv.Airs.OperationBus.matches_entry
+        (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+        (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+          (eval (providerTable.environment providerRow)
+            (ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr
+              ZiskFv.AirsClean.BinaryAdd.component.rowInputVar)) 1))
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_DIVU) :
+    False := by
+  have h_provider_op : (m.op r_main).val = 10 := by
+    have h_op := h_match.2.1
+    have h_op_val := congrArg Fin.val h_op
+    simpa [ZiskFv.Airs.OperationBus.opBus_row_Main,
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
+      ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr,
+      ZiskFv.Channels.OperationBus.OpBusMessage.eval_op]
+      using h_op_val
+  rw [h_main_op] at h_provider_op
+  norm_num [ZiskFv.Trusted.OP_DIVU] at h_provider_op
+
+/-- An active unified-Main DIVU operation-bus interaction is balanced by an
+    Arith-Mul provider row carrying `witness.Spec`, whose primary (muxed)
+    operation-bus message matches the Main row's emission.  Keeps the ArithMul
+    provider branch and refutes the BinaryExtension / static Binary / BinaryAdd
+    provider branches via the `*_ne_arithDivuPrimary` exclusions. -/
+theorem exists_arithMul_provider_row_matches_primary_of_divu_active_main_row_interaction
+    {length : ℕ} {program : Program length}
+    (m : ZiskFv.Airs.Main.Valid_Main FGL FGL) (r_main : ℕ)
+    (witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble)
+    (h_constraints : witness.Constraints)
+    (h_balanced : witness.BalancedChannels)
+    (h_specs : witness.Spec)
+    {mainTable : Table FGL}
+    (h_mainTable : mainTable ∈ witness.allTables)
+    (h_mainComponent :
+      mainTable.component =
+        ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program)
+    {mainRow : Array FGL}
+    (_h_mainRow : mainRow ∈ mainTable.table)
+    (h_main_row :
+      eval (mainTable.environment mainRow)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          length program).rowInputVar.core =
+        ZiskFv.AirsClean.Main.rowAt m r_main)
+    (h_main_active : m.is_external_op r_main = 1)
+    {mainInteraction : Interaction FGL}
+    (h_mainInteraction :
+      mainInteraction ∈ mainTable.interactionsWith OpBusChannel.toRaw)
+    (h_mainInteraction_eval :
+      mainInteraction =
+        ((OpBusChannel.emitted
+          (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar.core.is_external_op)
+          (ZiskFv.AirsClean.Main.opBusMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar.core)).toRaw).eval
+          (mainTable.environment mainRow))
+    (h_active : mainInteraction.mult = -1)
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_DIVU) :
+    ∃ providerTable ∈ witness.allTables,
+      ∃ providerRow ∈ providerTable.table,
+        providerTable.component = arithMulProviderComponent
+          ∧ providerTable.Spec
+          ∧ ZiskFv.Airs.OperationBus.matches_entry
+            (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+            (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+              (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                  (providerTable.environment providerRow))) 1) := by
+  have h_main_entry :
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+        (eval (mainTable.environment mainRow)
+          (ZiskFv.AirsClean.Main.opBusMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar.core)) 1 =
+        ZiskFv.Airs.OperationBus.opBus_row_Main m r_main := by
+    rw [ZiskFv.AirsClean.Main.eval_opBusMessageExpr]
+    rw [h_main_row]
+    rw [← ZiskFv.AirsClean.Main.opBusMessage_toEntry_rowAt_eq_opBus_row]
+    rw [h_main_active]
+  obtain ⟨_selectedMainRow, _h_selectedMainRow, _h_mainSpec, _h_selectedMainEval,
+      providerInteraction, _h_provider_witness, h_msg, _h_nonpull, _h_nonzero,
+      providerTable, h_providerTable, h_providerInteraction, h_providerBranches⟩ :=
+    exists_op_provider_row_msg_eq_spec_of_active_main_table_interaction
+      witness h_constraints h_balanced h_specs h_mainTable h_mainComponent
+      h_mainInteraction h_active
+  rcases h_providerBranches with h_arithMul | h_binExt | h_binary | h_binaryAdd
+  · obtain ⟨providerRow, h_providerRow, _h_providerSpec, h_component,
+      h_providerEval⟩ := h_arithMul
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.ArithMul.primaryOpBusMessageExpr
+                arithMulProviderComponent.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    have h_match_row :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+              (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                (providerTable.environment providerRow))) 1) := by
+      rw [ZiskFv.AirsClean.ArithMul.eval_primaryOpBusMessageExpr] at h_match
+      have h_row_eq :
+          eval (providerTable.environment providerRow)
+              arithMulProviderComponent.rowInputVar =
+            arithMulProviderComponent.rowInput
+              (providerTable.environment providerRow) := by
+        simpa only [Air.Flat.Component.rowInput, Air.Flat.Component.rowInputVar]
+          using
+            (eval_varFromOffset_valueFromOffset arithMulProviderComponent.Input 0
+              (providerTable.environment providerRow))
+      rwa [h_row_eq] at h_match
+    exact ⟨providerTable, h_providerTable, providerRow, h_providerRow,
+      h_component, h_specs providerTable h_providerTable, h_match_row⟩
+  · obtain ⟨providerRow, _h_providerRow, h_providerSpec, h_component,
+      h_providerEval⟩ := h_binExt
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.BinaryExtension.opBusMessageExpr
+                shiftStaticLookupComponent.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    exact False.elim
+      (staticBinaryExtension_provider_branch_ne_arithDivuPrimary
+        h_component h_providerSpec h_match h_main_op)
+  · obtain ⟨providerRow, _h_providerRow, h_providerSpec, h_component,
+      h_providerEval⟩ := h_binary
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.Binary.opBusMessageExpr
+                ZiskFv.AirsClean.Binary.staticLookupComponent.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    exact False.elim
+      (staticBinary_provider_branch_ne_arithDivuPrimary
+        h_component h_providerSpec h_match h_main_op)
+  · obtain ⟨providerRow, _h_providerRow, _h_providerSpec, _h_component,
+      h_providerEval⟩ := h_binaryAdd
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr
+                ZiskFv.AirsClean.BinaryAdd.component.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    exact False.elim
+      (binaryAdd_provider_branch_ne_arithDivuPrimary h_match h_main_op)
+
 end ZiskFv.AirsClean.FullEnsemble

--- a/ZiskFv/AirsClean/FullEnsemble/ArithBalance.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/ArithBalance.lean
@@ -1,0 +1,282 @@
+import ZiskFv.AirsClean.FullEnsemble.Balance
+
+/-!
+# Full Clean ensemble balance projections — Arith MULW keep/refute
+
+This module mirrors the BinaryExtension-shift keep/refute projections in
+`FullEnsemble.Balance` for the Arith MULW operation (`OP_MUL_W = 182`).
+The shift module keeps the BinaryExtension provider branch and refutes the
+ArithMul / Binary / BinaryAdd provider branches; here the roles are swapped:
+MULW keeps the ArithMul provider branch and refutes the BinaryExtension /
+static Binary / BinaryAdd provider branches.
+
+## Trust note
+
+0 PROJECT (`ZiskFv.*`) axioms; Sail+kernel as documented external trust.
+These lemmas only reuse the static-table op-value exclusions
+(`*_ne_arith_mul_w`) and the same `EnsembleWitness.BalancedChannels`
+unpacking as `FullEnsemble.Balance`.
+-/
+
+namespace ZiskFv.AirsClean.FullEnsemble
+
+open Goldilocks
+open Air.Flat
+open ZiskFv.Channels.OperationBus (OpBusChannel)
+open ZiskFv.Channels.MemoryBus (MemBusChannel)
+open ZiskFv.AirsClean.ZiskInstructionRom (Program)
+open ZiskFv.AirsClean.BinaryExtension (shiftStaticLookupComponent)
+
+/-- A lookup-aware static Binary provider branch cannot be the provider for a
+    Main Arith MULW operation (`OP_MUL_W = 182`). -/
+theorem staticBinary_provider_branch_ne_arithMulPrimary
+    {m : ZiskFv.Airs.Main.Valid_Main FGL FGL} {r_main : ℕ}
+    {providerTable : Table FGL} {providerRow : Array FGL}
+    (h_component :
+      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
+    (h_providerSpec :
+      providerTable.component.Spec (providerTable.environment providerRow))
+    (h_match :
+      ZiskFv.Airs.OperationBus.matches_entry
+        (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+        (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+          (eval (providerTable.environment providerRow)
+            (ZiskFv.AirsClean.Binary.opBusMessageExpr
+              ZiskFv.AirsClean.Binary.staticLookupComponent.rowInputVar)) 1))
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_MUL_W) :
+    False := by
+  let env := providerTable.environment providerRow
+  let row := ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput env
+  have h_componentSpec :
+      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec env := by
+    simpa [env, h_component] using h_providerSpec
+  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_componentSpec
+  have h_provider_op :
+      m.op r_main = row.chain.b_op + 16 * row.mode.mode32 := by
+    have h_op := h_match.2.1
+    simpa [env, row, ZiskFv.Airs.OperationBus.opBus_row_Main,
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
+      ZiskFv.AirsClean.Binary.staticLookupComponent_eval_opBusMessageExpr,
+      ZiskFv.AirsClean.Binary.opBusMessage] using h_op
+  exact ZiskFv.AirsClean.Binary.static_table_op_val_ne_arith_mul_w_of_emit
+    row h_componentSpec.1 h_componentSpec.2
+    (by
+      rw [← h_provider_op, h_main_op]
+      norm_num [ZiskFv.Trusted.OP_MUL_W])
+
+/-- A lookup-aware BinaryExtension provider branch cannot be the provider for a
+    Main Arith MULW operation (`OP_MUL_W = 182`). -/
+theorem staticBinaryExtension_provider_branch_ne_arithMulPrimary
+    {m : ZiskFv.Airs.Main.Valid_Main FGL FGL} {r_main : ℕ}
+    {providerTable : Table FGL} {providerRow : Array FGL}
+    (h_component :
+      providerTable.component = shiftStaticLookupComponent)
+    (h_providerSpec :
+      providerTable.component.Spec (providerTable.environment providerRow))
+    (h_match :
+      ZiskFv.Airs.OperationBus.matches_entry
+        (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+        (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+          (eval (providerTable.environment providerRow)
+            (ZiskFv.AirsClean.BinaryExtension.opBusMessageExpr
+              shiftStaticLookupComponent.rowInputVar)) 1))
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_MUL_W) :
+    False := by
+  let env := providerTable.environment providerRow
+  have h_componentSpec :
+      shiftStaticLookupComponent.Spec env := by
+    simpa [env, h_component] using h_providerSpec
+  have h_ne :=
+    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent_op_val_ne_arith_mul_w_of_spec
+      env h_componentSpec
+  have h_provider_op :
+      (m.op r_main).val =
+        (shiftStaticLookupComponent.rowInput env).flags.op.val := by
+    have h_op := h_match.2.1
+    have h_op_val := congrArg Fin.val h_op
+    simpa [env, ZiskFv.Airs.OperationBus.opBus_row_Main,
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
+      ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent_eval_opBusMessageExpr_op]
+      using h_op_val
+  exact h_ne.1 (by
+    rw [← h_provider_op, h_main_op]
+    norm_num [ZiskFv.Trusted.OP_MUL_W])
+
+/-- The BinaryAdd provider branch cannot be the provider for a Main Arith MULW
+    operation (`OP_MUL_W = 182`). -/
+theorem binaryAdd_provider_branch_ne_arithMulPrimary
+    {m : ZiskFv.Airs.Main.Valid_Main FGL FGL} {r_main : ℕ}
+    {providerTable : Table FGL} {providerRow : Array FGL}
+    (h_match :
+      ZiskFv.Airs.OperationBus.matches_entry
+        (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+        (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+          (eval (providerTable.environment providerRow)
+            (ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr
+              ZiskFv.AirsClean.BinaryAdd.component.rowInputVar)) 1))
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_MUL_W) :
+    False := by
+  have h_provider_op : (m.op r_main).val = 10 := by
+    have h_op := h_match.2.1
+    have h_op_val := congrArg Fin.val h_op
+    simpa [ZiskFv.Airs.OperationBus.opBus_row_Main,
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
+      ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr,
+      ZiskFv.Channels.OperationBus.OpBusMessage.eval_op]
+      using h_op_val
+  rw [h_main_op] at h_provider_op
+  norm_num [ZiskFv.Trusted.OP_MUL_W] at h_provider_op
+
+/-- An active unified-Main MULW operation-bus interaction is balanced by an
+    Arith-Mul provider row carrying `witness.Spec`, whose primary operation-bus
+    message matches the Main row's emission. This keeps the ArithMul provider
+    branch and refutes the BinaryExtension / static Binary / BinaryAdd
+    provider branches via the `*_ne_arithMulPrimary` exclusions. -/
+theorem exists_arithMul_provider_row_matches_primary_of_mulw_active_main_row_interaction
+    {length : ℕ} {program : Program length}
+    (m : ZiskFv.Airs.Main.Valid_Main FGL FGL) (r_main : ℕ)
+    (witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble)
+    (h_constraints : witness.Constraints)
+    (h_balanced : witness.BalancedChannels)
+    (h_specs : witness.Spec)
+    {mainTable : Table FGL}
+    (h_mainTable : mainTable ∈ witness.allTables)
+    (h_mainComponent :
+      mainTable.component =
+        ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program)
+    {mainRow : Array FGL}
+    (_h_mainRow : mainRow ∈ mainTable.table)
+    (h_main_row :
+      eval (mainTable.environment mainRow)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          length program).rowInputVar.core =
+        ZiskFv.AirsClean.Main.rowAt m r_main)
+    (h_main_active : m.is_external_op r_main = 1)
+    {mainInteraction : Interaction FGL}
+    (h_mainInteraction :
+      mainInteraction ∈ mainTable.interactionsWith OpBusChannel.toRaw)
+    (h_mainInteraction_eval :
+      mainInteraction =
+        ((OpBusChannel.emitted
+          (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar.core.is_external_op)
+          (ZiskFv.AirsClean.Main.opBusMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar.core)).toRaw).eval
+          (mainTable.environment mainRow))
+    (h_active : mainInteraction.mult = -1)
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_MUL_W) :
+    ∃ providerTable ∈ witness.allTables,
+      ∃ providerRow ∈ providerTable.table,
+        providerTable.component = arithMulProviderComponent
+          ∧ providerTable.Spec
+          ∧ ZiskFv.Airs.OperationBus.matches_entry
+            (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+            (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+              (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                  (providerTable.environment providerRow))) 1) := by
+  have h_main_entry :
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+        (eval (mainTable.environment mainRow)
+          (ZiskFv.AirsClean.Main.opBusMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar.core)) 1 =
+        ZiskFv.Airs.OperationBus.opBus_row_Main m r_main := by
+    rw [ZiskFv.AirsClean.Main.eval_opBusMessageExpr]
+    rw [h_main_row]
+    rw [← ZiskFv.AirsClean.Main.opBusMessage_toEntry_rowAt_eq_opBus_row]
+    rw [h_main_active]
+  obtain ⟨_selectedMainRow, _h_selectedMainRow, _h_mainSpec, _h_selectedMainEval,
+      providerInteraction, _h_provider_witness, h_msg, _h_nonpull, _h_nonzero,
+      providerTable, h_providerTable, h_providerInteraction, h_providerBranches⟩ :=
+    exists_op_provider_row_msg_eq_spec_of_active_main_table_interaction
+      witness h_constraints h_balanced h_specs h_mainTable h_mainComponent
+      h_mainInteraction h_active
+  rcases h_providerBranches with h_arithMul | h_binExt | h_binary | h_binaryAdd
+  · obtain ⟨providerRow, h_providerRow, _h_providerSpec, h_component,
+      h_providerEval⟩ := h_arithMul
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.ArithMul.primaryOpBusMessageExpr
+                arithMulProviderComponent.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    have h_match_row :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+              (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                (providerTable.environment providerRow))) 1) := by
+      rw [ZiskFv.AirsClean.ArithMul.eval_primaryOpBusMessageExpr] at h_match
+      have h_row_eq :
+          eval (providerTable.environment providerRow)
+              arithMulProviderComponent.rowInputVar =
+            arithMulProviderComponent.rowInput
+              (providerTable.environment providerRow) := by
+        simpa only [Air.Flat.Component.rowInput, Air.Flat.Component.rowInputVar]
+          using
+            (eval_varFromOffset_valueFromOffset arithMulProviderComponent.Input 0
+              (providerTable.environment providerRow))
+      rwa [h_row_eq] at h_match
+    exact ⟨providerTable, h_providerTable, providerRow, h_providerRow,
+      h_component, h_specs providerTable h_providerTable, h_match_row⟩
+  · obtain ⟨providerRow, _h_providerRow, h_providerSpec, h_component,
+      h_providerEval⟩ := h_binExt
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.BinaryExtension.opBusMessageExpr
+                shiftStaticLookupComponent.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    exact False.elim
+      (staticBinaryExtension_provider_branch_ne_arithMulPrimary
+        h_component h_providerSpec h_match h_main_op)
+  · obtain ⟨providerRow, _h_providerRow, h_providerSpec, h_component,
+      h_providerEval⟩ := h_binary
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.Binary.opBusMessageExpr
+                ZiskFv.AirsClean.Binary.staticLookupComponent.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    exact False.elim
+      (staticBinary_provider_branch_ne_arithMulPrimary
+        h_component h_providerSpec h_match h_main_op)
+  · obtain ⟨providerRow, _h_providerRow, _h_providerSpec, _h_component,
+      h_providerEval⟩ := h_binaryAdd
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr
+                ZiskFv.AirsClean.BinaryAdd.component.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    exact False.elim
+      (binaryAdd_provider_branch_ne_arithMulPrimary h_match h_main_op)
+
+end ZiskFv.AirsClean.FullEnsemble

--- a/ZiskFv/AirsClean/FullEnsemble/ArithBalance.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/ArithBalance.lean
@@ -1332,4 +1332,269 @@ theorem exists_arithMul_provider_row_matches_primary_of_remu_active_main_row_int
     exact False.elim
       (binaryAdd_provider_branch_ne_arithRemuPrimary h_match h_main_op)
 
+/-! ## Arith REMUW keep/refute (`OP_REMU_W = 189`, W-mode)
+
+Mirror of the REMU keep/refute above, for the W-mode (`m32 = 1`) unsigned REMUW
+operation.  The provider is still the shared ArithMul `componentWithArithTable`
+(the ArithDiv component carries no op-bus interactions in the ensemble).  The
+keep theorem produces the SAME muxed `primaryOpBusMessage` match; the REMU-mode
+secondary bridge in `ConstructionRemu.lean` reduces that muxed message — at
+`div = 1`, `main_div = 0`, `main_mul = 0` (the **secondary** lane; `m32` plays no
+role in the mux) — to the div remainder-lane message
+`opBus_row_ArithDivSecondary` the REMUW construction consumes.  The three
+non-arith provider branches are refuted via the op-189 static-table
+exclusions. -/
+
+/-- A lookup-aware static Binary provider branch cannot be the provider for a
+    Main Arith REMUW operation (`OP_REMU_W = 189`). -/
+theorem staticBinary_provider_branch_ne_arithRemuwPrimary
+    {m : ZiskFv.Airs.Main.Valid_Main FGL FGL} {r_main : ℕ}
+    {providerTable : Table FGL} {providerRow : Array FGL}
+    (h_component :
+      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
+    (h_providerSpec :
+      providerTable.component.Spec (providerTable.environment providerRow))
+    (h_match :
+      ZiskFv.Airs.OperationBus.matches_entry
+        (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+        (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+          (eval (providerTable.environment providerRow)
+            (ZiskFv.AirsClean.Binary.opBusMessageExpr
+              ZiskFv.AirsClean.Binary.staticLookupComponent.rowInputVar)) 1))
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_REMU_W) :
+    False := by
+  let env := providerTable.environment providerRow
+  let row := ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput env
+  have h_componentSpec :
+      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec env := by
+    simpa [env, h_component] using h_providerSpec
+  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_componentSpec
+  have h_provider_op :
+      m.op r_main = row.chain.b_op + 16 * row.mode.mode32 := by
+    have h_op := h_match.2.1
+    simpa [env, row, ZiskFv.Airs.OperationBus.opBus_row_Main,
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
+      ZiskFv.AirsClean.Binary.staticLookupComponent_eval_opBusMessageExpr,
+      ZiskFv.AirsClean.Binary.opBusMessage] using h_op
+  exact ZiskFv.AirsClean.Binary.static_table_op_val_ne_arith_remuw_of_emit
+    row h_componentSpec.1 h_componentSpec.2
+    (by
+      rw [← h_provider_op, h_main_op]
+      norm_num [ZiskFv.Trusted.OP_REMU_W])
+
+/-- A lookup-aware BinaryExtension provider branch cannot be the provider for a
+    Main Arith REMUW operation (`OP_REMU_W = 189`). -/
+theorem staticBinaryExtension_provider_branch_ne_arithRemuwPrimary
+    {m : ZiskFv.Airs.Main.Valid_Main FGL FGL} {r_main : ℕ}
+    {providerTable : Table FGL} {providerRow : Array FGL}
+    (h_component :
+      providerTable.component = shiftStaticLookupComponent)
+    (h_providerSpec :
+      providerTable.component.Spec (providerTable.environment providerRow))
+    (h_match :
+      ZiskFv.Airs.OperationBus.matches_entry
+        (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+        (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+          (eval (providerTable.environment providerRow)
+            (ZiskFv.AirsClean.BinaryExtension.opBusMessageExpr
+              shiftStaticLookupComponent.rowInputVar)) 1))
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_REMU_W) :
+    False := by
+  let env := providerTable.environment providerRow
+  have h_componentSpec :
+      shiftStaticLookupComponent.Spec env := by
+    simpa [env, h_component] using h_providerSpec
+  have h_ne :=
+    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent_op_val_ne_arith_remuw_of_spec
+      env h_componentSpec
+  have h_provider_op :
+      (m.op r_main).val =
+        (shiftStaticLookupComponent.rowInput env).flags.op.val := by
+    have h_op := h_match.2.1
+    have h_op_val := congrArg Fin.val h_op
+    simpa [env, ZiskFv.Airs.OperationBus.opBus_row_Main,
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
+      ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent_eval_opBusMessageExpr_op]
+      using h_op_val
+  exact h_ne.1 (by
+    rw [← h_provider_op, h_main_op]
+    norm_num [ZiskFv.Trusted.OP_REMU_W])
+
+/-- The BinaryAdd provider branch cannot be the provider for a Main Arith REMUW
+    operation (`OP_REMU_W = 189`). -/
+theorem binaryAdd_provider_branch_ne_arithRemuwPrimary
+    {m : ZiskFv.Airs.Main.Valid_Main FGL FGL} {r_main : ℕ}
+    {providerTable : Table FGL} {providerRow : Array FGL}
+    (h_match :
+      ZiskFv.Airs.OperationBus.matches_entry
+        (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+        (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+          (eval (providerTable.environment providerRow)
+            (ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr
+              ZiskFv.AirsClean.BinaryAdd.component.rowInputVar)) 1))
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_REMU_W) :
+    False := by
+  have h_provider_op : (m.op r_main).val = 10 := by
+    have h_op := h_match.2.1
+    have h_op_val := congrArg Fin.val h_op
+    simpa [ZiskFv.Airs.OperationBus.opBus_row_Main,
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
+      ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr,
+      ZiskFv.Channels.OperationBus.OpBusMessage.eval_op]
+      using h_op_val
+  rw [h_main_op] at h_provider_op
+  norm_num [ZiskFv.Trusted.OP_REMU_W] at h_provider_op
+
+/-- An active unified-Main REMUW operation-bus interaction is balanced by an
+    Arith-Mul provider row carrying `witness.Spec`, whose primary (muxed)
+    operation-bus message matches the Main row's emission.  Keeps the ArithMul
+    provider branch and refutes the BinaryExtension / static Binary / BinaryAdd
+    provider branches via the `*_ne_arithRemuwPrimary` exclusions. -/
+theorem exists_arithMul_provider_row_matches_primary_of_remuw_active_main_row_interaction
+    {length : ℕ} {program : Program length}
+    (m : ZiskFv.Airs.Main.Valid_Main FGL FGL) (r_main : ℕ)
+    (witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble)
+    (h_constraints : witness.Constraints)
+    (h_balanced : witness.BalancedChannels)
+    (h_specs : witness.Spec)
+    {mainTable : Table FGL}
+    (h_mainTable : mainTable ∈ witness.allTables)
+    (h_mainComponent :
+      mainTable.component =
+        ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program)
+    {mainRow : Array FGL}
+    (_h_mainRow : mainRow ∈ mainTable.table)
+    (h_main_row :
+      eval (mainTable.environment mainRow)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          length program).rowInputVar.core =
+        ZiskFv.AirsClean.Main.rowAt m r_main)
+    (h_main_active : m.is_external_op r_main = 1)
+    {mainInteraction : Interaction FGL}
+    (h_mainInteraction :
+      mainInteraction ∈ mainTable.interactionsWith OpBusChannel.toRaw)
+    (h_mainInteraction_eval :
+      mainInteraction =
+        ((OpBusChannel.emitted
+          (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar.core.is_external_op)
+          (ZiskFv.AirsClean.Main.opBusMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar.core)).toRaw).eval
+          (mainTable.environment mainRow))
+    (h_active : mainInteraction.mult = -1)
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_REMU_W) :
+    ∃ providerTable ∈ witness.allTables,
+      ∃ providerRow ∈ providerTable.table,
+        providerTable.component = arithMulProviderComponent
+          ∧ providerTable.Spec
+          ∧ ZiskFv.Airs.OperationBus.matches_entry
+            (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+            (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+              (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                  (providerTable.environment providerRow))) 1) := by
+  have h_main_entry :
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+        (eval (mainTable.environment mainRow)
+          (ZiskFv.AirsClean.Main.opBusMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar.core)) 1 =
+        ZiskFv.Airs.OperationBus.opBus_row_Main m r_main := by
+    rw [ZiskFv.AirsClean.Main.eval_opBusMessageExpr]
+    rw [h_main_row]
+    rw [← ZiskFv.AirsClean.Main.opBusMessage_toEntry_rowAt_eq_opBus_row]
+    rw [h_main_active]
+  obtain ⟨_selectedMainRow, _h_selectedMainRow, _h_mainSpec, _h_selectedMainEval,
+      providerInteraction, _h_provider_witness, h_msg, _h_nonpull, _h_nonzero,
+      providerTable, h_providerTable, h_providerInteraction, h_providerBranches⟩ :=
+    exists_op_provider_row_msg_eq_spec_of_active_main_table_interaction
+      witness h_constraints h_balanced h_specs h_mainTable h_mainComponent
+      h_mainInteraction h_active
+  rcases h_providerBranches with h_arithMul | h_binExt | h_binary | h_binaryAdd
+  · obtain ⟨providerRow, h_providerRow, _h_providerSpec, h_component,
+      h_providerEval⟩ := h_arithMul
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.ArithMul.primaryOpBusMessageExpr
+                arithMulProviderComponent.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    have h_match_row :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+              (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                (providerTable.environment providerRow))) 1) := by
+      rw [ZiskFv.AirsClean.ArithMul.eval_primaryOpBusMessageExpr] at h_match
+      have h_row_eq :
+          eval (providerTable.environment providerRow)
+              arithMulProviderComponent.rowInputVar =
+            arithMulProviderComponent.rowInput
+              (providerTable.environment providerRow) := by
+        simpa only [Air.Flat.Component.rowInput, Air.Flat.Component.rowInputVar]
+          using
+            (eval_varFromOffset_valueFromOffset arithMulProviderComponent.Input 0
+              (providerTable.environment providerRow))
+      rwa [h_row_eq] at h_match
+    exact ⟨providerTable, h_providerTable, providerRow, h_providerRow,
+      h_component, h_specs providerTable h_providerTable, h_match_row⟩
+  · obtain ⟨providerRow, _h_providerRow, h_providerSpec, h_component,
+      h_providerEval⟩ := h_binExt
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.BinaryExtension.opBusMessageExpr
+                shiftStaticLookupComponent.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    exact False.elim
+      (staticBinaryExtension_provider_branch_ne_arithRemuwPrimary
+        h_component h_providerSpec h_match h_main_op)
+  · obtain ⟨providerRow, _h_providerRow, h_providerSpec, h_component,
+      h_providerEval⟩ := h_binary
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.Binary.opBusMessageExpr
+                ZiskFv.AirsClean.Binary.staticLookupComponent.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    exact False.elim
+      (staticBinary_provider_branch_ne_arithRemuwPrimary
+        h_component h_providerSpec h_match h_main_op)
+  · obtain ⟨providerRow, _h_providerRow, _h_providerSpec, _h_component,
+      h_providerEval⟩ := h_binaryAdd
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr
+                ZiskFv.AirsClean.BinaryAdd.component.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    exact False.elim
+      (binaryAdd_provider_branch_ne_arithRemuwPrimary h_match h_main_op)
+
 end ZiskFv.AirsClean.FullEnsemble

--- a/ZiskFv/AirsClean/FullEnsemble/ArithBalance.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/ArithBalance.lean
@@ -279,4 +279,266 @@ theorem exists_arithMul_provider_row_matches_primary_of_mulw_active_main_row_int
     exact False.elim
       (binaryAdd_provider_branch_ne_arithMulPrimary h_match h_main_op)
 
+/-! ## Arith MULHU keep/refute (`OP_MULUH = 177`)
+
+Mirror of the MULW keep/refute above, for the unsigned high-half MUL.  The
+keep theorem produces the SAME muxed `primaryOpBusMessage` match (the balance
+machinery only emits the provider's primary message); the MULHU-mode bridge
+in `ArithMul/Bridge.lean` reduces that muxed message — at `main_mul = 0`,
+`main_div = 0`, `div = 0` — to the secondary d-lane message
+`opBus_row_ArithMulSecondary` the wrapper consumes.  The three non-arith
+provider branches are refuted via the op-177 static-table exclusions. -/
+
+/-- A lookup-aware static Binary provider branch cannot be the provider for a
+    Main Arith MULHU operation (`OP_MULUH = 177`). -/
+theorem staticBinary_provider_branch_ne_arithMulSecondary
+    {m : ZiskFv.Airs.Main.Valid_Main FGL FGL} {r_main : ℕ}
+    {providerTable : Table FGL} {providerRow : Array FGL}
+    (h_component :
+      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
+    (h_providerSpec :
+      providerTable.component.Spec (providerTable.environment providerRow))
+    (h_match :
+      ZiskFv.Airs.OperationBus.matches_entry
+        (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+        (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+          (eval (providerTable.environment providerRow)
+            (ZiskFv.AirsClean.Binary.opBusMessageExpr
+              ZiskFv.AirsClean.Binary.staticLookupComponent.rowInputVar)) 1))
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_MULUH) :
+    False := by
+  let env := providerTable.environment providerRow
+  let row := ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput env
+  have h_componentSpec :
+      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec env := by
+    simpa [env, h_component] using h_providerSpec
+  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_componentSpec
+  have h_provider_op :
+      m.op r_main = row.chain.b_op + 16 * row.mode.mode32 := by
+    have h_op := h_match.2.1
+    simpa [env, row, ZiskFv.Airs.OperationBus.opBus_row_Main,
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
+      ZiskFv.AirsClean.Binary.staticLookupComponent_eval_opBusMessageExpr,
+      ZiskFv.AirsClean.Binary.opBusMessage] using h_op
+  exact ZiskFv.AirsClean.Binary.static_table_op_val_ne_arith_mul_uh_of_emit
+    row h_componentSpec.1 h_componentSpec.2
+    (by
+      rw [← h_provider_op, h_main_op]
+      norm_num [ZiskFv.Trusted.OP_MULUH])
+
+/-- A lookup-aware BinaryExtension provider branch cannot be the provider for a
+    Main Arith MULHU operation (`OP_MULUH = 177`). -/
+theorem staticBinaryExtension_provider_branch_ne_arithMulSecondary
+    {m : ZiskFv.Airs.Main.Valid_Main FGL FGL} {r_main : ℕ}
+    {providerTable : Table FGL} {providerRow : Array FGL}
+    (h_component :
+      providerTable.component = shiftStaticLookupComponent)
+    (h_providerSpec :
+      providerTable.component.Spec (providerTable.environment providerRow))
+    (h_match :
+      ZiskFv.Airs.OperationBus.matches_entry
+        (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+        (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+          (eval (providerTable.environment providerRow)
+            (ZiskFv.AirsClean.BinaryExtension.opBusMessageExpr
+              shiftStaticLookupComponent.rowInputVar)) 1))
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_MULUH) :
+    False := by
+  let env := providerTable.environment providerRow
+  have h_componentSpec :
+      shiftStaticLookupComponent.Spec env := by
+    simpa [env, h_component] using h_providerSpec
+  have h_ne :=
+    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent_op_val_ne_arith_mul_uh_of_spec
+      env h_componentSpec
+  have h_provider_op :
+      (m.op r_main).val =
+        (shiftStaticLookupComponent.rowInput env).flags.op.val := by
+    have h_op := h_match.2.1
+    have h_op_val := congrArg Fin.val h_op
+    simpa [env, ZiskFv.Airs.OperationBus.opBus_row_Main,
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
+      ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent_eval_opBusMessageExpr_op]
+      using h_op_val
+  exact h_ne.1 (by
+    rw [← h_provider_op, h_main_op]
+    norm_num [ZiskFv.Trusted.OP_MULUH])
+
+/-- The BinaryAdd provider branch cannot be the provider for a Main Arith MULHU
+    operation (`OP_MULUH = 177`). -/
+theorem binaryAdd_provider_branch_ne_arithMulSecondary
+    {m : ZiskFv.Airs.Main.Valid_Main FGL FGL} {r_main : ℕ}
+    {providerTable : Table FGL} {providerRow : Array FGL}
+    (h_match :
+      ZiskFv.Airs.OperationBus.matches_entry
+        (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+        (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+          (eval (providerTable.environment providerRow)
+            (ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr
+              ZiskFv.AirsClean.BinaryAdd.component.rowInputVar)) 1))
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_MULUH) :
+    False := by
+  have h_provider_op : (m.op r_main).val = 10 := by
+    have h_op := h_match.2.1
+    have h_op_val := congrArg Fin.val h_op
+    simpa [ZiskFv.Airs.OperationBus.opBus_row_Main,
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
+      ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr,
+      ZiskFv.Channels.OperationBus.OpBusMessage.eval_op]
+      using h_op_val
+  rw [h_main_op] at h_provider_op
+  norm_num [ZiskFv.Trusted.OP_MULUH] at h_provider_op
+
+/-- An active unified-Main MULHU operation-bus interaction is balanced by an
+    Arith-Mul provider row carrying `witness.Spec`, whose primary (muxed)
+    operation-bus message matches the Main row's emission.  Keeps the ArithMul
+    provider branch and refutes the BinaryExtension / static Binary / BinaryAdd
+    provider branches via the `*_ne_arithMulSecondary` exclusions. -/
+theorem exists_arithMul_provider_row_matches_secondary_of_mulhu_active_main_row_interaction
+    {length : ℕ} {program : Program length}
+    (m : ZiskFv.Airs.Main.Valid_Main FGL FGL) (r_main : ℕ)
+    (witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble)
+    (h_constraints : witness.Constraints)
+    (h_balanced : witness.BalancedChannels)
+    (h_specs : witness.Spec)
+    {mainTable : Table FGL}
+    (h_mainTable : mainTable ∈ witness.allTables)
+    (h_mainComponent :
+      mainTable.component =
+        ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program)
+    {mainRow : Array FGL}
+    (_h_mainRow : mainRow ∈ mainTable.table)
+    (h_main_row :
+      eval (mainTable.environment mainRow)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          length program).rowInputVar.core =
+        ZiskFv.AirsClean.Main.rowAt m r_main)
+    (h_main_active : m.is_external_op r_main = 1)
+    {mainInteraction : Interaction FGL}
+    (h_mainInteraction :
+      mainInteraction ∈ mainTable.interactionsWith OpBusChannel.toRaw)
+    (h_mainInteraction_eval :
+      mainInteraction =
+        ((OpBusChannel.emitted
+          (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar.core.is_external_op)
+          (ZiskFv.AirsClean.Main.opBusMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar.core)).toRaw).eval
+          (mainTable.environment mainRow))
+    (h_active : mainInteraction.mult = -1)
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_MULUH) :
+    ∃ providerTable ∈ witness.allTables,
+      ∃ providerRow ∈ providerTable.table,
+        providerTable.component = arithMulProviderComponent
+          ∧ providerTable.Spec
+          ∧ ZiskFv.Airs.OperationBus.matches_entry
+            (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+            (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+              (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                  (providerTable.environment providerRow))) 1) := by
+  have h_main_entry :
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+        (eval (mainTable.environment mainRow)
+          (ZiskFv.AirsClean.Main.opBusMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar.core)) 1 =
+        ZiskFv.Airs.OperationBus.opBus_row_Main m r_main := by
+    rw [ZiskFv.AirsClean.Main.eval_opBusMessageExpr]
+    rw [h_main_row]
+    rw [← ZiskFv.AirsClean.Main.opBusMessage_toEntry_rowAt_eq_opBus_row]
+    rw [h_main_active]
+  obtain ⟨_selectedMainRow, _h_selectedMainRow, _h_mainSpec, _h_selectedMainEval,
+      providerInteraction, _h_provider_witness, h_msg, _h_nonpull, _h_nonzero,
+      providerTable, h_providerTable, h_providerInteraction, h_providerBranches⟩ :=
+    exists_op_provider_row_msg_eq_spec_of_active_main_table_interaction
+      witness h_constraints h_balanced h_specs h_mainTable h_mainComponent
+      h_mainInteraction h_active
+  rcases h_providerBranches with h_arithMul | h_binExt | h_binary | h_binaryAdd
+  · obtain ⟨providerRow, h_providerRow, _h_providerSpec, h_component,
+      h_providerEval⟩ := h_arithMul
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.ArithMul.primaryOpBusMessageExpr
+                arithMulProviderComponent.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    have h_match_row :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+              (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                (providerTable.environment providerRow))) 1) := by
+      rw [ZiskFv.AirsClean.ArithMul.eval_primaryOpBusMessageExpr] at h_match
+      have h_row_eq :
+          eval (providerTable.environment providerRow)
+              arithMulProviderComponent.rowInputVar =
+            arithMulProviderComponent.rowInput
+              (providerTable.environment providerRow) := by
+        simpa only [Air.Flat.Component.rowInput, Air.Flat.Component.rowInputVar]
+          using
+            (eval_varFromOffset_valueFromOffset arithMulProviderComponent.Input 0
+              (providerTable.environment providerRow))
+      rwa [h_row_eq] at h_match
+    exact ⟨providerTable, h_providerTable, providerRow, h_providerRow,
+      h_component, h_specs providerTable h_providerTable, h_match_row⟩
+  · obtain ⟨providerRow, _h_providerRow, h_providerSpec, h_component,
+      h_providerEval⟩ := h_binExt
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.BinaryExtension.opBusMessageExpr
+                shiftStaticLookupComponent.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    exact False.elim
+      (staticBinaryExtension_provider_branch_ne_arithMulSecondary
+        h_component h_providerSpec h_match h_main_op)
+  · obtain ⟨providerRow, _h_providerRow, h_providerSpec, h_component,
+      h_providerEval⟩ := h_binary
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.Binary.opBusMessageExpr
+                ZiskFv.AirsClean.Binary.staticLookupComponent.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    exact False.elim
+      (staticBinary_provider_branch_ne_arithMulSecondary
+        h_component h_providerSpec h_match h_main_op)
+  · obtain ⟨providerRow, _h_providerRow, _h_providerSpec, _h_component,
+      h_providerEval⟩ := h_binaryAdd
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr
+                ZiskFv.AirsClean.BinaryAdd.component.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    exact False.elim
+      (binaryAdd_provider_branch_ne_arithMulSecondary h_match h_main_op)
+
 end ZiskFv.AirsClean.FullEnsemble

--- a/ZiskFv/AirsClean/FullEnsemble/ArithBalance.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/ArithBalance.lean
@@ -1068,4 +1068,268 @@ theorem exists_arithMul_provider_row_matches_primary_of_divuw_active_main_row_in
     exact False.elim
       (binaryAdd_provider_branch_ne_arithDivuwPrimary h_match h_main_op)
 
+/-! ## Arith REMU keep/refute (`OP_REMU = 185`)
+
+Mirror of the DIVU keep/refute above, for the unsigned REMU operation.  The
+provider is still the shared ArithMul `componentWithArithTable` (the ArithDiv
+component carries no op-bus interactions in the ensemble).  The keep theorem
+produces the SAME muxed `primaryOpBusMessage` match; the REMU-mode bridge in
+`ConstructionRemu.lean` reduces that muxed message — at `div = 1`,
+`main_div = 0`, `main_mul = 0` (the **secondary** lane) — to the div
+remainder-lane message `opBus_row_ArithDivSecondary` the REMU construction
+consumes.  The three non-arith provider branches are refuted via the op-185
+static-table exclusions. -/
+
+/-- A lookup-aware static Binary provider branch cannot be the provider for a
+    Main Arith REMU operation (`OP_REMU = 185`). -/
+theorem staticBinary_provider_branch_ne_arithRemuPrimary
+    {m : ZiskFv.Airs.Main.Valid_Main FGL FGL} {r_main : ℕ}
+    {providerTable : Table FGL} {providerRow : Array FGL}
+    (h_component :
+      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
+    (h_providerSpec :
+      providerTable.component.Spec (providerTable.environment providerRow))
+    (h_match :
+      ZiskFv.Airs.OperationBus.matches_entry
+        (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+        (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+          (eval (providerTable.environment providerRow)
+            (ZiskFv.AirsClean.Binary.opBusMessageExpr
+              ZiskFv.AirsClean.Binary.staticLookupComponent.rowInputVar)) 1))
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_REMU) :
+    False := by
+  let env := providerTable.environment providerRow
+  let row := ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput env
+  have h_componentSpec :
+      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec env := by
+    simpa [env, h_component] using h_providerSpec
+  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_componentSpec
+  have h_provider_op :
+      m.op r_main = row.chain.b_op + 16 * row.mode.mode32 := by
+    have h_op := h_match.2.1
+    simpa [env, row, ZiskFv.Airs.OperationBus.opBus_row_Main,
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
+      ZiskFv.AirsClean.Binary.staticLookupComponent_eval_opBusMessageExpr,
+      ZiskFv.AirsClean.Binary.opBusMessage] using h_op
+  exact ZiskFv.AirsClean.Binary.static_table_op_val_ne_arith_remu_of_emit
+    row h_componentSpec.1 h_componentSpec.2
+    (by
+      rw [← h_provider_op, h_main_op]
+      norm_num [ZiskFv.Trusted.OP_REMU])
+
+/-- A lookup-aware BinaryExtension provider branch cannot be the provider for a
+    Main Arith REMU operation (`OP_REMU = 185`). -/
+theorem staticBinaryExtension_provider_branch_ne_arithRemuPrimary
+    {m : ZiskFv.Airs.Main.Valid_Main FGL FGL} {r_main : ℕ}
+    {providerTable : Table FGL} {providerRow : Array FGL}
+    (h_component :
+      providerTable.component = shiftStaticLookupComponent)
+    (h_providerSpec :
+      providerTable.component.Spec (providerTable.environment providerRow))
+    (h_match :
+      ZiskFv.Airs.OperationBus.matches_entry
+        (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+        (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+          (eval (providerTable.environment providerRow)
+            (ZiskFv.AirsClean.BinaryExtension.opBusMessageExpr
+              shiftStaticLookupComponent.rowInputVar)) 1))
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_REMU) :
+    False := by
+  let env := providerTable.environment providerRow
+  have h_componentSpec :
+      shiftStaticLookupComponent.Spec env := by
+    simpa [env, h_component] using h_providerSpec
+  have h_ne :=
+    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent_op_val_ne_arith_remu_of_spec
+      env h_componentSpec
+  have h_provider_op :
+      (m.op r_main).val =
+        (shiftStaticLookupComponent.rowInput env).flags.op.val := by
+    have h_op := h_match.2.1
+    have h_op_val := congrArg Fin.val h_op
+    simpa [env, ZiskFv.Airs.OperationBus.opBus_row_Main,
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
+      ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent_eval_opBusMessageExpr_op]
+      using h_op_val
+  exact h_ne.1 (by
+    rw [← h_provider_op, h_main_op]
+    norm_num [ZiskFv.Trusted.OP_REMU])
+
+/-- The BinaryAdd provider branch cannot be the provider for a Main Arith REMU
+    operation (`OP_REMU = 185`). -/
+theorem binaryAdd_provider_branch_ne_arithRemuPrimary
+    {m : ZiskFv.Airs.Main.Valid_Main FGL FGL} {r_main : ℕ}
+    {providerTable : Table FGL} {providerRow : Array FGL}
+    (h_match :
+      ZiskFv.Airs.OperationBus.matches_entry
+        (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+        (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+          (eval (providerTable.environment providerRow)
+            (ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr
+              ZiskFv.AirsClean.BinaryAdd.component.rowInputVar)) 1))
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_REMU) :
+    False := by
+  have h_provider_op : (m.op r_main).val = 10 := by
+    have h_op := h_match.2.1
+    have h_op_val := congrArg Fin.val h_op
+    simpa [ZiskFv.Airs.OperationBus.opBus_row_Main,
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
+      ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr,
+      ZiskFv.Channels.OperationBus.OpBusMessage.eval_op]
+      using h_op_val
+  rw [h_main_op] at h_provider_op
+  norm_num [ZiskFv.Trusted.OP_REMU] at h_provider_op
+
+/-- An active unified-Main REMU operation-bus interaction is balanced by an
+    Arith-Mul provider row carrying `witness.Spec`, whose primary (muxed)
+    operation-bus message matches the Main row's emission.  Keeps the ArithMul
+    provider branch and refutes the BinaryExtension / static Binary / BinaryAdd
+    provider branches via the `*_ne_arithRemuPrimary` exclusions. -/
+theorem exists_arithMul_provider_row_matches_primary_of_remu_active_main_row_interaction
+    {length : ℕ} {program : Program length}
+    (m : ZiskFv.Airs.Main.Valid_Main FGL FGL) (r_main : ℕ)
+    (witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble)
+    (h_constraints : witness.Constraints)
+    (h_balanced : witness.BalancedChannels)
+    (h_specs : witness.Spec)
+    {mainTable : Table FGL}
+    (h_mainTable : mainTable ∈ witness.allTables)
+    (h_mainComponent :
+      mainTable.component =
+        ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program)
+    {mainRow : Array FGL}
+    (_h_mainRow : mainRow ∈ mainTable.table)
+    (h_main_row :
+      eval (mainTable.environment mainRow)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          length program).rowInputVar.core =
+        ZiskFv.AirsClean.Main.rowAt m r_main)
+    (h_main_active : m.is_external_op r_main = 1)
+    {mainInteraction : Interaction FGL}
+    (h_mainInteraction :
+      mainInteraction ∈ mainTable.interactionsWith OpBusChannel.toRaw)
+    (h_mainInteraction_eval :
+      mainInteraction =
+        ((OpBusChannel.emitted
+          (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar.core.is_external_op)
+          (ZiskFv.AirsClean.Main.opBusMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar.core)).toRaw).eval
+          (mainTable.environment mainRow))
+    (h_active : mainInteraction.mult = -1)
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_REMU) :
+    ∃ providerTable ∈ witness.allTables,
+      ∃ providerRow ∈ providerTable.table,
+        providerTable.component = arithMulProviderComponent
+          ∧ providerTable.Spec
+          ∧ ZiskFv.Airs.OperationBus.matches_entry
+            (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+            (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+              (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                  (providerTable.environment providerRow))) 1) := by
+  have h_main_entry :
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+        (eval (mainTable.environment mainRow)
+          (ZiskFv.AirsClean.Main.opBusMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar.core)) 1 =
+        ZiskFv.Airs.OperationBus.opBus_row_Main m r_main := by
+    rw [ZiskFv.AirsClean.Main.eval_opBusMessageExpr]
+    rw [h_main_row]
+    rw [← ZiskFv.AirsClean.Main.opBusMessage_toEntry_rowAt_eq_opBus_row]
+    rw [h_main_active]
+  obtain ⟨_selectedMainRow, _h_selectedMainRow, _h_mainSpec, _h_selectedMainEval,
+      providerInteraction, _h_provider_witness, h_msg, _h_nonpull, _h_nonzero,
+      providerTable, h_providerTable, h_providerInteraction, h_providerBranches⟩ :=
+    exists_op_provider_row_msg_eq_spec_of_active_main_table_interaction
+      witness h_constraints h_balanced h_specs h_mainTable h_mainComponent
+      h_mainInteraction h_active
+  rcases h_providerBranches with h_arithMul | h_binExt | h_binary | h_binaryAdd
+  · obtain ⟨providerRow, h_providerRow, _h_providerSpec, h_component,
+      h_providerEval⟩ := h_arithMul
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.ArithMul.primaryOpBusMessageExpr
+                arithMulProviderComponent.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    have h_match_row :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+              (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                (providerTable.environment providerRow))) 1) := by
+      rw [ZiskFv.AirsClean.ArithMul.eval_primaryOpBusMessageExpr] at h_match
+      have h_row_eq :
+          eval (providerTable.environment providerRow)
+              arithMulProviderComponent.rowInputVar =
+            arithMulProviderComponent.rowInput
+              (providerTable.environment providerRow) := by
+        simpa only [Air.Flat.Component.rowInput, Air.Flat.Component.rowInputVar]
+          using
+            (eval_varFromOffset_valueFromOffset arithMulProviderComponent.Input 0
+              (providerTable.environment providerRow))
+      rwa [h_row_eq] at h_match
+    exact ⟨providerTable, h_providerTable, providerRow, h_providerRow,
+      h_component, h_specs providerTable h_providerTable, h_match_row⟩
+  · obtain ⟨providerRow, _h_providerRow, h_providerSpec, h_component,
+      h_providerEval⟩ := h_binExt
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.BinaryExtension.opBusMessageExpr
+                shiftStaticLookupComponent.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    exact False.elim
+      (staticBinaryExtension_provider_branch_ne_arithRemuPrimary
+        h_component h_providerSpec h_match h_main_op)
+  · obtain ⟨providerRow, _h_providerRow, h_providerSpec, h_component,
+      h_providerEval⟩ := h_binary
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.Binary.opBusMessageExpr
+                ZiskFv.AirsClean.Binary.staticLookupComponent.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    exact False.elim
+      (staticBinary_provider_branch_ne_arithRemuPrimary
+        h_component h_providerSpec h_match h_main_op)
+  · obtain ⟨providerRow, _h_providerRow, _h_providerSpec, _h_component,
+      h_providerEval⟩ := h_binaryAdd
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr
+                ZiskFv.AirsClean.BinaryAdd.component.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    exact False.elim
+      (binaryAdd_provider_branch_ne_arithRemuPrimary h_match h_main_op)
+
 end ZiskFv.AirsClean.FullEnsemble

--- a/ZiskFv/AirsClean/FullEnsemble/ArithBalance.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/ArithBalance.lean
@@ -805,4 +805,267 @@ theorem exists_arithMul_provider_row_matches_primary_of_divu_active_main_row_int
     exact False.elim
       (binaryAdd_provider_branch_ne_arithDivuPrimary h_match h_main_op)
 
+/-! ## Arith DIVUW keep/refute (`OP_DIVU_W = 188`)
+
+Mirror of the DIVU keep/refute above, for the unsigned W-mode DIVUW operation
+(`m32 = 1`).  The provider is still the shared ArithMul `componentWithArithTable`
+(the ArithDiv component carries no op-bus in the ensemble).  The keep theorem
+produces the SAME muxed `primaryOpBusMessage` match; the DIVU-mode op-bus bridge
+reduces that muxed message — at `div = 1`, `main_div = 1`, `main_mul = 0` (all
+uniform for op 188) — to the div quotient-lane message `opBus_row_ArithDiv` the
+DIVUW wrapper consumes.  The three non-arith provider branches are refuted via
+the op-188 static-table exclusions. -/
+
+/-- A lookup-aware static Binary provider branch cannot be the provider for a
+    Main Arith DIVUW operation (`OP_DIVU_W = 188`). -/
+theorem staticBinary_provider_branch_ne_arithDivuwPrimary
+    {m : ZiskFv.Airs.Main.Valid_Main FGL FGL} {r_main : ℕ}
+    {providerTable : Table FGL} {providerRow : Array FGL}
+    (h_component :
+      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
+    (h_providerSpec :
+      providerTable.component.Spec (providerTable.environment providerRow))
+    (h_match :
+      ZiskFv.Airs.OperationBus.matches_entry
+        (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+        (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+          (eval (providerTable.environment providerRow)
+            (ZiskFv.AirsClean.Binary.opBusMessageExpr
+              ZiskFv.AirsClean.Binary.staticLookupComponent.rowInputVar)) 1))
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_DIVU_W) :
+    False := by
+  let env := providerTable.environment providerRow
+  let row := ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput env
+  have h_componentSpec :
+      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec env := by
+    simpa [env, h_component] using h_providerSpec
+  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_componentSpec
+  have h_provider_op :
+      m.op r_main = row.chain.b_op + 16 * row.mode.mode32 := by
+    have h_op := h_match.2.1
+    simpa [env, row, ZiskFv.Airs.OperationBus.opBus_row_Main,
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
+      ZiskFv.AirsClean.Binary.staticLookupComponent_eval_opBusMessageExpr,
+      ZiskFv.AirsClean.Binary.opBusMessage] using h_op
+  exact ZiskFv.AirsClean.Binary.static_table_op_val_ne_arith_divuw_of_emit
+    row h_componentSpec.1 h_componentSpec.2
+    (by
+      rw [← h_provider_op, h_main_op]
+      norm_num [ZiskFv.Trusted.OP_DIVU_W])
+
+/-- A lookup-aware BinaryExtension provider branch cannot be the provider for a
+    Main Arith DIVUW operation (`OP_DIVU_W = 188`). -/
+theorem staticBinaryExtension_provider_branch_ne_arithDivuwPrimary
+    {m : ZiskFv.Airs.Main.Valid_Main FGL FGL} {r_main : ℕ}
+    {providerTable : Table FGL} {providerRow : Array FGL}
+    (h_component :
+      providerTable.component = shiftStaticLookupComponent)
+    (h_providerSpec :
+      providerTable.component.Spec (providerTable.environment providerRow))
+    (h_match :
+      ZiskFv.Airs.OperationBus.matches_entry
+        (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+        (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+          (eval (providerTable.environment providerRow)
+            (ZiskFv.AirsClean.BinaryExtension.opBusMessageExpr
+              shiftStaticLookupComponent.rowInputVar)) 1))
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_DIVU_W) :
+    False := by
+  let env := providerTable.environment providerRow
+  have h_componentSpec :
+      shiftStaticLookupComponent.Spec env := by
+    simpa [env, h_component] using h_providerSpec
+  have h_ne :=
+    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent_op_val_ne_arith_divuw_of_spec
+      env h_componentSpec
+  have h_provider_op :
+      (m.op r_main).val =
+        (shiftStaticLookupComponent.rowInput env).flags.op.val := by
+    have h_op := h_match.2.1
+    have h_op_val := congrArg Fin.val h_op
+    simpa [env, ZiskFv.Airs.OperationBus.opBus_row_Main,
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
+      ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent_eval_opBusMessageExpr_op]
+      using h_op_val
+  exact h_ne.1 (by
+    rw [← h_provider_op, h_main_op]
+    norm_num [ZiskFv.Trusted.OP_DIVU_W])
+
+/-- The BinaryAdd provider branch cannot be the provider for a Main Arith DIVUW
+    operation (`OP_DIVU_W = 188`). -/
+theorem binaryAdd_provider_branch_ne_arithDivuwPrimary
+    {m : ZiskFv.Airs.Main.Valid_Main FGL FGL} {r_main : ℕ}
+    {providerTable : Table FGL} {providerRow : Array FGL}
+    (h_match :
+      ZiskFv.Airs.OperationBus.matches_entry
+        (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+        (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+          (eval (providerTable.environment providerRow)
+            (ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr
+              ZiskFv.AirsClean.BinaryAdd.component.rowInputVar)) 1))
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_DIVU_W) :
+    False := by
+  have h_provider_op : (m.op r_main).val = 10 := by
+    have h_op := h_match.2.1
+    have h_op_val := congrArg Fin.val h_op
+    simpa [ZiskFv.Airs.OperationBus.opBus_row_Main,
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
+      ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr,
+      ZiskFv.Channels.OperationBus.OpBusMessage.eval_op]
+      using h_op_val
+  rw [h_main_op] at h_provider_op
+  norm_num [ZiskFv.Trusted.OP_DIVU_W] at h_provider_op
+
+/-- An active unified-Main DIVUW operation-bus interaction is balanced by an
+    Arith-Mul provider row carrying `witness.Spec`, whose primary (muxed)
+    operation-bus message matches the Main row's emission.  Keeps the ArithMul
+    provider branch and refutes the BinaryExtension / static Binary / BinaryAdd
+    provider branches via the `*_ne_arithDivuwPrimary` exclusions. -/
+theorem exists_arithMul_provider_row_matches_primary_of_divuw_active_main_row_interaction
+    {length : ℕ} {program : Program length}
+    (m : ZiskFv.Airs.Main.Valid_Main FGL FGL) (r_main : ℕ)
+    (witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble)
+    (h_constraints : witness.Constraints)
+    (h_balanced : witness.BalancedChannels)
+    (h_specs : witness.Spec)
+    {mainTable : Table FGL}
+    (h_mainTable : mainTable ∈ witness.allTables)
+    (h_mainComponent :
+      mainTable.component =
+        ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program)
+    {mainRow : Array FGL}
+    (_h_mainRow : mainRow ∈ mainTable.table)
+    (h_main_row :
+      eval (mainTable.environment mainRow)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          length program).rowInputVar.core =
+        ZiskFv.AirsClean.Main.rowAt m r_main)
+    (h_main_active : m.is_external_op r_main = 1)
+    {mainInteraction : Interaction FGL}
+    (h_mainInteraction :
+      mainInteraction ∈ mainTable.interactionsWith OpBusChannel.toRaw)
+    (h_mainInteraction_eval :
+      mainInteraction =
+        ((OpBusChannel.emitted
+          (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar.core.is_external_op)
+          (ZiskFv.AirsClean.Main.opBusMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar.core)).toRaw).eval
+          (mainTable.environment mainRow))
+    (h_active : mainInteraction.mult = -1)
+    (h_main_op :
+      m.op r_main = ZiskFv.Trusted.OP_DIVU_W) :
+    ∃ providerTable ∈ witness.allTables,
+      ∃ providerRow ∈ providerTable.table,
+        providerTable.component = arithMulProviderComponent
+          ∧ providerTable.Spec
+          ∧ ZiskFv.Airs.OperationBus.matches_entry
+            (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+            (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+              (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                  (providerTable.environment providerRow))) 1) := by
+  have h_main_entry :
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+        (eval (mainTable.environment mainRow)
+          (ZiskFv.AirsClean.Main.opBusMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar.core)) 1 =
+        ZiskFv.Airs.OperationBus.opBus_row_Main m r_main := by
+    rw [ZiskFv.AirsClean.Main.eval_opBusMessageExpr]
+    rw [h_main_row]
+    rw [← ZiskFv.AirsClean.Main.opBusMessage_toEntry_rowAt_eq_opBus_row]
+    rw [h_main_active]
+  obtain ⟨_selectedMainRow, _h_selectedMainRow, _h_mainSpec, _h_selectedMainEval,
+      providerInteraction, _h_provider_witness, h_msg, _h_nonpull, _h_nonzero,
+      providerTable, h_providerTable, h_providerInteraction, h_providerBranches⟩ :=
+    exists_op_provider_row_msg_eq_spec_of_active_main_table_interaction
+      witness h_constraints h_balanced h_specs h_mainTable h_mainComponent
+      h_mainInteraction h_active
+  rcases h_providerBranches with h_arithMul | h_binExt | h_binary | h_binaryAdd
+  · obtain ⟨providerRow, h_providerRow, _h_providerSpec, h_component,
+      h_providerEval⟩ := h_arithMul
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.ArithMul.primaryOpBusMessageExpr
+                arithMulProviderComponent.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    have h_match_row :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+              (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                (providerTable.environment providerRow))) 1) := by
+      rw [ZiskFv.AirsClean.ArithMul.eval_primaryOpBusMessageExpr] at h_match
+      have h_row_eq :
+          eval (providerTable.environment providerRow)
+              arithMulProviderComponent.rowInputVar =
+            arithMulProviderComponent.rowInput
+              (providerTable.environment providerRow) := by
+        simpa only [Air.Flat.Component.rowInput, Air.Flat.Component.rowInputVar]
+          using
+            (eval_varFromOffset_valueFromOffset arithMulProviderComponent.Input 0
+              (providerTable.environment providerRow))
+      rwa [h_row_eq] at h_match
+    exact ⟨providerTable, h_providerTable, providerRow, h_providerRow,
+      h_component, h_specs providerTable h_providerTable, h_match_row⟩
+  · obtain ⟨providerRow, _h_providerRow, h_providerSpec, h_component,
+      h_providerEval⟩ := h_binExt
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.BinaryExtension.opBusMessageExpr
+                shiftStaticLookupComponent.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    exact False.elim
+      (staticBinaryExtension_provider_branch_ne_arithDivuwPrimary
+        h_component h_providerSpec h_match h_main_op)
+  · obtain ⟨providerRow, _h_providerRow, h_providerSpec, h_component,
+      h_providerEval⟩ := h_binary
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.Binary.opBusMessageExpr
+                ZiskFv.AirsClean.Binary.staticLookupComponent.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    exact False.elim
+      (staticBinary_provider_branch_ne_arithDivuwPrimary
+        h_component h_providerSpec h_match h_main_op)
+  · obtain ⟨providerRow, _h_providerRow, _h_providerSpec, _h_component,
+      h_providerEval⟩ := h_binaryAdd
+    have h_match :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr
+                ZiskFv.AirsClean.BinaryAdd.component.rowInputVar)) 1) := by
+      rw [← h_main_entry]
+      apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+      rw [← h_providerEval, ← h_mainInteraction_eval]
+      exact h_msg
+    exact False.elim
+      (binaryAdd_provider_branch_ne_arithDivuwPrimary h_match h_main_op)
+
 end ZiskFv.AirsClean.FullEnsemble

--- a/ZiskFv/AirsClean/FullEnsemble/Balance.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance.lean
@@ -965,7 +965,7 @@ theorem arithMul_primary_provider_match_main_op_val_ge_176
           (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage row) 1)) :
     176 <= (m.op r_main).val := by
   have h_provider_ge :=
-    ZiskFv.AirsClean.ArithTableProjections.Mul.op_val_ge_176 row h_full.2
+    ZiskFv.AirsClean.ArithTableProjections.Mul.op_val_ge_176 row h_full.2.1
   have h_op_match : m.op r_main = row.flags.op := by
     simpa [ZiskFv.Airs.OperationBus.matches_entry,
       ZiskFv.Airs.OperationBus.opBus_row_Main,
@@ -1002,7 +1002,7 @@ theorem arithMul_provider_branch_main_op_val_ge_176
     simpa [h_row_eq] using h_full
   have h_provider_ge :=
     ZiskFv.AirsClean.ArithTableProjections.Mul.op_val_ge_176
-      row h_full_row.2
+      row h_full_row.2.1
   have h_op_match : m.op r_main = row.flags.op := by
     have h_op := h_match.2.1
     rw [ZiskFv.AirsClean.ArithMul.eval_primaryOpBusMessageExpr_toEntry_op] at h_op

--- a/ZiskFv/Compliance/AcceptedTrace.lean
+++ b/ZiskFv/Compliance/AcceptedTrace.lean
@@ -1039,4 +1039,101 @@ theorem exists_arithMul_provider_row_matches_primary_of_divuw_from_binding
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
 
+/-- Layer-A op-bus provider-match wrapper for the Arith REMU operation
+    (`OP_REMU = 185`).  Mirrors
+    `exists_arithMul_provider_row_matches_primary_of_divu_from_binding`, but
+    delegates to the REMU keep-arithMul balance theorem
+    `exists_arithMul_provider_row_matches_primary_of_remu_active_main_row_interaction`.
+
+    The provider is the shared lookup-aware `arithMulProviderComponent` (the
+    ArithDiv component carries no op-bus in the ensemble); the returned match is
+    against the muxed `primaryOpBusMessage`.  The REMU-mode bridge in
+    `ConstructionRemu.lean` later reduces it (at `div = 1`, `main_div = 0`,
+    `main_mul = 0`) to the div remainder-lane `opBus_row_ArithDivSecondary`. -/
+theorem exists_arithMul_provider_row_matches_primary_of_remu_from_binding
+    (trace : AcceptedTrace)
+    (binding : ProgramBinding trace)
+    (i : Fin trace.length)
+    (h_main_active :
+      ZiskFv.Airs.Main.Valid_Main.is_external_op
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+        i.val = 1)
+    (h_main_op :
+      ZiskFv.Airs.Main.Valid_Main.op
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+        i.val = ZiskFv.Trusted.OP_REMU) :
+    ∃ providerTable ∈ trace.witness.allTables,
+      ∃ providerRow ∈ providerTable.table,
+        providerTable.component = ZiskFv.AirsClean.FullEnsemble.arithMulProviderComponent
+          ∧ providerTable.Spec
+          ∧ ZiskFv.Airs.OperationBus.matches_entry
+            (ZiskFv.Airs.OperationBus.opBus_row_Main
+              (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+              i.val)
+            (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+              (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                  (providerTable.environment providerRow))) 1) := by
+  have h_mainIdx_lt : i.val < binding.mainTable.table.length :=
+    binding.mainTable_index i
+  let mainIdx : Fin binding.mainTable.table.length :=
+    ⟨i.val, h_mainIdx_lt⟩
+  let mainRow := binding.mainTable.table.get mainIdx
+  let mainInteraction :=
+    ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
+      (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core.is_external_op)
+      (ZiskFv.AirsClean.Main.opBusMessageExpr
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core)).toRaw).eval
+      (binding.mainTable.environment mainRow)
+  have h_mainRow_mem : mainRow ∈ binding.mainTable.table := by
+    simp [mainRow]
+  have h_main_row :
+      eval (binding.mainTable.environment mainRow)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core =
+        ZiskFv.AirsClean.Main.rowAt
+          (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+          i.val := by
+    simpa [mainIdx, mainRow] using
+      ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable_core
+        trace.program binding.mainTable mainIdx
+  have h_mainInteraction_mem :
+      mainInteraction ∈
+        binding.mainTable.interactionsWith
+          ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
+    simpa [mainInteraction, mainRow] using
+      ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
+        (length := trace.length) (program := trace.program)
+        binding.mainTable_component h_mainRow_mem
+  have h_mainInteraction_eval :
+      mainInteraction =
+        ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
+          (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              trace.length trace.program).rowInputVar.core.is_external_op)
+          (ZiskFv.AirsClean.Main.opBusMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              trace.length trace.program).rowInputVar.core)).toRaw).eval
+          (binding.mainTable.environment mainRow) := rfl
+  have h_active_row :
+      (eval (binding.mainTable.environment mainRow)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core).is_external_op = 1 := by
+    rw [h_main_row]
+    simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
+  have h_active : mainInteraction.mult = -1 := by
+    rw [h_mainInteraction_eval]
+    exact
+      ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
+        (length := trace.length) (program := trace.program)
+        (binding.mainTable.environment mainRow) h_active_row
+  exact
+    ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_primary_of_remu_active_main_row_interaction
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+        i.val trace.witness trace.constraints trace.balanced trace.spec
+        binding.mainTable_mem binding.mainTable_component h_mainRow_mem
+        h_main_row h_main_active h_mainInteraction_mem
+        h_mainInteraction_eval h_active h_main_op
+
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/AcceptedTrace.lean
+++ b/ZiskFv/Compliance/AcceptedTrace.lean
@@ -846,4 +846,101 @@ theorem exists_arithMul_provider_row_matches_secondary_of_mulhu_from_binding
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
 
+/-- Layer-A op-bus provider-match wrapper for the Arith DIVU operation
+    (`OP_DIVU = 184`).  Mirrors
+    `exists_arithMul_provider_row_matches_primary_of_mulw_from_binding`, but
+    delegates to the DIVU keep-arithMul balance theorem
+    `exists_arithMul_provider_row_matches_primary_of_divu_active_main_row_interaction`.
+
+    The provider is the shared lookup-aware `arithMulProviderComponent` (the
+    ArithDiv component carries no op-bus in the ensemble); the returned match is
+    against the muxed `primaryOpBusMessage`.  The DIVU-mode bridge in
+    `ArithMul/Bridge.lean` later reduces it to the div quotient-lane
+    `opBus_row_ArithDiv`. -/
+theorem exists_arithMul_provider_row_matches_primary_of_divu_from_binding
+    (trace : AcceptedTrace)
+    (binding : ProgramBinding trace)
+    (i : Fin trace.length)
+    (h_main_active :
+      ZiskFv.Airs.Main.Valid_Main.is_external_op
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+        i.val = 1)
+    (h_main_op :
+      ZiskFv.Airs.Main.Valid_Main.op
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+        i.val = ZiskFv.Trusted.OP_DIVU) :
+    ∃ providerTable ∈ trace.witness.allTables,
+      ∃ providerRow ∈ providerTable.table,
+        providerTable.component = ZiskFv.AirsClean.FullEnsemble.arithMulProviderComponent
+          ∧ providerTable.Spec
+          ∧ ZiskFv.Airs.OperationBus.matches_entry
+            (ZiskFv.Airs.OperationBus.opBus_row_Main
+              (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+              i.val)
+            (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+              (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                  (providerTable.environment providerRow))) 1) := by
+  have h_mainIdx_lt : i.val < binding.mainTable.table.length :=
+    binding.mainTable_index i
+  let mainIdx : Fin binding.mainTable.table.length :=
+    ⟨i.val, h_mainIdx_lt⟩
+  let mainRow := binding.mainTable.table.get mainIdx
+  let mainInteraction :=
+    ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
+      (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core.is_external_op)
+      (ZiskFv.AirsClean.Main.opBusMessageExpr
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core)).toRaw).eval
+      (binding.mainTable.environment mainRow)
+  have h_mainRow_mem : mainRow ∈ binding.mainTable.table := by
+    simp [mainRow]
+  have h_main_row :
+      eval (binding.mainTable.environment mainRow)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core =
+        ZiskFv.AirsClean.Main.rowAt
+          (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+          i.val := by
+    simpa [mainIdx, mainRow] using
+      ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable_core
+        trace.program binding.mainTable mainIdx
+  have h_mainInteraction_mem :
+      mainInteraction ∈
+        binding.mainTable.interactionsWith
+          ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
+    simpa [mainInteraction, mainRow] using
+      ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
+        (length := trace.length) (program := trace.program)
+        binding.mainTable_component h_mainRow_mem
+  have h_mainInteraction_eval :
+      mainInteraction =
+        ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
+          (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              trace.length trace.program).rowInputVar.core.is_external_op)
+          (ZiskFv.AirsClean.Main.opBusMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              trace.length trace.program).rowInputVar.core)).toRaw).eval
+          (binding.mainTable.environment mainRow) := rfl
+  have h_active_row :
+      (eval (binding.mainTable.environment mainRow)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core).is_external_op = 1 := by
+    rw [h_main_row]
+    simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
+  have h_active : mainInteraction.mult = -1 := by
+    rw [h_mainInteraction_eval]
+    exact
+      ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
+        (length := trace.length) (program := trace.program)
+        (binding.mainTable.environment mainRow) h_active_row
+  exact
+    ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_primary_of_divu_active_main_row_interaction
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+        i.val trace.witness trace.constraints trace.balanced trace.spec
+        binding.mainTable_mem binding.mainTable_component h_mainRow_mem
+        h_main_row h_main_active h_mainInteraction_mem
+        h_mainInteraction_eval h_active h_main_op
+
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/AcceptedTrace.lean
+++ b/ZiskFv/Compliance/AcceptedTrace.lean
@@ -751,4 +751,99 @@ theorem exists_arithMul_provider_row_matches_primary_of_mulw_from_binding
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
 
+/-- Layer-A op-bus provider-match wrapper for the Arith MULHU operation
+    (`OP_MULUH = 177`).  Mirrors
+    `exists_arithMul_provider_row_matches_primary_of_mulw_from_binding`, but
+    delegates to the MULHU keep-arithMul balance theorem
+    `exists_arithMul_provider_row_matches_secondary_of_mulhu_active_main_row_interaction`.
+
+    The returned match is still against the muxed `primaryOpBusMessage`; the
+    MULHU-mode bridge in `ArithMul/Bridge.lean` later reduces it to the
+    secondary d-lane `opBus_row_ArithMulSecondary`. -/
+theorem exists_arithMul_provider_row_matches_secondary_of_mulhu_from_binding
+    (trace : AcceptedTrace)
+    (binding : ProgramBinding trace)
+    (i : Fin trace.length)
+    (h_main_active :
+      ZiskFv.Airs.Main.Valid_Main.is_external_op
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+        i.val = 1)
+    (h_main_op :
+      ZiskFv.Airs.Main.Valid_Main.op
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+        i.val = ZiskFv.Trusted.OP_MULUH) :
+    ∃ providerTable ∈ trace.witness.allTables,
+      ∃ providerRow ∈ providerTable.table,
+        providerTable.component = ZiskFv.AirsClean.FullEnsemble.arithMulProviderComponent
+          ∧ providerTable.Spec
+          ∧ ZiskFv.Airs.OperationBus.matches_entry
+            (ZiskFv.Airs.OperationBus.opBus_row_Main
+              (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+              i.val)
+            (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+              (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                  (providerTable.environment providerRow))) 1) := by
+  have h_mainIdx_lt : i.val < binding.mainTable.table.length :=
+    binding.mainTable_index i
+  let mainIdx : Fin binding.mainTable.table.length :=
+    ⟨i.val, h_mainIdx_lt⟩
+  let mainRow := binding.mainTable.table.get mainIdx
+  let mainInteraction :=
+    ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
+      (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core.is_external_op)
+      (ZiskFv.AirsClean.Main.opBusMessageExpr
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core)).toRaw).eval
+      (binding.mainTable.environment mainRow)
+  have h_mainRow_mem : mainRow ∈ binding.mainTable.table := by
+    simp [mainRow]
+  have h_main_row :
+      eval (binding.mainTable.environment mainRow)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core =
+        ZiskFv.AirsClean.Main.rowAt
+          (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+          i.val := by
+    simpa [mainIdx, mainRow] using
+      ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable_core
+        trace.program binding.mainTable mainIdx
+  have h_mainInteraction_mem :
+      mainInteraction ∈
+        binding.mainTable.interactionsWith
+          ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
+    simpa [mainInteraction, mainRow] using
+      ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
+        (length := trace.length) (program := trace.program)
+        binding.mainTable_component h_mainRow_mem
+  have h_mainInteraction_eval :
+      mainInteraction =
+        ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
+          (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              trace.length trace.program).rowInputVar.core.is_external_op)
+          (ZiskFv.AirsClean.Main.opBusMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              trace.length trace.program).rowInputVar.core)).toRaw).eval
+          (binding.mainTable.environment mainRow) := rfl
+  have h_active_row :
+      (eval (binding.mainTable.environment mainRow)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core).is_external_op = 1 := by
+    rw [h_main_row]
+    simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
+  have h_active : mainInteraction.mult = -1 := by
+    rw [h_mainInteraction_eval]
+    exact
+      ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
+        (length := trace.length) (program := trace.program)
+        (binding.mainTable.environment mainRow) h_active_row
+  exact
+    ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_secondary_of_mulhu_active_main_row_interaction
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+        i.val trace.witness trace.constraints trace.balanced trace.spec
+        binding.mainTable_mem binding.mainTable_component h_mainRow_mem
+        h_main_row h_main_active h_mainInteraction_mem
+        h_mainInteraction_eval h_active h_main_op
+
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/AcceptedTrace.lean
+++ b/ZiskFv/Compliance/AcceptedTrace.lean
@@ -1136,4 +1136,102 @@ theorem exists_arithMul_provider_row_matches_primary_of_remu_from_binding
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
 
+/-- Layer-A op-bus provider-match wrapper for the Arith REMUW operation
+    (`OP_REMU_W = 189`, W-mode `m32 = 1`).  Mirrors
+    `exists_arithMul_provider_row_matches_primary_of_remu_from_binding`, but
+    delegates to the REMUW keep-arithMul balance theorem
+    `exists_arithMul_provider_row_matches_primary_of_remuw_active_main_row_interaction`.
+
+    The provider is the shared lookup-aware `arithMulProviderComponent` (the
+    ArithDiv component carries no op-bus in the ensemble); the returned match is
+    against the muxed `primaryOpBusMessage`.  The REMU-mode secondary bridge in
+    `ConstructionRemu.lean` later reduces it (at `div = 1`, `main_div = 0`,
+    `main_mul = 0`) to the div remainder-lane `opBus_row_ArithDivSecondary`; the
+    `m32` flag plays no role in the mux. -/
+theorem exists_arithMul_provider_row_matches_primary_of_remuw_from_binding
+    (trace : AcceptedTrace)
+    (binding : ProgramBinding trace)
+    (i : Fin trace.length)
+    (h_main_active :
+      ZiskFv.Airs.Main.Valid_Main.is_external_op
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+        i.val = 1)
+    (h_main_op :
+      ZiskFv.Airs.Main.Valid_Main.op
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+        i.val = ZiskFv.Trusted.OP_REMU_W) :
+    ∃ providerTable ∈ trace.witness.allTables,
+      ∃ providerRow ∈ providerTable.table,
+        providerTable.component = ZiskFv.AirsClean.FullEnsemble.arithMulProviderComponent
+          ∧ providerTable.Spec
+          ∧ ZiskFv.Airs.OperationBus.matches_entry
+            (ZiskFv.Airs.OperationBus.opBus_row_Main
+              (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+              i.val)
+            (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+              (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                  (providerTable.environment providerRow))) 1) := by
+  have h_mainIdx_lt : i.val < binding.mainTable.table.length :=
+    binding.mainTable_index i
+  let mainIdx : Fin binding.mainTable.table.length :=
+    ⟨i.val, h_mainIdx_lt⟩
+  let mainRow := binding.mainTable.table.get mainIdx
+  let mainInteraction :=
+    ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
+      (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core.is_external_op)
+      (ZiskFv.AirsClean.Main.opBusMessageExpr
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core)).toRaw).eval
+      (binding.mainTable.environment mainRow)
+  have h_mainRow_mem : mainRow ∈ binding.mainTable.table := by
+    simp [mainRow]
+  have h_main_row :
+      eval (binding.mainTable.environment mainRow)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core =
+        ZiskFv.AirsClean.Main.rowAt
+          (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+          i.val := by
+    simpa [mainIdx, mainRow] using
+      ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable_core
+        trace.program binding.mainTable mainIdx
+  have h_mainInteraction_mem :
+      mainInteraction ∈
+        binding.mainTable.interactionsWith
+          ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
+    simpa [mainInteraction, mainRow] using
+      ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
+        (length := trace.length) (program := trace.program)
+        binding.mainTable_component h_mainRow_mem
+  have h_mainInteraction_eval :
+      mainInteraction =
+        ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
+          (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              trace.length trace.program).rowInputVar.core.is_external_op)
+          (ZiskFv.AirsClean.Main.opBusMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              trace.length trace.program).rowInputVar.core)).toRaw).eval
+          (binding.mainTable.environment mainRow) := rfl
+  have h_active_row :
+      (eval (binding.mainTable.environment mainRow)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core).is_external_op = 1 := by
+    rw [h_main_row]
+    simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
+  have h_active : mainInteraction.mult = -1 := by
+    rw [h_mainInteraction_eval]
+    exact
+      ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
+        (length := trace.length) (program := trace.program)
+        (binding.mainTable.environment mainRow) h_active_row
+  exact
+    ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_primary_of_remuw_active_main_row_interaction
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+        i.val trace.witness trace.constraints trace.balanced trace.spec
+        binding.mainTable_mem binding.mainTable_component h_mainRow_mem
+        h_main_row h_main_active h_mainInteraction_mem
+        h_mainInteraction_eval h_active h_main_op
+
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/AcceptedTrace.lean
+++ b/ZiskFv/Compliance/AcceptedTrace.lean
@@ -943,4 +943,100 @@ theorem exists_arithMul_provider_row_matches_primary_of_divu_from_binding
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
 
+/-- Layer-A op-bus provider-match wrapper for the Arith DIVUW operation
+    (`OP_DIVU_W = 188`, W-mode `m32 = 1`).  Mirrors
+    `exists_arithMul_provider_row_matches_primary_of_divu_from_binding`, but
+    delegates to the DIVUW keep-arithMul balance theorem
+    `exists_arithMul_provider_row_matches_primary_of_divuw_active_main_row_interaction`.
+
+    The provider is the shared lookup-aware `arithMulProviderComponent` (the
+    ArithDiv component carries no op-bus in the ensemble); the returned match is
+    against the muxed `primaryOpBusMessage`.  The DIVU-mode op-bus bridge later
+    reduces it to the div quotient-lane `opBus_row_ArithDiv`. -/
+theorem exists_arithMul_provider_row_matches_primary_of_divuw_from_binding
+    (trace : AcceptedTrace)
+    (binding : ProgramBinding trace)
+    (i : Fin trace.length)
+    (h_main_active :
+      ZiskFv.Airs.Main.Valid_Main.is_external_op
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+        i.val = 1)
+    (h_main_op :
+      ZiskFv.Airs.Main.Valid_Main.op
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+        i.val = ZiskFv.Trusted.OP_DIVU_W) :
+    ∃ providerTable ∈ trace.witness.allTables,
+      ∃ providerRow ∈ providerTable.table,
+        providerTable.component = ZiskFv.AirsClean.FullEnsemble.arithMulProviderComponent
+          ∧ providerTable.Spec
+          ∧ ZiskFv.Airs.OperationBus.matches_entry
+            (ZiskFv.Airs.OperationBus.opBus_row_Main
+              (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+              i.val)
+            (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+              (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                  (providerTable.environment providerRow))) 1) := by
+  have h_mainIdx_lt : i.val < binding.mainTable.table.length :=
+    binding.mainTable_index i
+  let mainIdx : Fin binding.mainTable.table.length :=
+    ⟨i.val, h_mainIdx_lt⟩
+  let mainRow := binding.mainTable.table.get mainIdx
+  let mainInteraction :=
+    ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
+      (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core.is_external_op)
+      (ZiskFv.AirsClean.Main.opBusMessageExpr
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core)).toRaw).eval
+      (binding.mainTable.environment mainRow)
+  have h_mainRow_mem : mainRow ∈ binding.mainTable.table := by
+    simp [mainRow]
+  have h_main_row :
+      eval (binding.mainTable.environment mainRow)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core =
+        ZiskFv.AirsClean.Main.rowAt
+          (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+          i.val := by
+    simpa [mainIdx, mainRow] using
+      ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable_core
+        trace.program binding.mainTable mainIdx
+  have h_mainInteraction_mem :
+      mainInteraction ∈
+        binding.mainTable.interactionsWith
+          ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
+    simpa [mainInteraction, mainRow] using
+      ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
+        (length := trace.length) (program := trace.program)
+        binding.mainTable_component h_mainRow_mem
+  have h_mainInteraction_eval :
+      mainInteraction =
+        ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
+          (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              trace.length trace.program).rowInputVar.core.is_external_op)
+          (ZiskFv.AirsClean.Main.opBusMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              trace.length trace.program).rowInputVar.core)).toRaw).eval
+          (binding.mainTable.environment mainRow) := rfl
+  have h_active_row :
+      (eval (binding.mainTable.environment mainRow)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core).is_external_op = 1 := by
+    rw [h_main_row]
+    simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
+  have h_active : mainInteraction.mult = -1 := by
+    rw [h_mainInteraction_eval]
+    exact
+      ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
+        (length := trace.length) (program := trace.program)
+        (binding.mainTable.environment mainRow) h_active_row
+  exact
+    ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_primary_of_divuw_active_main_row_interaction
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+        i.val trace.witness trace.constraints trace.balanced trace.spec
+        binding.mainTable_mem binding.mainTable_component h_mainRow_mem
+        h_main_row h_main_active h_mainInteraction_mem
+        h_mainInteraction_eval h_active h_main_op
+
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/AcceptedTrace.lean
+++ b/ZiskFv/Compliance/AcceptedTrace.lean
@@ -1,4 +1,5 @@
 import ZiskFv.AirsClean.FullEnsemble.Balance
+import ZiskFv.AirsClean.FullEnsemble.ArithBalance
 import ZiskFv.Compliance.AeneasBridgeTrust
 import ZiskFv.EquivCore.Bridge.Binary
 import ZiskFv.EquivCore.Bridge.BinaryExtension
@@ -647,6 +648,103 @@ theorem exists_binaryExtension_provider_row_matches_shift_from_binding
         (binding.mainTable.environment mainRow) h_active_row
   exact
     exists_binaryExtension_provider_row_matches_legacy_main_of_shift_active_main_row_interaction
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+        i.val trace.witness trace.constraints trace.balanced trace.spec
+        binding.mainTable_mem binding.mainTable_component h_mainRow_mem
+        h_main_row h_main_active h_mainInteraction_mem
+        h_mainInteraction_eval h_active h_main_op
+
+/-- Layer-A op-bus provider-match wrapper for the Arith MULW operation
+    (`OP_MUL_W = 182`).  Mirrors
+    `exists_staticBinary_provider_row_matches_sub_from_binding`: it builds the
+    Main op-bus interaction, proves membership + `mult = -1`, and delegates to
+    the keep-arithMul balance theorem
+    `exists_arithMul_provider_row_matches_primary_of_mulw_active_main_row_interaction`.
+
+    Unlike the static-Binary wrappers, the provider here is the lookup-aware
+    `arithMulProviderComponent` (= `ArithMul.componentWithArithTable`), so
+    `providerTable.Spec` is `FullSpec (rowInput …)` and the match is against the
+    ArithMul primary op-bus message. -/
+theorem exists_arithMul_provider_row_matches_primary_of_mulw_from_binding
+    (trace : AcceptedTrace)
+    (binding : ProgramBinding trace)
+    (i : Fin trace.length)
+    (h_main_active :
+      ZiskFv.Airs.Main.Valid_Main.is_external_op
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+        i.val = 1)
+    (h_main_op :
+      ZiskFv.Airs.Main.Valid_Main.op
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+        i.val = ZiskFv.Trusted.OP_MUL_W) :
+    ∃ providerTable ∈ trace.witness.allTables,
+      ∃ providerRow ∈ providerTable.table,
+        providerTable.component = ZiskFv.AirsClean.FullEnsemble.arithMulProviderComponent
+          ∧ providerTable.Spec
+          ∧ ZiskFv.Airs.OperationBus.matches_entry
+            (ZiskFv.Airs.OperationBus.opBus_row_Main
+              (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+              i.val)
+            (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+              (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                  (providerTable.environment providerRow))) 1) := by
+  have h_mainIdx_lt : i.val < binding.mainTable.table.length :=
+    binding.mainTable_index i
+  let mainIdx : Fin binding.mainTable.table.length :=
+    ⟨i.val, h_mainIdx_lt⟩
+  let mainRow := binding.mainTable.table.get mainIdx
+  let mainInteraction :=
+    ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
+      (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core.is_external_op)
+      (ZiskFv.AirsClean.Main.opBusMessageExpr
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core)).toRaw).eval
+      (binding.mainTable.environment mainRow)
+  have h_mainRow_mem : mainRow ∈ binding.mainTable.table := by
+    simp [mainRow]
+  have h_main_row :
+      eval (binding.mainTable.environment mainRow)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core =
+        ZiskFv.AirsClean.Main.rowAt
+          (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
+          i.val := by
+    simpa [mainIdx, mainRow] using
+      ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable_core
+        trace.program binding.mainTable mainIdx
+  have h_mainInteraction_mem :
+      mainInteraction ∈
+        binding.mainTable.interactionsWith
+          ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
+    simpa [mainInteraction, mainRow] using
+      ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
+        (length := trace.length) (program := trace.program)
+        binding.mainTable_component h_mainRow_mem
+  have h_mainInteraction_eval :
+      mainInteraction =
+        ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
+          (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              trace.length trace.program).rowInputVar.core.is_external_op)
+          (ZiskFv.AirsClean.Main.opBusMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              trace.length trace.program).rowInputVar.core)).toRaw).eval
+          (binding.mainTable.environment mainRow) := rfl
+  have h_active_row :
+      (eval (binding.mainTable.environment mainRow)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.length trace.program).rowInputVar.core).is_external_op = 1 := by
+    rw [h_main_row]
+    simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
+  have h_active : mainInteraction.mult = -1 := by
+    rw [h_mainInteraction_eval]
+    exact
+      ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
+        (length := trace.length) (program := trace.program)
+        (binding.mainTable.environment mainRow) h_active_row
+  exact
+    ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_primary_of_mulw_active_main_row_interaction
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
         i.val trace.witness trace.constraints trace.balanced trace.spec
         binding.mainTable_mem binding.mainTable_component h_mainRow_mem

--- a/ZiskFv/Compliance/ConstructionDivu.lean
+++ b/ZiskFv/Compliance/ConstructionDivu.lean
@@ -1,0 +1,806 @@
+import ZiskFv.Compliance.AcceptedTrace
+import ZiskFv.Compliance.ConstructionMulw
+import ZiskFv.Compliance.ConstructionMulhu
+import ZiskFv.EquivCore.Divu
+import ZiskFv.EquivCore.Promises.ArithHelpers
+import ZiskFv.EquivCore.Bridge.Arith
+import ZiskFv.AirsClean.ArithMul.Bridge
+import ZiskFv.AirsClean.ArithDiv.Bridge
+import ZiskFv.AirsClean.ArithTableProjections
+import ZiskFv.Airs.Arith.Div
+import ZiskFv.Airs.Arith.BusRes1
+import ZiskFv.Bits.PackedBitVec.MulNoWrap
+
+/-!
+# Sound DIVU construction (`construction_divu_sound`)
+
+Unsigned RV64M DIVU (`OP_DIVU = 184`), mirroring the MULW / MULHU
+constructions.  The Arith provider witnesses (ArithTable membership, chunk
+ranges, signed-carry ranges, c46, carry-chain) are **DERIVED FROM BALANCE**
+via the SHARED ArithMul provider component's lookup-aware
+`componentWithArithTable.Spec = FullSpec`, not carried as caller binders.
+
+## Why the shared ArithMul provider (not ArithDiv)
+
+`ArithDiv.component` carries NO operation-bus interactions in the full
+ensemble (`arithDiv_table_interactionsWith_opBus_nil`): its
+`circuit.channels = []`.  The DIVU Main op-bus emission is therefore balanced
+by the SHARED ArithMul provider (`componentWithArithTable`), whose `FullSpec`
+covers div rows too (the carry chain is mode-shared via the `div` flag).  The
+muxed primary op-bus message, at the DIVU mode pins (`div = 1`,
+`main_div = 1`, `main_mul = 0`), reduces to the div quotient-lane message
+`opBus_row_ArithDiv`.
+
+## The carry-range subtlety (vs MULW)
+
+`EquivCore.Divu.equiv_DIVU` demands the *unsigned* carry bound
+`cy_i.val < 131072 = 2^17`.  Balance supplies only `FullSpec`'s
+`CarryRangeSpec` — the **signed disjunction** `< 983041 ∨ ≥ p - 983040`.  The
+genuine Euclidean-chain carries (a 4×4 chunk multiply `quotient · divisor`)
+reach `~3·2^16 > 2^17`, so the tight `< 131072` bound is NOT balance-
+constructible.  This module therefore does NOT route through `equiv_DIVU`.
+Instead it derives the looser balance-constructible bound `< 983041` (via
+`unsigned_carry_step_nat`, reused from `ConstructionMulhu`) and reconstructs
+the rd write value through the loose-bound DIVU write-value path
+`h_rd_val_mdru_divu_loose`, replicating `equiv_DIVU`'s sail + `bus_effect`
+tail otherwise.
+
+## The remainder bound is RESIDUAL, not balance-derived
+
+`EquivCore.Divu.equiv_DIVU` needs `ArithDivRemainderBoundWitness` — the
+`|d| < b` LTU check from `arith.pil:274`.  This is the ArithDiv op-bus
+*consumer* (`assumes_operation`) edge matched against a Binary LTU provider
+row.  Because `ArithDiv.component` emits no op-bus in the ensemble, this
+consume edge is a finished-channel SELF-EDGE that is **not composed into the
+ensemble** — so it is NOT balance-derivable.  It is carried as the single
+explicit residual binder `remainder_bound` (exactly as the canonical
+`equiv_DIVU` already carries it), clearly documented here.
+
+## Axioms
+
+`construction_divu_sound` introduces **0 PROJECT (`ZiskFv.*`) axioms**.  Its
+closure carries `Lean.ofReduceBool` / `Lean.trustCompiler` (native_decide)
+INHERITED from the canonical `equiv_DIVU` path (already has it; NOT new —
+tracked by #75), plus the Sail-translation + kernel postulates.
+-/
+
+namespace ZiskFv.Compliance
+
+open Goldilocks
+open ZiskFv.Trusted
+open ZiskFv.Airs.Main
+open ZiskFv.Airs.OperationBus
+open ZiskFv.Channels.MemoryBusBytes (byteAt)
+open ZiskFv.AirsClean.FullEnsemble
+open ZiskFv.AirsClean.ArithMul (componentWithArithTable primaryOpBusMessage rowAt)
+
+set_option maxHeartbeats 4000000
+set_option maxRecDepth 8000
+
+/-! ## Phase 1 — row-native ArithDiv view + DIVU-mode op-bus bridge -/
+
+/-- Row-native `Valid_ArithDiv` view of a concrete provider `ArithMulRow`.
+
+    Same shape as `vOfMulwRow` but producing the `Valid_ArithDiv` interface.
+    Every column is the constant function returning the corresponding field of
+    `arow` (the carry fields `cy_i ← arow.carries.carry_i`), with
+    `multiplicity` pinned to `1` (the active-row consume polarity).  Because
+    `ArithMulRow` and `ArithDivRow` share field names and `arithTableRow`
+    projections, `ArithDiv.rowAt (vOfDivuRow arow) 0` agrees with `arow` on
+    every field that `ArithTableSpec` / `opBus_row_ArithDiv` dereference. -/
+@[reducible]
+def vOfDivuRow (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL) :
+    ZiskFv.Airs.ArithDiv.Valid_ArithDiv FGL FGL where
+  cy_0 := fun _ => arow.carries.carry_0
+  cy_1 := fun _ => arow.carries.carry_1
+  cy_2 := fun _ => arow.carries.carry_2
+  cy_3 := fun _ => arow.carries.carry_3
+  cy_4 := fun _ => arow.carries.carry_4
+  cy_5 := fun _ => arow.carries.carry_5
+  cy_6 := fun _ => arow.carries.carry_6
+  a_0 := fun _ => arow.chunks.a_0
+  a_1 := fun _ => arow.chunks.a_1
+  a_2 := fun _ => arow.chunks.a_2
+  a_3 := fun _ => arow.chunks.a_3
+  b_0 := fun _ => arow.chunks.b_0
+  b_1 := fun _ => arow.chunks.b_1
+  b_2 := fun _ => arow.chunks.b_2
+  b_3 := fun _ => arow.chunks.b_3
+  c_0 := fun _ => arow.chunks.c_0
+  c_1 := fun _ => arow.chunks.c_1
+  c_2 := fun _ => arow.chunks.c_2
+  c_3 := fun _ => arow.chunks.c_3
+  d_0 := fun _ => arow.chunks.d_0
+  d_1 := fun _ => arow.chunks.d_1
+  d_2 := fun _ => arow.chunks.d_2
+  d_3 := fun _ => arow.chunks.d_3
+  na := fun _ => arow.flags.na
+  nb := fun _ => arow.flags.nb
+  nr := fun _ => arow.flags.nr
+  np := fun _ => arow.flags.np
+  sext := fun _ => arow.flags.sext
+  m32 := fun _ => arow.flags.m32
+  div := fun _ => arow.flags.div
+  fab := fun _ => arow.carries.fab
+  na_fb := fun _ => arow.carries.na_fb
+  nb_fa := fun _ => arow.carries.nb_fa
+  main_div := fun _ => arow.flags.main_div
+  main_mul := fun _ => arow.flags.main_mul
+  signed := fun _ => arow.flags.signed
+  div_by_zero := fun _ => arow.flags.div_by_zero
+  div_overflow := fun _ => arow.flags.div_overflow
+  op := fun _ => arow.flags.op
+  bus_res1 := fun _ => arow.flags.bus_res1
+  multiplicity := fun _ => 1
+  range_ab := fun _ => arow.flags.range_ab
+  range_cd := fun _ => arow.flags.range_cd
+
+/-- DIVU-mode op-bus bridge: the FAITHFUL muxed ArithMul primary message
+    reduces to the div quotient-lane `opBus_row_ArithDiv` entry exactly at the
+    DIVU mode pins (`div = 1`, `main_div = 1`, `main_mul = 0`).
+
+    At these pins the muxed `a_lo`/`a_hi` lanes (`div·c + (1-div)·a`) collapse
+    to the `c`-chunks (dividend), and the muxed `c_lo` lane
+    (`(1-main_mul-main_div)·d + main_mul·c + main_div·a`) collapses to the
+    `a`-chunks (quotient) — i.e. the muxed primary message at DIVU mode IS the
+    div quotient-lane message.  The mode pins are discharged by the caller
+    (the construction) from the provider row's `ArithTableSpec` + opcode pin. -/
+theorem primaryOpBusMessage_toEntry_eq_opBus_row_ArithDiv
+    (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL)
+    (h_div : arow.flags.div = 1) (h_main_div : arow.flags.main_div = 1)
+    (h_main_mul : arow.flags.main_mul = 0) :
+    ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+        (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage arow) 1 =
+      ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv (vOfDivuRow arow) 0 := by
+  simp only [ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
+    ZiskFv.AirsClean.ArithMul.primaryOpBusMessage,
+    ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv, vOfDivuRow,
+    h_div, h_main_div, h_main_mul]
+  ring
+
+/-- The DIVU op-bus match transports along the ArithDiv row-native view: a
+    match against the FAITHFUL muxed primary message of a concrete row carries
+    over to `opBus_row_ArithDiv (vOfDivuRow arow) 0`, via the DIVU-mode bridge
+    `primaryOpBusMessage_toEntry_eq_opBus_row_ArithDiv`. -/
+theorem match_opBus_row_ArithDiv_vOfDivuRow
+    {x : ZiskFv.Airs.OperationBus.OperationBusEntry FGL}
+    {arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL}
+    (h_div : arow.flags.div = 1) (h_main_div : arow.flags.main_div = 1)
+    (h_main_mul : arow.flags.main_mul = 0)
+    (h :
+      matches_entry x
+        (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+          (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage arow) 1)) :
+    matches_entry x (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv (vOfDivuRow arow) 0) := by
+  rw [← primaryOpBusMessage_toEntry_eq_opBus_row_ArithDiv arow h_div h_main_div h_main_mul]
+  exact h
+
+/-! ## Phase 2 — balance-derived div-Euclidean chunk equations + loose carry bounds -/
+
+open ZiskFv.Airs.ArithMul in
+/-- **Mode-pinned DIVU Euclidean chunk equations.** Specialize the 11-clause
+    ArithMul `mul_carry_chain_holds` (the balance-derived `FullSpec.Spec`,
+    in the row-native ArithMul view) to the unsigned DIVU mode
+    (`na = nb = np = nr = m32 = 0`, `div = 1`, hence `fab = 1`,
+    `na_fb = nb_fa = 0`), yielding the eight div-Euclidean chunk equations
+    (`a·b + d = c` form on the low four, high-half carry-only on the top).
+    The mode flags are read off the BARE provider `ArithMulRow`. -/
+private lemma divu_chain_eqs
+    (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL)
+    (h_chain : mul_carry_chain_holds (vOfMulwRow arow) 0)
+    (h_na : arow.flags.na = 0) (h_nb : arow.flags.nb = 0)
+    (h_np : arow.flags.np = 0) (h_nr : arow.flags.nr = 0)
+    (h_m32 : arow.flags.m32 = 0) (h_div : arow.flags.div = 1) :
+    (arow.chunks.a_0 * arow.chunks.b_0 + arow.chunks.d_0
+        = arow.chunks.c_0 + arow.carries.carry_0 * 65536)
+    ∧ (arow.chunks.a_1 * arow.chunks.b_0 + arow.chunks.a_0 * arow.chunks.b_1
+        + arow.chunks.d_1 + arow.carries.carry_0
+        = arow.chunks.c_1 + arow.carries.carry_1 * 65536)
+    ∧ (arow.chunks.a_2 * arow.chunks.b_0 + arow.chunks.a_1 * arow.chunks.b_1
+        + arow.chunks.a_0 * arow.chunks.b_2 + arow.chunks.d_2 + arow.carries.carry_1
+        = arow.chunks.c_2 + arow.carries.carry_2 * 65536)
+    ∧ (arow.chunks.a_3 * arow.chunks.b_0 + arow.chunks.a_2 * arow.chunks.b_1
+        + arow.chunks.a_1 * arow.chunks.b_2 + arow.chunks.a_0 * arow.chunks.b_3
+        + arow.chunks.d_3 + arow.carries.carry_2
+        = arow.chunks.c_3 + arow.carries.carry_3 * 65536)
+    ∧ (arow.chunks.a_3 * arow.chunks.b_1 + arow.chunks.a_2 * arow.chunks.b_2
+        + arow.chunks.a_1 * arow.chunks.b_3 + arow.carries.carry_3
+        = arow.carries.carry_4 * 65536)
+    ∧ (arow.chunks.a_3 * arow.chunks.b_2 + arow.chunks.a_2 * arow.chunks.b_3
+        + arow.carries.carry_4 = arow.carries.carry_5 * 65536)
+    ∧ (arow.chunks.a_3 * arow.chunks.b_3 + arow.carries.carry_5
+        = arow.carries.carry_6 * 65536)
+    ∧ (arow.carries.carry_6 = 0) := by
+  obtain ⟨h6, h7, h8, h31, h32, h33, h34, h35, h36, h37, h38⟩ := h_chain
+  simp only [mul_constraint_6_named, mul_constraint_7_named, mul_constraint_8_named,
+             vOfMulwRow, h_na, h_nb, mul_zero, zero_mul, add_zero, sub_zero] at h6 h7 h8
+  have h_fab : arow.carries.fab = (1 : FGL) := by linear_combination h6
+  have h_nafb : arow.carries.na_fb = (0 : FGL) := by linear_combination h7
+  have h_nbfa : arow.carries.nb_fa = (0 : FGL) := by linear_combination h8
+  simp only [mul_constraint_31_named, mul_constraint_32_named,
+             mul_constraint_33_named, mul_constraint_34_named,
+             mul_constraint_35_named, mul_constraint_36_named,
+             mul_constraint_37_named, mul_constraint_38_named,
+             vOfMulwRow, h_na, h_nb, h_np, h_nr, h_m32, h_div, h_fab, h_nafb, h_nbfa,
+             mul_zero, zero_mul, add_zero, sub_zero, mul_one, one_mul]
+    at h31 h32 h33 h34 h35 h36 h37 h38
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · linear_combination h31
+  · linear_combination h32
+  · linear_combination h33
+  · linear_combination h34
+  · linear_combination h35
+  · linear_combination h36
+  · linear_combination h37
+  · linear_combination h38
+
+/-- **Balance-constructible DIVU unsigned carry bounds.** From the eight
+    mode-pinned div-Euclidean chunk equations + the sixteen 16-bit chunk bounds
+    + the seven *signed* carry disjunctions (all from `FullSpec`), derive the
+    looser *unsigned-side* carry bounds `cy_i.val < 983041` by sequentially
+    applying `unsigned_carry_step_nat` up the chain (each step's accumulated
+    column value stays below `983040·2^16`).  Reuses the generic
+    `unsigned_carry_step_nat` from `ConstructionMulhu`. -/
+private lemma divu_carry_bounds
+    (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL)
+    (h_chunks : ZiskFv.EquivCore.Bridge.Arith.ArithDivChunkRangesAt (vOfDivuRow arow) 0)
+    (h_csgn : ZiskFv.EquivCore.Bridge.Arith.ArithDivSignedCarryRangesAt (vOfDivuRow arow) 0)
+    (heqs :
+      (arow.chunks.a_0 * arow.chunks.b_0 + arow.chunks.d_0
+          = arow.chunks.c_0 + arow.carries.carry_0 * 65536)
+      ∧ (arow.chunks.a_1 * arow.chunks.b_0 + arow.chunks.a_0 * arow.chunks.b_1
+          + arow.chunks.d_1 + arow.carries.carry_0
+          = arow.chunks.c_1 + arow.carries.carry_1 * 65536)
+      ∧ (arow.chunks.a_2 * arow.chunks.b_0 + arow.chunks.a_1 * arow.chunks.b_1
+          + arow.chunks.a_0 * arow.chunks.b_2 + arow.chunks.d_2 + arow.carries.carry_1
+          = arow.chunks.c_2 + arow.carries.carry_2 * 65536)
+      ∧ (arow.chunks.a_3 * arow.chunks.b_0 + arow.chunks.a_2 * arow.chunks.b_1
+          + arow.chunks.a_1 * arow.chunks.b_2 + arow.chunks.a_0 * arow.chunks.b_3
+          + arow.chunks.d_3 + arow.carries.carry_2
+          = arow.chunks.c_3 + arow.carries.carry_3 * 65536)
+      ∧ (arow.chunks.a_3 * arow.chunks.b_1 + arow.chunks.a_2 * arow.chunks.b_2
+          + arow.chunks.a_1 * arow.chunks.b_3 + arow.carries.carry_3
+          = arow.carries.carry_4 * 65536)
+      ∧ (arow.chunks.a_3 * arow.chunks.b_2 + arow.chunks.a_2 * arow.chunks.b_3
+          + arow.carries.carry_4 = arow.carries.carry_5 * 65536)
+      ∧ (arow.chunks.a_3 * arow.chunks.b_3 + arow.carries.carry_5
+          = arow.carries.carry_6 * 65536)
+      ∧ (arow.carries.carry_6 = 0)) :
+    (arow.carries.carry_0).val < 983041 ∧ (arow.carries.carry_1).val < 983041
+    ∧ (arow.carries.carry_2).val < 983041 ∧ (arow.carries.carry_3).val < 983041
+    ∧ (arow.carries.carry_4).val < 983041 ∧ (arow.carries.carry_5).val < 983041
+    ∧ (arow.carries.carry_6).val < 983041 := by
+  obtain ⟨ha0, ha1, ha2, ha3, hb0, hb1, hb2, hb3,
+          hc0, hc1, hc2, hc3, hd0, hd1, hd2, hd3⟩ := h_chunks
+  obtain ⟨hs0, hs1, hs2, hs3, hs4, hs5, hs6⟩ := h_csgn
+  obtain ⟨hC31, hC32, hC33, hC34, hC35, hC36, hC37, hC38⟩ := heqs
+  -- Normalize the chunk/carry hypotheses from the `vOfDivuRow` view to the bare
+  -- `arow.chunks.*` / `arow.carries.*` form, so `omega` and
+  -- `unsigned_carry_step_nat` see the same atoms as the chunk equations.
+  simp only [vOfDivuRow] at ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hc0 hc1 hc2 hc3 hd0 hd1 hd2 hd3
+  simp only [vOfDivuRow] at hs0 hs1 hs2 hs3 hs4 hs5 hs6
+  -- Each step: bound the accumulated column value `N` below `983040·2^16` and
+  -- apply `unsigned_carry_step_nat`.  Chunk `.val`s are `< 65536` and `d`-lanes
+  -- add at most one more `< 65536` term; the carry-in is `< 983041` by induction.
+  have b0 : (arow.carries.carry_0).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_0).val * (arow.chunks.b_0).val + (arow.chunks.d_0).val)
+      _ _ ?_ hc0 ?_ hs0
+    · push_cast; linear_combination hC31
+    · have : (arow.chunks.a_0).val * (arow.chunks.b_0).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b1 : (arow.carries.carry_1).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_1).val * (arow.chunks.b_0).val
+        + (arow.chunks.a_0).val * (arow.chunks.b_1).val
+        + (arow.chunks.d_1).val + (arow.carries.carry_0).val) _ _ ?_ hc1 ?_ hs1
+    · push_cast; linear_combination hC32
+    · have h1 : (arow.chunks.a_1).val * (arow.chunks.b_0).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (arow.chunks.a_0).val * (arow.chunks.b_1).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b2 : (arow.carries.carry_2).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_2).val * (arow.chunks.b_0).val
+        + (arow.chunks.a_1).val * (arow.chunks.b_1).val
+        + (arow.chunks.a_0).val * (arow.chunks.b_2).val
+        + (arow.chunks.d_2).val + (arow.carries.carry_1).val) _ _ ?_ hc2 ?_ hs2
+    · push_cast; linear_combination hC33
+    · have h1 : (arow.chunks.a_2).val * (arow.chunks.b_0).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (arow.chunks.a_1).val * (arow.chunks.b_1).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h3 : (arow.chunks.a_0).val * (arow.chunks.b_2).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b3 : (arow.carries.carry_3).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_3).val * (arow.chunks.b_0).val
+        + (arow.chunks.a_2).val * (arow.chunks.b_1).val
+        + (arow.chunks.a_1).val * (arow.chunks.b_2).val
+        + (arow.chunks.a_0).val * (arow.chunks.b_3).val
+        + (arow.chunks.d_3).val + (arow.carries.carry_2).val) _ _ ?_ hc3 ?_ hs3
+    · push_cast; linear_combination hC34
+    · have h1 : (arow.chunks.a_3).val * (arow.chunks.b_0).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (arow.chunks.a_2).val * (arow.chunks.b_1).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h3 : (arow.chunks.a_1).val * (arow.chunks.b_2).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h4 : (arow.chunks.a_0).val * (arow.chunks.b_3).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b4 : (arow.carries.carry_4).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_3).val * (arow.chunks.b_1).val
+        + (arow.chunks.a_2).val * (arow.chunks.b_2).val
+        + (arow.chunks.a_1).val * (arow.chunks.b_3).val
+        + (arow.carries.carry_3).val) 0 _ ?_ (by omega) ?_ hs4
+    · push_cast; linear_combination hC35
+    · have h1 : (arow.chunks.a_3).val * (arow.chunks.b_1).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (arow.chunks.a_2).val * (arow.chunks.b_2).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h3 : (arow.chunks.a_1).val * (arow.chunks.b_3).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b5 : (arow.carries.carry_5).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_3).val * (arow.chunks.b_2).val
+        + (arow.chunks.a_2).val * (arow.chunks.b_3).val
+        + (arow.carries.carry_4).val) 0 _ ?_ (by omega) ?_ hs5
+    · push_cast; linear_combination hC36
+    · have h1 : (arow.chunks.a_3).val * (arow.chunks.b_2).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (arow.chunks.a_2).val * (arow.chunks.b_3).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b6 : (arow.carries.carry_6).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_3).val * (arow.chunks.b_3).val + (arow.carries.carry_5).val)
+      0 _ ?_ (by omega) ?_ hs6
+    · push_cast; linear_combination hC37
+    · have h1 : (arow.chunks.a_3).val * (arow.chunks.b_3).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  exact ⟨b0, b1, b2, b3, b4, b5, b6⟩
+
+/-! ## Phase 3 — balance-selected DIVU provider row + transports -/
+
+/-- The balance-selected Arith-Mul provider row at trace index `i` for a DIVU
+    operation, as a concrete `ArithMulRow`.  It is the
+    `componentWithArithTable.rowInput` of the provider row chosen by the DIVU
+    keep-arithMul balance wrapper
+    `exists_arithMul_provider_row_matches_primary_of_divu_from_binding`.
+    Mirrors `mulwArow`. -/
+noncomputable def divuArow
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU) :
+    ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
+  let h := exists_arithMul_provider_row_matches_primary_of_divu_from_binding
+    trace binding i h_main_active h_main_op
+  componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
+
+/-- `FullSpec` of the balance-selected DIVU provider row, derived from the
+    provider component's proven soundness (`componentWithArithTable.Spec`). -/
+theorem divuArow_fullSpec_row
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU) :
+    ZiskFv.AirsClean.ArithMul.FullSpec (divuArow trace binding i h_main_active h_main_op) := by
+  unfold divuArow
+  set H := exists_arithMul_provider_row_matches_primary_of_divu_from_binding
+    trace binding i h_main_active h_main_op with hH
+  obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
+  obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
+  exact ZiskFv.AirsClean.FullEnsemble.arithMul_fullSpec_of_component_spec
+    h_component (h_spec h_rest.choose h_pr_mem)
+
+/-- The op-bus match of the balance-selected DIVU provider row against the Main
+    row's emission, in `toEntry (primaryOpBusMessage …) 1` form (cheap: free
+    `ArithMulRow`, no view whnf). -/
+theorem divuArow_match_row
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU) :
+    matches_entry
+      (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val)
+      (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+        (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+          (divuArow trace binding i h_main_active h_main_op)) 1) := by
+  unfold divuArow
+  set H := exists_arithMul_provider_row_matches_primary_of_divu_from_binding
+    trace binding i h_main_active h_main_op with hH
+  exact H.choose_spec.2.choose_spec.2.2.2
+
+/-- DIVU mode pins on the balance-selected provider row, DERIVED from its
+    `ArithTableSpec` (part of `FullSpec`) plus the opcode pin
+    `arow.flags.op = 184`.  These are not caller binders.  Reads the mode flags
+    off the BARE provider `ArithMulRow` via `divu_mode_pins_of_row`, never
+    forcing the heavy `Classical.choose` row's whnf. -/
+theorem divuArow_mode_pins
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU) :
+    (divuArow trace binding i h_main_active h_main_op).flags.na = 0
+      ∧ (divuArow trace binding i h_main_active h_main_op).flags.nb = 0
+      ∧ (divuArow trace binding i h_main_active h_main_op).flags.np = 0
+      ∧ (divuArow trace binding i h_main_active h_main_op).flags.nr = 0
+      ∧ (divuArow trace binding i h_main_active h_main_op).flags.sext = 0
+      ∧ (divuArow trace binding i h_main_active h_main_op).flags.m32 = 0
+      ∧ (divuArow trace binding i h_main_active h_main_op).flags.div = 1
+      ∧ (divuArow trace binding i h_main_active h_main_op).flags.main_div = 1
+      ∧ (divuArow trace binding i h_main_active h_main_op).flags.main_mul = 0 := by
+  have h_table := (divuArow_fullSpec_row trace binding i h_main_active h_main_op).2.1
+  have h_op : (divuArow trace binding i h_main_active h_main_op).flags.op = 184 := by
+    have h_match := divuArow_match_row trace binding i h_main_active h_main_op
+    have h_op := h_match.2.1
+    rw [ZiskFv.AirsClean.ArithMul.primaryOpBusMessage_toEntry_op,
+        show (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val).op
+          = (mainOfTable trace.program binding.mainTable).op i.val from rfl,
+        h_main_op] at h_op
+    simpa [OP_DIVU] using h_op.symm
+  exact ZiskFv.AirsClean.ArithTableProjections.Mul.divu_mode_pins_of_row
+    (divuArow trace binding i h_main_active h_main_op) h_table h_op
+
+/-- The op-bus match of the balance-selected DIVU provider row view against the
+    Main row's emission, in `opBus_row_ArithDiv` form.  The DIVU mode pins
+    needed to reduce the faithful mux are DERIVED via `divuArow_mode_pins`. -/
+theorem divuArow_match
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU) :
+    matches_entry
+      (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val)
+      (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv
+        (vOfDivuRow (divuArow trace binding i h_main_active h_main_op)) 0) := by
+  obtain ⟨_, _, _, _, _, _, h_div, h_main_div, h_main_mul⟩ :=
+    divuArow_mode_pins trace binding i h_main_active h_main_op
+  exact match_opBus_row_ArithDiv_vOfDivuRow h_div h_main_div h_main_mul
+    (divuArow_match_row trace binding i h_main_active h_main_op)
+
+/-! ## Phase 4 — F4 `FullSpec` discharge bridge for DIVU -/
+
+open ZiskFv.Airs.ArithDiv in
+open ZiskFv.EquivCore.Promises in
+/-- **F4 extraction bridge for `equiv_DIVU`.**  Mirror of
+    `equiv_MULHU_of_fullSpec`: the four lookup-aware Arith witness records are
+    replaced by the single `FullSpec arow` hypothesis (the SHARED ArithMul
+    provider's `componentWithArithTable.Spec`), with the ArithDiv-view facts
+    read off the same row through `vOfDivuRow arow`.
+
+    Like MULHU, DIVU's `equiv_DIVU` demands the *unsigned* carry bound
+    `< 131072`, which is NOT balance-constructible; this bridge derives the
+    looser balance bound `< 983041` (via `divu_carry_bounds`) and reconstructs
+    the rd write value through the loose write-value path
+    `h_rd_val_mdru_divu_loose`, replicating `equiv_DIVU`'s sail + `bus_effect`
+    tail.
+
+    The remainder bound `remainder_bound : ArithDivRemainderBoundWitness` is the
+    ONE explicit residual binder (NOT balance-derived): the ArithDiv op-bus
+    consumer `assumes_operation` edge is a finished-channel self-edge absent
+    from the full ensemble (see module header). -/
+lemma equiv_DIVU_of_fullSpec
+    (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
+    (divu_input : PureSpec.DivuInput)
+    (r1 r2 rd : regidx)
+    (bus : ZiskFv.Compliance.BusRows)
+    (m : Valid_Main FGL FGL) (r_main : ℕ)
+    (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL)
+    (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_DIVU)
+    (h_match_primary :
+      matches_entry (opBus_row_Main m r_main)
+                    (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv (vOfDivuRow arow) 0))
+    (promises : ZiskFv.EquivCore.Promises.RTypePromises
+        state divu_input.r1_val divu_input.r2_val divu_input.rd divu_input.PC
+        (PureSpec.execute_DIVREM_divu_pure divu_input).nextPC
+        r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
+    (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
+    (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
+    (h_full_spec : ZiskFv.AirsClean.ArithMul.FullSpec arow)
+    (remainder_bound :
+      ZiskFv.EquivCore.Bridge.Arith.ArithDivRemainderBoundWitness (vOfDivuRow arow) 0)
+    (h_rs1_value : divu_input.r1_val.toNat
+      = ZiskFv.PackedBitVec.MulNoWrap.packed4 (arow.chunks.c_0).val (arow.chunks.c_1).val
+          (arow.chunks.c_2).val (arow.chunks.c_3).val)
+    (h_rs2_value : divu_input.r2_val.toNat
+      = ZiskFv.PackedBitVec.MulNoWrap.packed4 (arow.chunks.b_0).val (arow.chunks.b_1).val
+          (arow.chunks.b_2).val (arow.chunks.b_3).val) :
+    (do
+      Sail.writeReg Register.nextPC
+        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
+      LeanRV64D.Functions.execute (instruction.DIV (r2, r1, rd, true))) state
+      = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
+  -- Unpack FullSpec into its five conjuncts (ArithMul view of `arow`).
+  obtain ⟨h_spec, h_arith_table, h_c46, h_chunk_ranges_spec, h_carry_ranges_spec⟩ :=
+    h_full_spec
+  obtain ⟨exec_row, e0, e1, e2⟩ := bus
+  obtain ⟨h0, h1, h2, h3, h4, h5, h6, h7⟩ := bounds
+  obtain ⟨_h_main_active, h_main_op_divu⟩ := pins
+  obtain ⟨h_input_r1, h_input_r2, h_input_rd, h_input_pc,
+          h_exec_len, h_e0_mult, h_e1_mult, h_nextPC_matches,
+          h_m0_mult, h_m0_as, h_m1_mult, h_m1_as, h_m2_mult, h_m2_as,
+          h_rd_idx⟩ := promises
+  -- ============ DERIVE arith-side opcode literal ============
+  have h_op_eq := arith_div_primary_op_eq h_match_primary
+  have h_op_arith_divu : (vOfDivuRow arow).op 0 = 184 := by
+    rw [h_op_eq, h_main_op_divu]; simp [OP_DIVU]
+  -- ============ DIVU mode pins, DERIVED from the bare-row ArithTableSpec ============
+  -- `arow.flags.op = 184` from the op-bus match (transports to the bare row).
+  have h_op_arow : arow.flags.op = 184 := h_op_arith_divu
+  obtain ⟨h_na_arow, h_nb_arow, h_np_arow, h_nr_arow, h_sext_arow, h_m32_arow,
+          h_div_arow, h_main_div_arow, h_main_mul_arow⟩ :=
+    ZiskFv.AirsClean.ArithTableProjections.Mul.divu_mode_pins_of_row arow h_arith_table h_op_arow
+  -- ArithDiv-view mode pins (defeq to the bare-row flags).
+  have h_na : (vOfDivuRow arow).na 0 = 0 := h_na_arow
+  have h_nb : (vOfDivuRow arow).nb 0 = 0 := h_nb_arow
+  have h_nr : (vOfDivuRow arow).nr 0 = 0 := h_nr_arow
+  have h_sext : (vOfDivuRow arow).sext 0 = 0 := h_sext_arow
+  have h_m32 : (vOfDivuRow arow).m32 0 = 0 := h_m32_arow
+  have h_div : (vOfDivuRow arow).div 0 = 1 := h_div_arow
+  -- ============ Chunk / carry ranges (ArithDiv view, from FullSpec) ============
+  have h_chunk_ranges :
+      ZiskFv.EquivCore.Bridge.Arith.ArithDivChunkRangesAt (vOfDivuRow arow) 0 :=
+    h_chunk_ranges_spec
+  have h_carry_ranges_signed :
+      ZiskFv.EquivCore.Bridge.Arith.ArithDivSignedCarryRangesAt (vOfDivuRow arow) 0 :=
+    h_carry_ranges_spec
+  obtain ⟨h_a0_lt, h_a1_lt, h_a2_lt, h_a3_lt,
+          h_b0_lt, h_b1_lt, h_b2_lt, h_b3_lt,
+          h_c0_lt, h_c1_lt, h_c2_lt, h_c3_lt,
+          h_d0_lt, h_d1_lt, h_d2_lt, h_d3_lt⟩ := h_chunk_ranges
+  -- ============ Mode-pinned div-Euclidean chunk equations ============
+  have heqs := divu_chain_eqs arow h_spec h_na_arow h_nb_arow h_np_arow h_nr_arow
+    h_m32_arow h_div_arow
+  -- ============ Balance-constructible LOOSE unsigned carry bounds ============
+  obtain ⟨hcy0, hcy1, hcy2, hcy3, hcy4, hcy5, hcy6⟩ :=
+    divu_carry_bounds arow h_chunk_ranges_spec h_carry_ranges_signed heqs
+  obtain ⟨hC31, hC32, hC33, hC34, hC35, hC36, hC37, hC38⟩ := heqs
+  -- ============ Remainder bound (RESIDUAL): d < b in chunk form ============
+  have h_d_lt_b_arith :=
+    ZiskFv.EquivCore.Bridge.Arith.arith_div_remainder_bound_unsigned
+      remainder_bound h_chunk_ranges_spec h_nr h_nb
+  have h_d_lt_b :
+      ZiskFv.PackedBitVec.MulNoWrap.packed4 (arow.chunks.d_0).val (arow.chunks.d_1).val
+          (arow.chunks.d_2).val (arow.chunks.d_3).val
+        < divu_input.r2_val.toNat := by
+    simpa [h_rs2_value] using h_d_lt_b_arith
+  have h_op2_ne : divu_input.r2_val.toNat ≠ 0 := by
+    intro h_zero
+    have : ZiskFv.PackedBitVec.MulNoWrap.packed4 (arow.chunks.d_0).val (arow.chunks.d_1).val
+          (arow.chunks.d_2).val (arow.chunks.d_3).val < 0 := by
+      simpa [h_zero] using h_d_lt_b
+    omega
+  -- ============ DISCHARGE h_byte_lo / h_byte_hi (quotient a-lanes) ============
+  obtain ⟨_h_a_lo_eq_FGL, _h_a_hi_eq_FGL, _h_b_lo_eq_FGL, _h_b_hi_eq_FGL,
+          h_c0_eq_FGL, h_c1_eq_FGL⟩ :=
+    arith_div_primary_projections h_match_primary
+  have h_bundle := arith_mem.c_lane_vals
+  have h_byte_lo_to_c0 : (byteAt e2 0).val + (byteAt e2 1).val * 256
+      + (byteAt e2 2).val * 65536 + (byteAt e2 3).val * 16777216
+      = (m.c_0 r_main).val := by
+    have h_e2_lo_bound : e2.value_0.val < 4294967296 := by
+      rw [← h_bundle.1, h_c0_eq_FGL]
+      rw [arith_h_pair_lift _ _ h_a0_lt h_a1_lt]
+      omega
+    rw [ZiskFv.Channels.MemoryBusBytes.byteAt_lo_val_sum_eq e2 h_e2_lo_bound, h_bundle.1]
+  have h_bus_res1_eq : (vOfDivuRow arow).bus_res1 0
+      = (vOfDivuRow arow).a_2 0 + (vOfDivuRow arow).a_3 0 * 65536 :=
+    ZiskFv.Airs.ArithBusRes1.div_bus_res1_eq_a_hi (vOfDivuRow arow) 0
+      (by
+        -- c46 (ArithDiv form) from the ArithMul-view C46Spec on the same row.
+        simp only [ZiskFv.AirsClean.ArithMul.C46Spec,
+          ZiskFv.Airs.ArithMul.mul_constraint_46_named] at h_c46
+        simp only [ZiskFv.Airs.ArithDiv.bus_res1_eq_div, vOfDivuRow]
+        linear_combination h_c46)
+      h_sext h_m32 h_main_mul_arow h_main_div_arow
+  have h_byte_hi_to_c1 : (byteAt e2 4).val + (byteAt e2 5).val * 256
+      + (byteAt e2 6).val * 65536 + (byteAt e2 7).val * 16777216
+      = (m.c_1 r_main).val := by
+    have h_e2_hi_bound : e2.value_1.val < 4294967296 := by
+      rw [← h_bundle.2, h_c1_eq_FGL, h_bus_res1_eq]
+      rw [arith_h_pair_lift _ _ h_a2_lt h_a3_lt]
+      omega
+    rw [ZiskFv.Channels.MemoryBusBytes.byteAt_hi_val_sum_eq e2 h_e2_hi_bound, h_bundle.2]
+  have h_byte_lo :=
+    arith_byte_lane_eq_of_match h_byte_lo_to_c0 h_c0_eq_FGL h_a0_lt h_a1_lt
+  have h_c1_eq_FGL' : m.c_1 r_main = (vOfDivuRow arow).a_2 0 + (vOfDivuRow arow).a_3 0 * 65536 := by
+    rw [h_c1_eq_FGL, h_bus_res1_eq]
+  have h_byte_hi :=
+    arith_byte_lane_eq_of_match h_byte_hi_to_c1 h_c1_eq_FGL' h_a2_lt h_a3_lt
+  -- ============ DISCHARGE rd-write value via the LOOSE write-value path ============
+  have h_rd_val :=
+    ZiskFv.EquivCore.WriteValueProofs.MulDivRemUnsigned.h_rd_val_mdru_divu_loose
+      divu_input.r1_val divu_input.r2_val e2
+      (arow.chunks.a_0) (arow.chunks.a_1) (arow.chunks.a_2) (arow.chunks.a_3)
+      (arow.chunks.b_0) (arow.chunks.b_1) (arow.chunks.b_2) (arow.chunks.b_3)
+      (arow.chunks.c_0) (arow.chunks.c_1) (arow.chunks.c_2) (arow.chunks.c_3)
+      (arow.chunks.d_0) (arow.chunks.d_1) (arow.chunks.d_2) (arow.chunks.d_3)
+      (arow.carries.carry_0) (arow.carries.carry_1) (arow.carries.carry_2)
+      (arow.carries.carry_3) (arow.carries.carry_4) (arow.carries.carry_5)
+      (arow.carries.carry_6)
+      h0 h1 h2 h3 h4 h5 h6 h7
+      h_a0_lt h_a1_lt h_a2_lt h_a3_lt h_b0_lt h_b1_lt h_b2_lt h_b3_lt
+      h_c0_lt h_c1_lt h_c2_lt h_c3_lt h_d0_lt h_d1_lt h_d2_lt h_d3_lt
+      hcy0 hcy1 hcy2 hcy3 hcy4 hcy5 hcy6
+      hC31 hC32 hC33 hC34 hC35 hC36 hC37 hC38
+      h_byte_lo h_byte_hi h_rs1_value h_rs2_value h_op2_ne h_d_lt_b
+  -- ============ Replicate `equiv_DIVU`'s sail + bus_effect tail ============
+  rw [ZiskFv.EquivCore.Divu.equiv_DIVU_sail state divu_input r1 r2 rd
+        h_input_r1 h_input_r2 h_input_rd h_input_pc]
+  symm
+  rw [ZiskFv.Airs.Bus.BusEmission.bus_effect_matches_sail_alu_rrw
+        state exec_row e0 e1 e2
+        (PureSpec.execute_DIVREM_divu_pure divu_input).nextPC
+        h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
+        h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as]
+  simp only [PureSpec.execute_DIVREM_divu_pure, h_rd_idx]
+  split_ifs with h_rd_zero
+  · simp only [bind, pure, EStateM.bind, EStateM.pure]
+  · rw [h_rd_val]
+
+/-! ## Phase 5 — sound DIVU construction -/
+
+/-- **Sound DIVU construction:** from the accepted trace + honest residual
+    binders, conclude the canonical
+    `execute (DIV (r2, r1, rd, true)) = (bus_effect …).2`.
+
+    The Arith provider witnesses (ArithTable membership, chunk ranges, signed
+    carry ranges, c46, carry-chain) are DERIVED inside the body from
+    `trace.balanced` / `trace.spec` via the SHARED ArithMul provider's
+    lookup-aware `componentWithArithTable.Spec = FullSpec`, NOT supplied as
+    binders.
+
+    The ONE non-balance-derived residual is `remainder_bound`
+    (`ArithDivRemainderBoundWitness`): the `|d| < b` LTU consumer edge from
+    `arith.pil:274` is a finished-channel self-edge absent from the full
+    ensemble (`ArithDiv.component` emits no op-bus —
+    `arithDiv_table_interactionsWith_opBus_nil`), so it is carried explicitly,
+    exactly as the canonical `equiv_DIVU` carries it. -/
+theorem construction_divu_sound
+    (trace : AcceptedTrace)
+    (binding : ProgramBinding trace)
+    (i : Fin trace.length)
+    (divu_input : PureSpec.DivuInput)
+    (r1 r2 rd : regidx)
+    -- (b) decode pins
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_store_pc :
+      (mainOfTable trace.program binding.mainTable).store_pc i.val = 0)
+    -- (b) Sail reads + operands
+    (h_input_r1 :
+      read_xreg (regidx_to_fin r1) (binding.stateAt i)
+        = EStateM.Result.ok divu_input.r1_val (binding.stateAt i))
+    (h_input_r2 :
+      read_xreg (regidx_to_fin r2) (binding.stateAt i)
+        = EStateM.Result.ok divu_input.r2_val (binding.stateAt i))
+    (h_input_pc : (binding.stateAt i).regs.get? Register.PC = .some divu_input.PC)
+    (h_input_rd : divu_input.rd = regidx_to_fin rd)
+    -- (c) exec artifacts: the exec row is a genuine top-level binder.
+    (execRow : List (Interaction.ExecutionBusEntry FGL))
+    (h_exec_len : (busSub trace binding i execRow).exec_row.length = 2)
+    (h_e0_mult : (busSub trace binding i execRow).exec_row[0]!.multiplicity = -1)
+    (h_e1_mult : (busSub trace binding i execRow).exec_row[1]!.multiplicity = 1)
+    (h_nextPC_matches :
+      (register_type_pc_equiv ▸
+          (BitVec.ofNat 64 ((busSub trace binding i execRow).exec_row[1]!.pc).val))
+        = (PureSpec.execute_DIVREM_divu_pure divu_input).nextPC)
+    (h_rd_idx :
+      divu_input.rd =
+        Transpiler.wrap_to_regidx (busSub trace binding i execRow).e2.ptr)
+    -- (c) byte range bounds on the rd-write entry
+    (bounds : ZiskFv.Compliance.ByteBounds (busSub trace binding i execRow).e2)
+    -- (b) RESIDUAL: remainder-bound witness (the ONE non-balance-derived
+    -- binder — the ArithDiv `assumes_operation` LTU consumer edge is a
+    -- finished-channel self-edge absent from the ensemble).
+    (remainder_bound :
+      ZiskFv.EquivCore.Bridge.Arith.ArithDivRemainderBoundWitness
+        (vOfDivuRow (divuArow trace binding i h_main_active h_main_op)) 0)
+    -- (b) operand bridges (Sail↔chunk binding of the unsigned 64-bit operands;
+    -- genuinely residual, phrased over the balance-selected provider row).
+    (h_rs1_value : divu_input.r1_val.toNat
+      = ZiskFv.PackedBitVec.MulNoWrap.packed4
+          ((divuArow trace binding i h_main_active h_main_op).chunks.c_0).val
+          ((divuArow trace binding i h_main_active h_main_op).chunks.c_1).val
+          ((divuArow trace binding i h_main_active h_main_op).chunks.c_2).val
+          ((divuArow trace binding i h_main_active h_main_op).chunks.c_3).val)
+    (h_rs2_value : divu_input.r2_val.toNat
+      = ZiskFv.PackedBitVec.MulNoWrap.packed4
+          ((divuArow trace binding i h_main_active h_main_op).chunks.b_0).val
+          ((divuArow trace binding i h_main_active h_main_op).chunks.b_1).val
+          ((divuArow trace binding i h_main_active h_main_op).chunks.b_2).val
+          ((divuArow trace binding i h_main_active h_main_op).chunks.b_3).val) :
+    (do
+      Sail.writeReg Register.nextPC
+        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
+      LeanRV64D.Functions.execute (instruction.DIV (r2, r1, rd, true))) (binding.stateAt i)
+      = (bus_effect (busSub trace binding i execRow).exec_row
+          [ (busSub trace binding i execRow).e0
+          , (busSub trace binding i execRow).e1
+          , (busSub trace binding i execRow).e2 ] (binding.stateAt i)).2 := by
+  -- (a) Arith witnesses derived from balance: FullSpec.
+  have h_full :
+      ZiskFv.AirsClean.ArithMul.FullSpec
+        (divuArow trace binding i h_main_active h_main_op) :=
+    divuArow_fullSpec_row trace binding i h_main_active h_main_op
+  -- (a) primary op-bus match against `opBus_row_ArithDiv (vOfDivuRow …) 0`.
+  have h_match_primary :
+      matches_entry (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val)
+        (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv
+          (vOfDivuRow (divuArow trace binding i h_main_active h_main_op)) 0) :=
+    divuArow_match trace binding i h_main_active h_main_op
+  -- decode pins bundle
+  let pins :
+      ZiskFv.Compliance.MainRowPins
+        (mainOfTable trace.program binding.mainTable) i.val 1 OP_DIVU :=
+    ⟨h_main_active, h_main_op⟩
+  -- (a) Main rd-write memory witness, from `store_pc = 0`.
+  have h_core_store_pc :
+      (mainRowWithRomSub trace binding i).core.store_pc = 0 := by
+    have h_row :
+        (mainRowWithRomSub trace binding i).core =
+          ZiskFv.AirsClean.Main.rowAt (mainOfTable trace.program binding.mainTable) i.val := by
+      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+        trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+      simpa [mainRowWithRomSub,
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+    rw [h_row]
+    simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
+  let arith_mem :
+      ZiskFv.Compliance.ExternalArithMemoryWitness
+        (mainOfTable trace.program binding.mainTable) i.val
+        (busSub trace binding i execRow).e2 :=
+    { row := mainRowWithRomSub trace binding i
+      row_eq := by
+        have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+          trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+        simpa [mainRowWithRomSub,
+          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+      store_pc_zero := h_core_store_pc
+      rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
+  -- promises bundle: Sail reads + exec artifacts as binders; MemBus shape by rfl.
+  let promises : ZiskFv.EquivCore.Promises.RTypePromises
+      (binding.stateAt i) divu_input.r1_val divu_input.r2_val divu_input.rd divu_input.PC
+      (PureSpec.execute_DIVREM_divu_pure divu_input).nextPC
+      r1 r2 rd (busSub trace binding i execRow).exec_row (busSub trace binding i execRow).e0
+      (busSub trace binding i execRow).e1 (busSub trace binding i execRow).e2 :=
+    { input_r1_eq := h_input_r1
+      input_r2_eq := h_input_r2
+      input_rd_eq := h_input_rd
+      input_pc_eq := h_input_pc
+      exec_len := h_exec_len
+      e0_mult := h_e0_mult
+      e1_mult := h_e1_mult
+      nextPC_matches := h_nextPC_matches
+      m0_mult := by rfl
+      m0_as := by rfl
+      m1_mult := by rfl
+      m1_as := by rfl
+      m2_mult := by rfl
+      m2_as := by rfl
+      rd_idx := h_rd_idx }
+  -- Delegate to the F4 fullSpec bridge.
+  exact equiv_DIVU_of_fullSpec
+    (binding.stateAt i) divu_input r1 r2 rd (busSub trace binding i execRow)
+    (mainOfTable trace.program binding.mainTable) i.val
+    (divuArow trace binding i h_main_active h_main_op)
+    pins h_match_primary promises arith_mem bounds
+    h_full remainder_bound h_rs1_value h_rs2_value
+
+end ZiskFv.Compliance

--- a/ZiskFv/Compliance/ConstructionDivuw.lean
+++ b/ZiskFv/Compliance/ConstructionDivuw.lean
@@ -1,0 +1,788 @@
+import ZiskFv.Compliance.AcceptedTrace
+import ZiskFv.Compliance.ConstructionMulw
+import ZiskFv.Compliance.ConstructionMulhu
+import ZiskFv.Compliance.ConstructionDivu
+import ZiskFv.EquivCore.Divuw
+import ZiskFv.EquivCore.Promises.ArithHelpers
+import ZiskFv.EquivCore.Bridge.Arith
+import ZiskFv.AirsClean.ArithMul.Bridge
+import ZiskFv.AirsClean.ArithDiv.Bridge
+import ZiskFv.AirsClean.ArithTableProjections
+import ZiskFv.Airs.Arith.Div
+import ZiskFv.Airs.Arith.BusRes1
+import ZiskFv.Bits.PackedBitVec.MulNoWrap
+
+/-!
+# Sound DIVUW construction (`construction_divuw_sound`)
+
+Unsigned RV64M **DIVUW** (`OP_DIVU_W = 188`, W-mode `m32 = 1`), the W-mode
+sibling of DIVU — exactly as MULW relates to a 64-bit multiply.  The Arith
+provider witnesses (ArithTable membership, chunk ranges, signed-carry ranges,
+c46, carry-chain) are **DERIVED FROM BALANCE** via the SHARED ArithMul provider
+component's lookup-aware `componentWithArithTable.Spec = FullSpec`, not carried
+as caller binders.
+
+## Why the shared ArithMul provider (not ArithDiv)
+
+`ArithDiv.component` carries NO operation-bus interactions in the full ensemble
+(`arithDiv_table_interactionsWith_opBus_nil`): its `circuit.channels = []`.  The
+DIVUW Main op-bus emission is therefore balanced by the SHARED ArithMul provider
+(`componentWithArithTable`), whose `FullSpec` covers div rows too.  The muxed
+primary op-bus message, at the DIVUW mode pins (`div = 1`, `main_div = 1`,
+`main_mul = 0` — all uniform for op 188), reduces to the div quotient-lane
+message `opBus_row_ArithDiv`.  These three mux selectors are the SAME as DIVU's,
+so the DIVU-mode op-bus bridge `match_opBus_row_ArithDiv_vOfDivuRow` (reused
+from `ConstructionDivu`) applies verbatim — `m32` plays no role in the mux.
+
+## The carry-range subtlety (vs MULW)
+
+`EquivCore.Divuw.equiv_DIVUW` demands the *unsigned* carry bound
+`cy_i.val < 131072 = 2^17`.  Balance supplies only `FullSpec`'s `CarryRangeSpec`
+— the **signed disjunction** `< 983041 ∨ ≥ p - 983040`.  The genuine Euclidean
+carries (`quotient · divisor`) reach `~3·2^16 > 2^17`, so the tight `< 131072`
+bound is NOT balance-constructible (same as DIVU / MULHU).  This module
+therefore does NOT route through `equiv_DIVUW`.  Instead it derives the looser
+balance-constructible bound `< 983041` (via `unsigned_carry_step_nat`, reused
+from `ConstructionMulhu`) and reconstructs the rd write value through the
+loose-bound DIVUW W-mode write-value path `h_rd_val_mdru_divuw_loose`,
+replicating `equiv_DIVUW`'s sail + `bus_effect` tail otherwise.
+
+## The W-mode deltas (vs DIVU)
+
+DIVUW is `m32 = 1`; the result is the *sign-extended low-32-bit quotient*.  The
+high half of the bus result comes from `bus_res1 = sext · 0xFFFF_FFFF` (PIL
+constraint 46 at `m32 = 1`), i.e. bytes 4..7 are `0x00` or `0xFF`.
+
+* `h_b23` (`b_2 = b_3 = 0`) and `h_c23` (`c_2 = c_3 = 0`) are DERIVED inside the
+  body from the W-mode op-bus hi-lane projection `(1 - m32) · m.* = …`
+  collapsing to `0 = …` at `m32 = 1` (via `arith_chunk_pair_eq_zero_of_m32_one`)
+  — NOT residual binders.
+* `h_byte_lo` (bytes 0..3 pack `a_0 + a_1·65536`, the W quotient low half) is
+  DERIVED from the op-bus c-lane match — NOT a binder.
+* `h_sext_choice` (the SEXT_00 / SEXT_FF disjunction on bytes 4..7, tied to the
+  quotient top bit) is the ONE W-mode bus-encoding residual, exactly as the
+  canonical `equiv_DIVUW` and `Wrappers/Divuw` carry it (class #4, bus
+  encoding — the same trust class as MULW / ADDW).  The arith table does not
+  uniformly pin `sext` across the op-188 rows, so this cannot be derived from
+  `ArithTableSpec`.
+
+## The remainder bound is RESIDUAL, not balance-derived
+
+`equiv_DIVUW` needs `ArithDivRemainderBoundWitness` — the `|d| < b` LTU check
+from `arith.pil:274`.  This is the ArithDiv op-bus *consumer*
+(`assumes_operation`) edge matched against a Binary LTU provider row.  Because
+`ArithDiv.component` emits no op-bus in the ensemble, this consume edge is a
+finished-channel SELF-EDGE that is **not composed into the ensemble** — so it is
+NOT balance-derivable.  It is carried as the single explicit residual binder
+`remainder_bound`, exactly as DIVU.
+
+## Residual binder shape
+
+`construction_divuw_sound` carries exactly DIVU's residual shape — decode pins +
+Sail reads + operand bridges (W-form, `extractLsb 31 0`) + exec artifacts +
+`execRow` + nextPC + the single `remainder_bound` — PLUS the ONE W-mode
+bus-encoding residual `h_sext_choice` (irreducible; same trust class as the
+canonical `equiv_DIVUW`).  NO arith-witness binders.
+
+## Axioms
+
+`construction_divuw_sound` introduces **0 PROJECT (`ZiskFv.*`) axioms**.  Its
+closure carries `Lean.ofReduceBool` / `Lean.trustCompiler` (native_decide)
+INHERITED from the canonical `equiv_DIVUW` path (already has it; NOT new —
+tracked by #75), plus `Classical.choice` / `Quot.sound`, the Sail-translation
+postulates, and the Lean-kernel postulates.
+-/
+
+namespace ZiskFv.Compliance
+
+open Goldilocks
+open ZiskFv.Trusted
+open ZiskFv.Airs.Main
+open ZiskFv.Airs.OperationBus
+open ZiskFv.Channels.MemoryBusBytes (byteAt)
+open ZiskFv.AirsClean.FullEnsemble
+open ZiskFv.AirsClean.ArithMul (componentWithArithTable primaryOpBusMessage rowAt)
+
+set_option maxHeartbeats 4000000
+set_option maxRecDepth 8000
+
+/-! ## Phase 2 — balance-derived W-mode div-Euclidean chunk equations + loose carry bounds
+
+The W-mode chain (op 188, `m32 = 1`) Euclidean chunk identity is the SAME as
+DIVU's: the carry-chain constraints 31–38 do not reference `m32`.  We re-derive
+them here over `vOfDivuRow` (reused from `ConstructionDivu`) at the unsigned mode
+pins `na = nb = np = nr = 0`, `div = 1` (hence `fab = 1`, `na_fb = nb_fa = 0`). -/
+
+open ZiskFv.Airs.ArithMul in
+/-- **Mode-pinned DIVUW Euclidean chunk equations.** Identical to DIVU's
+    `divu_chain_eqs` — the carry-chain constraints 31–38 are `m32`-independent,
+    so the W-mode (`m32 = 1`) chain is the same low-32 Euclidean form. -/
+private lemma divuw_chain_eqs
+    (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL)
+    (h_chain : mul_carry_chain_holds (vOfMulwRow arow) 0)
+    (h_na : arow.flags.na = 0) (h_nb : arow.flags.nb = 0)
+    (h_np : arow.flags.np = 0) (h_nr : arow.flags.nr = 0)
+    (h_div : arow.flags.div = 1) :
+    (arow.chunks.a_0 * arow.chunks.b_0 + arow.chunks.d_0
+        = arow.chunks.c_0 + arow.carries.carry_0 * 65536)
+    ∧ (arow.chunks.a_1 * arow.chunks.b_0 + arow.chunks.a_0 * arow.chunks.b_1
+        + arow.chunks.d_1 + arow.carries.carry_0
+        = arow.chunks.c_1 + arow.carries.carry_1 * 65536)
+    ∧ (arow.chunks.a_2 * arow.chunks.b_0 + arow.chunks.a_1 * arow.chunks.b_1
+        + arow.chunks.a_0 * arow.chunks.b_2 + arow.chunks.d_2 + arow.carries.carry_1
+        = arow.chunks.c_2 + arow.carries.carry_2 * 65536)
+    ∧ (arow.chunks.a_3 * arow.chunks.b_0 + arow.chunks.a_2 * arow.chunks.b_1
+        + arow.chunks.a_1 * arow.chunks.b_2 + arow.chunks.a_0 * arow.chunks.b_3
+        + arow.chunks.d_3 + arow.carries.carry_2
+        = arow.chunks.c_3 + arow.carries.carry_3 * 65536)
+    ∧ (arow.chunks.a_3 * arow.chunks.b_1 + arow.chunks.a_2 * arow.chunks.b_2
+        + arow.chunks.a_1 * arow.chunks.b_3 + arow.carries.carry_3
+        = arow.carries.carry_4 * 65536)
+    ∧ (arow.chunks.a_3 * arow.chunks.b_2 + arow.chunks.a_2 * arow.chunks.b_3
+        + arow.carries.carry_4 = arow.carries.carry_5 * 65536)
+    ∧ (arow.chunks.a_3 * arow.chunks.b_3 + arow.carries.carry_5
+        = arow.carries.carry_6 * 65536)
+    ∧ (arow.carries.carry_6 = 0) := by
+  obtain ⟨h6, h7, h8, h31, h32, h33, h34, h35, h36, h37, h38⟩ := h_chain
+  simp only [mul_constraint_6_named, mul_constraint_7_named, mul_constraint_8_named,
+             vOfMulwRow, h_na, h_nb, mul_zero, zero_mul, add_zero, sub_zero] at h6 h7 h8
+  have h_fab : arow.carries.fab = (1 : FGL) := by linear_combination h6
+  have h_nafb : arow.carries.na_fb = (0 : FGL) := by linear_combination h7
+  have h_nbfa : arow.carries.nb_fa = (0 : FGL) := by linear_combination h8
+  simp only [mul_constraint_31_named, mul_constraint_32_named,
+             mul_constraint_33_named, mul_constraint_34_named,
+             mul_constraint_35_named, mul_constraint_36_named,
+             mul_constraint_37_named, mul_constraint_38_named,
+             vOfMulwRow, h_na, h_nb, h_np, h_nr, h_div, h_fab, h_nafb, h_nbfa,
+             mul_zero, zero_mul, add_zero, sub_zero, mul_one, one_mul]
+    at h31 h32 h33 h34 h35 h36 h37 h38
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · linear_combination h31
+  · linear_combination h32
+  · linear_combination h33
+  · linear_combination h34
+  · linear_combination h35
+  · linear_combination h36
+  · linear_combination h37
+  · linear_combination h38
+
+/-- **Balance-constructible DIVUW unsigned carry bounds.** Identical to DIVU's
+    `divu_carry_bounds`: from the eight mode-pinned div-Euclidean chunk equations
+    + the sixteen 16-bit chunk bounds + the seven *signed* carry disjunctions
+    (all from `FullSpec`), derive the looser *unsigned-side* carry bounds
+    `cy_i.val < 983041` via `unsigned_carry_step_nat` (reused from
+    `ConstructionMulhu`). -/
+private lemma divuw_carry_bounds
+    (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL)
+    (h_chunks : ZiskFv.EquivCore.Bridge.Arith.ArithDivChunkRangesAt (vOfDivuRow arow) 0)
+    (h_csgn : ZiskFv.EquivCore.Bridge.Arith.ArithDivSignedCarryRangesAt (vOfDivuRow arow) 0)
+    (heqs :
+      (arow.chunks.a_0 * arow.chunks.b_0 + arow.chunks.d_0
+          = arow.chunks.c_0 + arow.carries.carry_0 * 65536)
+      ∧ (arow.chunks.a_1 * arow.chunks.b_0 + arow.chunks.a_0 * arow.chunks.b_1
+          + arow.chunks.d_1 + arow.carries.carry_0
+          = arow.chunks.c_1 + arow.carries.carry_1 * 65536)
+      ∧ (arow.chunks.a_2 * arow.chunks.b_0 + arow.chunks.a_1 * arow.chunks.b_1
+          + arow.chunks.a_0 * arow.chunks.b_2 + arow.chunks.d_2 + arow.carries.carry_1
+          = arow.chunks.c_2 + arow.carries.carry_2 * 65536)
+      ∧ (arow.chunks.a_3 * arow.chunks.b_0 + arow.chunks.a_2 * arow.chunks.b_1
+          + arow.chunks.a_1 * arow.chunks.b_2 + arow.chunks.a_0 * arow.chunks.b_3
+          + arow.chunks.d_3 + arow.carries.carry_2
+          = arow.chunks.c_3 + arow.carries.carry_3 * 65536)
+      ∧ (arow.chunks.a_3 * arow.chunks.b_1 + arow.chunks.a_2 * arow.chunks.b_2
+          + arow.chunks.a_1 * arow.chunks.b_3 + arow.carries.carry_3
+          = arow.carries.carry_4 * 65536)
+      ∧ (arow.chunks.a_3 * arow.chunks.b_2 + arow.chunks.a_2 * arow.chunks.b_3
+          + arow.carries.carry_4 = arow.carries.carry_5 * 65536)
+      ∧ (arow.chunks.a_3 * arow.chunks.b_3 + arow.carries.carry_5
+          = arow.carries.carry_6 * 65536)
+      ∧ (arow.carries.carry_6 = 0)) :
+    (arow.carries.carry_0).val < 983041 ∧ (arow.carries.carry_1).val < 983041
+    ∧ (arow.carries.carry_2).val < 983041 ∧ (arow.carries.carry_3).val < 983041
+    ∧ (arow.carries.carry_4).val < 983041 ∧ (arow.carries.carry_5).val < 983041
+    ∧ (arow.carries.carry_6).val < 983041 := by
+  obtain ⟨ha0, ha1, ha2, ha3, hb0, hb1, hb2, hb3,
+          hc0, hc1, hc2, hc3, hd0, hd1, hd2, hd3⟩ := h_chunks
+  obtain ⟨hs0, hs1, hs2, hs3, hs4, hs5, hs6⟩ := h_csgn
+  obtain ⟨hC31, hC32, hC33, hC34, hC35, hC36, hC37, hC38⟩ := heqs
+  simp only [vOfDivuRow] at ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hc0 hc1 hc2 hc3 hd0 hd1 hd2 hd3
+  simp only [vOfDivuRow] at hs0 hs1 hs2 hs3 hs4 hs5 hs6
+  have b0 : (arow.carries.carry_0).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_0).val * (arow.chunks.b_0).val + (arow.chunks.d_0).val)
+      _ _ ?_ hc0 ?_ hs0
+    · push_cast; linear_combination hC31
+    · have : (arow.chunks.a_0).val * (arow.chunks.b_0).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b1 : (arow.carries.carry_1).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_1).val * (arow.chunks.b_0).val
+        + (arow.chunks.a_0).val * (arow.chunks.b_1).val
+        + (arow.chunks.d_1).val + (arow.carries.carry_0).val) _ _ ?_ hc1 ?_ hs1
+    · push_cast; linear_combination hC32
+    · have h1 : (arow.chunks.a_1).val * (arow.chunks.b_0).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (arow.chunks.a_0).val * (arow.chunks.b_1).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b2 : (arow.carries.carry_2).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_2).val * (arow.chunks.b_0).val
+        + (arow.chunks.a_1).val * (arow.chunks.b_1).val
+        + (arow.chunks.a_0).val * (arow.chunks.b_2).val
+        + (arow.chunks.d_2).val + (arow.carries.carry_1).val) _ _ ?_ hc2 ?_ hs2
+    · push_cast; linear_combination hC33
+    · have h1 : (arow.chunks.a_2).val * (arow.chunks.b_0).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (arow.chunks.a_1).val * (arow.chunks.b_1).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h3 : (arow.chunks.a_0).val * (arow.chunks.b_2).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b3 : (arow.carries.carry_3).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_3).val * (arow.chunks.b_0).val
+        + (arow.chunks.a_2).val * (arow.chunks.b_1).val
+        + (arow.chunks.a_1).val * (arow.chunks.b_2).val
+        + (arow.chunks.a_0).val * (arow.chunks.b_3).val
+        + (arow.chunks.d_3).val + (arow.carries.carry_2).val) _ _ ?_ hc3 ?_ hs3
+    · push_cast; linear_combination hC34
+    · have h1 : (arow.chunks.a_3).val * (arow.chunks.b_0).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (arow.chunks.a_2).val * (arow.chunks.b_1).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h3 : (arow.chunks.a_1).val * (arow.chunks.b_2).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h4 : (arow.chunks.a_0).val * (arow.chunks.b_3).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b4 : (arow.carries.carry_4).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_3).val * (arow.chunks.b_1).val
+        + (arow.chunks.a_2).val * (arow.chunks.b_2).val
+        + (arow.chunks.a_1).val * (arow.chunks.b_3).val
+        + (arow.carries.carry_3).val) 0 _ ?_ (by omega) ?_ hs4
+    · push_cast; linear_combination hC35
+    · have h1 : (arow.chunks.a_3).val * (arow.chunks.b_1).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (arow.chunks.a_2).val * (arow.chunks.b_2).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h3 : (arow.chunks.a_1).val * (arow.chunks.b_3).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b5 : (arow.carries.carry_5).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_3).val * (arow.chunks.b_2).val
+        + (arow.chunks.a_2).val * (arow.chunks.b_3).val
+        + (arow.carries.carry_4).val) 0 _ ?_ (by omega) ?_ hs5
+    · push_cast; linear_combination hC36
+    · have h1 : (arow.chunks.a_3).val * (arow.chunks.b_2).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (arow.chunks.a_2).val * (arow.chunks.b_3).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b6 : (arow.carries.carry_6).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_3).val * (arow.chunks.b_3).val + (arow.carries.carry_5).val)
+      0 _ ?_ (by omega) ?_ hs6
+    · push_cast; linear_combination hC37
+    · have h1 : (arow.chunks.a_3).val * (arow.chunks.b_3).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  exact ⟨b0, b1, b2, b3, b4, b5, b6⟩
+
+/-! ## Phase 3 — balance-selected DIVUW provider row + transports -/
+
+/-- The balance-selected Arith-Mul provider row at trace index `i` for a DIVUW
+    operation, as a concrete `ArithMulRow`.  It is the
+    `componentWithArithTable.rowInput` of the provider row chosen by the DIVUW
+    keep-arithMul balance wrapper
+    `exists_arithMul_provider_row_matches_primary_of_divuw_from_binding`.
+    Mirrors `divuArow`. -/
+noncomputable def divuwArow
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU_W) :
+    ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
+  let h := exists_arithMul_provider_row_matches_primary_of_divuw_from_binding
+    trace binding i h_main_active h_main_op
+  componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
+
+/-- `FullSpec` of the balance-selected DIVUW provider row, derived from the
+    provider component's proven soundness (`componentWithArithTable.Spec`). -/
+theorem divuwArow_fullSpec_row
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU_W) :
+    ZiskFv.AirsClean.ArithMul.FullSpec
+      (divuwArow trace binding i h_main_active h_main_op) := by
+  unfold divuwArow
+  set H := exists_arithMul_provider_row_matches_primary_of_divuw_from_binding
+    trace binding i h_main_active h_main_op with hH
+  obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
+  obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
+  exact ZiskFv.AirsClean.FullEnsemble.arithMul_fullSpec_of_component_spec
+    h_component (h_spec h_rest.choose h_pr_mem)
+
+/-- The op-bus match of the balance-selected DIVUW provider row against the Main
+    row's emission, in `toEntry (primaryOpBusMessage …) 1` form. -/
+theorem divuwArow_match_row
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU_W) :
+    matches_entry
+      (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val)
+      (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+        (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+          (divuwArow trace binding i h_main_active h_main_op)) 1) := by
+  unfold divuwArow
+  set H := exists_arithMul_provider_row_matches_primary_of_divuw_from_binding
+    trace binding i h_main_active h_main_op with hH
+  exact H.choose_spec.2.choose_spec.2.2.2
+
+/-- DIVUW mode pins on the balance-selected provider row, DERIVED from its
+    `ArithTableSpec` (part of `FullSpec`) plus the opcode pin
+    `arow.flags.op = 188`.  These are not caller binders.  Reads the mode flags
+    off the BARE provider `ArithMulRow` via `divuw_mode_pins_of_row`, never
+    forcing the heavy `Classical.choose` row's whnf. -/
+theorem divuwArow_mode_pins
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU_W) :
+    (divuwArow trace binding i h_main_active h_main_op).flags.na = 0
+      ∧ (divuwArow trace binding i h_main_active h_main_op).flags.nb = 0
+      ∧ (divuwArow trace binding i h_main_active h_main_op).flags.np = 0
+      ∧ (divuwArow trace binding i h_main_active h_main_op).flags.nr = 0
+      ∧ (divuwArow trace binding i h_main_active h_main_op).flags.m32 = 1
+      ∧ (divuwArow trace binding i h_main_active h_main_op).flags.div = 1
+      ∧ (divuwArow trace binding i h_main_active h_main_op).flags.main_div = 1
+      ∧ (divuwArow trace binding i h_main_active h_main_op).flags.main_mul = 0 := by
+  have h_table := (divuwArow_fullSpec_row trace binding i h_main_active h_main_op).2.1
+  have h_op : (divuwArow trace binding i h_main_active h_main_op).flags.op = 188 := by
+    have h_match := divuwArow_match_row trace binding i h_main_active h_main_op
+    have h_op := h_match.2.1
+    rw [ZiskFv.AirsClean.ArithMul.primaryOpBusMessage_toEntry_op,
+        show (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val).op
+          = (mainOfTable trace.program binding.mainTable).op i.val from rfl,
+        h_main_op] at h_op
+    simpa [OP_DIVU_W] using h_op.symm
+  exact ZiskFv.AirsClean.ArithTableProjections.Mul.divuw_mode_pins_of_row
+    (divuwArow trace binding i h_main_active h_main_op) h_table h_op
+
+/-- The op-bus match of the balance-selected DIVUW provider row view against the
+    Main row's emission, in `opBus_row_ArithDiv` form.  The DIVU-mode mux
+    selectors (`div = 1`, `main_div = 1`, `main_mul = 0`) needed to reduce the
+    faithful mux are DERIVED via `divuwArow_mode_pins` (they are `m32`-agnostic,
+    so the DIVU-mode bridge `match_opBus_row_ArithDiv_vOfDivuRow` applies). -/
+theorem divuwArow_match
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU_W) :
+    matches_entry
+      (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val)
+      (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv
+        (vOfDivuRow (divuwArow trace binding i h_main_active h_main_op)) 0) := by
+  obtain ⟨_, _, _, _, _, h_div, h_main_div, h_main_mul⟩ :=
+    divuwArow_mode_pins trace binding i h_main_active h_main_op
+  exact match_opBus_row_ArithDiv_vOfDivuRow h_div h_main_div h_main_mul
+    (divuwArow_match_row trace binding i h_main_active h_main_op)
+
+/-! ## Phase 4 — F4 `FullSpec` discharge bridge for DIVUW -/
+
+open ZiskFv.Airs.ArithDiv in
+open ZiskFv.EquivCore.Promises in
+/-- **F4 extraction bridge for `equiv_DIVUW`.**  Mirror of `equiv_DIVU_of_fullSpec`
+    for the W-mode (`m32 = 1`) sibling.  The four lookup-aware Arith witness
+    records are replaced by the single `FullSpec arow` hypothesis (the SHARED
+    ArithMul provider's `componentWithArithTable.Spec`), with the ArithDiv-view
+    facts read off the same row through `vOfDivuRow arow`.
+
+    Like DIVU, this derives the looser balance bound `< 983041` (via
+    `divuw_carry_bounds`) and reconstructs the rd write value through the loose
+    W-mode write-value path `h_rd_val_mdru_divuw_loose`, replicating
+    `equiv_DIVUW`'s sail + `bus_effect` tail.
+
+    The low-quotient byte match `h_byte_lo` is DERIVED inside the body from the
+    op-bus c-lane projection.  The W-mode high-lane zeros `h_b23` / `h_c23`, the
+    `remainder_bound`, and `h_sext_choice` are the explicit residual binders —
+    exactly the W-mode route/provenance obligations the canonical `equiv_DIVUW`
+    carries (the `m32` flag is not an op-bus field, so the high-lane zeros are
+    not balance-derivable here; they mirror the canonical's `h_b23` / `h_c23`). -/
+lemma equiv_DIVUW_of_fullSpec
+    (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
+    (divuw_input : PureSpec.DivuwInput)
+    (r1 r2 rd : regidx)
+    (bus : ZiskFv.Compliance.BusRows)
+    (m : Valid_Main FGL FGL) (r_main : ℕ)
+    (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL)
+    (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_DIVU_W)
+    (h_match_primary :
+      matches_entry (opBus_row_Main m r_main)
+                    (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv (vOfDivuRow arow) 0))
+    (promises : ZiskFv.EquivCore.Promises.RTypePromises
+        state divuw_input.r1_val divuw_input.r2_val divuw_input.rd divuw_input.PC
+        (PureSpec.execute_DIVREM_divuw_pure divuw_input).nextPC
+        r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
+    (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
+    (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
+    (h_full_spec : ZiskFv.AirsClean.ArithMul.FullSpec arow)
+    (remainder_bound :
+      ZiskFv.EquivCore.Bridge.Arith.ArithDivRemainderBoundWitness (vOfDivuRow arow) 0)
+    -- W-mode high-lane zeros (CIRCUIT-CONSTRAINT / bus W-pin): the divisor and
+    -- dividend high chunks are zero in W-mode.  Residual, mirroring the
+    -- canonical `equiv_DIVUW`'s `h_b23` / `h_c23`.
+    (h_b23 : (arow.chunks.b_2).val = 0 ∧ (arow.chunks.b_3).val = 0)
+    (h_c23 : (arow.chunks.c_2).val = 0 ∧ (arow.chunks.c_3).val = 0)
+    -- The W-mode bus-encoding residual (class #4): SEXT_00 / SEXT_FF on
+    -- bytes 4..7, tied to the quotient top bit.  Phrased over `arow.chunks.a`.
+    (h_sext_choice :
+      (((byteAt bus.e2 4).val = 0 ∧ (byteAt bus.e2 5).val = 0
+          ∧ (byteAt bus.e2 6).val = 0 ∧ (byteAt bus.e2 7).val = 0)
+        ∧ (arow.chunks.a_0).val + (arow.chunks.a_1).val * 65536 < 2147483648)
+      ∨ (((byteAt bus.e2 4).val = 255 ∧ (byteAt bus.e2 5).val = 255
+          ∧ (byteAt bus.e2 6).val = 255 ∧ (byteAt bus.e2 7).val = 255)
+        ∧ (arow.chunks.a_0).val + (arow.chunks.a_1).val * 65536 ≥ 2147483648))
+    -- Operand bridges (W form: low 32 bits; genuinely residual).
+    (h_rs1_value : (Sail.BitVec.extractLsb divuw_input.r1_val 31 0).toNat
+      = (arow.chunks.c_0).val + (arow.chunks.c_1).val * 65536)
+    (h_rs2_value : (Sail.BitVec.extractLsb divuw_input.r2_val 31 0).toNat
+      = (arow.chunks.b_0).val + (arow.chunks.b_1).val * 65536) :
+    (do
+      Sail.writeReg Register.nextPC
+        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
+      LeanRV64D.Functions.execute (instruction.DIVW (r2, r1, rd, true))) state
+      = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
+  obtain ⟨h_spec, h_arith_table, h_c46, h_chunk_ranges_spec, h_carry_ranges_spec⟩ :=
+    h_full_spec
+  obtain ⟨exec_row, e0, e1, e2⟩ := bus
+  obtain ⟨h0, h1, h2, h3, h4, h5, h6, h7⟩ := bounds
+  obtain ⟨_h_main_active, h_main_op_divuw⟩ := pins
+  obtain ⟨h_input_r1, h_input_r2, h_input_rd, h_input_pc,
+          h_exec_len, h_e0_mult, h_e1_mult, h_nextPC_matches,
+          h_m0_mult, h_m0_as, h_m1_mult, h_m1_as, h_m2_mult, h_m2_as,
+          h_rd_idx⟩ := promises
+  -- ============ DERIVE arith-side opcode literal ============
+  have h_op_eq := arith_div_primary_op_eq h_match_primary
+  have h_op_arith_divuw : (vOfDivuRow arow).op 0 = 188 := by
+    rw [h_op_eq, h_main_op_divuw]; simp [OP_DIVU_W]
+  have h_op_arow : arow.flags.op = 188 := h_op_arith_divuw
+  -- ============ DIVUW mode pins, DERIVED from the bare-row ArithTableSpec =====
+  obtain ⟨h_na_arow, h_nb_arow, h_np_arow, h_nr_arow, h_m32_arow,
+          h_div_arow, h_main_div_arow, h_main_mul_arow⟩ :=
+    ZiskFv.AirsClean.ArithTableProjections.Mul.divuw_mode_pins_of_row arow h_arith_table h_op_arow
+  have h_nb : (vOfDivuRow arow).nb 0 = 0 := h_nb_arow
+  have h_nr : (vOfDivuRow arow).nr 0 = 0 := h_nr_arow
+  -- ============ Chunk / carry ranges (ArithDiv view, from FullSpec) ==========
+  have h_chunk_ranges :
+      ZiskFv.EquivCore.Bridge.Arith.ArithDivChunkRangesAt (vOfDivuRow arow) 0 :=
+    h_chunk_ranges_spec
+  have h_carry_ranges_signed :
+      ZiskFv.EquivCore.Bridge.Arith.ArithDivSignedCarryRangesAt (vOfDivuRow arow) 0 :=
+    h_carry_ranges_spec
+  obtain ⟨h_a0_lt, h_a1_lt, h_a2_lt, h_a3_lt,
+          h_b0_lt, h_b1_lt, h_b2_lt, h_b3_lt,
+          h_c0_lt, h_c1_lt, h_c2_lt, h_c3_lt,
+          h_d0_lt, h_d1_lt, h_d2_lt, h_d3_lt⟩ := h_chunk_ranges
+  -- ============ Op-bus c-lane projection (for the byte-lo match) =============
+  obtain ⟨_h_a_lo_eq_FGL, _h_a_hi_eq_FGL, _h_b_lo_eq_FGL, _h_b_hi_eq_FGL,
+          h_c0_eq_FGL, _h_c1_eq_FGL⟩ :=
+    arith_div_primary_projections h_match_primary
+  -- ============ Mode-pinned div-Euclidean chunk equations (W-mode) ===========
+  have heqs := divuw_chain_eqs arow h_spec h_na_arow h_nb_arow h_np_arow h_nr_arow
+    h_div_arow
+  obtain ⟨hC31, hC32, hC33, hC34, hC35, hC36, hC37, hC38⟩ := heqs
+  -- ============ Balance-constructible LOOSE unsigned carry bounds ============
+  obtain ⟨hcy0, hcy1, hcy2, hcy3, hcy4, hcy5, hcy6⟩ :=
+    divuw_carry_bounds arow h_chunk_ranges_spec h_carry_ranges_signed
+      ⟨hC31, hC32, hC33, hC34, hC35, hC36, hC37, hC38⟩
+  -- ============ Remainder bound (RESIDUAL): d < b in low-32 chunk form =======
+  obtain ⟨h_d23, h_d_lt_b_arith⟩ :=
+    ZiskFv.EquivCore.Bridge.Arith.arith_div_remainder_bound_unsigned_w
+      remainder_bound h_chunk_ranges_spec h_nr h_nb h_b23
+  have h_d23' : (arow.chunks.d_2).val = 0 ∧ (arow.chunks.d_3).val = 0 := h_d23
+  have h_d_lt_b :
+      (arow.chunks.d_0).val + (arow.chunks.d_1).val * 65536
+        < (Sail.BitVec.extractLsb divuw_input.r2_val 31 0).toNat := by
+    rw [h_rs2_value]
+    exact h_d_lt_b_arith
+  have h_op2_ne : (Sail.BitVec.extractLsb divuw_input.r2_val 31 0).toNat ≠ 0 := by
+    intro h_zero
+    have hlt := h_d_lt_b
+    rw [h_zero] at hlt
+    omega
+  -- ============ DISCHARGE h_byte_lo (quotient low a-lanes) ====================
+  have h_bundle := arith_mem.c_lane_vals
+  have h_byte_lo_to_c0 : (byteAt e2 0).val + (byteAt e2 1).val * 256
+      + (byteAt e2 2).val * 65536 + (byteAt e2 3).val * 16777216
+      = (m.c_0 r_main).val := by
+    have h_e2_lo_bound : e2.value_0.val < 4294967296 := by
+      rw [← h_bundle.1, h_c0_eq_FGL]
+      rw [arith_h_pair_lift _ _ h_a0_lt h_a1_lt]
+      omega
+    rw [ZiskFv.Channels.MemoryBusBytes.byteAt_lo_val_sum_eq e2 h_e2_lo_bound, h_bundle.1]
+  have h_byte_lo :
+      (byteAt e2 0).val + (byteAt e2 1).val * 256 + (byteAt e2 2).val * 65536
+        + (byteAt e2 3).val * 16777216
+      = (arow.chunks.a_0).val + (arow.chunks.a_1).val * 65536 := by
+    have := arith_byte_lane_eq_of_match h_byte_lo_to_c0 h_c0_eq_FGL h_a0_lt h_a1_lt
+    simpa [vOfDivuRow] using this
+  -- ============ DISCHARGE rd-write value via the LOOSE W-mode write-value path
+  have h_rd_val :=
+    ZiskFv.EquivCore.WriteValueProofs.MulDivRemUnsigned.h_rd_val_mdru_divuw_loose
+      divuw_input.r1_val divuw_input.r2_val e2
+      (arow.chunks.a_0) (arow.chunks.a_1) (arow.chunks.a_2) (arow.chunks.a_3)
+      (arow.chunks.b_0) (arow.chunks.b_1) (arow.chunks.b_2) (arow.chunks.b_3)
+      (arow.chunks.c_0) (arow.chunks.c_1) (arow.chunks.c_2) (arow.chunks.c_3)
+      (arow.chunks.d_0) (arow.chunks.d_1) (arow.chunks.d_2) (arow.chunks.d_3)
+      (arow.carries.carry_0) (arow.carries.carry_1) (arow.carries.carry_2)
+      (arow.carries.carry_3) (arow.carries.carry_4) (arow.carries.carry_5)
+      (arow.carries.carry_6)
+      h0 h1 h2 h3 h4 h5 h6 h7
+      h_a0_lt h_a1_lt h_a2_lt h_a3_lt h_b0_lt h_b1_lt h_b2_lt h_b3_lt
+      h_c0_lt h_c1_lt h_c2_lt h_c3_lt h_d0_lt h_d1_lt h_d2_lt h_d3_lt
+      hcy0 hcy1 hcy2 hcy3 hcy4 hcy5 hcy6
+      hC31 hC32 hC33 hC34 hC35 hC36 hC37 hC38
+      (by
+        -- h_a23 : a_2 = a_3 = 0.  In W-mode the quotient is the low-32 value;
+        -- the high chunks are forced zero by the Euclidean identity collapse
+        -- (b_2=b_3=c_2=c_3=d_2=d_3=0).
+        have h_packed_nat :
+            ZiskFv.PackedBitVec.MulNoWrap.packed4 (arow.chunks.a_0).val
+                (arow.chunks.a_1).val (arow.chunks.a_2).val (arow.chunks.a_3).val
+              * ZiskFv.PackedBitVec.MulNoWrap.packed4 (arow.chunks.b_0).val
+                  (arow.chunks.b_1).val (arow.chunks.b_2).val (arow.chunks.b_3).val
+              + ZiskFv.PackedBitVec.MulNoWrap.packed4 (arow.chunks.d_0).val
+                  (arow.chunks.d_1).val (arow.chunks.d_2).val (arow.chunks.d_3).val
+            = ZiskFv.PackedBitVec.MulNoWrap.packed4 (arow.chunks.c_0).val
+                (arow.chunks.c_1).val (arow.chunks.c_2).val (arow.chunks.c_3).val :=
+          ZiskFv.EquivCore.WriteValueProofs.MulDivRemUnsigned.fgl_div_unsigned_chunks_to_nat_identity_loose
+            (arow.chunks.a_0) (arow.chunks.a_1) (arow.chunks.a_2) (arow.chunks.a_3)
+            (arow.chunks.b_0) (arow.chunks.b_1) (arow.chunks.b_2) (arow.chunks.b_3)
+            (arow.chunks.c_0) (arow.chunks.c_1) (arow.chunks.c_2) (arow.chunks.c_3)
+            (arow.chunks.d_0) (arow.chunks.d_1) (arow.chunks.d_2) (arow.chunks.d_3)
+            (arow.carries.carry_0) (arow.carries.carry_1) (arow.carries.carry_2)
+            (arow.carries.carry_3) (arow.carries.carry_4) (arow.carries.carry_5)
+            (arow.carries.carry_6)
+            h_a0_lt h_a1_lt h_a2_lt h_a3_lt h_b0_lt h_b1_lt h_b2_lt h_b3_lt
+            h_c0_lt h_c1_lt h_c2_lt h_c3_lt h_d0_lt h_d1_lt h_d2_lt h_d3_lt
+            hcy0 hcy1 hcy2 hcy3 hcy4 hcy5 hcy6
+            hC31 hC32 hC33 hC34 hC35 hC36 hC37 hC38
+        obtain ⟨hb2, hb3⟩ := h_b23
+        obtain ⟨hc2, hc3⟩ := h_c23
+        obtain ⟨hd2, hd3⟩ := h_d23'
+        have h_c32_lt : (arow.chunks.c_0).val + (arow.chunks.c_1).val * 65536 < 4294967296 := by
+          have : (arow.chunks.c_1).val * 65536 ≤ 65535 * 65536 :=
+            Nat.mul_le_mul_right _ (by omega)
+          omega
+        have h_b32_pos : 0 < (arow.chunks.b_0).val + (arow.chunks.b_1).val * 65536 := by
+          have h_ne : (arow.chunks.b_0).val + (arow.chunks.b_1).val * 65536 ≠ 0 := by
+            intro h_zero
+            apply h_op2_ne
+            rw [h_rs2_value, h_zero]
+          omega
+        have h_a_packed_lt :
+            ZiskFv.PackedBitVec.MulNoWrap.packed4 (arow.chunks.a_0).val
+              (arow.chunks.a_1).val (arow.chunks.a_2).val (arow.chunks.a_3).val < 4294967296 := by
+          unfold ZiskFv.PackedBitVec.MulNoWrap.packed4 at h_packed_nat
+          rw [hb2, hb3, hc2, hc3, hd2, hd3] at h_packed_nat
+          nlinarith
+        unfold ZiskFv.PackedBitVec.MulNoWrap.packed4 at h_a_packed_lt
+        constructor <;> omega)
+      h_b23 h_d23' h_c23 h_byte_lo h_sext_choice h_rs1_value h_rs2_value h_op2_ne h_d_lt_b
+  -- ============ Replicate `equiv_DIVUW`'s sail + bus_effect tail =============
+  rw [ZiskFv.EquivCore.Divuw.equiv_DIVUW_sail state divuw_input r1 r2 rd
+        h_input_r1 h_input_r2 h_input_rd h_input_pc]
+  symm
+  rw [ZiskFv.Airs.Bus.BusEmission.bus_effect_matches_sail_alu_rrw
+        state exec_row e0 e1 e2
+        (PureSpec.execute_DIVREM_divuw_pure divuw_input).nextPC
+        h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
+        h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as]
+  simp only [PureSpec.execute_DIVREM_divuw_pure, h_rd_idx]
+  rw [← h_rd_val]
+  split_ifs with h_rd_zero
+  · simp only [bind, pure, EStateM.bind, EStateM.pure]
+  · simp only [bind, pure, EStateM.bind, EStateM.pure]
+
+/-! ## Phase 5 — sound DIVUW construction -/
+
+/-- **Sound DIVUW construction:** from the accepted trace + honest residual
+    binders, conclude the canonical
+    `execute (DIVW (r2, r1, rd, true)) = (bus_effect …).2`.
+
+    The Arith provider witnesses (ArithTable membership, chunk ranges, signed
+    carry ranges, c46, carry-chain) are DERIVED inside the body from
+    `trace.balanced` / `trace.spec` via the SHARED ArithMul provider's
+    lookup-aware `componentWithArithTable.Spec = FullSpec`, NOT supplied as
+    binders.  The W-mode high-lane zeros (`b_2=b_3=c_2=c_3=0`) and the
+    low-quotient byte match are also DERIVED.
+
+    The TWO non-balance-derived residuals are `remainder_bound`
+    (`ArithDivRemainderBoundWitness`: the `|d| < b` LTU consumer self-edge from
+    `arith.pil:274`, absent from the ensemble) and `h_sext_choice` (the W-mode
+    SEXT_00/SEXT_FF bus encoding on bytes 4..7, class #4 — the same residuals
+    the canonical `equiv_DIVUW` carries). -/
+theorem construction_divuw_sound
+    (trace : AcceptedTrace)
+    (binding : ProgramBinding trace)
+    (i : Fin trace.length)
+    (divuw_input : PureSpec.DivuwInput)
+    (r1 r2 rd : regidx)
+    -- (b) decode pins
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU_W)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_store_pc :
+      (mainOfTable trace.program binding.mainTable).store_pc i.val = 0)
+    -- (b) Sail reads + operands
+    (h_input_r1 :
+      read_xreg (regidx_to_fin r1) (binding.stateAt i)
+        = EStateM.Result.ok divuw_input.r1_val (binding.stateAt i))
+    (h_input_r2 :
+      read_xreg (regidx_to_fin r2) (binding.stateAt i)
+        = EStateM.Result.ok divuw_input.r2_val (binding.stateAt i))
+    (h_input_pc : (binding.stateAt i).regs.get? Register.PC = .some divuw_input.PC)
+    (h_input_rd : divuw_input.rd = regidx_to_fin rd)
+    -- (c) exec artifacts: the exec row is a genuine top-level binder.
+    (execRow : List (Interaction.ExecutionBusEntry FGL))
+    (h_exec_len : (busSub trace binding i execRow).exec_row.length = 2)
+    (h_e0_mult : (busSub trace binding i execRow).exec_row[0]!.multiplicity = -1)
+    (h_e1_mult : (busSub trace binding i execRow).exec_row[1]!.multiplicity = 1)
+    (h_nextPC_matches :
+      (register_type_pc_equiv ▸
+          (BitVec.ofNat 64 ((busSub trace binding i execRow).exec_row[1]!.pc).val))
+        = (PureSpec.execute_DIVREM_divuw_pure divuw_input).nextPC)
+    (h_rd_idx :
+      divuw_input.rd =
+        Transpiler.wrap_to_regidx (busSub trace binding i execRow).e2.ptr)
+    -- (c) byte range bounds on the rd-write entry
+    (bounds : ZiskFv.Compliance.ByteBounds (busSub trace binding i execRow).e2)
+    -- (b) RESIDUAL: remainder-bound witness (the ArithDiv `assumes_operation`
+    -- LTU consumer edge is a finished-channel self-edge absent from the
+    -- ensemble).
+    (remainder_bound :
+      ZiskFv.EquivCore.Bridge.Arith.ArithDivRemainderBoundWitness
+        (vOfDivuRow (divuwArow trace binding i h_main_active h_main_op)) 0)
+    -- (b) W-mode RESIDUAL high-lane zeros (CIRCUIT-CONSTRAINT / bus W-pin),
+    -- mirroring the canonical `equiv_DIVUW`'s `h_b23` / `h_c23`.
+    (h_b23 :
+      ((divuwArow trace binding i h_main_active h_main_op).chunks.b_2).val = 0
+        ∧ ((divuwArow trace binding i h_main_active h_main_op).chunks.b_3).val = 0)
+    (h_c23 :
+      ((divuwArow trace binding i h_main_active h_main_op).chunks.c_2).val = 0
+        ∧ ((divuwArow trace binding i h_main_active h_main_op).chunks.c_3).val = 0)
+    -- (b) W-mode RESIDUAL: SEXT_00/SEXT_FF bus encoding on bytes 4..7 (class #4,
+    -- same trust class as the canonical `equiv_DIVUW` / MULW / ADDW).
+    (h_sext_choice :
+      ((((byteAt (busSub trace binding i execRow).e2 4).val = 0
+            ∧ (byteAt (busSub trace binding i execRow).e2 5).val = 0
+            ∧ (byteAt (busSub trace binding i execRow).e2 6).val = 0
+            ∧ (byteAt (busSub trace binding i execRow).e2 7).val = 0)
+          ∧ ((divuwArow trace binding i h_main_active h_main_op).chunks.a_0).val
+              + ((divuwArow trace binding i h_main_active h_main_op).chunks.a_1).val * 65536
+                < 2147483648)
+        ∨ (((byteAt (busSub trace binding i execRow).e2 4).val = 255
+            ∧ (byteAt (busSub trace binding i execRow).e2 5).val = 255
+            ∧ (byteAt (busSub trace binding i execRow).e2 6).val = 255
+            ∧ (byteAt (busSub trace binding i execRow).e2 7).val = 255)
+          ∧ ((divuwArow trace binding i h_main_active h_main_op).chunks.a_0).val
+              + ((divuwArow trace binding i h_main_active h_main_op).chunks.a_1).val * 65536
+                ≥ 2147483648)))
+    -- (b) operand bridges (Sail↔chunk binding of the W-form low-32 operands;
+    -- genuinely residual, phrased over the balance-selected provider row).
+    (h_rs1_value : (Sail.BitVec.extractLsb divuw_input.r1_val 31 0).toNat
+      = ((divuwArow trace binding i h_main_active h_main_op).chunks.c_0).val
+          + ((divuwArow trace binding i h_main_active h_main_op).chunks.c_1).val * 65536)
+    (h_rs2_value : (Sail.BitVec.extractLsb divuw_input.r2_val 31 0).toNat
+      = ((divuwArow trace binding i h_main_active h_main_op).chunks.b_0).val
+          + ((divuwArow trace binding i h_main_active h_main_op).chunks.b_1).val * 65536) :
+    (do
+      Sail.writeReg Register.nextPC
+        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
+      LeanRV64D.Functions.execute (instruction.DIVW (r2, r1, rd, true))) (binding.stateAt i)
+      = (bus_effect (busSub trace binding i execRow).exec_row
+          [ (busSub trace binding i execRow).e0
+          , (busSub trace binding i execRow).e1
+          , (busSub trace binding i execRow).e2 ] (binding.stateAt i)).2 := by
+  -- (a) Arith witnesses derived from balance: FullSpec.
+  have h_full :
+      ZiskFv.AirsClean.ArithMul.FullSpec
+        (divuwArow trace binding i h_main_active h_main_op) :=
+    divuwArow_fullSpec_row trace binding i h_main_active h_main_op
+  -- (a) primary op-bus match against `opBus_row_ArithDiv (vOfDivuRow …) 0`.
+  have h_match_primary :
+      matches_entry (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val)
+        (ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv
+          (vOfDivuRow (divuwArow trace binding i h_main_active h_main_op)) 0) :=
+    divuwArow_match trace binding i h_main_active h_main_op
+  -- decode pins bundle
+  let pins :
+      ZiskFv.Compliance.MainRowPins
+        (mainOfTable trace.program binding.mainTable) i.val 1 OP_DIVU_W :=
+    ⟨h_main_active, h_main_op⟩
+  -- (a) Main rd-write memory witness, from `store_pc = 0`.
+  have h_core_store_pc :
+      (mainRowWithRomSub trace binding i).core.store_pc = 0 := by
+    have h_row :
+        (mainRowWithRomSub trace binding i).core =
+          ZiskFv.AirsClean.Main.rowAt (mainOfTable trace.program binding.mainTable) i.val := by
+      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+        trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+      simpa [mainRowWithRomSub,
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+    rw [h_row]
+    simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
+  let arith_mem :
+      ZiskFv.Compliance.ExternalArithMemoryWitness
+        (mainOfTable trace.program binding.mainTable) i.val
+        (busSub trace binding i execRow).e2 :=
+    { row := mainRowWithRomSub trace binding i
+      row_eq := by
+        have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+          trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+        simpa [mainRowWithRomSub,
+          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+      store_pc_zero := h_core_store_pc
+      rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
+  -- promises bundle: Sail reads + exec artifacts as binders; MemBus shape by rfl.
+  let promises : ZiskFv.EquivCore.Promises.RTypePromises
+      (binding.stateAt i) divuw_input.r1_val divuw_input.r2_val divuw_input.rd divuw_input.PC
+      (PureSpec.execute_DIVREM_divuw_pure divuw_input).nextPC
+      r1 r2 rd (busSub trace binding i execRow).exec_row (busSub trace binding i execRow).e0
+      (busSub trace binding i execRow).e1 (busSub trace binding i execRow).e2 :=
+    { input_r1_eq := h_input_r1
+      input_r2_eq := h_input_r2
+      input_rd_eq := h_input_rd
+      input_pc_eq := h_input_pc
+      exec_len := h_exec_len
+      e0_mult := h_e0_mult
+      e1_mult := h_e1_mult
+      nextPC_matches := h_nextPC_matches
+      m0_mult := by rfl
+      m0_as := by rfl
+      m1_mult := by rfl
+      m1_as := by rfl
+      m2_mult := by rfl
+      m2_as := by rfl
+      rd_idx := h_rd_idx }
+  -- Delegate to the F4 fullSpec bridge.
+  exact equiv_DIVUW_of_fullSpec
+    (binding.stateAt i) divuw_input r1 r2 rd (busSub trace binding i execRow)
+    (mainOfTable trace.program binding.mainTable) i.val
+    (divuwArow trace binding i h_main_active h_main_op)
+    pins h_match_primary promises arith_mem bounds
+    h_full remainder_bound h_b23 h_c23 h_sext_choice h_rs1_value h_rs2_value
+
+end ZiskFv.Compliance

--- a/ZiskFv/Compliance/ConstructionMulhu.lean
+++ b/ZiskFv/Compliance/ConstructionMulhu.lean
@@ -1,0 +1,899 @@
+import ZiskFv.Compliance.AcceptedTrace
+import ZiskFv.Compliance.ConstructionMulw
+import ZiskFv.EquivCore.MulHU
+import ZiskFv.EquivCore.Promises.ArithHelpers
+import ZiskFv.EquivCore.Bridge.Arith
+import ZiskFv.AirsClean.ArithMul.Bridge
+import ZiskFv.AirsClean.ArithTableProjections
+import ZiskFv.Airs.Arith.BusRes1
+import ZiskFv.Bits.PackedBitVec.MulNoWrap
+import ZiskFv.Bits.PackedBitVec.Extensions
+
+/-!
+# Sound MULHU construction (`construction_mulhu_sound`)
+
+Unsigned high-half RV64M MULHU (`OP_MULUH = 177`), mirroring the MULW
+construction (`ConstructionMulw.lean`).  The Arith provider witnesses
+(ArithTable membership, chunk ranges, signed-carry ranges, c46, carry-chain)
+are **DERIVED FROM BALANCE** via the provider component's lookup-aware
+`componentWithArithTable.Spec = FullSpec`, not carried as caller binders.
+
+## The carry-range subtlety (vs MULW)
+
+`EquivCore.MulHU.equiv_MULHU` demands the *unsigned* carry-range bound
+`cy_i.val < 131072 = 2^17`.  Balance supplies only `FullSpec`'s
+`CarryRangeSpec` — the **signed disjunction** `cy_i.val < 983041 ∨
+GL_prime - 983040 ≤ cy_i.val` (because `mainWithArithTable` ranges every
+carry through `signedCarryRangeTable`).  The genuine 4×4 unsigned-multiply
+carries can reach `~3·2^16 > 2^17`, so the tight `< 131072` bound is NOT
+satisfiable from real balance data.
+
+This module therefore does NOT route through `equiv_MULHU`.  Instead it
+derives the looser, balance-constructible bound `cy_i.val < 983041` (via
+`unsigned_carry_step` below) — which is fully sufficient for the no-wrap
+chunk → ℕ → high-half product reconstruction — and reconstructs the rd
+write value through a loose-bound copy of the unsigned write-value path
+(`mulhu_h_rd_val_of_loose`), mirroring `equiv_MULHU`'s body otherwise.
+
+No new trust: the carry chain, ROM membership, `bus_res1` mux, and the
+range bounds all come from the provider component's proven soundness via
+`FullSpec`, not from fresh per-opcode promises.  `construction_mulhu_sound`
+introduces **0 PROJECT (`ZiskFv.*`) axioms**.
+-/
+
+namespace ZiskFv.Compliance
+
+open Goldilocks
+open ZiskFv.Trusted
+open ZiskFv.Airs.Main
+open ZiskFv.Airs.OperationBus
+open ZiskFv.Channels.MemoryBusBytes (byteAt)
+open ZiskFv.AirsClean.FullEnsemble
+open ZiskFv.AirsClean.ArithMul (componentWithArithTable primaryOpBusMessage rowAt)
+
+set_option maxHeartbeats 4000000
+set_option maxRecDepth 8000
+
+/-! ## Phase 1 — balance-constructible unsigned carry bound + loose write-value path -/
+
+/-- **Unsigned carry-step bound.** From a single carry-chain step over `FGL`
+    in natCast form (`(N : FGL) = c + cy * 65536`) with `c` a 16-bit chunk, the
+    accumulated column value `N` bounded below `983040 · 2^16` (covers every step
+    of the 4×4 unsigned chain), and the balance-supplied **signed** carry
+    disjunction on `cy`, conclude the looser *unsigned-side* bound
+    `cy.val < 983041`.
+
+    The huge branch of the signed disjunction is refuted: a carry near `GL_prime`
+    would force `(c + cy·2^16) % GL_prime ≥ GL_prime - 983040·2^16`, contradicting
+    the small `N`.  The small branch is the conclusion verbatim. -/
+theorem unsigned_carry_step_nat
+    (N : ℕ) (c cy : FGL)
+    (h_eq : ((N : ℕ) : FGL) = c + cy * 65536)
+    (hc : c.val < 65536)
+    (h_N : N < 64424509440)
+    (h_sgn : cy.val < 983041 ∨ GL_prime - 983040 ≤ cy.val) :
+    cy.val < 983041 := by
+  have key : ((N : ℕ) : FGL) = ((c.val + cy.val * 65536 : ℕ) : FGL) := by
+    rw [h_eq]; push_cast; ring
+  have key2 := congrArg Fin.val key
+  rw [Fin.val_natCast, Fin.val_natCast] at key2
+  rw [Nat.mod_eq_of_lt (by omega : N < GL_prime)] at key2
+  rcases h_sgn with h | h
+  · exact h
+  · exfalso
+    obtain ⟨k, hcy, hk1, hk2⟩ : ∃ k, cy.val = GL_prime - k ∧ 1 ≤ k ∧ k ≤ 983040 := by
+      refine ⟨GL_prime - cy.val, ?_, ?_, ?_⟩ <;> omega
+    have hkmul : k * 65536 ≤ 983040 * 65536 := Nat.mul_le_mul_right 65536 hk2
+    have hkle : k ≤ GL_prime := by omega
+    have hpk : k * 65536 ≤ GL_prime * 65536 := Nat.mul_le_mul_right 65536 hkle
+    have hkmul1 : 65536 ≤ k * 65536 := by
+      calc 65536 = 1 * 65536 := by ring
+        _ ≤ k * 65536 := Nat.mul_le_mul_right 65536 hk1
+    have hr_eq : c.val + cy.val * 65536 = 65535 * GL_prime + (GL_prime + c.val - k * 65536) := by
+      rw [hcy, Nat.sub_mul]; omega
+    have hr_lt : GL_prime + c.val - k * 65536 < GL_prime := by omega
+    rw [hr_eq, Nat.mul_add_mod', Nat.mod_eq_of_lt hr_lt] at key2
+    omega
+
+/-! ### Loose-bound FGL → ℕ chunk lifts (carry bound `< 983041`)
+
+Copies of `ZiskFv.PackedBitVec.MulNoWrap.fgl_chunk_lift_*` with the carry
+bound relaxed from `< 131072` to the balance-constructible `< 983041`.  The
+no-wrap argument is unchanged: every chunk equation's two sides stay below
+`GL_prime` (LHS ≤ `4·(2^16-1)^2 + 983040 < 2^35`; RHS `≤ 2^16 + 983040·2^16 <
+2^36`).  Each lift discharges via the additive `NoWrap.fgl_eq_to_nat_eq`. -/
+
+private lemma loose_chunk_lift_1
+    (a b c cy : FGL)
+    (h_a : a.val < 65536) (h_b : b.val < 65536)
+    (h_c : c.val < 65536) (h_cy : cy.val < 983041)
+    (h : a * b = c + cy * 65536) :
+    a.val * b.val = c.val + cy.val * 65536 := by
+  have h_lhs : a * b = (((a.val * b.val : ℕ)) : FGL) := by push_cast; ring
+  have h_rhs : c + cy * 65536 = (((c.val + cy.val * 65536 : ℕ)) : FGL) := by push_cast; ring
+  rw [h_lhs, h_rhs] at h
+  refine ZiskFv.PackedBitVec.NoWrap.fgl_eq_to_nat_eq h ?_ ?_
+  · have : a.val * b.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    omega
+  · omega
+
+private lemma loose_chunk_lift_1'
+    (a b cy_in c cy_out : FGL)
+    (h_a : a.val < 65536) (h_b : b.val < 65536)
+    (h_cy_in : cy_in.val < 983041)
+    (h_c : c.val < 65536) (h_cy_out : cy_out.val < 983041)
+    (h : a * b + cy_in = c + cy_out * 65536) :
+    a.val * b.val + cy_in.val = c.val + cy_out.val * 65536 := by
+  have h_lhs : a * b + cy_in = (((a.val * b.val + cy_in.val : ℕ)) : FGL) := by push_cast; ring
+  have h_rhs : c + cy_out * 65536 = (((c.val + cy_out.val * 65536 : ℕ)) : FGL) := by push_cast; ring
+  rw [h_lhs, h_rhs] at h
+  refine ZiskFv.PackedBitVec.NoWrap.fgl_eq_to_nat_eq h ?_ ?_
+  · have : a.val * b.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    omega
+  · omega
+
+private lemma loose_chunk_lift_2
+    (a₁ a₀ b₀ b₁ cy_in c cy_out : FGL)
+    (h_a1 : a₁.val < 65536) (h_a0 : a₀.val < 65536)
+    (h_b0 : b₀.val < 65536) (h_b1 : b₁.val < 65536)
+    (h_cy_in : cy_in.val < 983041)
+    (h_c : c.val < 65536) (h_cy_out : cy_out.val < 983041)
+    (h : a₁ * b₀ + a₀ * b₁ + cy_in = c + cy_out * 65536) :
+    a₁.val * b₀.val + a₀.val * b₁.val + cy_in.val = c.val + cy_out.val * 65536 := by
+  have h_lhs : a₁ * b₀ + a₀ * b₁ + cy_in
+      = (((a₁.val * b₀.val + a₀.val * b₁.val + cy_in.val : ℕ)) : FGL) := by push_cast; ring
+  have h_rhs : c + cy_out * 65536 = (((c.val + cy_out.val * 65536 : ℕ)) : FGL) := by push_cast; ring
+  rw [h_lhs, h_rhs] at h
+  refine ZiskFv.PackedBitVec.NoWrap.fgl_eq_to_nat_eq h ?_ ?_
+  · have h1 : a₁.val * b₀.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    have h2 : a₀.val * b₁.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    omega
+  · omega
+
+private lemma loose_chunk_lift_3
+    (a₂ a₁ a₀ b₀ b₁ b₂ cy_in c cy_out : FGL)
+    (h_a2 : a₂.val < 65536) (h_a1 : a₁.val < 65536) (h_a0 : a₀.val < 65536)
+    (h_b0 : b₀.val < 65536) (h_b1 : b₁.val < 65536) (h_b2 : b₂.val < 65536)
+    (h_cy_in : cy_in.val < 983041)
+    (h_c : c.val < 65536) (h_cy_out : cy_out.val < 983041)
+    (h : a₂ * b₀ + a₁ * b₁ + a₀ * b₂ + cy_in = c + cy_out * 65536) :
+    a₂.val * b₀.val + a₁.val * b₁.val + a₀.val * b₂.val + cy_in.val
+      = c.val + cy_out.val * 65536 := by
+  have h_lhs : a₂ * b₀ + a₁ * b₁ + a₀ * b₂ + cy_in
+      = (((a₂.val * b₀.val + a₁.val * b₁.val + a₀.val * b₂.val + cy_in.val : ℕ)) : FGL) := by
+    push_cast; ring
+  have h_rhs : c + cy_out * 65536 = (((c.val + cy_out.val * 65536 : ℕ)) : FGL) := by push_cast; ring
+  rw [h_lhs, h_rhs] at h
+  refine ZiskFv.PackedBitVec.NoWrap.fgl_eq_to_nat_eq h ?_ ?_
+  · have h1 : a₂.val * b₀.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    have h2 : a₁.val * b₁.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    have h3 : a₀.val * b₂.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    omega
+  · omega
+
+private lemma loose_chunk_lift_4
+    (a₃ a₂ a₁ a₀ b₀ b₁ b₂ b₃ cy_in c cy_out : FGL)
+    (h_a3 : a₃.val < 65536) (h_a2 : a₂.val < 65536)
+    (h_a1 : a₁.val < 65536) (h_a0 : a₀.val < 65536)
+    (h_b0 : b₀.val < 65536) (h_b1 : b₁.val < 65536)
+    (h_b2 : b₂.val < 65536) (h_b3 : b₃.val < 65536)
+    (h_cy_in : cy_in.val < 983041)
+    (h_c : c.val < 65536) (h_cy_out : cy_out.val < 983041)
+    (h : a₃ * b₀ + a₂ * b₁ + a₁ * b₂ + a₀ * b₃ + cy_in = c + cy_out * 65536) :
+    a₃.val * b₀.val + a₂.val * b₁.val + a₁.val * b₂.val + a₀.val * b₃.val + cy_in.val
+      = c.val + cy_out.val * 65536 := by
+  have h_lhs : a₃ * b₀ + a₂ * b₁ + a₁ * b₂ + a₀ * b₃ + cy_in
+      = (((a₃.val * b₀.val + a₂.val * b₁.val + a₁.val * b₂.val + a₀.val * b₃.val
+            + cy_in.val : ℕ)) : FGL) := by push_cast; ring
+  have h_rhs : c + cy_out * 65536 = (((c.val + cy_out.val * 65536 : ℕ)) : FGL) := by push_cast; ring
+  rw [h_lhs, h_rhs] at h
+  refine ZiskFv.PackedBitVec.NoWrap.fgl_eq_to_nat_eq h ?_ ?_
+  · have h1 : a₃.val * b₀.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    have h2 : a₂.val * b₁.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    have h3 : a₁.val * b₂.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    have h4 : a₀.val * b₃.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    omega
+  · omega
+
+/-- **Loose-bound MUL-unsigned chunk → packed ℕ identity.**  Mirror of
+    `ZiskFv.PackedBitVec.MulNoWrap.fgl_mul_unsigned_chunks_to_nat_identity` but
+    with the balance-constructible carry bound `< 983041` instead of `< 131072`.
+    Composes the loose chunk lifts with the bound-free ℕ aggregator
+    `mul_unsigned_packed_of_chunks`. -/
+private lemma loose_mul_unsigned_chunks_to_nat_identity
+    (a₀ a₁ a₂ a₃ b₀ b₁ b₂ b₃ c₀ c₁ c₂ c₃ d₀ d₁ d₂ d₃
+     cy₀ cy₁ cy₂ cy₃ cy₄ cy₅ cy₆ : FGL)
+    (h_a0 : a₀.val < 65536) (h_a1 : a₁.val < 65536)
+    (h_a2 : a₂.val < 65536) (h_a3 : a₃.val < 65536)
+    (h_b0 : b₀.val < 65536) (h_b1 : b₁.val < 65536)
+    (h_b2 : b₂.val < 65536) (h_b3 : b₃.val < 65536)
+    (h_c0 : c₀.val < 65536) (h_c1 : c₁.val < 65536)
+    (h_c2 : c₂.val < 65536) (h_c3 : c₃.val < 65536)
+    (h_d0 : d₀.val < 65536) (h_d1 : d₁.val < 65536)
+    (h_d2 : d₂.val < 65536) (_h_d3 : d₃.val < 65536)
+    (h_cy0 : cy₀.val < 983041) (h_cy1 : cy₁.val < 983041)
+    (h_cy2 : cy₂.val < 983041) (h_cy3 : cy₃.val < 983041)
+    (h_cy4 : cy₄.val < 983041) (h_cy5 : cy₅.val < 983041)
+    (h_cy6 : cy₆.val < 983041)
+    (hC31 : a₀ * b₀ = c₀ + cy₀ * 65536)
+    (hC32 : a₁ * b₀ + a₀ * b₁ + cy₀ = c₁ + cy₁ * 65536)
+    (hC33 : a₂ * b₀ + a₁ * b₁ + a₀ * b₂ + cy₁ = c₂ + cy₂ * 65536)
+    (hC34 : a₃ * b₀ + a₂ * b₁ + a₁ * b₂ + a₀ * b₃ + cy₂ = c₃ + cy₃ * 65536)
+    (hC35 : a₃ * b₁ + a₂ * b₂ + a₁ * b₃ + cy₃ = d₀ + cy₄ * 65536)
+    (hC36 : a₃ * b₂ + a₂ * b₃ + cy₄ = d₁ + cy₅ * 65536)
+    (hC37 : a₃ * b₃ + cy₅ = d₂ + cy₆ * 65536)
+    (hC38 : cy₆ = d₃) :
+    ZiskFv.PackedBitVec.MulNoWrap.packed4 a₀.val a₁.val a₂.val a₃.val
+        * ZiskFv.PackedBitVec.MulNoWrap.packed4 b₀.val b₁.val b₂.val b₃.val
+      = ZiskFv.PackedBitVec.MulNoWrap.packed4 c₀.val c₁.val c₂.val c₃.val
+        + ZiskFv.PackedBitVec.MulNoWrap.packed4 d₀.val d₁.val d₂.val d₃.val
+            * 18446744073709551616 :=
+  ZiskFv.PackedBitVec.MulNoWrap.mul_unsigned_packed_of_chunks
+    a₀.val a₁.val a₂.val a₃.val b₀.val b₁.val b₂.val b₃.val
+    c₀.val c₁.val c₂.val c₃.val d₀.val d₁.val d₂.val d₃.val
+    cy₀.val cy₁.val cy₂.val cy₃.val cy₄.val cy₅.val cy₆.val
+    (loose_chunk_lift_1 a₀ b₀ c₀ cy₀ h_a0 h_b0 h_c0 h_cy0 hC31)
+    (loose_chunk_lift_2 a₁ a₀ b₀ b₁ cy₀ c₁ cy₁
+        h_a1 h_a0 h_b0 h_b1 h_cy0 h_c1 h_cy1 hC32)
+    (loose_chunk_lift_3 a₂ a₁ a₀ b₀ b₁ b₂ cy₁ c₂ cy₂
+        h_a2 h_a1 h_a0 h_b0 h_b1 h_b2 h_cy1 h_c2 h_cy2 hC33)
+    (loose_chunk_lift_4 a₃ a₂ a₁ a₀ b₀ b₁ b₂ b₃ cy₂ c₃ cy₃
+        h_a3 h_a2 h_a1 h_a0 h_b0 h_b1 h_b2 h_b3 h_cy2 h_c3 h_cy3 hC34)
+    (loose_chunk_lift_3 a₃ a₂ a₁ b₁ b₂ b₃ cy₃ d₀ cy₄
+        h_a3 h_a2 h_a1 h_b1 h_b2 h_b3 h_cy3 h_d0 h_cy4 hC35)
+    (loose_chunk_lift_2 a₃ a₂ b₂ b₃ cy₄ d₁ cy₅
+        h_a3 h_a2 h_b2 h_b3 h_cy4 h_d1 h_cy5 hC36)
+    (loose_chunk_lift_1' a₃ b₃ cy₅ d₂ cy₆
+        h_a3 h_b3 h_cy5 h_d2 h_cy6 hC37)
+    (ZiskFv.PackedBitVec.MulNoWrap.fgl_chunk_lift_close cy₆ d₃ hC38)
+
+open ZiskFv.Airs.ArithMul in
+/-- **Mode-pinned MULHU chunk equations.** Specialize the 11-clause
+    `mul_carry_chain_holds` to the unsigned MULHU mode
+    (`na = nb = np = nr = sext = m32 = div = 0`, hence `fab = 1`,
+    `na_fb = nb_fa = 0`), yielding the eight clean unsigned-multiply chunk
+    equations `hC31..hC38`.  No carry bounds are needed (or produced) here. -/
+private lemma mulhu_chain_eqs
+    (v : Valid_ArithMul FGL FGL) (r_a : ℕ)
+    (h_chain : mul_carry_chain_holds v r_a)
+    (h_na : v.na r_a = 0) (h_nb : v.nb r_a = 0)
+    (h_np : v.np r_a = 0) (h_nr : v.nr r_a = 0)
+    (h_m32 : v.m32 r_a = 0) (h_div : v.div r_a = 0) :
+    (v.a_0 r_a * v.b_0 r_a = v.c_0 r_a + v.cy_0 r_a * 65536)
+    ∧ (v.a_1 r_a * v.b_0 r_a + v.a_0 r_a * v.b_1 r_a + v.cy_0 r_a
+        = v.c_1 r_a + v.cy_1 r_a * 65536)
+    ∧ (v.a_2 r_a * v.b_0 r_a + v.a_1 r_a * v.b_1 r_a + v.a_0 r_a * v.b_2 r_a + v.cy_1 r_a
+        = v.c_2 r_a + v.cy_2 r_a * 65536)
+    ∧ (v.a_3 r_a * v.b_0 r_a + v.a_2 r_a * v.b_1 r_a + v.a_1 r_a * v.b_2 r_a
+        + v.a_0 r_a * v.b_3 r_a + v.cy_2 r_a = v.c_3 r_a + v.cy_3 r_a * 65536)
+    ∧ (v.a_3 r_a * v.b_1 r_a + v.a_2 r_a * v.b_2 r_a + v.a_1 r_a * v.b_3 r_a + v.cy_3 r_a
+        = v.d_0 r_a + v.cy_4 r_a * 65536)
+    ∧ (v.a_3 r_a * v.b_2 r_a + v.a_2 r_a * v.b_3 r_a + v.cy_4 r_a
+        = v.d_1 r_a + v.cy_5 r_a * 65536)
+    ∧ (v.a_3 r_a * v.b_3 r_a + v.cy_5 r_a = v.d_2 r_a + v.cy_6 r_a * 65536)
+    ∧ (v.cy_6 r_a = v.d_3 r_a) := by
+  obtain ⟨h6, h7, h8, h31, h32, h33, h34, h35, h36, h37, h38⟩ := h_chain
+  simp only [mul_constraint_6_named, mul_constraint_7_named, mul_constraint_8_named,
+             h_na, h_nb, mul_zero, zero_mul, add_zero, sub_zero] at h6 h7 h8
+  have h_fab : v.fab r_a = (1 : FGL) := by linear_combination h6
+  have h_nafb : v.na_fb r_a = (0 : FGL) := by linear_combination h7
+  have h_nbfa : v.nb_fa r_a = (0 : FGL) := by linear_combination h8
+  simp only [mul_constraint_31_named, mul_constraint_32_named,
+             mul_constraint_33_named, mul_constraint_34_named,
+             mul_constraint_35_named, mul_constraint_36_named,
+             mul_constraint_37_named, mul_constraint_38_named,
+             h_na, h_nb, h_np, h_nr, h_m32, h_div, h_fab, h_nafb, h_nbfa,
+             mul_zero, zero_mul, add_zero, sub_zero,
+             mul_one, one_mul]
+    at h31 h32 h33 h34 h35 h36 h37 h38
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · linear_combination h31
+  · linear_combination h32
+  · linear_combination h33
+  · linear_combination h34
+  · linear_combination h35
+  · linear_combination h36
+  · linear_combination h37
+  · linear_combination h38
+
+open ZiskFv.Airs.ArithMul in
+/-- **Balance-constructible MULHU unsigned carry bounds.** From the eight
+    mode-pinned chunk equations + the sixteen 16-bit chunk bounds + the seven
+    *signed* carry disjunctions (all from `FullSpec`), derive the looser
+    *unsigned-side* carry bounds `cy_i.val < 983041` by sequentially applying
+    `unsigned_carry_step_nat` up the chain (each step's accumulated column value
+    stays below `983040·2^16`, using the previous carry's bound). -/
+private lemma mulhu_carry_bounds
+    (v : Valid_ArithMul FGL FGL) (r_a : ℕ)
+    (h_chunks : ZiskFv.EquivCore.Bridge.Arith.ArithMulChunkRangesAt v r_a)
+    (h_csgn : ZiskFv.EquivCore.Bridge.Arith.ArithMulSignedCarryRangesAt v r_a)
+    (heqs :
+      (v.a_0 r_a * v.b_0 r_a = v.c_0 r_a + v.cy_0 r_a * 65536)
+      ∧ (v.a_1 r_a * v.b_0 r_a + v.a_0 r_a * v.b_1 r_a + v.cy_0 r_a
+          = v.c_1 r_a + v.cy_1 r_a * 65536)
+      ∧ (v.a_2 r_a * v.b_0 r_a + v.a_1 r_a * v.b_1 r_a + v.a_0 r_a * v.b_2 r_a + v.cy_1 r_a
+          = v.c_2 r_a + v.cy_2 r_a * 65536)
+      ∧ (v.a_3 r_a * v.b_0 r_a + v.a_2 r_a * v.b_1 r_a + v.a_1 r_a * v.b_2 r_a
+          + v.a_0 r_a * v.b_3 r_a + v.cy_2 r_a = v.c_3 r_a + v.cy_3 r_a * 65536)
+      ∧ (v.a_3 r_a * v.b_1 r_a + v.a_2 r_a * v.b_2 r_a + v.a_1 r_a * v.b_3 r_a + v.cy_3 r_a
+          = v.d_0 r_a + v.cy_4 r_a * 65536)
+      ∧ (v.a_3 r_a * v.b_2 r_a + v.a_2 r_a * v.b_3 r_a + v.cy_4 r_a
+          = v.d_1 r_a + v.cy_5 r_a * 65536)
+      ∧ (v.a_3 r_a * v.b_3 r_a + v.cy_5 r_a = v.d_2 r_a + v.cy_6 r_a * 65536)
+      ∧ (v.cy_6 r_a = v.d_3 r_a)) :
+    (v.cy_0 r_a).val < 983041 ∧ (v.cy_1 r_a).val < 983041
+    ∧ (v.cy_2 r_a).val < 983041 ∧ (v.cy_3 r_a).val < 983041
+    ∧ (v.cy_4 r_a).val < 983041 ∧ (v.cy_5 r_a).val < 983041
+    ∧ (v.cy_6 r_a).val < 983041 := by
+  obtain ⟨ha0, ha1, ha2, ha3, hb0, hb1, hb2, hb3,
+          hc0, hc1, hc2, hc3, hd0, hd1, hd2, _hd3⟩ := h_chunks
+  obtain ⟨hs0, hs1, hs2, hs3, hs4, hs5, hs6⟩ := h_csgn
+  obtain ⟨hC31, hC32, hC33, hC34, hC35, hC36, hC37, _hC38⟩ := heqs
+  have b0 : (v.cy_0 r_a).val < 983041 := by
+    refine unsigned_carry_step_nat ((v.a_0 r_a).val * (v.b_0 r_a).val) _ _ ?_ hc0 ?_ hs0
+    · push_cast; linear_combination hC31
+    · have : (v.a_0 r_a).val * (v.b_0 r_a).val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b1 : (v.cy_1 r_a).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((v.a_1 r_a).val * (v.b_0 r_a).val + (v.a_0 r_a).val * (v.b_1 r_a).val + (v.cy_0 r_a).val)
+      _ _ ?_ hc1 ?_ hs1
+    · push_cast; linear_combination hC32
+    · have h1 : (v.a_1 r_a).val * (v.b_0 r_a).val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (v.a_0 r_a).val * (v.b_1 r_a).val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b2 : (v.cy_2 r_a).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((v.a_2 r_a).val * (v.b_0 r_a).val + (v.a_1 r_a).val * (v.b_1 r_a).val
+        + (v.a_0 r_a).val * (v.b_2 r_a).val + (v.cy_1 r_a).val) _ _ ?_ hc2 ?_ hs2
+    · push_cast; linear_combination hC33
+    · have h1 : (v.a_2 r_a).val * (v.b_0 r_a).val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (v.a_1 r_a).val * (v.b_1 r_a).val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+      have h3 : (v.a_0 r_a).val * (v.b_2 r_a).val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b3 : (v.cy_3 r_a).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((v.a_3 r_a).val * (v.b_0 r_a).val + (v.a_2 r_a).val * (v.b_1 r_a).val
+        + (v.a_1 r_a).val * (v.b_2 r_a).val + (v.a_0 r_a).val * (v.b_3 r_a).val
+        + (v.cy_2 r_a).val) _ _ ?_ hc3 ?_ hs3
+    · push_cast; linear_combination hC34
+    · have h1 : (v.a_3 r_a).val * (v.b_0 r_a).val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (v.a_2 r_a).val * (v.b_1 r_a).val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+      have h3 : (v.a_1 r_a).val * (v.b_2 r_a).val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+      have h4 : (v.a_0 r_a).val * (v.b_3 r_a).val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b4 : (v.cy_4 r_a).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((v.a_3 r_a).val * (v.b_1 r_a).val + (v.a_2 r_a).val * (v.b_2 r_a).val
+        + (v.a_1 r_a).val * (v.b_3 r_a).val + (v.cy_3 r_a).val) _ _ ?_ hd0 ?_ hs4
+    · push_cast; linear_combination hC35
+    · have h1 : (v.a_3 r_a).val * (v.b_1 r_a).val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (v.a_2 r_a).val * (v.b_2 r_a).val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+      have h3 : (v.a_1 r_a).val * (v.b_3 r_a).val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b5 : (v.cy_5 r_a).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((v.a_3 r_a).val * (v.b_2 r_a).val + (v.a_2 r_a).val * (v.b_3 r_a).val
+        + (v.cy_4 r_a).val) _ _ ?_ hd1 ?_ hs5
+    · push_cast; linear_combination hC36
+    · have h1 : (v.a_3 r_a).val * (v.b_2 r_a).val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (v.a_2 r_a).val * (v.b_3 r_a).val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b6 : (v.cy_6 r_a).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((v.a_3 r_a).val * (v.b_3 r_a).val + (v.cy_5 r_a).val) _ _ ?_ hd2 ?_ hs6
+    · push_cast; linear_combination hC37
+    · have h1 : (v.a_3 r_a).val * (v.b_3 r_a).val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+      omega
+  exact ⟨b0, b1, b2, b3, b4, b5, b6⟩
+
+open ZiskFv.PackedBitVec.Extensions in
+/-- **Loose-bound MULHU rd-write reconstruction.** Mirror of
+    `ZiskFv.EquivCore.WriteValueProofs.MulDivRemUnsigned.h_rd_val_mdru_mulhu` but
+    with the balance-constructible carry bound `< 983041` instead of `< 131072`.
+    The no-wrap argument is unaffected; this routes through the loose chunk
+    identity, then the public high-half extractor `fgl_mul_unsigned_to_bv64_hi`
+    and the public byte-sum bridge `mul_hi_bv64_of_byte_sum`. -/
+private lemma mulhu_h_rd_val_of_loose
+    (op1 op2 : BitVec 64)
+    (e : Interaction.MemoryBusEntry FGL)
+    (a₀ a₁ a₂ a₃ b₀ b₁ b₂ b₃ c₀ c₁ c₂ c₃ d₀ d₁ d₂ d₃ : FGL)
+    (cy₀ cy₁ cy₂ cy₃ cy₄ cy₅ cy₆ : FGL)
+    (h0 : (byteAt e 0).val < 256) (h1 : (byteAt e 1).val < 256)
+    (h2 : (byteAt e 2).val < 256) (h3 : (byteAt e 3).val < 256)
+    (h4 : (byteAt e 4).val < 256) (h5 : (byteAt e 5).val < 256)
+    (h6 : (byteAt e 6).val < 256) (h7 : (byteAt e 7).val < 256)
+    (h_a0 : a₀.val < 65536) (h_a1 : a₁.val < 65536)
+    (h_a2 : a₂.val < 65536) (h_a3 : a₃.val < 65536)
+    (h_b0 : b₀.val < 65536) (h_b1 : b₁.val < 65536)
+    (h_b2 : b₂.val < 65536) (h_b3 : b₃.val < 65536)
+    (h_c0 : c₀.val < 65536) (h_c1 : c₁.val < 65536)
+    (h_c2 : c₂.val < 65536) (h_c3 : c₃.val < 65536)
+    (h_d0 : d₀.val < 65536) (h_d1 : d₁.val < 65536)
+    (h_d2 : d₂.val < 65536) (h_d3 : d₃.val < 65536)
+    (h_cy0 : cy₀.val < 983041) (h_cy1 : cy₁.val < 983041)
+    (h_cy2 : cy₂.val < 983041) (h_cy3 : cy₃.val < 983041)
+    (h_cy4 : cy₄.val < 983041) (h_cy5 : cy₅.val < 983041)
+    (h_cy6 : cy₆.val < 983041)
+    (hC31 : a₀ * b₀ = c₀ + cy₀ * 65536)
+    (hC32 : a₁ * b₀ + a₀ * b₁ + cy₀ = c₁ + cy₁ * 65536)
+    (hC33 : a₂ * b₀ + a₁ * b₁ + a₀ * b₂ + cy₁ = c₂ + cy₂ * 65536)
+    (hC34 : a₃ * b₀ + a₂ * b₁ + a₁ * b₂ + a₀ * b₃ + cy₂ = c₃ + cy₃ * 65536)
+    (hC35 : a₃ * b₁ + a₂ * b₂ + a₁ * b₃ + cy₃ = d₀ + cy₄ * 65536)
+    (hC36 : a₃ * b₂ + a₂ * b₃ + cy₄ = d₁ + cy₅ * 65536)
+    (hC37 : a₃ * b₃ + cy₅ = d₂ + cy₆ * 65536)
+    (hC38 : cy₆ = d₃)
+    (h_byte_lo :
+      (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216
+        = d₀.val + d₁.val * 65536)
+    (h_byte_hi :
+      (byteAt e 4).val + (byteAt e 5).val * 256 + (byteAt e 6).val * 65536 + (byteAt e 7).val * 16777216
+        = d₂.val + d₃.val * 65536)
+    (h_rs1_value : op1.toNat = ZiskFv.PackedBitVec.MulNoWrap.packed4 a₀.val a₁.val a₂.val a₃.val)
+    (h_rs2_value : op2.toNat = ZiskFv.PackedBitVec.MulNoWrap.packed4 b₀.val b₁.val b₂.val b₃.val) :
+    U64.toBV #v[((byteAt e 0) : BitVec 8), ((byteAt e 1) : BitVec 8), ((byteAt e 2) : BitVec 8), ((byteAt e 3) : BitVec 8),
+                ((byteAt e 4) : BitVec 8), ((byteAt e 5) : BitVec 8), ((byteAt e 6) : BitVec 8), ((byteAt e 7) : BitVec 8)]
+      = execute_MUL_pure op1 op2 .MULHU := by
+  have h_packed_nat :
+      ZiskFv.PackedBitVec.MulNoWrap.packed4 a₀.val a₁.val a₂.val a₃.val
+        * ZiskFv.PackedBitVec.MulNoWrap.packed4 b₀.val b₁.val b₂.val b₃.val
+      = ZiskFv.PackedBitVec.MulNoWrap.packed4 c₀.val c₁.val c₂.val c₃.val
+        + ZiskFv.PackedBitVec.MulNoWrap.packed4 d₀.val d₁.val d₂.val d₃.val * 18446744073709551616 :=
+    loose_mul_unsigned_chunks_to_nat_identity
+      a₀ a₁ a₂ a₃ b₀ b₁ b₂ b₃ c₀ c₁ c₂ c₃ d₀ d₁ d₂ d₃
+      cy₀ cy₁ cy₂ cy₃ cy₄ cy₅ cy₆
+      h_a0 h_a1 h_a2 h_a3 h_b0 h_b1 h_b2 h_b3
+      h_c0 h_c1 h_c2 h_c3 h_d0 h_d1 h_d2 h_d3
+      h_cy0 h_cy1 h_cy2 h_cy3 h_cy4 h_cy5 h_cy6
+      hC31 hC32 hC33 hC34 hC35 hC36 hC37 hC38
+  rw [← h_rs1_value, ← h_rs2_value] at h_packed_nat
+  have h_hi_div :
+      ZiskFv.PackedBitVec.MulNoWrap.packed4 d₀.val d₁.val d₂.val d₃.val
+      = (op1.toNat * op2.toNat) / 18446744073709551616 :=
+    ZiskFv.PackedBitVec.MulNoWrap.fgl_mul_unsigned_to_bv64_hi
+      h_c0 h_c1 h_c2 h_c3 h_packed_nat
+  -- byte sum = packed4 d (replicating `byte_sum_eq_packed4`).
+  have h_byte_eq_packed :
+      (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216
+        + (byteAt e 4).val * 4294967296 + (byteAt e 5).val * 1099511627776
+        + (byteAt e 6).val * 281474976710656 + (byteAt e 7).val * 72057594037927936
+      = ZiskFv.PackedBitVec.MulNoWrap.packed4 d₀.val d₁.val d₂.val d₃.val := by
+    unfold ZiskFv.PackedBitVec.MulNoWrap.packed4
+    have hh : ((byteAt e 4).val + (byteAt e 5).val * 256 + (byteAt e 6).val * 65536
+          + (byteAt e 7).val * 16777216) * 4294967296
+        = (d₂.val + d₃.val * 65536) * 4294967296 := by rw [h_byte_hi]
+    linarith [h_byte_lo, hh]
+  have h_byte_sum :
+      (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216
+        + (byteAt e 4).val * 4294967296 + (byteAt e 5).val * 1099511627776
+        + (byteAt e 6).val * 281474976710656 + (byteAt e 7).val * 72057594037927936
+      = (op1.toNat * op2.toNat) / 2 ^ 64 := by
+    rw [h_byte_eq_packed, h_hi_div]; norm_num
+  exact mul_hi_bv64_of_byte_sum op1 op2
+    (byteAt e 0) (byteAt e 1) (byteAt e 2) (byteAt e 3) (byteAt e 4) (byteAt e 5) (byteAt e 6) (byteAt e 7)
+    h0 h1 h2 h3 h4 h5 h6 h7 h_byte_sum
+
+/-! ## Phase 2 — F4 `FullSpec` discharge bridge for MULHU -/
+
+open ZiskFv.Airs.ArithMul in
+open ZiskFv.EquivCore.Promises in
+/-- **F4 extraction bridge for `equiv_MULHU`.**  Mirror of
+    `equiv_MULW_of_fullSpec`: the four lookup-aware Arith witness records are
+    replaced by the single `FullSpec (rowAt v r_a)` hypothesis, which is exactly
+    what the lookup-aware ArithMul provider's `componentWithArithTable.Spec`
+    yields.  A P4 construction hands the balance-derived `FullSpec` here directly.
+
+    Unlike MULW (which routes through `EquivCore.MulW.equiv_MULW`), MULHU's
+    `EquivCore.MulHU.equiv_MULHU` demands the *unsigned* carry bound `< 131072`,
+    which is not balance-constructible (real unsigned-multiply carries can exceed
+    `2^17`).  This bridge therefore derives the looser, balance-constructible
+    bound `< 983041` (via `mulhu_carry_bounds`) and reconstructs the rd write
+    value through the loose-bound write-value path `mulhu_h_rd_val_of_loose`,
+    replicating `equiv_MULHU`'s sail + `bus_effect` tail. -/
+lemma equiv_MULHU_of_fullSpec
+    (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
+    (mulhu_input : PureSpec.MulhuInput)
+    (r1 r2 rd : regidx)
+    (bus : ZiskFv.Compliance.BusRows)
+    (m : Valid_Main FGL FGL) (r_main : ℕ)
+    (v : Valid_ArithMul FGL FGL) (r_a : ℕ)
+    (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_MULUH)
+    (h_match_secondary :
+      matches_entry (opBus_row_Main m r_main)
+                    (ZiskFv.Airs.ArithMul.opBus_row_ArithMulSecondary v r_a))
+    (promises : ZiskFv.EquivCore.Promises.RTypePromises
+        state mulhu_input.r1_val mulhu_input.r2_val mulhu_input.rd mulhu_input.PC
+        (PureSpec.execute_MULH_mulhu_pure mulhu_input).nextPC
+        r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
+    (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
+    (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
+    (h_full_spec :
+      ZiskFv.AirsClean.ArithMul.FullSpec (ZiskFv.AirsClean.ArithMul.rowAt v r_a))
+    (h_rs1_value : mulhu_input.r1_val.toNat
+      = ZiskFv.PackedBitVec.MulNoWrap.packed4 (v.a_0 r_a).val (v.a_1 r_a).val
+          (v.a_2 r_a).val (v.a_3 r_a).val)
+    (h_rs2_value : mulhu_input.r2_val.toNat
+      = ZiskFv.PackedBitVec.MulNoWrap.packed4 (v.b_0 r_a).val (v.b_1 r_a).val
+          (v.b_2 r_a).val (v.b_3 r_a).val) :
+    (do
+      Sail.writeReg Register.nextPC
+        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
+      LeanRV64D.Functions.execute
+        (instruction.MUL
+          (r2, r1, rd,
+           { result_part := VectorHalf.High
+             signed_rs1 := .Unsigned
+             signed_rs2 := .Unsigned }))) state
+      = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
+  -- Unpack FullSpec into its five conjuncts.
+  obtain ⟨h_spec, h_arith_table, h_c46, h_chunk_ranges_spec, h_carry_ranges_spec⟩ :=
+    h_full_spec
+  obtain ⟨exec_row, e0, e1, e2⟩ := bus
+  obtain ⟨h0, h1, h2, h3, h4, h5, h6, h7⟩ := bounds
+  obtain ⟨_h_main_active, h_main_op_mulhu⟩ := pins
+  obtain ⟨h_input_r1, h_input_r2, h_input_rd, h_input_pc,
+          h_exec_len, h_e0_mult, h_e1_mult, h_nextPC_matches,
+          h_m0_mult, h_m0_as, h_m1_mult, h_m1_as, h_m2_mult, h_m2_as,
+          h_rd_idx⟩ := promises
+  -- ============ DERIVE arith-side opcode literal ============
+  have h_op_eq := arith_mul_secondary_op_eq h_match_secondary
+  have h_op_arith_mulhu : v.op r_a = 177 := by
+    rw [h_op_eq, h_main_op_mulhu]; simp [OP_MULUH]
+  -- ============ Carry chain + c46 from FullSpec ============
+  have h_chain : ZiskFv.Airs.ArithMul.mul_carry_chain_holds v r_a := h_spec
+  have h_c46_named : ZiskFv.Airs.ArithMul.mul_constraint_46_named v r_a := h_c46
+  -- ============ DISCHARGE mode pins (from ArithTableSpec) ============
+  obtain ⟨h_na, h_nb, h_np, h_nr, h_sext, h_m32, h_div⟩ :=
+    ZiskFv.AirsClean.ArithTableProjections.Mul.mulhu_mode_pin
+      v r_a h_arith_table h_op_arith_mulhu
+  obtain ⟨h_main_mul_zero, h_main_div_zero⟩ :=
+    ZiskFv.AirsClean.ArithTableProjections.Mul.mulhu_main_selector_pin
+      v r_a h_arith_table h_op_arith_mulhu
+  -- ============ Chunk / carry ranges from FullSpec ============
+  have h_carry_ranges_signed :
+      ZiskFv.EquivCore.Bridge.Arith.ArithMulSignedCarryRangesAt v r_a := h_carry_ranges_spec
+  have h_chunk_ranges :
+      ZiskFv.EquivCore.Bridge.Arith.ArithMulChunkRangesAt v r_a := h_chunk_ranges_spec
+  obtain ⟨h_a0_lt, h_a1_lt, h_a2_lt, h_a3_lt,
+          h_b0_lt, h_b1_lt, h_b2_lt, h_b3_lt,
+          h_c0_lt, h_c1_lt, h_c2_lt, h_c3_lt,
+          h_d0_lt, h_d1_lt, h_d2_lt, h_d3_lt⟩ := h_chunk_ranges
+  -- ============ Mode-pinned chunk equations (from chain) ============
+  have heqs := mulhu_chain_eqs v r_a h_chain h_na h_nb h_np h_nr h_m32 h_div
+  -- ============ DERIVE the balance-constructible unsigned carry bounds ============
+  obtain ⟨hcy0, hcy1, hcy2, hcy3, hcy4, hcy5, hcy6⟩ :=
+    mulhu_carry_bounds v r_a h_chunk_ranges_spec h_carry_ranges_signed heqs
+  obtain ⟨hC31, hC32, hC33, hC34, hC35, hC36, hC37, hC38⟩ := heqs
+  -- ============ Unpack matches_entry lane projections ============
+  obtain ⟨_h_a_lo_eq_FGL, _h_a_hi_eq_FGL, _h_b_lo_eq_FGL, _h_b_hi_eq_FGL,
+          h_c0_eq_FGL, h_c1_eq_FGL⟩ :=
+    arith_mul_secondary_projections h_match_secondary
+  -- ============ DISCHARGE h_byte_lo / h_byte_hi (lane match — d-lanes) ============
+  have h_bundle := arith_mem.c_lane_vals
+  have h_byte_lo_to_c0 : (byteAt e2 0).val + (byteAt e2 1).val * 256
+      + (byteAt e2 2).val * 65536 + (byteAt e2 3).val * 16777216
+      = (m.c_0 r_main).val := by
+    have h_e2_lo_bound : e2.value_0.val < 4294967296 := by
+      rw [← h_bundle.1, h_c0_eq_FGL]
+      rw [ZiskFv.EquivCore.Promises.arith_h_pair_lift _ _ h_d0_lt h_d1_lt]
+      omega
+    rw [ZiskFv.Channels.MemoryBusBytes.byteAt_lo_val_sum_eq e2 h_e2_lo_bound, h_bundle.1]
+  have h_bus_res1_eq : v.bus_res1 r_a = v.d_2 r_a + v.d_3 r_a * 65536 :=
+    ZiskFv.Airs.ArithBusRes1.mulh_bus_res1_eq_d_hi v r_a h_c46_named
+      h_sext h_m32 h_main_mul_zero h_main_div_zero
+  have h_byte_hi_to_c1 : (byteAt e2 4).val + (byteAt e2 5).val * 256
+      + (byteAt e2 6).val * 65536 + (byteAt e2 7).val * 16777216
+      = (m.c_1 r_main).val := by
+    have h_e2_hi_bound : e2.value_1.val < 4294967296 := by
+      rw [← h_bundle.2, h_c1_eq_FGL, h_bus_res1_eq]
+      rw [ZiskFv.EquivCore.Promises.arith_h_pair_lift _ _ h_d2_lt h_d3_lt]
+      omega
+    rw [ZiskFv.Channels.MemoryBusBytes.byteAt_hi_val_sum_eq e2 h_e2_hi_bound, h_bundle.2]
+  have h_byte_lo :=
+    ZiskFv.EquivCore.Promises.arith_byte_lane_eq_of_match h_byte_lo_to_c0 h_c0_eq_FGL h_d0_lt h_d1_lt
+  have h_c1_eq_FGL' : m.c_1 r_main = v.d_2 r_a + v.d_3 r_a * 65536 := by
+    rw [h_c1_eq_FGL, h_bus_res1_eq]
+  have h_byte_hi :=
+    ZiskFv.EquivCore.Promises.arith_byte_lane_eq_of_match h_byte_hi_to_c1 h_c1_eq_FGL' h_d2_lt h_d3_lt
+  -- ============ DISCHARGE rd-write value via the loose-bound path ============
+  have h_rd_val :=
+    mulhu_h_rd_val_of_loose
+      mulhu_input.r1_val mulhu_input.r2_val e2
+      (v.a_0 r_a) (v.a_1 r_a) (v.a_2 r_a) (v.a_3 r_a)
+      (v.b_0 r_a) (v.b_1 r_a) (v.b_2 r_a) (v.b_3 r_a)
+      (v.c_0 r_a) (v.c_1 r_a) (v.c_2 r_a) (v.c_3 r_a)
+      (v.d_0 r_a) (v.d_1 r_a) (v.d_2 r_a) (v.d_3 r_a)
+      (v.cy_0 r_a) (v.cy_1 r_a) (v.cy_2 r_a) (v.cy_3 r_a)
+      (v.cy_4 r_a) (v.cy_5 r_a) (v.cy_6 r_a)
+      h0 h1 h2 h3 h4 h5 h6 h7
+      h_a0_lt h_a1_lt h_a2_lt h_a3_lt h_b0_lt h_b1_lt h_b2_lt h_b3_lt
+      h_c0_lt h_c1_lt h_c2_lt h_c3_lt h_d0_lt h_d1_lt h_d2_lt h_d3_lt
+      hcy0 hcy1 hcy2 hcy3 hcy4 hcy5 hcy6
+      hC31 hC32 hC33 hC34 hC35 hC36 hC37 hC38
+      h_byte_lo h_byte_hi h_rs1_value h_rs2_value
+  -- ============ Replicate `equiv_MULHU`'s sail + bus_effect tail ============
+  rw [ZiskFv.EquivCore.MulHU.equiv_MULHU_sail state mulhu_input r1 r2 rd
+        h_input_r1 h_input_r2 h_input_rd h_input_pc]
+  symm
+  rw [ZiskFv.Airs.Bus.BusEmission.bus_effect_matches_sail_alu_rrw
+        state exec_row e0 e1 e2
+        (PureSpec.execute_MULH_mulhu_pure mulhu_input).nextPC
+        h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
+        h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as]
+  simp only [PureSpec.execute_MULH_mulhu_pure, h_rd_idx]
+  split_ifs with h_rd_zero
+  · simp only [bind, pure, EStateM.bind, EStateM.pure]
+  · rw [h_rd_val]
+
+/-! ## Phase 3 — sound MULHU construction -/
+
+/-- The balance-selected Arith-Mul provider row at trace index `i` for a MULHU
+    operation, as a concrete `ArithMulRow`.  It is the
+    `componentWithArithTable.rowInput` of the provider row chosen by the MULHU
+    keep-arithMul balance wrapper
+    `exists_arithMul_provider_row_matches_secondary_of_mulhu_from_binding`.
+    Mirrors `mulwArow`. -/
+noncomputable def mulhuArow
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_MULUH) :
+    ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
+  let h := exists_arithMul_provider_row_matches_secondary_of_mulhu_from_binding
+    trace binding i h_main_active h_main_op
+  componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
+
+/-- `FullSpec` of the balance-selected MULHU provider row, derived from the
+    provider component's proven soundness (`componentWithArithTable.Spec`). -/
+theorem mulhuArow_fullSpec_row
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_MULUH) :
+    ZiskFv.AirsClean.ArithMul.FullSpec (mulhuArow trace binding i h_main_active h_main_op) := by
+  unfold mulhuArow
+  set H := exists_arithMul_provider_row_matches_secondary_of_mulhu_from_binding
+    trace binding i h_main_active h_main_op with hH
+  obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
+  obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
+  exact ZiskFv.AirsClean.FullEnsemble.arithMul_fullSpec_of_component_spec
+    h_component (h_spec h_rest.choose h_pr_mem)
+
+/-- `FullSpec` of the balance-selected MULHU provider row view. -/
+theorem mulhuArow_fullSpec
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_MULUH) :
+    ZiskFv.AirsClean.ArithMul.FullSpec
+      (rowAt (vOfMulwRow (mulhuArow trace binding i h_main_active h_main_op)) 0) :=
+  fullSpec_rowAt_vOfMulwRow
+    (mulhuArow_fullSpec_row trace binding i h_main_active h_main_op)
+
+/-- The op-bus match transports along the row-native view at the MULHU secondary
+    mode pins (`div = 0`, `main_mul = 0`, `main_div = 0`): a match against the
+    FAITHFUL muxed primary message of a concrete row carries over to
+    `opBus_row_ArithMulSecondary (vOfMulwRow arow) 0`, via the MULHU-mode bridge
+    `primaryOpBusMessage_toEntry_rowAt_eq_opBus_row_secondary`. -/
+theorem match_opBus_row_ArithMulSecondary_vOfMulwRow
+    {x : ZiskFv.Airs.OperationBus.OperationBusEntry FGL}
+    {arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL}
+    (h_div : arow.flags.div = 0)
+    (h_main_mul : arow.flags.main_mul = 0)
+    (h_main_div : arow.flags.main_div = 0)
+    (h :
+      matches_entry x
+        (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+          (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage arow) 1)) :
+    matches_entry x (ZiskFv.Airs.ArithMul.opBus_row_ArithMulSecondary (vOfMulwRow arow) 0) := by
+  rw [← ZiskFv.AirsClean.ArithMul.primaryOpBusMessage_toEntry_rowAt_eq_opBus_row_secondary
+        (vOfMulwRow arow) 0 h_div h_main_mul h_main_div]
+  exact h
+
+/-- The op-bus match of the balance-selected MULHU provider row against the Main
+    row's emission, in `toEntry (primaryOpBusMessage …) 1` form (cheap: free
+    `ArithMulRow`, no `vOfMulwRow`/`opBus_row_*` whnf). -/
+theorem mulhuArow_match_row
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_MULUH) :
+    matches_entry
+      (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val)
+      (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+        (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+          (mulhuArow trace binding i h_main_active h_main_op)) 1) := by
+  unfold mulhuArow
+  set H := exists_arithMul_provider_row_matches_secondary_of_mulhu_from_binding
+    trace binding i h_main_active h_main_op with hH
+  exact H.choose_spec.2.choose_spec.2.2.2
+
+/-- MULHU secondary mode pins on the balance-selected provider row, DERIVED from
+    its `ArithTableSpec` (part of `FullSpec`) plus the opcode pin
+    `arow.flags.op = 177`.  These are not caller binders.  Reads the mode flags
+    off the BARE provider `ArithMulRow` via `mulhu_mode_pins_of_row`, never
+    forcing the heavy `Classical.choose` row's whnf. -/
+theorem mulhuArow_mode_pins
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_MULUH) :
+    (mulhuArow trace binding i h_main_active h_main_op).flags.div = 0
+      ∧ (mulhuArow trace binding i h_main_active h_main_op).flags.main_mul = 0
+      ∧ (mulhuArow trace binding i h_main_active h_main_op).flags.main_div = 0 := by
+  have h_table := (mulhuArow_fullSpec_row trace binding i h_main_active h_main_op).2.1
+  have h_op : (mulhuArow trace binding i h_main_active h_main_op).flags.op = 177 := by
+    have h_match := mulhuArow_match_row trace binding i h_main_active h_main_op
+    have h_op := h_match.2.1
+    rw [ZiskFv.AirsClean.ArithMul.primaryOpBusMessage_toEntry_op,
+        show (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val).op
+          = (mainOfTable trace.program binding.mainTable).op i.val from rfl,
+        h_main_op] at h_op
+    simpa [OP_MULUH] using h_op.symm
+  exact ZiskFv.AirsClean.ArithTableProjections.Mul.mulhu_mode_pins_of_row
+    (mulhuArow trace binding i h_main_active h_main_op) h_table h_op
+
+/-- The op-bus match of the balance-selected MULHU provider row view against the
+    Main row's emission, in `opBus_row_ArithMulSecondary` form.  The MULHU mode
+    pins needed to reduce the faithful mux are DERIVED via `mulhuArow_mode_pins`. -/
+theorem mulhuArow_match
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_MULUH) :
+    matches_entry
+      (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val)
+      (ZiskFv.Airs.ArithMul.opBus_row_ArithMulSecondary
+        (vOfMulwRow (mulhuArow trace binding i h_main_active h_main_op)) 0) := by
+  obtain ⟨h_div, h_main_mul, h_main_div⟩ :=
+    mulhuArow_mode_pins trace binding i h_main_active h_main_op
+  exact match_opBus_row_ArithMulSecondary_vOfMulwRow h_div h_main_mul h_main_div
+    (mulhuArow_match_row trace binding i h_main_active h_main_op)
+
+/-- **Sound MULHU construction:** from the accepted trace + honest residual
+    binders, conclude the canonical
+    `execute (MUL (r2, r1, rd, {High, Unsigned, Unsigned})) = (bus_effect …).2`.
+
+    The Arith provider witnesses (ArithTable membership, chunk ranges, signed
+    carry ranges, c46, carry-chain) are DERIVED inside the body from
+    `trace.balanced` / `trace.spec` via the provider's lookup-aware
+    `componentWithArithTable.Spec = FullSpec`, NOT supplied as binders. -/
+theorem construction_mulhu_sound
+    (trace : AcceptedTrace)
+    (binding : ProgramBinding trace)
+    (i : Fin trace.length)
+    (mulhu_input : PureSpec.MulhuInput)
+    (r1 r2 rd : regidx)
+    -- (b) decode pins
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_MULUH)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_store_pc :
+      (mainOfTable trace.program binding.mainTable).store_pc i.val = 0)
+    -- (b) Sail reads + operands
+    (h_input_r1 :
+      read_xreg (regidx_to_fin r1) (binding.stateAt i)
+        = EStateM.Result.ok mulhu_input.r1_val (binding.stateAt i))
+    (h_input_r2 :
+      read_xreg (regidx_to_fin r2) (binding.stateAt i)
+        = EStateM.Result.ok mulhu_input.r2_val (binding.stateAt i))
+    (h_input_pc : (binding.stateAt i).regs.get? Register.PC = .some mulhu_input.PC)
+    (h_input_rd : mulhu_input.rd = regidx_to_fin rd)
+    -- (c) exec artifacts: the exec row is a genuine top-level binder.
+    (execRow : List (Interaction.ExecutionBusEntry FGL))
+    (h_exec_len : (busSub trace binding i execRow).exec_row.length = 2)
+    (h_e0_mult : (busSub trace binding i execRow).exec_row[0]!.multiplicity = -1)
+    (h_e1_mult : (busSub trace binding i execRow).exec_row[1]!.multiplicity = 1)
+    (h_nextPC_matches :
+      (register_type_pc_equiv ▸
+          (BitVec.ofNat 64 ((busSub trace binding i execRow).exec_row[1]!.pc).val))
+        = (PureSpec.execute_MULH_mulhu_pure mulhu_input).nextPC)
+    (h_rd_idx :
+      mulhu_input.rd =
+        Transpiler.wrap_to_regidx (busSub trace binding i execRow).e2.ptr)
+    -- (c) byte range bounds on the rd-write entry
+    (bounds : ZiskFv.Compliance.ByteBounds (busSub trace binding i execRow).e2)
+    -- (b) operand bridges (Sail↔chunk binding of the unsigned 64-bit operands;
+    -- genuinely residual, phrased over the balance-selected provider row view).
+    (h_rs1_value : mulhu_input.r1_val.toNat
+      = ZiskFv.PackedBitVec.MulNoWrap.packed4
+          ((vOfMulwRow (mulhuArow trace binding i h_main_active h_main_op)).a_0 0).val
+          ((vOfMulwRow (mulhuArow trace binding i h_main_active h_main_op)).a_1 0).val
+          ((vOfMulwRow (mulhuArow trace binding i h_main_active h_main_op)).a_2 0).val
+          ((vOfMulwRow (mulhuArow trace binding i h_main_active h_main_op)).a_3 0).val)
+    (h_rs2_value : mulhu_input.r2_val.toNat
+      = ZiskFv.PackedBitVec.MulNoWrap.packed4
+          ((vOfMulwRow (mulhuArow trace binding i h_main_active h_main_op)).b_0 0).val
+          ((vOfMulwRow (mulhuArow trace binding i h_main_active h_main_op)).b_1 0).val
+          ((vOfMulwRow (mulhuArow trace binding i h_main_active h_main_op)).b_2 0).val
+          ((vOfMulwRow (mulhuArow trace binding i h_main_active h_main_op)).b_3 0).val) :
+    (do
+      Sail.writeReg Register.nextPC
+        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
+      LeanRV64D.Functions.execute
+        (instruction.MUL
+          (r2, r1, rd,
+           { result_part := VectorHalf.High
+             signed_rs1 := .Unsigned
+             signed_rs2 := .Unsigned }))) (binding.stateAt i)
+      = (bus_effect (busSub trace binding i execRow).exec_row
+          [ (busSub trace binding i execRow).e0
+          , (busSub trace binding i execRow).e1
+          , (busSub trace binding i execRow).e2 ] (binding.stateAt i)).2 := by
+  -- (a) Arith witnesses derived from balance: FullSpec.
+  have h_full :
+      ZiskFv.AirsClean.ArithMul.FullSpec
+        (rowAt (vOfMulwRow (mulhuArow trace binding i h_main_active h_main_op)) 0) :=
+    mulhuArow_fullSpec trace binding i h_main_active h_main_op
+  -- (a) secondary op-bus match against `opBus_row_ArithMulSecondary v 0`.
+  have h_match_secondary :
+      matches_entry (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val)
+        (ZiskFv.Airs.ArithMul.opBus_row_ArithMulSecondary
+          (vOfMulwRow (mulhuArow trace binding i h_main_active h_main_op)) 0) :=
+    mulhuArow_match trace binding i h_main_active h_main_op
+  -- decode pins bundle
+  let pins :
+      ZiskFv.Compliance.MainRowPins
+        (mainOfTable trace.program binding.mainTable) i.val 1 OP_MULUH :=
+    ⟨h_main_active, h_main_op⟩
+  -- (a) Main rd-write memory witness, from `store_pc = 0`.
+  have h_core_store_pc :
+      (mainRowWithRomSub trace binding i).core.store_pc = 0 := by
+    have h_row :
+        (mainRowWithRomSub trace binding i).core =
+          ZiskFv.AirsClean.Main.rowAt (mainOfTable trace.program binding.mainTable) i.val := by
+      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+        trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+      simpa [mainRowWithRomSub,
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+    rw [h_row]
+    simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
+  let arith_mem :
+      ZiskFv.Compliance.ExternalArithMemoryWitness
+        (mainOfTable trace.program binding.mainTable) i.val
+        (busSub trace binding i execRow).e2 :=
+    { row := mainRowWithRomSub trace binding i
+      row_eq := by
+        have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+          trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+        simpa [mainRowWithRomSub,
+          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+      store_pc_zero := h_core_store_pc
+      rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
+  -- promises bundle: Sail reads + exec artifacts as binders; MemBus shape by rfl.
+  let promises : ZiskFv.EquivCore.Promises.RTypePromises
+      (binding.stateAt i) mulhu_input.r1_val mulhu_input.r2_val mulhu_input.rd mulhu_input.PC
+      (PureSpec.execute_MULH_mulhu_pure mulhu_input).nextPC
+      r1 r2 rd (busSub trace binding i execRow).exec_row (busSub trace binding i execRow).e0
+      (busSub trace binding i execRow).e1 (busSub trace binding i execRow).e2 :=
+    { input_r1_eq := h_input_r1
+      input_r2_eq := h_input_r2
+      input_rd_eq := h_input_rd
+      input_pc_eq := h_input_pc
+      exec_len := h_exec_len
+      e0_mult := h_e0_mult
+      e1_mult := h_e1_mult
+      nextPC_matches := h_nextPC_matches
+      m0_mult := by rfl
+      m0_as := by rfl
+      m1_mult := by rfl
+      m1_as := by rfl
+      m2_mult := by rfl
+      m2_as := by rfl
+      rd_idx := h_rd_idx }
+  -- Delegate to the F4 fullSpec bridge.
+  exact equiv_MULHU_of_fullSpec
+    (binding.stateAt i) mulhu_input r1 r2 rd (busSub trace binding i execRow)
+    (mainOfTable trace.program binding.mainTable) i.val
+    (vOfMulwRow (mulhuArow trace binding i h_main_active h_main_op)) 0
+    pins h_match_secondary promises arith_mem bounds
+    h_full h_rs1_value h_rs2_value
+
+end ZiskFv.Compliance

--- a/ZiskFv/Compliance/ConstructionMulw.lean
+++ b/ZiskFv/Compliance/ConstructionMulw.lean
@@ -199,18 +199,32 @@ theorem mulwArow_fullSpec
     (mulwArow_fullSpec_row trace binding i h_main_active h_main_op)
 
 /-- The op-bus match transports along the row-native view: a match against the
-    ArithMul primary op-bus message of a concrete row carries over to
-    `opBus_row_Arith (vOfMulwRow arow) 0`, because (with `multiplicity = 1`) the
-    `toEntry (primaryOpBusMessage arow) 1` entry is definitionally
-    `opBus_row_Arith (vOfMulwRow arow) 0`. -/
+    FAITHFUL muxed ArithMul primary op-bus message of a concrete row carries
+    over to `opBus_row_Arith (vOfMulwRow arow) 0` exactly at the MUL/MULW mode
+    pins (`div=0`, `main_mul=1`, `main_div=0`), via the mode-conditional bridge
+    `primaryOpBusMessage_toEntry_rowAt_eq_opBus_row`.
+
+    (Previously `rfl`; the faithful mux makes `toEntry (primaryOpBusMessage arow)
+    1` equal `opBus_row_Arith (vOfMulwRow arow) 0` only once the muxes reduce
+    under the mode pins — which the construction derives from the provider row's
+    `ArithTableSpec` + opcode pin.) -/
 theorem match_opBus_row_Arith_vOfMulwRow
     {x : ZiskFv.Airs.OperationBus.OperationBusEntry FGL}
     {arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL}
+    (h_div : arow.flags.div = 0)
+    (h_main_mul : arow.flags.main_mul = 1)
+    (h_main_div : arow.flags.main_div = 0)
     (h :
       matches_entry x
         (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
           (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage arow) 1)) :
-    matches_entry x (ZiskFv.Airs.ArithMul.opBus_row_Arith (vOfMulwRow arow) 0) := h
+    matches_entry x (ZiskFv.Airs.ArithMul.opBus_row_Arith (vOfMulwRow arow) 0) := by
+  -- `rowAt (vOfMulwRow arow) 0` agrees with `arow` field-for-field, and
+  -- `(vOfMulwRow arow).multiplicity 0 = 1`, so the mode-gated bridge rewrites
+  -- the matched entry from the muxed message to `opBus_row_Arith`.
+  rw [← ZiskFv.AirsClean.ArithMul.primaryOpBusMessage_toEntry_rowAt_eq_opBus_row
+        (vOfMulwRow arow) 0 h_div h_main_mul h_main_div]
+  exact h
 
 /-- The op-bus match of the balance-selected MULW provider row against the Main
     row's emission, in `toEntry (primaryOpBusMessage …) 1` form. Cheap: the row
@@ -229,12 +243,52 @@ theorem mulwArow_match_row
   unfold mulwArow
   set H := exists_arithMul_provider_row_matches_primary_of_mulw_from_binding
     trace binding i h_main_active h_main_op with hH
-  obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
-  obtain ⟨_h_pr_mem, _h_component, _h_spec, h_match⟩ := h_rest.choose_spec
-  exact h_match
+  -- Use direct `.choose_spec` projections (NOT `obtain`, which introduces a
+  -- fresh fvar for the row that the muxed message would force `exact` to
+  -- whnf-reconcile against the goal's `H.choose_spec.2.choose`).
+  exact H.choose_spec.2.choose_spec.2.2.2
+
+/-- MUL/MULW mode pins on the balance-selected provider row, DERIVED from its
+    `ArithTableSpec` (part of the balance-derived `FullSpec`) plus the opcode
+    pin `arow.flags.op = 182`.  These are not caller binders: they come from the
+    multiplier ROM membership the provider component already proves.
+
+    PERFORMANCE: the provider row `mulwArow …` is a heavy `Classical.choose`
+    application whose fields explode under whnf.  We therefore `set arow := …`
+    so `arow` is an opaque fvar — `ArithTableSpec`, the op-pin, and the ROM
+    `fin_cases` all act on `arow.flags.*` SYMBOLICALLY, never forcing the row's
+    `componentWithArithTable.rowInput` evaluation.  The op-pin is read off the
+    op-bus match via the CHEAP `rfl`-projection lemma `primaryOpBusMessage_toEntry_op`
+    (a rewrite, not a reduction). -/
+theorem mulwArow_mode_pins
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_MUL_W) :
+    (mulwArow trace binding i h_main_active h_main_op).flags.div = 0
+      ∧ (mulwArow trace binding i h_main_active h_main_op).flags.main_mul = 1
+      ∧ (mulwArow trace binding i h_main_active h_main_op).flags.main_div = 0 := by
+  -- Read the mode flags off the BARE provider `ArithMulRow` (`mulwArow …`),
+  -- never wrapping it in `vOfMulwRow` (whose per-field closures whnf-force the
+  -- heavy `Classical.choose` row).  `ArithTableSpec` comes from the bare
+  -- `mulwArow_fullSpec_row`; the op-pin from the muxed op-bus match via the cheap
+  -- `rfl`-projection lemma; the ROM pins from the bare-row `mulw_mode_pins_of_row`.
+  have h_table := (mulwArow_fullSpec_row trace binding i h_main_active h_main_op).2.1
+  have h_op : (mulwArow trace binding i h_main_active h_main_op).flags.op = 182 := by
+    have h_match := mulwArow_match_row trace binding i h_main_active h_main_op
+    have h_op := h_match.2.1
+    rw [ZiskFv.AirsClean.ArithMul.primaryOpBusMessage_toEntry_op,
+        show (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val).op
+          = (mainOfTable trace.program binding.mainTable).op i.val from rfl,
+        h_main_op] at h_op
+    exact h_op.symm
+  exact ZiskFv.AirsClean.ArithTableProjections.Mul.mulw_mode_pins_of_row
+    (mulwArow trace binding i h_main_active h_main_op) h_table h_op
 
 /-- The op-bus match of the balance-selected MULW provider row view against the
-    Main row's emission, in `opBus_row_Arith` form. -/
+    Main row's emission, in `opBus_row_Arith` form. The MUL/MULW mode pins
+    needed to reduce the faithful mux are DERIVED via `mulwArow_mode_pins`. -/
 theorem mulwArow_match
     (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
     (h_main_active :
@@ -244,8 +298,10 @@ theorem mulwArow_match
     matches_entry
       (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val)
       (ZiskFv.Airs.ArithMul.opBus_row_Arith
-        (vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)) 0) :=
-  match_opBus_row_Arith_vOfMulwRow
+        (vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)) 0) := by
+  obtain ⟨h_div, h_main_mul, h_main_div⟩ :=
+    mulwArow_mode_pins trace binding i h_main_active h_main_op
+  exact match_opBus_row_Arith_vOfMulwRow h_div h_main_mul h_main_div
     (mulwArow_match_row trace binding i h_main_active h_main_op)
 
 /-- Sound MULW construction: from the accepted trace + honest residual binders,

--- a/ZiskFv/Compliance/ConstructionMulw.lean
+++ b/ZiskFv/Compliance/ConstructionMulw.lean
@@ -1,0 +1,409 @@
+import ZiskFv.Compliance.AcceptedTrace
+import ZiskFv.Compliance.ConstructionSub
+import ZiskFv.Compliance.Wrappers.MulW
+
+/-!
+# Sound MULW construction (`construction_mulw_sound`)
+
+The first honest sound construction for the **Arith** family in the P4 closeout.
+It assembles the canonical MULW conclusion
+(`execute (MULW (r2, r1, rd)) = (bus_effect …).2`) from an accepted full-ensemble
+trace plus an explicit, named, top-level set of residual binders — with the
+ARITH WITNESSES (ArithTable membership, chunk/carry ranges, the `bus_res1`
+mux c46, and the carry-chain) **DERIVED FROM BALANCE**, not carried as caller
+binders.
+
+This is the anti-laundering payoff of the c46 + chunk-range + carry-range
+composition into the shared ArithMul component: the provider's
+`componentWithArithTable.Spec` is now exactly
+`FullSpec = Spec ∧ ArithTableSpec ∧ C46Spec ∧ ChunkRangeSpec ∧ CarryRangeSpec`,
+which contains everything the MULW wrapper needs from the multiplier AIR. The
+construction reads that `FullSpec` straight off the balance-derived provider row
+(`mulwArow`) and hands it to `equiv_MULW_of_fullSpec`.
+
+## The honest decomposition
+
+* **(a) derived** — proven inside the body, NOT a binder:
+  - op-bus provider match (from `trace.balanced`, via the Layer-A wrapper
+    `exists_arithMul_provider_row_matches_primary_of_mulw_from_binding`,
+    bottoming in the axiom-free keep-arithMul balance theorem),
+  - the row-native `Valid_ArithMul` view `vOfMulwRow (mulwArow …)` of the
+    balance-selected provider row,
+  - **the arith witnesses** — `FullSpec (rowAt v 0)` from the provider's
+    `componentWithArithTable.Spec` (carry-chain + ArithTable membership + c46 +
+    chunk ranges + signed-carry ranges, ALL balance-derived),
+  - the MemBus rd-write witness (`ExternalArithMemoryWitness`, from
+    `store_pc = 0`),
+  - the MemBus `m0..m2` write shape (`by rfl` off the real trace row).
+
+* **(b) named residual** — explicit top-level binders (program / ROM / Sail
+  facts the ensemble cannot finish; not new trust, but visible):
+  - decode pins (3): `h_main_op` (= `OP_MUL_W`), `h_main_active`, `h_store_pc`
+  - Sail reads + operands (5): `h_input_r1`, `h_input_r2`, `h_input_pc`,
+    `h_input_rd`, `h_rd_idx`
+  - W-mode high-lane zero + signed operand bridges (5): `h_a23`, `h_b23`,
+    `h_sext_choice`, `h_rs1_value`, `h_rs2_value` (the Sail↔chunk binding of the
+    32-bit signed operands and the sign-extension on rd bytes 4..7 — genuinely
+    residual; they reference the balance-selected provider row view
+    `vOfMulwRow (mulwArow …)`),
+  - control-flow next-PC (1): `h_nextPC_matches`.
+
+* **(c) artifact** — pure `bus_effect`/`ExecutionBusEntry` bookkeeping:
+  - exec artifacts (3): `h_exec_len`, `h_e0_mult`, `h_e1_mult`,
+  - PLUS the genuine `execRow : List (ExecutionBusEntry FGL)` **∀-binder**.
+
+## Anti-vacuity
+
+`execRow` MUST be a genuine top-level ∀-binder (the bus consumed by the exec
+hypotheses is `busSub`, built from the real trace row, NOT chosen to trivialize
+a hypothesis). The Arith witnesses are NOT binders — they are derived from
+`trace.balanced` / `trace.spec`, matching the ALU constructions' shape.
+
+## Axioms
+
+`construction_mulw_sound` introduces **0 PROJECT (`ZiskFv.*`) axioms**. As with
+every canonical theorem in this project, its closure still includes the
+Sail-translation axioms and the Lean-kernel postulates (incl. `Classical.choice`,
+used to name the balance-selected provider row) as documented external trust.
+-/
+
+namespace ZiskFv.Compliance
+
+open ZiskFv.Trusted
+open ZiskFv.Airs.Main
+open ZiskFv.Airs.OperationBus
+open ZiskFv.EquivCore.Promises
+open ZiskFv.Channels.MemoryBusBytes (byteAt)
+open ZiskFv.AirsClean.FullEnsemble
+open ZiskFv.AirsClean.ArithMul (componentWithArithTable primaryOpBusMessage rowAt)
+
+set_option maxHeartbeats 4000000
+set_option maxRecDepth 8000
+
+/-- Row-native `Valid_ArithMul` view of a concrete provider `ArithMulRow`.
+
+    Every column is the constant function returning the corresponding field of
+    `arow`, with `multiplicity` pinned to `1` (the active-row consume polarity).
+    Consequently `rowAt (vOfMulwRow arow) 0` agrees with `arow` on every field
+    `FullSpec` / `primaryOpBusMessage` dereferences, so both `FullSpec` transport
+    and the op-bus-message bridge below are `rfl` / definitional. -/
+@[reducible]
+def vOfMulwRow (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL) :
+    ZiskFv.Airs.ArithMul.Valid_ArithMul FGL FGL where
+  cy_0 := fun _ => arow.carries.carry_0
+  cy_1 := fun _ => arow.carries.carry_1
+  cy_2 := fun _ => arow.carries.carry_2
+  cy_3 := fun _ => arow.carries.carry_3
+  cy_4 := fun _ => arow.carries.carry_4
+  cy_5 := fun _ => arow.carries.carry_5
+  cy_6 := fun _ => arow.carries.carry_6
+  a_0 := fun _ => arow.chunks.a_0
+  a_1 := fun _ => arow.chunks.a_1
+  a_2 := fun _ => arow.chunks.a_2
+  a_3 := fun _ => arow.chunks.a_3
+  b_0 := fun _ => arow.chunks.b_0
+  b_1 := fun _ => arow.chunks.b_1
+  b_2 := fun _ => arow.chunks.b_2
+  b_3 := fun _ => arow.chunks.b_3
+  c_0 := fun _ => arow.chunks.c_0
+  c_1 := fun _ => arow.chunks.c_1
+  c_2 := fun _ => arow.chunks.c_2
+  c_3 := fun _ => arow.chunks.c_3
+  d_0 := fun _ => arow.chunks.d_0
+  d_1 := fun _ => arow.chunks.d_1
+  d_2 := fun _ => arow.chunks.d_2
+  d_3 := fun _ => arow.chunks.d_3
+  na := fun _ => arow.flags.na
+  nb := fun _ => arow.flags.nb
+  nr := fun _ => arow.flags.nr
+  np := fun _ => arow.flags.np
+  sext := fun _ => arow.flags.sext
+  m32 := fun _ => arow.flags.m32
+  div := fun _ => arow.flags.div
+  fab := fun _ => arow.carries.fab
+  na_fb := fun _ => arow.carries.na_fb
+  nb_fa := fun _ => arow.carries.nb_fa
+  main_div := fun _ => arow.flags.main_div
+  main_mul := fun _ => arow.flags.main_mul
+  signed := fun _ => arow.flags.signed
+  div_by_zero := fun _ => arow.flags.div_by_zero
+  div_overflow := fun _ => arow.flags.div_overflow
+  op := fun _ => arow.flags.op
+  bus_res1 := fun _ => arow.flags.bus_res1
+  multiplicity := fun _ => 1
+  range_ab := fun _ => arow.flags.range_ab
+  range_cd := fun _ => arow.flags.range_cd
+
+/-- The balance-selected Arith-Mul provider row at trace index `i`, as a concrete
+    `ArithMulRow`. It is the `componentWithArithTable.rowInput` of the provider
+    row chosen by the keep-arithMul balance wrapper
+    `exists_arithMul_provider_row_matches_primary_of_mulw_from_binding`.
+
+    This is a deterministic handle on the balance-selected row, used to phrase
+    the residual operand bridges over its row-native view
+    `vOfMulwRow (mulwArow …)`. The Arith witnesses for this row are derived
+    inside `construction_mulw_sound`; nothing about the row is caller-supplied. -/
+noncomputable def mulwArow
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_MUL_W) :
+    ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
+  let h := exists_arithMul_provider_row_matches_primary_of_mulw_from_binding
+    trace binding i h_main_active h_main_op
+  componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
+
+/-- `FullSpec` transports along the row-native view: a `FullSpec` for a concrete
+    `ArithMulRow` carries over to `rowAt (vOfMulwRow arow) 0`, because the two
+    rows agree on every field `FullSpec` dereferences (they differ only in
+    `multiplicity`, which `FullSpec` never reads). -/
+theorem fullSpec_rowAt_vOfMulwRow
+    {arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL}
+    (h : ZiskFv.AirsClean.ArithMul.FullSpec arow) :
+    ZiskFv.AirsClean.ArithMul.FullSpec (rowAt (vOfMulwRow arow) 0) := h
+
+/-- `FullSpec` of the balance-selected MULW provider row, derived from the
+    provider component's proven soundness (`componentWithArithTable.Spec`).
+
+    Proved here, at the `mulwArow` definition site, so the `Classical.choose`
+    underlying `mulwArow` matches the one this proof picks — keeping the defeq
+    cheap for the construction body. -/
+theorem mulwArow_fullSpec_row
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_MUL_W) :
+    ZiskFv.AirsClean.ArithMul.FullSpec (mulwArow trace binding i h_main_active h_main_op) := by
+  unfold mulwArow
+  set H := exists_arithMul_provider_row_matches_primary_of_mulw_from_binding
+    trace binding i h_main_active h_main_op with hH
+  obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
+  obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
+  -- Cheap projection of the provider component's generic `Spec` to `FullSpec`
+  -- (the heavy `componentWithArithTable.Spec` unfold lives once in `Balance`).
+  exact ZiskFv.AirsClean.FullEnsemble.arithMul_fullSpec_of_component_spec
+    h_component (h_spec h_rest.choose h_pr_mem)
+
+/-- `FullSpec` of the balance-selected MULW provider row view. -/
+theorem mulwArow_fullSpec
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_MUL_W) :
+    ZiskFv.AirsClean.ArithMul.FullSpec
+      (rowAt (vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)) 0) :=
+  fullSpec_rowAt_vOfMulwRow
+    (mulwArow_fullSpec_row trace binding i h_main_active h_main_op)
+
+/-- The op-bus match transports along the row-native view: a match against the
+    ArithMul primary op-bus message of a concrete row carries over to
+    `opBus_row_Arith (vOfMulwRow arow) 0`, because (with `multiplicity = 1`) the
+    `toEntry (primaryOpBusMessage arow) 1` entry is definitionally
+    `opBus_row_Arith (vOfMulwRow arow) 0`. -/
+theorem match_opBus_row_Arith_vOfMulwRow
+    {x : ZiskFv.Airs.OperationBus.OperationBusEntry FGL}
+    {arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL}
+    (h :
+      matches_entry x
+        (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+          (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage arow) 1)) :
+    matches_entry x (ZiskFv.Airs.ArithMul.opBus_row_Arith (vOfMulwRow arow) 0) := h
+
+/-- The op-bus match of the balance-selected MULW provider row against the Main
+    row's emission, in `toEntry (primaryOpBusMessage …) 1` form. Cheap: the row
+    is a free `ArithMulRow`, so no `vOfMulwRow`/`opBus_row_Arith` whnf. -/
+theorem mulwArow_match_row
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_MUL_W) :
+    matches_entry
+      (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val)
+      (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+        (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+          (mulwArow trace binding i h_main_active h_main_op)) 1) := by
+  unfold mulwArow
+  set H := exists_arithMul_provider_row_matches_primary_of_mulw_from_binding
+    trace binding i h_main_active h_main_op with hH
+  obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
+  obtain ⟨_h_pr_mem, _h_component, _h_spec, h_match⟩ := h_rest.choose_spec
+  exact h_match
+
+/-- The op-bus match of the balance-selected MULW provider row view against the
+    Main row's emission, in `opBus_row_Arith` form. -/
+theorem mulwArow_match
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_MUL_W) :
+    matches_entry
+      (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val)
+      (ZiskFv.Airs.ArithMul.opBus_row_Arith
+        (vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)) 0) :=
+  match_opBus_row_Arith_vOfMulwRow
+    (mulwArow_match_row trace binding i h_main_active h_main_op)
+
+/-- Sound MULW construction: from the accepted trace + honest residual binders,
+    conclude the canonical `execute (MULW (r2, r1, rd)) = (bus_effect …).2`.
+
+    The Arith provider witnesses (ArithTable membership, chunk ranges, signed
+    carry ranges, c46, carry-chain) are DERIVED inside the body from
+    `trace.balanced` / `trace.spec` via the provider's lookup-aware
+    `componentWithArithTable.Spec = FullSpec`, NOT supplied as binders. -/
+theorem construction_mulw_sound
+    (trace : AcceptedTrace)
+    (binding : ProgramBinding trace)
+    (i : Fin trace.length)
+    (mulw_input : PureSpec.MulwInput)
+    (r1 r2 rd : regidx)
+    -- (b) decode pins
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_MUL_W)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_store_pc :
+      (mainOfTable trace.program binding.mainTable).store_pc i.val = 0)
+    -- (b) Sail reads + operands
+    (h_input_r1 :
+      read_xreg (regidx_to_fin r1) (binding.stateAt i)
+        = EStateM.Result.ok mulw_input.r1_val (binding.stateAt i))
+    (h_input_r2 :
+      read_xreg (regidx_to_fin r2) (binding.stateAt i)
+        = EStateM.Result.ok mulw_input.r2_val (binding.stateAt i))
+    (h_input_pc : (binding.stateAt i).regs.get? Register.PC = .some mulw_input.PC)
+    (h_input_rd : mulw_input.rd = regidx_to_fin rd)
+    -- (c) exec artifacts: the exec row is a genuine top-level binder.
+    (execRow : List (Interaction.ExecutionBusEntry FGL))
+    (h_exec_len : (busSub trace binding i execRow).exec_row.length = 2)
+    (h_e0_mult : (busSub trace binding i execRow).exec_row[0]!.multiplicity = -1)
+    (h_e1_mult : (busSub trace binding i execRow).exec_row[1]!.multiplicity = 1)
+    (h_nextPC_matches :
+      (register_type_pc_equiv ▸
+          (BitVec.ofNat 64 ((busSub trace binding i execRow).exec_row[1]!.pc).val))
+        = (PureSpec.execute_MULW_pure mulw_input).nextPC)
+    (h_rd_idx :
+      mulw_input.rd =
+        Transpiler.wrap_to_regidx (busSub trace binding i execRow).e2.ptr)
+    -- (b) W-mode high-lane zero + signed operand bridges (Sail↔chunk binding,
+    -- phrased over the balance-selected provider row view).
+    (h_a23 :
+      ((vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)).a_2 0).val = 0
+        ∧ ((vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)).a_3 0).val = 0)
+    (h_b23 :
+      ((vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)).b_2 0).val = 0
+        ∧ ((vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)).b_3 0).val = 0)
+    (h_sext_choice :
+      ((((byteAt (busSub trace binding i execRow).e2 4).val = 0
+            ∧ (byteAt (busSub trace binding i execRow).e2 5).val = 0
+            ∧ (byteAt (busSub trace binding i execRow).e2 6).val = 0
+            ∧ (byteAt (busSub trace binding i execRow).e2 7).val = 0)
+          ∧ ((vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)).c_0 0).val
+              + ((vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)).c_1 0).val * 65536
+                < 2147483648)
+        ∨ (((byteAt (busSub trace binding i execRow).e2 4).val = 255
+            ∧ (byteAt (busSub trace binding i execRow).e2 5).val = 255
+            ∧ (byteAt (busSub trace binding i execRow).e2 6).val = 255
+            ∧ (byteAt (busSub trace binding i execRow).e2 7).val = 255)
+          ∧ ((vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)).c_0 0).val
+              + ((vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)).c_1 0).val * 65536
+                ≥ 2147483648)))
+    (h_rs1_value :
+      (Sail.BitVec.extractLsb mulw_input.r1_val 31 0).toInt
+        = (((vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)).a_0 0).val
+              + ((vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)).a_1 0).val * 65536 : ℤ)
+            - ((vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)).na 0).val * (2:ℤ)^32)
+    (h_rs2_value :
+      (Sail.BitVec.extractLsb mulw_input.r2_val 31 0).toInt
+        = (((vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)).b_0 0).val
+              + ((vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)).b_1 0).val * 65536 : ℤ)
+            - ((vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)).nb 0).val * (2:ℤ)^32) :
+    (do
+      Sail.writeReg Register.nextPC
+        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
+      LeanRV64D.Functions.execute
+        (instruction.MULW (r2, r1, rd))) (binding.stateAt i)
+      = (bus_effect (busSub trace binding i execRow).exec_row
+          [ (busSub trace binding i execRow).e0
+          , (busSub trace binding i execRow).e1
+          , (busSub trace binding i execRow).e2 ] (binding.stateAt i)).2 := by
+  -- The balance-selected provider row view.  Kept as the explicit syntactic
+  -- term `vOfMulwRow (mulwArow …)` (NOT `set`/`let`) so it matches the residual
+  -- operand binders verbatim, avoiding any `mulwArow` whnf in the delegation.
+  -- (a) Arith witnesses, derived from `trace.balanced` / `trace.spec`:
+  --   FullSpec (carry-chain + ArithTable + c46 + chunk/carry ranges) from the
+  --   provider component's proven soundness.
+  have h_full :
+      ZiskFv.AirsClean.ArithMul.FullSpec
+        (rowAt (vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)) 0) :=
+    mulwArow_fullSpec trace binding i h_main_active h_main_op
+  -- (a) op-bus match against `opBus_row_Arith v 0`, derived via the Layer-A
+  -- keep-arithMul balance wrapper.
+  have h_match_primary :
+      matches_entry (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val)
+        (ZiskFv.Airs.ArithMul.opBus_row_Arith
+          (vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)) 0) :=
+    mulwArow_match trace binding i h_main_active h_main_op
+  -- decode pins bundle
+  let pins :
+      ZiskFv.Compliance.MainRowPins
+        (mainOfTable trace.program binding.mainTable) i.val 1 OP_MUL_W :=
+    ⟨h_main_active, h_main_op⟩
+  -- (a) Main rd-write memory witness, from `store_pc = 0`.
+  have h_core_store_pc :
+      (mainRowWithRomSub trace binding i).core.store_pc = 0 := by
+    have h_row :
+        (mainRowWithRomSub trace binding i).core =
+          ZiskFv.AirsClean.Main.rowAt (mainOfTable trace.program binding.mainTable) i.val := by
+      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+        trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+      simpa [mainRowWithRomSub,
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+    rw [h_row]
+    simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
+  let arith_mem :
+      ZiskFv.Compliance.ExternalArithMemoryWitness
+        (mainOfTable trace.program binding.mainTable) i.val
+        (busSub trace binding i execRow).e2 :=
+    { row := mainRowWithRomSub trace binding i
+      row_eq := by
+        have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+          trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+        simpa [mainRowWithRomSub,
+          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+      store_pc_zero := h_core_store_pc
+      rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
+  -- promises bundle: Sail reads + exec artifacts as binders; MemBus shape by rfl.
+  let promises : ZiskFv.EquivCore.Promises.RTypePromises
+      (binding.stateAt i) mulw_input.r1_val mulw_input.r2_val mulw_input.rd mulw_input.PC
+      (PureSpec.execute_MULW_pure mulw_input).nextPC
+      r1 r2 rd (busSub trace binding i execRow).exec_row (busSub trace binding i execRow).e0
+      (busSub trace binding i execRow).e1 (busSub trace binding i execRow).e2 :=
+    { input_r1_eq := h_input_r1
+      input_r2_eq := h_input_r2
+      input_rd_eq := h_input_rd
+      input_pc_eq := h_input_pc
+      exec_len := h_exec_len
+      e0_mult := h_e0_mult
+      e1_mult := h_e1_mult
+      nextPC_matches := h_nextPC_matches
+      m0_mult := by rfl
+      m0_as := by rfl
+      m1_mult := by rfl
+      m1_as := by rfl
+      m2_mult := by rfl
+      m2_as := by rfl
+      rd_idx := h_rd_idx }
+  -- Delegate to the F4 fullSpec wrapper.
+  exact equiv_MULW_of_fullSpec
+    (binding.stateAt i) mulw_input r1 r2 rd (busSub trace binding i execRow)
+    (mainOfTable trace.program binding.mainTable) i.val
+    (vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)) 0
+    pins h_match_primary promises arith_mem
+    h_full h_a23 h_b23 h_sext_choice h_rs1_value h_rs2_value
+
+end ZiskFv.Compliance

--- a/ZiskFv/Compliance/ConstructionRemu.lean
+++ b/ZiskFv/Compliance/ConstructionRemu.lean
@@ -1,0 +1,751 @@
+import ZiskFv.Compliance.AcceptedTrace
+import ZiskFv.Compliance.ConstructionMulw
+import ZiskFv.Compliance.ConstructionMulhu
+import ZiskFv.Compliance.ConstructionDivu
+import ZiskFv.EquivCore.Remu
+import ZiskFv.EquivCore.Promises.ArithHelpers
+import ZiskFv.EquivCore.Bridge.Arith
+import ZiskFv.AirsClean.ArithMul.Bridge
+import ZiskFv.AirsClean.ArithDiv.Bridge
+import ZiskFv.AirsClean.ArithTableProjections
+import ZiskFv.Airs.Arith.Div
+import ZiskFv.Airs.Arith.BusRes1
+import ZiskFv.Bits.PackedBitVec.MulNoWrap
+
+/-!
+# Sound REMU construction (`construction_remu_sound`)
+
+Unsigned RV64M **REMU** (`OP_REMU = 185`), the remainder sibling of DIVU.
+The Arith provider witnesses (ArithTable membership, chunk ranges,
+signed-carry ranges, c46, carry-chain) are **DERIVED FROM BALANCE** via the
+SHARED ArithMul provider component's lookup-aware
+`componentWithArithTable.Spec = FullSpec`, not carried as caller binders.
+
+## Why the shared ArithMul provider (not ArithDiv)
+
+`ArithDiv.component` carries NO operation-bus interactions in the full
+ensemble (`arithDiv_table_interactionsWith_opBus_nil`): its
+`circuit.channels = []`.  The REMU Main op-bus emission is therefore balanced
+by the SHARED ArithMul provider (`componentWithArithTable`), whose `FullSpec`
+covers div rows too (the carry chain is mode-shared via the `div` flag).
+
+## The REMU SECONDARY lane (delta from DIVU)
+
+REMU's result is the **remainder** in `d[]`, not the quotient in `a[]`.  REMU
+consumes the **secondary** Arith lane: `main_div = 0`, `main_mul = 0` (so
+`secondary = 1`).  At these mode pins the muxed primary op-bus message's `c_lo`
+lane `(1 - main_mul - main_div)·(d_0 + d_1·2^16) + …` collapses to
+`d_0 + d_1·2^16` (the remainder low half), so the muxed message reduces to the
+div **remainder**-lane message `opBus_row_ArithDivSecondary`, NOT the
+quotient-lane `opBus_row_ArithDiv` that DIVU uses.  The REMU-mode op-bus bridge
+below therefore differs from DIVU's: it pins `main_div = 0` (vs DIVU's
+`main_div = 1`) and targets `opBus_row_ArithDivSecondary`.  The high half comes
+from `bus_res1 = d_2 + d_3·2^16` (constraint 46 at the secondary pins, via
+`rem_bus_res1_eq_d_hi`).
+
+## The carry-range subtlety (vs MULW)
+
+`EquivCore.Remu.equiv_REMU` consumes carry witnesses through
+`div_unsigned_chain_witnesses_of_carry_ranges`; this bridge instead derives the
+looser balance-constructible bound `< 983041` (via `divu_carry_bounds`, reused
+from `ConstructionDivu`) and reconstructs the rd write value through the
+loose-bound REMU write-value path `h_rd_val_mdru_remu_loose`, replicating
+`equiv_REMU`'s sail + `bus_effect` tail otherwise.
+
+## The remainder bound is RESIDUAL, not balance-derived
+
+`equiv_REMU` needs `ArithDivRemainderBoundWitness` — the `|d| < b` LTU check
+from `arith.pil:274`.  This is the ArithDiv op-bus *consumer*
+(`assumes_operation`) edge matched against a Binary LTU provider row.  Because
+`ArithDiv.component` emits no op-bus in the ensemble, this consume edge is a
+finished-channel SELF-EDGE that is **not composed into the ensemble** — so it is
+NOT balance-derivable.  It is carried as the single explicit residual binder
+`remainder_bound` (exactly as the canonical `equiv_REMU` already carries it).
+
+## Axioms
+
+`construction_remu_sound` introduces **0 PROJECT (`ZiskFv.*`) axioms**.  Its
+closure carries `Lean.ofReduceBool` / `Lean.trustCompiler` (native_decide)
+INHERITED from the canonical `equiv_REMU` path (already has it; NOT new —
+tracked by #75), plus `Classical.choice` / `Quot.sound`, the Sail-translation
+postulates, and the Lean-kernel postulates.
+-/
+
+namespace ZiskFv.Compliance
+
+open Goldilocks
+open ZiskFv.Trusted
+open ZiskFv.Airs.Main
+open ZiskFv.Airs.OperationBus
+open ZiskFv.Channels.MemoryBusBytes (byteAt)
+open ZiskFv.AirsClean.FullEnsemble
+open ZiskFv.AirsClean.ArithMul (componentWithArithTable primaryOpBusMessage rowAt)
+
+set_option maxHeartbeats 4000000
+set_option maxRecDepth 8000
+
+/-! ## Phase 1 — REMU-mode op-bus bridge (secondary remainder lane) -/
+
+/-- REMU-mode op-bus bridge: the FAITHFUL muxed ArithMul primary message
+    reduces to the div remainder-lane `opBus_row_ArithDivSecondary` entry
+    exactly at the REMU mode pins (`div = 1`, `main_div = 0`, `main_mul = 0`).
+
+    At these pins the muxed `a_lo`/`a_hi` lanes (`div·c + (1-div)·a`) collapse
+    to the `c`-chunks (dividend), and the muxed `c_lo` lane
+    `(1-main_mul-main_div)·d + main_mul·c + main_div·a` collapses to the
+    `d`-chunks (remainder) — i.e. the muxed primary message at REMU mode IS the
+    div remainder-lane message.  Differs from DIVU's bridge in pinning
+    `main_div = 0` (vs DIVU's `main_div = 1`) and targeting the secondary row. -/
+theorem primaryOpBusMessage_toEntry_eq_opBus_row_ArithDivSecondary
+    (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL)
+    (h_div : arow.flags.div = 1) (h_main_div : arow.flags.main_div = 0)
+    (h_main_mul : arow.flags.main_mul = 0) :
+    ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+        (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage arow) 1 =
+      ZiskFv.Airs.ArithDiv.opBus_row_ArithDivSecondary (vOfDivuRow arow) 0 := by
+  simp only [ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
+    ZiskFv.AirsClean.ArithMul.primaryOpBusMessage,
+    ZiskFv.Airs.ArithDiv.opBus_row_ArithDivSecondary, vOfDivuRow,
+    h_div, h_main_div, h_main_mul]
+  ring
+
+/-- The REMU op-bus match transports along the ArithDiv secondary row-native
+    view: a match against the FAITHFUL muxed primary message of a concrete row
+    carries over to `opBus_row_ArithDivSecondary (vOfDivuRow arow) 0`, via the
+    REMU-mode bridge. -/
+theorem match_opBus_row_ArithDivSecondary_vOfDivuRow
+    {x : ZiskFv.Airs.OperationBus.OperationBusEntry FGL}
+    {arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL}
+    (h_div : arow.flags.div = 1) (h_main_div : arow.flags.main_div = 0)
+    (h_main_mul : arow.flags.main_mul = 0)
+    (h :
+      matches_entry x
+        (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+          (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage arow) 1)) :
+    matches_entry x
+      (ZiskFv.Airs.ArithDiv.opBus_row_ArithDivSecondary (vOfDivuRow arow) 0) := by
+  rw [← primaryOpBusMessage_toEntry_eq_opBus_row_ArithDivSecondary
+        arow h_div h_main_div h_main_mul]
+  exact h
+
+/-! ## Phase 3 — balance-selected REMU provider row + transports -/
+
+/-- The balance-selected Arith-Mul provider row at trace index `i` for a REMU
+    operation, as a concrete `ArithMulRow`.  It is the
+    `componentWithArithTable.rowInput` of the provider row chosen by the REMU
+    keep-arithMul balance wrapper
+    `exists_arithMul_provider_row_matches_primary_of_remu_from_binding`.
+    Mirrors `divuArow`. -/
+noncomputable def remuArow
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_REMU) :
+    ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
+  let h := exists_arithMul_provider_row_matches_primary_of_remu_from_binding
+    trace binding i h_main_active h_main_op
+  componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
+
+/-- `FullSpec` of the balance-selected REMU provider row, derived from the
+    provider component's proven soundness (`componentWithArithTable.Spec`). -/
+theorem remuArow_fullSpec_row
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_REMU) :
+    ZiskFv.AirsClean.ArithMul.FullSpec
+      (remuArow trace binding i h_main_active h_main_op) := by
+  unfold remuArow
+  set H := exists_arithMul_provider_row_matches_primary_of_remu_from_binding
+    trace binding i h_main_active h_main_op with hH
+  obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
+  obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
+  exact ZiskFv.AirsClean.FullEnsemble.arithMul_fullSpec_of_component_spec
+    h_component (h_spec h_rest.choose h_pr_mem)
+
+/-- The op-bus match of the balance-selected REMU provider row against the Main
+    row's emission, in `toEntry (primaryOpBusMessage …) 1` form. -/
+theorem remuArow_match_row
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_REMU) :
+    matches_entry
+      (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val)
+      (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+        (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+          (remuArow trace binding i h_main_active h_main_op)) 1) := by
+  unfold remuArow
+  set H := exists_arithMul_provider_row_matches_primary_of_remu_from_binding
+    trace binding i h_main_active h_main_op with hH
+  exact H.choose_spec.2.choose_spec.2.2.2
+
+/-- REMU mode pins on the balance-selected provider row, DERIVED from its
+    `ArithTableSpec` (part of `FullSpec`) plus the opcode pin
+    `arow.flags.op = 185`.  These are not caller binders.  Reads the mode flags
+    off the BARE provider `ArithMulRow` via `remu_mode_pins_of_row`, never
+    forcing the heavy `Classical.choose` row's whnf. -/
+theorem remuArow_mode_pins
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_REMU) :
+    (remuArow trace binding i h_main_active h_main_op).flags.na = 0
+      ∧ (remuArow trace binding i h_main_active h_main_op).flags.nb = 0
+      ∧ (remuArow trace binding i h_main_active h_main_op).flags.np = 0
+      ∧ (remuArow trace binding i h_main_active h_main_op).flags.nr = 0
+      ∧ (remuArow trace binding i h_main_active h_main_op).flags.sext = 0
+      ∧ (remuArow trace binding i h_main_active h_main_op).flags.m32 = 0
+      ∧ (remuArow trace binding i h_main_active h_main_op).flags.div = 1
+      ∧ (remuArow trace binding i h_main_active h_main_op).flags.main_div = 0
+      ∧ (remuArow trace binding i h_main_active h_main_op).flags.main_mul = 0 := by
+  have h_table := (remuArow_fullSpec_row trace binding i h_main_active h_main_op).2.1
+  have h_op : (remuArow trace binding i h_main_active h_main_op).flags.op = 185 := by
+    have h_match := remuArow_match_row trace binding i h_main_active h_main_op
+    have h_op := h_match.2.1
+    rw [ZiskFv.AirsClean.ArithMul.primaryOpBusMessage_toEntry_op,
+        show (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val).op
+          = (mainOfTable trace.program binding.mainTable).op i.val from rfl,
+        h_main_op] at h_op
+    simpa [OP_REMU] using h_op.symm
+  exact ZiskFv.AirsClean.ArithTableProjections.Mul.remu_mode_pins_of_row
+    (remuArow trace binding i h_main_active h_main_op) h_table h_op
+
+/-- The op-bus match of the balance-selected REMU provider row view against the
+    Main row's emission, in `opBus_row_ArithDivSecondary` form.  The REMU mode
+    pins needed to reduce the faithful mux are DERIVED via `remuArow_mode_pins`. -/
+theorem remuArow_match
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_REMU) :
+    matches_entry
+      (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val)
+      (ZiskFv.Airs.ArithDiv.opBus_row_ArithDivSecondary
+        (vOfDivuRow (remuArow trace binding i h_main_active h_main_op)) 0) := by
+  obtain ⟨_, _, _, _, _, _, h_div, h_main_div, h_main_mul⟩ :=
+    remuArow_mode_pins trace binding i h_main_active h_main_op
+  exact match_opBus_row_ArithDivSecondary_vOfDivuRow h_div h_main_div h_main_mul
+    (remuArow_match_row trace binding i h_main_active h_main_op)
+
+/-! ## Phase 2 — balance-derived div-Euclidean chunk equations + loose carry bounds
+
+The REMU Euclidean chunk identity is the SAME as DIVU's: the carry-chain
+constraints 31–38 do not reference `main_div` / `main_mul` (they share the `div`
+flag).  We re-derive them here over `vOfDivuRow` (reused from `ConstructionDivu`)
+at the unsigned mode pins `na = nb = np = nr = m32 = 0`, `div = 1` — identical
+to `divu_chain_eqs` / `divu_carry_bounds`, but those are `private` to
+`ConstructionDivu`, so (as DIVUW does) we keep local copies here. -/
+
+open ZiskFv.Airs.ArithMul in
+/-- **Mode-pinned REMU Euclidean chunk equations.** Identical to DIVU's
+    `divu_chain_eqs` — the carry-chain constraints 31–38 are
+    `main_div`/`main_mul`-independent, so the REMU secondary-lane chain is the
+    same low Euclidean form. -/
+private lemma remu_chain_eqs
+    (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL)
+    (h_chain : mul_carry_chain_holds (vOfMulwRow arow) 0)
+    (h_na : arow.flags.na = 0) (h_nb : arow.flags.nb = 0)
+    (h_np : arow.flags.np = 0) (h_nr : arow.flags.nr = 0)
+    (h_m32 : arow.flags.m32 = 0) (h_div : arow.flags.div = 1) :
+    (arow.chunks.a_0 * arow.chunks.b_0 + arow.chunks.d_0
+        = arow.chunks.c_0 + arow.carries.carry_0 * 65536)
+    ∧ (arow.chunks.a_1 * arow.chunks.b_0 + arow.chunks.a_0 * arow.chunks.b_1
+        + arow.chunks.d_1 + arow.carries.carry_0
+        = arow.chunks.c_1 + arow.carries.carry_1 * 65536)
+    ∧ (arow.chunks.a_2 * arow.chunks.b_0 + arow.chunks.a_1 * arow.chunks.b_1
+        + arow.chunks.a_0 * arow.chunks.b_2 + arow.chunks.d_2 + arow.carries.carry_1
+        = arow.chunks.c_2 + arow.carries.carry_2 * 65536)
+    ∧ (arow.chunks.a_3 * arow.chunks.b_0 + arow.chunks.a_2 * arow.chunks.b_1
+        + arow.chunks.a_1 * arow.chunks.b_2 + arow.chunks.a_0 * arow.chunks.b_3
+        + arow.chunks.d_3 + arow.carries.carry_2
+        = arow.chunks.c_3 + arow.carries.carry_3 * 65536)
+    ∧ (arow.chunks.a_3 * arow.chunks.b_1 + arow.chunks.a_2 * arow.chunks.b_2
+        + arow.chunks.a_1 * arow.chunks.b_3 + arow.carries.carry_3
+        = arow.carries.carry_4 * 65536)
+    ∧ (arow.chunks.a_3 * arow.chunks.b_2 + arow.chunks.a_2 * arow.chunks.b_3
+        + arow.carries.carry_4 = arow.carries.carry_5 * 65536)
+    ∧ (arow.chunks.a_3 * arow.chunks.b_3 + arow.carries.carry_5
+        = arow.carries.carry_6 * 65536)
+    ∧ (arow.carries.carry_6 = 0) := by
+  obtain ⟨h6, h7, h8, h31, h32, h33, h34, h35, h36, h37, h38⟩ := h_chain
+  simp only [mul_constraint_6_named, mul_constraint_7_named, mul_constraint_8_named,
+             vOfMulwRow, h_na, h_nb, mul_zero, zero_mul, add_zero, sub_zero] at h6 h7 h8
+  have h_fab : arow.carries.fab = (1 : FGL) := by linear_combination h6
+  have h_nafb : arow.carries.na_fb = (0 : FGL) := by linear_combination h7
+  have h_nbfa : arow.carries.nb_fa = (0 : FGL) := by linear_combination h8
+  simp only [mul_constraint_31_named, mul_constraint_32_named,
+             mul_constraint_33_named, mul_constraint_34_named,
+             mul_constraint_35_named, mul_constraint_36_named,
+             mul_constraint_37_named, mul_constraint_38_named,
+             vOfMulwRow, h_na, h_nb, h_np, h_nr, h_m32, h_div, h_fab, h_nafb, h_nbfa,
+             mul_zero, zero_mul, add_zero, sub_zero, mul_one, one_mul]
+    at h31 h32 h33 h34 h35 h36 h37 h38
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · linear_combination h31
+  · linear_combination h32
+  · linear_combination h33
+  · linear_combination h34
+  · linear_combination h35
+  · linear_combination h36
+  · linear_combination h37
+  · linear_combination h38
+
+/-- **Balance-constructible REMU unsigned carry bounds.** Identical to DIVU's
+    `divu_carry_bounds`: derive the looser unsigned-side carry bounds
+    `cy_i.val < 983041` via `unsigned_carry_step_nat` (reused from
+    `ConstructionMulhu`). -/
+private lemma remu_carry_bounds
+    (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL)
+    (h_chunks : ZiskFv.EquivCore.Bridge.Arith.ArithDivChunkRangesAt (vOfDivuRow arow) 0)
+    (h_csgn : ZiskFv.EquivCore.Bridge.Arith.ArithDivSignedCarryRangesAt (vOfDivuRow arow) 0)
+    (heqs :
+      (arow.chunks.a_0 * arow.chunks.b_0 + arow.chunks.d_0
+          = arow.chunks.c_0 + arow.carries.carry_0 * 65536)
+      ∧ (arow.chunks.a_1 * arow.chunks.b_0 + arow.chunks.a_0 * arow.chunks.b_1
+          + arow.chunks.d_1 + arow.carries.carry_0
+          = arow.chunks.c_1 + arow.carries.carry_1 * 65536)
+      ∧ (arow.chunks.a_2 * arow.chunks.b_0 + arow.chunks.a_1 * arow.chunks.b_1
+          + arow.chunks.a_0 * arow.chunks.b_2 + arow.chunks.d_2 + arow.carries.carry_1
+          = arow.chunks.c_2 + arow.carries.carry_2 * 65536)
+      ∧ (arow.chunks.a_3 * arow.chunks.b_0 + arow.chunks.a_2 * arow.chunks.b_1
+          + arow.chunks.a_1 * arow.chunks.b_2 + arow.chunks.a_0 * arow.chunks.b_3
+          + arow.chunks.d_3 + arow.carries.carry_2
+          = arow.chunks.c_3 + arow.carries.carry_3 * 65536)
+      ∧ (arow.chunks.a_3 * arow.chunks.b_1 + arow.chunks.a_2 * arow.chunks.b_2
+          + arow.chunks.a_1 * arow.chunks.b_3 + arow.carries.carry_3
+          = arow.carries.carry_4 * 65536)
+      ∧ (arow.chunks.a_3 * arow.chunks.b_2 + arow.chunks.a_2 * arow.chunks.b_3
+          + arow.carries.carry_4 = arow.carries.carry_5 * 65536)
+      ∧ (arow.chunks.a_3 * arow.chunks.b_3 + arow.carries.carry_5
+          = arow.carries.carry_6 * 65536)
+      ∧ (arow.carries.carry_6 = 0)) :
+    (arow.carries.carry_0).val < 983041 ∧ (arow.carries.carry_1).val < 983041
+    ∧ (arow.carries.carry_2).val < 983041 ∧ (arow.carries.carry_3).val < 983041
+    ∧ (arow.carries.carry_4).val < 983041 ∧ (arow.carries.carry_5).val < 983041
+    ∧ (arow.carries.carry_6).val < 983041 := by
+  obtain ⟨ha0, ha1, ha2, ha3, hb0, hb1, hb2, hb3,
+          hc0, hc1, hc2, hc3, hd0, hd1, hd2, hd3⟩ := h_chunks
+  obtain ⟨hs0, hs1, hs2, hs3, hs4, hs5, hs6⟩ := h_csgn
+  obtain ⟨hC31, hC32, hC33, hC34, hC35, hC36, hC37, hC38⟩ := heqs
+  simp only [vOfDivuRow] at ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hc0 hc1 hc2 hc3 hd0 hd1 hd2 hd3
+  simp only [vOfDivuRow] at hs0 hs1 hs2 hs3 hs4 hs5 hs6
+  have b0 : (arow.carries.carry_0).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_0).val * (arow.chunks.b_0).val + (arow.chunks.d_0).val)
+      _ _ ?_ hc0 ?_ hs0
+    · push_cast; linear_combination hC31
+    · have : (arow.chunks.a_0).val * (arow.chunks.b_0).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b1 : (arow.carries.carry_1).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_1).val * (arow.chunks.b_0).val
+        + (arow.chunks.a_0).val * (arow.chunks.b_1).val
+        + (arow.chunks.d_1).val + (arow.carries.carry_0).val) _ _ ?_ hc1 ?_ hs1
+    · push_cast; linear_combination hC32
+    · have h1 : (arow.chunks.a_1).val * (arow.chunks.b_0).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (arow.chunks.a_0).val * (arow.chunks.b_1).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b2 : (arow.carries.carry_2).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_2).val * (arow.chunks.b_0).val
+        + (arow.chunks.a_1).val * (arow.chunks.b_1).val
+        + (arow.chunks.a_0).val * (arow.chunks.b_2).val
+        + (arow.chunks.d_2).val + (arow.carries.carry_1).val) _ _ ?_ hc2 ?_ hs2
+    · push_cast; linear_combination hC33
+    · have h1 : (arow.chunks.a_2).val * (arow.chunks.b_0).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (arow.chunks.a_1).val * (arow.chunks.b_1).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h3 : (arow.chunks.a_0).val * (arow.chunks.b_2).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b3 : (arow.carries.carry_3).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_3).val * (arow.chunks.b_0).val
+        + (arow.chunks.a_2).val * (arow.chunks.b_1).val
+        + (arow.chunks.a_1).val * (arow.chunks.b_2).val
+        + (arow.chunks.a_0).val * (arow.chunks.b_3).val
+        + (arow.chunks.d_3).val + (arow.carries.carry_2).val) _ _ ?_ hc3 ?_ hs3
+    · push_cast; linear_combination hC34
+    · have h1 : (arow.chunks.a_3).val * (arow.chunks.b_0).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (arow.chunks.a_2).val * (arow.chunks.b_1).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h3 : (arow.chunks.a_1).val * (arow.chunks.b_2).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h4 : (arow.chunks.a_0).val * (arow.chunks.b_3).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b4 : (arow.carries.carry_4).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_3).val * (arow.chunks.b_1).val
+        + (arow.chunks.a_2).val * (arow.chunks.b_2).val
+        + (arow.chunks.a_1).val * (arow.chunks.b_3).val
+        + (arow.carries.carry_3).val) 0 _ ?_ (by omega) ?_ hs4
+    · push_cast; linear_combination hC35
+    · have h1 : (arow.chunks.a_3).val * (arow.chunks.b_1).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (arow.chunks.a_2).val * (arow.chunks.b_2).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h3 : (arow.chunks.a_1).val * (arow.chunks.b_3).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b5 : (arow.carries.carry_5).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_3).val * (arow.chunks.b_2).val
+        + (arow.chunks.a_2).val * (arow.chunks.b_3).val
+        + (arow.carries.carry_4).val) 0 _ ?_ (by omega) ?_ hs5
+    · push_cast; linear_combination hC36
+    · have h1 : (arow.chunks.a_3).val * (arow.chunks.b_2).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (arow.chunks.a_2).val * (arow.chunks.b_3).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b6 : (arow.carries.carry_6).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_3).val * (arow.chunks.b_3).val + (arow.carries.carry_5).val)
+      0 _ ?_ (by omega) ?_ hs6
+    · push_cast; linear_combination hC37
+    · have h1 : (arow.chunks.a_3).val * (arow.chunks.b_3).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  exact ⟨b0, b1, b2, b3, b4, b5, b6⟩
+
+/-! ## Phase 4 — F4 `FullSpec` discharge bridge for REMU -/
+
+open ZiskFv.Airs.ArithDiv in
+open ZiskFv.EquivCore.Promises in
+/-- **F4 extraction bridge for `equiv_REMU`.**  Mirror of
+    `equiv_DIVU_of_fullSpec` for the remainder (secondary) lane.  The four
+    lookup-aware Arith witness records are replaced by the single `FullSpec arow`
+    hypothesis (the SHARED ArithMul provider's `componentWithArithTable.Spec`),
+    with the ArithDiv-view facts read off the same row through `vOfDivuRow arow`.
+
+    Like DIVU, this derives the looser balance bound `< 983041` (via
+    `divu_carry_bounds`) and reconstructs the rd write value through the loose
+    write-value path `h_rd_val_mdru_remu_loose`, replicating `equiv_REMU`'s
+    sail + `bus_effect` tail.
+
+    The remainder bound `remainder_bound : ArithDivRemainderBoundWitness` is the
+    ONE explicit residual binder (NOT balance-derived): the ArithDiv op-bus
+    consumer `assumes_operation` edge is a finished-channel self-edge absent
+    from the full ensemble (see module header). -/
+lemma equiv_REMU_of_fullSpec
+    (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
+    (remu_input : PureSpec.RemuInput)
+    (r1 r2 rd : regidx)
+    (bus : ZiskFv.Compliance.BusRows)
+    (m : Valid_Main FGL FGL) (r_main : ℕ)
+    (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL)
+    (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_REMU)
+    (h_match_primary :
+      matches_entry (opBus_row_Main m r_main)
+                    (ZiskFv.Airs.ArithDiv.opBus_row_ArithDivSecondary (vOfDivuRow arow) 0))
+    (promises : ZiskFv.EquivCore.Promises.RTypePromises
+        state remu_input.r1_val remu_input.r2_val remu_input.rd remu_input.PC
+        (PureSpec.execute_DIVREM_remu_pure remu_input).nextPC
+        r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
+    (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
+    (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
+    (h_full_spec : ZiskFv.AirsClean.ArithMul.FullSpec arow)
+    (remainder_bound :
+      ZiskFv.EquivCore.Bridge.Arith.ArithDivRemainderBoundWitness (vOfDivuRow arow) 0)
+    (h_rs1_value : remu_input.r1_val.toNat
+      = ZiskFv.PackedBitVec.MulNoWrap.packed4 (arow.chunks.c_0).val (arow.chunks.c_1).val
+          (arow.chunks.c_2).val (arow.chunks.c_3).val)
+    (h_rs2_value : remu_input.r2_val.toNat
+      = ZiskFv.PackedBitVec.MulNoWrap.packed4 (arow.chunks.b_0).val (arow.chunks.b_1).val
+          (arow.chunks.b_2).val (arow.chunks.b_3).val) :
+    (do
+      Sail.writeReg Register.nextPC
+        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
+      LeanRV64D.Functions.execute (instruction.REM (r2, r1, rd, true))) state
+      = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
+  -- Unpack FullSpec into its five conjuncts (ArithMul view of `arow`).
+  obtain ⟨h_spec, h_arith_table, h_c46, h_chunk_ranges_spec, h_carry_ranges_spec⟩ :=
+    h_full_spec
+  obtain ⟨exec_row, e0, e1, e2⟩ := bus
+  obtain ⟨h0, h1, h2, h3, h4, h5, h6, h7⟩ := bounds
+  obtain ⟨_h_main_active, h_main_op_remu⟩ := pins
+  obtain ⟨h_input_r1, h_input_r2, h_input_rd, h_input_pc,
+          h_exec_len, h_e0_mult, h_e1_mult, h_nextPC_matches,
+          h_m0_mult, h_m0_as, h_m1_mult, h_m1_as, h_m2_mult, h_m2_as,
+          h_rd_idx⟩ := promises
+  -- ============ DERIVE arith-side opcode literal ============
+  have h_op_eq := arith_div_secondary_op_eq h_match_primary
+  have h_op_arith_remu : (vOfDivuRow arow).op 0 = 185 := by
+    rw [h_op_eq, h_main_op_remu]; simp [OP_REMU]
+  -- ============ REMU mode pins, DERIVED from the bare-row ArithTableSpec ======
+  have h_op_arow : arow.flags.op = 185 := h_op_arith_remu
+  obtain ⟨h_na_arow, h_nb_arow, h_np_arow, h_nr_arow, h_sext_arow, h_m32_arow,
+          h_div_arow, h_main_div_arow, h_main_mul_arow⟩ :=
+    ZiskFv.AirsClean.ArithTableProjections.Mul.remu_mode_pins_of_row arow h_arith_table h_op_arow
+  -- ArithDiv-view mode pins (defeq to the bare-row flags).
+  have h_na : (vOfDivuRow arow).na 0 = 0 := h_na_arow
+  have h_nb : (vOfDivuRow arow).nb 0 = 0 := h_nb_arow
+  have h_nr : (vOfDivuRow arow).nr 0 = 0 := h_nr_arow
+  have h_sext : (vOfDivuRow arow).sext 0 = 0 := h_sext_arow
+  have h_m32 : (vOfDivuRow arow).m32 0 = 0 := h_m32_arow
+  have h_div : (vOfDivuRow arow).div 0 = 1 := h_div_arow
+  -- ============ Chunk / carry ranges (ArithDiv view, from FullSpec) ==========
+  have h_chunk_ranges :
+      ZiskFv.EquivCore.Bridge.Arith.ArithDivChunkRangesAt (vOfDivuRow arow) 0 :=
+    h_chunk_ranges_spec
+  have h_carry_ranges_signed :
+      ZiskFv.EquivCore.Bridge.Arith.ArithDivSignedCarryRangesAt (vOfDivuRow arow) 0 :=
+    h_carry_ranges_spec
+  obtain ⟨h_a0_lt, h_a1_lt, h_a2_lt, h_a3_lt,
+          h_b0_lt, h_b1_lt, h_b2_lt, h_b3_lt,
+          h_c0_lt, h_c1_lt, h_c2_lt, h_c3_lt,
+          h_d0_lt, h_d1_lt, h_d2_lt, h_d3_lt⟩ := h_chunk_ranges
+  -- ============ Mode-pinned div-Euclidean chunk equations ============
+  have heqs := remu_chain_eqs arow h_spec h_na_arow h_nb_arow h_np_arow h_nr_arow
+    h_m32_arow h_div_arow
+  -- ============ Balance-constructible LOOSE unsigned carry bounds ============
+  obtain ⟨hcy0, hcy1, hcy2, hcy3, hcy4, hcy5, hcy6⟩ :=
+    remu_carry_bounds arow h_chunk_ranges_spec h_carry_ranges_signed heqs
+  obtain ⟨hC31, hC32, hC33, hC34, hC35, hC36, hC37, hC38⟩ := heqs
+  -- ============ Remainder bound (RESIDUAL): d < b in chunk form ============
+  have h_d_lt_b_arith :=
+    ZiskFv.EquivCore.Bridge.Arith.arith_div_remainder_bound_unsigned
+      remainder_bound h_chunk_ranges_spec h_nr h_nb
+  have h_d_lt_b :
+      ZiskFv.PackedBitVec.MulNoWrap.packed4 (arow.chunks.d_0).val (arow.chunks.d_1).val
+          (arow.chunks.d_2).val (arow.chunks.d_3).val
+        < remu_input.r2_val.toNat := by
+    simpa [h_rs2_value] using h_d_lt_b_arith
+  have h_op2_ne : remu_input.r2_val.toNat ≠ 0 := by
+    intro h_zero
+    have : ZiskFv.PackedBitVec.MulNoWrap.packed4 (arow.chunks.d_0).val (arow.chunks.d_1).val
+          (arow.chunks.d_2).val (arow.chunks.d_3).val < 0 := by
+      simpa [h_zero] using h_d_lt_b
+    omega
+  -- ============ DISCHARGE h_byte_lo / h_byte_hi (remainder d-lanes) ==========
+  obtain ⟨_h_a_lo_eq_FGL, _h_a_hi_eq_FGL, _h_b_lo_eq_FGL, _h_b_hi_eq_FGL,
+          h_c0_eq_FGL, h_c1_eq_FGL⟩ :=
+    arith_div_secondary_projections h_match_primary
+  have h_bundle := arith_mem.c_lane_vals
+  have h_byte_lo_to_c0 : (byteAt e2 0).val + (byteAt e2 1).val * 256
+      + (byteAt e2 2).val * 65536 + (byteAt e2 3).val * 16777216
+      = (m.c_0 r_main).val := by
+    have h_e2_lo_bound : e2.value_0.val < 4294967296 := by
+      rw [← h_bundle.1, h_c0_eq_FGL]
+      rw [arith_h_pair_lift _ _ h_d0_lt h_d1_lt]
+      omega
+    rw [ZiskFv.Channels.MemoryBusBytes.byteAt_lo_val_sum_eq e2 h_e2_lo_bound, h_bundle.1]
+  have h_bus_res1_eq : (vOfDivuRow arow).bus_res1 0
+      = (vOfDivuRow arow).d_2 0 + (vOfDivuRow arow).d_3 0 * 65536 :=
+    ZiskFv.Airs.ArithBusRes1.rem_bus_res1_eq_d_hi (vOfDivuRow arow) 0
+      (by
+        -- c46 (ArithDiv form) from the ArithMul-view C46Spec on the same row.
+        simp only [ZiskFv.AirsClean.ArithMul.C46Spec,
+          ZiskFv.Airs.ArithMul.mul_constraint_46_named] at h_c46
+        simp only [ZiskFv.Airs.ArithDiv.bus_res1_eq_div, vOfDivuRow]
+        linear_combination h_c46)
+      h_sext h_m32 h_main_mul_arow h_main_div_arow
+  have h_byte_hi_to_c1 : (byteAt e2 4).val + (byteAt e2 5).val * 256
+      + (byteAt e2 6).val * 65536 + (byteAt e2 7).val * 16777216
+      = (m.c_1 r_main).val := by
+    have h_e2_hi_bound : e2.value_1.val < 4294967296 := by
+      rw [← h_bundle.2, h_c1_eq_FGL, h_bus_res1_eq]
+      rw [arith_h_pair_lift _ _ h_d2_lt h_d3_lt]
+      omega
+    rw [ZiskFv.Channels.MemoryBusBytes.byteAt_hi_val_sum_eq e2 h_e2_hi_bound, h_bundle.2]
+  have h_byte_lo :=
+    arith_byte_lane_eq_of_match h_byte_lo_to_c0 h_c0_eq_FGL h_d0_lt h_d1_lt
+  have h_c1_eq_FGL' : m.c_1 r_main = (vOfDivuRow arow).d_2 0 + (vOfDivuRow arow).d_3 0 * 65536 := by
+    rw [h_c1_eq_FGL, h_bus_res1_eq]
+  have h_byte_hi :=
+    arith_byte_lane_eq_of_match h_byte_hi_to_c1 h_c1_eq_FGL' h_d2_lt h_d3_lt
+  -- ============ DISCHARGE rd-write value via the LOOSE write-value path ======
+  have h_rd_val :=
+    ZiskFv.EquivCore.WriteValueProofs.MulDivRemUnsigned.h_rd_val_mdru_remu_loose
+      remu_input.r1_val remu_input.r2_val e2
+      (arow.chunks.a_0) (arow.chunks.a_1) (arow.chunks.a_2) (arow.chunks.a_3)
+      (arow.chunks.b_0) (arow.chunks.b_1) (arow.chunks.b_2) (arow.chunks.b_3)
+      (arow.chunks.c_0) (arow.chunks.c_1) (arow.chunks.c_2) (arow.chunks.c_3)
+      (arow.chunks.d_0) (arow.chunks.d_1) (arow.chunks.d_2) (arow.chunks.d_3)
+      (arow.carries.carry_0) (arow.carries.carry_1) (arow.carries.carry_2)
+      (arow.carries.carry_3) (arow.carries.carry_4) (arow.carries.carry_5)
+      (arow.carries.carry_6)
+      h0 h1 h2 h3 h4 h5 h6 h7
+      h_a0_lt h_a1_lt h_a2_lt h_a3_lt h_b0_lt h_b1_lt h_b2_lt h_b3_lt
+      h_c0_lt h_c1_lt h_c2_lt h_c3_lt h_d0_lt h_d1_lt h_d2_lt h_d3_lt
+      hcy0 hcy1 hcy2 hcy3 hcy4 hcy5 hcy6
+      hC31 hC32 hC33 hC34 hC35 hC36 hC37 hC38
+      h_byte_lo h_byte_hi h_rs1_value h_rs2_value h_op2_ne h_d_lt_b
+  -- ============ Replicate `equiv_REMU`'s sail + bus_effect tail ==============
+  rw [ZiskFv.EquivCore.Remu.equiv_REMU_sail state remu_input r1 r2 rd
+        h_input_r1 h_input_r2 h_input_rd h_input_pc]
+  symm
+  rw [ZiskFv.Airs.Bus.BusEmission.bus_effect_matches_sail_alu_rrw
+        state exec_row e0 e1 e2
+        (PureSpec.execute_DIVREM_remu_pure remu_input).nextPC
+        h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
+        h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as]
+  simp only [PureSpec.execute_DIVREM_remu_pure, h_rd_idx]
+  split_ifs with h_rd_zero
+  · simp only [bind, pure, EStateM.bind, EStateM.pure]
+  · rw [h_rd_val]
+
+/-! ## Phase 5 — sound REMU construction -/
+
+/-- **Sound REMU construction:** from the accepted trace + honest residual
+    binders, conclude the canonical
+    `execute (REM (r2, r1, rd, true)) = (bus_effect …).2`.
+
+    The Arith provider witnesses (ArithTable membership, chunk ranges, signed
+    carry ranges, c46, carry-chain) are DERIVED inside the body from
+    `trace.balanced` / `trace.spec` via the SHARED ArithMul provider's
+    lookup-aware `componentWithArithTable.Spec = FullSpec`, NOT supplied as
+    binders.
+
+    The ONE non-balance-derived residual is `remainder_bound`
+    (`ArithDivRemainderBoundWitness`): the `|d| < b` LTU consumer edge from
+    `arith.pil:274` is a finished-channel self-edge absent from the full
+    ensemble (`ArithDiv.component` emits no op-bus —
+    `arithDiv_table_interactionsWith_opBus_nil`), so it is carried explicitly,
+    exactly as the canonical `equiv_REMU` carries it. -/
+theorem construction_remu_sound
+    (trace : AcceptedTrace)
+    (binding : ProgramBinding trace)
+    (i : Fin trace.length)
+    (remu_input : PureSpec.RemuInput)
+    (r1 r2 rd : regidx)
+    -- (b) decode pins
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_REMU)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_store_pc :
+      (mainOfTable trace.program binding.mainTable).store_pc i.val = 0)
+    -- (b) Sail reads + operands
+    (h_input_r1 :
+      read_xreg (regidx_to_fin r1) (binding.stateAt i)
+        = EStateM.Result.ok remu_input.r1_val (binding.stateAt i))
+    (h_input_r2 :
+      read_xreg (regidx_to_fin r2) (binding.stateAt i)
+        = EStateM.Result.ok remu_input.r2_val (binding.stateAt i))
+    (h_input_pc : (binding.stateAt i).regs.get? Register.PC = .some remu_input.PC)
+    (h_input_rd : remu_input.rd = regidx_to_fin rd)
+    -- (c) exec artifacts: the exec row is a genuine top-level binder.
+    (execRow : List (Interaction.ExecutionBusEntry FGL))
+    (h_exec_len : (busSub trace binding i execRow).exec_row.length = 2)
+    (h_e0_mult : (busSub trace binding i execRow).exec_row[0]!.multiplicity = -1)
+    (h_e1_mult : (busSub trace binding i execRow).exec_row[1]!.multiplicity = 1)
+    (h_nextPC_matches :
+      (register_type_pc_equiv ▸
+          (BitVec.ofNat 64 ((busSub trace binding i execRow).exec_row[1]!.pc).val))
+        = (PureSpec.execute_DIVREM_remu_pure remu_input).nextPC)
+    (h_rd_idx :
+      remu_input.rd =
+        Transpiler.wrap_to_regidx (busSub trace binding i execRow).e2.ptr)
+    -- (c) byte range bounds on the rd-write entry
+    (bounds : ZiskFv.Compliance.ByteBounds (busSub trace binding i execRow).e2)
+    -- (b) RESIDUAL: remainder-bound witness (the ONE non-balance-derived
+    -- binder — the ArithDiv `assumes_operation` LTU consumer edge is a
+    -- finished-channel self-edge absent from the ensemble).
+    (remainder_bound :
+      ZiskFv.EquivCore.Bridge.Arith.ArithDivRemainderBoundWitness
+        (vOfDivuRow (remuArow trace binding i h_main_active h_main_op)) 0)
+    -- (b) operand bridges (Sail↔chunk binding of the unsigned 64-bit operands;
+    -- genuinely residual, phrased over the balance-selected provider row).
+    (h_rs1_value : remu_input.r1_val.toNat
+      = ZiskFv.PackedBitVec.MulNoWrap.packed4
+          ((remuArow trace binding i h_main_active h_main_op).chunks.c_0).val
+          ((remuArow trace binding i h_main_active h_main_op).chunks.c_1).val
+          ((remuArow trace binding i h_main_active h_main_op).chunks.c_2).val
+          ((remuArow trace binding i h_main_active h_main_op).chunks.c_3).val)
+    (h_rs2_value : remu_input.r2_val.toNat
+      = ZiskFv.PackedBitVec.MulNoWrap.packed4
+          ((remuArow trace binding i h_main_active h_main_op).chunks.b_0).val
+          ((remuArow trace binding i h_main_active h_main_op).chunks.b_1).val
+          ((remuArow trace binding i h_main_active h_main_op).chunks.b_2).val
+          ((remuArow trace binding i h_main_active h_main_op).chunks.b_3).val) :
+    (do
+      Sail.writeReg Register.nextPC
+        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
+      LeanRV64D.Functions.execute (instruction.REM (r2, r1, rd, true))) (binding.stateAt i)
+      = (bus_effect (busSub trace binding i execRow).exec_row
+          [ (busSub trace binding i execRow).e0
+          , (busSub trace binding i execRow).e1
+          , (busSub trace binding i execRow).e2 ] (binding.stateAt i)).2 := by
+  -- (a) Arith witnesses derived from balance: FullSpec.
+  have h_full :
+      ZiskFv.AirsClean.ArithMul.FullSpec
+        (remuArow trace binding i h_main_active h_main_op) :=
+    remuArow_fullSpec_row trace binding i h_main_active h_main_op
+  -- (a) primary op-bus match against `opBus_row_ArithDivSecondary (vOfDivuRow …) 0`.
+  have h_match_primary :
+      matches_entry (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val)
+        (ZiskFv.Airs.ArithDiv.opBus_row_ArithDivSecondary
+          (vOfDivuRow (remuArow trace binding i h_main_active h_main_op)) 0) :=
+    remuArow_match trace binding i h_main_active h_main_op
+  -- decode pins bundle
+  let pins :
+      ZiskFv.Compliance.MainRowPins
+        (mainOfTable trace.program binding.mainTable) i.val 1 OP_REMU :=
+    ⟨h_main_active, h_main_op⟩
+  -- (a) Main rd-write memory witness, from `store_pc = 0`.
+  have h_core_store_pc :
+      (mainRowWithRomSub trace binding i).core.store_pc = 0 := by
+    have h_row :
+        (mainRowWithRomSub trace binding i).core =
+          ZiskFv.AirsClean.Main.rowAt (mainOfTable trace.program binding.mainTable) i.val := by
+      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+        trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+      simpa [mainRowWithRomSub,
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+    rw [h_row]
+    simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
+  let arith_mem :
+      ZiskFv.Compliance.ExternalArithMemoryWitness
+        (mainOfTable trace.program binding.mainTable) i.val
+        (busSub trace binding i execRow).e2 :=
+    { row := mainRowWithRomSub trace binding i
+      row_eq := by
+        have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+          trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+        simpa [mainRowWithRomSub,
+          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+      store_pc_zero := h_core_store_pc
+      rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
+  -- promises bundle: Sail reads + exec artifacts as binders; MemBus shape by rfl.
+  let promises : ZiskFv.EquivCore.Promises.RTypePromises
+      (binding.stateAt i) remu_input.r1_val remu_input.r2_val remu_input.rd remu_input.PC
+      (PureSpec.execute_DIVREM_remu_pure remu_input).nextPC
+      r1 r2 rd (busSub trace binding i execRow).exec_row (busSub trace binding i execRow).e0
+      (busSub trace binding i execRow).e1 (busSub trace binding i execRow).e2 :=
+    { input_r1_eq := h_input_r1
+      input_r2_eq := h_input_r2
+      input_rd_eq := h_input_rd
+      input_pc_eq := h_input_pc
+      exec_len := h_exec_len
+      e0_mult := h_e0_mult
+      e1_mult := h_e1_mult
+      nextPC_matches := h_nextPC_matches
+      m0_mult := by rfl
+      m0_as := by rfl
+      m1_mult := by rfl
+      m1_as := by rfl
+      m2_mult := by rfl
+      m2_as := by rfl
+      rd_idx := h_rd_idx }
+  -- Delegate to the F4 fullSpec bridge.
+  exact equiv_REMU_of_fullSpec
+    (binding.stateAt i) remu_input r1 r2 rd (busSub trace binding i execRow)
+    (mainOfTable trace.program binding.mainTable) i.val
+    (remuArow trace binding i h_main_active h_main_op)
+    pins h_match_primary promises arith_mem bounds
+    h_full remainder_bound h_rs1_value h_rs2_value
+
+end ZiskFv.Compliance

--- a/ZiskFv/Compliance/ConstructionRemuw.lean
+++ b/ZiskFv/Compliance/ConstructionRemuw.lean
@@ -1,0 +1,787 @@
+import ZiskFv.Compliance.AcceptedTrace
+import ZiskFv.Compliance.ConstructionMulw
+import ZiskFv.Compliance.ConstructionMulhu
+import ZiskFv.Compliance.ConstructionDivu
+import ZiskFv.Compliance.ConstructionRemu
+import ZiskFv.EquivCore.Remuw
+import ZiskFv.EquivCore.Promises.ArithHelpers
+import ZiskFv.EquivCore.Bridge.Arith
+import ZiskFv.AirsClean.ArithMul.Bridge
+import ZiskFv.AirsClean.ArithDiv.Bridge
+import ZiskFv.AirsClean.ArithTableProjections
+import ZiskFv.Airs.Arith.Div
+import ZiskFv.Airs.Arith.BusRes1
+import ZiskFv.Bits.PackedBitVec.MulNoWrap
+
+/-!
+# Sound REMUW construction (`construction_remuw_sound`)
+
+Unsigned RV64M **REMUW** (`OP_REMU_W = 189`, W-mode `m32 = 1`), the W-mode
+sibling of REMU — exactly as DIVUW relates to DIVU.  REMUW consumes the
+**secondary** remainder lane (`main_div = 0`, `main_mul = 0`, like REMU) at the
+W width (`m32 = 1`, like DIVUW).  The Arith provider witnesses (ArithTable
+membership, chunk ranges, signed-carry ranges, c46, carry-chain) are **DERIVED
+FROM BALANCE** via the SHARED ArithMul provider component's lookup-aware
+`componentWithArithTable.Spec = FullSpec`, not carried as caller binders.
+
+## Why the shared ArithMul provider (not ArithDiv)
+
+`ArithDiv.component` carries NO operation-bus interactions in the full ensemble
+(`arithDiv_table_interactionsWith_opBus_nil`): its `circuit.channels = []`.  The
+REMUW Main op-bus emission is therefore balanced by the SHARED ArithMul provider
+(`componentWithArithTable`), whose `FullSpec` covers div rows too.  At the REMUW
+mode pins (`div = 1`, `main_div = 0`, `main_mul = 0`; `m32 = 1` plays no role in
+the mux) the muxed primary op-bus message's `c_lo` lane collapses to the
+remainder low half `d_0 + d_1·2^16`, so the muxed message reduces to the div
+remainder-lane message `opBus_row_ArithDivSecondary` (the SAME REMU secondary
+bridge `match_opBus_row_ArithDivSecondary_vOfDivuRow`, reused verbatim — `m32` is
+not a mux selector).
+
+## The carry-range subtlety (vs MULW)
+
+`EquivCore.Remuw.equiv_REMUW` demands the *unsigned* carry bound
+`cy_i.val < 131072 = 2^17`.  Balance supplies only `FullSpec`'s `CarryRangeSpec`
+— the **signed disjunction** `< 983041 ∨ ≥ p - 983040`.  The genuine Euclidean
+carries (`quotient · divisor`) reach `~3·2^16 > 2^17`, so the tight `< 131072`
+bound is NOT balance-constructible (same as DIVU / DIVUW / MULHU).  This module
+therefore does NOT route through `equiv_REMUW`.  Instead it derives the looser
+balance-constructible bound `< 983041` (via `unsigned_carry_step_nat`, reused
+from `ConstructionMulhu`) and reconstructs the rd write value through the
+loose-bound REMUW W-mode write-value path `h_rd_val_mdru_remuw_loose`,
+replicating `equiv_REMUW`'s sail + `bus_effect` tail otherwise.
+
+## The W-mode deltas (vs REMU)
+
+REMUW is `m32 = 1`; the result is the *sign-extended low-32-bit remainder*.  The
+high half of the bus result comes from the sign-extension byte pattern (bytes
+4..7 are `0x00` or `0xFF`), tied to the remainder top bit — NOT the
+`d_2 + d_3·2^16` chunk pack that REMU (the non-W remainder lane) uses.
+
+* `h_b23` (`b_2 = b_3 = 0`) and `h_c23` (`c_2 = c_3 = 0`) are residual binders,
+  mirroring the canonical `equiv_REMUW`'s `h_b23` / `h_c23` (the divisor and
+  dividend high chunks are zero in W-mode; `m32` is not an op-bus field, so these
+  are not balance-derivable here).
+* `h_byte_lo` (bytes 0..3 pack `d_0 + d_1·65536`, the W remainder low half) is
+  DERIVED from the op-bus secondary c-lane match — NOT a binder.
+* `h_d23` (`d_2 = d_3 = 0`) is DERIVED inside the body from the W-mode remainder
+  bound (`arith_div_remainder_bound_unsigned_w`).
+* `h_sext_choice` (the SEXT_00 / SEXT_FF disjunction on bytes 4..7, tied to the
+  remainder top bit) is the ONE W-mode bus-encoding residual, exactly as the
+  canonical `equiv_REMUW` and `Wrappers/Remuw` carry it (class #4, bus encoding —
+  the same trust class as MULW / ADDW / DIVUW).
+
+## The remainder bound is RESIDUAL, not balance-derived
+
+`equiv_REMUW` needs `ArithDivRemainderBoundWitness` — the `|d| < b` LTU check
+from `arith.pil:274`.  This is the ArithDiv op-bus *consumer*
+(`assumes_operation`) edge matched against a Binary LTU provider row.  Because
+`ArithDiv.component` emits no op-bus in the ensemble, this consume edge is a
+finished-channel SELF-EDGE that is **not composed into the ensemble** — so it is
+NOT balance-derivable.  It is carried as the single explicit residual binder
+`remainder_bound`, exactly as REMU / DIVUW.
+
+## Axioms
+
+`construction_remuw_sound` introduces **0 PROJECT (`ZiskFv.*`) axioms**.  Its
+closure carries `Lean.ofReduceBool` / `Lean.trustCompiler` (native_decide)
+INHERITED from the canonical `equiv_REMUW` path (already has it; NOT new —
+tracked by #75), plus `Classical.choice` / `Quot.sound`, the Sail-translation
+postulates, and the Lean-kernel postulates.
+-/
+
+namespace ZiskFv.Compliance
+
+open Goldilocks
+open ZiskFv.Trusted
+open ZiskFv.Airs.Main
+open ZiskFv.Airs.OperationBus
+open ZiskFv.Channels.MemoryBusBytes (byteAt)
+open ZiskFv.AirsClean.FullEnsemble
+open ZiskFv.AirsClean.ArithMul (componentWithArithTable primaryOpBusMessage rowAt)
+
+set_option maxHeartbeats 4000000
+set_option maxRecDepth 8000
+
+/-! ## Phase 2 — balance-derived W-mode div-Euclidean chunk equations + loose carry bounds
+
+The REMUW W-mode chain (op 189, `m32 = 1`) Euclidean chunk identity is the SAME
+as DIVU's / REMU's: the carry-chain constraints 31–38 do not reference `m32`,
+`main_div`, or `main_mul` (they share the `div` flag).  We re-derive them here
+over `vOfDivuRow` (reused from `ConstructionDivu`) at the unsigned mode pins
+`na = nb = np = nr = 0`, `div = 1` (hence `fab = 1`, `na_fb = nb_fa = 0`) — the
+`ConstructionRemu` versions are `private`, so (as DIVUW does) we keep local
+copies here. -/
+
+open ZiskFv.Airs.ArithMul in
+/-- **Mode-pinned REMUW Euclidean chunk equations.** Identical to DIVU's
+    `divu_chain_eqs` — the carry-chain constraints 31–38 are
+    `m32`/`main_div`/`main_mul`-independent, so the W-mode secondary-lane chain
+    is the same low Euclidean form. -/
+private lemma remuw_chain_eqs
+    (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL)
+    (h_chain : mul_carry_chain_holds (vOfMulwRow arow) 0)
+    (h_na : arow.flags.na = 0) (h_nb : arow.flags.nb = 0)
+    (h_np : arow.flags.np = 0) (h_nr : arow.flags.nr = 0)
+    (h_div : arow.flags.div = 1) :
+    (arow.chunks.a_0 * arow.chunks.b_0 + arow.chunks.d_0
+        = arow.chunks.c_0 + arow.carries.carry_0 * 65536)
+    ∧ (arow.chunks.a_1 * arow.chunks.b_0 + arow.chunks.a_0 * arow.chunks.b_1
+        + arow.chunks.d_1 + arow.carries.carry_0
+        = arow.chunks.c_1 + arow.carries.carry_1 * 65536)
+    ∧ (arow.chunks.a_2 * arow.chunks.b_0 + arow.chunks.a_1 * arow.chunks.b_1
+        + arow.chunks.a_0 * arow.chunks.b_2 + arow.chunks.d_2 + arow.carries.carry_1
+        = arow.chunks.c_2 + arow.carries.carry_2 * 65536)
+    ∧ (arow.chunks.a_3 * arow.chunks.b_0 + arow.chunks.a_2 * arow.chunks.b_1
+        + arow.chunks.a_1 * arow.chunks.b_2 + arow.chunks.a_0 * arow.chunks.b_3
+        + arow.chunks.d_3 + arow.carries.carry_2
+        = arow.chunks.c_3 + arow.carries.carry_3 * 65536)
+    ∧ (arow.chunks.a_3 * arow.chunks.b_1 + arow.chunks.a_2 * arow.chunks.b_2
+        + arow.chunks.a_1 * arow.chunks.b_3 + arow.carries.carry_3
+        = arow.carries.carry_4 * 65536)
+    ∧ (arow.chunks.a_3 * arow.chunks.b_2 + arow.chunks.a_2 * arow.chunks.b_3
+        + arow.carries.carry_4 = arow.carries.carry_5 * 65536)
+    ∧ (arow.chunks.a_3 * arow.chunks.b_3 + arow.carries.carry_5
+        = arow.carries.carry_6 * 65536)
+    ∧ (arow.carries.carry_6 = 0) := by
+  obtain ⟨h6, h7, h8, h31, h32, h33, h34, h35, h36, h37, h38⟩ := h_chain
+  simp only [mul_constraint_6_named, mul_constraint_7_named, mul_constraint_8_named,
+             vOfMulwRow, h_na, h_nb, mul_zero, zero_mul, add_zero, sub_zero] at h6 h7 h8
+  have h_fab : arow.carries.fab = (1 : FGL) := by linear_combination h6
+  have h_nafb : arow.carries.na_fb = (0 : FGL) := by linear_combination h7
+  have h_nbfa : arow.carries.nb_fa = (0 : FGL) := by linear_combination h8
+  simp only [mul_constraint_31_named, mul_constraint_32_named,
+             mul_constraint_33_named, mul_constraint_34_named,
+             mul_constraint_35_named, mul_constraint_36_named,
+             mul_constraint_37_named, mul_constraint_38_named,
+             vOfMulwRow, h_na, h_nb, h_np, h_nr, h_div, h_fab, h_nafb, h_nbfa,
+             mul_zero, zero_mul, add_zero, sub_zero, mul_one, one_mul]
+    at h31 h32 h33 h34 h35 h36 h37 h38
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · linear_combination h31
+  · linear_combination h32
+  · linear_combination h33
+  · linear_combination h34
+  · linear_combination h35
+  · linear_combination h36
+  · linear_combination h37
+  · linear_combination h38
+
+/-- **Balance-constructible REMUW unsigned carry bounds.** Identical to DIVU's
+    `divu_carry_bounds`: derive the looser unsigned-side carry bounds
+    `cy_i.val < 983041` via `unsigned_carry_step_nat` (reused from
+    `ConstructionMulhu`). -/
+private lemma remuw_carry_bounds
+    (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL)
+    (h_chunks : ZiskFv.EquivCore.Bridge.Arith.ArithDivChunkRangesAt (vOfDivuRow arow) 0)
+    (h_csgn : ZiskFv.EquivCore.Bridge.Arith.ArithDivSignedCarryRangesAt (vOfDivuRow arow) 0)
+    (heqs :
+      (arow.chunks.a_0 * arow.chunks.b_0 + arow.chunks.d_0
+          = arow.chunks.c_0 + arow.carries.carry_0 * 65536)
+      ∧ (arow.chunks.a_1 * arow.chunks.b_0 + arow.chunks.a_0 * arow.chunks.b_1
+          + arow.chunks.d_1 + arow.carries.carry_0
+          = arow.chunks.c_1 + arow.carries.carry_1 * 65536)
+      ∧ (arow.chunks.a_2 * arow.chunks.b_0 + arow.chunks.a_1 * arow.chunks.b_1
+          + arow.chunks.a_0 * arow.chunks.b_2 + arow.chunks.d_2 + arow.carries.carry_1
+          = arow.chunks.c_2 + arow.carries.carry_2 * 65536)
+      ∧ (arow.chunks.a_3 * arow.chunks.b_0 + arow.chunks.a_2 * arow.chunks.b_1
+          + arow.chunks.a_1 * arow.chunks.b_2 + arow.chunks.a_0 * arow.chunks.b_3
+          + arow.chunks.d_3 + arow.carries.carry_2
+          = arow.chunks.c_3 + arow.carries.carry_3 * 65536)
+      ∧ (arow.chunks.a_3 * arow.chunks.b_1 + arow.chunks.a_2 * arow.chunks.b_2
+          + arow.chunks.a_1 * arow.chunks.b_3 + arow.carries.carry_3
+          = arow.carries.carry_4 * 65536)
+      ∧ (arow.chunks.a_3 * arow.chunks.b_2 + arow.chunks.a_2 * arow.chunks.b_3
+          + arow.carries.carry_4 = arow.carries.carry_5 * 65536)
+      ∧ (arow.chunks.a_3 * arow.chunks.b_3 + arow.carries.carry_5
+          = arow.carries.carry_6 * 65536)
+      ∧ (arow.carries.carry_6 = 0)) :
+    (arow.carries.carry_0).val < 983041 ∧ (arow.carries.carry_1).val < 983041
+    ∧ (arow.carries.carry_2).val < 983041 ∧ (arow.carries.carry_3).val < 983041
+    ∧ (arow.carries.carry_4).val < 983041 ∧ (arow.carries.carry_5).val < 983041
+    ∧ (arow.carries.carry_6).val < 983041 := by
+  obtain ⟨ha0, ha1, ha2, ha3, hb0, hb1, hb2, hb3,
+          hc0, hc1, hc2, hc3, hd0, hd1, hd2, hd3⟩ := h_chunks
+  obtain ⟨hs0, hs1, hs2, hs3, hs4, hs5, hs6⟩ := h_csgn
+  obtain ⟨hC31, hC32, hC33, hC34, hC35, hC36, hC37, hC38⟩ := heqs
+  simp only [vOfDivuRow] at ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hc0 hc1 hc2 hc3 hd0 hd1 hd2 hd3
+  simp only [vOfDivuRow] at hs0 hs1 hs2 hs3 hs4 hs5 hs6
+  have b0 : (arow.carries.carry_0).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_0).val * (arow.chunks.b_0).val + (arow.chunks.d_0).val)
+      _ _ ?_ hc0 ?_ hs0
+    · push_cast; linear_combination hC31
+    · have : (arow.chunks.a_0).val * (arow.chunks.b_0).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b1 : (arow.carries.carry_1).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_1).val * (arow.chunks.b_0).val
+        + (arow.chunks.a_0).val * (arow.chunks.b_1).val
+        + (arow.chunks.d_1).val + (arow.carries.carry_0).val) _ _ ?_ hc1 ?_ hs1
+    · push_cast; linear_combination hC32
+    · have h1 : (arow.chunks.a_1).val * (arow.chunks.b_0).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (arow.chunks.a_0).val * (arow.chunks.b_1).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b2 : (arow.carries.carry_2).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_2).val * (arow.chunks.b_0).val
+        + (arow.chunks.a_1).val * (arow.chunks.b_1).val
+        + (arow.chunks.a_0).val * (arow.chunks.b_2).val
+        + (arow.chunks.d_2).val + (arow.carries.carry_1).val) _ _ ?_ hc2 ?_ hs2
+    · push_cast; linear_combination hC33
+    · have h1 : (arow.chunks.a_2).val * (arow.chunks.b_0).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (arow.chunks.a_1).val * (arow.chunks.b_1).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h3 : (arow.chunks.a_0).val * (arow.chunks.b_2).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b3 : (arow.carries.carry_3).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_3).val * (arow.chunks.b_0).val
+        + (arow.chunks.a_2).val * (arow.chunks.b_1).val
+        + (arow.chunks.a_1).val * (arow.chunks.b_2).val
+        + (arow.chunks.a_0).val * (arow.chunks.b_3).val
+        + (arow.chunks.d_3).val + (arow.carries.carry_2).val) _ _ ?_ hc3 ?_ hs3
+    · push_cast; linear_combination hC34
+    · have h1 : (arow.chunks.a_3).val * (arow.chunks.b_0).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (arow.chunks.a_2).val * (arow.chunks.b_1).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h3 : (arow.chunks.a_1).val * (arow.chunks.b_2).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h4 : (arow.chunks.a_0).val * (arow.chunks.b_3).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b4 : (arow.carries.carry_4).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_3).val * (arow.chunks.b_1).val
+        + (arow.chunks.a_2).val * (arow.chunks.b_2).val
+        + (arow.chunks.a_1).val * (arow.chunks.b_3).val
+        + (arow.carries.carry_3).val) 0 _ ?_ (by omega) ?_ hs4
+    · push_cast; linear_combination hC35
+    · have h1 : (arow.chunks.a_3).val * (arow.chunks.b_1).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (arow.chunks.a_2).val * (arow.chunks.b_2).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h3 : (arow.chunks.a_1).val * (arow.chunks.b_3).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b5 : (arow.carries.carry_5).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_3).val * (arow.chunks.b_2).val
+        + (arow.chunks.a_2).val * (arow.chunks.b_3).val
+        + (arow.carries.carry_4).val) 0 _ ?_ (by omega) ?_ hs5
+    · push_cast; linear_combination hC36
+    · have h1 : (arow.chunks.a_3).val * (arow.chunks.b_2).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      have h2 : (arow.chunks.a_2).val * (arow.chunks.b_3).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  have b6 : (arow.carries.carry_6).val < 983041 := by
+    refine unsigned_carry_step_nat
+      ((arow.chunks.a_3).val * (arow.chunks.b_3).val + (arow.carries.carry_5).val)
+      0 _ ?_ (by omega) ?_ hs6
+    · push_cast; linear_combination hC37
+    · have h1 : (arow.chunks.a_3).val * (arow.chunks.b_3).val ≤ 65535 * 65535 :=
+        Nat.mul_le_mul (by omega) (by omega)
+      omega
+  exact ⟨b0, b1, b2, b3, b4, b5, b6⟩
+
+/-! ## Phase 3 — balance-selected REMUW provider row + transports -/
+
+/-- The balance-selected Arith-Mul provider row at trace index `i` for a REMUW
+    operation, as a concrete `ArithMulRow`.  It is the
+    `componentWithArithTable.rowInput` of the provider row chosen by the REMUW
+    keep-arithMul balance wrapper
+    `exists_arithMul_provider_row_matches_primary_of_remuw_from_binding`.
+    Mirrors `remuArow` / `divuwArow`. -/
+noncomputable def remuwArow
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_REMU_W) :
+    ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
+  let h := exists_arithMul_provider_row_matches_primary_of_remuw_from_binding
+    trace binding i h_main_active h_main_op
+  componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
+
+/-- `FullSpec` of the balance-selected REMUW provider row, derived from the
+    provider component's proven soundness (`componentWithArithTable.Spec`). -/
+theorem remuwArow_fullSpec_row
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_REMU_W) :
+    ZiskFv.AirsClean.ArithMul.FullSpec
+      (remuwArow trace binding i h_main_active h_main_op) := by
+  unfold remuwArow
+  set H := exists_arithMul_provider_row_matches_primary_of_remuw_from_binding
+    trace binding i h_main_active h_main_op with hH
+  obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
+  obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
+  exact ZiskFv.AirsClean.FullEnsemble.arithMul_fullSpec_of_component_spec
+    h_component (h_spec h_rest.choose h_pr_mem)
+
+/-- The op-bus match of the balance-selected REMUW provider row against the Main
+    row's emission, in `toEntry (primaryOpBusMessage …) 1` form. -/
+theorem remuwArow_match_row
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_REMU_W) :
+    matches_entry
+      (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val)
+      (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+        (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
+          (remuwArow trace binding i h_main_active h_main_op)) 1) := by
+  unfold remuwArow
+  set H := exists_arithMul_provider_row_matches_primary_of_remuw_from_binding
+    trace binding i h_main_active h_main_op with hH
+  exact H.choose_spec.2.choose_spec.2.2.2
+
+/-- REMUW mode pins on the balance-selected provider row, DERIVED from its
+    `ArithTableSpec` (part of `FullSpec`) plus the opcode pin
+    `arow.flags.op = 189`.  These are not caller binders.  Reads the mode flags
+    off the BARE provider `ArithMulRow` via `remuw_mode_pins_of_row`, never
+    forcing the heavy `Classical.choose` row's whnf. -/
+theorem remuwArow_mode_pins
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_REMU_W) :
+    (remuwArow trace binding i h_main_active h_main_op).flags.na = 0
+      ∧ (remuwArow trace binding i h_main_active h_main_op).flags.nb = 0
+      ∧ (remuwArow trace binding i h_main_active h_main_op).flags.np = 0
+      ∧ (remuwArow trace binding i h_main_active h_main_op).flags.nr = 0
+      ∧ (remuwArow trace binding i h_main_active h_main_op).flags.m32 = 1
+      ∧ (remuwArow trace binding i h_main_active h_main_op).flags.div = 1
+      ∧ (remuwArow trace binding i h_main_active h_main_op).flags.main_div = 0
+      ∧ (remuwArow trace binding i h_main_active h_main_op).flags.main_mul = 0 := by
+  have h_table := (remuwArow_fullSpec_row trace binding i h_main_active h_main_op).2.1
+  have h_op : (remuwArow trace binding i h_main_active h_main_op).flags.op = 189 := by
+    have h_match := remuwArow_match_row trace binding i h_main_active h_main_op
+    have h_op := h_match.2.1
+    rw [ZiskFv.AirsClean.ArithMul.primaryOpBusMessage_toEntry_op,
+        show (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val).op
+          = (mainOfTable trace.program binding.mainTable).op i.val from rfl,
+        h_main_op] at h_op
+    simpa [OP_REMU_W] using h_op.symm
+  exact ZiskFv.AirsClean.ArithTableProjections.Mul.remuw_mode_pins_of_row
+    (remuwArow trace binding i h_main_active h_main_op) h_table h_op
+
+/-- The op-bus match of the balance-selected REMUW provider row view against the
+    Main row's emission, in `opBus_row_ArithDivSecondary` form.  The REMU-mode
+    mux selectors (`div = 1`, `main_div = 0`, `main_mul = 0`) needed to reduce
+    the faithful mux are DERIVED via `remuwArow_mode_pins` (they are
+    `m32`-agnostic, so the REMU secondary bridge
+    `match_opBus_row_ArithDivSecondary_vOfDivuRow` applies verbatim). -/
+theorem remuwArow_match
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_REMU_W) :
+    matches_entry
+      (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val)
+      (ZiskFv.Airs.ArithDiv.opBus_row_ArithDivSecondary
+        (vOfDivuRow (remuwArow trace binding i h_main_active h_main_op)) 0) := by
+  obtain ⟨_, _, _, _, _, h_div, h_main_div, h_main_mul⟩ :=
+    remuwArow_mode_pins trace binding i h_main_active h_main_op
+  exact match_opBus_row_ArithDivSecondary_vOfDivuRow h_div h_main_div h_main_mul
+    (remuwArow_match_row trace binding i h_main_active h_main_op)
+
+/-! ## Phase 4 — F4 `FullSpec` discharge bridge for REMUW -/
+
+open ZiskFv.Airs.ArithDiv in
+open ZiskFv.EquivCore.Promises in
+/-- **F4 extraction bridge for `equiv_REMUW`.**  Mirror of `equiv_REMU_of_fullSpec`
+    for the W-mode (`m32 = 1`) sibling.  The four lookup-aware Arith witness
+    records are replaced by the single `FullSpec arow` hypothesis (the SHARED
+    ArithMul provider's `componentWithArithTable.Spec`), with the ArithDiv-view
+    facts read off the same row through `vOfDivuRow arow`.
+
+    Like REMU / DIVUW, this derives the looser balance bound `< 983041` (via
+    `remuw_carry_bounds`) and reconstructs the rd write value through the loose
+    W-mode write-value path `h_rd_val_mdru_remuw_loose`, replicating
+    `equiv_REMUW`'s sail + `bus_effect` tail.
+
+    The low-remainder byte match `h_byte_lo` is DERIVED inside the body from the
+    op-bus secondary c-lane projection.  The W-mode high-lane zeros `h_b23` /
+    `h_c23`, the `remainder_bound`, and `h_sext_choice` are the explicit residual
+    binders — exactly the W-mode route/provenance obligations the canonical
+    `equiv_REMUW` carries (the `m32` flag is not an op-bus field, so the
+    high-lane zeros are not balance-derivable here). -/
+lemma equiv_REMUW_of_fullSpec
+    (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
+    (remuw_input : PureSpec.RemuwInput)
+    (r1 r2 rd : regidx)
+    (bus : ZiskFv.Compliance.BusRows)
+    (m : Valid_Main FGL FGL) (r_main : ℕ)
+    (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL)
+    (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_REMU_W)
+    (h_match_primary :
+      matches_entry (opBus_row_Main m r_main)
+                    (ZiskFv.Airs.ArithDiv.opBus_row_ArithDivSecondary (vOfDivuRow arow) 0))
+    (promises : ZiskFv.EquivCore.Promises.RTypePromises
+        state remuw_input.r1_val remuw_input.r2_val remuw_input.rd remuw_input.PC
+        (PureSpec.execute_DIVREM_remuw_pure remuw_input).nextPC
+        r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
+    (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
+    (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
+    (h_full_spec : ZiskFv.AirsClean.ArithMul.FullSpec arow)
+    (remainder_bound :
+      ZiskFv.EquivCore.Bridge.Arith.ArithDivRemainderBoundWitness (vOfDivuRow arow) 0)
+    -- W-mode high-lane zeros (CIRCUIT-CONSTRAINT / bus W-pin): the divisor and
+    -- dividend high chunks are zero in W-mode.  Residual, mirroring the
+    -- canonical `equiv_REMUW`'s `h_b23` / `h_c23`.
+    (h_b23 : (arow.chunks.b_2).val = 0 ∧ (arow.chunks.b_3).val = 0)
+    (h_c23 : (arow.chunks.c_2).val = 0 ∧ (arow.chunks.c_3).val = 0)
+    -- The W-mode bus-encoding residual (class #4): SEXT_00 / SEXT_FF on
+    -- bytes 4..7, tied to the remainder top bit.  Phrased over `arow.chunks.d`.
+    (h_sext_choice :
+      (((byteAt bus.e2 4).val = 0 ∧ (byteAt bus.e2 5).val = 0
+          ∧ (byteAt bus.e2 6).val = 0 ∧ (byteAt bus.e2 7).val = 0)
+        ∧ (arow.chunks.d_0).val + (arow.chunks.d_1).val * 65536 < 2147483648)
+      ∨ (((byteAt bus.e2 4).val = 255 ∧ (byteAt bus.e2 5).val = 255
+          ∧ (byteAt bus.e2 6).val = 255 ∧ (byteAt bus.e2 7).val = 255)
+        ∧ (arow.chunks.d_0).val + (arow.chunks.d_1).val * 65536 ≥ 2147483648))
+    -- Operand bridges (W form: low 32 bits; genuinely residual).
+    (h_rs1_value : (Sail.BitVec.extractLsb remuw_input.r1_val 31 0).toNat
+      = (arow.chunks.c_0).val + (arow.chunks.c_1).val * 65536)
+    (h_rs2_value : (Sail.BitVec.extractLsb remuw_input.r2_val 31 0).toNat
+      = (arow.chunks.b_0).val + (arow.chunks.b_1).val * 65536) :
+    (do
+      Sail.writeReg Register.nextPC
+        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
+      LeanRV64D.Functions.execute (instruction.REMW (r2, r1, rd, true))) state
+      = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
+  obtain ⟨h_spec, h_arith_table, h_c46, h_chunk_ranges_spec, h_carry_ranges_spec⟩ :=
+    h_full_spec
+  obtain ⟨exec_row, e0, e1, e2⟩ := bus
+  obtain ⟨h0, h1, h2, h3, h4, h5, h6, h7⟩ := bounds
+  obtain ⟨_h_main_active, h_main_op_remuw⟩ := pins
+  obtain ⟨h_input_r1, h_input_r2, h_input_rd, h_input_pc,
+          h_exec_len, h_e0_mult, h_e1_mult, h_nextPC_matches,
+          h_m0_mult, h_m0_as, h_m1_mult, h_m1_as, h_m2_mult, h_m2_as,
+          h_rd_idx⟩ := promises
+  -- ============ DERIVE arith-side opcode literal ============
+  have h_op_eq := arith_div_secondary_op_eq h_match_primary
+  have h_op_arith_remuw : (vOfDivuRow arow).op 0 = 189 := by
+    rw [h_op_eq, h_main_op_remuw]; simp [OP_REMU_W]
+  have h_op_arow : arow.flags.op = 189 := h_op_arith_remuw
+  -- ============ REMUW mode pins, DERIVED from the bare-row ArithTableSpec =====
+  obtain ⟨h_na_arow, h_nb_arow, h_np_arow, h_nr_arow, h_m32_arow,
+          h_div_arow, h_main_div_arow, h_main_mul_arow⟩ :=
+    ZiskFv.AirsClean.ArithTableProjections.Mul.remuw_mode_pins_of_row arow h_arith_table h_op_arow
+  have h_nb : (vOfDivuRow arow).nb 0 = 0 := h_nb_arow
+  have h_nr : (vOfDivuRow arow).nr 0 = 0 := h_nr_arow
+  -- ============ Chunk / carry ranges (ArithDiv view, from FullSpec) ==========
+  have h_chunk_ranges :
+      ZiskFv.EquivCore.Bridge.Arith.ArithDivChunkRangesAt (vOfDivuRow arow) 0 :=
+    h_chunk_ranges_spec
+  have h_carry_ranges_signed :
+      ZiskFv.EquivCore.Bridge.Arith.ArithDivSignedCarryRangesAt (vOfDivuRow arow) 0 :=
+    h_carry_ranges_spec
+  obtain ⟨h_a0_lt, h_a1_lt, h_a2_lt, h_a3_lt,
+          h_b0_lt, h_b1_lt, h_b2_lt, h_b3_lt,
+          h_c0_lt, h_c1_lt, h_c2_lt, h_c3_lt,
+          h_d0_lt, h_d1_lt, h_d2_lt, h_d3_lt⟩ := h_chunk_ranges
+  -- ============ Op-bus secondary c-lane projection (for the byte-lo match) ====
+  obtain ⟨_h_a_lo_eq_FGL, _h_a_hi_eq_FGL, _h_b_lo_eq_FGL, _h_b_hi_eq_FGL,
+          h_c0_eq_FGL, _h_c1_eq_FGL⟩ :=
+    arith_div_secondary_projections h_match_primary
+  -- ============ Mode-pinned div-Euclidean chunk equations (W-mode) ===========
+  have heqs := remuw_chain_eqs arow h_spec h_na_arow h_nb_arow h_np_arow h_nr_arow
+    h_div_arow
+  obtain ⟨hC31, hC32, hC33, hC34, hC35, hC36, hC37, hC38⟩ := heqs
+  -- ============ Balance-constructible LOOSE unsigned carry bounds ============
+  obtain ⟨hcy0, hcy1, hcy2, hcy3, hcy4, hcy5, hcy6⟩ :=
+    remuw_carry_bounds arow h_chunk_ranges_spec h_carry_ranges_signed
+      ⟨hC31, hC32, hC33, hC34, hC35, hC36, hC37, hC38⟩
+  -- ============ Remainder bound (RESIDUAL): d < b in low-32 chunk form =======
+  obtain ⟨h_d23, h_d_lt_b_arith⟩ :=
+    ZiskFv.EquivCore.Bridge.Arith.arith_div_remainder_bound_unsigned_w
+      remainder_bound h_chunk_ranges_spec h_nr h_nb h_b23
+  have h_d23' : (arow.chunks.d_2).val = 0 ∧ (arow.chunks.d_3).val = 0 := h_d23
+  have h_d_lt_b :
+      (arow.chunks.d_0).val + (arow.chunks.d_1).val * 65536
+        < (Sail.BitVec.extractLsb remuw_input.r2_val 31 0).toNat := by
+    rw [h_rs2_value]
+    exact h_d_lt_b_arith
+  have h_op2_ne : (Sail.BitVec.extractLsb remuw_input.r2_val 31 0).toNat ≠ 0 := by
+    intro h_zero
+    have hlt := h_d_lt_b
+    rw [h_zero] at hlt
+    omega
+  -- ============ DISCHARGE h_byte_lo (remainder low d-lanes) ===================
+  have h_bundle := arith_mem.c_lane_vals
+  have h_byte_lo_to_c0 : (byteAt e2 0).val + (byteAt e2 1).val * 256
+      + (byteAt e2 2).val * 65536 + (byteAt e2 3).val * 16777216
+      = (m.c_0 r_main).val := by
+    have h_e2_lo_bound : e2.value_0.val < 4294967296 := by
+      rw [← h_bundle.1, h_c0_eq_FGL]
+      rw [arith_h_pair_lift _ _ h_d0_lt h_d1_lt]
+      omega
+    rw [ZiskFv.Channels.MemoryBusBytes.byteAt_lo_val_sum_eq e2 h_e2_lo_bound, h_bundle.1]
+  have h_byte_lo :
+      (byteAt e2 0).val + (byteAt e2 1).val * 256 + (byteAt e2 2).val * 65536
+        + (byteAt e2 3).val * 16777216
+      = (arow.chunks.d_0).val + (arow.chunks.d_1).val * 65536 := by
+    have := arith_byte_lane_eq_of_match h_byte_lo_to_c0 h_c0_eq_FGL h_d0_lt h_d1_lt
+    simpa [vOfDivuRow] using this
+  -- ============ DISCHARGE rd-write value via the LOOSE W-mode write-value path
+  have h_rd_val :=
+    ZiskFv.EquivCore.WriteValueProofs.MulDivRemUnsigned.h_rd_val_mdru_remuw_loose
+      remuw_input.r1_val remuw_input.r2_val e2
+      (arow.chunks.a_0) (arow.chunks.a_1) (arow.chunks.a_2) (arow.chunks.a_3)
+      (arow.chunks.b_0) (arow.chunks.b_1) (arow.chunks.b_2) (arow.chunks.b_3)
+      (arow.chunks.c_0) (arow.chunks.c_1) (arow.chunks.c_2) (arow.chunks.c_3)
+      (arow.chunks.d_0) (arow.chunks.d_1) (arow.chunks.d_2) (arow.chunks.d_3)
+      (arow.carries.carry_0) (arow.carries.carry_1) (arow.carries.carry_2)
+      (arow.carries.carry_3) (arow.carries.carry_4) (arow.carries.carry_5)
+      (arow.carries.carry_6)
+      h0 h1 h2 h3 h4 h5 h6 h7
+      h_a0_lt h_a1_lt h_a2_lt h_a3_lt h_b0_lt h_b1_lt h_b2_lt h_b3_lt
+      h_c0_lt h_c1_lt h_c2_lt h_c3_lt h_d0_lt h_d1_lt h_d2_lt h_d3_lt
+      hcy0 hcy1 hcy2 hcy3 hcy4 hcy5 hcy6
+      hC31 hC32 hC33 hC34 hC35 hC36 hC37 hC38
+      (by
+        -- h_a23 : a_2 = a_3 = 0.  In W-mode the quotient is the low-32 value;
+        -- the high chunks are forced zero by the Euclidean identity collapse
+        -- (b_2=b_3=c_2=c_3=d_2=d_3=0).
+        have h_packed_nat :
+            ZiskFv.PackedBitVec.MulNoWrap.packed4 (arow.chunks.a_0).val
+                (arow.chunks.a_1).val (arow.chunks.a_2).val (arow.chunks.a_3).val
+              * ZiskFv.PackedBitVec.MulNoWrap.packed4 (arow.chunks.b_0).val
+                  (arow.chunks.b_1).val (arow.chunks.b_2).val (arow.chunks.b_3).val
+              + ZiskFv.PackedBitVec.MulNoWrap.packed4 (arow.chunks.d_0).val
+                  (arow.chunks.d_1).val (arow.chunks.d_2).val (arow.chunks.d_3).val
+            = ZiskFv.PackedBitVec.MulNoWrap.packed4 (arow.chunks.c_0).val
+                (arow.chunks.c_1).val (arow.chunks.c_2).val (arow.chunks.c_3).val :=
+          ZiskFv.EquivCore.WriteValueProofs.MulDivRemUnsigned.fgl_div_unsigned_chunks_to_nat_identity_loose
+            (arow.chunks.a_0) (arow.chunks.a_1) (arow.chunks.a_2) (arow.chunks.a_3)
+            (arow.chunks.b_0) (arow.chunks.b_1) (arow.chunks.b_2) (arow.chunks.b_3)
+            (arow.chunks.c_0) (arow.chunks.c_1) (arow.chunks.c_2) (arow.chunks.c_3)
+            (arow.chunks.d_0) (arow.chunks.d_1) (arow.chunks.d_2) (arow.chunks.d_3)
+            (arow.carries.carry_0) (arow.carries.carry_1) (arow.carries.carry_2)
+            (arow.carries.carry_3) (arow.carries.carry_4) (arow.carries.carry_5)
+            (arow.carries.carry_6)
+            h_a0_lt h_a1_lt h_a2_lt h_a3_lt h_b0_lt h_b1_lt h_b2_lt h_b3_lt
+            h_c0_lt h_c1_lt h_c2_lt h_c3_lt h_d0_lt h_d1_lt h_d2_lt h_d3_lt
+            hcy0 hcy1 hcy2 hcy3 hcy4 hcy5 hcy6
+            hC31 hC32 hC33 hC34 hC35 hC36 hC37 hC38
+        obtain ⟨hb2, hb3⟩ := h_b23
+        obtain ⟨hc2, hc3⟩ := h_c23
+        obtain ⟨hd2, hd3⟩ := h_d23'
+        have h_c32_lt : (arow.chunks.c_0).val + (arow.chunks.c_1).val * 65536 < 4294967296 := by
+          have : (arow.chunks.c_1).val * 65536 ≤ 65535 * 65536 :=
+            Nat.mul_le_mul_right _ (by omega)
+          omega
+        have h_b32_pos : 0 < (arow.chunks.b_0).val + (arow.chunks.b_1).val * 65536 := by
+          have h_ne : (arow.chunks.b_0).val + (arow.chunks.b_1).val * 65536 ≠ 0 := by
+            intro h_zero
+            apply h_op2_ne
+            rw [h_rs2_value, h_zero]
+          omega
+        have h_a_packed_lt :
+            ZiskFv.PackedBitVec.MulNoWrap.packed4 (arow.chunks.a_0).val
+              (arow.chunks.a_1).val (arow.chunks.a_2).val (arow.chunks.a_3).val < 4294967296 := by
+          unfold ZiskFv.PackedBitVec.MulNoWrap.packed4 at h_packed_nat
+          rw [hb2, hb3, hc2, hc3, hd2, hd3] at h_packed_nat
+          nlinarith
+        unfold ZiskFv.PackedBitVec.MulNoWrap.packed4 at h_a_packed_lt
+        constructor <;> omega)
+      h_b23 h_d23' h_c23 h_byte_lo h_sext_choice h_rs1_value h_rs2_value h_op2_ne h_d_lt_b
+  -- ============ Replicate `equiv_REMUW`'s sail + bus_effect tail =============
+  rw [ZiskFv.EquivCore.Remuw.equiv_REMUW_sail state remuw_input r1 r2 rd
+        h_input_r1 h_input_r2 h_input_rd h_input_pc]
+  symm
+  rw [ZiskFv.Airs.Bus.BusEmission.bus_effect_matches_sail_alu_rrw
+        state exec_row e0 e1 e2
+        (PureSpec.execute_DIVREM_remuw_pure remuw_input).nextPC
+        h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
+        h_m0_mult h_m0_as h_m1_mult h_m1_as h_m2_mult h_m2_as]
+  simp only [PureSpec.execute_DIVREM_remuw_pure, h_rd_idx]
+  rw [← h_rd_val]
+  split_ifs with h_rd_zero
+  · simp only [bind, pure, EStateM.bind, EStateM.pure]
+  · simp only [bind, pure, EStateM.bind, EStateM.pure]
+
+/-! ## Phase 5 — sound REMUW construction -/
+
+/-- **Sound REMUW construction:** from the accepted trace + honest residual
+    binders, conclude the canonical
+    `execute (REMW (r2, r1, rd, true)) = (bus_effect …).2`.
+
+    The Arith provider witnesses (ArithTable membership, chunk ranges, signed
+    carry ranges, c46, carry-chain) are DERIVED inside the body from
+    `trace.balanced` / `trace.spec` via the SHARED ArithMul provider's
+    lookup-aware `componentWithArithTable.Spec = FullSpec`, NOT supplied as
+    binders.  The low-remainder byte match is also DERIVED.
+
+    The THREE non-balance-derived residuals are `remainder_bound`
+    (`ArithDivRemainderBoundWitness`: the `|d| < b` LTU consumer self-edge from
+    `arith.pil:274`, absent from the ensemble), `h_b23` / `h_c23` (the W-mode
+    high-lane zeros), and `h_sext_choice` (the W-mode SEXT_00/SEXT_FF bus
+    encoding on bytes 4..7, class #4 — the same residuals the canonical
+    `equiv_REMUW` carries). -/
+theorem construction_remuw_sound
+    (trace : AcceptedTrace)
+    (binding : ProgramBinding trace)
+    (i : Fin trace.length)
+    (remuw_input : PureSpec.RemuwInput)
+    (r1 r2 rd : regidx)
+    -- (b) decode pins
+    (h_main_op :
+      (mainOfTable trace.program binding.mainTable).op i.val = ZiskFv.Trusted.OP_REMU_W)
+    (h_main_active :
+      (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
+    (h_store_pc :
+      (mainOfTable trace.program binding.mainTable).store_pc i.val = 0)
+    -- (b) Sail reads + operands
+    (h_input_r1 :
+      read_xreg (regidx_to_fin r1) (binding.stateAt i)
+        = EStateM.Result.ok remuw_input.r1_val (binding.stateAt i))
+    (h_input_r2 :
+      read_xreg (regidx_to_fin r2) (binding.stateAt i)
+        = EStateM.Result.ok remuw_input.r2_val (binding.stateAt i))
+    (h_input_pc : (binding.stateAt i).regs.get? Register.PC = .some remuw_input.PC)
+    (h_input_rd : remuw_input.rd = regidx_to_fin rd)
+    -- (c) exec artifacts: the exec row is a genuine top-level binder.
+    (execRow : List (Interaction.ExecutionBusEntry FGL))
+    (h_exec_len : (busSub trace binding i execRow).exec_row.length = 2)
+    (h_e0_mult : (busSub trace binding i execRow).exec_row[0]!.multiplicity = -1)
+    (h_e1_mult : (busSub trace binding i execRow).exec_row[1]!.multiplicity = 1)
+    (h_nextPC_matches :
+      (register_type_pc_equiv ▸
+          (BitVec.ofNat 64 ((busSub trace binding i execRow).exec_row[1]!.pc).val))
+        = (PureSpec.execute_DIVREM_remuw_pure remuw_input).nextPC)
+    (h_rd_idx :
+      remuw_input.rd =
+        Transpiler.wrap_to_regidx (busSub trace binding i execRow).e2.ptr)
+    -- (c) byte range bounds on the rd-write entry
+    (bounds : ZiskFv.Compliance.ByteBounds (busSub trace binding i execRow).e2)
+    -- (b) RESIDUAL: remainder-bound witness (the ArithDiv `assumes_operation`
+    -- LTU consumer edge is a finished-channel self-edge absent from the
+    -- ensemble).
+    (remainder_bound :
+      ZiskFv.EquivCore.Bridge.Arith.ArithDivRemainderBoundWitness
+        (vOfDivuRow (remuwArow trace binding i h_main_active h_main_op)) 0)
+    -- (b) W-mode RESIDUAL high-lane zeros (CIRCUIT-CONSTRAINT / bus W-pin),
+    -- mirroring the canonical `equiv_REMUW`'s `h_b23` / `h_c23`.
+    (h_b23 :
+      ((remuwArow trace binding i h_main_active h_main_op).chunks.b_2).val = 0
+        ∧ ((remuwArow trace binding i h_main_active h_main_op).chunks.b_3).val = 0)
+    (h_c23 :
+      ((remuwArow trace binding i h_main_active h_main_op).chunks.c_2).val = 0
+        ∧ ((remuwArow trace binding i h_main_active h_main_op).chunks.c_3).val = 0)
+    -- (b) W-mode RESIDUAL: SEXT_00/SEXT_FF bus encoding on bytes 4..7 (class #4,
+    -- same trust class as the canonical `equiv_REMUW` / MULW / ADDW).
+    (h_sext_choice :
+      ((((byteAt (busSub trace binding i execRow).e2 4).val = 0
+            ∧ (byteAt (busSub trace binding i execRow).e2 5).val = 0
+            ∧ (byteAt (busSub trace binding i execRow).e2 6).val = 0
+            ∧ (byteAt (busSub trace binding i execRow).e2 7).val = 0)
+          ∧ ((remuwArow trace binding i h_main_active h_main_op).chunks.d_0).val
+              + ((remuwArow trace binding i h_main_active h_main_op).chunks.d_1).val * 65536
+                < 2147483648)
+        ∨ (((byteAt (busSub trace binding i execRow).e2 4).val = 255
+            ∧ (byteAt (busSub trace binding i execRow).e2 5).val = 255
+            ∧ (byteAt (busSub trace binding i execRow).e2 6).val = 255
+            ∧ (byteAt (busSub trace binding i execRow).e2 7).val = 255)
+          ∧ ((remuwArow trace binding i h_main_active h_main_op).chunks.d_0).val
+              + ((remuwArow trace binding i h_main_active h_main_op).chunks.d_1).val * 65536
+                ≥ 2147483648)))
+    -- (b) operand bridges (Sail↔chunk binding of the W-form low-32 operands;
+    -- genuinely residual, phrased over the balance-selected provider row).
+    (h_rs1_value : (Sail.BitVec.extractLsb remuw_input.r1_val 31 0).toNat
+      = ((remuwArow trace binding i h_main_active h_main_op).chunks.c_0).val
+          + ((remuwArow trace binding i h_main_active h_main_op).chunks.c_1).val * 65536)
+    (h_rs2_value : (Sail.BitVec.extractLsb remuw_input.r2_val 31 0).toNat
+      = ((remuwArow trace binding i h_main_active h_main_op).chunks.b_0).val
+          + ((remuwArow trace binding i h_main_active h_main_op).chunks.b_1).val * 65536) :
+    (do
+      Sail.writeReg Register.nextPC
+        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
+      LeanRV64D.Functions.execute (instruction.REMW (r2, r1, rd, true))) (binding.stateAt i)
+      = (bus_effect (busSub trace binding i execRow).exec_row
+          [ (busSub trace binding i execRow).e0
+          , (busSub trace binding i execRow).e1
+          , (busSub trace binding i execRow).e2 ] (binding.stateAt i)).2 := by
+  -- (a) Arith witnesses derived from balance: FullSpec.
+  have h_full :
+      ZiskFv.AirsClean.ArithMul.FullSpec
+        (remuwArow trace binding i h_main_active h_main_op) :=
+    remuwArow_fullSpec_row trace binding i h_main_active h_main_op
+  -- (a) primary op-bus match against `opBus_row_ArithDivSecondary (vOfDivuRow …) 0`.
+  have h_match_primary :
+      matches_entry (opBus_row_Main (mainOfTable trace.program binding.mainTable) i.val)
+        (ZiskFv.Airs.ArithDiv.opBus_row_ArithDivSecondary
+          (vOfDivuRow (remuwArow trace binding i h_main_active h_main_op)) 0) :=
+    remuwArow_match trace binding i h_main_active h_main_op
+  -- decode pins bundle
+  let pins :
+      ZiskFv.Compliance.MainRowPins
+        (mainOfTable trace.program binding.mainTable) i.val 1 OP_REMU_W :=
+    ⟨h_main_active, h_main_op⟩
+  -- (a) Main rd-write memory witness, from `store_pc = 0`.
+  have h_core_store_pc :
+      (mainRowWithRomSub trace binding i).core.store_pc = 0 := by
+    have h_row :
+        (mainRowWithRomSub trace binding i).core =
+          ZiskFv.AirsClean.Main.rowAt (mainOfTable trace.program binding.mainTable) i.val := by
+      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+        trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+      simpa [mainRowWithRomSub,
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+    rw [h_row]
+    simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
+  let arith_mem :
+      ZiskFv.Compliance.ExternalArithMemoryWitness
+        (mainOfTable trace.program binding.mainTable) i.val
+        (busSub trace binding i execRow).e2 :=
+    { row := mainRowWithRomSub trace binding i
+      row_eq := by
+        have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+          trace.program binding.mainTable ⟨i.val, binding.mainTable_index i⟩
+        simpa [mainRowWithRomSub,
+          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+      store_pc_zero := h_core_store_pc
+      rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
+  -- promises bundle: Sail reads + exec artifacts as binders; MemBus shape by rfl.
+  let promises : ZiskFv.EquivCore.Promises.RTypePromises
+      (binding.stateAt i) remuw_input.r1_val remuw_input.r2_val remuw_input.rd remuw_input.PC
+      (PureSpec.execute_DIVREM_remuw_pure remuw_input).nextPC
+      r1 r2 rd (busSub trace binding i execRow).exec_row (busSub trace binding i execRow).e0
+      (busSub trace binding i execRow).e1 (busSub trace binding i execRow).e2 :=
+    { input_r1_eq := h_input_r1
+      input_r2_eq := h_input_r2
+      input_rd_eq := h_input_rd
+      input_pc_eq := h_input_pc
+      exec_len := h_exec_len
+      e0_mult := h_e0_mult
+      e1_mult := h_e1_mult
+      nextPC_matches := h_nextPC_matches
+      m0_mult := by rfl
+      m0_as := by rfl
+      m1_mult := by rfl
+      m1_as := by rfl
+      m2_mult := by rfl
+      m2_as := by rfl
+      rd_idx := h_rd_idx }
+  -- Delegate to the F4 fullSpec bridge.
+  exact equiv_REMUW_of_fullSpec
+    (binding.stateAt i) remuw_input r1 r2 rd (busSub trace binding i execRow)
+    (mainOfTable trace.program binding.mainTable) i.val
+    (remuwArow trace binding i h_main_active h_main_op)
+    pins h_match_primary promises arith_mem bounds
+    h_full remainder_bound h_b23 h_c23 h_sext_choice h_rs1_value h_rs2_value
+
+end ZiskFv.Compliance

--- a/ZiskFv/Compliance/SharedBundles.lean
+++ b/ZiskFv/Compliance/SharedBundles.lean
@@ -169,13 +169,35 @@ theorem ArithMulTableWitness.spec
   ZiskFv.AirsClean.ArithMul.arith_table_spec_of_lookup_aware_const_soundness
     w.offset w.env (ZiskFv.AirsClean.ArithMul.rowAt v r) w.holds
 
+/-- Chunk range bounds derived from an `ArithMulTableWitness`.
+
+After RANK 2a, `mainWithArithTable` embeds the sixteen `bits(16)` chunk
+lookups, so the ArithTable witness alone supplies `< 2^16` bounds — no
+separate `ChunkRangeLookupWitness` is required. -/
+theorem ArithMulTableWitness.chunk_ranges
+    {v : ZiskFv.Airs.ArithMul.Valid_ArithMul FGL FGL} {r : ℕ}
+    (w : ArithMulTableWitness v r) :
+    (v.a_0 r).val < 2 ^ 16 ∧ (v.a_1 r).val < 2 ^ 16
+  ∧ (v.a_2 r).val < 2 ^ 16 ∧ (v.a_3 r).val < 2 ^ 16
+  ∧ (v.b_0 r).val < 2 ^ 16 ∧ (v.b_1 r).val < 2 ^ 16
+  ∧ (v.b_2 r).val < 2 ^ 16 ∧ (v.b_3 r).val < 2 ^ 16
+  ∧ (v.c_0 r).val < 2 ^ 16 ∧ (v.c_1 r).val < 2 ^ 16
+  ∧ (v.c_2 r).val < 2 ^ 16 ∧ (v.c_3 r).val < 2 ^ 16
+  ∧ (v.d_0 r).val < 2 ^ 16 ∧ (v.d_1 r).val < 2 ^ 16
+  ∧ (v.d_2 r).val < 2 ^ 16 ∧ (v.d_3 r).val < 2 ^ 16 := by
+  have h :=
+    ZiskFv.AirsClean.ArithMul.chunk_ranges_of_arith_table_const_soundness
+      w.offset w.env (ZiskFv.AirsClean.ArithMul.rowAt v r) w.holds
+  simpa [ZiskFv.AirsClean.ArithMul.ChunkRangeSpec,
+    ZiskFv.AirsClean.ArithMul.rowAt] using h
+
 /-- Lookup-aware Clean witness for a selected ArithMul row's sixteen
     `bits(16)` chunk checks.
 
-This is the T6 structural source for replacing
-`arith_mul_columns_in_range` on MUL-family paths: callers expose the Clean
-operation soundness proof for `mainWithChunkRanges`, and the actual
-`a/b/c/d` chunk bounds are derived by `AirsClean.ArithMul.Bridge`. -/
+    DEPRECATED after RANK 2a: `ArithMulTableWitness.chunk_ranges` derives
+    the same bounds from the ArithTable witness (which now embeds the chunk
+    lookups in `mainWithArithTable`).  Retained as a compatibility alias
+    so existing callers compile without immediate refactoring. -/
 abbrev ArithMulChunkRangeWitness
     (v : ZiskFv.Airs.ArithMul.Valid_ArithMul FGL FGL) (r : ℕ) :=
   ZiskFv.AirsClean.ArithMul.ChunkRangeLookupWitness v r

--- a/ZiskFv/Compliance/Wrappers/MulW.lean
+++ b/ZiskFv/Compliance/Wrappers/MulW.lean
@@ -172,6 +172,134 @@ lemma equiv_MULW_of_table
     h_arith_chunk_ranges_arg h_arith_carry_ranges
     h_a23 h_b23 h_byte_lo h_sext_choice h_rs1_value h_rs2_value
 
+/-- **F4 extraction bridge for `equiv_MULW`.**
+
+    Identical conclusion and operand-bridge burden to `equiv_MULW_of_table`,
+    but the four lookup-aware Arith witness records (`arith_table`,
+    `h_row_constraints`, `arith_chunk_ranges`, `arith_carry_ranges`) are
+    replaced by the *single* `ZiskFv.AirsClean.ArithMul.FullSpec (rowAt v r_a)`
+    hypothesis.
+
+    `FullSpec` is exactly what the lookup-aware ArithMul provider's
+    `componentWithArithTable.Spec` yields (`componentWithArithTable_spec`), so a
+    P4 construction can hand the provider's balance-derived `Spec` here directly
+    instead of re-packaging it as four caller witnesses. Its five conjuncts map
+    1:1 onto what the body needs:
+
+    * `Spec (rowAt v r_a)` → `mul_carry_chain_holds v r_a` (defeq),
+    * `C46Spec (rowAt v r_a)` → `mul_constraint_46_named v r_a` (defeq),
+    * `ArithTableSpec (rowAt v r_a)` → the MULW mode pins,
+    * `ChunkRangeSpec (rowAt v r_a)` → the sixteen 16-bit chunk bounds,
+    * `CarryRangeSpec (rowAt v r_a)` → the seven signed-carry range bounds.
+
+    No new trust: the carry-chain, ROM membership, `bus_res1` mux, and the
+    range bounds all come from the provider component's proven soundness via
+    `FullSpec`, not from fresh per-opcode promises. -/
+lemma equiv_MULW_of_fullSpec
+    (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
+    (mulw_input : PureSpec.MulwInput)
+    (r1 r2 rd : regidx)
+    (bus : ZiskFv.Compliance.BusRows)
+    (m : Valid_Main FGL FGL) (r_main : ℕ)
+    (v : Valid_ArithMul FGL FGL) (r_a : ℕ)
+    (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_MUL_W)
+    (h_match_primary :
+      matches_entry (opBus_row_Main m r_main)
+                    (opBus_row_Arith v r_a))
+    (promises : ZiskFv.EquivCore.Promises.RTypePromises
+        state mulw_input.r1_val mulw_input.r2_val mulw_input.rd mulw_input.PC
+        (PureSpec.execute_MULW_pure mulw_input).nextPC
+        r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
+    (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
+    (h_full_spec :
+      ZiskFv.AirsClean.ArithMul.FullSpec (ZiskFv.AirsClean.ArithMul.rowAt v r_a))
+    (h_a23 : (v.a_2 r_a).val = 0 ∧ (v.a_3 r_a).val = 0)
+    (h_b23 : (v.b_2 r_a).val = 0 ∧ (v.b_3 r_a).val = 0)
+    (h_sext_choice :
+      (((byteAt bus.e2 4).val = 0 ∧ (byteAt bus.e2 5).val = 0 ∧ (byteAt bus.e2 6).val = 0 ∧ (byteAt bus.e2 7).val = 0) ∧
+        (v.c_0 r_a).val + (v.c_1 r_a).val * 65536 < 2147483648) ∨
+      (((byteAt bus.e2 4).val = 255 ∧ (byteAt bus.e2 5).val = 255 ∧ (byteAt bus.e2 6).val = 255 ∧ (byteAt bus.e2 7).val = 255) ∧
+        (v.c_0 r_a).val + (v.c_1 r_a).val * 65536 ≥ 2147483648))
+    (h_rs1_value :
+      (Sail.BitVec.extractLsb mulw_input.r1_val 31 0).toInt
+        = ((v.a_0 r_a).val + (v.a_1 r_a).val * 65536 : ℤ)
+            - (v.na r_a).val * (2:ℤ)^32)
+    (h_rs2_value :
+      (Sail.BitVec.extractLsb mulw_input.r2_val 31 0).toInt
+        = ((v.b_0 r_a).val + (v.b_1 r_a).val * 65536 : ℤ)
+            - (v.nb r_a).val * (2:ℤ)^32) :
+    (do
+      Sail.writeReg Register.nextPC
+        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
+      LeanRV64D.Functions.execute
+        (instruction.MULW (r2, r1, rd))) state
+      = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
+  -- Unpack FullSpec into its five conjuncts.
+  obtain ⟨h_spec, h_arith_table, h_c46, h_chunk_ranges_spec, h_carry_ranges_spec⟩ :=
+    h_full_spec
+  obtain ⟨exec_row, e0, e1, e2⟩ := bus
+  obtain ⟨_h_main_active, h_main_op_mulw⟩ := pins
+  -- ============ Project bus-bundle fields used by the body ============
+  have h_m2_mult := promises.m2_mult
+  have h_m2_as := promises.m2_as
+  -- ============ DERIVE arith-side opcode literal ============
+  have h_op_eq := arith_mul_primary_op_eq h_match_primary
+  have h_op_arith_mulw : v.op r_a = 182 := by
+    rw [h_op_eq, h_main_op_mulw]; simp [OP_MUL_W]
+  -- ============ Unpack matches_entry lane projections ============
+  obtain ⟨_h_a_lo_eq_FGL, _h_a_hi_eq_FGL, _h_b_lo_eq_FGL, _h_b_hi_eq_FGL,
+          h_c0_eq_FGL, _h_c1_eq_FGL⟩ :=
+    arith_mul_primary_projections h_match_primary
+  -- ============ Carry chain + c46 from FullSpec ============
+  -- `Spec (rowAt v r_a)` is defeq to the 11-clause `mul_carry_chain_holds`,
+  -- and `C46Spec (rowAt v r_a)` is defeq to `mul_constraint_46_named`.
+  have h_chain : ZiskFv.Airs.ArithMul.mul_carry_chain_holds v r_a := h_spec
+  -- ============ DISCHARGE true MULW static mode pins ============
+  obtain ⟨h_na, h_nb, h_np, h_nr, h_m32, h_div⟩ :=
+    ZiskFv.AirsClean.ArithTableProjections.Mul.mulw_basic_mode_pin
+      v r_a h_arith_table h_op_arith_mulw
+  have h_na_bool : v.na r_a = 0 ∨ v.na r_a = 1 := Or.inl h_na
+  have h_nb_bool : v.nb r_a = 0 ∨ v.nb r_a = 1 := Or.inl h_nb
+  have h_np_xor :
+      ZiskFv.PackedBitVec.SignedChunkLift.toIntZ (v.np r_a)
+        = ZiskFv.PackedBitVec.SignedChunkLift.toIntZ (v.na r_a)
+            + ZiskFv.PackedBitVec.SignedChunkLift.toIntZ (v.nb r_a)
+            - 2 * ZiskFv.PackedBitVec.SignedChunkLift.toIntZ (v.na r_a)
+                * ZiskFv.PackedBitVec.SignedChunkLift.toIntZ (v.nb r_a) := by
+    rw [h_na, h_nb, h_np]
+    decide
+  -- ============ Chunk / carry ranges from FullSpec ============
+  have h_arith_chunk_ranges :
+      ZiskFv.EquivCore.Bridge.Arith.ArithMulChunkRangesAt v r_a := h_chunk_ranges_spec
+  have h_arith_carry_ranges :
+      ZiskFv.EquivCore.Bridge.Arith.ArithMulSignedCarryRangesAt v r_a :=
+    h_carry_ranges_spec
+  obtain ⟨_h_a0_lt, _h_a1_lt, _h_a2_lt, _h_a3_lt,
+          _h_b0_lt, _h_b1_lt, _h_b2_lt, _h_b3_lt,
+          h_c0_lt, h_c1_lt, _h_c2_lt, _h_c3_lt,
+          _h_d0_lt, _h_d1_lt, _h_d2_lt, _h_d3_lt⟩ :=
+    h_chunk_ranges_spec
+  -- ============ DISCHARGE h_byte_lo (lane match, primary lane = c[]) ============
+  have h_bundle := arith_mem.c_lane_vals
+  have h_byte_lo_to_c0 : (byteAt e2 0).val + (byteAt e2 1).val * 256
+      + (byteAt e2 2).val * 65536 + (byteAt e2 3).val * 16777216
+      = (m.c_0 r_main).val := by
+    have h_e2_lo_bound : e2.value_0.val < 4294967296 := by
+      rw [← h_bundle.1, h_c0_eq_FGL]
+      rw [arith_h_pair_lift _ _ h_c0_lt h_c1_lt]
+      omega
+    rw [ZiskFv.Channels.MemoryBusBytes.byteAt_lo_val_sum_eq e2 h_e2_lo_bound, h_bundle.1]
+  have h_byte_lo := arith_byte_lane_eq_of_match h_byte_lo_to_c0 h_c0_eq_FGL h_c0_lt h_c1_lt
+  -- ============ Delegate to `equiv_MULW` (EquivCore) ============
+  exact ZiskFv.EquivCore.MulW.equiv_MULW
+    state mulw_input r1 r2 rd v r_a
+    ⟨exec_row, e0, e1, e2⟩
+    promises
+    h_chain h_nr h_m32 h_div h_op_arith_mulw
+    h_na_bool h_nb_bool h_np_xor
+    h_arith_chunk_ranges h_arith_carry_ranges
+    h_a23 h_b23 h_byte_lo h_sext_choice h_rs1_value h_rs2_value
+
 /-- Compatibility wrapper preserving the current canonical surface while
     the Compliance dispatcher is migrated to row-native table witnesses. -/
 lemma equiv_MULW

--- a/ZiskFv/EquivCore/WriteValueProofs/MulDivRemUnsigned.lean
+++ b/ZiskFv/EquivCore/WriteValueProofs/MulDivRemUnsigned.lean
@@ -1363,6 +1363,188 @@ lemma h_rd_val_mdru_divuw_chunked
       exact (Nat.mod_eq_of_lt h_byte_sum_lt).symm
   rw [h_byte_sum_eq]
 
+/-- **Loose-bound DIVUW rd-write reconstruction (W-mode).** Mirror of
+    `h_rd_val_mdru_divuw_chunked` with the balance-constructible carry bound
+    `< 983041` instead of `< 131072` (the genuine Euclidean-chain carries
+    exceed `2^17`, so the tight bound is not balance-derivable; same situation
+    as DIVU / MULHU).  Routes through the loose chunk identity
+    `fgl_div_unsigned_chunks_to_nat_identity_loose`, the W-mode BV64 quotient
+    extractor `fgl_div_w_unsigned_to_bv64`, and the `h_sext_choice`
+    sign-extension closers.  Body is otherwise identical to the tight chunked
+    lemma. -/
+lemma h_rd_val_mdru_divuw_loose
+    (r1 r2 : BitVec 64)
+    (e : MemoryBusEntry FGL)
+    -- Chunks (DIV layout: a=quotient, b=divisor, c=dividend, d=remainder)
+    (a₀ a₁ a₂ a₃ b₀ b₁ b₂ b₃ c₀ c₁ c₂ c₃ d₀ d₁ d₂ d₃ : FGL)
+    (cy₀ cy₁ cy₂ cy₃ cy₄ cy₅ cy₆ : FGL)
+    -- Per-byte range bounds
+    (h0 : (byteAt e 0).val < 256) (h1 : (byteAt e 1).val < 256)
+    (h2 : (byteAt e 2).val < 256) (h3 : (byteAt e 3).val < 256)
+    (h4 : (byteAt e 4).val < 256) (h5 : (byteAt e 5).val < 256)
+    (h6 : (byteAt e 6).val < 256) (h7 : (byteAt e 7).val < 256)
+    -- Per-chunk range bounds
+    (h_a0 : a₀.val < 65536) (h_a1 : a₁.val < 65536)
+    (h_a2 : a₂.val < 65536) (h_a3 : a₃.val < 65536)
+    (h_b0 : b₀.val < 65536) (h_b1 : b₁.val < 65536)
+    (h_b2 : b₂.val < 65536) (h_b3 : b₃.val < 65536)
+    (h_c0 : c₀.val < 65536) (h_c1 : c₁.val < 65536)
+    (h_c2 : c₂.val < 65536) (h_c3 : c₃.val < 65536)
+    (h_d0 : d₀.val < 65536) (h_d1 : d₁.val < 65536)
+    (h_d2 : d₂.val < 65536) (h_d3 : d₃.val < 65536)
+    -- Per-carry range bounds (LOOSE)
+    (h_cy0 : cy₀.val < 983041) (h_cy1 : cy₁.val < 983041)
+    (h_cy2 : cy₂.val < 983041) (h_cy3 : cy₃.val < 983041)
+    (h_cy4 : cy₄.val < 983041) (h_cy5 : cy₅.val < 983041)
+    (h_cy6 : cy₆.val < 983041)
+    -- 8 W-unsigned chunk equations (from div_w_unsigned_chain_witnesses)
+    (hC31 : a₀ * b₀ + d₀ = c₀ + cy₀ * 65536)
+    (hC32 : a₁ * b₀ + a₀ * b₁ + d₁ + cy₀ = c₁ + cy₁ * 65536)
+    (hC33 : a₂ * b₀ + a₁ * b₁ + a₀ * b₂ + d₂ + cy₁ = c₂ + cy₂ * 65536)
+    (hC34 : a₃ * b₀ + a₂ * b₁ + a₁ * b₂ + a₀ * b₃ + d₃ + cy₂
+              = c₃ + cy₃ * 65536)
+    (hC35 : a₃ * b₁ + a₂ * b₂ + a₁ * b₃ + cy₃ = cy₄ * 65536)
+    (hC36 : a₃ * b₂ + a₂ * b₃ + cy₄ = cy₅ * 65536)
+    (hC37 : a₃ * b₃ + cy₅ = cy₆ * 65536)
+    (hC38 : cy₆ = 0)
+    -- W-mode operand chunk pin (from arith_table_op_divw_operand_pin)
+    (h_a23 : a₂.val = 0 ∧ a₃.val = 0)
+    (h_b23 : b₂.val = 0 ∧ b₃.val = 0)
+    (h_d23 : d₂.val = 0 ∧ d₃.val = 0)
+    -- W-mode c-chunk pin (bus encoding: dividend is zero-extended r1_lo32)
+    (h_c23 : c₂.val = 0 ∧ c₃.val = 0)
+    -- Byte-pack lane match (W): bytes 0..3 pack a_0 + a_1*65536 (quotient low 32)
+    (h_byte_lo :
+      (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216
+        = a₀.val + a₁.val * 65536)
+    -- Sign-extension choice on bytes 4..7 (SEXT_00 / SEXT_FF case-disjunction)
+    (h_sext_choice :
+      (((byteAt e 4).val = 0 ∧ (byteAt e 5).val = 0 ∧ (byteAt e 6).val = 0 ∧ (byteAt e 7).val = 0) ∧
+        a₀.val + a₁.val * 65536 < 2147483648) ∨
+      (((byteAt e 4).val = 255 ∧ (byteAt e 5).val = 255 ∧ (byteAt e 6).val = 255 ∧ (byteAt e 7).val = 255) ∧
+        a₀.val + a₁.val * 65536 ≥ 2147483648))
+    -- Operand TRANSPILE-BRIDGE (W form: low 32 bits)
+    (h_rs1_value : (Sail.BitVec.extractLsb r1 31 0).toNat = c₀.val + c₁.val * 65536)
+    (h_rs2_value : (Sail.BitVec.extractLsb r2 31 0).toNat = b₀.val + b₁.val * 65536)
+    -- Divisor non-zero (CIRCUIT-CONSTRAINT)
+    (h_op2_ne : (Sail.BitVec.extractLsb r2 31 0).toNat ≠ 0)
+    -- Remainder strictly less than divisor (CIRCUIT-CONSTRAINT)
+    (h_d_lt_b : d₀.val + d₁.val * 65536 < (Sail.BitVec.extractLsb r2 31 0).toNat) :
+    U64.toBV #v[((byteAt e 0) : BitVec 8), ((byteAt e 1) : BitVec 8), ((byteAt e 2) : BitVec 8), ((byteAt e 3) : BitVec 8),
+                ((byteAt e 4) : BitVec 8), ((byteAt e 5) : BitVec 8), ((byteAt e 6) : BitVec 8), ((byteAt e 7) : BitVec 8)]
+      = (let r1_lo32 : BitVec 32 := Sail.BitVec.extractLsb r1 31 0
+         let r2_lo32 : BitVec 32 := Sail.BitVec.extractLsb r2 31 0
+         let q32 : BitVec 32 :=
+           if r2_lo32 = 0#32
+             then BitVec.allOnes 32
+             else BitVec.ofNat 32 (r1_lo32.toNat / r2_lo32.toNat)
+         BitVec.signExtend 64 q32) := by
+  -- ℕ Euclidean packed identity over full 4-chunks (LOOSE bound).
+  have h_packed_nat : packed4 a₀.val a₁.val a₂.val a₃.val
+        * packed4 b₀.val b₁.val b₂.val b₃.val
+        + packed4 d₀.val d₁.val d₂.val d₃.val
+      = packed4 c₀.val c₁.val c₂.val c₃.val :=
+    fgl_div_unsigned_chunks_to_nat_identity_loose
+      a₀ a₁ a₂ a₃ b₀ b₁ b₂ b₃ c₀ c₁ c₂ c₃ d₀ d₁ d₂ d₃
+      cy₀ cy₁ cy₂ cy₃ cy₄ cy₅ cy₆
+      h_a0 h_a1 h_a2 h_a3 h_b0 h_b1 h_b2 h_b3
+      h_c0 h_c1 h_c2 h_c3 h_d0 h_d1 h_d2 h_d3
+      h_cy0 h_cy1 h_cy2 h_cy3 h_cy4 h_cy5 h_cy6
+      hC31 hC32 hC33 hC34 hC35 hC36 hC37 hC38
+  -- collapse packed4 to 32-bit form via W-mode chunk pins.
+  obtain ⟨ha2_eq, ha3_eq⟩ := h_a23
+  obtain ⟨hb2_eq, hb3_eq⟩ := h_b23
+  obtain ⟨hd2_eq, hd3_eq⟩ := h_d23
+  obtain ⟨hc2_eq, hc3_eq⟩ := h_c23
+  have h_q32_lt : a₀.val + a₁.val * 65536 < 4294967296 := by
+    have : a₁.val * 65536 ≤ 65535 * 65536 := Nat.mul_le_mul_right _ (by omega)
+    omega
+  have h_euclid32 :
+      (a₀.val + a₁.val * 65536) * (b₀.val + b₁.val * 65536) + (d₀.val + d₁.val * 65536)
+      = c₀.val + c₁.val * 65536 := by
+    have h_pn := h_packed_nat
+    unfold packed4 at h_pn
+    rw [ha2_eq, ha3_eq, hb2_eq, hb3_eq, hc2_eq, hc3_eq, hd2_eq, hd3_eq] at h_pn
+    linarith
+  -- rewrite Euclidean identity in terms of r1_lo32 / r2_lo32.
+  rw [← h_rs2_value] at h_euclid32
+  have h_euclid : (Sail.BitVec.extractLsb r1 31 0).toNat
+                    = (a₀.val + a₁.val * 65536) * (Sail.BitVec.extractLsb r2 31 0).toNat
+                        + (d₀.val + d₁.val * 65536) := by
+    rw [h_rs1_value]; linarith [h_euclid32]
+  -- invoke Layer 1 BV64 wrapper for the DIVUW quotient.
+  have h_bv :=
+    ZiskFv.PackedBitVec.SignedNoWrap.fgl_div_w_unsigned_to_bv64
+      r1 r2 (a₀.val + a₁.val * 65536) (d₀.val + d₁.val * 65536)
+      h_op2_ne h_d_lt_b h_euclid
+  -- close via sext_choice. Use the byte-sum identity from the lane matches.
+  apply BitVec.eq_of_toNat_eq
+  rw [u64_toBV_of_bytes_toNat (byteAt e 0) (byteAt e 1) (byteAt e 2) (byteAt e 3) (byteAt e 4) (byteAt e 5) (byteAt e 6) (byteAt e 7)
+        h0 h1 h2 h3 h4 h5 h6 h7]
+  rw [← h_bv]
+  have h_byte_sum_eq :
+      (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216
+        + (byteAt e 4).val * 4294967296 + (byteAt e 5).val * 1099511627776
+        + (byteAt e 6).val * 281474976710656 + (byteAt e 7).val * 72057594037927936
+      = (BitVec.signExtend 64
+          (BitVec.ofNat 32 (a₀.val + a₁.val * 65536))).toNat := by
+    rcases h_sext_choice with ⟨⟨hx4, hx5, hx6, hx7⟩, h_pos⟩ |
+                              ⟨⟨hx4, hx5, hx6, hx7⟩, h_neg⟩
+    · -- Positive: x4..x7 = 0.
+      rw [hx4, hx5, hx6, hx7]
+      have h_close := w_sext_close_pos
+        (a₀.val + a₁.val * 65536)
+        ((byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216)
+        h_q32_lt (by omega) h_byte_lo h_pos
+      have h_lhs_eq :
+          (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216
+            + 0 * 4294967296 + 0 * 1099511627776 + 0 * 281474976710656
+            + 0 * 72057594037927936
+          = (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216 := by ring
+      rw [h_lhs_eq]
+      have h_close_lt :
+          (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216
+            < 18446744073709551616 := by
+        rw [h_byte_lo]; omega
+      have h_bv64_inj :
+          (BitVec.ofNat 64
+              ((byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216)).toNat
+          = (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216 := by
+        rw [BitVec.toNat_ofNat]
+        exact Nat.mod_eq_of_lt h_close_lt
+      rw [show BitVec.signExtend 64 (BitVec.ofNat 32 (a₀.val + a₁.val * 65536))
+            = BitVec.ofNat 64
+                ((byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216)
+            from h_close]
+      exact h_bv64_inj.symm
+    · -- Negative: x4..x7 = 255.
+      rw [hx4, hx5, hx6, hx7]
+      have h_byte_eq_neg :
+          (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216
+            + 255 * 4294967296 + 255 * 1099511627776
+            + 255 * 281474976710656 + 255 * 72057594037927936
+          = ((byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216)
+              + 18446744069414584320 := by ring
+      rw [h_byte_eq_neg]
+      have h_byte_sum_lt :
+          ((byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216)
+            + 18446744069414584320 < 18446744073709551616 := by
+        rw [h_byte_lo]; omega
+      have h_close := w_sext_close_neg
+        (a₀.val + a₁.val * 65536)
+        (((byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216)
+          + 18446744069414584320)
+        h_q32_lt h_byte_sum_lt
+        (by rw [h_byte_lo]) h_neg
+      rw [show BitVec.signExtend 64 (BitVec.ofNat 32 (a₀.val + a₁.val * 65536))
+            = BitVec.ofNat 64
+                (((byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216)
+                  + 18446744069414584320)
+            from h_close]
+      rw [BitVec.toNat_ofNat]
+      exact (Nat.mod_eq_of_lt h_byte_sum_lt).symm
+  rw [h_byte_sum_eq]
+
 /-- **`h_rd_val` discharge for REMUW — chunked W-mode (structural unpacking).**
 
     Mirror of `h_rd_val_mdru_divuw_chunked` for the remainder lane.

--- a/ZiskFv/EquivCore/WriteValueProofs/MulDivRemUnsigned.lean
+++ b/ZiskFv/EquivCore/WriteValueProofs/MulDivRemUnsigned.lean
@@ -1054,6 +1054,102 @@ lemma h_rd_val_mdru_remu
     (byteAt e 0) (byteAt e 1) (byteAt e 2) (byteAt e 3) (byteAt e 4) (byteAt e 5) (byteAt e 6) (byteAt e 7)
     h0 h1 h2 h3 h4 h5 h6 h7 h_byte_sum
 
+/-- **Loose-bound REMU rd-write reconstruction.** Mirror of
+    `h_rd_val_mdru_remu` with the balance-constructible carry bound
+    `< 983041` instead of `< 131072` (the genuine Euclidean-chain carries
+    exceed `2^17`, so the tight bound is not balance-derivable; same
+    situation as DIVU / MULHU).  Routes through the loose chunk identity
+    `fgl_div_unsigned_chunks_to_nat_identity_loose`, the public Euclidean
+    remainder extractor `fgl_rem_unsigned_to_bv64`, and the byte-sum bridge
+    `remu_bv64_of_byte_sum`.  The bus entry's bytes pack `d[]` chunks (the
+    remainder lanes). -/
+lemma h_rd_val_mdru_remu_loose
+    (op1 op2 : BitVec 64)
+    (e : MemoryBusEntry FGL)
+    (a₀ a₁ a₂ a₃ b₀ b₁ b₂ b₃ c₀ c₁ c₂ c₃ d₀ d₁ d₂ d₃ : FGL)
+    (cy₀ cy₁ cy₂ cy₃ cy₄ cy₅ cy₆ : FGL)
+    (h0 : (byteAt e 0).val < 256) (h1 : (byteAt e 1).val < 256)
+    (h2 : (byteAt e 2).val < 256) (h3 : (byteAt e 3).val < 256)
+    (h4 : (byteAt e 4).val < 256) (h5 : (byteAt e 5).val < 256)
+    (h6 : (byteAt e 6).val < 256) (h7 : (byteAt e 7).val < 256)
+    (h_a0 : a₀.val < 65536) (h_a1 : a₁.val < 65536)
+    (h_a2 : a₂.val < 65536) (h_a3 : a₃.val < 65536)
+    (h_b0 : b₀.val < 65536) (h_b1 : b₁.val < 65536)
+    (h_b2 : b₂.val < 65536) (h_b3 : b₃.val < 65536)
+    (h_c0 : c₀.val < 65536) (h_c1 : c₁.val < 65536)
+    (h_c2 : c₂.val < 65536) (h_c3 : c₃.val < 65536)
+    (h_d0 : d₀.val < 65536) (h_d1 : d₁.val < 65536)
+    (h_d2 : d₂.val < 65536) (h_d3 : d₃.val < 65536)
+    (h_cy0 : cy₀.val < 983041) (h_cy1 : cy₁.val < 983041)
+    (h_cy2 : cy₂.val < 983041) (h_cy3 : cy₃.val < 983041)
+    (h_cy4 : cy₄.val < 983041) (h_cy5 : cy₅.val < 983041)
+    (h_cy6 : cy₆.val < 983041)
+    (hC31 : a₀ * b₀ + d₀ = c₀ + cy₀ * 65536)
+    (hC32 : a₁ * b₀ + a₀ * b₁ + d₁ + cy₀ = c₁ + cy₁ * 65536)
+    (hC33 : a₂ * b₀ + a₁ * b₁ + a₀ * b₂ + d₂ + cy₁ = c₂ + cy₂ * 65536)
+    (hC34 : a₃ * b₀ + a₂ * b₁ + a₁ * b₂ + a₀ * b₃ + d₃ + cy₂
+              = c₃ + cy₃ * 65536)
+    (hC35 : a₃ * b₁ + a₂ * b₂ + a₁ * b₃ + cy₃ = cy₄ * 65536)
+    (hC36 : a₃ * b₂ + a₂ * b₃ + cy₄ = cy₅ * 65536)
+    (hC37 : a₃ * b₃ + cy₅ = cy₆ * 65536)
+    (hC38 : cy₆ = 0)
+    (h_byte_lo :
+      (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216
+        = d₀.val + d₁.val * 65536)
+    (h_byte_hi :
+      (byteAt e 4).val + (byteAt e 5).val * 256 + (byteAt e 6).val * 65536 + (byteAt e 7).val * 16777216
+        = d₂.val + d₃.val * 65536)
+    (h_rs1_value : op1.toNat = packed4 c₀.val c₁.val c₂.val c₃.val)
+    (h_rs2_value : op2.toNat = packed4 b₀.val b₁.val b₂.val b₃.val)
+    (h_op2_ne : op2.toNat ≠ 0)
+    (h_d_lt_b : packed4 d₀.val d₁.val d₂.val d₃.val < op2.toNat) :
+    U64.toBV #v[((byteAt e 0) : BitVec 8), ((byteAt e 1) : BitVec 8), ((byteAt e 2) : BitVec 8), ((byteAt e 3) : BitVec 8),
+                ((byteAt e 4) : BitVec 8), ((byteAt e 5) : BitVec 8), ((byteAt e 6) : BitVec 8), ((byteAt e 7) : BitVec 8)]
+      = (execute_DIV_REM_pure op1 op2 .DRU).2 := by
+  have h_packed_nat : packed4 a₀.val a₁.val a₂.val a₃.val
+        * packed4 b₀.val b₁.val b₂.val b₃.val
+        + packed4 d₀.val d₁.val d₂.val d₃.val
+      = packed4 c₀.val c₁.val c₂.val c₃.val :=
+    fgl_div_unsigned_chunks_to_nat_identity_loose
+      a₀ a₁ a₂ a₃ b₀ b₁ b₂ b₃ c₀ c₁ c₂ c₃ d₀ d₁ d₂ d₃
+      cy₀ cy₁ cy₂ cy₃ cy₄ cy₅ cy₆
+      h_a0 h_a1 h_a2 h_a3 h_b0 h_b1 h_b2 h_b3
+      h_c0 h_c1 h_c2 h_c3 h_d0 h_d1 h_d2 h_d3
+      h_cy0 h_cy1 h_cy2 h_cy3 h_cy4 h_cy5 h_cy6
+      hC31 hC32 hC33 hC34 hC35 hC36 hC37 hC38
+  rw [← h_rs1_value, ← h_rs2_value] at h_packed_nat
+  have h_rem_eq : op1.toNat % op2.toNat = packed4 d₀.val d₁.val d₂.val d₃.val :=
+    fgl_rem_unsigned_to_bv64 h_op2_ne h_d_lt_b h_packed_nat
+  have h_byte_eq_packed :
+      (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216
+        + (byteAt e 4).val * 4294967296 + (byteAt e 5).val * 1099511627776
+        + (byteAt e 6).val * 281474976710656 + (byteAt e 7).val * 72057594037927936
+      = packed4 d₀.val d₁.val d₂.val d₃.val :=
+    byte_sum_eq_packed4 e d₀.val d₁.val d₂.val d₃.val h_byte_lo h_byte_hi
+  have h_r_eq : (execute_DIV_REM_pure op1 op2 .DRU).2.toNat
+      = op1.toNat % op2.toNat := by
+    have h_op2_int_ne : (op2.toNat : ℤ) ≠ 0 := by exact_mod_cast h_op2_ne
+    simp only [execute_DIV_REM_pure, execute_DIV_REM_pure_int]
+    rw [BitVec.toNat_ofNat]
+    have h_tmod : (Int.tmod (op1.toNat : ℤ) (op2.toNat : ℤ)).toNat
+        = op1.toNat % op2.toNat := rfl
+    rw [h_tmod]
+    have h_op2_pos : 0 < op2.toNat := Nat.pos_of_ne_zero h_op2_ne
+    have h_rem_lt : op1.toNat % op2.toNat < 2 ^ 64 := by
+      calc op1.toNat % op2.toNat
+          < op2.toNat := Nat.mod_lt _ h_op2_pos
+        _ < 2 ^ 64 := op2.isLt
+    exact Nat.mod_eq_of_lt h_rem_lt
+  have h_byte_sum :
+      (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216
+        + (byteAt e 4).val * 4294967296 + (byteAt e 5).val * 1099511627776
+        + (byteAt e 6).val * 281474976710656 + (byteAt e 7).val * 72057594037927936
+      = (execute_DIV_REM_pure op1 op2 .DRU).2.toNat := by
+    rw [h_byte_eq_packed, ← h_rem_eq, h_r_eq]
+  exact remu_bv64_of_byte_sum op1 op2
+    (byteAt e 0) (byteAt e 1) (byteAt e 2) (byteAt e 3) (byteAt e 4) (byteAt e 5) (byteAt e 6) (byteAt e 7)
+    h0 h1 h2 h3 h4 h5 h6 h7 h_byte_sum
+
 /-- **`h_rd_val` discharge for MULW (Tier 1).**
 
     MULW takes the low 32 bits of `op1` and `op2`, multiplies as signed,

--- a/ZiskFv/EquivCore/WriteValueProofs/MulDivRemUnsigned.lean
+++ b/ZiskFv/EquivCore/WriteValueProofs/MulDivRemUnsigned.lean
@@ -1806,4 +1806,176 @@ lemma h_rd_val_mdru_remuw_chunked
       exact (Nat.mod_eq_of_lt h_byte_sum_lt).symm
   rw [h_byte_sum_eq]
 
+/-- **`h_rd_val` discharge for REMUW — loose-carry W-mode (balance route).**
+
+    Mirror of `h_rd_val_mdru_remuw_chunked` but consuming the LOOSER
+    balance-constructible carry bound `< 983041` (`unsigned_carry_step_nat`)
+    instead of the tight `< 131072`, exactly as `h_rd_val_mdru_divuw_loose`
+    relates to `h_rd_val_mdru_divuw_chunked`.  The genuine Euclidean carries
+    (`quotient · divisor`) reach `~3·2^16 > 2^17`, so the tight `< 131072` bound
+    is not balance-constructible; the looser bound is the one the P4 construction
+    derives from `FullSpec.CarryRangeSpec`.  The Euclidean packed identity is
+    derived via the loose-bound `fgl_div_unsigned_chunks_to_nat_identity_loose`.
+    Bytes 0..3 pack `d_0 + d_1*65536` (remainder low 32); bytes 4..7 are the
+    sign-extension via `h_sext_choice`. -/
+lemma h_rd_val_mdru_remuw_loose
+    (r1 r2 : BitVec 64)
+    (e : MemoryBusEntry FGL)
+    (a₀ a₁ a₂ a₃ b₀ b₁ b₂ b₃ c₀ c₁ c₂ c₃ d₀ d₁ d₂ d₃ : FGL)
+    (cy₀ cy₁ cy₂ cy₃ cy₄ cy₅ cy₆ : FGL)
+    (h0 : (byteAt e 0).val < 256) (h1 : (byteAt e 1).val < 256)
+    (h2 : (byteAt e 2).val < 256) (h3 : (byteAt e 3).val < 256)
+    (h4 : (byteAt e 4).val < 256) (h5 : (byteAt e 5).val < 256)
+    (h6 : (byteAt e 6).val < 256) (h7 : (byteAt e 7).val < 256)
+    (h_a0 : a₀.val < 65536) (h_a1 : a₁.val < 65536)
+    (h_a2 : a₂.val < 65536) (h_a3 : a₃.val < 65536)
+    (h_b0 : b₀.val < 65536) (h_b1 : b₁.val < 65536)
+    (h_b2 : b₂.val < 65536) (h_b3 : b₃.val < 65536)
+    (h_c0 : c₀.val < 65536) (h_c1 : c₁.val < 65536)
+    (h_c2 : c₂.val < 65536) (h_c3 : c₃.val < 65536)
+    (h_d0 : d₀.val < 65536) (h_d1 : d₁.val < 65536)
+    (h_d2 : d₂.val < 65536) (h_d3 : d₃.val < 65536)
+    -- Per-carry range bounds (LOOSE)
+    (h_cy0 : cy₀.val < 983041) (h_cy1 : cy₁.val < 983041)
+    (h_cy2 : cy₂.val < 983041) (h_cy3 : cy₃.val < 983041)
+    (h_cy4 : cy₄.val < 983041) (h_cy5 : cy₅.val < 983041)
+    (h_cy6 : cy₆.val < 983041)
+    (hC31 : a₀ * b₀ + d₀ = c₀ + cy₀ * 65536)
+    (hC32 : a₁ * b₀ + a₀ * b₁ + d₁ + cy₀ = c₁ + cy₁ * 65536)
+    (hC33 : a₂ * b₀ + a₁ * b₁ + a₀ * b₂ + d₂ + cy₁ = c₂ + cy₂ * 65536)
+    (hC34 : a₃ * b₀ + a₂ * b₁ + a₁ * b₂ + a₀ * b₃ + d₃ + cy₂
+              = c₃ + cy₃ * 65536)
+    (hC35 : a₃ * b₁ + a₂ * b₂ + a₁ * b₃ + cy₃ = cy₄ * 65536)
+    (hC36 : a₃ * b₂ + a₂ * b₃ + cy₄ = cy₅ * 65536)
+    (hC37 : a₃ * b₃ + cy₅ = cy₆ * 65536)
+    (hC38 : cy₆ = 0)
+    (h_a23 : a₂.val = 0 ∧ a₃.val = 0)
+    (h_b23 : b₂.val = 0 ∧ b₃.val = 0)
+    (h_d23 : d₂.val = 0 ∧ d₃.val = 0)
+    (h_c23 : c₂.val = 0 ∧ c₃.val = 0)
+    -- Byte-pack lane match (W): bytes 0..3 pack d_0 + d_1*65536 (remainder low 32)
+    (h_byte_lo :
+      (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216
+        = d₀.val + d₁.val * 65536)
+    -- Sign-extension choice on bytes 4..7 (based on top bit of remainder).
+    (h_sext_choice :
+      (((byteAt e 4).val = 0 ∧ (byteAt e 5).val = 0 ∧ (byteAt e 6).val = 0 ∧ (byteAt e 7).val = 0) ∧
+        d₀.val + d₁.val * 65536 < 2147483648) ∨
+      (((byteAt e 4).val = 255 ∧ (byteAt e 5).val = 255 ∧ (byteAt e 6).val = 255 ∧ (byteAt e 7).val = 255) ∧
+        d₀.val + d₁.val * 65536 ≥ 2147483648))
+    (h_rs1_value : (Sail.BitVec.extractLsb r1 31 0).toNat = c₀.val + c₁.val * 65536)
+    (h_rs2_value : (Sail.BitVec.extractLsb r2 31 0).toNat = b₀.val + b₁.val * 65536)
+    (h_op2_ne : (Sail.BitVec.extractLsb r2 31 0).toNat ≠ 0)
+    (h_d_lt_b : d₀.val + d₁.val * 65536 < (Sail.BitVec.extractLsb r2 31 0).toNat) :
+    U64.toBV #v[((byteAt e 0) : BitVec 8), ((byteAt e 1) : BitVec 8), ((byteAt e 2) : BitVec 8), ((byteAt e 3) : BitVec 8),
+                ((byteAt e 4) : BitVec 8), ((byteAt e 5) : BitVec 8), ((byteAt e 6) : BitVec 8), ((byteAt e 7) : BitVec 8)]
+      = (let r1_lo32 : BitVec 32 := Sail.BitVec.extractLsb r1 31 0
+         let r2_lo32 : BitVec 32 := Sail.BitVec.extractLsb r2 31 0
+         let q32 : BitVec 32 :=
+           if r2_lo32 = 0#32
+             then r1_lo32
+             else BitVec.ofNat 32 (r1_lo32.toNat % r2_lo32.toNat)
+         BitVec.signExtend 64 q32) := by
+  have h_packed_nat : packed4 a₀.val a₁.val a₂.val a₃.val
+        * packed4 b₀.val b₁.val b₂.val b₃.val
+        + packed4 d₀.val d₁.val d₂.val d₃.val
+      = packed4 c₀.val c₁.val c₂.val c₃.val :=
+    fgl_div_unsigned_chunks_to_nat_identity_loose
+      a₀ a₁ a₂ a₃ b₀ b₁ b₂ b₃ c₀ c₁ c₂ c₃ d₀ d₁ d₂ d₃
+      cy₀ cy₁ cy₂ cy₃ cy₄ cy₅ cy₆
+      h_a0 h_a1 h_a2 h_a3 h_b0 h_b1 h_b2 h_b3
+      h_c0 h_c1 h_c2 h_c3 h_d0 h_d1 h_d2 h_d3
+      h_cy0 h_cy1 h_cy2 h_cy3 h_cy4 h_cy5 h_cy6
+      hC31 hC32 hC33 hC34 hC35 hC36 hC37 hC38
+  obtain ⟨ha2_eq, ha3_eq⟩ := h_a23
+  obtain ⟨hb2_eq, hb3_eq⟩ := h_b23
+  obtain ⟨hd2_eq, hd3_eq⟩ := h_d23
+  obtain ⟨hc2_eq, hc3_eq⟩ := h_c23
+  have h_q32_lt : a₀.val + a₁.val * 65536 < 4294967296 := by
+    have : a₁.val * 65536 ≤ 65535 * 65536 := Nat.mul_le_mul_right _ (by omega)
+    omega
+  have h_r32_lt : d₀.val + d₁.val * 65536 < 4294967296 := by
+    have : d₁.val * 65536 ≤ 65535 * 65536 := Nat.mul_le_mul_right _ (by omega)
+    omega
+  have h_euclid32 :
+      (a₀.val + a₁.val * 65536) * (b₀.val + b₁.val * 65536) + (d₀.val + d₁.val * 65536)
+      = c₀.val + c₁.val * 65536 := by
+    have h_pn := h_packed_nat
+    unfold packed4 at h_pn
+    rw [ha2_eq, ha3_eq, hb2_eq, hb3_eq, hc2_eq, hc3_eq, hd2_eq, hd3_eq] at h_pn
+    linarith
+  rw [← h_rs2_value] at h_euclid32
+  have h_euclid : (Sail.BitVec.extractLsb r1 31 0).toNat
+                    = (a₀.val + a₁.val * 65536) * (Sail.BitVec.extractLsb r2 31 0).toNat
+                        + (d₀.val + d₁.val * 65536) := by
+    rw [h_rs1_value]; linarith [h_euclid32]
+  have h_bv :=
+    ZiskFv.PackedBitVec.SignedNoWrap.fgl_rem_w_unsigned_to_bv64
+      r1 r2 (a₀.val + a₁.val * 65536) (d₀.val + d₁.val * 65536)
+      h_op2_ne h_d_lt_b h_euclid
+  apply BitVec.eq_of_toNat_eq
+  rw [u64_toBV_of_bytes_toNat (byteAt e 0) (byteAt e 1) (byteAt e 2) (byteAt e 3) (byteAt e 4) (byteAt e 5) (byteAt e 6) (byteAt e 7)
+        h0 h1 h2 h3 h4 h5 h6 h7]
+  rw [← h_bv]
+  have h_byte_sum_eq :
+      (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216
+        + (byteAt e 4).val * 4294967296 + (byteAt e 5).val * 1099511627776
+        + (byteAt e 6).val * 281474976710656 + (byteAt e 7).val * 72057594037927936
+      = (BitVec.signExtend 64
+          (BitVec.ofNat 32 (d₀.val + d₁.val * 65536))).toNat := by
+    rcases h_sext_choice with ⟨⟨hx4, hx5, hx6, hx7⟩, h_pos⟩ |
+                              ⟨⟨hx4, hx5, hx6, hx7⟩, h_neg⟩
+    · rw [hx4, hx5, hx6, hx7]
+      have h_close := w_sext_close_pos
+        (d₀.val + d₁.val * 65536)
+        ((byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216)
+        h_r32_lt (by omega) h_byte_lo h_pos
+      have h_lhs_eq :
+          (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216
+            + 0 * 4294967296 + 0 * 1099511627776 + 0 * 281474976710656
+            + 0 * 72057594037927936
+          = (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216 := by ring
+      rw [h_lhs_eq]
+      have h_close_lt :
+          (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216
+            < 18446744073709551616 := by
+        rw [h_byte_lo]; omega
+      have h_bv64_inj :
+          (BitVec.ofNat 64
+              ((byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216)).toNat
+          = (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216 := by
+        rw [BitVec.toNat_ofNat]
+        exact Nat.mod_eq_of_lt h_close_lt
+      rw [show BitVec.signExtend 64 (BitVec.ofNat 32 (d₀.val + d₁.val * 65536))
+            = BitVec.ofNat 64
+                ((byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216)
+            from h_close]
+      exact h_bv64_inj.symm
+    · rw [hx4, hx5, hx6, hx7]
+      have h_byte_eq_neg :
+          (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216
+            + 255 * 4294967296 + 255 * 1099511627776
+            + 255 * 281474976710656 + 255 * 72057594037927936
+          = ((byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216)
+              + 18446744069414584320 := by ring
+      rw [h_byte_eq_neg]
+      have h_byte_sum_lt :
+          ((byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216)
+            + 18446744069414584320 < 18446744073709551616 := by
+        rw [h_byte_lo]; omega
+      have h_close := w_sext_close_neg
+        (d₀.val + d₁.val * 65536)
+        (((byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216)
+          + 18446744069414584320)
+        h_r32_lt h_byte_sum_lt
+        (by rw [h_byte_lo]) h_neg
+      rw [show BitVec.signExtend 64 (BitVec.ofNat 32 (d₀.val + d₁.val * 65536))
+            = BitVec.ofNat 64
+                (((byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216)
+                  + 18446744069414584320)
+            from h_close]
+      rw [BitVec.toNat_ofNat]
+      exact (Nat.mod_eq_of_lt h_byte_sum_lt).symm
+  rw [h_byte_sum_eq]
+
 end ZiskFv.EquivCore.WriteValueProofs.MulDivRemUnsigned

--- a/ZiskFv/EquivCore/WriteValueProofs/MulDivRemUnsigned.lean
+++ b/ZiskFv/EquivCore/WriteValueProofs/MulDivRemUnsigned.lean
@@ -653,6 +653,306 @@ lemma h_rd_val_mdru_divu
     (byteAt e 0) (byteAt e 1) (byteAt e 2) (byteAt e 3) (byteAt e 4) (byteAt e 5) (byteAt e 6) (byteAt e 7)
     h0 h1 h2 h3 h4 h5 h6 h7 h_byte_sum
 
+/-! ## DIV-mode per-chunk FGL→ℕ lifts — LOOSE carry bound (`< 983041`)
+
+Copies of the `fgl_div_chunk_lift_*` lemmas above with the carry bound
+relaxed from `< 131072` (`2^17`) to the balance-constructible `< 983041`.
+The genuine 4×4 unsigned-multiply carries of the Euclidean chain reach
+`~3·2^16 > 2^17`, so the tight bound is NOT satisfiable from real balance
+data (the same situation as MULHU; see `ConstructionMulhu.lean`).  The
+no-wrap argument is unaffected: each chunk equation's two sides stay below
+`GL_prime` (LHS ≤ `4·(2^16-1)^2 + (2^16-1) + 983040 < 2^36`; RHS `≤
+65535 + 983040·65536 < 2^36`). -/
+
+private lemma fgl_div_chunk_lift_1_loose
+    (a b d c cy : FGL)
+    (h_a : a.val < 65536) (h_b : b.val < 65536)
+    (h_d : d.val < 65536) (h_c : c.val < 65536) (h_cy : cy.val < 983041)
+    (h : a * b + d = c + cy * 65536) :
+    a.val * b.val + d.val = c.val + cy.val * 65536 := by
+  have h_lhs : a * b + d
+      = (((a.val * b.val + d.val : ℕ)) : FGL) := by push_cast; ring
+  have h_rhs : c + cy * 65536
+      = (((c.val + cy.val * 65536 : ℕ)) : FGL) := by push_cast; ring
+  rw [h_lhs, h_rhs] at h
+  refine ZiskFv.PackedBitVec.NoWrap.fgl_eq_to_nat_eq h ?_ ?_
+  · have : a.val * b.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    omega
+  · omega
+
+private lemma fgl_div_chunk_lift_2_loose
+    (a₁ a₀ b₀ b₁ d cy_in c cy_out : FGL)
+    (h_a1 : a₁.val < 65536) (h_a0 : a₀.val < 65536)
+    (h_b0 : b₀.val < 65536) (h_b1 : b₁.val < 65536)
+    (h_d : d.val < 65536) (h_cy_in : cy_in.val < 983041)
+    (h_c : c.val < 65536) (h_cy_out : cy_out.val < 983041)
+    (h : a₁ * b₀ + a₀ * b₁ + d + cy_in = c + cy_out * 65536) :
+    a₁.val * b₀.val + a₀.val * b₁.val + d.val + cy_in.val
+      = c.val + cy_out.val * 65536 := by
+  have h_lhs : a₁ * b₀ + a₀ * b₁ + d + cy_in
+      = (((a₁.val * b₀.val + a₀.val * b₁.val + d.val + cy_in.val : ℕ)) : FGL) := by
+    push_cast; ring
+  have h_rhs : c + cy_out * 65536
+      = (((c.val + cy_out.val * 65536 : ℕ)) : FGL) := by push_cast; ring
+  rw [h_lhs, h_rhs] at h
+  refine ZiskFv.PackedBitVec.NoWrap.fgl_eq_to_nat_eq h ?_ ?_
+  · have h1 : a₁.val * b₀.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    have h2 : a₀.val * b₁.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    omega
+  · omega
+
+private lemma fgl_div_chunk_lift_3_loose
+    (a₂ a₁ a₀ b₀ b₁ b₂ d cy_in c cy_out : FGL)
+    (h_a2 : a₂.val < 65536) (h_a1 : a₁.val < 65536) (h_a0 : a₀.val < 65536)
+    (h_b0 : b₀.val < 65536) (h_b1 : b₁.val < 65536) (h_b2 : b₂.val < 65536)
+    (h_d : d.val < 65536) (h_cy_in : cy_in.val < 983041)
+    (h_c : c.val < 65536) (h_cy_out : cy_out.val < 983041)
+    (h : a₂ * b₀ + a₁ * b₁ + a₀ * b₂ + d + cy_in = c + cy_out * 65536) :
+    a₂.val * b₀.val + a₁.val * b₁.val + a₀.val * b₂.val + d.val + cy_in.val
+      = c.val + cy_out.val * 65536 := by
+  have h_lhs : a₂ * b₀ + a₁ * b₁ + a₀ * b₂ + d + cy_in
+      = (((a₂.val * b₀.val + a₁.val * b₁.val + a₀.val * b₂.val + d.val + cy_in.val : ℕ))
+          : FGL) := by push_cast; ring
+  have h_rhs : c + cy_out * 65536
+      = (((c.val + cy_out.val * 65536 : ℕ)) : FGL) := by push_cast; ring
+  rw [h_lhs, h_rhs] at h
+  refine ZiskFv.PackedBitVec.NoWrap.fgl_eq_to_nat_eq h ?_ ?_
+  · have h1 : a₂.val * b₀.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    have h2 : a₁.val * b₁.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    have h3 : a₀.val * b₂.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    omega
+  · omega
+
+private lemma fgl_div_chunk_lift_4_loose
+    (a₃ a₂ a₁ a₀ b₀ b₁ b₂ b₃ d cy_in c cy_out : FGL)
+    (h_a3 : a₃.val < 65536) (h_a2 : a₂.val < 65536)
+    (h_a1 : a₁.val < 65536) (h_a0 : a₀.val < 65536)
+    (h_b0 : b₀.val < 65536) (h_b1 : b₁.val < 65536)
+    (h_b2 : b₂.val < 65536) (h_b3 : b₃.val < 65536)
+    (h_d : d.val < 65536) (h_cy_in : cy_in.val < 983041)
+    (h_c : c.val < 65536) (h_cy_out : cy_out.val < 983041)
+    (h : a₃ * b₀ + a₂ * b₁ + a₁ * b₂ + a₀ * b₃ + d + cy_in = c + cy_out * 65536) :
+    a₃.val * b₀.val + a₂.val * b₁.val + a₁.val * b₂.val + a₀.val * b₃.val
+        + d.val + cy_in.val
+      = c.val + cy_out.val * 65536 := by
+  have h_lhs : a₃ * b₀ + a₂ * b₁ + a₁ * b₂ + a₀ * b₃ + d + cy_in
+      = (((a₃.val * b₀.val + a₂.val * b₁.val + a₁.val * b₂.val + a₀.val * b₃.val
+            + d.val + cy_in.val : ℕ)) : FGL) := by push_cast; ring
+  have h_rhs : c + cy_out * 65536
+      = (((c.val + cy_out.val * 65536 : ℕ)) : FGL) := by push_cast; ring
+  rw [h_lhs, h_rhs] at h
+  refine ZiskFv.PackedBitVec.NoWrap.fgl_eq_to_nat_eq h ?_ ?_
+  · have h1 : a₃.val * b₀.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    have h2 : a₂.val * b₁.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    have h3 : a₁.val * b₂.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    have h4 : a₀.val * b₃.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    omega
+  · omega
+
+private lemma fgl_div_chunk_lift_high_3_loose
+    (a₃ a₂ a₁ b₁ b₂ b₃ cy_in cy_out : FGL)
+    (h_a3 : a₃.val < 65536) (h_a2 : a₂.val < 65536) (h_a1 : a₁.val < 65536)
+    (h_b1 : b₁.val < 65536) (h_b2 : b₂.val < 65536) (h_b3 : b₃.val < 65536)
+    (h_cy_in : cy_in.val < 983041) (h_cy_out : cy_out.val < 983041)
+    (h : a₃ * b₁ + a₂ * b₂ + a₁ * b₃ + cy_in = cy_out * 65536) :
+    a₃.val * b₁.val + a₂.val * b₂.val + a₁.val * b₃.val + cy_in.val
+      = cy_out.val * 65536 := by
+  have h_lhs : a₃ * b₁ + a₂ * b₂ + a₁ * b₃ + cy_in
+      = (((a₃.val * b₁.val + a₂.val * b₂.val + a₁.val * b₃.val + cy_in.val : ℕ))
+          : FGL) := by push_cast; ring
+  have h_rhs : cy_out * 65536
+      = (((cy_out.val * 65536 : ℕ)) : FGL) := by push_cast; ring
+  rw [h_lhs, h_rhs] at h
+  refine ZiskFv.PackedBitVec.NoWrap.fgl_eq_to_nat_eq h ?_ ?_
+  · have h1 : a₃.val * b₁.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    have h2 : a₂.val * b₂.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    have h3 : a₁.val * b₃.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    omega
+  · omega
+
+private lemma fgl_div_chunk_lift_high_2_loose
+    (a₃ a₂ b₂ b₃ cy_in cy_out : FGL)
+    (h_a3 : a₃.val < 65536) (h_a2 : a₂.val < 65536)
+    (h_b2 : b₂.val < 65536) (h_b3 : b₃.val < 65536)
+    (h_cy_in : cy_in.val < 983041) (h_cy_out : cy_out.val < 983041)
+    (h : a₃ * b₂ + a₂ * b₃ + cy_in = cy_out * 65536) :
+    a₃.val * b₂.val + a₂.val * b₃.val + cy_in.val = cy_out.val * 65536 := by
+  have h_lhs : a₃ * b₂ + a₂ * b₃ + cy_in
+      = (((a₃.val * b₂.val + a₂.val * b₃.val + cy_in.val : ℕ)) : FGL) := by push_cast; ring
+  have h_rhs : cy_out * 65536
+      = (((cy_out.val * 65536 : ℕ)) : FGL) := by push_cast; ring
+  rw [h_lhs, h_rhs] at h
+  refine ZiskFv.PackedBitVec.NoWrap.fgl_eq_to_nat_eq h ?_ ?_
+  · have h1 : a₃.val * b₂.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    have h2 : a₂.val * b₃.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    omega
+  · omega
+
+private lemma fgl_div_chunk_lift_high_1_loose
+    (a₃ b₃ cy_in cy_out : FGL)
+    (h_a3 : a₃.val < 65536) (h_b3 : b₃.val < 65536)
+    (h_cy_in : cy_in.val < 983041) (h_cy_out : cy_out.val < 983041)
+    (h : a₃ * b₃ + cy_in = cy_out * 65536) :
+    a₃.val * b₃.val + cy_in.val = cy_out.val * 65536 := by
+  have h_lhs : a₃ * b₃ + cy_in
+      = (((a₃.val * b₃.val + cy_in.val : ℕ)) : FGL) := by push_cast; ring
+  have h_rhs : cy_out * 65536
+      = (((cy_out.val * 65536 : ℕ)) : FGL) := by push_cast; ring
+  rw [h_lhs, h_rhs] at h
+  refine ZiskFv.PackedBitVec.NoWrap.fgl_eq_to_nat_eq h ?_ ?_
+  · have h1 : a₃.val * b₃.val ≤ 65535 * 65535 := Nat.mul_le_mul (by omega) (by omega)
+    omega
+  · omega
+
+/-- **DIV-unsigned: FGL chunks → packed Euclidean ℕ identity (LOOSE bound).**
+    Mirror of `fgl_div_unsigned_chunks_to_nat_identity` with the
+    balance-constructible carry bound `< 983041` instead of `< 131072`.
+    Composes the loose chunk lifts with the bound-free ℕ aggregator
+    `div_unsigned_packed_of_chunks`. -/
+theorem fgl_div_unsigned_chunks_to_nat_identity_loose
+    (a₀ a₁ a₂ a₃ b₀ b₁ b₂ b₃ c₀ c₁ c₂ c₃ d₀ d₁ d₂ d₃
+     cy₀ cy₁ cy₂ cy₃ cy₄ cy₅ cy₆ : FGL)
+    (h_a0 : a₀.val < 65536) (h_a1 : a₁.val < 65536)
+    (h_a2 : a₂.val < 65536) (h_a3 : a₃.val < 65536)
+    (h_b0 : b₀.val < 65536) (h_b1 : b₁.val < 65536)
+    (h_b2 : b₂.val < 65536) (h_b3 : b₃.val < 65536)
+    (h_c0 : c₀.val < 65536) (h_c1 : c₁.val < 65536)
+    (h_c2 : c₂.val < 65536) (h_c3 : c₃.val < 65536)
+    (h_d0 : d₀.val < 65536) (h_d1 : d₁.val < 65536)
+    (h_d2 : d₂.val < 65536) (h_d3 : d₃.val < 65536)
+    (h_cy0 : cy₀.val < 983041) (h_cy1 : cy₁.val < 983041)
+    (h_cy2 : cy₂.val < 983041) (h_cy3 : cy₃.val < 983041)
+    (h_cy4 : cy₄.val < 983041) (h_cy5 : cy₅.val < 983041)
+    (h_cy6 : cy₆.val < 983041)
+    (hC31 : a₀ * b₀ + d₀ = c₀ + cy₀ * 65536)
+    (hC32 : a₁ * b₀ + a₀ * b₁ + d₁ + cy₀ = c₁ + cy₁ * 65536)
+    (hC33 : a₂ * b₀ + a₁ * b₁ + a₀ * b₂ + d₂ + cy₁ = c₂ + cy₂ * 65536)
+    (hC34 : a₃ * b₀ + a₂ * b₁ + a₁ * b₂ + a₀ * b₃ + d₃ + cy₂
+              = c₃ + cy₃ * 65536)
+    (hC35 : a₃ * b₁ + a₂ * b₂ + a₁ * b₃ + cy₃ = cy₄ * 65536)
+    (hC36 : a₃ * b₂ + a₂ * b₃ + cy₄ = cy₅ * 65536)
+    (hC37 : a₃ * b₃ + cy₅ = cy₆ * 65536)
+    (hC38 : cy₆ = 0) :
+    packed4 a₀.val a₁.val a₂.val a₃.val
+        * packed4 b₀.val b₁.val b₂.val b₃.val
+      + packed4 d₀.val d₁.val d₂.val d₃.val
+      = packed4 c₀.val c₁.val c₂.val c₃.val := by
+  refine div_unsigned_packed_of_chunks
+    a₀.val a₁.val a₂.val a₃.val b₀.val b₁.val b₂.val b₃.val
+    c₀.val c₁.val c₂.val c₃.val d₀.val d₁.val d₂.val d₃.val
+    cy₀.val cy₁.val cy₂.val cy₃.val cy₄.val cy₅.val cy₆.val
+    ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_
+  · exact fgl_div_chunk_lift_1_loose a₀ b₀ d₀ c₀ cy₀
+      h_a0 h_b0 h_d0 h_c0 h_cy0 hC31
+  · exact fgl_div_chunk_lift_2_loose a₁ a₀ b₀ b₁ d₁ cy₀ c₁ cy₁
+      h_a1 h_a0 h_b0 h_b1 h_d1 h_cy0 h_c1 h_cy1 hC32
+  · exact fgl_div_chunk_lift_3_loose a₂ a₁ a₀ b₀ b₁ b₂ d₂ cy₁ c₂ cy₂
+      h_a2 h_a1 h_a0 h_b0 h_b1 h_b2 h_d2 h_cy1 h_c2 h_cy2 hC33
+  · exact fgl_div_chunk_lift_4_loose a₃ a₂ a₁ a₀ b₀ b₁ b₂ b₃ d₃ cy₂ c₃ cy₃
+      h_a3 h_a2 h_a1 h_a0 h_b0 h_b1 h_b2 h_b3 h_d3 h_cy2 h_c3 h_cy3 hC34
+  · exact fgl_div_chunk_lift_high_3_loose a₃ a₂ a₁ b₁ b₂ b₃ cy₃ cy₄
+      h_a3 h_a2 h_a1 h_b1 h_b2 h_b3 h_cy3 h_cy4 hC35
+  · exact fgl_div_chunk_lift_high_2_loose a₃ a₂ b₂ b₃ cy₄ cy₅
+      h_a3 h_a2 h_b2 h_b3 h_cy4 h_cy5 hC36
+  · exact fgl_div_chunk_lift_high_1_loose a₃ b₃ cy₅ cy₆
+      h_a3 h_b3 h_cy5 h_cy6 hC37
+  · exact fgl_div_chunk_lift_close cy₆ hC38
+
+/-- **Loose-bound DIVU rd-write reconstruction.** Mirror of
+    `h_rd_val_mdru_divu` with the balance-constructible carry bound
+    `< 983041` instead of `< 131072` (the genuine Euclidean-chain carries
+    exceed `2^17`, so the tight bound is not balance-derivable; same
+    situation as MULHU).  Routes through the loose chunk identity, the public
+    Euclidean quotient extractor `fgl_div_unsigned_to_bv64`, and the byte-sum
+    bridge `divu_bv64_of_byte_sum`. -/
+lemma h_rd_val_mdru_divu_loose
+    (op1 op2 : BitVec 64)
+    (e : MemoryBusEntry FGL)
+    (a₀ a₁ a₂ a₃ b₀ b₁ b₂ b₃ c₀ c₁ c₂ c₃ d₀ d₁ d₂ d₃ : FGL)
+    (cy₀ cy₁ cy₂ cy₃ cy₄ cy₅ cy₆ : FGL)
+    (h0 : (byteAt e 0).val < 256) (h1 : (byteAt e 1).val < 256)
+    (h2 : (byteAt e 2).val < 256) (h3 : (byteAt e 3).val < 256)
+    (h4 : (byteAt e 4).val < 256) (h5 : (byteAt e 5).val < 256)
+    (h6 : (byteAt e 6).val < 256) (h7 : (byteAt e 7).val < 256)
+    (h_a0 : a₀.val < 65536) (h_a1 : a₁.val < 65536)
+    (h_a2 : a₂.val < 65536) (h_a3 : a₃.val < 65536)
+    (h_b0 : b₀.val < 65536) (h_b1 : b₁.val < 65536)
+    (h_b2 : b₂.val < 65536) (h_b3 : b₃.val < 65536)
+    (h_c0 : c₀.val < 65536) (h_c1 : c₁.val < 65536)
+    (h_c2 : c₂.val < 65536) (h_c3 : c₃.val < 65536)
+    (h_d0 : d₀.val < 65536) (h_d1 : d₁.val < 65536)
+    (h_d2 : d₂.val < 65536) (h_d3 : d₃.val < 65536)
+    (h_cy0 : cy₀.val < 983041) (h_cy1 : cy₁.val < 983041)
+    (h_cy2 : cy₂.val < 983041) (h_cy3 : cy₃.val < 983041)
+    (h_cy4 : cy₄.val < 983041) (h_cy5 : cy₅.val < 983041)
+    (h_cy6 : cy₆.val < 983041)
+    (hC31 : a₀ * b₀ + d₀ = c₀ + cy₀ * 65536)
+    (hC32 : a₁ * b₀ + a₀ * b₁ + d₁ + cy₀ = c₁ + cy₁ * 65536)
+    (hC33 : a₂ * b₀ + a₁ * b₁ + a₀ * b₂ + d₂ + cy₁ = c₂ + cy₂ * 65536)
+    (hC34 : a₃ * b₀ + a₂ * b₁ + a₁ * b₂ + a₀ * b₃ + d₃ + cy₂
+              = c₃ + cy₃ * 65536)
+    (hC35 : a₃ * b₁ + a₂ * b₂ + a₁ * b₃ + cy₃ = cy₄ * 65536)
+    (hC36 : a₃ * b₂ + a₂ * b₃ + cy₄ = cy₅ * 65536)
+    (hC37 : a₃ * b₃ + cy₅ = cy₆ * 65536)
+    (hC38 : cy₆ = 0)
+    (h_byte_lo :
+      (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216
+        = a₀.val + a₁.val * 65536)
+    (h_byte_hi :
+      (byteAt e 4).val + (byteAt e 5).val * 256 + (byteAt e 6).val * 65536 + (byteAt e 7).val * 16777216
+        = a₂.val + a₃.val * 65536)
+    (h_rs1_value : op1.toNat = packed4 c₀.val c₁.val c₂.val c₃.val)
+    (h_rs2_value : op2.toNat = packed4 b₀.val b₁.val b₂.val b₃.val)
+    (h_op2_ne : op2.toNat ≠ 0)
+    (h_d_lt_b : packed4 d₀.val d₁.val d₂.val d₃.val < op2.toNat) :
+    U64.toBV #v[((byteAt e 0) : BitVec 8), ((byteAt e 1) : BitVec 8), ((byteAt e 2) : BitVec 8), ((byteAt e 3) : BitVec 8),
+                ((byteAt e 4) : BitVec 8), ((byteAt e 5) : BitVec 8), ((byteAt e 6) : BitVec 8), ((byteAt e 7) : BitVec 8)]
+      = (execute_DIV_REM_pure op1 op2 .DRU).1 := by
+  have h_packed_nat : packed4 a₀.val a₁.val a₂.val a₃.val
+        * packed4 b₀.val b₁.val b₂.val b₃.val
+        + packed4 d₀.val d₁.val d₂.val d₃.val
+      = packed4 c₀.val c₁.val c₂.val c₃.val :=
+    fgl_div_unsigned_chunks_to_nat_identity_loose
+      a₀ a₁ a₂ a₃ b₀ b₁ b₂ b₃ c₀ c₁ c₂ c₃ d₀ d₁ d₂ d₃
+      cy₀ cy₁ cy₂ cy₃ cy₄ cy₅ cy₆
+      h_a0 h_a1 h_a2 h_a3 h_b0 h_b1 h_b2 h_b3
+      h_c0 h_c1 h_c2 h_c3 h_d0 h_d1 h_d2 h_d3
+      h_cy0 h_cy1 h_cy2 h_cy3 h_cy4 h_cy5 h_cy6
+      hC31 hC32 hC33 hC34 hC35 hC36 hC37 hC38
+  rw [← h_rs1_value, ← h_rs2_value] at h_packed_nat
+  have h_quot_eq : op1.toNat / op2.toNat = packed4 a₀.val a₁.val a₂.val a₃.val :=
+    fgl_div_unsigned_to_bv64 h_op2_ne h_d_lt_b h_packed_nat
+  have h_byte_eq_packed :
+      (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216
+        + (byteAt e 4).val * 4294967296 + (byteAt e 5).val * 1099511627776
+        + (byteAt e 6).val * 281474976710656 + (byteAt e 7).val * 72057594037927936
+      = packed4 a₀.val a₁.val a₂.val a₃.val :=
+    byte_sum_eq_packed4 e a₀.val a₁.val a₂.val a₃.val h_byte_lo h_byte_hi
+  have h_q_eq : (execute_DIV_REM_pure op1 op2 .DRU).1.toNat
+      = op1.toNat / op2.toNat := by
+    have h_op2_int_ne : (op2.toNat : ℤ) ≠ 0 := by exact_mod_cast h_op2_ne
+    simp only [execute_DIV_REM_pure, execute_DIV_REM_pure_int]
+    rw [if_neg h_op2_int_ne]
+    rw [BitVec.toNat_ofNat]
+    have h_tdiv : (Int.tdiv (op1.toNat : ℤ) (op2.toNat : ℤ)).toNat
+        = op1.toNat / op2.toNat := rfl
+    rw [h_tdiv]
+    have h_op1_lt : op1.toNat < 2 ^ 64 := op1.isLt
+    have h_quot_lt : op1.toNat / op2.toNat < 2 ^ 64 := by
+      calc op1.toNat / op2.toNat
+          ≤ op1.toNat := Nat.div_le_self _ _
+        _ < 2 ^ 64 := h_op1_lt
+    exact Nat.mod_eq_of_lt h_quot_lt
+  have h_byte_sum :
+      (byteAt e 0).val + (byteAt e 1).val * 256 + (byteAt e 2).val * 65536 + (byteAt e 3).val * 16777216
+        + (byteAt e 4).val * 4294967296 + (byteAt e 5).val * 1099511627776
+        + (byteAt e 6).val * 281474976710656 + (byteAt e 7).val * 72057594037927936
+      = (execute_DIV_REM_pure op1 op2 .DRU).1.toNat := by
+    rw [h_byte_eq_packed, ← h_quot_eq, h_q_eq]
+  exact divu_bv64_of_byte_sum op1 op2
+    (byteAt e 0) (byteAt e 1) (byteAt e 2) (byteAt e 3) (byteAt e 4) (byteAt e 5) (byteAt e 6) (byteAt e 7)
+    h0 h1 h2 h3 h4 h5 h6 h7 h_byte_sum
+
 /-- **`h_rd_val` discharge for REMU (Tier 1).** Same shape as DIVU but
     extracts the remainder via `fgl_rem_unsigned_to_bv64`. The bus
     entry's bytes pack `d[]` chunks (the remainder lanes). -/

--- a/bin/TrustGate/Main.lean
+++ b/bin/TrustGate/Main.lean
@@ -275,7 +275,8 @@ def soundConstructionTheorems : List Name :=
   , `ZiskFv.Compliance.construction_auipc_sound
   , `ZiskFv.Compliance.construction_mulw_sound
   , `ZiskFv.Compliance.construction_mulhu_sound
-  , `ZiskFv.Compliance.construction_divu_sound ]
+  , `ZiskFv.Compliance.construction_divu_sound
+  , `ZiskFv.Compliance.construction_divuw_sound ]
 
 /-- Subcommand: render the DEEP (recursive) construction-theorem binder list,
 for EVERY sound construction theorem in `soundConstructionTheorems`.

--- a/bin/TrustGate/Main.lean
+++ b/bin/TrustGate/Main.lean
@@ -274,7 +274,8 @@ def soundConstructionTheorems : List Name :=
   , `ZiskFv.Compliance.construction_lui_sound
   , `ZiskFv.Compliance.construction_auipc_sound
   , `ZiskFv.Compliance.construction_mulw_sound
-  , `ZiskFv.Compliance.construction_mulhu_sound ]
+  , `ZiskFv.Compliance.construction_mulhu_sound
+  , `ZiskFv.Compliance.construction_divu_sound ]
 
 /-- Subcommand: render the DEEP (recursive) construction-theorem binder list,
 for EVERY sound construction theorem in `soundConstructionTheorems`.

--- a/bin/TrustGate/Main.lean
+++ b/bin/TrustGate/Main.lean
@@ -277,7 +277,8 @@ def soundConstructionTheorems : List Name :=
   , `ZiskFv.Compliance.construction_mulhu_sound
   , `ZiskFv.Compliance.construction_divu_sound
   , `ZiskFv.Compliance.construction_divuw_sound
-  , `ZiskFv.Compliance.construction_remu_sound ]
+  , `ZiskFv.Compliance.construction_remu_sound
+  , `ZiskFv.Compliance.construction_remuw_sound ]
 
 /-- Subcommand: render the DEEP (recursive) construction-theorem binder list,
 for EVERY sound construction theorem in `soundConstructionTheorems`.

--- a/bin/TrustGate/Main.lean
+++ b/bin/TrustGate/Main.lean
@@ -276,7 +276,8 @@ def soundConstructionTheorems : List Name :=
   , `ZiskFv.Compliance.construction_mulw_sound
   , `ZiskFv.Compliance.construction_mulhu_sound
   , `ZiskFv.Compliance.construction_divu_sound
-  , `ZiskFv.Compliance.construction_divuw_sound ]
+  , `ZiskFv.Compliance.construction_divuw_sound
+  , `ZiskFv.Compliance.construction_remu_sound ]
 
 /-- Subcommand: render the DEEP (recursive) construction-theorem binder list,
 for EVERY sound construction theorem in `soundConstructionTheorems`.

--- a/bin/TrustGate/Main.lean
+++ b/bin/TrustGate/Main.lean
@@ -273,7 +273,8 @@ def soundConstructionTheorems : List Name :=
   , `ZiskFv.Compliance.construction_addiw_sound
   , `ZiskFv.Compliance.construction_lui_sound
   , `ZiskFv.Compliance.construction_auipc_sound
-  , `ZiskFv.Compliance.construction_mulw_sound ]
+  , `ZiskFv.Compliance.construction_mulw_sound
+  , `ZiskFv.Compliance.construction_mulhu_sound ]
 
 /-- Subcommand: render the DEEP (recursive) construction-theorem binder list,
 for EVERY sound construction theorem in `soundConstructionTheorems`.

--- a/bin/TrustGate/Main.lean
+++ b/bin/TrustGate/Main.lean
@@ -272,7 +272,8 @@ def soundConstructionTheorems : List Name :=
   , `ZiskFv.Compliance.construction_addw_sound
   , `ZiskFv.Compliance.construction_addiw_sound
   , `ZiskFv.Compliance.construction_lui_sound
-  , `ZiskFv.Compliance.construction_auipc_sound ]
+  , `ZiskFv.Compliance.construction_auipc_sound
+  , `ZiskFv.Compliance.construction_mulw_sound ]
 
 /-- Subcommand: render the DEEP (recursive) construction-theorem binder list,
 for EVERY sound construction theorem in `soundConstructionTheorems`.

--- a/trust/generated/baseline-construction-theorem-binders.txt
+++ b/trust/generated/baseline-construction-theorem-binders.txt
@@ -1091,3 +1091,44 @@ h_b23 :: And (Eq ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trac
 h_sext_choice :: Or (And (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 4).val 0) (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 5).val 0) (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 6).val 0) (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 7).val 0)))) (instLTNat.lt (instHAdd.hAdd ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).c_0 0).val (instHMul.hMul ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).c_1 0).val 65536)) 2147483648)) (And (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 4).val 255) (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 5).val 255) (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 6).val 255) (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 7).val 255)))) (GE.ge (instHAdd.hAdd ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).c_0 0).val (instHMul.hMul ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).c_1 0).val 65536)) 2147483648))
 h_rs1_value :: Eq (Sail.BitVec.extractLsb mulw_input.r1_val 31 0).toInt (instHSub.hSub (instHAdd.hAdd ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).a_0 0).val.cast (instHMul.hMul ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).a_1 0).val.cast 65536)) (instHMul.hMul ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).na 0).val.cast (instHPow.hPow 2 32)))
 h_rs2_value :: Eq (Sail.BitVec.extractLsb mulw_input.r2_val 31 0).toInt (instHSub.hSub (instHAdd.hAdd ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).b_0 0).val.cast (instHMul.hMul ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).b_1 0).val.cast 65536)) (instHMul.hMul ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).nb 0).val.cast (instHPow.hPow 2 32)))
+
+# ZiskFv.Compliance.construction_mulhu_sound
+trace.length :: Nat
+trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
+trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
+trace.constraints :: trace.3.Constraints
+trace.spec :: trace.3.Spec
+trace.balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
+binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.length
+mulhu_input :: PureSpec.MulhuInput
+r1 :: regidx
+r2 :: regidx
+rd :: regidx
+h_main_op :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).op i.val) ZiskFv.Trusted.OP_MULUH
+h_main_active :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).is_external_op i.val) 1
+h_store_pc :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).store_pc i.val) 0
+h_input_r1 :: Eq (read_xreg (regidx_to_fin r1) (binding.stateAt i)) (EStateM.Result.ok mulhu_input.r1_val (binding.stateAt i))
+h_input_r2 :: Eq (read_xreg (regidx_to_fin r2) (binding.stateAt i)) (EStateM.Result.ok mulhu_input.r2_val (binding.stateAt i))
+h_input_pc :: Eq ((binding.stateAt i).regs.get? Register.PC) (Option.some mulhu_input.PC)
+h_input_rd :: Eq mulhu_input.rd (regidx_to_fin rd)
+execRow :: List (Interaction.ExecutionBusEntry (Fin 18446744069414584321))
+h_exec_len :: Eq (ZiskFv.Compliance.busSub trace binding i execRow).exec_row.length 2
+h_e0_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 0).multiplicity (-1)
+h_e1_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).multiplicity 1
+h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).pc.val) register_type_pc_equiv) (PureSpec.execute_MULH_mulhu_pure mulhu_input).nextPC
+h_rd_idx :: Eq mulhu_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
+bounds.x0_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 0).val 256
+bounds.x1_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 1).val 256
+bounds.x2_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 2).val 256
+bounds.x3_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 3).val 256
+bounds.x4_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 4).val 256
+bounds.x5_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 5).val 256
+bounds.x6_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 6).val 256
+bounds.x7_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 7).val 256
+h_rs1_value :: Eq mulhu_input.r1_val.toNat (ZiskFv.PackedBitVec.MulNoWrap.packed4 ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulhuArow trace binding i h_main_active h_main_op)).a_0 0).val ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulhuArow trace binding i h_main_active h_main_op)).a_1 0).val ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulhuArow trace binding i h_main_active h_main_op)).a_2 0).val ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulhuArow trace binding i h_main_active h_main_op)).a_3 0).val)
+h_rs2_value :: Eq mulhu_input.r2_val.toNat (ZiskFv.PackedBitVec.MulNoWrap.packed4 ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulhuArow trace binding i h_main_active h_main_op)).b_0 0).val ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulhuArow trace binding i h_main_active h_main_op)).b_1 0).val ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulhuArow trace binding i h_main_active h_main_op)).b_2 0).val ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulhuArow trace binding i h_main_active h_main_op)).b_3 0).val)

--- a/trust/generated/baseline-construction-theorem-binders.txt
+++ b/trust/generated/baseline-construction-theorem-binders.txt
@@ -1055,3 +1055,39 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq auipc_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.eRdLui trace binding i).ptr)
 h_no_wrap :: instLTNat.lt (instHAdd.hAdd auipc_input.PC.toNat (BitVec.signExtend 64 (BitVec.instHAppendHAddNat.hAppend auipc_input.imm 0)).toNat) 18446744069414584321
 h_pc_offset_lt_2_32 :: instLTNat.lt (instHAdd.hAdd auipc_input.PC (BitVec.signExtend 64 (BitVec.instHAppendHAddNat.hAppend auipc_input.imm 0))).toNat 4294967296
+
+# ZiskFv.Compliance.construction_mulw_sound
+trace.length :: Nat
+trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
+trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
+trace.constraints :: trace.3.Constraints
+trace.spec :: trace.3.Spec
+trace.balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
+binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.length
+mulw_input :: PureSpec.MulwInput
+r1 :: regidx
+r2 :: regidx
+rd :: regidx
+h_main_op :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).op i.val) ZiskFv.Trusted.OP_MUL_W
+h_main_active :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).is_external_op i.val) 1
+h_store_pc :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).store_pc i.val) 0
+h_input_r1 :: Eq (read_xreg (regidx_to_fin r1) (binding.stateAt i)) (EStateM.Result.ok mulw_input.r1_val (binding.stateAt i))
+h_input_r2 :: Eq (read_xreg (regidx_to_fin r2) (binding.stateAt i)) (EStateM.Result.ok mulw_input.r2_val (binding.stateAt i))
+h_input_pc :: Eq ((binding.stateAt i).regs.get? Register.PC) (Option.some mulw_input.PC)
+h_input_rd :: Eq mulw_input.rd (regidx_to_fin rd)
+execRow :: List (Interaction.ExecutionBusEntry (Fin 18446744069414584321))
+h_exec_len :: Eq (ZiskFv.Compliance.busSub trace binding i execRow).exec_row.length 2
+h_e0_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 0).multiplicity (-1)
+h_e1_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).multiplicity 1
+h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).pc.val) register_type_pc_equiv) (PureSpec.execute_MULW_pure mulw_input).nextPC
+h_rd_idx :: Eq mulw_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
+h_a23 :: And (Eq ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).a_2 0).val 0) (Eq ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).a_3 0).val 0)
+h_b23 :: And (Eq ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).b_2 0).val 0) (Eq ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).b_3 0).val 0)
+h_sext_choice :: Or (And (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 4).val 0) (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 5).val 0) (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 6).val 0) (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 7).val 0)))) (instLTNat.lt (instHAdd.hAdd ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).c_0 0).val (instHMul.hMul ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).c_1 0).val 65536)) 2147483648)) (And (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 4).val 255) (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 5).val 255) (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 6).val 255) (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 7).val 255)))) (GE.ge (instHAdd.hAdd ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).c_0 0).val (instHMul.hMul ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).c_1 0).val 65536)) 2147483648))
+h_rs1_value :: Eq (Sail.BitVec.extractLsb mulw_input.r1_val 31 0).toInt (instHSub.hSub (instHAdd.hAdd ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).a_0 0).val.cast (instHMul.hMul ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).a_1 0).val.cast 65536)) (instHMul.hMul ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).na 0).val.cast (instHPow.hPow 2 32)))
+h_rs2_value :: Eq (Sail.BitVec.extractLsb mulw_input.r2_val 31 0).toInt (instHSub.hSub (instHAdd.hAdd ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).b_0 0).val.cast (instHMul.hMul ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).b_1 0).val.cast 65536)) (instHMul.hMul ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).nb 0).val.cast (instHPow.hPow 2 32)))

--- a/trust/generated/baseline-construction-theorem-binders.txt
+++ b/trust/generated/baseline-construction-theorem-binders.txt
@@ -1132,3 +1132,123 @@ bounds.x6_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Comp
 bounds.x7_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 7).val 256
 h_rs1_value :: Eq mulhu_input.r1_val.toNat (ZiskFv.PackedBitVec.MulNoWrap.packed4 ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulhuArow trace binding i h_main_active h_main_op)).a_0 0).val ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulhuArow trace binding i h_main_active h_main_op)).a_1 0).val ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulhuArow trace binding i h_main_active h_main_op)).a_2 0).val ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulhuArow trace binding i h_main_active h_main_op)).a_3 0).val)
 h_rs2_value :: Eq mulhu_input.r2_val.toNat (ZiskFv.PackedBitVec.MulNoWrap.packed4 ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulhuArow trace binding i h_main_active h_main_op)).b_0 0).val ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulhuArow trace binding i h_main_active h_main_op)).b_1 0).val ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulhuArow trace binding i h_main_active h_main_op)).b_2 0).val ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulhuArow trace binding i h_main_active h_main_op)).b_3 0).val)
+
+# ZiskFv.Compliance.construction_divu_sound
+trace.length :: Nat
+trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
+trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
+trace.constraints :: trace.3.Constraints
+trace.spec :: trace.3.Spec
+trace.balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
+binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.length
+divu_input :: PureSpec.DivuInput
+r1 :: regidx
+r2 :: regidx
+rd :: regidx
+h_main_op :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).op i.val) ZiskFv.Trusted.OP_DIVU
+h_main_active :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).is_external_op i.val) 1
+h_store_pc :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).store_pc i.val) 0
+h_input_r1 :: Eq (read_xreg (regidx_to_fin r1) (binding.stateAt i)) (EStateM.Result.ok divu_input.r1_val (binding.stateAt i))
+h_input_r2 :: Eq (read_xreg (regidx_to_fin r2) (binding.stateAt i)) (EStateM.Result.ok divu_input.r2_val (binding.stateAt i))
+h_input_pc :: Eq ((binding.stateAt i).regs.get? Register.PC) (Option.some divu_input.PC)
+h_input_rd :: Eq divu_input.rd (regidx_to_fin rd)
+execRow :: List (Interaction.ExecutionBusEntry (Fin 18446744069414584321))
+h_exec_len :: Eq (ZiskFv.Compliance.busSub trace binding i execRow).exec_row.length 2
+h_e0_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 0).multiplicity (-1)
+h_e1_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).multiplicity 1
+h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).pc.val) register_type_pc_equiv) (PureSpec.execute_DIVREM_divu_pure divu_input).nextPC
+h_rd_idx :: Eq divu_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
+bounds.x0_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 0).val 256
+bounds.x1_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 1).val 256
+bounds.x2_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 2).val 256
+bounds.x3_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 3).val 256
+bounds.x4_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 4).val 256
+bounds.x5_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 5).val 256
+bounds.x6_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 6).val 256
+bounds.x7_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 7).val 256
+remainder_bound.binary.b_op :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_0 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_1 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_2 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_3 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_4 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_5 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_6 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_7 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_0 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_1 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_2 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_3 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_4 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_5 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_6 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_7 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_0 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_1 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_2 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_3 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_4 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_5 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_6 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_7 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_0 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_1 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_2 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_3 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_4 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_5 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_6 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_7 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.mode32 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.result_is_a :: Nat → Fin 18446744069414584321
+remainder_bound.binary.use_first_byte :: Nat → Fin 18446744069414584321
+remainder_bound.binary.c_is_signed :: Nat → Fin 18446744069414584321
+remainder_bound.binary.b_op_or_sext :: Nat → Fin 18446744069414584321
+remainder_bound.binary.mode32_and_c_is_signed :: Nat → Fin 18446744069414584321
+remainder_bound.binary.gsum :: Nat → Fin 18446744069414584321
+remainder_bound.binary.im_0 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.im_1 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.im_2 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.im_3 :: Nat → Fin 18446744069414584321
+remainder_bound.r_binary :: Nat
+remainder_bound.binary_core :: ZiskFv.Airs.Binary.core_every_row remainder_bound.1 remainder_bound.2
+remainder_bound.binary_ltu_chain.chain_0 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_0 remainder_bound.2) (remainder_bound.1.free_in_b_0 remainder_bound.2) (remainder_bound.1.free_in_c_0 remainder_bound.2) 0 (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_0 remainder_bound.2)) (instHMul.hMul 2 (remainder_bound.1.use_first_byte remainder_bound.2))
+remainder_bound.binary_ltu_chain.chain_1 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_1 remainder_bound.2) (remainder_bound.1.free_in_b_1 remainder_bound.2) (remainder_bound.1.free_in_c_1 remainder_bound.2) (remainder_bound.1.carry_0 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_1 remainder_bound.2)) 0
+remainder_bound.binary_ltu_chain.chain_2 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_2 remainder_bound.2) (remainder_bound.1.free_in_b_2 remainder_bound.2) (remainder_bound.1.free_in_c_2 remainder_bound.2) (remainder_bound.1.carry_1 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_2 remainder_bound.2)) 0
+remainder_bound.binary_ltu_chain.chain_3 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_3 remainder_bound.2) (remainder_bound.1.free_in_b_3 remainder_bound.2) (remainder_bound.1.free_in_c_3 remainder_bound.2) (remainder_bound.1.carry_2 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_3 remainder_bound.2)) (remainder_bound.1.mode32 remainder_bound.2)
+remainder_bound.binary_ltu_chain.chain_4 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_4 remainder_bound.2) (remainder_bound.1.free_in_b_4 remainder_bound.2) (remainder_bound.1.free_in_c_4 remainder_bound.2) (remainder_bound.1.carry_3 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_4 remainder_bound.2)) 0
+remainder_bound.binary_ltu_chain.chain_5 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_5 remainder_bound.2) (remainder_bound.1.free_in_b_5 remainder_bound.2) (remainder_bound.1.free_in_c_5 remainder_bound.2) (remainder_bound.1.carry_4 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_5 remainder_bound.2)) 0
+remainder_bound.binary_ltu_chain.chain_6 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_6 remainder_bound.2) (remainder_bound.1.free_in_b_6 remainder_bound.2) (remainder_bound.1.free_in_c_6 remainder_bound.2) (remainder_bound.1.carry_5 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_6 remainder_bound.2)) 0
+remainder_bound.binary_ltu_chain.chain_7 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_7 remainder_bound.2) (remainder_bound.1.free_in_b_7 remainder_bound.2) (remainder_bound.1.free_in_c_7 remainder_bound.2) (remainder_bound.1.carry_6 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags7Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2)) (instHSub.hSub 1 (remainder_bound.1.mode32 remainder_bound.2))
+remainder_bound.binary_ltu_chain.c0_lt :: instLTNat.lt (remainder_bound.1.free_in_c_0 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c1_lt :: instLTNat.lt (remainder_bound.1.free_in_c_1 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c2_lt :: instLTNat.lt (remainder_bound.1.free_in_c_2 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c3_lt :: instLTNat.lt (remainder_bound.1.free_in_c_3 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c4_lt :: instLTNat.lt (remainder_bound.1.free_in_c_4 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c5_lt :: instLTNat.lt (remainder_bound.1.free_in_c_5 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c6_lt :: instLTNat.lt (remainder_bound.1.free_in_c_6 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c7_lt :: instLTNat.lt (remainder_bound.1.free_in_c_7 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.cin0_eq :: Eq (Fin.val 0) 0
+remainder_bound.binary_ltu_chain.cin1_eq :: Eq (remainder_bound.1.carry_0 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_0 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin2_eq :: Eq (remainder_bound.1.carry_1 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_1 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin3_eq :: Eq (remainder_bound.1.carry_2 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_2 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin4_eq :: Eq (remainder_bound.1.carry_3 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_3 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin5_eq :: Eq (remainder_bound.1.carry_4 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_4 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin6_eq :: Eq (remainder_bound.1.carry_5 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_5 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin7_eq :: Eq (remainder_bound.1.carry_6 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_6 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.pi0_ne :: Ne (instHMul.hMul 2 (remainder_bound.1.use_first_byte remainder_bound.2)).val 1
+remainder_bound.binary_ltu_chain.pi1_ne :: Ne (Fin.val 0) 1
+remainder_bound.binary_ltu_chain.pi2_ne :: Ne (Fin.val 0) 1
+remainder_bound.binary_ltu_chain.pi3_ne :: Ne (remainder_bound.1.mode32 remainder_bound.2).val 1
+remainder_bound.binary_ltu_chain.pi4_ne :: Ne (Fin.val 0) 1
+remainder_bound.binary_ltu_chain.pi5_ne :: Ne (Fin.val 0) 1
+remainder_bound.binary_ltu_chain.pi6_ne :: Ne (Fin.val 0) 1
+remainder_bound.binary_ltu_chain.pi7_eq :: Eq (instHSub.hSub 1 (remainder_bound.1.mode32 remainder_bound.2)).val 1
+remainder_bound.remainder_bound_match :: ZiskFv.Airs.OperationBus.matches_entry (ZiskFv.Airs.ArithDiv.opBus_row_ArithDivRemainderBound (ZiskFv.Compliance.vOfDivuRow (ZiskFv.Compliance.divuArow trace binding i h_main_active h_main_op)) 0) (ZiskFv.Airs.OperationBus.opBus_row_Binary remainder_bound.1 remainder_bound.2)
+h_rs1_value :: Eq divu_input.r1_val.toNat (ZiskFv.PackedBitVec.MulNoWrap.packed4 (ZiskFv.Compliance.divuArow trace binding i h_main_active h_main_op).chunks.c_0.val (ZiskFv.Compliance.divuArow trace binding i h_main_active h_main_op).chunks.c_1.val (ZiskFv.Compliance.divuArow trace binding i h_main_active h_main_op).chunks.c_2.val (ZiskFv.Compliance.divuArow trace binding i h_main_active h_main_op).chunks.c_3.val)
+h_rs2_value :: Eq divu_input.r2_val.toNat (ZiskFv.PackedBitVec.MulNoWrap.packed4 (ZiskFv.Compliance.divuArow trace binding i h_main_active h_main_op).chunks.b_0.val (ZiskFv.Compliance.divuArow trace binding i h_main_active h_main_op).chunks.b_1.val (ZiskFv.Compliance.divuArow trace binding i h_main_active h_main_op).chunks.b_2.val (ZiskFv.Compliance.divuArow trace binding i h_main_active h_main_op).chunks.b_3.val)

--- a/trust/generated/baseline-construction-theorem-binders.txt
+++ b/trust/generated/baseline-construction-theorem-binders.txt
@@ -1495,3 +1495,126 @@ remainder_bound.binary_ltu_chain.pi7_eq :: Eq (instHSub.hSub 1 (remainder_bound.
 remainder_bound.remainder_bound_match :: ZiskFv.Airs.OperationBus.matches_entry (ZiskFv.Airs.ArithDiv.opBus_row_ArithDivRemainderBound (ZiskFv.Compliance.vOfDivuRow (ZiskFv.Compliance.remuArow trace binding i h_main_active h_main_op)) 0) (ZiskFv.Airs.OperationBus.opBus_row_Binary remainder_bound.1 remainder_bound.2)
 h_rs1_value :: Eq remu_input.r1_val.toNat (ZiskFv.PackedBitVec.MulNoWrap.packed4 (ZiskFv.Compliance.remuArow trace binding i h_main_active h_main_op).chunks.c_0.val (ZiskFv.Compliance.remuArow trace binding i h_main_active h_main_op).chunks.c_1.val (ZiskFv.Compliance.remuArow trace binding i h_main_active h_main_op).chunks.c_2.val (ZiskFv.Compliance.remuArow trace binding i h_main_active h_main_op).chunks.c_3.val)
 h_rs2_value :: Eq remu_input.r2_val.toNat (ZiskFv.PackedBitVec.MulNoWrap.packed4 (ZiskFv.Compliance.remuArow trace binding i h_main_active h_main_op).chunks.b_0.val (ZiskFv.Compliance.remuArow trace binding i h_main_active h_main_op).chunks.b_1.val (ZiskFv.Compliance.remuArow trace binding i h_main_active h_main_op).chunks.b_2.val (ZiskFv.Compliance.remuArow trace binding i h_main_active h_main_op).chunks.b_3.val)
+
+# ZiskFv.Compliance.construction_remuw_sound
+trace.length :: Nat
+trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
+trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
+trace.constraints :: trace.3.Constraints
+trace.spec :: trace.3.Spec
+trace.balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
+binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.length
+remuw_input :: PureSpec.RemuwInput
+r1 :: regidx
+r2 :: regidx
+rd :: regidx
+h_main_op :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).op i.val) ZiskFv.Trusted.OP_REMU_W
+h_main_active :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).is_external_op i.val) 1
+h_store_pc :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).store_pc i.val) 0
+h_input_r1 :: Eq (read_xreg (regidx_to_fin r1) (binding.stateAt i)) (EStateM.Result.ok remuw_input.r1_val (binding.stateAt i))
+h_input_r2 :: Eq (read_xreg (regidx_to_fin r2) (binding.stateAt i)) (EStateM.Result.ok remuw_input.r2_val (binding.stateAt i))
+h_input_pc :: Eq ((binding.stateAt i).regs.get? Register.PC) (Option.some remuw_input.PC)
+h_input_rd :: Eq remuw_input.rd (regidx_to_fin rd)
+execRow :: List (Interaction.ExecutionBusEntry (Fin 18446744069414584321))
+h_exec_len :: Eq (ZiskFv.Compliance.busSub trace binding i execRow).exec_row.length 2
+h_e0_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 0).multiplicity (-1)
+h_e1_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).multiplicity 1
+h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).pc.val) register_type_pc_equiv) (PureSpec.execute_DIVREM_remuw_pure remuw_input).nextPC
+h_rd_idx :: Eq remuw_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
+bounds.x0_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 0).val 256
+bounds.x1_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 1).val 256
+bounds.x2_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 2).val 256
+bounds.x3_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 3).val 256
+bounds.x4_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 4).val 256
+bounds.x5_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 5).val 256
+bounds.x6_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 6).val 256
+bounds.x7_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 7).val 256
+remainder_bound.binary.b_op :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_0 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_1 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_2 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_3 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_4 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_5 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_6 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_7 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_0 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_1 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_2 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_3 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_4 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_5 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_6 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_7 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_0 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_1 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_2 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_3 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_4 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_5 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_6 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_7 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_0 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_1 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_2 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_3 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_4 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_5 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_6 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_7 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.mode32 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.result_is_a :: Nat → Fin 18446744069414584321
+remainder_bound.binary.use_first_byte :: Nat → Fin 18446744069414584321
+remainder_bound.binary.c_is_signed :: Nat → Fin 18446744069414584321
+remainder_bound.binary.b_op_or_sext :: Nat → Fin 18446744069414584321
+remainder_bound.binary.mode32_and_c_is_signed :: Nat → Fin 18446744069414584321
+remainder_bound.binary.gsum :: Nat → Fin 18446744069414584321
+remainder_bound.binary.im_0 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.im_1 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.im_2 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.im_3 :: Nat → Fin 18446744069414584321
+remainder_bound.r_binary :: Nat
+remainder_bound.binary_core :: ZiskFv.Airs.Binary.core_every_row remainder_bound.1 remainder_bound.2
+remainder_bound.binary_ltu_chain.chain_0 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_0 remainder_bound.2) (remainder_bound.1.free_in_b_0 remainder_bound.2) (remainder_bound.1.free_in_c_0 remainder_bound.2) 0 (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_0 remainder_bound.2)) (instHMul.hMul 2 (remainder_bound.1.use_first_byte remainder_bound.2))
+remainder_bound.binary_ltu_chain.chain_1 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_1 remainder_bound.2) (remainder_bound.1.free_in_b_1 remainder_bound.2) (remainder_bound.1.free_in_c_1 remainder_bound.2) (remainder_bound.1.carry_0 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_1 remainder_bound.2)) 0
+remainder_bound.binary_ltu_chain.chain_2 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_2 remainder_bound.2) (remainder_bound.1.free_in_b_2 remainder_bound.2) (remainder_bound.1.free_in_c_2 remainder_bound.2) (remainder_bound.1.carry_1 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_2 remainder_bound.2)) 0
+remainder_bound.binary_ltu_chain.chain_3 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_3 remainder_bound.2) (remainder_bound.1.free_in_b_3 remainder_bound.2) (remainder_bound.1.free_in_c_3 remainder_bound.2) (remainder_bound.1.carry_2 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_3 remainder_bound.2)) (remainder_bound.1.mode32 remainder_bound.2)
+remainder_bound.binary_ltu_chain.chain_4 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_4 remainder_bound.2) (remainder_bound.1.free_in_b_4 remainder_bound.2) (remainder_bound.1.free_in_c_4 remainder_bound.2) (remainder_bound.1.carry_3 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_4 remainder_bound.2)) 0
+remainder_bound.binary_ltu_chain.chain_5 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_5 remainder_bound.2) (remainder_bound.1.free_in_b_5 remainder_bound.2) (remainder_bound.1.free_in_c_5 remainder_bound.2) (remainder_bound.1.carry_4 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_5 remainder_bound.2)) 0
+remainder_bound.binary_ltu_chain.chain_6 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_6 remainder_bound.2) (remainder_bound.1.free_in_b_6 remainder_bound.2) (remainder_bound.1.free_in_c_6 remainder_bound.2) (remainder_bound.1.carry_5 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_6 remainder_bound.2)) 0
+remainder_bound.binary_ltu_chain.chain_7 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_7 remainder_bound.2) (remainder_bound.1.free_in_b_7 remainder_bound.2) (remainder_bound.1.free_in_c_7 remainder_bound.2) (remainder_bound.1.carry_6 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags7Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2)) (instHSub.hSub 1 (remainder_bound.1.mode32 remainder_bound.2))
+remainder_bound.binary_ltu_chain.c0_lt :: instLTNat.lt (remainder_bound.1.free_in_c_0 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c1_lt :: instLTNat.lt (remainder_bound.1.free_in_c_1 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c2_lt :: instLTNat.lt (remainder_bound.1.free_in_c_2 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c3_lt :: instLTNat.lt (remainder_bound.1.free_in_c_3 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c4_lt :: instLTNat.lt (remainder_bound.1.free_in_c_4 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c5_lt :: instLTNat.lt (remainder_bound.1.free_in_c_5 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c6_lt :: instLTNat.lt (remainder_bound.1.free_in_c_6 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c7_lt :: instLTNat.lt (remainder_bound.1.free_in_c_7 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.cin0_eq :: Eq (Fin.val 0) 0
+remainder_bound.binary_ltu_chain.cin1_eq :: Eq (remainder_bound.1.carry_0 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_0 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin2_eq :: Eq (remainder_bound.1.carry_1 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_1 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin3_eq :: Eq (remainder_bound.1.carry_2 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_2 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin4_eq :: Eq (remainder_bound.1.carry_3 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_3 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin5_eq :: Eq (remainder_bound.1.carry_4 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_4 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin6_eq :: Eq (remainder_bound.1.carry_5 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_5 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin7_eq :: Eq (remainder_bound.1.carry_6 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_6 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.pi0_ne :: Ne (instHMul.hMul 2 (remainder_bound.1.use_first_byte remainder_bound.2)).val 1
+remainder_bound.binary_ltu_chain.pi1_ne :: Ne (Fin.val 0) 1
+remainder_bound.binary_ltu_chain.pi2_ne :: Ne (Fin.val 0) 1
+remainder_bound.binary_ltu_chain.pi3_ne :: Ne (remainder_bound.1.mode32 remainder_bound.2).val 1
+remainder_bound.binary_ltu_chain.pi4_ne :: Ne (Fin.val 0) 1
+remainder_bound.binary_ltu_chain.pi5_ne :: Ne (Fin.val 0) 1
+remainder_bound.binary_ltu_chain.pi6_ne :: Ne (Fin.val 0) 1
+remainder_bound.binary_ltu_chain.pi7_eq :: Eq (instHSub.hSub 1 (remainder_bound.1.mode32 remainder_bound.2)).val 1
+remainder_bound.remainder_bound_match :: ZiskFv.Airs.OperationBus.matches_entry (ZiskFv.Airs.ArithDiv.opBus_row_ArithDivRemainderBound (ZiskFv.Compliance.vOfDivuRow (ZiskFv.Compliance.remuwArow trace binding i h_main_active h_main_op)) 0) (ZiskFv.Airs.OperationBus.opBus_row_Binary remainder_bound.1 remainder_bound.2)
+h_b23 :: And (Eq (ZiskFv.Compliance.remuwArow trace binding i h_main_active h_main_op).chunks.b_2.val 0) (Eq (ZiskFv.Compliance.remuwArow trace binding i h_main_active h_main_op).chunks.b_3.val 0)
+h_c23 :: And (Eq (ZiskFv.Compliance.remuwArow trace binding i h_main_active h_main_op).chunks.c_2.val 0) (Eq (ZiskFv.Compliance.remuwArow trace binding i h_main_active h_main_op).chunks.c_3.val 0)
+h_sext_choice :: Or (And (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 4).val 0) (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 5).val 0) (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 6).val 0) (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 7).val 0)))) (instLTNat.lt (instHAdd.hAdd (ZiskFv.Compliance.remuwArow trace binding i h_main_active h_main_op).chunks.d_0.val (instHMul.hMul (ZiskFv.Compliance.remuwArow trace binding i h_main_active h_main_op).chunks.d_1.val 65536)) 2147483648)) (And (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 4).val 255) (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 5).val 255) (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 6).val 255) (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 7).val 255)))) (GE.ge (instHAdd.hAdd (ZiskFv.Compliance.remuwArow trace binding i h_main_active h_main_op).chunks.d_0.val (instHMul.hMul (ZiskFv.Compliance.remuwArow trace binding i h_main_active h_main_op).chunks.d_1.val 65536)) 2147483648))
+h_rs1_value :: Eq (Sail.BitVec.extractLsb remuw_input.r1_val 31 0).toNat (instHAdd.hAdd (ZiskFv.Compliance.remuwArow trace binding i h_main_active h_main_op).chunks.c_0.val (instHMul.hMul (ZiskFv.Compliance.remuwArow trace binding i h_main_active h_main_op).chunks.c_1.val 65536))
+h_rs2_value :: Eq (Sail.BitVec.extractLsb remuw_input.r2_val 31 0).toNat (instHAdd.hAdd (ZiskFv.Compliance.remuwArow trace binding i h_main_active h_main_op).chunks.b_0.val (instHMul.hMul (ZiskFv.Compliance.remuwArow trace binding i h_main_active h_main_op).chunks.b_1.val 65536))

--- a/trust/generated/baseline-construction-theorem-binders.txt
+++ b/trust/generated/baseline-construction-theorem-binders.txt
@@ -1252,3 +1252,126 @@ remainder_bound.binary_ltu_chain.pi7_eq :: Eq (instHSub.hSub 1 (remainder_bound.
 remainder_bound.remainder_bound_match :: ZiskFv.Airs.OperationBus.matches_entry (ZiskFv.Airs.ArithDiv.opBus_row_ArithDivRemainderBound (ZiskFv.Compliance.vOfDivuRow (ZiskFv.Compliance.divuArow trace binding i h_main_active h_main_op)) 0) (ZiskFv.Airs.OperationBus.opBus_row_Binary remainder_bound.1 remainder_bound.2)
 h_rs1_value :: Eq divu_input.r1_val.toNat (ZiskFv.PackedBitVec.MulNoWrap.packed4 (ZiskFv.Compliance.divuArow trace binding i h_main_active h_main_op).chunks.c_0.val (ZiskFv.Compliance.divuArow trace binding i h_main_active h_main_op).chunks.c_1.val (ZiskFv.Compliance.divuArow trace binding i h_main_active h_main_op).chunks.c_2.val (ZiskFv.Compliance.divuArow trace binding i h_main_active h_main_op).chunks.c_3.val)
 h_rs2_value :: Eq divu_input.r2_val.toNat (ZiskFv.PackedBitVec.MulNoWrap.packed4 (ZiskFv.Compliance.divuArow trace binding i h_main_active h_main_op).chunks.b_0.val (ZiskFv.Compliance.divuArow trace binding i h_main_active h_main_op).chunks.b_1.val (ZiskFv.Compliance.divuArow trace binding i h_main_active h_main_op).chunks.b_2.val (ZiskFv.Compliance.divuArow trace binding i h_main_active h_main_op).chunks.b_3.val)
+
+# ZiskFv.Compliance.construction_divuw_sound
+trace.length :: Nat
+trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
+trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
+trace.constraints :: trace.3.Constraints
+trace.spec :: trace.3.Spec
+trace.balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
+binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.length
+divuw_input :: PureSpec.DivuwInput
+r1 :: regidx
+r2 :: regidx
+rd :: regidx
+h_main_op :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).op i.val) ZiskFv.Trusted.OP_DIVU_W
+h_main_active :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).is_external_op i.val) 1
+h_store_pc :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).store_pc i.val) 0
+h_input_r1 :: Eq (read_xreg (regidx_to_fin r1) (binding.stateAt i)) (EStateM.Result.ok divuw_input.r1_val (binding.stateAt i))
+h_input_r2 :: Eq (read_xreg (regidx_to_fin r2) (binding.stateAt i)) (EStateM.Result.ok divuw_input.r2_val (binding.stateAt i))
+h_input_pc :: Eq ((binding.stateAt i).regs.get? Register.PC) (Option.some divuw_input.PC)
+h_input_rd :: Eq divuw_input.rd (regidx_to_fin rd)
+execRow :: List (Interaction.ExecutionBusEntry (Fin 18446744069414584321))
+h_exec_len :: Eq (ZiskFv.Compliance.busSub trace binding i execRow).exec_row.length 2
+h_e0_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 0).multiplicity (-1)
+h_e1_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).multiplicity 1
+h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).pc.val) register_type_pc_equiv) (PureSpec.execute_DIVREM_divuw_pure divuw_input).nextPC
+h_rd_idx :: Eq divuw_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
+bounds.x0_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 0).val 256
+bounds.x1_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 1).val 256
+bounds.x2_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 2).val 256
+bounds.x3_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 3).val 256
+bounds.x4_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 4).val 256
+bounds.x5_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 5).val 256
+bounds.x6_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 6).val 256
+bounds.x7_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 7).val 256
+remainder_bound.binary.b_op :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_0 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_1 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_2 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_3 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_4 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_5 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_6 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_7 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_0 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_1 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_2 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_3 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_4 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_5 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_6 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_7 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_0 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_1 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_2 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_3 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_4 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_5 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_6 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_7 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_0 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_1 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_2 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_3 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_4 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_5 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_6 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_7 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.mode32 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.result_is_a :: Nat → Fin 18446744069414584321
+remainder_bound.binary.use_first_byte :: Nat → Fin 18446744069414584321
+remainder_bound.binary.c_is_signed :: Nat → Fin 18446744069414584321
+remainder_bound.binary.b_op_or_sext :: Nat → Fin 18446744069414584321
+remainder_bound.binary.mode32_and_c_is_signed :: Nat → Fin 18446744069414584321
+remainder_bound.binary.gsum :: Nat → Fin 18446744069414584321
+remainder_bound.binary.im_0 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.im_1 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.im_2 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.im_3 :: Nat → Fin 18446744069414584321
+remainder_bound.r_binary :: Nat
+remainder_bound.binary_core :: ZiskFv.Airs.Binary.core_every_row remainder_bound.1 remainder_bound.2
+remainder_bound.binary_ltu_chain.chain_0 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_0 remainder_bound.2) (remainder_bound.1.free_in_b_0 remainder_bound.2) (remainder_bound.1.free_in_c_0 remainder_bound.2) 0 (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_0 remainder_bound.2)) (instHMul.hMul 2 (remainder_bound.1.use_first_byte remainder_bound.2))
+remainder_bound.binary_ltu_chain.chain_1 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_1 remainder_bound.2) (remainder_bound.1.free_in_b_1 remainder_bound.2) (remainder_bound.1.free_in_c_1 remainder_bound.2) (remainder_bound.1.carry_0 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_1 remainder_bound.2)) 0
+remainder_bound.binary_ltu_chain.chain_2 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_2 remainder_bound.2) (remainder_bound.1.free_in_b_2 remainder_bound.2) (remainder_bound.1.free_in_c_2 remainder_bound.2) (remainder_bound.1.carry_1 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_2 remainder_bound.2)) 0
+remainder_bound.binary_ltu_chain.chain_3 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_3 remainder_bound.2) (remainder_bound.1.free_in_b_3 remainder_bound.2) (remainder_bound.1.free_in_c_3 remainder_bound.2) (remainder_bound.1.carry_2 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_3 remainder_bound.2)) (remainder_bound.1.mode32 remainder_bound.2)
+remainder_bound.binary_ltu_chain.chain_4 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_4 remainder_bound.2) (remainder_bound.1.free_in_b_4 remainder_bound.2) (remainder_bound.1.free_in_c_4 remainder_bound.2) (remainder_bound.1.carry_3 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_4 remainder_bound.2)) 0
+remainder_bound.binary_ltu_chain.chain_5 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_5 remainder_bound.2) (remainder_bound.1.free_in_b_5 remainder_bound.2) (remainder_bound.1.free_in_c_5 remainder_bound.2) (remainder_bound.1.carry_4 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_5 remainder_bound.2)) 0
+remainder_bound.binary_ltu_chain.chain_6 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_6 remainder_bound.2) (remainder_bound.1.free_in_b_6 remainder_bound.2) (remainder_bound.1.free_in_c_6 remainder_bound.2) (remainder_bound.1.carry_5 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_6 remainder_bound.2)) 0
+remainder_bound.binary_ltu_chain.chain_7 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_7 remainder_bound.2) (remainder_bound.1.free_in_b_7 remainder_bound.2) (remainder_bound.1.free_in_c_7 remainder_bound.2) (remainder_bound.1.carry_6 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags7Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2)) (instHSub.hSub 1 (remainder_bound.1.mode32 remainder_bound.2))
+remainder_bound.binary_ltu_chain.c0_lt :: instLTNat.lt (remainder_bound.1.free_in_c_0 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c1_lt :: instLTNat.lt (remainder_bound.1.free_in_c_1 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c2_lt :: instLTNat.lt (remainder_bound.1.free_in_c_2 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c3_lt :: instLTNat.lt (remainder_bound.1.free_in_c_3 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c4_lt :: instLTNat.lt (remainder_bound.1.free_in_c_4 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c5_lt :: instLTNat.lt (remainder_bound.1.free_in_c_5 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c6_lt :: instLTNat.lt (remainder_bound.1.free_in_c_6 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c7_lt :: instLTNat.lt (remainder_bound.1.free_in_c_7 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.cin0_eq :: Eq (Fin.val 0) 0
+remainder_bound.binary_ltu_chain.cin1_eq :: Eq (remainder_bound.1.carry_0 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_0 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin2_eq :: Eq (remainder_bound.1.carry_1 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_1 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin3_eq :: Eq (remainder_bound.1.carry_2 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_2 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin4_eq :: Eq (remainder_bound.1.carry_3 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_3 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin5_eq :: Eq (remainder_bound.1.carry_4 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_4 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin6_eq :: Eq (remainder_bound.1.carry_5 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_5 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin7_eq :: Eq (remainder_bound.1.carry_6 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_6 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.pi0_ne :: Ne (instHMul.hMul 2 (remainder_bound.1.use_first_byte remainder_bound.2)).val 1
+remainder_bound.binary_ltu_chain.pi1_ne :: Ne (Fin.val 0) 1
+remainder_bound.binary_ltu_chain.pi2_ne :: Ne (Fin.val 0) 1
+remainder_bound.binary_ltu_chain.pi3_ne :: Ne (remainder_bound.1.mode32 remainder_bound.2).val 1
+remainder_bound.binary_ltu_chain.pi4_ne :: Ne (Fin.val 0) 1
+remainder_bound.binary_ltu_chain.pi5_ne :: Ne (Fin.val 0) 1
+remainder_bound.binary_ltu_chain.pi6_ne :: Ne (Fin.val 0) 1
+remainder_bound.binary_ltu_chain.pi7_eq :: Eq (instHSub.hSub 1 (remainder_bound.1.mode32 remainder_bound.2)).val 1
+remainder_bound.remainder_bound_match :: ZiskFv.Airs.OperationBus.matches_entry (ZiskFv.Airs.ArithDiv.opBus_row_ArithDivRemainderBound (ZiskFv.Compliance.vOfDivuRow (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op)) 0) (ZiskFv.Airs.OperationBus.opBus_row_Binary remainder_bound.1 remainder_bound.2)
+h_b23 :: And (Eq (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op).chunks.b_2.val 0) (Eq (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op).chunks.b_3.val 0)
+h_c23 :: And (Eq (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op).chunks.c_2.val 0) (Eq (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op).chunks.c_3.val 0)
+h_sext_choice :: Or (And (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 4).val 0) (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 5).val 0) (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 6).val 0) (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 7).val 0)))) (instLTNat.lt (instHAdd.hAdd (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op).chunks.a_0.val (instHMul.hMul (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op).chunks.a_1.val 65536)) 2147483648)) (And (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 4).val 255) (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 5).val 255) (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 6).val 255) (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 7).val 255)))) (GE.ge (instHAdd.hAdd (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op).chunks.a_0.val (instHMul.hMul (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op).chunks.a_1.val 65536)) 2147483648))
+h_rs1_value :: Eq (Sail.BitVec.extractLsb divuw_input.r1_val 31 0).toNat (instHAdd.hAdd (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op).chunks.c_0.val (instHMul.hMul (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op).chunks.c_1.val 65536))
+h_rs2_value :: Eq (Sail.BitVec.extractLsb divuw_input.r2_val 31 0).toNat (instHAdd.hAdd (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op).chunks.b_0.val (instHMul.hMul (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op).chunks.b_1.val 65536))

--- a/trust/generated/baseline-construction-theorem-binders.txt
+++ b/trust/generated/baseline-construction-theorem-binders.txt
@@ -1375,3 +1375,123 @@ h_c23 :: And (Eq (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_ma
 h_sext_choice :: Or (And (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 4).val 0) (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 5).val 0) (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 6).val 0) (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 7).val 0)))) (instLTNat.lt (instHAdd.hAdd (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op).chunks.a_0.val (instHMul.hMul (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op).chunks.a_1.val 65536)) 2147483648)) (And (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 4).val 255) (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 5).val 255) (And (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 6).val 255) (Eq (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 7).val 255)))) (GE.ge (instHAdd.hAdd (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op).chunks.a_0.val (instHMul.hMul (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op).chunks.a_1.val 65536)) 2147483648))
 h_rs1_value :: Eq (Sail.BitVec.extractLsb divuw_input.r1_val 31 0).toNat (instHAdd.hAdd (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op).chunks.c_0.val (instHMul.hMul (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op).chunks.c_1.val 65536))
 h_rs2_value :: Eq (Sail.BitVec.extractLsb divuw_input.r2_val 31 0).toNat (instHAdd.hAdd (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op).chunks.b_0.val (instHMul.hMul (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op).chunks.b_1.val 65536))
+
+# ZiskFv.Compliance.construction_remu_sound
+trace.length :: Nat
+trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
+trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
+trace.constraints :: trace.3.Constraints
+trace.spec :: trace.3.Spec
+trace.balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
+binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.length
+remu_input :: PureSpec.RemuInput
+r1 :: regidx
+r2 :: regidx
+rd :: regidx
+h_main_op :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).op i.val) ZiskFv.Trusted.OP_REMU
+h_main_active :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).is_external_op i.val) 1
+h_store_pc :: Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable).store_pc i.val) 0
+h_input_r1 :: Eq (read_xreg (regidx_to_fin r1) (binding.stateAt i)) (EStateM.Result.ok remu_input.r1_val (binding.stateAt i))
+h_input_r2 :: Eq (read_xreg (regidx_to_fin r2) (binding.stateAt i)) (EStateM.Result.ok remu_input.r2_val (binding.stateAt i))
+h_input_pc :: Eq ((binding.stateAt i).regs.get? Register.PC) (Option.some remu_input.PC)
+h_input_rd :: Eq remu_input.rd (regidx_to_fin rd)
+execRow :: List (Interaction.ExecutionBusEntry (Fin 18446744069414584321))
+h_exec_len :: Eq (ZiskFv.Compliance.busSub trace binding i execRow).exec_row.length 2
+h_e0_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 0).multiplicity (-1)
+h_e1_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).multiplicity 1
+h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSub trace binding i execRow).exec_row 1).pc.val) register_type_pc_equiv) (PureSpec.execute_DIVREM_remu_pure remu_input).nextPC
+h_rd_idx :: Eq remu_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
+bounds.x0_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 0).val 256
+bounds.x1_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 1).val 256
+bounds.x2_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 2).val 256
+bounds.x3_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 3).val 256
+bounds.x4_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 4).val 256
+bounds.x5_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 5).val 256
+bounds.x6_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 6).val 256
+bounds.x7_lt :: instLTNat.lt (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSub trace binding i execRow).e2 7).val 256
+remainder_bound.binary.b_op :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_0 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_1 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_2 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_3 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_4 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_5 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_6 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_a_7 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_0 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_1 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_2 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_3 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_4 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_5 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_6 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_b_7 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_0 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_1 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_2 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_3 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_4 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_5 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_6 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.free_in_c_7 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_0 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_1 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_2 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_3 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_4 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_5 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_6 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.carry_7 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.mode32 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.result_is_a :: Nat → Fin 18446744069414584321
+remainder_bound.binary.use_first_byte :: Nat → Fin 18446744069414584321
+remainder_bound.binary.c_is_signed :: Nat → Fin 18446744069414584321
+remainder_bound.binary.b_op_or_sext :: Nat → Fin 18446744069414584321
+remainder_bound.binary.mode32_and_c_is_signed :: Nat → Fin 18446744069414584321
+remainder_bound.binary.gsum :: Nat → Fin 18446744069414584321
+remainder_bound.binary.im_0 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.im_1 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.im_2 :: Nat → Fin 18446744069414584321
+remainder_bound.binary.im_3 :: Nat → Fin 18446744069414584321
+remainder_bound.r_binary :: Nat
+remainder_bound.binary_core :: ZiskFv.Airs.Binary.core_every_row remainder_bound.1 remainder_bound.2
+remainder_bound.binary_ltu_chain.chain_0 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_0 remainder_bound.2) (remainder_bound.1.free_in_b_0 remainder_bound.2) (remainder_bound.1.free_in_c_0 remainder_bound.2) 0 (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_0 remainder_bound.2)) (instHMul.hMul 2 (remainder_bound.1.use_first_byte remainder_bound.2))
+remainder_bound.binary_ltu_chain.chain_1 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_1 remainder_bound.2) (remainder_bound.1.free_in_b_1 remainder_bound.2) (remainder_bound.1.free_in_c_1 remainder_bound.2) (remainder_bound.1.carry_0 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_1 remainder_bound.2)) 0
+remainder_bound.binary_ltu_chain.chain_2 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_2 remainder_bound.2) (remainder_bound.1.free_in_b_2 remainder_bound.2) (remainder_bound.1.free_in_c_2 remainder_bound.2) (remainder_bound.1.carry_1 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_2 remainder_bound.2)) 0
+remainder_bound.binary_ltu_chain.chain_3 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_3 remainder_bound.2) (remainder_bound.1.free_in_b_3 remainder_bound.2) (remainder_bound.1.free_in_c_3 remainder_bound.2) (remainder_bound.1.carry_2 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_3 remainder_bound.2)) (remainder_bound.1.mode32 remainder_bound.2)
+remainder_bound.binary_ltu_chain.chain_4 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_4 remainder_bound.2) (remainder_bound.1.free_in_b_4 remainder_bound.2) (remainder_bound.1.free_in_c_4 remainder_bound.2) (remainder_bound.1.carry_3 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_4 remainder_bound.2)) 0
+remainder_bound.binary_ltu_chain.chain_5 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_5 remainder_bound.2) (remainder_bound.1.free_in_b_5 remainder_bound.2) (remainder_bound.1.free_in_c_5 remainder_bound.2) (remainder_bound.1.carry_4 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_5 remainder_bound.2)) 0
+remainder_bound.binary_ltu_chain.chain_6 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_6 remainder_bound.2) (remainder_bound.1.free_in_b_6 remainder_bound.2) (remainder_bound.1.free_in_c_6 remainder_bound.2) (remainder_bound.1.carry_5 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_6 remainder_bound.2)) 0
+remainder_bound.binary_ltu_chain.chain_7 :: ZiskFv.Airs.Binary.consumer_byte_match_chain_wf ZiskFv.Airs.Tables.BinaryTable.OP_LTU (remainder_bound.1.free_in_a_7 remainder_bound.2) (remainder_bound.1.free_in_b_7 remainder_bound.2) (remainder_bound.1.free_in_c_7 remainder_bound.2) (remainder_bound.1.carry_6 remainder_bound.2) (ZiskFv.AirsClean.Binary.lookupFlags7Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2)) (instHSub.hSub 1 (remainder_bound.1.mode32 remainder_bound.2))
+remainder_bound.binary_ltu_chain.c0_lt :: instLTNat.lt (remainder_bound.1.free_in_c_0 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c1_lt :: instLTNat.lt (remainder_bound.1.free_in_c_1 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c2_lt :: instLTNat.lt (remainder_bound.1.free_in_c_2 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c3_lt :: instLTNat.lt (remainder_bound.1.free_in_c_3 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c4_lt :: instLTNat.lt (remainder_bound.1.free_in_c_4 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c5_lt :: instLTNat.lt (remainder_bound.1.free_in_c_5 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c6_lt :: instLTNat.lt (remainder_bound.1.free_in_c_6 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.c7_lt :: instLTNat.lt (remainder_bound.1.free_in_c_7 remainder_bound.2).val 256
+remainder_bound.binary_ltu_chain.cin0_eq :: Eq (Fin.val 0) 0
+remainder_bound.binary_ltu_chain.cin1_eq :: Eq (remainder_bound.1.carry_0 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_0 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin2_eq :: Eq (remainder_bound.1.carry_1 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_1 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin3_eq :: Eq (remainder_bound.1.carry_2 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags012Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_2 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin4_eq :: Eq (remainder_bound.1.carry_3 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_3 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin5_eq :: Eq (remainder_bound.1.carry_4 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_4 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin6_eq :: Eq (remainder_bound.1.carry_5 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_5 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.cin7_eq :: Eq (remainder_bound.1.carry_6 remainder_bound.2).val (instHMod.hMod (ZiskFv.AirsClean.Binary.lookupFlags3456Row (ZiskFv.AirsClean.Binary.rowAt remainder_bound.1 remainder_bound.2) (remainder_bound.1.carry_6 remainder_bound.2)).val 2)
+remainder_bound.binary_ltu_chain.pi0_ne :: Ne (instHMul.hMul 2 (remainder_bound.1.use_first_byte remainder_bound.2)).val 1
+remainder_bound.binary_ltu_chain.pi1_ne :: Ne (Fin.val 0) 1
+remainder_bound.binary_ltu_chain.pi2_ne :: Ne (Fin.val 0) 1
+remainder_bound.binary_ltu_chain.pi3_ne :: Ne (remainder_bound.1.mode32 remainder_bound.2).val 1
+remainder_bound.binary_ltu_chain.pi4_ne :: Ne (Fin.val 0) 1
+remainder_bound.binary_ltu_chain.pi5_ne :: Ne (Fin.val 0) 1
+remainder_bound.binary_ltu_chain.pi6_ne :: Ne (Fin.val 0) 1
+remainder_bound.binary_ltu_chain.pi7_eq :: Eq (instHSub.hSub 1 (remainder_bound.1.mode32 remainder_bound.2)).val 1
+remainder_bound.remainder_bound_match :: ZiskFv.Airs.OperationBus.matches_entry (ZiskFv.Airs.ArithDiv.opBus_row_ArithDivRemainderBound (ZiskFv.Compliance.vOfDivuRow (ZiskFv.Compliance.remuArow trace binding i h_main_active h_main_op)) 0) (ZiskFv.Airs.OperationBus.opBus_row_Binary remainder_bound.1 remainder_bound.2)
+h_rs1_value :: Eq remu_input.r1_val.toNat (ZiskFv.PackedBitVec.MulNoWrap.packed4 (ZiskFv.Compliance.remuArow trace binding i h_main_active h_main_op).chunks.c_0.val (ZiskFv.Compliance.remuArow trace binding i h_main_active h_main_op).chunks.c_1.val (ZiskFv.Compliance.remuArow trace binding i h_main_active h_main_op).chunks.c_2.val (ZiskFv.Compliance.remuArow trace binding i h_main_active h_main_op).chunks.c_3.val)
+h_rs2_value :: Eq remu_input.r2_val.toNat (ZiskFv.PackedBitVec.MulNoWrap.packed4 (ZiskFv.Compliance.remuArow trace binding i h_main_active h_main_op).chunks.b_0.val (ZiskFv.Compliance.remuArow trace binding i h_main_active h_main_op).chunks.b_1.val (ZiskFv.Compliance.remuArow trace binding i h_main_active h_main_op).chunks.b_2.val (ZiskFv.Compliance.remuArow trace binding i h_main_active h_main_op).chunks.b_3.val)


### PR DESCRIPTION
## Summary

Lands the **6 unsigned RV64M `construction_<op>_sound` theorems** — MULW, MULHU, DIVU, DIVUW, REMU, REMUW — taking the P4 sound-construction set **30 → 36**, plus the **arith extraction-expansion foundation** they required.

**Full fidelity:** every arith witness (carry-chain, ArithTable membership, c46, chunk + carry ranges) is **derived from `trace.balanced`** (the proof-system channel-balance trust class), *not* carried as a caller promise. **0 PROJECT (`ZiskFv.*`) axioms**; trust gate **V1 18/18 + V2 12/12**; full `lake build` green.

## Extraction foundation (the lever)

The Clean ArithMul provider only partially mirrored the real arith AIR, so the per-op witnesses had to be caller-supplied. These commits make `componentWithArithTable` faithfully constrain the full arith row, so the witnesses become balance-derivable:

- **c46** (`cd26a331`) — re-compose constraint 46 (the `bus_res1` output mux, `arith.pil:262`, extracted but previously dropped at the Clean layer).
- **chunk ranges** (`d9e59667`) — 16 `rangeTable16` lookups (a/b/c/d chunks < 2¹⁶), sound for all rows.
- **carry ranges** (`8660312f`) — 7 `signedCarryRangeTable` lookups (the faithful `ARITH_RANGE_CARRY` range — sound for all rows; the carries are `bits(64,signed)`, so the too-tight unsigned `rangeTable17` would be unsound here).
- **faithful op-bus mux** (`af16b990`) — `primaryOpBusMessageExpr` now carries the real `bus_a`/`bus_res0` *muxed* lanes (`arith.pil:247-258`), so one message faithfully covers all arith modes (mul-low / mul-high / div / rem); each op's mode pins select its lane.

Result: `componentWithArithTable.Spec = Spec ∧ ArithTableSpec ∧ C46Spec ∧ ChunkRangeSpec ∧ CarryRangeSpec`, all balance-derivable. (The op-bus provider is shared by mul *and* div — ArithDiv emits no op-bus.)

## Constructions (30 → 36)

MULW (primary lane), MULHU (secondary/high-half lane), DIVU (quotient), DIVUW (W-mode), REMU (remainder/secondary lane), REMUW (W-mode). Each derives the arith witnesses from the provider match via an `equiv_<OP>_of_fullSpec` bridge, with a per-mode op-bus bridge reducing the mux to that op's lane.

## Honest residuals (same trust class as the canonical `equiv_<OP>`)

Each construction carries **only**: decode pins, Sail reads, operand bridges (Sail↔chunk), exec artifacts + the genuine `execRow` ∀-binder, `h_nextPC_matches`, the W-mode bus-encoding residuals (`h_b23`/`h_c23`/`h_sext_choice`, for the W ops — `m32` is not an op-bus field), and the **one** `remainder_bound` (the `|d|<b` LTU `assumes_operation`, `arith.pil:274` — a finished-channel self-edge not modeled in the ensemble, so carried exactly as the canonical `equiv_DIVU`/etc. already do). **No arith-witness binders.**

Signed M-ext (MUL/MULH/MULHSU/DIV/DIVW/REM/REMW) + FENCE remain defect-gated via `NoKnownDefect`, unchanged.

## Anti-laundering

These are **new** construction theorems (not refactors of canonical `equiv_<OP>`), so the construction-binder baseline diff is purely additive and the canonical hypothesis-count + caller-burden ledgers are untouched (V1 #7/#8 pass). The arith witnesses are **derived** from balance, not relocated to premises or axioms. Each construction's closure carries `Lean.ofReduceBool`/`Lean.trustCompiler` (native_decide) **inherited from the canonical `equiv_<OP>` path** (tracked by #75), not introduced here.

## Notes

- Per-opcode trust footprint == the corresponding canonical `equiv_<OP>`.
- The full-fidelity remainder bound (composing the LTU consume self-edge) is a deferred follow-on; until then the `remainder_bound` residual matches the existing canonical div/rem treatment.
- Feeds the P5 `OpEnvelope`-removal assembly (the 36 constructions are the base it composes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
