### PR TITLE
#76 memory-timeline: cross-segment seam (step D) + store-driven Fold-B reduction [inspection]

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,58 @@
-Active plan: docs/ai/plan/PLAN_ENDGAME_P4_MEMORY.md (#76 PR-76.5) +
+Active plan: docs/ai/plan/PLAN_ENDGAME_P4_MEMORY.md (#76 — PR-76.0 DONE/GO; PR-76.1 next) +
 docs/ai/research/RESEARCH_XCAP.md §3 (#103 deep refactor B→A→C→D…).
 Branch: p76-memory. Worktree: .worktrees/p76-memory.
 
-## Current focus: PR-76.5 STEP D (seg_last-gated REAL Mem AIR) — DONE, GREEN. GO.
+## PR-76.0 make-or-break Fold-B reduction — DONE, GREEN, GO (2026-06-19).
+
+New module ZiskFv/ZiskCircuit/MemTimeline/Spike.lean (additive; no canonical
+equiv_<OP> or baseline touched). The store-driven Fold-B reduction (PLAN §3/§5):
+DERIVED the byte-local stateBytesAtPrefix / MemoryTraceAgreement for a load from
+{store-fold replayAgreement_of_rowTraceCoherence} + {seed initialAgreement} +
+{prefixReadSound (PR#65)}, with the load state OPAQUE — modulo ONE explicit NAMED
+trace-coherence residual `RowTraceCoherence` (external trust, like channel-balance).
+Metric STRICTLY SHRANK: whole-SailState `MemoryPrefixStateAlignment` identity →
+per-row memory-only `RowTraceCoherence` (never constrains regs/PC/cycleCount).
+Non-degenerate witness (witness_nondegenerate / witness_memoryTraceAgreement):
+realistic store-then-read same-address segment, load state's regs AND cycleCount
+≠ initial (NOT the rfl/frozen floor); store step from the canonical write
+transition (replayMemoryAgreement_write_entry), not a hand-built {state with mem}.
+0 new ZiskFv.* axioms (kernel-only: propext/Classical.choice/Quot.sound). Full
+lake build GREEN (8693). V2 semantic ALL PASS; baselines byte-identical. V1
+substantive pass — only the PRE-EXISTING check-13 "spike"-wording hit on the
+parent's committed Spike/MultiRowSegmentSeam.lean remains (untouched). NOT committed.
+Next: PR-76.1 (per-STORE EventReplayStep from equiv_<store> for SB/SH/SW/SD +
+.mem-invariance for loads/non-mem, supplying RowTraceCoherence's per-row conjuncts).
+
+## SPIKE (2026-06-19): re-attempt #76 the OpenVM "channel-level from balance" way — NO-GO.
+
+Investigated whether deriving memory consistency from `trace.balanced` (the MemBus
+channel balance), OpenVM-template style (rising-bus + per-ptr quotient + single-balancer
+characterisation), gets FURTHER than the row-level route toward discharging
+`h_memory_timeline`. Conclusion: **NO-GO** — it does not reach a different layer.
+Findings (full report in the agent transcript):
+1. OpenVM's `memory_bus_consistency_per_ptr` (the channel-balance result) has ZERO
+   consumers in openvm-fv — it never binds the Sail-side load value. OpenVM's loads
+   take `state.mem[ptr]? = read_data` as a `bus_effect.1` premise, exactly like zisk's
+   `h_memory_timeline.memoryTraceAgreement`. So the template does NOT close the gap that
+   #76 is about.
+2. zisk ALREADY has the per-pointer "read = previous write at addr" result
+   (`MemoryBusRowsPrefixReadSound`, derived in FullEnsemble/Balance.lean:8353-8768) — the
+   exact analog of OpenVM's consistency theorem. It is `[✓ already derived]`, NOT the
+   residual (PLAN_ENDGAME_P4_MEMORY §1 line 41-42). Wiring it / re-deriving it from
+   balance buys nothing.
+3. The actual residual is `MemoryPrefixStateAlignment` / `stateBytesAtPrefix`
+   (Construction.lean:21-31): the load's *real Sail execution state* memory =
+   replay of the accepted prefix. That is a TRACE-COHERENCE premise (`stateAt(i+1) =
+   execute step_i (stateAt i)`); neither balance nor per-row Mem constraints supply it.
+   OpenVM doesn't close it either.
+4. Infrastructure: the OpenVM rising-bus engine (`rising_bus_with_single_balancer_
+   characterisation` + ~44 supporting lemmas, ~1100 lines) is ABSENT from ZiskFv and
+   the Clean Air framework, and sits on `LeanZKCircuit.Interactions` (a substrate zisk
+   does not use; Clean uses count-based `BalancedInteractions`). A port would be large
+   AND would only re-derive item (2), which is already in hand. No code landed (landing
+   would be non-shrinking scaffolding). Build warm + green (8148). 0 new ZiskFv.* axioms.
+
+## Prior focus: PR-76.5 STEP D (seg_last-gated REAL Mem AIR) — DONE, GREEN. GO.
 
 STEP D landed the `seg_last` (SEGMENT_LAST) selector into the REAL `MemRow`,
 gated the `memWithDualMemBus` seam emission by it (one live pull/push per

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,27 @@
-Active plan: docs/ai/plan/PLAN_ENDGAME_P4_103.md (#103 cross-segment memory seam, route (b)).
-Branch: p4-103-landing. Worktree: .worktrees/xcap-seam-tag.
+Active plan: docs/ai/plan/PLAN_ENDGAME_P4_MEMORY.md (#76 PR-76.5) +
+docs/ai/research/RESEARCH_XCAP.md §3 (#103 deep refactor B→A→C→D…).
+Branch: p76-memory. Worktree: .worktrees/p76-memory.
 
-## Current focus: L5 STEP 1 (the "tie", step B) — DONE, GREEN.
+## Current focus: PR-76.5 STEP D (seg_last-gated REAL Mem AIR) — DONE, GREEN. GO.
+
+STEP D landed the `seg_last` (SEGMENT_LAST) selector into the REAL `MemRow`,
+gated the `memWithDualMemBus` seam emission by it (one live pull/push per
+segment + k-1 dead rows), rippled the new column through the full
+componentWithDualMemBus/MemRow/rowAt/memOfTable blast radius, and re-proved a
+k≥2 (2-rows-per-segment) cross-segment seam from balance on a REAL multi-row
+`mkTable` witness. Whole project GREEN (8692). 0 PROJECT axioms (kernel-only).
+V2 semantic gate ALL PASS; V1 substantive all pass (only pre-existing check-13
+"spike"-wording hit on the parent's committed Spike file remains, untouched).
+
+GO/NO-GO: **GO**. (a) the seg_last-gated REAL Mem AIR compiles across the full
+blast radius (no #103-L4.5 dispatch break); (b) the k≥2 cross-segment seam
+(`multiRow_seam_value_equality` / `good_multiRow_seam_holds`) is derived from
+balance on a real 4-row Mem trace (2 segments × [dead, live]), dead rows
+balance-inert. Remaining for E/F/G: airval↔column bridge
+(MemTimeline/Construction/Linkage), SegmentLastRowTie from the segment Spec (not
+h_tie), and the #76 `initialAgreement` wiring.
+
+## (Superseded) Prior focus: #103 L5 STEP 1 (the "tie", step B) — DONE, GREEN.
 
 The seam boundary columns are now TIED to real Mem-row state. The L1 seam forced
 seg_{i+1}.previous_segment_* = seg_i.segment_last_* on the CHANNEL/emission

--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -130,6 +130,7 @@ import ZiskFv.AirsClean.FullEnsemble
 import ZiskFv.AirsClean.FullEnsemble.Balance
 import ZiskFv.ZiskCircuit.MemTimeline.Construction
 import ZiskFv.ZiskCircuit.MemTimeline.Linkage
+import ZiskFv.ZiskCircuit.MemTimeline.Spike
 import ZiskFv.AirsClean.Mem.SeamRowTie
 import ZiskFv.Compliance.RowProvenance
 import ZiskFv.Compliance.AcceptedTrace

--- a/ZiskFv/Airs/Mem.lean
+++ b/ZiskFv/Airs/Mem.lean
@@ -100,6 +100,11 @@ structure Valid_Mem (F ExtF : Type) [Field F] [Field ExtF] where
   segment_last_addr : ℕ → F := fun _ => 0
   segment_last_step : ℕ → F := fun _ => 0
   is_last_segment : ℕ → F := fun _ => 0
+  /-- SEGMENT_LAST gating column (XCAP #103 deep refactor, step B). `1` exactly on
+      a segment's last row (`mem.pil:87` `SEGMENT_LAST = SEGMENT_L1'`). Gates the
+      cross-segment seam emission so a multi-row segment emits one live pull/push
+      and `k - 1` dead emissions. Defaults to `0`. -/
+  seg_last : ℕ → F := fun _ => 0
 
 variable {F ExtF : Type} [Field F] [Field ExtF]
 

--- a/ZiskFv/AirsClean/FullEnsemble/Balance.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance.lean
@@ -4453,6 +4453,7 @@ def zeroMemRow : ZiskFv.AirsClean.Mem.MemRow FGL where
   segment_last_addr := 0
   segment_last_step := 0
   is_last_segment := 0
+  seg_last := 0
 
 /-- Project row `row` of a concrete Clean Mem table to the Mem row input.
     Out-of-range rows use `zeroMemRow` only to make the named-column view total. -/
@@ -4505,6 +4506,7 @@ def memOfTable
   segment_last_addr := fun row => (memTableRowAtOrZero table row).segment_last_addr
   segment_last_step := fun row => (memTableRowAtOrZero table row).segment_last_step
   is_last_segment := fun row => (memTableRowAtOrZero table row).is_last_segment
+  seg_last := fun row => (memTableRowAtOrZero table row).seg_last
 
 /-- In-range concrete table projection agrees with `List.get`. -/
 theorem memTableRowAtOrZero_get
@@ -4552,7 +4554,8 @@ theorem rowAt_memOfTable
       segment_last_value_1 := row.segment_last_value_1
       segment_last_addr := row.segment_last_addr
       segment_last_step := row.segment_last_step
-      is_last_segment := row.is_last_segment } = row
+      is_last_segment := row.is_last_segment
+      seg_last := row.seg_last } = row
   cases row
   rfl
 

--- a/ZiskFv/AirsClean/FullEnsemble/SeamNonVacuity.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/SeamNonVacuity.lean
@@ -176,11 +176,23 @@ theorem bootTable_interactionsWith (v : BootRow FGL) (data : ProverData FGL) :
     eval_emittedSeam, eval_bootPushMsg]
   simp only [Expression.eval, Variable.index, mul_one]
 
-/-- A single Mem row's evaluated seam contribution: prev pull (tag `segment_id`,
-    mult -1) + last push (tag `segment_id + 1`, gated mult `1 - is_last_segment`). -/
+/-- A single Mem row's evaluated seam contribution (XCAP #103 deep refactor,
+    `seg_last`-gated): prev pull (tag `segment_id`, mult `-seg_last`) + last push
+    (tag `segment_id + 1`, mult `seg_last * (1 - is_last_segment)`). A non-last
+    row of a segment (`seg_last = 0`) contributes TWO multiplicity-0 (DEAD)
+    interactions; the segment's last row (`seg_last = 1`) carries the live pull +
+    gated push. -/
 @[reducible] def memRowSeamContribution (v : MemRow FGL) : List (Interaction FGL) :=
-  [ emittedSeamValue (-1) (segPrevVal v),
-    emittedSeamValue (1 - v.is_last_segment) (segLastVal v) ]
+  [ emittedSeamValue (-v.seg_last) (segPrevVal v),
+    emittedSeamValue (v.seg_last * (1 - v.is_last_segment)) (segLastVal v) ]
+
+/-- Evaluate the `seg_last` column of a `toElements` row. -/
+theorem eval_seg_last (v : MemRow FGL) (data : ProverData FGL) :
+    (Environment.fromArray (toElements v).toArray data)
+        (varFromOffset MemRow 0 |>.seg_last) = v.seg_last := by
+  simp only [eval, explicit_provable_type, circuit_norm,
+    eval_varFromOffset_valueFromOffset, valueFromOffset_fromArray]
+  rfl
 
 /-- The Mem component's per-row seam contribution evaluated at a `toElements`
     row equals `memRowSeamContribution`. -/
@@ -192,14 +204,21 @@ theorem memRow_interactionValuesWith (v : MemRow FGL) (data : ProverData FGL) :
     ZiskFv.AirsClean.Mem.componentWithDualMemBus_interactionsWith_seam,
     List.map_cons, List.map_nil, memRowSeamContribution]
   have h_prevmult : (Environment.fromArray (toElements v).toArray data)
-      (-1 : Expression FGL) = (-1 : FGL) := by
-    simp only [Expression.eval, Variable.index, mul_one]
+      (-(varFromOffset MemRow 0).seg_last) = -v.seg_last := by
+    show (-1 : FGL) * ((Environment.fromArray (toElements v).toArray data)
+        ((varFromOffset MemRow 0).seg_last)) = -v.seg_last
+    rw [eval_seg_last]; ring
   have h_lastmult : (Environment.fromArray (toElements v).toArray data)
-      (1 - (varFromOffset MemRow 0).is_last_segment) = 1 - v.is_last_segment := by
-    show (1 : FGL) + (-1 : FGL) *
-        ((Environment.fromArray (toElements v).toArray data)
-          ((varFromOffset MemRow 0).is_last_segment)) = 1 - v.is_last_segment
-    rw [eval_is_last]; ring
+      ((varFromOffset MemRow 0).seg_last *
+        (1 - (varFromOffset MemRow 0).is_last_segment))
+      = v.seg_last * (1 - v.is_last_segment) := by
+    show ((Environment.fromArray (toElements v).toArray data)
+          ((varFromOffset MemRow 0).seg_last)) *
+        ((1 : FGL) + (-1 : FGL) *
+          ((Environment.fromArray (toElements v).toArray data)
+            ((varFromOffset MemRow 0).is_last_segment)))
+      = v.seg_last * (1 - v.is_last_segment)
+    rw [eval_seg_last, eval_is_last]; ring
   rw [show componentWithDualMemBus.rowInputVar = varFromOffset MemRow 0 from rfl,
     eval_emittedSeam, eval_emittedSeam, eval_segPrevMsg, eval_segLastMsg,
     h_prevmult, h_lastmult]
@@ -213,13 +232,14 @@ theorem memTable_interactionsWith (rows : List (MemRow FGL)) (data : ProverData 
   intro v _
   exact memRow_interactionValuesWith v data
 
-/-- A 2-row Mem table's seam interactions = the two rows' contributions. -/
+/-- A 2-row Mem table's seam interactions = the two rows' (`seg_last`-gated)
+    contributions. -/
 theorem memTable_two_interactionsWith (v0 v1 : MemRow FGL) (data : ProverData FGL) :
     (mkTable componentWithDualMemBus [v0, v1] data).interactionsWith SeamContChannel.toRaw
-      = [ emittedSeamValue (-1) (segPrevVal v0),
-          emittedSeamValue (1 - v0.is_last_segment) (segLastVal v0),
-          emittedSeamValue (-1) (segPrevVal v1),
-          emittedSeamValue (1 - v1.is_last_segment) (segLastVal v1) ] := by
+      = [ emittedSeamValue (-v0.seg_last) (segPrevVal v0),
+          emittedSeamValue (v0.seg_last * (1 - v0.is_last_segment)) (segLastVal v0),
+          emittedSeamValue (-v1.seg_last) (segPrevVal v1),
+          emittedSeamValue (v1.seg_last * (1 - v1.is_last_segment)) (segLastVal v1) ] := by
   rw [memTable_interactionsWith]
   simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil,
     memRowSeamContribution, List.cons_append, List.nil_append]
@@ -272,10 +292,10 @@ theorem mkFullWitness_interactionsWith (vb : BootRow FGL) (v0 v1 : MemRow FGL)
     (mkFullWitness (length := length) (program := program) vb v0 v1 publicInput data).interactionsWith
         SeamContChannel.toRaw
       = [ emittedSeamValue 1 (bootPushVal vb),
-          emittedSeamValue (-1) (segPrevVal v0),
-          emittedSeamValue (1 - v0.is_last_segment) (segLastVal v0),
-          emittedSeamValue (-1) (segPrevVal v1),
-          emittedSeamValue (1 - v1.is_last_segment) (segLastVal v1) ] := by
+          emittedSeamValue (-v0.seg_last) (segPrevVal v0),
+          emittedSeamValue (v0.seg_last * (1 - v0.is_last_segment)) (segLastVal v0),
+          emittedSeamValue (-v1.seg_last) (segPrevVal v1),
+          emittedSeamValue (v1.seg_last * (1 - v1.is_last_segment)) (segLastVal v1) ] := by
   rw [EnsembleWitness.interactionsWith_of_verifier_empty (by rfl)]
   simp only [mkFullWitness, List.flatMap_cons, List.flatMap_nil, List.append_nil,
     mkTable_nil_interactionsWith, bootTable_interactionsWith, memTable_two_interactionsWith,
@@ -329,20 +349,24 @@ theorem toElements_seamMessage (a b c d e : FGL) :
     v1.segment_last_value_0 v1.segment_last_value_1 v1.segment_last_addr v1.segment_last_step
     (1 - v1.is_last_segment)
 
-/-- The full seam list projects onto `asBootList2` PROVIDED seg0 is non-last
-    (`is_last_segment = 0`, so its push multiplicity is `1 - 0 = 1`, matching
-    `bootList2`'s `pushMsg5`). seg1's gate stays free (= `1 - v1.is_last`). -/
+/-- The full (`seg_last`-gated) seam list projects onto `asBootList2` PROVIDED
+    each segment's row is its OWN last row (`seg_last = 1`, so the gated pull mult
+    `-seg_last = -1` and the gated push mult `seg_last * (1 - is_last) =
+    1 - is_last`), and seg0 is non-last (`is_last_segment = 0`, push mult `1`,
+    matching `bootList2`'s `pushMsg5`). seg1's gate stays free (= `1 - v1.is_last`).
+    This is the k = 1 (one row per segment) reduction; the k ≥ 2 reduction lives in
+    `memTable_multiRow_*` below and drops the `seg_last = 0` dead rows. -/
 theorem proj_eq (vb : BootRow FGL) (v0 v1 : MemRow FGL)
-    (h0 : v0.is_last_segment = 0) :
+    (h0 : v0.is_last_segment = 0) (hl0 : v0.seg_last = 1) (hl1 : v1.seg_last = 1) :
     ([ emittedSeamValue 1 (bootPushVal vb),
-       emittedSeamValue (-1) (segPrevVal v0),
-       emittedSeamValue (1 - v0.is_last_segment) (segLastVal v0),
-       emittedSeamValue (-1) (segPrevVal v1),
-       emittedSeamValue (1 - v1.is_last_segment) (segLastVal v1) ]
+       emittedSeamValue (-v0.seg_last) (segPrevVal v0),
+       emittedSeamValue (v0.seg_last * (1 - v0.is_last_segment)) (segLastVal v0),
+       emittedSeamValue (-v1.seg_last) (segPrevVal v1),
+       emittedSeamValue (v1.seg_last * (1 - v1.is_last_segment)) (segLastVal v1) ]
         : List (Interaction FGL)).map (fun i => (i.mult, i.msg))
       = (asBootList2 vb v0 v1).map (fun i => (i.mult, i.msg)) := by
   simp only [asBootList2, bootList2, List.map_cons, List.map_nil,
-    pushMsg5, pullMsg5, gatedMsg5, emittedSeamValue, h0, sub_zero,
+    pushMsg5, pullMsg5, gatedMsg5, emittedSeamValue, h0, hl0, hl1, sub_zero, one_mul,
     bootPushVal, segPrevVal, segLastVal, toElements_seamMessage]
 
 /-! ## EXTRACTION: ensemble `BalancedChannels` → `bootList2` balance. -/
@@ -354,14 +378,14 @@ theorem proj_eq (vb : BootRow FGL) (v0 v1 : MemRow FGL)
     channel's. -/
 theorem asBootList2_balanced_of_seamBalance (vb : BootRow FGL) (v0 v1 : MemRow FGL)
     (publicInput : unit FGL) (data : ProverData FGL)
-    (h0 : v0.is_last_segment = 0)
+    (h0 : v0.is_last_segment = 0) (hl0 : v0.seg_last = 1) (hl1 : v1.seg_last = 1)
     (hseam : EnsembleWitness.BalancedChannel
       (mkFullWitness (length := length) (program := program) vb v0 v1 publicInput data)
       SeamContChannel.toRaw) :
     BalancedInteractions (asBootList2 vb v0 v1) := by
   rw [EnsembleWitness.BalancedChannel, EnsembleWitness.interactionsWith_allTablesWitness,
     mkFullWitness_interactionsWith] at hseam
-  exact balancedInteractions_of_proj (proj_eq vb v0 v1 h0) hseam
+  exact balancedInteractions_of_proj (proj_eq vb v0 v1 h0 hl0 hl1) hseam
 
 /-! ## THE SEAM VALUE-EQUALITY, derived end-to-end from real-ensemble balance. -/
 
@@ -373,6 +397,7 @@ theorem asBootList2_balanced_of_seamBalance (vb : BootRow FGL) (v0 v1 : MemRow F
 theorem seam_value_equality (vb : BootRow FGL) (v0 v1 : MemRow FGL)
     (publicInput : unit FGL) (data : ProverData FGL)
     (h0 : v0.is_last_segment = 0) (h1 : v1.is_last_segment = 1)
+    (hl0 : v0.seg_last = 1) (hl1 : v1.seg_last = 1)
     (hseam : EnsembleWitness.BalancedChannel
       (mkFullWitness (length := length) (program := program) vb v0 v1 publicInput data)
       SeamContChannel.toRaw) :
@@ -382,7 +407,7 @@ theorem seam_value_equality (vb : BootRow FGL) (v0 v1 : MemRow FGL)
         = seam5 v0.segment_last_value_0 v0.segment_last_value_1
           v0.segment_last_addr v0.segment_last_step (v0.segment_id + 1) := by
   have hbalanced := asBootList2_balanced_of_seamBalance (length := length)
-    (program := program) vb v0 v1 publicInput data h0 hseam
+    (program := program) vb v0 v1 publicInput data h0 hl0 hl1 hseam
   rw [asBootList2, h1] at hbalanced
   simp only [show (1 : FGL) - 1 = 0 from by ring] at hbalanced
   obtain ⟨ht0, ht1, _hseam0, hseam⟩ := boot_chain_derived
@@ -422,7 +447,7 @@ balance, transported from `SeamTagChain.goodBootList2_balanced`. -/
     previous_segment_addr := 335544320, previous_segment_step := 0,
     segment_last_value_0 := 1, segment_last_value_1 := 0,
     segment_last_addr := 100, segment_last_step := 5,
-    is_last_segment := 0 }
+    is_last_segment := 0, seg_last := 1 }
 
 /-- seg1 (`MemRow`): segment 1, the LAST segment (`is_last_segment = 1`, its push
     gated off). prev = seg0.last `(1,0,100,5)` (THE SEAM); would-be last
@@ -436,7 +461,7 @@ balance, transported from `SeamTagChain.goodBootList2_balanced`. -/
     previous_segment_addr := 100, previous_segment_step := 5,
     segment_last_value_0 := 2, segment_last_value_1 := 0,
     segment_last_addr := 200, segment_last_step := 9,
-    is_last_segment := 1 }
+    is_last_segment := 1, seg_last := 1 }
 
 /-- The intended chain's `asBootList2` is exactly `SeamTagChain.goodBootList2`. -/
 theorem asBootList2_good : asBootList2 goodBoot goodSeg0 goodSeg1 = goodBootList2 := by
@@ -455,7 +480,7 @@ theorem good_seam_balancedChannel (publicInput : unit FGL) (data : ProverData FG
     mkFullWitness_interactionsWith]
   refine balancedInteractions_of_proj (as := goodBootList2) ?_ goodBootList2_balanced
   rw [← asBootList2_good]
-  exact (proj_eq goodBoot goodSeg0 goodSeg1 (by rfl)).symm
+  exact (proj_eq goodBoot goodSeg0 goodSeg1 (by rfl) (by rfl) (by rfl)).symm
 
 /-- NON-VACUOUS instantiation: running `seam_value_equality` on the concrete
     balanced 2-nonzero-segment witness lands the tags at `(0,1)` and the SEAM
@@ -468,8 +493,345 @@ theorem good_seam_holds (length : ℕ) (program : Program length)
     (publicInput : unit FGL) (data : ProverData FGL) :
     seam5 1 0 100 5 1 = seam5 1 0 100 5 (0 + 1) := by
   obtain ⟨_, _, hseam⟩ := seam_value_equality (length := length) (program := program)
-    goodBoot goodSeg0 goodSeg1 publicInput data (by rfl) (by rfl)
+    goodBoot goodSeg0 goodSeg1 publicInput data (by rfl) (by rfl) (by rfl) (by rfl)
     (good_seam_balancedChannel (length := length) (program := program) publicInput data)
+  simpa using hseam
+
+/-! ## k ≥ 2 NON-VACUITY: the cross-segment seam on a REAL MULTI-ROW Mem table
+    (XCAP #103 deep refactor, step C — the acceptance bar).
+
+The witness above (`mkFullWitness [v0, v1]`) puts ONE row per segment. The
+`seg_last`-gated emission (Phase A/B) makes the seam faithful to a MULTI-ROW
+segment: a segment's non-last rows carry `seg_last = 0` (their pull/push
+multiplicities vanish — DEAD, balance-inert), and only its last row
+(`seg_last = 1`) carries the live pull + gated push. We now witness the seam on a
+REAL 4-row `mkTable componentWithDualMemBus` table modelling 2 segments × 2 rows
+(one dead leading row + one live last row each), proving the dead rows drop out of
+`balanceOf` so the multi-row trace balances exactly as the engine's `bootList2`. -/
+
+/-- A `seg_last = 0` (DEAD) Mem row's seam contribution is balance-inert: both its
+    interactions carry multiplicity `0`, so `balanceOf` over them is `0` for every
+    message. The production analogue of the channel-level dead-row drop lemma. -/
+theorem balanceOf_memRowSeamContribution_dead (v : MemRow FGL) (hd : v.seg_last = 0)
+    (msg : Array FGL) : balanceOf (memRowSeamContribution v) msg = 0 := by
+  simp only [memRowSeamContribution, hd, neg_zero, zero_mul, balanceOf,
+    List.filter_cons, emittedSeamValue]
+  split <;> split <;> simp
+
+/-- A `seg_last = 1` (LIVE) Mem row, with `is_last_segment = g`, has the same
+    per-message `balanceOf` as the engine's `[pull (mult -1), gated push (mult
+    1 - g)]` pair. (For a live row the gated mults are `-1` and `1 - g`.) -/
+theorem balanceOf_memRowSeamContribution_live (v : MemRow FGL) (hl : v.seg_last = 1)
+    (msg : Array FGL) :
+    balanceOf (memRowSeamContribution v) msg
+      = balanceOf [ emittedSeamValue (-1) (segPrevVal v),
+          emittedSeamValue (1 - v.is_last_segment) (segLastVal v) ] msg := by
+  simp only [memRowSeamContribution, hl, neg_one_mul, one_mul, mul_one, neg_neg]
+
+/-- **THE k ≥ 2 CORE REDUCTION (production, step C).** A 4-row Mem table modelling
+    2 segments × 2 rows — a DEAD leading row (`seg_last = 0`, arbitrary junk
+    boundary) then a LIVE last row (`seg_last = 1`, the segment's genuine boundary)
+    per segment — has the SAME `balanceOf` (every message) as the one-row-per-
+    segment witness's seam list. The two DEAD rows drop out (multiplicity 0); the
+    two LIVE rows collapse to the engine's pull + gated push. -/
+theorem memTable_multiRow_balanceOf
+    (d0 v0 d1 v1 : MemRow FGL) (data : ProverData FGL)
+    (hd0 : d0.seg_last = 0) (hl0 : v0.seg_last = 1)
+    (hd1 : d1.seg_last = 0) (hl1 : v1.seg_last = 1)
+    (msg : Array FGL) :
+    balanceOf ((mkTable componentWithDualMemBus [d0, v0, d1, v1] data).interactionsWith
+        SeamContChannel.toRaw) msg
+      = balanceOf [ emittedSeamValue (-1) (segPrevVal v0),
+          emittedSeamValue (1 - v0.is_last_segment) (segLastVal v0),
+          emittedSeamValue (-1) (segPrevVal v1),
+          emittedSeamValue (1 - v1.is_last_segment) (segLastVal v1) ] msg := by
+  rw [memTable_interactionsWith]
+  -- flatMap over [d0, v0, d1, v1] = d0 ++ v0 ++ d1 ++ v1 contributions
+  rw [show [d0, v0, d1, v1].flatMap memRowSeamContribution
+      = memRowSeamContribution d0 ++ memRowSeamContribution v0
+        ++ memRowSeamContribution d1 ++ memRowSeamContribution v1
+      from by simp [List.flatMap_cons, List.flatMap_nil, List.append_assoc]]
+  rw [balanceOf_append, balanceOf_append, balanceOf_append,
+    balanceOf_memRowSeamContribution_dead d0 hd0,
+    balanceOf_memRowSeamContribution_dead d1 hd1,
+    balanceOf_memRowSeamContribution_live v0 hl0,
+    balanceOf_memRowSeamContribution_live v1 hl1]
+  -- LHS now: 0 + (live0 balance) + 0 + (live1 balance); RHS: live0 ++ live1.
+  rw [show ([ emittedSeamValue (-1) (segPrevVal v0),
+        emittedSeamValue (1 - v0.is_last_segment) (segLastVal v0),
+        emittedSeamValue (-1) (segPrevVal v1),
+        emittedSeamValue (1 - v1.is_last_segment) (segLastVal v1) ] : List (Interaction FGL))
+      = [ emittedSeamValue (-1) (segPrevVal v0),
+          emittedSeamValue (1 - v0.is_last_segment) (segLastVal v0) ]
+        ++ [ emittedSeamValue (-1) (segPrevVal v1),
+          emittedSeamValue (1 - v1.is_last_segment) (segLastVal v1) ] from rfl,
+    balanceOf_append]
+  ring
+
+/-! ## The concrete k ≥ 2 (2-rows-per-segment) real-ensemble witness. -/
+
+/-- The full multi-row witness over the REAL `fullRv64imEnsemble`: identical to
+    `mkFullWitness` except the Mem table now carries FOUR rows (2 segments ×
+    [dead, live]). Every non-Mem, non-boot table stays empty. -/
+def mkFullWitnessMultiRow (vb : BootRow FGL) (d0 v0 d1 v1 : MemRow FGL)
+    (publicInput : unit FGL) (data : ProverData FGL) :
+    EnsembleWitness (fullRv64imEnsemble length program).ensemble where
+  tables :=
+    [ mkTable ZiskFv.AirsClean.MemAlignReadByte.component [] data
+    , mkTable ZiskFv.AirsClean.MemAlignByte.component [] data
+    , mkTable ZiskFv.AirsClean.MemAlign.component [] data
+    , mkTable bootComp [vb] data
+    , mkTable componentWithDualMemBus [d0, v0, d1, v1] data
+    , mkTable ZiskFv.AirsClean.ArithDiv.component [] data
+    , mkTable ZiskFv.AirsClean.ArithMul.componentWithArithTable [] data
+    , mkTable ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent [] data
+    , mkTable ZiskFv.AirsClean.Binary.staticLookupComponent [] data
+    , mkTable ZiskFv.AirsClean.BinaryAdd.component [] data
+    , mkTable (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program) [] data ]
+  data := data
+  publicInput := publicInput
+  same_length := by
+    simp [fullRv64imEnsemble, SoundEnsemble.toFormal, SoundEnsemble.addTable_tables,
+      SoundEnsemble.addFinishedChannel_tables, SoundEnsemble.addChannel_tables,
+      SoundEnsemble.empty_tables]
+  same_circuits := by
+    intro i hi
+    simp only [fullRv64imEnsemble, SoundEnsemble.toFormal, SoundEnsemble.addTable_tables,
+      SoundEnsemble.addFinishedChannel_tables, SoundEnsemble.addChannel_tables,
+      SoundEnsemble.empty_tables, List.length_cons, List.length_nil] at hi ⊢
+    interval_cases i <;> rfl
+  same_data := by
+    intro table htable
+    simp only [List.mem_cons, List.not_mem_nil, or_false] at htable
+    rcases htable with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;> rfl
+
+/-- The multi-row witness's seam interactions = boot push + the 4 Mem rows'
+    contributions (dead rows included; they are balance-inert). -/
+theorem mkFullWitnessMultiRow_interactionsWith (vb : BootRow FGL) (d0 v0 d1 v1 : MemRow FGL)
+    (publicInput : unit FGL) (data : ProverData FGL) :
+    (mkFullWitnessMultiRow (length := length) (program := program)
+        vb d0 v0 d1 v1 publicInput data).interactionsWith SeamContChannel.toRaw
+      = emittedSeamValue 1 (bootPushVal vb) ::
+        (mkTable componentWithDualMemBus [d0, v0, d1, v1] data).interactionsWith
+          SeamContChannel.toRaw := by
+  rw [EnsembleWitness.interactionsWith_of_verifier_empty (by rfl)]
+  simp only [mkFullWitnessMultiRow, List.flatMap_cons, List.flatMap_nil, List.append_nil,
+    mkTable_nil_interactionsWith, bootTable_interactionsWith,
+    List.nil_append, List.cons_append, List.singleton_append]
+
+/-- **k ≥ 2 BALANCE TRANSPORT.** The multi-row (2-rows-per-segment) seam channel
+    balance reduces to `asBootList2`'s balance: the boot push is shared, and the
+    4 Mem-row contributions collapse (dead rows drop, live rows project) onto the
+    one-row-per-segment list. Requires the live rows be the segments' last rows
+    (`seg_last = 1`) and the dead rows be non-last (`seg_last = 0`), with seg0
+    non-last so its live push mult is `1`. -/
+theorem asBootList2_balanced_of_multiRow_seamBalance
+    (vb : BootRow FGL) (d0 v0 d1 v1 : MemRow FGL)
+    (publicInput : unit FGL) (data : ProverData FGL)
+    (hd0 : d0.seg_last = 0) (hl0 : v0.seg_last = 1)
+    (hd1 : d1.seg_last = 0) (hl1 : v1.seg_last = 1)
+    (h0 : v0.is_last_segment = 0)
+    (hseam : EnsembleWitness.BalancedChannel
+      (mkFullWitnessMultiRow (length := length) (program := program)
+        vb d0 v0 d1 v1 publicInput data) SeamContChannel.toRaw) :
+    BalancedInteractions (asBootList2 vb v0 v1) := by
+  rw [EnsembleWitness.BalancedChannel, EnsembleWitness.interactionsWith_allTablesWitness,
+    mkFullWitnessMultiRow_interactionsWith] at hseam
+  refine ⟨?_, ?_⟩
+  · -- `asBootList2` has 5 interactions, well under `ringChar FGL`.
+    left
+    have : (5 : ℕ) < ringChar FGL := by
+      haveI hc : CharP FGL GL_prime := inferInstanceAs (CharP (Fin GL_prime) GL_prime)
+      rw [ringChar.eq FGL GL_prime]; norm_num
+    simpa [asBootList2, bootList2] using this
+  · intro msg
+    -- Transport: the multi-row balance (boot :: 4-row table) equals `asBootList2`'s.
+    have hbal := hseam.2 msg
+    rw [show emittedSeamValue 1 (bootPushVal vb) ::
+          (mkTable componentWithDualMemBus [d0, v0, d1, v1] data).interactionsWith
+            SeamContChannel.toRaw
+        = [emittedSeamValue 1 (bootPushVal vb)]
+          ++ (mkTable componentWithDualMemBus [d0, v0, d1, v1] data).interactionsWith
+            SeamContChannel.toRaw from rfl,
+      balanceOf_append,
+      memTable_multiRow_balanceOf d0 v0 d1 v1 data hd0 hl0 hd1 hl1] at hbal
+    -- `asBootList2`'s balance equals the boot + live shape's balance, because
+    -- `balanceOf` depends only on the `(mult, msg)` projection (`balanceOf_proj`),
+    -- and that projection matches via `proj_eq` (seg0 non-last; both rows live).
+    rw [balanceOf_proj (asBootList2 vb v0 v1), ← proj_eq vb v0 v1 h0 hl0 hl1,
+      ← balanceOf_proj]
+    rw [show ([ emittedSeamValue 1 (bootPushVal vb),
+          emittedSeamValue (-v0.seg_last) (segPrevVal v0),
+          emittedSeamValue (v0.seg_last * (1 - v0.is_last_segment)) (segLastVal v0),
+          emittedSeamValue (-v1.seg_last) (segPrevVal v1),
+          emittedSeamValue (v1.seg_last * (1 - v1.is_last_segment)) (segLastVal v1) ]
+          : List (Interaction FGL))
+        = [emittedSeamValue 1 (bootPushVal vb)]
+          ++ [ emittedSeamValue (-v0.seg_last) (segPrevVal v0),
+            emittedSeamValue (v0.seg_last * (1 - v0.is_last_segment)) (segLastVal v0),
+            emittedSeamValue (-v1.seg_last) (segPrevVal v1),
+            emittedSeamValue (v1.seg_last * (1 - v1.is_last_segment)) (segLastVal v1) ]
+        from rfl,
+      balanceOf_append]
+    -- The live4 list reduces to the `-1`/`1 - is_last` shape via `seg_last = 1`.
+    simp only [hl0, hl1, neg_one_mul, one_mul, mul_one, neg_neg] at hbal ⊢
+    exact hbal
+
+/-! ## THE k ≥ 2 SEAM VALUE-EQUALITY (the deep deliverable). -/
+
+/-- **THE k ≥ 2 CROSS-SEGMENT SEAM, from REAL MULTI-ROW balance.** For a real
+    `fullRv64imEnsemble` accepted trace whose Mem table spans TWO segments × TWO
+    rows (a DEAD leading row + a LIVE last row each), with seg0 non-last and seg1
+    the last segment, the `seg_last`-gated seam channel balance FORCES the
+    cross-segment VALUE seam `seg1.previous_segment_* = seg0.segment_last_*`. The
+    DEAD rows (`d0`/`d1`, `seg_last = 0`) carry GENUINELY FREE boundary columns and
+    play NO role — balance does not depend on them. This is the k ≥ 2 (multi-row
+    per segment) instance the one-row-per-segment witness could not state. -/
+theorem multiRow_seam_value_equality
+    (vb : BootRow FGL) (d0 v0 d1 v1 : MemRow FGL)
+    (publicInput : unit FGL) (data : ProverData FGL)
+    (hd0 : d0.seg_last = 0) (hl0 : v0.seg_last = 1)
+    (hd1 : d1.seg_last = 0) (hl1 : v1.seg_last = 1)
+    (h0 : v0.is_last_segment = 0) (h1 : v1.is_last_segment = 1)
+    (hseam : EnsembleWitness.BalancedChannel
+      (mkFullWitnessMultiRow (length := length) (program := program)
+        vb d0 v0 d1 v1 publicInput data) SeamContChannel.toRaw) :
+    v0.segment_id = 0 ∧ v1.segment_id = 1
+      ∧ seam5 v1.previous_segment_value_0 v1.previous_segment_value_1
+          v1.previous_segment_addr v1.previous_segment_step v1.segment_id
+        = seam5 v0.segment_last_value_0 v0.segment_last_value_1
+          v0.segment_last_addr v0.segment_last_step (v0.segment_id + 1) := by
+  have hbalanced := asBootList2_balanced_of_multiRow_seamBalance (length := length)
+    (program := program) vb d0 v0 d1 v1 publicInput data hd0 hl0 hd1 hl1 h0 hseam
+  rw [asBootList2, h1] at hbalanced
+  simp only [show (1 : FGL) - 1 = 0 from by ring] at hbalanced
+  obtain ⟨ht0, ht1, _hseam0, hseam'⟩ := boot_chain_derived
+    vb.boot_value_0 vb.boot_value_1 vb.boot_addr vb.boot_step
+    v0.previous_segment_value_0 v0.previous_segment_value_1 v0.previous_segment_addr
+    v0.previous_segment_step v0.segment_id
+    v0.segment_last_value_0 v0.segment_last_value_1 v0.segment_last_addr v0.segment_last_step
+    v1.previous_segment_value_0 v1.previous_segment_value_1 v1.previous_segment_addr
+    v1.previous_segment_step v1.segment_id
+    v1.segment_last_value_0 v1.segment_last_value_1 v1.segment_last_addr v1.segment_last_step
+    hbalanced
+  exact ⟨ht0, ht1, hseam'⟩
+
+/-! ## k ≥ 2 NON-VACUITY: a concrete balanced 2-segment × 2-row witness. -/
+
+/-- seg0 DEAD leading row: `seg_last = 0`, carrying GENUINELY DISTINCT junk
+    boundary columns (`7`s/`8`s) — a real non-`SEGMENT_LAST` row's
+    `segment_last_*`/`previous_segment_*` columns ARE unconstrained, so this junk is
+    exactly what a real dead row looks like. Its emission is suppressed by the
+    gate. -/
+@[reducible] def goodDead0 : MemRow FGL :=
+  { addr := 7, step := 7, sel := 1, addr_changes := 1, step_dual := 0, sel_dual := 0,
+    value_0 := 7, value_1 := 7, wr := 1, previous_step := 0, increment_0 := 0,
+    increment_1 := 0, read_same_addr := 0,
+    segment_id := 0,
+    previous_segment_value_0 := 7, previous_segment_value_1 := 7,
+    previous_segment_addr := 7, previous_segment_step := 7,
+    segment_last_value_0 := 8, segment_last_value_1 := 8,
+    segment_last_addr := 8, segment_last_step := 8,
+    is_last_segment := 0, seg_last := 0 }
+
+/-- seg1 DEAD leading row: `seg_last = 0`, distinct junk (`9`s/`11`s). -/
+@[reducible] def goodDead1 : MemRow FGL :=
+  { addr := 9, step := 9, sel := 1, addr_changes := 1, step_dual := 0, sel_dual := 0,
+    value_0 := 9, value_1 := 9, wr := 1, previous_step := 0, increment_0 := 0,
+    increment_1 := 0, read_same_addr := 0,
+    segment_id := 1,
+    previous_segment_value_0 := 9, previous_segment_value_1 := 9,
+    previous_segment_addr := 9, previous_segment_step := 9,
+    segment_last_value_0 := 11, segment_last_value_1 := 11,
+    segment_last_addr := 11, segment_last_step := 11,
+    is_last_segment := 1, seg_last := 0 }
+
+/-- Sanity: the DEAD rows' boundary columns are genuinely distinct from the LIVE
+    boundaries — so the witness is NOT the degenerate "all rows identical" shape
+    and the gating truly suppresses unconstrained junk. -/
+theorem goodMultiRow_dead_distinct :
+    goodDead0.previous_segment_value_0 ≠ goodSeg0.previous_segment_value_0
+    ∧ goodDead0.segment_last_addr ≠ goodSeg0.segment_last_addr
+    ∧ goodDead1.previous_segment_value_0 ≠ goodSeg1.previous_segment_value_0
+    ∧ goodDead1.segment_last_addr ≠ goodSeg1.segment_last_addr := by
+  refine ⟨?_, ?_, ?_, ?_⟩ <;>
+    simp only [goodDead0, goodDead1, goodSeg0, goodSeg1] <;> decide
+
+/-- **THE k ≥ 2 SATISFIABILITY WITNESS.** The concrete 2-segment × 2-row chain
+    (`[goodDead0, goodSeg0, goodDead1, goodSeg1]`, each segment a dead leading row
+    + a live last row) BALANCES on the REAL `fullRv64imEnsemble`. The 2 DEAD rows'
+    8 boundary columns are arbitrary junk; the dead rows drop out of `balanceOf`,
+    leaving the live boot chain `goodBootList2`. -/
+theorem good_multiRow_seam_balancedChannel (publicInput : unit FGL) (data : ProverData FGL) :
+    EnsembleWitness.BalancedChannel
+      (mkFullWitnessMultiRow (length := length) (program := program)
+        goodBoot goodDead0 goodSeg0 goodDead1 goodSeg1 publicInput data)
+      SeamContChannel.toRaw := by
+  rw [EnsembleWitness.BalancedChannel, EnsembleWitness.interactionsWith_allTablesWitness,
+    mkFullWitnessMultiRow_interactionsWith]
+  refine ⟨?_, ?_⟩
+  · left
+    have : (1 + 8 : ℕ) < ringChar FGL := by
+      haveI hc : CharP FGL GL_prime := inferInstanceAs (CharP (Fin GL_prime) GL_prime)
+      rw [ringChar.eq FGL GL_prime]; norm_num
+    -- boot :: 4 rows × 2 emissions = 1 + 8 = 9 interactions.
+    have hlen : (emittedSeamValue 1 (bootPushVal goodBoot) ::
+        (mkTable componentWithDualMemBus [goodDead0, goodSeg0, goodDead1, goodSeg1]
+          data).interactionsWith SeamContChannel.toRaw).length = 9 := by
+      rw [memTable_interactionsWith]
+      simp [memRowSeamContribution, List.flatMap_cons, List.flatMap_nil]
+    rw [hlen]; simpa using this
+  · intro msg
+    rw [show emittedSeamValue 1 (bootPushVal goodBoot) ::
+          (mkTable componentWithDualMemBus [goodDead0, goodSeg0, goodDead1, goodSeg1]
+            data).interactionsWith SeamContChannel.toRaw
+        = [emittedSeamValue 1 (bootPushVal goodBoot)]
+          ++ (mkTable componentWithDualMemBus [goodDead0, goodSeg0, goodDead1, goodSeg1]
+            data).interactionsWith SeamContChannel.toRaw from rfl,
+      balanceOf_append,
+      memTable_multiRow_balanceOf goodDead0 goodSeg0 goodDead1 goodSeg1 data
+        (by rfl) (by rfl) (by rfl) (by rfl)]
+    -- the boot + 2 live rows IS `goodBootList2`'s `(mult,msg)` shape; balanced.
+    -- `goodBootList2 = asBootList2 goodBoot goodSeg0 goodSeg1` (`asBootList2_good`),
+    -- and `proj_eq` matches its projection to the boot ++ live4 list, so balances
+    -- transport via `balanceOf_proj`.
+    have hgood := goodBootList2_balanced.2 msg
+    rw [← asBootList2_good, balanceOf_proj (asBootList2 goodBoot goodSeg0 goodSeg1),
+      ← proj_eq goodBoot goodSeg0 goodSeg1 (by rfl) (by rfl) (by rfl), ← balanceOf_proj,
+      show ([ emittedSeamValue 1 (bootPushVal goodBoot),
+          emittedSeamValue (-goodSeg0.seg_last) (segPrevVal goodSeg0),
+          emittedSeamValue (goodSeg0.seg_last * (1 - goodSeg0.is_last_segment))
+            (segLastVal goodSeg0),
+          emittedSeamValue (-goodSeg1.seg_last) (segPrevVal goodSeg1),
+          emittedSeamValue (goodSeg1.seg_last * (1 - goodSeg1.is_last_segment))
+            (segLastVal goodSeg1) ] : List (Interaction FGL))
+        = [emittedSeamValue 1 (bootPushVal goodBoot)]
+          ++ [ emittedSeamValue (-goodSeg0.seg_last) (segPrevVal goodSeg0),
+            emittedSeamValue (goodSeg0.seg_last * (1 - goodSeg0.is_last_segment))
+              (segLastVal goodSeg0),
+            emittedSeamValue (-goodSeg1.seg_last) (segPrevVal goodSeg1),
+            emittedSeamValue (goodSeg1.seg_last * (1 - goodSeg1.is_last_segment))
+              (segLastVal goodSeg1) ] from rfl,
+      balanceOf_append] at hgood
+    simp only [goodSeg0, goodSeg1, neg_one_mul, one_mul, mul_one, neg_neg] at hgood ⊢
+    exact hgood
+
+/-- **k ≥ 2 NON-VACUITY END-TO-END.** Running `multiRow_seam_value_equality` on the
+    concrete balanced 2-segment × 2-row witness (each segment a dead row + a live
+    row) lands the tags at `(0,1)` and the SEAM holds:
+    `seg1.previous_segment_* (1,0,100,5) = seg0.segment_last_* (1,0,100,5)`. This
+    certifies the k ≥ 2 cross-segment seam from balance is NON-VACUOUS on the REAL
+    `fullRv64imEnsemble` — satisfiable on a genuine MULTI-ROW (≥ 2 rows per
+    segment) Mem trace with dead rows distinct from live, NOT just the one-row
+    floor. -/
+theorem good_multiRow_seam_holds (length : ℕ) (program : Program length)
+    (publicInput : unit FGL) (data : ProverData FGL) :
+    seam5 1 0 100 5 1 = seam5 1 0 100 5 (0 + 1) := by
+  obtain ⟨_, _, hseam⟩ := multiRow_seam_value_equality (length := length) (program := program)
+    goodBoot goodDead0 goodSeg0 goodDead1 goodSeg1 publicInput data
+    (by rfl) (by rfl) (by rfl) (by rfl) (by rfl) (by rfl)
+    (good_multiRow_seam_balancedChannel (length := length) (program := program)
+      publicInput data)
   simpa using hseam
 
 end ZiskFv.AirsClean.FullEnsemble.SeamNonVacuity
@@ -484,3 +846,8 @@ kernel-only, NON-VACUOUSLY satisfied by a concrete 2-nonzero-segment witness. -/
 #print axioms ZiskFv.AirsClean.FullEnsemble.SeamNonVacuity.seam_value_equality
 #print axioms ZiskFv.AirsClean.FullEnsemble.SeamNonVacuity.good_seam_balancedChannel
 #print axioms ZiskFv.AirsClean.FullEnsemble.SeamNonVacuity.good_seam_holds
+-- k ≥ 2 (multi-row per segment) deliverables (XCAP #103 deep refactor, step C):
+#print axioms ZiskFv.AirsClean.FullEnsemble.SeamNonVacuity.memTable_multiRow_balanceOf
+#print axioms ZiskFv.AirsClean.FullEnsemble.SeamNonVacuity.multiRow_seam_value_equality
+#print axioms ZiskFv.AirsClean.FullEnsemble.SeamNonVacuity.good_multiRow_seam_balancedChannel
+#print axioms ZiskFv.AirsClean.FullEnsemble.SeamNonVacuity.good_multiRow_seam_holds

--- a/ZiskFv/AirsClean/Mem/Bridge.lean
+++ b/ZiskFv/AirsClean/Mem/Bridge.lean
@@ -61,6 +61,7 @@ def rowAt (v : ZiskFv.Airs.Mem.Valid_Mem FGL FGL) (r : ℕ) : MemRow FGL where
   segment_last_addr := v.segment_last_addr r
   segment_last_step := v.segment_last_step r
   is_last_segment := v.is_last_segment r
+  seg_last := v.seg_last r
 
 @[reducible]
 def constVar (row : MemRow FGL) : Var MemRow FGL where
@@ -87,6 +88,7 @@ def constVar (row : MemRow FGL) : Var MemRow FGL where
   segment_last_addr := .const row.segment_last_addr
   segment_last_step := .const row.segment_last_step
   is_last_segment := .const row.is_last_segment
+  seg_last := .const row.seg_last
 
 @[reducible]
 def validOfRow (row : MemRow FGL) :

--- a/ZiskFv/AirsClean/Mem/Circuit.lean
+++ b/ZiskFv/AirsClean/Mem/Circuit.lean
@@ -71,7 +71,8 @@ def memRowOf (sel selDual wr addrChanges : Bool)
     segment_last_value_1 := 0
     segment_last_addr := 0
     segment_last_step := 0
-    is_last_segment := 0 }
+    is_last_segment := 0
+    seg_last := 0 }
 
 lemma memRowOf_constraintsHold (sel selDual wr addrChanges : Bool)
     (addr step stepDual previousStep increment_0 increment_1 value_0 value_1 : FGL)
@@ -269,15 +270,17 @@ theorem componentWithDualMemBus_interactionsWith_memBus :
     contribution through this lemma. -/
 theorem componentWithDualMemBus_interactionsWith_seam :
     componentWithDualMemBus.operations.interactionsWith SeamContChannel.toRaw =
-      [ ((SeamContChannel.emitted (-1)
+      [ ((SeamContChannel.emitted (-componentWithDualMemBus.rowInputVar.seg_last)
             (prevSeamMessageExpr componentWithDualMemBus.rowInputVar)).toRaw)
-        , ((SeamContChannel.emitted (1 - componentWithDualMemBus.rowInputVar.is_last_segment)
+        , ((SeamContChannel.emitted (componentWithDualMemBus.rowInputVar.seg_last *
+              (1 - componentWithDualMemBus.rowInputVar.is_last_segment))
             (lastSeamMessageExpr componentWithDualMemBus.rowInputVar)).toRaw) ] := by
   apply Component.interactionsWith_of_exposedChannels
   change ⟨SeamContChannel.toRaw,
-      [ ((SeamContChannel.emitted (-1)
+      [ ((SeamContChannel.emitted (-componentWithDualMemBus.rowInputVar.seg_last)
             (prevSeamMessageExpr componentWithDualMemBus.rowInputVar)).toRaw)
-        , ((SeamContChannel.emitted (1 - componentWithDualMemBus.rowInputVar.is_last_segment)
+        , ((SeamContChannel.emitted (componentWithDualMemBus.rowInputVar.seg_last *
+              (1 - componentWithDualMemBus.rowInputVar.is_last_segment))
             (lastSeamMessageExpr componentWithDualMemBus.rowInputVar)).toRaw) ]⟩ ∈
     componentWithDualMemBus.exposedChannels
   simp only [componentWithDualMemBus, circuitWithDualMemBus, memWithDualMemBusElaborated,
@@ -457,7 +460,8 @@ theorem spec_via_component (row : MemRow FGL)
       segment_last_value_1 := .const row.segment_last_value_1
       segment_last_addr := .const row.segment_last_addr
       segment_last_step := .const row.segment_last_step
-      is_last_segment := .const row.is_last_segment }
+      is_last_segment := .const row.is_last_segment
+      seg_last := .const row.seg_last }
     row ?_ ?_
   · rfl
   · simpa only [Spec, sub_eq_add_neg] using h_constraints

--- a/ZiskFv/AirsClean/Mem/Constraints.lean
+++ b/ZiskFv/AirsClean/Mem/Constraints.lean
@@ -263,16 +263,24 @@ def memWithMemBus (row : Var MemRow FGL) : Circuit FGL Unit := do
     into `channelsWithRequirements` (`assumeGuarantees = false`), keeping the
     seam OUT of `channelsWithGuarantees` (PLAN §4 gotcha — a `pull` would land in
     guarantees, which `SoundEnsemble.subset_finished` drags into `finished`).
-    The incoming boundary is pulled (mult `-1`, tag `segment_id`); the outgoing
-    boundary is pushed gated by `(1 - is_last_segment)` (tag `segment_id + 1`,
-    `mem.pil:198/235/241`). -/
+    The incoming boundary is pulled (mult `-seg_last`, tag `segment_id`); the
+    outgoing boundary is pushed gated by `seg_last * (1 - is_last_segment)`
+    (tag `segment_id + 1`, `mem.pil:198/235/241`).
+
+    XCAP #103 deep refactor (steps B/A): BOTH seam emissions are now gated by
+    `seg_last` (`SEGMENT_LAST`, `mem.pil:87`). A multi-row segment therefore emits
+    exactly ONE live pull + ONE live push (its `seg_last = 1` last row) and `k - 1`
+    DEAD (multiplicity-0) emissions — making the cross-segment continuation
+    faithful to a real multi-row Mem trace (the ungated per-row emission only
+    balanced at k = 1). The dead rows are balance-inert (`balanceOf` of a
+    multiplicity-0 interaction is `0`), so global balance is unaffected by them. -/
 @[circuit_norm]
 def memWithDualMemBus (row : Var MemRow FGL) : Circuit FGL Unit := do
   main row
   MemBusChannel.emit row.sel (memBusMessageExpr row)
   MemBusChannel.emit row.sel_dual (memBusDualMessageExpr row)
-  SeamContChannel.emit (-1) (prevSeamMessageExpr row)
-  SeamContChannel.emit (1 - row.is_last_segment) (lastSeamMessageExpr row)
+  SeamContChannel.emit (-row.seg_last) (prevSeamMessageExpr row)
+  SeamContChannel.emit (row.seg_last * (1 - row.is_last_segment)) (lastSeamMessageExpr row)
 
 /-- Elaborated `memWithMemBus` circuit, ready for use in Clean
     memory-bus component assembly. -/
@@ -307,8 +315,9 @@ def memWithDualMemBus (row : Var MemRow FGL) : Circuit FGL Unit := do
       [ MemBusChannel.emitted row.sel (memBusMessageExpr row)
         , MemBusChannel.emitted row.sel_dual (memBusDualMessageExpr row) ]
     ++ expose SeamContChannel
-      [ SeamContChannel.emitted (-1) (prevSeamMessageExpr row),
-        SeamContChannel.emitted (1 - row.is_last_segment) (lastSeamMessageExpr row) ]
+      [ SeamContChannel.emitted (-row.seg_last) (prevSeamMessageExpr row),
+        SeamContChannel.emitted (row.seg_last * (1 - row.is_last_segment))
+          (lastSeamMessageExpr row) ]
   channelsLawful := by
     simp [circuit_norm, memWithDualMemBus, main, memBusMessageExpr,
       memBusDualMessageExpr, prevSeamMessageExpr, lastSeamMessageExpr,

--- a/ZiskFv/AirsClean/Mem/Row.lean
+++ b/ZiskFv/AirsClean/Mem/Row.lean
@@ -54,6 +54,13 @@ structure MemRow (F : Type) where
   -- multiplied by `(1 - is_last_segment)` so the final segment emits NO push
   -- (`mem.pil:241` `direct_gsum_1` gated `* (1 - is_last_segment)`).
   is_last_segment : F
+  -- SEGMENT_LAST gating column (XCAP #103 deep refactor, step B). `1` exactly on
+  -- the LAST row of a segment (`mem.pil:87` `SEGMENT_LAST = SEGMENT_L1'`), `0`
+  -- elsewhere. The seam emission is gated by it so a k-row segment emits exactly
+  -- ONE live pull + ONE live push (the `seg_last = 1` row) and `k - 1` DEAD
+  -- (multiplicity-0) emissions — making the per-segment continuation faithful to
+  -- a multi-row Mem trace (the ungated per-row emission only balanced at k = 1).
+  seg_last : F
 deriving ProvableStruct
 
 end ZiskFv.AirsClean.Mem

--- a/ZiskFv/AirsClean/Mem/SeamRowTie.lean
+++ b/ZiskFv/AirsClean/Mem/SeamRowTie.lean
@@ -162,6 +162,7 @@ theorem cross_segment_real_memory_continuity
     (vb : BootRow FGL) (v0 v1 : MemRow FGL)
     (publicInput : unit FGL) (data : ProverData FGL)
     (h0 : v0.is_last_segment = 0) (h1 : v1.is_last_segment = 1)
+    (hl0 : v0.seg_last = 1) (hl1 : v1.seg_last = 1)
     (hseam : Air.Flat.EnsembleWitness.BalancedChannel
       (mkFullWitness (length := length) (program := program) vb v0 v1 publicInput data)
       ZiskFv.Channels.SegmentContinuation.SeamContChannel.toRaw)
@@ -173,7 +174,7 @@ theorem cross_segment_real_memory_continuity
             (v0.segment_id + 1) := by
   obtain ⟨ht0, ht1, hseamEq⟩ :=
     seam_value_equality (length := length) (program := program)
-      vb v0 v1 publicInput data h0 h1 hseam
+      vb v0 v1 publicInput data h0 h1 hl0 hl1 hseam
   refine ⟨ht0, ht1, ?_⟩
   -- `hseamEq : seg1.previous = seg0.segment_last_*` (the SEAM, channel columns)
   -- `tie    : seg0.segment_last_* = seg0's real last state` (the TIE)
@@ -212,7 +213,7 @@ theorem good_cross_segment_continuity
     seam5 1 0 100 5 1 = seam5 1 0 100 5 (0 + 1) := by
   obtain ⟨_, _, hcont⟩ :=
     cross_segment_real_memory_continuity (length := length) (program := program)
-      goodBoot goodSeg0 goodSeg1 publicInput data (by rfl) (by rfl)
+      goodBoot goodSeg0 goodSeg1 publicInput data (by rfl) (by rfl) (by rfl) (by rfl)
       (good_seam_balancedChannel (length := length) (program := program)
         publicInput data)
       good_seg0_tie

--- a/ZiskFv/Spike/MultiRowSegmentSeam.lean
+++ b/ZiskFv/Spike/MultiRowSegmentSeam.lean
@@ -1,0 +1,386 @@
+import ZiskFv.Channels.SeamTagChain
+
+/-!
+# SPIKE (#76 PR-76.0 / PR-76.5): cross-segment seam on a NON-VACUOUS k≥2-row segment
+
+**Make-or-break question.** The banked #103 capability (`SeamTagChain.boot_chain_derived`,
+lifted to `fullRv64imEnsemble` by `FullEnsemble.SeamNonVacuity`) derives the cross-segment
+value seam `seg_{i+1}.prev = seg_i.last` from channel balance — BUT only on a model where
+**each segment is ONE `MemRow`** (`memWithDualMemBus` emits the seam per-row, ungated; the
+witness `[v0, v1]` is one row per segment). A real Mem segment spans **k ≥ 2 rows**; the
+per-row ungated emission makes a k-row segment emit k pulls + k pushes → balances only at
+k = 1. As banked, the seam is therefore VACUOUS for real multi-row segments.
+
+**The deep refactor (RESEARCH_XCAP §3 sequencing B → A → C):**
+- **B** — add a per-row `seg_last` (`SEGMENT_LAST`) selector column to the row model.
+- **A** — gate BOTH seam emissions by `seg_last`: the pull's multiplicity becomes
+  `-seg_last` and the push's becomes `seg_last * (1 - is_last_segment)`. So a segment's
+  k rows emit exactly ONE live pull + ONE live push (the `seg_last = 1` row) and `k - 1`
+  DEAD (multiplicity-0) emissions.
+- **C** — re-establish the `addChannel` balance for multi-row segments and re-prove a
+  **k ≥ 2 non-vacuity witness** (the acceptance bar).
+
+This file is the channel-level spike of B + A + C: it models a multi-row segment whose
+rows carry the `seg_last`-gated emission, proves the gated multi-row interaction list has
+the SAME balance as the engine's one-emission-per-segment `bootChainN` list (the dead
+multiplicity-0 rows drop out of `balanceOf`), and therefore derives the cross-segment seam
+from balance on a **k = 2-rows-per-segment, 2-segment** witness — the non-vacuous k ≥ 2
+instance that defeats the laundering trap.
+
+## Make-or-break lemma
+
+`multiRowSegSeam_k2` (below): on a 2-segment trace where EACH segment has 2 rows (one
+non-`seg_last` dead row + one `seg_last` live row), channel balance of the gated multi-row
+seam list forces the cross-segment value seam `seg1.prev = seg0.last`. NON-VACUOUS:
+`goodMultiRow_balanced` exhibits a concrete balanced 2×2-row witness; `multiRowSegSeam_k2`
+fires on it.
+
+## Trust note
+
+No axioms. The whole derivation is kernel-only; it consumes the channel-balance trust
+class (the same `BalancedInteractions` antecedent the banked #103 work consumes) and the
+banked `SeamTagChain` engine verbatim. NO new project axiom, NO `sorry`, NO `native_decide`.
+-/
+
+set_option linter.unnecessarySimpa false
+set_option linter.unusedSimpArgs false
+
+namespace ZiskFv.Spike.MultiRowSegmentSeam
+
+open Goldilocks
+open ZiskFv.Channels.SeamTagChain
+
+/-! ## Foundational: multiplicity-0 interactions are balance-inert.
+
+`balanceOf l msg` filters `l` by message then sums multiplicities. An interaction with
+multiplicity `0` contributes `0` to every message's sum, so dropping it (or inserting it)
+leaves `balanceOf` unchanged for every message. This is what lets a `seg_last`-gated k-row
+segment (k − 1 dead rows) have the same balance as the engine's single-emission segment. -/
+
+/-- A zero-multiplicity interaction does not change `balanceOf` for any message. -/
+theorem balanceOf_cons_zero_mult (i : Interaction FGL) (rest : List (Interaction FGL))
+    (hz : i.mult = 0) (msg : Array FGL) :
+    balanceOf (i :: rest) msg = balanceOf rest msg := by
+  simp only [balanceOf, List.filter_cons]
+  split
+  · simp only [List.map_cons, List.sum_cons]; rw [hz]; ring
+  · rfl
+
+/-- `BalancedInteractions` of `as` (the MULTI-ROW gated list) transfers to `bs` (the
+    engine's one-emission-per-segment list) given a per-message `balanceOf` equality and
+    the no-overflow bound on the SHORTER engine list. We do NOT need the lengths to match:
+    the multi-row list is strictly LONGER (it carries `k-1` dead rows per segment), but its
+    per-message balance equals the engine list's (the dead rows are multiplicity-0). The
+    direction we use is multi-row balance ⇒ engine balance, so we discharge the engine
+    list's own (smaller) overflow bound directly. -/
+theorem engineBalanced_of_multiRow {as bs : List (Interaction FGL)}
+    (hlen : bs.length < ringChar FGL ∨ ringChar FGL = 0)
+    (hbal : ∀ msg, balanceOf bs msg = balanceOf as msg)
+    (h : BalancedInteractions as) : BalancedInteractions bs := by
+  refine ⟨hlen, ?_⟩
+  intro msg; rw [hbal msg]; exact h.2 msg
+
+/-! ## The B + A model: a `seg_last`-gated multi-row segment.
+
+A segment now spans MULTIPLE rows. Each row carries a `seg_last` selector (`1` on the
+segment's last row, `0` elsewhere) and a `pushGate` (`1 - is_last_segment`, the global
+last-segment gate). The seam interactions a row emits (mirroring the would-be gated
+`memWithDualMemBus`):
+
+  pull  at tag `t`,     multiplicity `- seg_last`
+  push  at tag `t + 1`, multiplicity `seg_last * pushGate`
+
+A `seg_last = 0` row emits TWO multiplicity-0 interactions (DEAD); a `seg_last = 1` row
+emits the live pull + gated push — exactly the engine's `segPair`. -/
+
+/-- A row's `seg_last`-gated seam contribution: a pull at tag `t` (mult `-segLast`) and a
+    push at tag `t + 1` (mult `segLast * pushGate`). With `segLast = 1` this is the live
+    `[pullMsg5 …, gatedMsg5 pushGate …]`; with `segLast = 0` both multiplicities vanish. -/
+def rowSeam (segLast pushGate : FGL) (prev last : SeamVal) (t : FGL) :
+    List (Interaction FGL) :=
+  [ gatedMsg5 (-segLast) (prev.msg t) (SeamVal.msg_size ..)
+  , gatedMsg5 (segLast * pushGate) (last.msg (t + 1)) (SeamVal.msg_size ..) ]
+
+/-- A DEAD row (`segLast = 0`) has `balanceOf = 0` for every message: both its
+    interactions carry multiplicity `0`. -/
+theorem balanceOf_deadRow (pushGate : FGL) (prev last : SeamVal) (t : FGL) (msg : Array FGL) :
+    balanceOf (rowSeam 0 pushGate prev last t) msg = 0 := by
+  simp only [rowSeam]
+  rw [balanceOf_cons_zero_mult _ _ (by simp [gatedMsg5]) msg,
+      balanceOf_cons_zero_mult _ _ (by simp [gatedMsg5]) msg]
+  rfl
+
+/-- A LIVE row (`segLast = 1`) has the same `balanceOf` as the engine's `segPair`-style
+    pull + gated push (the two differ only in `assumeGuarantees`, which `balanceOf`
+    ignores). -/
+theorem balanceOf_liveRow (pushGate : FGL) (prev last : SeamVal) (t : FGL) (msg : Array FGL) :
+    balanceOf (rowSeam 1 pushGate prev last t) msg
+      = balanceOf [pullMsg5 (prev.msg t) (SeamVal.msg_size ..),
+          gatedMsg5 pushGate (last.msg (t + 1)) (SeamVal.msg_size ..)] msg := by
+  simp only [rowSeam, balanceOf, List.filter_cons, List.filter_nil,
+    pullMsg5, gatedMsg5, neg_one_mul, one_mul]
+  -- the two sides differ only in `assumeGuarantees` on the pull, which `balanceOf`
+  -- (via `.map (·.mult)`) ignores; the `if`-guards and multiplicities are identical.
+  split <;> split <;> simp
+
+/-! ## A k = 2-rows-per-segment, 2-segment chain (the acceptance-bar instance).
+
+We model TWO segments, EACH spanning TWO rows: one DEAD row (`seg_last = 0`) followed by
+one LIVE row (`seg_last = 1`) carrying the segment's `prev`/`last` boundary at the
+segment tag. seg0 is non-last (`pushGate = 1`); seg1 is last (`pushGate = 0`). The boot
+push at tag 0 closes the chain. This is exactly the real emission once gated by
+`SEGMENT_LAST` — a 9-interaction list (1 boot + 2 segments × (2 rows × 2 emissions =
+4 interactions, but 1 dead) ... concretely 1 + 4 + 4 = 9). The DEAD rows carry ARBITRARY
+boundary values (a real non-last row's `segment_last_*` columns are unconstrained until
+its own `SEGMENT_LAST` fires), which is the whole point: balance must NOT depend on them. -/
+
+/-- The two rows of a `seg_last`-gated segment: a dead leading row then the live last row.
+    `deadPrev`/`deadLast` are the dead row's (arbitrary, unconstrained) boundary; `prev`/
+    `last` are the live row's genuine segment boundary; `t` the segment tag; `pushGate` the
+    `1 - is_last_segment` global gate. -/
+def twoRowSeg (pushGate : FGL) (deadPrev deadLast prev last : SeamVal) (t : FGL) :
+    List (Interaction FGL) :=
+  rowSeam 0 pushGate deadPrev deadLast t ++ rowSeam 1 pushGate prev last t
+
+/-- The full k = 2-rows-per-segment, 2-segment multi-row chain. -/
+def multiRowChain2x2
+    (boot : SeamVal)
+    (d0p d0l p0 l0 : SeamVal) (t0 : FGL)         -- seg0: dead row + live row, tag t0
+    (d1p d1l p1 l1 : SeamVal) (t1 : FGL)         -- seg1: dead row + live row, tag t1
+    : List (Interaction FGL) :=
+  pushMsg5 (boot.msg 0) (SeamVal.msg_size ..) ::
+    (twoRowSeg 1 d0p d0l p0 l0 t0 ++ twoRowSeg 0 d1p d1l p1 l1 t1)
+
+/-- `gatedMsg5 1` and `pushMsg5` have the same `balanceOf` for any singleton (they differ
+    only in `assumeGuarantees`, which `balanceOf` ignores; both have multiplicity `1`). -/
+theorem balanceOf_gatedMsg5_one (m : Array FGL) (hm : m.size = 5) (msg : Array FGL) :
+    balanceOf [gatedMsg5 1 m (by simpa using hm)] msg
+      = balanceOf [pushMsg5 m (by simpa using hm)] msg := by
+  simp only [balanceOf, List.filter_cons, List.filter_nil, gatedMsg5, pushMsg5]
+
+/-- **THE CORE REDUCTION (step C).** The k = 2-rows-per-segment multi-row chain has the
+    SAME `balanceOf` (every message) as the engine's one-emission-per-segment `bootList2`.
+    The DEAD rows drop out (`balanceOf_deadRow`); each LIVE row collapses to the engine's
+    pull + gated push (`balanceOf_liveRow`). seg1's `pushGate = 0` matches `bootList2`'s
+    gated-off last push. This is what makes the multi-row trace's balance equivalent to the
+    engine's — the gating turns k rows into one effective emission per segment. -/
+theorem balanceOf_multiRowChain2x2_eq_bootList2
+    (boot : SeamVal)
+    (d0p d0l p0 l0 : SeamVal) (t0 : FGL)
+    (d1p d1l p1 l1 : SeamVal) (t1 : FGL) (msg : Array FGL) :
+    balanceOf (multiRowChain2x2 boot d0p d0l p0 l0 t0 d1p d1l p1 l1 t1) msg
+      = balanceOf (bootList2
+          boot.v0 boot.v1 boot.addr boot.step
+          p0.v0 p0.v1 p0.addr p0.step t0
+          l0.v0 l0.v1 l0.addr l0.step
+          p1.v0 p1.v1 p1.addr p1.step t1
+          l1.v0 l1.v1 l1.addr l1.step 0) msg := by
+  -- Decompose the multi-row chain into appended pieces:
+  --   [boot] ++ deadRow0 ++ liveRow0 ++ deadRow1 ++ liveRow1.
+  rw [show multiRowChain2x2 boot d0p d0l p0 l0 t0 d1p d1l p1 l1 t1
+      = [pushMsg5 (boot.msg 0) (SeamVal.msg_size ..)]
+        ++ rowSeam 0 1 d0p d0l t0 ++ rowSeam 1 1 p0 l0 t0
+        ++ rowSeam 0 0 d1p d1l t1 ++ rowSeam 1 0 p1 l1 t1
+      from by simp [multiRowChain2x2, twoRowSeg, List.append_assoc]]
+  -- Distribute `balanceOf` over every append; dead rows vanish, live rows collapse to the
+  -- engine's pull + gated push.
+  rw [balanceOf_append, balanceOf_append, balanceOf_append, balanceOf_append,
+      balanceOf_deadRow, balanceOf_deadRow, balanceOf_liveRow, balanceOf_liveRow]
+  -- The engine's `bootList2` is boot push :: seg0(pull, push) ++ seg1(pull, gated push).
+  -- Distribute its `balanceOf` the same way; seg0's push is `pushMsg5`, bridged to
+  -- `gatedMsg5 1` by `balanceOf` guarantee-blindness; seg1's gated push (gate 0) matches.
+  rw [bootList2]
+  rw [show (pushMsg5 (seam5 boot.v0 boot.v1 boot.addr boot.step 0) (seam5_size ..) ::
+        pullMsg5 (seam5 p0.v0 p0.v1 p0.addr p0.step t0) (seam5_size ..) ::
+        pushMsg5 (seam5 l0.v0 l0.v1 l0.addr l0.step (t0 + 1)) (seam5_size ..) ::
+        pullMsg5 (seam5 p1.v0 p1.v1 p1.addr p1.step t1) (seam5_size ..) ::
+        [gatedMsg5 0 (seam5 l1.v0 l1.v1 l1.addr l1.step (t1 + 1)) (seam5_size ..)])
+      = [pushMsg5 (boot.msg 0) (SeamVal.msg_size ..)]
+        ++ ([pullMsg5 (p0.msg t0) (SeamVal.msg_size ..)]
+        ++ [pushMsg5 (l0.msg (t0 + 1)) (SeamVal.msg_size ..)])
+        ++ ([pullMsg5 (p1.msg t1) (SeamVal.msg_size ..)]
+        ++ [gatedMsg5 0 (l1.msg (t1 + 1)) (SeamVal.msg_size ..)])
+      from by simp only [SeamVal.msg, List.cons_append, List.nil_append, List.singleton_append]]
+  rw [balanceOf_append, balanceOf_append, balanceOf_append, balanceOf_append]
+  -- Split the LHS 2-element live-row lists into singletons via `balanceOf_append`.
+  rw [show ([pullMsg5 (p0.msg t0) (SeamVal.msg_size ..),
+        gatedMsg5 1 (l0.msg (t0 + 1)) (SeamVal.msg_size ..)] : List (Interaction FGL))
+      = [pullMsg5 (p0.msg t0) (SeamVal.msg_size ..)]
+        ++ [gatedMsg5 1 (l0.msg (t0 + 1)) (SeamVal.msg_size ..)] from rfl,
+    show ([pullMsg5 (p1.msg t1) (SeamVal.msg_size ..),
+        gatedMsg5 0 (l1.msg (t1 + 1)) (SeamVal.msg_size ..)] : List (Interaction FGL))
+      = [pullMsg5 (p1.msg t1) (SeamVal.msg_size ..)]
+        ++ [gatedMsg5 0 (l1.msg (t1 + 1)) (SeamVal.msg_size ..)] from rfl,
+    balanceOf_append, balanceOf_append,
+    balanceOf_gatedMsg5_one (l0.msg (t0 + 1)) (SeamVal.msg_size ..)]
+  ring
+
+/-! ## THE MAKE-OR-BREAK THEOREM: cross-segment seam from MULTI-ROW (k = 2) balance.
+
+We now run the engine on the multi-row trace. From `BalancedInteractions` of the REAL
+k = 2-rows-per-segment chain (the channel-balance trust class on a genuine multi-row Mem
+trace), the core reduction transports the balance to the engine's `bootList2`, and
+`SeamTagChain.boot_chain_derived` lands the cross-segment value seam
+`seg1.prev = seg0.last`. Crucially the antecedent is balance of a chain where EACH segment
+spans TWO rows — the k ≥ 2 instance the banked one-row-per-segment witness could not state. -/
+
+/-- The `bootList2` engine list has fewer than `ringChar FGL` interactions (it has 5). -/
+theorem bootList2_length_lt_ringChar
+    (bv0 bv1 ba bs p0v0 p0v1 p0a p0s t0 l0v0 l0v1 l0a l0s
+     p1v0 p1v1 p1a p1s t1 l1v0 l1v1 l1a l1s g1 : FGL) :
+    (bootList2 bv0 bv1 ba bs p0v0 p0v1 p0a p0s t0 l0v0 l0v1 l0a l0s
+        p1v0 p1v1 p1a p1s t1 l1v0 l1v1 l1a l1s g1).length < ringChar FGL ∨ ringChar FGL = 0 := by
+  left
+  have : (5 : ℕ) < ringChar FGL := by
+    haveI hc : CharP FGL GL_prime := inferInstanceAs (CharP (Fin GL_prime) GL_prime)
+    rw [ringChar.eq FGL GL_prime]; norm_num
+  simpa [bootList2] using this
+
+/-- **THE MAKE-OR-BREAK LEMMA (#76 PR-76.0 / PR-76.5 acceptance bar).**
+
+    For a 2-segment trace where EACH segment spans TWO `MemRow`s (one DEAD `seg_last = 0`
+    row carrying arbitrary boundary `d0p/d0l`, `d1p/d1l`, then one LIVE `seg_last = 1` row
+    carrying the segment's genuine boundary `p0/l0`, `p1/l1`), with seg1 the last segment
+    (its `pushGate = 0`), channel balance of the `seg_last`-GATED multi-row seam emission
+    FORCES the cross-segment value seam:
+
+      `t0 = 0`, `t1 = 1`, and `seg1.prev (= p1) = seg0.last (= l0)`.
+
+    This is the k ≥ 2 cross-segment seam derived from balance — the deliverable the banked
+    one-row-per-segment model could not reach. The DEAD rows' boundary values
+    (`d0p/d0l/d1p/d1l`) are GENUINELY FREE and play NO role: balance does not depend on
+    them (the gating zeroes their emission), so the seam is forced by the live rows alone. -/
+theorem multiRowSegSeam_k2
+    (boot : SeamVal)
+    (d0p d0l p0 l0 : SeamVal) (t0 : FGL)
+    (d1p d1l p1 l1 : SeamVal) (t1 : FGL)
+    (balance : BalancedInteractions
+      (multiRowChain2x2 boot d0p d0l p0 l0 t0 d1p d1l p1 l1 t1)) :
+    t0 = 0 ∧ t1 = 1
+      ∧ seam5 p1.v0 p1.v1 p1.addr p1.step t1
+        = seam5 l0.v0 l0.v1 l0.addr l0.step (t0 + 1) := by
+  -- Transport the multi-row balance to the engine's `bootList2` balance (step C).
+  have hengine : BalancedInteractions
+      (bootList2 boot.v0 boot.v1 boot.addr boot.step
+        p0.v0 p0.v1 p0.addr p0.step t0 l0.v0 l0.v1 l0.addr l0.step
+        p1.v0 p1.v1 p1.addr p1.step t1 l1.v0 l1.v1 l1.addr l1.step 0) :=
+    engineBalanced_of_multiRow (bootList2_length_lt_ringChar ..)
+      (fun msg =>
+        (balanceOf_multiRowChain2x2_eq_bootList2 boot d0p d0l p0 l0 t0 d1p d1l p1 l1 t1 msg).symm)
+      balance
+  -- Run the banked engine derivation on the transported balance.
+  obtain ⟨ht0, ht1, _hseam0, hseam⟩ := boot_chain_derived
+    boot.v0 boot.v1 boot.addr boot.step
+    p0.v0 p0.v1 p0.addr p0.step t0 l0.v0 l0.v1 l0.addr l0.step
+    p1.v0 p1.v1 p1.addr p1.step t1 l1.v0 l1.v1 l1.addr l1.step hengine
+  exact ⟨ht0, ht1, hseam⟩
+
+/-! ## NON-VACUITY (the anti-laundering guard — the acceptance bar).
+
+`multiRowSegSeam_k2` is worthless if its antecedent `BalancedInteractions
+(multiRowChain2x2 …)` is unsatisfiable, or only satisfiable for a degenerate one-row /
+`rfl` instance. We exhibit a CONCRETE k = 2-rows-per-segment, 2-segment chain whose:
+
+  * DEAD rows carry GENUINELY DISTINCT junk boundary values (NOT equal to the live
+    boundary, NOT zero) — proving the gating truly suppresses them; and
+  * LIVE rows carry the intended cross-segment chain (boot → seg0.last → seg1.prev seam).
+
+We PROVE this concrete multi-row chain BALANCES (via the core reduction to the banked
+`goodBootList2_balanced`) and run `multiRowSegSeam_k2` on it, landing the SEAM
+`seg1.prev = seg0.last = (1,0,100,5)`. This is a genuine k = 2 (two rows per segment),
+non-`rfl` witness — it defeats the laundering shape the one-row banked witness exhibits. -/
+
+/-- The boot value: `(0,0,B,0)` at tag 0 (`B = 335544320`, ZisK's `internal_base_address`). -/
+def vBoot : SeamVal := ⟨0, 0, 335544320, 0⟩
+
+/-- seg0 DEAD row's junk prev boundary — distinct from every live value (note: a real
+    non-`SEGMENT_LAST` row's `segment_last_*`/`previous_segment_*` columns are
+    unconstrained, so this junk is exactly what a real dead row looks like). -/
+def vDead0Prev : SeamVal := ⟨7, 7, 7, 7⟩
+def vDead0Last : SeamVal := ⟨8, 8, 8, 8⟩
+def vDead1Prev : SeamVal := ⟨9, 9, 9, 9⟩
+def vDead1Last : SeamVal := ⟨11, 11, 11, 11⟩
+
+/-- seg0 LIVE boundary: prev = boot `(0,0,B,0)`, last = `(1,0,100,5)`. -/
+def vSeg0Prev : SeamVal := ⟨0, 0, 335544320, 0⟩
+def vSeg0Last : SeamVal := ⟨1, 0, 100, 5⟩
+/-- seg1 LIVE boundary: prev = seg0.last `(1,0,100,5)` (THE SEAM), last = `(2,0,200,9)`. -/
+def vSeg1Prev : SeamVal := ⟨1, 0, 100, 5⟩
+def vSeg1Last : SeamVal := ⟨2, 0, 200, 9⟩
+
+/-- The concrete k = 2-rows-per-segment, 2-segment multi-row chain (9 interactions:
+    boot push + 2 segments × (dead row 2 + live row 2)). -/
+def goodMultiRow : List (Interaction FGL) :=
+  multiRowChain2x2 vBoot
+    vDead0Prev vDead0Last vSeg0Prev vSeg0Last 0
+    vDead1Prev vDead1Last vSeg1Prev vSeg1Last 1
+
+/-- Sanity: the DEAD rows are genuinely distinct from the live boundary (so the witness is
+    NOT the degenerate "all rows identical" shape). -/
+theorem goodMultiRow_dead_distinct :
+    vDead0Prev ≠ vSeg0Prev ∧ vDead0Prev ≠ vSeg0Last
+    ∧ vDead1Prev ≠ vSeg1Prev ∧ vDead1Prev ≠ vSeg1Last := by
+  refine ⟨?_, ?_, ?_, ?_⟩ <;>
+    simp only [vDead0Prev, vDead1Prev, vSeg0Prev, vSeg0Last, vSeg1Prev, vSeg1Last,
+      ne_eq, SeamVal.mk.injEq, not_and] <;>
+    intro h <;> exact absurd h (by decide)
+
+/-- The concrete multi-row chain has 9 interactions (genuinely k = 2 per segment: each
+    segment contributes 4 emissions, of which 2 are dead). NOT the one-row floor. -/
+theorem goodMultiRow_length : goodMultiRow.length = 9 := by
+  simp [goodMultiRow, multiRowChain2x2, twoRowSeg, rowSeam]
+
+/-- **THE SATISFIABILITY WITNESS (k = 2 non-vacuity).** The concrete 2-rows-per-segment
+    chain BALANCES: its `balanceOf` reduces (core reduction) to the engine's `goodBootList2`
+    balance, which is the banked `goodBootList2_balanced`. The 4 DEAD interactions
+    (multiplicity 0) drop out; the 5 live interactions are the intended boot chain. -/
+theorem goodMultiRow_balanced : BalancedInteractions goodMultiRow := by
+  refine ⟨?_, ?_⟩
+  · left; rw [goodMultiRow_length]
+    have : (9 : ℕ) < ringChar FGL := by
+      haveI hc : CharP FGL GL_prime := inferInstanceAs (CharP (Fin GL_prime) GL_prime)
+      rw [ringChar.eq FGL GL_prime]; norm_num
+    simpa using this
+  · intro msg
+    rw [goodMultiRow,
+      balanceOf_multiRowChain2x2_eq_bootList2 vBoot
+        vDead0Prev vDead0Last vSeg0Prev vSeg0Last 0
+        vDead1Prev vDead1Last vSeg1Prev vSeg1Last 1 msg]
+    -- the reduced engine list IS `goodBootList2`; its balance is the banked fact.
+    rw [show bootList2
+          vBoot.v0 vBoot.v1 vBoot.addr vBoot.step
+          vSeg0Prev.v0 vSeg0Prev.v1 vSeg0Prev.addr vSeg0Prev.step 0
+          vSeg0Last.v0 vSeg0Last.v1 vSeg0Last.addr vSeg0Last.step
+          vSeg1Prev.v0 vSeg1Prev.v1 vSeg1Prev.addr vSeg1Prev.step 1
+          vSeg1Last.v0 vSeg1Last.v1 vSeg1Last.addr vSeg1Last.step 0
+        = goodBootList2 from by
+          simp [goodBootList2, bootList2, vBoot, vSeg0Prev, vSeg0Last, vSeg1Prev, vSeg1Last]]
+    exact goodBootList2_balanced.2 msg
+
+/-- **NON-VACUITY END-TO-END.** Running `multiRowSegSeam_k2` on the concrete BALANCED
+    2-rows-per-segment witness lands the tags at `(0,1)` and the SEAM holds:
+    `seg1.prev (1,0,100,5) = seg0.last (1,0,100,5)`. This certifies that the k ≥ 2
+    cross-segment seam derivation from balance is NON-VACUOUS — the antecedent is
+    satisfiable on a genuine 2-rows-per-segment trace (dead rows distinct from live),
+    NOT only on the degenerate one-row instance the banked model was limited to. -/
+theorem goodMultiRow_seam_holds :
+    seam5 1 0 100 5 1 = seam5 1 0 100 5 (0 + 1) := by
+  obtain ⟨_, _, hseam⟩ := multiRowSegSeam_k2 vBoot
+    vDead0Prev vDead0Last vSeg0Prev vSeg0Last 0
+    vDead1Prev vDead1Last vSeg1Prev vSeg1Last 1
+    goodMultiRow_balanced
+  simpa [vSeg1Prev, vSeg0Last] using hseam
+
+end ZiskFv.Spike.MultiRowSegmentSeam
+
+/-! ## Axiom-closure checks.
+
+`#print axioms` returns only Lean-kernel axioms (`propext`, `Classical.choice`,
+`Quot.sound`): 0 PROJECT (`ZiskFv.*`) axioms. NO `sorry`, NO project axiom, NO
+`native_decide`. The k ≥ 2 cross-segment seam derivation + its non-vacuity on the concrete
+2-rows-per-segment witness are kernel-only. -/
+#print axioms ZiskFv.Spike.MultiRowSegmentSeam.balanceOf_multiRowChain2x2_eq_bootList2
+#print axioms ZiskFv.Spike.MultiRowSegmentSeam.multiRowSegSeam_k2
+#print axioms ZiskFv.Spike.MultiRowSegmentSeam.goodMultiRow_balanced
+#print axioms ZiskFv.Spike.MultiRowSegmentSeam.goodMultiRow_seam_holds
+#print axioms ZiskFv.Spike.MultiRowSegmentSeam.goodMultiRow_dead_distinct

--- a/ZiskFv/ZiskCircuit/MemTimeline/Spike.lean
+++ b/ZiskFv/ZiskCircuit/MemTimeline/Spike.lean
@@ -1,0 +1,415 @@
+import ZiskFv.ZiskCircuit.MemTimeline.Construction
+
+/-!
+# Memory timeline — store-driven Fold-B reduction (PR-76.0)
+
+This module is the make-or-break PR-76.0 reduction for issue #76 (`PLAN_ENDGAME_P4_MEMORY.md`
+§3/§5). It demonstrates that the **byte-local** memory agreement that the load arms
+actually consume (`ReplayMemoryAgreementOnBytes … entry.ptr`, i.e. the
+`stateBytesAtPrefix` field of `MemoryTimelineEvidence`) is **derived** from:
+
+* the store-driven replay fold (per-store `EventReplayStep` induction over the
+  accepted chronological prefix — only stores transport the memory map; loads and
+  non-memory ops are `.mem`-invariant);
+* the already-derived read-soundness `prefixReadSound` (PR#65); and
+* a single, **explicit, named trace-coherence residual** (`RowTraceCoherence`),
+
+with the load's Sail `state` left **opaque** (`stateAt priorRows`), so the
+derivation does **not** freeze registers / PC the way the whole-`SailState`
+`MemoryPrefixStateAlignment` identity does.
+
+## What is *derived* vs what *remains* (anti-laundering, plan §3 P0/P1/P2)
+
+The Sail↔circuit memory connection is *conserved*: the replay engine only
+**transports** agreement, it never manufactures it. Concretely:
+
+* **Derived here:** the byte-local agreement `stateBytesAtPrefix` and the full
+  `MemoryTraceAgreement` for the selected load, obtained by folding the per-store
+  steps from the seed agreement and combining with `prefixReadSound`.
+* **The named residual (`RowTraceCoherence`):** at each consumed prefix row the
+  Sail state at the next execution cursor must be the row's memory transition of
+  the Sail state at the current cursor. This is the *trace-coherence* premise
+  (`stateAt (i+1)` is the execution successor of `stateAt i`); `ProgramBinding`
+  carries no field for it, so it stands as **external trust**, exactly like
+  channel-balance. It is NOT removed by this reduction — it is named, exposed as a
+  binder, and is *strictly smaller* than the original whole-state
+  `MemoryPrefixStateAlignment` existential (see §metric below).
+* **Also a residual:** the *seed* `initialAgreement` (the segment's initial Sail
+  memory agrees with the replay's initial memory) — the seg-0 boot / cross-segment
+  seed correctness already tracked as external trust.
+
+This reduction does **not** make the load arms premise-free. It **reduces** the load
+memory obligation from the whole-`SailState` identity to {byte-local agreement,
+which is derived} + {`RowTraceCoherence`, a named trace-coherence residual}.
+
+## Metric shrink (plan §5 gate 5, §7 invariant 3)
+
+* **Before:** `MemoryPrefixStateAlignment initialState state priorRows`, i.e.
+  `state = stateAfterMemoryBusRows initialState priorRows` — a *whole-`SailState`*
+  equality. It pins every field of `state` (regs, choiceState, mem, tags,
+  cycleCount, sailOutput) to a closed-form replay of the prefix. This is strictly
+  stronger than anything the load consumer needs and is unprovable without a
+  closed form for the entire execution state.
+* **After:** `RowTraceCoherence stateAt [] priorRows` — a *per-row, memory-map-only*
+  chain of `EventReplayStep`s. Each conjunct constrains only `.mem` (`regs`/PC are
+  free); the load `state` is `stateAt priorRows`, left opaque. The byte agreement
+  the consumer needs is then *derived*, not assumed.
+
+`RowTraceCoherence` is strictly weaker than the whole-state identity: it never
+constrains `regs`/`choiceState`/`cycleCount`/`sailOutput`, and it is a memory-map
+agreement chain rather than a closed-form whole-state identity. The non-vacuity
+witness below exhibits a model where the load state's `regs` **and** `cycleCount`
+differ from the initial state — impossible under the frozen `MemoryPrefixStateAlignment`
+route, demonstrating the residual genuinely shrank.
+
+No new project (`ZiskFv.*`) axioms; everything here is kernel-only
+(`propext`/`Classical.choice`/`Quot.sound`).
+-/
+
+namespace ZiskFv.ZiskCircuit.MemTimeline.Spike
+
+open Goldilocks
+open Interaction
+open ZiskFv.ZiskCircuit.MemTrace
+
+/-! ## The named trace-coherence residual and the Fold-B core -/
+
+/-- **Named trace-coherence residual** (plan §3 P1, §6 (c)).
+
+For an opaque cursor-indexed Sail state assignment `stateAt`, every consumed
+prefix row is an `EventReplayStep` between the Sail states at consecutive
+execution cursors: the row's memory transition takes any replay memory agreeing
+with the current cursor's Sail memory to one agreeing with the next cursor's Sail
+memory. Stores transport the map via `writeMemoryOfEntry`; reads / inactive /
+non-memory rows leave it unchanged. **Only `.mem` is constrained** — `regs`, PC,
+`cycleCount`, etc. are free, so this never freezes the whole Sail state.
+
+This is the trace-coherence premise that `ProgramBinding` does not supply; it is
+carried as explicit external trust (like channel-balance), NOT derived here. -/
+def RowTraceCoherence
+    (stateAt : List (MemoryBusEntry FGL) → SailState) :
+    List (MemoryBusEntry FGL) → List (MemoryBusEntry FGL) → Prop
+  | _done, [] => True
+  | done, row :: rest =>
+      (∀ mem : Std.ExtHashMap Nat (BitVec 8),
+        ReplayMemoryAgreement (stateAt done) mem →
+          ReplayMemoryAgreement (stateAt (done ++ [row]))
+            (replayMemoryAfterBusRow mem row))
+      ∧ RowTraceCoherence stateAt (done ++ [row]) rest
+
+/-- Trace coherence restricts to any prefix of the consumed rows. -/
+theorem rowTraceCoherence_of_append
+    (stateAt : List (MemoryBusEntry FGL) → SailState)
+    (done pref suffix : List (MemoryBusEntry FGL))
+    (h_steps : RowTraceCoherence stateAt done (pref ++ suffix)) :
+    RowTraceCoherence stateAt done pref := by
+  induction pref generalizing done with
+  | nil => trivial
+  | cons row rest ih =>
+      simp only [List.cons_append, RowTraceCoherence] at h_steps ⊢
+      exact ⟨h_steps.1, ih (done ++ [row]) h_steps.2⟩
+
+/-- **Fold-B core.** From a seed agreement at the prefix start and the named
+trace-coherence residual over the prefix, derive whole-map Sail/replay agreement
+at the prefix end. The replay engine only *transports* the seed agreement through
+the per-store memory transitions; the Sail state at the end is `stateAt …`, opaque.
+
+This is the genuine store-driven derivation (plan §7 invariant 1): the agreement
+is folded out of the per-row steps, never re-posited. -/
+theorem replayAgreement_of_rowTraceCoherence
+    (stateAt : List (MemoryBusEntry FGL) → SailState)
+    (done rows : List (MemoryBusEntry FGL))
+    (mem : Std.ExtHashMap Nat (BitVec 8))
+    (h_initial : ReplayMemoryAgreement (stateAt done) mem)
+    (h_steps : RowTraceCoherence stateAt done rows) :
+    ReplayMemoryAgreement (stateAt (done ++ rows))
+      (replayMemoryAfterBusRows mem rows) := by
+  induction rows generalizing done mem with
+  | nil =>
+      simpa [RowTraceCoherence, replayMemoryAfterBusRows] using h_initial
+  | cons row rest ih =>
+      simp only [RowTraceCoherence] at h_steps
+      have h_next := h_steps.1 mem h_initial
+      have h_tail :=
+        ih (done ++ [row]) (replayMemoryAfterBusRow mem row) h_next h_steps.2
+      simpa [replayMemoryAfterBusRows, List.append_assoc] using h_tail
+
+/-! ## Per-row step constructors (store-driven; loads/non-memory invariant) -/
+
+/-- **Per-store step (plan §3 P2 producer side, §5 gate 3).** A write row is a
+`RowTraceCoherence` step whenever the next cursor's Sail memory is the eight-lane
+`bus_effect` write of the current cursor's Sail memory. This is discharged from
+the canonical write-entry transition `replayMemoryAgreement_write_entry` (the same
+`{state with mem := writeMemoryOfEntry …}` shape `bus_effect.2` produces for
+stores), **not** a hand-built `{state with mem}`. Only the memory field of the
+post-state is constrained, so the store's nextPC `writeReg` (regs / PC mutation)
+is free. -/
+theorem rowStep_store_entry
+    (before after : SailState) (row : MemoryBusEntry FGL)
+    (h_as : row.as = (2 : FGL))
+    (h_write : row.multiplicity = (1 : FGL))
+    (h_after_mem : after.mem = writeMemoryOfEntry before.mem row)
+    (mem : Std.ExtHashMap Nat (BitVec 8))
+    (h_agree : ReplayMemoryAgreement before mem) :
+    ReplayMemoryAgreement after (replayMemoryAfterBusRow mem row) := by
+  rw [replayMemoryAfterBusRow, if_pos h_as, if_pos h_write]
+  have h_step := replayMemoryAgreement_write_entry before mem row h_agree
+  intro addr
+  have h_addr := h_step addr
+  rw [h_after_mem]
+  simpa using h_addr
+
+/-- **Load / non-memory step (plan §3 P2, §6 (d)).** Any row that is not an active
+memory write is a `RowTraceCoherence` step whenever the next cursor's Sail memory
+equals the current cursor's Sail memory. Regs / PC are free, so a load's `rd`
+write or a non-memory opcode's register effect does not interfere. -/
+theorem rowStep_mem_invariant
+    (before after : SailState) (row : MemoryBusEntry FGL)
+    (h_not_write : ¬ (row.as = (2 : FGL) ∧ row.multiplicity = (1 : FGL)))
+    (h_after_mem : after.mem = before.mem)
+    (mem : Std.ExtHashMap Nat (BitVec 8))
+    (h_agree : ReplayMemoryAgreement before mem) :
+    ReplayMemoryAgreement after (replayMemoryAfterBusRow mem row) := by
+  have h_row : replayMemoryAfterBusRow mem row = mem := by
+    unfold replayMemoryAfterBusRow
+    by_cases h_as : row.as = (2 : FGL)
+    · by_cases h_w : row.multiplicity = (1 : FGL)
+      · exact absurd ⟨h_as, h_w⟩ h_not_write
+      · simp [h_as, h_w]
+    · simp [h_as]
+  rw [h_row]
+  intro addr
+  rw [h_after_mem]
+  exact h_agree addr
+
+/-! ## The byte-local payoff: derived from the fold + the seed + prefixReadSound -/
+
+/-- **The byte-local agreement, DERIVED.** Given generated replay facts (which carry
+the seed `initialAgreement` and `prefixReadSound`), an opaque cursor-indexed state
+assignment whose empty-prefix state is the segment initial state, and the named
+trace-coherence residual over the selected prefix, the load state
+`stateAt priorRows` byte-agrees with the replayed prefix at the read pointer.
+
+This is exactly the `stateBytesAtPrefix` field of `MemoryTimelineEvidence`, now
+*folded out* of the per-store steps rather than read off a whole-state identity.
+The load `state` here is `stateAt priorRows` — **opaque**, NOT let-bound to
+`stateAfterMemoryBusRows …`. -/
+theorem stateBytesAtPrefix_of_rowTraceCoherence
+    {initialState : SailState}
+    {rows : List (MemoryBusEntry FGL)}
+    {entry : MemoryBusEntry FGL}
+    (facts : ZiskFv.AirsClean.Mem.GeneratedMemReplayFacts initialState rows)
+    (stateAt : List (MemoryBusEntry FGL) → SailState)
+    (priorRows : List (MemoryBusEntry FGL))
+    (h_seed : stateAt [] = initialState)
+    (h_coherence : RowTraceCoherence stateAt [] priorRows) :
+    ReplayMemoryAgreementOnBytes (stateAt priorRows)
+      (replayMemoryAfterBusRows facts.initialMemory priorRows)
+      entry.ptr.toNat := by
+  have h_seed_agree : ReplayMemoryAgreement (stateAt []) facts.initialMemory := by
+    rw [h_seed]; exact facts.initialAgreement
+  have h_whole :
+      ReplayMemoryAgreement (stateAt ([] ++ priorRows))
+        (replayMemoryAfterBusRows facts.initialMemory priorRows) :=
+    replayAgreement_of_rowTraceCoherence stateAt [] priorRows
+      facts.initialMemory h_seed_agree h_coherence
+  intro i _hi
+  simpa using h_whole (entry.ptr.toNat + i)
+
+/-- **Full selected-load byte agreement, DERIVED.** Combining the byte-local
+agreement (from the store fold) with the read row's `prefixReadSound` (PR#65) gives
+the `MemoryTraceAgreement` shape that the local load cores consume — for an opaque
+load `state`. This is the PR-76.0 end-to-end deliverable: the load memory
+obligation is satisfied from {fold + seed + prefixReadSound} modulo the single
+named `RowTraceCoherence` residual. -/
+theorem memoryTraceAgreement_of_rowTraceCoherence
+    {initialState : SailState}
+    {rows : List (MemoryBusEntry FGL)}
+    {entry : MemoryBusEntry FGL}
+    (facts : ZiskFv.AirsClean.Mem.GeneratedMemReplayFacts initialState rows)
+    (stateAt : List (MemoryBusEntry FGL) → SailState)
+    (priorRows laterRows : List (MemoryBusEntry FGL))
+    (h_traceSplit : rows = priorRows ++ entry :: laterRows)
+    (h_selectedRead :
+      memoryBusTraceEventOfRow entry = some (MemoryBusTraceEvent.read entry))
+    (h_seed : stateAt [] = initialState)
+    (h_coherence : RowTraceCoherence stateAt [] priorRows) :
+    MemoryTraceAgreement (stateAt priorRows) (eventOfEntry entry) := by
+  obtain ⟨h_as, h_mult⟩ :=
+    read_tags_of_memoryBusTraceEventOfRow_read entry h_selectedRead
+  have h_read :
+      ReadEventReplayAgreement
+        (replayMemoryAfterBusRows facts.initialMemory priorRows)
+        (eventOfEntry entry) :=
+    facts.prefixReadSound priorRows entry laterRows h_traceSplit h_as h_mult
+  exact
+    memoryTraceAgreement_of_replayAgreementOnBytes
+      (stateAt priorRows)
+      (replayMemoryAfterBusRows facts.initialMemory priorRows)
+      (eventOfEntry entry)
+      (by
+        simpa using
+          stateBytesAtPrefix_of_rowTraceCoherence (entry := entry)
+            facts stateAt priorRows h_seed h_coherence)
+      h_read
+
+/-! ## Non-degenerate non-vacuity witness (plan §5 gates 1-4, §7 invariant 4)
+
+A realistic store-then-read same-address segment. The store writes value chunks
+`(1, 0)` at byte pointer `100`; the load reads the same address. The Sail state
+assignment `stAt` makes the load state differ from the initial state in **both**
+`regs` and `cycleCount` — impossible under the frozen whole-state alignment, so
+this is genuinely non-degenerate (NOT the empty-prefix `rfl` floor §5 warns about).
+The store step is discharged via `rowStep_store_entry` (from the canonical write
+transition), and the full `MemoryTraceAgreement` is derived end-to-end. -/
+
+/-- The store row: write `(value_0, value_1) = (1, 0)` at byte pointer `100`. -/
+def witnessStoreRow : MemoryBusEntry FGL :=
+  { as := 2, ptr := 100, value_0 := 1, value_1 := 0, timestamp := 5, multiplicity := 1 }
+
+/-- The selected read row at the same address, reading the stored value. -/
+def witnessReadRow : MemoryBusEntry FGL :=
+  { as := 2, ptr := 100, value_0 := 1, value_1 := 0, timestamp := 7, multiplicity := -1 }
+
+/-- The segment's initial Sail state: empty memory, arbitrary regs / choice. -/
+def witnessInitState
+    (regs0 : Std.ExtDHashMap Register RegisterType)
+    (cs0 : Sail.trivialChoiceSource.α) : SailState :=
+  { regs := regs0, choiceState := cs0, mem := {}, tags := (),
+    cycleCount := 0, sailOutput := #[] }
+
+/-- The cursor-indexed Sail state assignment. The empty prefix is the initial
+state; after the store the load cursor's state has the written memory **and** a
+mutated `regs` (`regs1`) **and** a bumped `cycleCount` (`99`) — modelling the
+store's `nextPC`/register effect, which the byte-local route leaves free. -/
+def witnessStateAt
+    (regs0 regs1 : Std.ExtDHashMap Register RegisterType)
+    (cs0 : Sail.trivialChoiceSource.α) :
+    List (MemoryBusEntry FGL) → SailState
+  | [] => witnessInitState regs0 cs0
+  | _ =>
+      { regs := regs1, choiceState := cs0,
+        mem := writeMemoryOfEntry (witnessInitState regs0 cs0).mem witnessStoreRow,
+        tags := (), cycleCount := 99, sailOutput := #[] }
+
+/-- The named trace-coherence residual holds on the witness `[store]` prefix: the
+single store step is discharged from the canonical write-entry transition. -/
+theorem witness_rowTraceCoherence
+    (regs0 regs1 : Std.ExtDHashMap Register RegisterType)
+    (cs0 : Sail.trivialChoiceSource.α) :
+    RowTraceCoherence (witnessStateAt regs0 regs1 cs0) [] [witnessStoreRow] := by
+  refine ⟨?_, trivial⟩
+  intro mem h_agree
+  exact
+    rowStep_store_entry
+      (witnessStateAt regs0 regs1 cs0 [])
+      (witnessStateAt regs0 regs1 cs0 ([] ++ [witnessStoreRow]))
+      witnessStoreRow (by simp [witnessStoreRow]) (by simp [witnessStoreRow])
+      rfl mem h_agree
+
+/-- **Non-degeneracy (plan §5 gate 2).** Whenever `regs1 ≠ regs0`, the load state's
+`regs` and `cycleCount` both differ from the initial state's. This is exactly the
+non-frozen case that the whole-state `MemoryPrefixStateAlignment` identity cannot
+accommodate, proving the byte-local route is not the laundering `rfl`/frozen floor. -/
+theorem witness_nondegenerate
+    (regs0 regs1 : Std.ExtDHashMap Register RegisterType)
+    (cs0 : Sail.trivialChoiceSource.α)
+    (h_regs : regs1 ≠ regs0) :
+    (witnessStateAt regs0 regs1 cs0 [witnessStoreRow]).regs
+        ≠ (witnessStateAt regs0 regs1 cs0 []).regs
+    ∧ (witnessStateAt regs0 regs1 cs0 [witnessStoreRow]).cycleCount
+        ≠ (witnessStateAt regs0 regs1 cs0 []).cycleCount := by
+  refine ⟨?_, ?_⟩
+  · simp [witnessStateAt, witnessInitState, h_regs]
+  · simp [witnessStateAt, witnessInitState]
+
+/-- `prefixReadSound` for the witness rows from empty initial memory: the selected
+read reads exactly what the store wrote. -/
+theorem witness_prefixReadSound :
+    MemoryBusRowsPrefixReadSound ({} : Std.ExtHashMap Nat (BitVec 8))
+      [witnessStoreRow, witnessReadRow] := by
+  intro priorRows row laterRows h_split h_as h_mult
+  match priorRows, h_split with
+  | [], h =>
+      simp only [List.nil_append, List.cons.injEq] at h
+      have hr : row = witnessStoreRow := h.1.symm
+      rw [hr] at h_mult
+      simp only [witnessStoreRow] at h_mult
+      exact absurd h_mult (by decide)
+  | [a], h =>
+      simp only [List.cons_append, List.nil_append, List.cons.injEq] at h
+      obtain ⟨ha, hrow, hlater⟩ := h
+      subst a; subst row; subst laterRows
+      have h_replay :
+          replayMemoryAfterBusRows ({} : Std.ExtHashMap Nat (BitVec 8))
+              [witnessStoreRow]
+            = writeMemoryOfEntry ({} : Std.ExtHashMap Nat (BitVec 8)) witnessStoreRow := by
+        simp [replayMemoryAfterBusRows, replayMemoryAfterBusRow, witnessStoreRow,
+          replayStoreEvent_storeEventOfEntry]
+      rw [h_replay]
+      exact
+        readEventReplayAgreement_of_writeMemoryOfEntry_same _
+          (by simp [witnessReadRow, witnessStoreRow])
+          (by simp [witnessReadRow, witnessStoreRow])
+          (by simp [witnessReadRow, witnessStoreRow])
+  | a :: b :: rest, h =>
+      simp only [List.cons_append, List.cons.injEq] at h
+      obtain ⟨_, _, h3⟩ := h
+      exact absurd h3.symm (by simp)
+
+/-- The witness initial state agrees with the empty replay memory (seed). -/
+theorem witness_initialAgreement
+    (regs0 : Std.ExtDHashMap Register RegisterType)
+    (cs0 : Sail.trivialChoiceSource.α) :
+    ReplayMemoryAgreement (witnessInitState regs0 cs0)
+      ({} : Std.ExtHashMap Nat (BitVec 8)) := by
+  intro addr; rfl
+
+/-- The generated replay facts for the witness segment. -/
+def witnessFacts
+    (regs0 : Std.ExtDHashMap Register RegisterType)
+    (cs0 : Sail.trivialChoiceSource.α) :
+    ZiskFv.AirsClean.Mem.GeneratedMemReplayFacts
+      (witnessInitState regs0 cs0) [witnessStoreRow, witnessReadRow] :=
+  { initialMemory := {}
+    prefixReadSound := witness_prefixReadSound
+    initialAgreement := witness_initialAgreement regs0 cs0 }
+
+/-- The selected read row is tagged as a memory read. -/
+theorem witness_selectedRead :
+    memoryBusTraceEventOfRow witnessReadRow
+      = some (MemoryBusTraceEvent.read witnessReadRow) := by
+  simp [memoryBusTraceEventOfRow, witnessReadRow]
+
+/-- **End-to-end non-vacuity (plan §5, §7 invariant 4).** On the realistic
+store-then-read witness — the load state `witnessStateAt … [witnessStoreRow]` is
+variable-bound, and its `regs`/`cycleCount` differ from the initial state — the full
+selected-load `MemoryTraceAgreement` is **derived** from the store fold + seed +
+`prefixReadSound`, modulo the named `RowTraceCoherence` residual only. This is the
+non-degenerate, non-`rfl` witness §5 requires. -/
+theorem witness_memoryTraceAgreement
+    (regs0 regs1 : Std.ExtDHashMap Register RegisterType)
+    (cs0 : Sail.trivialChoiceSource.α) :
+    MemoryTraceAgreement
+      (witnessStateAt regs0 regs1 cs0 [witnessStoreRow])
+      (eventOfEntry witnessReadRow) :=
+  memoryTraceAgreement_of_rowTraceCoherence
+    (entry := witnessReadRow)
+    (witnessFacts regs0 cs0)
+    (witnessStateAt regs0 regs1 cs0)
+    [witnessStoreRow] []
+    (by rfl)
+    witness_selectedRead
+    (by rfl)
+    (witness_rowTraceCoherence regs0 regs1 cs0)
+
+#print axioms replayAgreement_of_rowTraceCoherence
+#print axioms rowStep_store_entry
+#print axioms rowStep_mem_invariant
+#print axioms stateBytesAtPrefix_of_rowTraceCoherence
+#print axioms memoryTraceAgreement_of_rowTraceCoherence
+#print axioms witness_rowTraceCoherence
+#print axioms witness_nondegenerate
+#print axioms witness_memoryTraceAgreement
+
+end ZiskFv.ZiskCircuit.MemTimeline.Spike

--- a/trust/consistency/global_theorem_instantiation_ld.lean
+++ b/trust/consistency/global_theorem_instantiation_ld.lean
@@ -192,7 +192,8 @@ private def ldMemRow : ZiskFv.AirsClean.Mem.MemRow FGL :=
     segment_last_value_1 := 0
     segment_last_addr := 0
     segment_last_step := 0
-    is_last_segment := 0 }
+    is_last_segment := 0
+    seg_last := 0 }
 
 private def ldMem : ZiskFv.Airs.Mem.Valid_Mem FGL FGL :=
   ZiskFv.AirsClean.Mem.validOfRow ldMemRow


### PR DESCRIPTION
## Summary — the #76 memory-timeline work (this session), **for inspection**

Stacked on `p4-103-landing` (the banked #103 cross-segment capability), so this PR's diff is the *new* #76 work: the cross-segment seam productionization + the store-driven Fold-B reduction of `h_memory_timeline`. **Inspection PR** — stacked on an unmerged branch, not for direct merge.

## Commits
- **`9aee140a` — #76 spike (PR-76.0):** the channel-level make-or-break — `SEGMENT_LAST`-gated cross-segment seam derives the k≥2 seam from balance (standalone `ZiskFv/Spike/MultiRowSegmentSeam.lean`, kernel-only, 0 `ZiskFv.*` axioms). GO, no `addVm` wall.
- **`5027f23c` — step D:** cash the spike into the REAL Mem AIR (`seg_last` column + gated `memWithDualMemBus` emission, rippled through ~146/~50 refs + k≥2 non-vacuity on real multi-row `mkTable` rows). Full tree green; **no #103-L4.5 dispatch break**.
- **`dd1faabf` — Fold-B reduction (PR-76.0):** **REDUCES** `h_memory_timeline` from the whole-`SailState` identity (`MemoryPrefixStateAlignment`) to the memory-map-only `RowTraceCoherence` (`ZiskFv/ZiskCircuit/MemTimeline/Spike.lean`). Byte-local agreement **derived** from the per-store replay + `prefixReadSound` (PR #65); **non-degenerate witness** (`regs` *and* `cycleCount` can differ from initial); 0 new `ZiskFv.*` axioms.

## Honest framing
- `h_memory_timeline` is the **trace-coherence premise** (the Sail state = the chained execution). It is **not removable** from the circuit — **OpenVM assumes it too** (its memory-consistency theorem is unused; its load specs assume the Sail-value). The Fold-B **reduces** it (whole-state → memory-only `RowTraceCoherence`), not removes it; the trace-coherence is the documented floor, in the same class as channel-balance.
- This is the reduction **machinery + proof**; **wiring** `RowTraceCoherence` into the load constructions (replacing their `h_memory_timeline`) is the follow-on.
- **Known issue:** trust gate check-13 flags the "spike"-wording in `MultiRowSegmentSeam.lean` (`9aee140a`) — a naming reword needed before merge (not a soundness issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
