### PR TITLE
Refactor AcceptedTrace

### DIFF
--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -133,6 +133,7 @@ import ZiskFv.ZiskCircuit.MemTimeline.Linkage
 import ZiskFv.ZiskCircuit.MemTimeline.Spike
 import ZiskFv.Compliance.RowProvenance
 import ZiskFv.Compliance.AcceptedTrace
+import ZiskFv.Compliance.AcceptedTrace.Spec
 import ZiskFv.Compliance.ProgramBinding.Basic
 import ZiskFv.Compliance.ProgramBinding.Wrappers
 import ZiskFv.Compliance.ConstructionSub

--- a/ZiskFv/AirsClean/FullEnsemble.lean
+++ b/ZiskFv/AirsClean/FullEnsemble.lean
@@ -43,13 +43,13 @@ open ZiskFv.Channels.OperationBus (OpBusChannel)
 open ZiskFv.Channels.MemoryBus (MemBusChannel)
 open ZiskFv.AirsClean.ZiskInstructionRom (Program)
 
-/-- The currently migrated full Clean ensemble for the supported RV64IM
-    surface. It finishes the operation and memory channels and includes
-    lookup-aware Binary/BinaryExtension providers. Main is represented by
-    one row-coherent component exposing both operation-bus and memory-bus
-    interactions. -/
-def fullRv64imEnsemble (length : ℕ) (program : Program length) :
-    FormalEnsemble FGL unit :=
+/-- The sound channel-balanced backbone of the full RV64IM Clean ensemble:
+    every migrated component added as a table, with the operation and memory
+    channels finished. This is the `SoundEnsemble` from which both the formal
+    ensemble (`fullRv64imEnsemble`) and the table-soundness discharge
+    (`witness_spec_of_constraints`) are derived. -/
+def fullRv64imSoundEnsemble (length : ℕ) (program : Program length) :
+    SoundEnsemble FGL unit :=
   SoundEnsemble.empty FGL unit
     |>.addTable (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program)
         (by simp [circuit_norm,
@@ -123,16 +123,50 @@ def fullRv64imEnsemble (length : ℕ) (program : Program length) :
           ZiskFv.AirsClean.MemAlignReadByte.memAlignReadByteElaborated])
     |>.addFinishedChannel OpBusChannel.toRaw
     |>.addFinishedChannel MemBusChannel.toRaw
-    |>.toFormal (fun _ => True) (fun _ => True)
-        (by
-          intro _ _ table h_mem row _
-          have h := EnsembleWitness.mem_allTables_component_of_mem_allTables h_mem
-          clear h_mem
-          simp only [circuit_norm, Ensemble.allTables] at h
-          rcases h with
-            h | h | h | h | h | h | h | h | h | h | h <;>
-            (rw [h]
-             trivial))
-        (by intro _ _; trivial)
+
+/-- Per-table assumptions discharge for the full ensemble: each migrated
+    component's per-row `Assumptions` reduce to `True`, so the ensemble-level
+    `AssumptionsConsistency` (and hence `EnsembleWitness.Assumptions`) holds
+    against the trivial `fun _ => True` ensemble assumptions. -/
+theorem fullRv64imSoundEnsemble_assumptionsConsistency (length : ℕ) (program : Program length) :
+    (fullRv64imSoundEnsemble length program).AssumptionsConsistency (fun _ => True) := by
+  intro _ _ table h_mem row _
+  have h := EnsembleWitness.mem_allTables_component_of_mem_allTables h_mem
+  clear h_mem
+  simp only [fullRv64imSoundEnsemble, circuit_norm, Ensemble.allTables] at h
+  rcases h with
+    h | h | h | h | h | h | h | h | h | h | h <;>
+    (rw [h]
+     trivial)
+
+/-- The currently migrated full Clean ensemble for the supported RV64IM
+    surface. It finishes the operation and memory channels and includes
+    lookup-aware Binary/BinaryExtension providers. Main is represented by
+    one row-coherent component exposing both operation-bus and memory-bus
+    interactions. -/
+def fullRv64imEnsemble (length : ℕ) (program : Program length) :
+    FormalEnsemble FGL unit :=
+  (fullRv64imSoundEnsemble length program).toFormal (fun _ => True) (fun _ => True)
+    (fullRv64imSoundEnsemble_assumptionsConsistency length program)
+    (by intro _ _; trivial)
+
+/-- **Discharge of `EnsembleWitness.Spec` from constraints + channel balance.**
+
+    The full ensemble's table-soundness — `witness.Assumptions →
+    witness.Constraints → witness.BalancedChannels → witness.Spec` — follows
+    from `SoundEnsemble`'s sound finished channels (`tableSoundness_of_soundChannels`).
+    The per-table `Assumptions` obligation is the trivial `fun _ => True`
+    discharge above. Hence the spec each AIR encodes is *derived* from the
+    accepted constraints and balanced channels, not assumed. -/
+theorem witness_spec_of_constraints {length : ℕ} {program : Program length}
+    (w : EnsembleWitness (fullRv64imEnsemble length program).ensemble)
+    (hc : w.Constraints) (hb : w.BalancedChannels) : w.Spec := by
+  have h_sound : (fullRv64imSoundEnsemble length program).ensemble.TableSoundness :=
+    Ensemble.tableSoundness_of_soundChannels
+      ⟨(fullRv64imSoundEnsemble length program).finished,
+       (fullRv64imSoundEnsemble length program).finished_subset,
+       (fullRv64imSoundEnsemble length program).soundChannels⟩
+  exact h_sound w
+    (fullRv64imSoundEnsemble_assumptionsConsistency length program w trivial) hc hb
 
 end ZiskFv.AirsClean.FullEnsemble

--- a/ZiskFv/AirsClean/FullEnsemble/Balance.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance.lean
@@ -53,7 +53,7 @@ theorem component_mem_fullRv64im_cases
       ∨ component = ZiskFv.AirsClean.BinaryAdd.component
       ∨ component =
         ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program := by
-  simp [fullRv64imEnsemble, SoundEnsemble.toFormal, Ensemble.allTables,
+  simp [fullRv64imEnsemble, fullRv64imSoundEnsemble, SoundEnsemble.toFormal, Ensemble.allTables,
     SoundEnsemble.addTable_tables, SoundEnsemble.addFinishedChannel_tables]
     at h_mem
   rcases h_mem with
@@ -84,7 +84,7 @@ theorem exists_mem_table_of_fullRv64im_witness
   have h_component_mem :
       ZiskFv.AirsClean.Mem.componentWithDualMemBus ∈
         (fullRv64imEnsemble length program).ensemble.allTables := by
-    simp [fullRv64imEnsemble, SoundEnsemble.toFormal, Ensemble.allTables,
+    simp [fullRv64imEnsemble, fullRv64imSoundEnsemble, SoundEnsemble.toFormal, Ensemble.allTables,
       SoundEnsemble.addTable_tables, SoundEnsemble.addFinishedChannel_tables]
   have h_in_map :
       ZiskFv.AirsClean.Mem.componentWithDualMemBus ∈
@@ -106,7 +106,7 @@ theorem exists_main_table_of_fullRv64im_witness
   have h_component_mem :
       ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program ∈
         (fullRv64imEnsemble length program).ensemble.allTables := by
-    simp [fullRv64imEnsemble, SoundEnsemble.toFormal, Ensemble.allTables,
+    simp [fullRv64imEnsemble, fullRv64imSoundEnsemble, SoundEnsemble.toFormal, Ensemble.allTables,
       SoundEnsemble.addTable_tables, SoundEnsemble.addFinishedChannel_tables]
   have h_in_map :
       ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program ∈
@@ -127,7 +127,7 @@ theorem exists_binary_table_of_fullRv64im_witness
   have h_component_mem :
       ZiskFv.AirsClean.Binary.staticLookupComponent ∈
         (fullRv64imEnsemble length program).ensemble.allTables := by
-    simp [fullRv64imEnsemble, SoundEnsemble.toFormal, Ensemble.allTables,
+    simp [fullRv64imEnsemble, fullRv64imSoundEnsemble, SoundEnsemble.toFormal, Ensemble.allTables,
       SoundEnsemble.addTable_tables, SoundEnsemble.addFinishedChannel_tables]
   have h_in_map :
       ZiskFv.AirsClean.Binary.staticLookupComponent ∈
@@ -149,7 +149,7 @@ theorem exists_binaryExtension_table_of_fullRv64im_witness
   have h_component_mem :
       shiftStaticLookupComponent ∈
         (fullRv64imEnsemble length program).ensemble.allTables := by
-    simp [fullRv64imEnsemble, SoundEnsemble.toFormal, Ensemble.allTables,
+    simp [fullRv64imEnsemble, fullRv64imSoundEnsemble, SoundEnsemble.toFormal, Ensemble.allTables,
       SoundEnsemble.addTable_tables, SoundEnsemble.addFinishedChannel_tables]
   have h_in_map :
       shiftStaticLookupComponent ∈
@@ -165,7 +165,7 @@ theorem verifierTable_interactionsWith_opBus_nil
     (length : ℕ) (program : Program length) :
     (fullRv64imEnsemble length program).ensemble.verifierTable.operations.interactionsWith
       OpBusChannel.toRaw = [] := by
-  simp [fullRv64imEnsemble, SoundEnsemble.toFormal,
+  simp [fullRv64imEnsemble, fullRv64imSoundEnsemble, SoundEnsemble.toFormal,
     Ensemble.verifierTable_interactionsWith, Ensemble.verifierOperations,
     GeneralFormalCircuit.empty, circuit_norm]
 
@@ -175,7 +175,7 @@ theorem verifierTable_interactionsWith_memBus_nil
     (length : ℕ) (program : Program length) :
     (fullRv64imEnsemble length program).ensemble.verifierTable.operations.interactionsWith
       MemBusChannel.toRaw = [] := by
-  simp [fullRv64imEnsemble, SoundEnsemble.toFormal,
+  simp [fullRv64imEnsemble, fullRv64imSoundEnsemble, SoundEnsemble.toFormal,
     Ensemble.verifierTable_interactionsWith, Ensemble.verifierOperations,
     GeneralFormalCircuit.empty, circuit_norm]
 

--- a/ZiskFv/Compliance/AcceptedTrace.lean
+++ b/ZiskFv/Compliance/AcceptedTrace.lean
@@ -3,12 +3,35 @@ import ZiskFv.AirsClean.FullEnsemble
 /-!
 # Accepted trace
 
-The committed full-ensemble trace: a Clean ensemble witness for some RV64IM
-`program` together with the proofs that it satisfies the per-table constraints
-and spec and that all of its channels balance. It is the single object the
-soundness development quantifies over — everything downstream (`ProgramBinding`,
-the provider-match wrappers, the per-op constructions) is built relative to one
-of these.
+An `AcceptedTrace` is one fully-populated, verifier-accepted run of the RV64IM
+circuit for a fixed `program` of `length` instructions.
+
+The circuit is an **Air.Flat ensemble**: a collection of AIRs (the Main table
+plus the binary / arithmetic / memory / lookup tables) wired together by shared
+*channels* — the operation bus and the lookup / permutation buses.
+`(fullRv64imEnsemble length program).ensemble` is just that collection of column
+layouts and channels; it holds no data of its own.
+
+The `witness` is the ensemble *filled in* with concrete Goldilocks values: every
+AIR's grid of rows. The remaining three fields are the proofs that make the
+witness "accepted" — exactly what a real ZisK proof certifies:
+
+* `constraints : witness.Constraints` — every per-row algebraic gate of every
+  table holds (the polynomial constraint equations are satisfied).
+* `spec : witness.Spec` — every table additionally meets its higher-level *spec*
+  predicate: the semantic relation each AIR is meant to encode (e.g. a Binary
+  row really computes AND/OR/XOR; an ArithMul row's lanes are a correct
+  product). It is the meaning the constraints exist to enforce, stated directly
+  rather than as gate polynomials.
+* `balanced : witness.BalancedChannels` — despite the name, **not a boolean**: it
+  is the *proposition* that every cross-table channel balances, i.e. for each bus
+  the multiset of messages sent equals the multiset received (the logUp /
+  permutation argument). This is what stops a table from fabricating or dropping
+  a bus message, gluing the otherwise-independent AIRs into one sound machine.
+
+It is the single object the soundness development quantifies over; everything
+downstream (`ProgramBinding`, the provider-match wrappers, the per-op
+constructions) is built relative to one of these.
 -/
 
 namespace ZiskFv.Compliance

--- a/ZiskFv/Compliance/AcceptedTrace.lean
+++ b/ZiskFv/Compliance/AcceptedTrace.lean
@@ -13,21 +13,19 @@ plus the binary / arithmetic / memory / lookup tables) wired together by shared
 layouts and channels; it holds no data of its own.
 
 The `witness` is the ensemble *filled in* with concrete Goldilocks values: every
-AIR's grid of rows. The remaining three fields are the proofs that make the
+AIR's grid of rows. The remaining two fields are the proofs that make the
 witness "accepted" — exactly what a real ZisK proof certifies:
 
 * `constraints_hold : witness.Constraints` — every per-row algebraic gate of every
   table holds (the polynomial constraint equations are satisfied).
-* `spec_holds : witness.Spec` — every table additionally meets its higher-level *spec*
-  predicate: the semantic relation each AIR is meant to encode (e.g. a Binary
-  row really computes AND/OR/XOR; an ArithMul row's lanes are a correct
-  product). It is the meaning the constraints exist to enforce, stated directly
-  rather than as gate polynomials.
 * `channels_balanced : witness.BalancedChannels` — despite the name, **not a boolean**: it
   is the *proposition* that every cross-table channel balances, i.e. for each bus
   the multiset of messages sent equals the multiset received (the logUp /
   permutation argument). This is what stops a table from fabricating or dropping
   a bus message, gluing the otherwise-independent AIRs into one sound machine.
+
+The per-AIR *spec* is not an assumed field: it is derived from these two by
+`AcceptedTrace.spec_holds` (in `AcceptedTrace/Spec.lean`).
 
 It is the single object the soundness development quantifies over; everything
 downstream (`ProgramBinding`, the provider-match wrappers, the per-op
@@ -44,7 +42,6 @@ structure AcceptedTrace where
     Air.Flat.EnsembleWitness
       (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble numInstructions program).ensemble
   constraints_hold : witness.Constraints
-  spec_holds : witness.Spec
   channels_balanced : witness.BalancedChannels
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/AcceptedTrace.lean
+++ b/ZiskFv/Compliance/AcceptedTrace.lean
@@ -16,14 +16,14 @@ The `witness` is the ensemble *filled in* with concrete Goldilocks values: every
 AIR's grid of rows. The remaining three fields are the proofs that make the
 witness "accepted" — exactly what a real ZisK proof certifies:
 
-* `constraints : witness.Constraints` — every per-row algebraic gate of every
+* `constraints_hold : witness.Constraints` — every per-row algebraic gate of every
   table holds (the polynomial constraint equations are satisfied).
-* `spec : witness.Spec` — every table additionally meets its higher-level *spec*
+* `spec_holds : witness.Spec` — every table additionally meets its higher-level *spec*
   predicate: the semantic relation each AIR is meant to encode (e.g. a Binary
   row really computes AND/OR/XOR; an ArithMul row's lanes are a correct
   product). It is the meaning the constraints exist to enforce, stated directly
   rather than as gate polynomials.
-* `balanced : witness.BalancedChannels` — despite the name, **not a boolean**: it
+* `channels_balanced : witness.BalancedChannels` — despite the name, **not a boolean**: it
   is the *proposition* that every cross-table channel balances, i.e. for each bus
   the multiset of messages sent equals the multiset received (the logUp /
   permutation argument). This is what stops a table from fabricating or dropping
@@ -38,13 +38,13 @@ namespace ZiskFv.Compliance
 
 /-- Accepted committed trace for the full RV64IM Clean ensemble. -/
 structure AcceptedTrace where
-  length : Nat
-  program : ZiskFv.AirsClean.ZiskInstructionRom.Program length
+  numInstructions : Nat
+  program : ZiskFv.AirsClean.ZiskInstructionRom.Program numInstructions
   witness :
     Air.Flat.EnsembleWitness
-      (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble length program).ensemble
-  constraints : witness.Constraints
-  spec : witness.Spec
-  balanced : witness.BalancedChannels
+      (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble numInstructions program).ensemble
+  constraints_hold : witness.Constraints
+  spec_holds : witness.Spec
+  channels_balanced : witness.BalancedChannels
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/AcceptedTrace/Spec.lean
+++ b/ZiskFv/Compliance/AcceptedTrace/Spec.lean
@@ -1,0 +1,23 @@
+import ZiskFv.Compliance.AcceptedTrace
+
+/-!
+# Derived per-AIR spec accessor
+
+`AcceptedTrace` carries only the two genuine accepted-trace fields
+(`constraints_hold`, `channels_balanced`). The per-AIR *spec* — that each table
+really computes its intended relation — is **derived**, not assumed, and lives
+here as the accessor `AcceptedTrace.spec_holds`.
+-/
+
+namespace ZiskFv.Compliance
+
+/-- `spec_holds` is **derived**, not assumed: the spec each AIR encodes follows
+    from the accepted `constraints_hold` and `channels_balanced` via the
+    ensemble's table-soundness (`witness_spec_of_constraints`). It is
+    `@[reducible]` so every consumer (and the trust gate's `whnfR`) sees through
+    it exactly as it did the former struct field. -/
+@[reducible] def AcceptedTrace.spec_holds (trace : AcceptedTrace) : trace.witness.Spec :=
+  ZiskFv.AirsClean.FullEnsemble.witness_spec_of_constraints
+    trace.witness trace.constraints_hold trace.channels_balanced
+
+end ZiskFv.Compliance

--- a/ZiskFv/Compliance/ConstructionAdd.lean
+++ b/ZiskFv/Compliance/ConstructionAdd.lean
@@ -16,7 +16,7 @@ EITHER of two distinct providers with two distinct `opBusMessage` shapes:
 * the dedicated `BinaryAdd` provider (`BinaryAdd.component`).
 
 The salvaged Layer-A wrapper `exists_add_provider_row_matches_from_binding`
-(`AcceptedTrace.lean`) RESOLVES the op-bus from `trace.balanced` into the
+(`AcceptedTrace.lean`) RESOLVES the op-bus from `trace.channels_balanced` into the
 conjunction
 
 ```
@@ -85,7 +85,7 @@ set_option maxHeartbeats 2000000
 
     From the accepted trace + honest residual binders, conclude the canonical
     `execute (RTYPE ADD) = (bus_effect …).2`. The op-bus provider is resolved from
-    `trace.balanced` into a `staticLookup ∨ BinaryAdd` disjunction; BOTH arms are
+    `trace.channels_balanced` into a `staticLookup ∨ BinaryAdd` disjunction; BOTH arms are
     discharged, each deriving the rd data effect from the corresponding provider's
     Clean `Spec`. The `add_subset_holds` conjunct and the provider match are
     DERIVED (bucket-(a)), so the residual budget matches SUB: 17 + `execRow`.
@@ -102,7 +102,7 @@ set_option maxHeartbeats 2000000
 theorem construction_add_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (add_input : PureSpec.AddInput)
     (r1 r2 rd : regidx)
     -- (b) decode pins
@@ -173,7 +173,7 @@ theorem construction_add_sound_claimed_dead
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable with hm
   set state := binding.stateAt i with hstate
   let bus := busSub trace binding i execRow
-  -- (a) op-bus provider RESOLUTION, derived from `trace.balanced`: the
+  -- (a) op-bus provider RESOLUTION, derived from `trace.channels_balanced`: the
   -- `add_subset_holds` conjunct + a `staticLookup ∨ BinaryAdd` DISJUNCTION.
   obtain ⟨h_add_subset, h_disj⟩ :=
     exists_add_provider_row_matches_from_binding
@@ -310,7 +310,7 @@ theorem construction_add_sound_claimed_dead
 theorem construction_addi_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (addi_input : PureSpec.AddiInput)
     (r1 rd : regidx)
     (imm : BitVec 12)
@@ -377,7 +377,7 @@ theorem construction_addi_sound_claimed_dead
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable with hm
   set state := binding.stateAt i with hstate
   let bus := busSub trace binding i execRow
-  -- (a) op-bus provider RESOLUTION, derived from `trace.balanced`: the
+  -- (a) op-bus provider RESOLUTION, derived from `trace.channels_balanced`: the
   -- `add_subset_holds` conjunct + a `staticLookup ∨ BinaryAdd` DISJUNCTION
   -- (the op-bus match is operand-source-agnostic, so the SAME wrapper serves ADDI).
   obtain ⟨h_add_subset, h_disj⟩ :=

--- a/ZiskFv/Compliance/ConstructionAnd.lean
+++ b/ZiskFv/Compliance/ConstructionAnd.lean
@@ -34,7 +34,7 @@ and the residual budget — is reused verbatim.
 An AND envelope's content splits into the same three buckets as SUB:
 
 * **(a) derived** — proven inside the body, NOT a binder:
-  - op-bus provider match (from `trace.balanced`, via the salvaged logic
+  - op-bus provider match (from `trace.channels_balanced`, via the salvaged logic
     Layer-A wrapper, bottoming in an axiom-free Layer-B permutation theorem),
   - row shape (`mainOfTable` / `rowAt_mainOfTable`),
   - circuit-internal rd arithmetic (the already-proven packed byte-chain lemmas;
@@ -102,13 +102,13 @@ set_option maxHeartbeats 2000000
       not vacuous).
 
     Derived inside the body (NOT binders): op-bus provider match (from
-    `trace.balanced`, via the salvaged logic wrapper), row shape,
+    `trace.channels_balanced`, via the salvaged logic wrapper), row shape,
     circuit-internal rd arithmetic, the MemBus `m0..m2` shape, `h_lane_rd`, and
     the lane→Sail binding facts. -/
 theorem construction_and_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (and_input : PureSpec.AndInput)
     (r1 r2 rd : regidx)
     -- (b) decode pins
@@ -182,7 +182,7 @@ theorem construction_and_sound_claimed_dead
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable with hm
   set state := binding.stateAt i with hstate
   let bus := busSub trace binding i execRow
-  -- (a) op-bus provider match, derived from `trace.balanced` via the salvaged
+  -- (a) op-bus provider match, derived from `trace.channels_balanced` via the salvaged
   -- logic wrapper (serves AND / OR / XOR; op pin given as the AND disjunct).
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=

--- a/ZiskFv/Compliance/ConstructionAuipc.lean
+++ b/ZiskFv/Compliance/ConstructionAuipc.lean
@@ -79,7 +79,7 @@ set_option maxHeartbeats 2000000
 theorem construction_auipc_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (auipc_input : PureSpec.AuipcInput)
     (imm : BitVec 20)
     (rd : regidx)

--- a/ZiskFv/Compliance/ConstructionBranch.lean
+++ b/ZiskFv/Compliance/ConstructionBranch.lean
@@ -20,7 +20,7 @@ residual binders — mirroring `construction_add_sound`, but on the
 
 A conditional branch reads `rs1`/`rs2`, compares them, and updates only the PC.
 It emits NO operation-bus entry (so there is no provider disjunction to resolve
-from `trace.balanced`, in contrast to ADD/SUB), and NO memory-bus entry (so there
+from `trace.channels_balanced`, in contrast to ADD/SUB), and NO memory-bus entry (so there
 is no `StorePcMemoryWitness` / rd-write to discharge, in contrast to LUI/AUIPC).
 The entire state effect is carried by the execution bus's single PC update. The
 canonical `equiv_<BOP>` consumes only a `BranchInstrOperands` + a `BranchPromises`
@@ -108,7 +108,7 @@ set_option maxHeartbeats 2000000
 theorem construction_beq_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (beq_input : PureSpec.BeqInput)
     (imm : BitVec 13)
     (r1 r2 : regidx)
@@ -169,7 +169,7 @@ theorem construction_beq_sound_claimed_dead
 theorem construction_bne_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (bne_input : PureSpec.BneInput)
     (imm : BitVec 13)
     (r1 r2 : regidx)
@@ -221,7 +221,7 @@ theorem construction_bne_sound_claimed_dead
 theorem construction_blt_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (blt_input : PureSpec.BltInput)
     (imm : BitVec 13)
     (r1 r2 : regidx)
@@ -273,7 +273,7 @@ theorem construction_blt_sound_claimed_dead
 theorem construction_bge_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (bge_input : PureSpec.BgeInput)
     (imm : BitVec 13)
     (r1 r2 : regidx)
@@ -325,7 +325,7 @@ theorem construction_bge_sound_claimed_dead
 theorem construction_bltu_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (bltu_input : PureSpec.BltuInput)
     (imm : BitVec 13)
     (r1 r2 : regidx)
@@ -377,7 +377,7 @@ theorem construction_bltu_sound_claimed_dead
 theorem construction_bgeu_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (bgeu_input : PureSpec.BgeuInput)
     (imm : BitVec 13)
     (r1 r2 : regidx)

--- a/ZiskFv/Compliance/ConstructionCompare.lean
+++ b/ZiskFv/Compliance/ConstructionCompare.lean
@@ -76,13 +76,13 @@ set_option maxHeartbeats 2000000
       genuine `execRow` ∀-binder.
 
     Derived inside the body (NOT binders): op-bus provider match (from
-    `trace.balanced`, via the salvaged compare wrapper), row shape, circuit-internal
+    `trace.channels_balanced`, via the salvaged compare wrapper), row shape, circuit-internal
     rd arithmetic (incl. the signed-compare polarity, inside `equiv_SLT`), the
     MemBus `m0..m2` shape, `h_lane_rd`, and the lane→Sail binding facts. -/
 theorem construction_slt_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (slt_input : PureSpec.SltInput)
     (r1 r2 rd : regidx)
     -- (b) decode pins
@@ -153,7 +153,7 @@ theorem construction_slt_sound_claimed_dead
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable with hm
   set state := binding.stateAt i with hstate
   let bus := busSub trace binding i execRow
-  -- (a) op-bus provider match, derived from `trace.balanced` via the salvaged
+  -- (a) op-bus provider match, derived from `trace.channels_balanced` via the salvaged
   -- compare wrapper (serves SLT / SLTU; op pin given as the SLT disjunct).
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
@@ -277,7 +277,7 @@ theorem construction_slt_sound_claimed_dead
 theorem construction_sltu_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (sltu_input : PureSpec.SltuInput)
     (r1 r2 rd : regidx)
     -- (b) decode pins
@@ -348,7 +348,7 @@ theorem construction_sltu_sound_claimed_dead
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable with hm
   set state := binding.stateAt i with hstate
   let bus := busSub trace binding i execRow
-  -- (a) op-bus provider match, derived from `trace.balanced` via the salvaged
+  -- (a) op-bus provider match, derived from `trace.channels_balanced` via the salvaged
   -- compare wrapper (serves SLT / SLTU; op pin given as the SLTU disjunct).
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=

--- a/ZiskFv/Compliance/ConstructionDivu.lean
+++ b/ZiskFv/Compliance/ConstructionDivu.lean
@@ -437,7 +437,7 @@ private lemma divu_carry_bounds_claimed_dead
     `exists_arithMul_provider_row_matches_primary_of_divu_from_binding`.
     Mirrors `mulwArow`. -/
 noncomputable def divuArow
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -450,7 +450,7 @@ noncomputable def divuArow
 /-- `FullSpec` of the balance-selected DIVU provider row, derived from the
     provider component's proven soundness (`componentWithArithTable.Spec`). -/
 theorem divuArow_fullSpec_row
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -468,7 +468,7 @@ theorem divuArow_fullSpec_row
     row's emission, in `toEntry (primaryOpBusMessage …) 1` form (cheap: free
     `ArithMulRow`, no view whnf). -/
 theorem divuArow_match_row
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -489,7 +489,7 @@ theorem divuArow_match_row
     off the BARE provider `ArithMulRow` via `divu_mode_pins_of_row`, never
     forcing the heavy `Classical.choose` row's whnf. -/
 theorem divuArow_mode_pins
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -519,7 +519,7 @@ theorem divuArow_mode_pins
     Main row's emission, in `opBus_row_ArithDiv` form.  The DIVU mode pins
     needed to reduce the faithful mux are DERIVED via `divuArow_mode_pins`. -/
 theorem divuArow_match
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -721,7 +721,7 @@ lemma equiv_DIVU_of_fullSpec_claimed_dead
 
     The Arith provider witnesses (ArithTable membership, chunk ranges, signed
     carry ranges, c46, carry-chain) are DERIVED inside the body from
-    `trace.balanced` / `trace.spec` via the SHARED ArithMul provider's
+    `trace.channels_balanced` / `trace.spec_holds` via the SHARED ArithMul provider's
     lookup-aware `componentWithArithTable.Spec = FullSpec`, NOT supplied as
     binders.
 
@@ -734,7 +734,7 @@ lemma equiv_DIVU_of_fullSpec_claimed_dead
 theorem construction_divu_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (divu_input : PureSpec.DivuInput)
     (r1 r2 rd : regidx)
     -- (b) decode pins

--- a/ZiskFv/Compliance/ConstructionDivuw.lean
+++ b/ZiskFv/Compliance/ConstructionDivuw.lean
@@ -301,7 +301,7 @@ private lemma divuw_carry_bounds_claimed_dead
     `exists_arithMul_provider_row_matches_primary_of_divuw_from_binding`.
     Mirrors `divuArow`. -/
 noncomputable def divuwArow
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -314,7 +314,7 @@ noncomputable def divuwArow
 /-- `FullSpec` of the balance-selected DIVUW provider row, derived from the
     provider component's proven soundness (`componentWithArithTable.Spec`). -/
 theorem divuwArow_fullSpec_row
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -332,7 +332,7 @@ theorem divuwArow_fullSpec_row
 /-- The op-bus match of the balance-selected DIVUW provider row against the Main
     row's emission, in `toEntry (primaryOpBusMessage …) 1` form. -/
 theorem divuwArow_match_row
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -353,7 +353,7 @@ theorem divuwArow_match_row
     off the BARE provider `ArithMulRow` via `divuw_mode_pins_of_row`, never
     forcing the heavy `Classical.choose` row's whnf. -/
 theorem divuwArow_mode_pins
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -384,7 +384,7 @@ theorem divuwArow_mode_pins
     faithful mux are DERIVED via `divuwArow_mode_pins` (they are `m32`-agnostic,
     so the DIVU-mode bridge `match_opBus_row_ArithDiv_vOfDivuRow` applies). -/
 theorem divuwArow_match
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -623,7 +623,7 @@ lemma equiv_DIVUW_of_fullSpec_claimed_dead
 
     The Arith provider witnesses (ArithTable membership, chunk ranges, signed
     carry ranges, c46, carry-chain) are DERIVED inside the body from
-    `trace.balanced` / `trace.spec` via the SHARED ArithMul provider's
+    `trace.channels_balanced` / `trace.spec_holds` via the SHARED ArithMul provider's
     lookup-aware `componentWithArithTable.Spec = FullSpec`, NOT supplied as
     binders.  The W-mode high-lane zeros (`b_2=b_3=c_2=c_3=0`) and the
     low-quotient byte match are also DERIVED.
@@ -636,7 +636,7 @@ lemma equiv_DIVUW_of_fullSpec_claimed_dead
 theorem construction_divuw_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (divuw_input : PureSpec.DivuwInput)
     (r1 r2 rd : regidx)
     -- (b) decode pins

--- a/ZiskFv/Compliance/ConstructionIType.lean
+++ b/ZiskFv/Compliance/ConstructionIType.lean
@@ -119,14 +119,14 @@ set_option maxHeartbeats 2000000
       genuine `execRow` ∀-binder.
 
     Derived inside the body (NOT binders): op-bus provider match (from
-    `trace.balanced`, via the salvaged logic wrapper), row shape, the 8-byte
+    `trace.channels_balanced`, via the salvaged logic wrapper), row shape, the 8-byte
     immediate form `h_input_imm_row` (from `h_andi_subset` + `h_matches`),
     circuit-internal rd arithmetic, the MemBus `m0..m2` shape, `h_lane_rd`, and
     the r1 lane→Sail binding fact. -/
 theorem construction_andi_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (andi_input : PureSpec.AndiInput)
     (r1 rd : regidx)
     (imm : BitVec 12)
@@ -190,7 +190,7 @@ theorem construction_andi_sound_claimed_dead
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable with hm
   set state := binding.stateAt i with hstate
   let bus := busSub trace binding i execRow
-  -- (a) op-bus provider match, derived from `trace.balanced` via the salvaged
+  -- (a) op-bus provider match, derived from `trace.channels_balanced` via the salvaged
   -- logic wrapper (serves AND/ANDI / OR/ORI / XOR/XORI; op pin = AND disjunct).
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
@@ -316,7 +316,7 @@ theorem construction_andi_sound_claimed_dead
 theorem construction_ori_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (ori_input : PureSpec.OriInput)
     (r1 rd : regidx)
     (imm : BitVec 12)
@@ -497,7 +497,7 @@ theorem construction_ori_sound_claimed_dead
 theorem construction_xori_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (xori_input : PureSpec.XoriInput)
     (r1 rd : regidx)
     (imm : BitVec 12)
@@ -679,7 +679,7 @@ theorem construction_xori_sound_claimed_dead
 theorem construction_slti_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (slti_input : PureSpec.SltiInput)
     (r1 rd : regidx)
     (imm : BitVec 12)
@@ -854,7 +854,7 @@ theorem construction_slti_sound_claimed_dead
 theorem construction_sltiu_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (sltiu_input : PureSpec.SltiuInput)
     (r1 rd : regidx)
     (imm : BitVec 12)

--- a/ZiskFv/Compliance/ConstructionJump.lean
+++ b/ZiskFv/Compliance/ConstructionJump.lean
@@ -81,7 +81,7 @@ set_option maxHeartbeats 2000000
 theorem construction_jal_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (jal_input : PureSpec.JalInput)
     (imm : BitVec 21)
     (rd : regidx)
@@ -211,7 +211,7 @@ theorem construction_jal_sound_claimed_dead
 theorem construction_jalr_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (jalr_input : PureSpec.JalrInput)
     (imm : BitVec 12)
     (rs1 rd : regidx)

--- a/ZiskFv/Compliance/ConstructionLoad.lean
+++ b/ZiskFv/Compliance/ConstructionLoad.lean
@@ -47,7 +47,7 @@ obligations):
 
 Everything ELSE is derived/structural exactly as in the store/LUI pattern:
 the Main row provenance (`mainRowWithRomLd.core = rowAt …`), the per-row
-`Main.Spec` (from `trace.spec`), `store_pc = 0` lifted to the row, the
+`Main.Spec` (from `trace.spec_holds`), `store_pc = 0` lifted to the row, the
 self-referential `main_b_match`/`main_c_match` (`matches_memory_entry_refl` off
 the real Clean Main `b`/`c` emissions), and the `LoadPromises` bus shape facts
 (`m0..m2` by `rfl`).
@@ -100,7 +100,7 @@ set_option maxHeartbeats 2000000
     the real Main table. Its `.core` equals `rowAt (mainOfTable …) i`. -/
 @[reducible]
 def mainRowWithRomLd
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) :
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) :
     ZiskFv.AirsClean.Main.MainRowWithRom FGL :=
   ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
     trace.program binding.mainTable i.val
@@ -112,7 +112,7 @@ def mainRowWithRomLd
     `matches_memory_entry_refl`. -/
 @[reducible]
 def busLd
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (execRow : List (Interaction.ExecutionBusEntry FGL)) :
     ZiskFv.Compliance.BusRows where
   exec_row := execRow
@@ -126,7 +126,7 @@ def busLd
 /-- The Main row provenance at trace index `i`: `mainRowWithRomLd`'s `.core`
     equals the honest `rowAt (mainOfTable …) i`. Shared by all seven loads. -/
 theorem mainRowWithRomLd_core
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) :
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) :
     (mainRowWithRomLd trace binding i).core =
       ZiskFv.AirsClean.Main.rowAt
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
@@ -154,7 +154,7 @@ theorem mainRowWithRomLd_core
 theorem construction_ld_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (ld_input : PureSpec.LdInput)
     (regs : ZiskFv.Compliance.ModeRegsFull)
     -- (b) #76 Mem-AIR provider (irreducible — see header)
@@ -298,7 +298,7 @@ theorem construction_ld_sound_claimed_dead
 theorem construction_lbu_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (lbu_input : PureSpec.LbuInput)
     (regs : ZiskFv.Compliance.ModeRegsFull)
     -- (b) #76 Mem-AIR provider (irreducible — see header)
@@ -432,7 +432,7 @@ theorem construction_lbu_sound_claimed_dead
 theorem construction_lhu_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (lhu_input : PureSpec.LhuInput)
     (regs : ZiskFv.Compliance.ModeRegsFull)
     (mem : Valid_Mem FGL FGL)
@@ -558,7 +558,7 @@ theorem construction_lhu_sound_claimed_dead
 theorem construction_lwu_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (lwu_input : PureSpec.LwuInput)
     (regs : ZiskFv.Compliance.ModeRegsFull)
     (mem : Valid_Mem FGL FGL)
@@ -695,7 +695,7 @@ theorem construction_lwu_sound_claimed_dead
 theorem construction_lb_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (lb_input : PureSpec.LbInput)
     (regs : ZiskFv.Compliance.ModeRegsFull)
     -- (b) #76 Mem-AIR provider (irreducible — see header)
@@ -833,7 +833,7 @@ theorem construction_lb_sound_claimed_dead
 theorem construction_lh_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (lh_input : PureSpec.LhInput)
     (regs : ZiskFv.Compliance.ModeRegsFull)
     (mem : Valid_Mem FGL FGL)
@@ -963,7 +963,7 @@ theorem construction_lh_sound_claimed_dead
 theorem construction_lw_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (lw_input : PureSpec.LwInput)
     (regs : ZiskFv.Compliance.ModeRegsFull)
     (mem : Valid_Mem FGL FGL)

--- a/ZiskFv/Compliance/ConstructionLogic.lean
+++ b/ZiskFv/Compliance/ConstructionLogic.lean
@@ -84,13 +84,13 @@ set_option maxHeartbeats 2000000
       genuine `execRow` ∀-binder.
 
     Derived inside the body (NOT binders): op-bus provider match (from
-    `trace.balanced`, via the salvaged logic wrapper), row shape, circuit-internal
+    `trace.channels_balanced`, via the salvaged logic wrapper), row shape, circuit-internal
     rd arithmetic, the MemBus `m0..m2` shape, `h_lane_rd`, and the lane→Sail
     binding facts. -/
 theorem construction_or_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (or_input : PureSpec.OrInput)
     (r1 r2 rd : regidx)
     -- (b) decode pins
@@ -161,7 +161,7 @@ theorem construction_or_sound_claimed_dead
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable with hm
   set state := binding.stateAt i with hstate
   let bus := busSub trace binding i execRow
-  -- (a) op-bus provider match, derived from `trace.balanced` via the salvaged
+  -- (a) op-bus provider match, derived from `trace.channels_balanced` via the salvaged
   -- logic wrapper (serves AND / OR / XOR; op pin given as the OR disjunct).
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
@@ -285,7 +285,7 @@ theorem construction_or_sound_claimed_dead
 theorem construction_xor_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (xor_input : PureSpec.XorInput)
     (r1 r2 rd : regidx)
     -- (b) decode pins
@@ -356,7 +356,7 @@ theorem construction_xor_sound_claimed_dead
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable with hm
   set state := binding.stateAt i with hstate
   let bus := busSub trace binding i execRow
-  -- (a) op-bus provider match, derived from `trace.balanced` via the salvaged
+  -- (a) op-bus provider match, derived from `trace.channels_balanced` via the salvaged
   -- logic wrapper (serves AND / OR / XOR; op pin given as the XOR disjunct).
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=

--- a/ZiskFv/Compliance/ConstructionLui.lean
+++ b/ZiskFv/Compliance/ConstructionLui.lean
@@ -8,7 +8,7 @@ The first **provider-free** (`is_external_op = 0`) honest sound construction in
 the P4 sweep. LUI is realized by a single *internal* Zisk microinstruction
 (`OP_COPYB`), so it emits **no** operation-bus entry: there is no op-bus provider
 block at all (in contrast to `ConstructionSub.lean`, which derives the staticBinary
-op-bus provider match from `trace.balanced`). LUI is therefore STRICTLY MORE
+op-bus provider match from `trace.channels_balanced`). LUI is therefore STRICTLY MORE
 derivable than the 28 provider-backed families — the entire LUI Main constraint
 subset comes straight out of the per-row `Main.Spec`, and the rd-value is the
 identity copy `c_0/c_1 = b_0/b_1 = imm`.
@@ -64,7 +64,7 @@ set_option maxHeartbeats 2000000
     table.  Its `.core` equals `rowAt (mainOfTable …) i`. -/
 @[reducible]
 def mainRowWithRomLui
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) :
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) :
     ZiskFv.AirsClean.Main.MainRowWithRom FGL :=
   ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
     trace.program binding.mainTable i.val
@@ -74,15 +74,15 @@ def mainRowWithRomLui
     match is then `matches_memory_entry_refl`. -/
 @[reducible]
 def eRdLui
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) :
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) :
     Interaction.MemoryBusEntry FGL :=
   ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
     (ZiskFv.AirsClean.Main.cMemMessage (mainRowWithRomLui trace binding i)) 1 1
 
-/-- The Main per-row `Spec` at trace index `i`, derived from `trace.spec`.
+/-- The Main per-row `Spec` at trace index `i`, derived from `trace.spec_holds`.
     (Standalone version of the in-wrapper `h_main_spec` derivation.) -/
 theorem mainSpec_at
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) :
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) :
     ZiskFv.AirsClean.Main.Spec
       (ZiskFv.AirsClean.Main.rowAt
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
@@ -94,7 +94,7 @@ theorem mainSpec_at
       binding.mainTable.component.Spec
         (binding.mainTable.environment (binding.mainTable.table.get mainIdx)) := by
     simpa [mainRow] using
-      trace.spec binding.mainTable binding.mainTable_mem mainRow h_mainRow_mem
+      trace.spec_holds binding.mainTable binding.mainTable_mem mainRow h_mainRow_mem
   simpa [mainIdx] using
     ZiskFv.AirsClean.FullEnsemble.mainSpec_rowAt_mainOfTable_of_component_spec
       trace.program binding.mainTable mainIdx binding.mainTable_component
@@ -119,7 +119,7 @@ theorem mainSpec_at
 theorem construction_lui_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (lui_input : PureSpec.LuiInput)
     (imm : BitVec 20)
     (rd : regidx)

--- a/ZiskFv/Compliance/ConstructionMulhu.lean
+++ b/ZiskFv/Compliance/ConstructionMulhu.lean
@@ -616,7 +616,7 @@ lemma equiv_MULHU_of_fullSpec_claimed_dead
     `exists_arithMul_provider_row_matches_secondary_of_mulhu_from_binding`.
     Mirrors `mulwArow`. -/
 noncomputable def mulhuArow
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -629,7 +629,7 @@ noncomputable def mulhuArow
 /-- `FullSpec` of the balance-selected MULHU provider row, derived from the
     provider component's proven soundness (`componentWithArithTable.Spec`). -/
 theorem mulhuArow_fullSpec_row
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -645,7 +645,7 @@ theorem mulhuArow_fullSpec_row
 
 /-- `FullSpec` of the balance-selected MULHU provider row view. -/
 theorem mulhuArow_fullSpec
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -679,7 +679,7 @@ theorem match_opBus_row_ArithMulSecondary_vOfMulwRow
     row's emission, in `toEntry (primaryOpBusMessage …) 1` form (cheap: free
     `ArithMulRow`, no `vOfMulwRow`/`opBus_row_*` whnf). -/
 theorem mulhuArow_match_row
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -700,7 +700,7 @@ theorem mulhuArow_match_row
     off the BARE provider `ArithMulRow` via `mulhu_mode_pins_of_row`, never
     forcing the heavy `Classical.choose` row's whnf. -/
 theorem mulhuArow_mode_pins
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -724,7 +724,7 @@ theorem mulhuArow_mode_pins
     Main row's emission, in `opBus_row_ArithMulSecondary` form.  The MULHU mode
     pins needed to reduce the faithful mux are DERIVED via `mulhuArow_mode_pins`. -/
 theorem mulhuArow_match
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -744,12 +744,12 @@ theorem mulhuArow_match
 
     The Arith provider witnesses (ArithTable membership, chunk ranges, signed
     carry ranges, c46, carry-chain) are DERIVED inside the body from
-    `trace.balanced` / `trace.spec` via the provider's lookup-aware
+    `trace.channels_balanced` / `trace.spec_holds` via the provider's lookup-aware
     `componentWithArithTable.Spec = FullSpec`, NOT supplied as binders. -/
 theorem construction_mulhu_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (mulhu_input : PureSpec.MulhuInput)
     (r1 r2 rd : regidx)
     -- (b) decode pins

--- a/ZiskFv/Compliance/ConstructionMulw.lean
+++ b/ZiskFv/Compliance/ConstructionMulw.lean
@@ -24,7 +24,7 @@ construction reads that `FullSpec` straight off the balance-derived provider row
 ## The honest decomposition
 
 * **(a) derived** — proven inside the body, NOT a binder:
-  - op-bus provider match (from `trace.balanced`, via the Layer-A wrapper
+  - op-bus provider match (from `trace.channels_balanced`, via the Layer-A wrapper
     `exists_arithMul_provider_row_matches_primary_of_mulw_from_binding`,
     bottoming in the axiom-free keep-arithMul balance theorem),
   - the row-native `Valid_ArithMul` view `vOfMulwRow (mulwArow …)` of the
@@ -57,7 +57,7 @@ construction reads that `FullSpec` straight off the balance-derived provider row
 `execRow` MUST be a genuine top-level ∀-binder (the bus consumed by the exec
 hypotheses is `busSub`, built from the real trace row, NOT chosen to trivialize
 a hypothesis). The Arith witnesses are NOT binders — they are derived from
-`trace.balanced` / `trace.spec`, matching the ALU constructions' shape.
+`trace.channels_balanced` / `trace.spec_holds`, matching the ALU constructions' shape.
 
 ## Axioms
 
@@ -144,7 +144,7 @@ def vOfMulwRow (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL) :
     `vOfMulwRow (mulwArow …)`. The Arith witnesses for this row are derived
     inside `construction_mulw_sound`; nothing about the row is caller-supplied. -/
 noncomputable def mulwArow
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -170,7 +170,7 @@ theorem fullSpec_rowAt_vOfMulwRow
     underlying `mulwArow` matches the one this proof picks — keeping the defeq
     cheap for the construction body. -/
 theorem mulwArow_fullSpec_row
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -188,7 +188,7 @@ theorem mulwArow_fullSpec_row
 
 /-- `FullSpec` of the balance-selected MULW provider row view. -/
 theorem mulwArow_fullSpec
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -230,7 +230,7 @@ theorem match_opBus_row_Arith_vOfMulwRow
     row's emission, in `toEntry (primaryOpBusMessage …) 1` form. Cheap: the row
     is a free `ArithMulRow`, so no `vOfMulwRow`/`opBus_row_Arith` whnf. -/
 theorem mulwArow_match_row
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -261,7 +261,7 @@ theorem mulwArow_match_row
     op-bus match via the CHEAP `rfl`-projection lemma `primaryOpBusMessage_toEntry_op`
     (a rewrite, not a reduction). -/
 theorem mulwArow_mode_pins
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -290,7 +290,7 @@ theorem mulwArow_mode_pins
     Main row's emission, in `opBus_row_Arith` form. The MUL/MULW mode pins
     needed to reduce the faithful mux are DERIVED via `mulwArow_mode_pins`. -/
 theorem mulwArow_match
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -309,12 +309,12 @@ theorem mulwArow_match
 
     The Arith provider witnesses (ArithTable membership, chunk ranges, signed
     carry ranges, c46, carry-chain) are DERIVED inside the body from
-    `trace.balanced` / `trace.spec` via the provider's lookup-aware
+    `trace.channels_balanced` / `trace.spec_holds` via the provider's lookup-aware
     `componentWithArithTable.Spec = FullSpec`, NOT supplied as binders. -/
 theorem construction_mulw_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (mulw_input : PureSpec.MulwInput)
     (r1 r2 rd : regidx)
     -- (b) decode pins
@@ -390,7 +390,7 @@ theorem construction_mulw_sound_claimed_dead
   -- The balance-selected provider row view.  Kept as the explicit syntactic
   -- term `vOfMulwRow (mulwArow …)` (NOT `set`/`let`) so it matches the residual
   -- operand binders verbatim, avoiding any `mulwArow` whnf in the delegation.
-  -- (a) Arith witnesses, derived from `trace.balanced` / `trace.spec`:
+  -- (a) Arith witnesses, derived from `trace.channels_balanced` / `trace.spec_holds`:
   --   FullSpec (carry-chain + ArithTable + c46 + chunk/carry ranges) from the
   --   provider component's proven soundness.
   have h_full :

--- a/ZiskFv/Compliance/ConstructionRemu.lean
+++ b/ZiskFv/Compliance/ConstructionRemu.lean
@@ -137,7 +137,7 @@ theorem match_opBus_row_ArithDivSecondary_vOfDivuRow
     `exists_arithMul_provider_row_matches_primary_of_remu_from_binding`.
     Mirrors `divuArow`. -/
 noncomputable def remuArow
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -150,7 +150,7 @@ noncomputable def remuArow
 /-- `FullSpec` of the balance-selected REMU provider row, derived from the
     provider component's proven soundness (`componentWithArithTable.Spec`). -/
 theorem remuArow_fullSpec_row
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -168,7 +168,7 @@ theorem remuArow_fullSpec_row
 /-- The op-bus match of the balance-selected REMU provider row against the Main
     row's emission, in `toEntry (primaryOpBusMessage …) 1` form. -/
 theorem remuArow_match_row
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -189,7 +189,7 @@ theorem remuArow_match_row
     off the BARE provider `ArithMulRow` via `remu_mode_pins_of_row`, never
     forcing the heavy `Classical.choose` row's whnf. -/
 theorem remuArow_mode_pins
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -219,7 +219,7 @@ theorem remuArow_mode_pins
     Main row's emission, in `opBus_row_ArithDivSecondary` form.  The REMU mode
     pins needed to reduce the faithful mux are DERIVED via `remuArow_mode_pins`. -/
 theorem remuArow_match
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -605,7 +605,7 @@ lemma equiv_REMU_of_fullSpec_claimed_dead
 
     The Arith provider witnesses (ArithTable membership, chunk ranges, signed
     carry ranges, c46, carry-chain) are DERIVED inside the body from
-    `trace.balanced` / `trace.spec` via the SHARED ArithMul provider's
+    `trace.channels_balanced` / `trace.spec_holds` via the SHARED ArithMul provider's
     lookup-aware `componentWithArithTable.Spec = FullSpec`, NOT supplied as
     binders.
 
@@ -618,7 +618,7 @@ lemma equiv_REMU_of_fullSpec_claimed_dead
 theorem construction_remu_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (remu_input : PureSpec.RemuInput)
     (r1 r2 rd : regidx)
     -- (b) decode pins

--- a/ZiskFv/Compliance/ConstructionRemuw.lean
+++ b/ZiskFv/Compliance/ConstructionRemuw.lean
@@ -299,7 +299,7 @@ private lemma remuw_carry_bounds_claimed_dead
     `exists_arithMul_provider_row_matches_primary_of_remuw_from_binding`.
     Mirrors `remuArow` / `divuwArow`. -/
 noncomputable def remuwArow
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -312,7 +312,7 @@ noncomputable def remuwArow
 /-- `FullSpec` of the balance-selected REMUW provider row, derived from the
     provider component's proven soundness (`componentWithArithTable.Spec`). -/
 theorem remuwArow_fullSpec_row
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -330,7 +330,7 @@ theorem remuwArow_fullSpec_row
 /-- The op-bus match of the balance-selected REMUW provider row against the Main
     row's emission, in `toEntry (primaryOpBusMessage …) 1` form. -/
 theorem remuwArow_match_row
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -351,7 +351,7 @@ theorem remuwArow_match_row
     off the BARE provider `ArithMulRow` via `remuw_mode_pins_of_row`, never
     forcing the heavy `Classical.choose` row's whnf. -/
 theorem remuwArow_mode_pins
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -383,7 +383,7 @@ theorem remuwArow_mode_pins
     `m32`-agnostic, so the REMU secondary bridge
     `match_opBus_row_ArithDivSecondary_vOfDivuRow` applies verbatim). -/
 theorem remuwArow_match
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program binding.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -622,7 +622,7 @@ lemma equiv_REMUW_of_fullSpec_claimed_dead
 
     The Arith provider witnesses (ArithTable membership, chunk ranges, signed
     carry ranges, c46, carry-chain) are DERIVED inside the body from
-    `trace.balanced` / `trace.spec` via the SHARED ArithMul provider's
+    `trace.channels_balanced` / `trace.spec_holds` via the SHARED ArithMul provider's
     lookup-aware `componentWithArithTable.Spec = FullSpec`, NOT supplied as
     binders.  The low-remainder byte match is also DERIVED.
 
@@ -635,7 +635,7 @@ lemma equiv_REMUW_of_fullSpec_claimed_dead
 theorem construction_remuw_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (remuw_input : PureSpec.RemuwInput)
     (r1 r2 rd : regidx)
     -- (b) decode pins

--- a/ZiskFv/Compliance/ConstructionShift.lean
+++ b/ZiskFv/Compliance/ConstructionShift.lean
@@ -308,13 +308,13 @@ theorem shift_imm_shift_pin_row_of_facts
       genuine `execRow` ∀-binder.
 
     Derived inside the body (NOT binders): op-bus provider match (from
-    `trace.balanced`, via the salvaged shift Layer-A wrapper), the BinaryExtension
+    `trace.channels_balanced`, via the salvaged shift Layer-A wrapper), the BinaryExtension
     wf/byte facts, `op_is_shift = 1`, the MemBus `m0..m2` shape, `h_lane_rd`, and
     the lane→Sail bindings `h_input_r1_row` / `h_shift_pin_row` (m32 = 0 route). -/
 theorem construction_sll_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (sll_input : PureSpec.SllInput)
     (r1 r2 rd : regidx)
     -- (b) decode pins
@@ -381,7 +381,7 @@ theorem construction_sll_sound_claimed_dead
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable with hm
   set state := binding.stateAt i with hstate
   let bus := busSub trace binding i execRow
-  -- (a) op-bus provider match, derived from `trace.balanced`
+  -- (a) op-bus provider match, derived from `trace.channels_balanced`
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
     exists_binaryExtension_provider_row_matches_shift_from_binding
@@ -474,13 +474,13 @@ theorem construction_sll_sound_claimed_dead
       genuine `execRow` ∀-binder.
 
     Derived inside the body (NOT binders): op-bus provider match (from
-    `trace.balanced`, via the salvaged shift Layer-A wrapper), the BinaryExtension
+    `trace.channels_balanced`, via the salvaged shift Layer-A wrapper), the BinaryExtension
     wf/byte facts, `op_is_shift = 1`, the MemBus `m0..m2` shape, `h_lane_rd`, and
     the lane→Sail bindings `h_input_r1_row` / `h_shift_pin_row` (m32 = 0 route). -/
 theorem construction_srl_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (srl_input : PureSpec.SrlInput)
     (r1 r2 rd : regidx)
     -- (b) decode pins
@@ -547,7 +547,7 @@ theorem construction_srl_sound_claimed_dead
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable with hm
   set state := binding.stateAt i with hstate
   let bus := busSub trace binding i execRow
-  -- (a) op-bus provider match, derived from `trace.balanced`
+  -- (a) op-bus provider match, derived from `trace.channels_balanced`
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
     exists_binaryExtension_provider_row_matches_shift_from_binding
@@ -640,13 +640,13 @@ theorem construction_srl_sound_claimed_dead
       genuine `execRow` ∀-binder.
 
     Derived inside the body (NOT binders): op-bus provider match (from
-    `trace.balanced`, via the salvaged shift Layer-A wrapper), the BinaryExtension
+    `trace.channels_balanced`, via the salvaged shift Layer-A wrapper), the BinaryExtension
     wf/byte facts, `op_is_shift = 1`, the MemBus `m0..m2` shape, `h_lane_rd`, and
     the lane→Sail bindings `h_input_r1_row` / `h_shift_pin_row` (m32 = 0 route). -/
 theorem construction_sra_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (sra_input : PureSpec.SraInput)
     (r1 r2 rd : regidx)
     -- (b) decode pins
@@ -713,7 +713,7 @@ theorem construction_sra_sound_claimed_dead
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable with hm
   set state := binding.stateAt i with hstate
   let bus := busSub trace binding i execRow
-  -- (a) op-bus provider match, derived from `trace.balanced`
+  -- (a) op-bus provider match, derived from `trace.channels_balanced`
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
     exists_binaryExtension_provider_row_matches_shift_from_binding
@@ -808,7 +808,7 @@ theorem construction_sra_sound_claimed_dead
 theorem construction_slli_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (slli_input : PureSpec.SlliInput)
     (r1 rd : regidx) (shamt : BitVec 6)
     -- (b) decode pins
@@ -954,7 +954,7 @@ theorem construction_slli_sound_claimed_dead
 theorem construction_srli_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (srli_input : PureSpec.SrliInput)
     (r1 rd : regidx) (shamt : BitVec 6)
     -- (b) decode pins
@@ -1100,7 +1100,7 @@ theorem construction_srli_sound_claimed_dead
 theorem construction_srai_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (srai_input : PureSpec.SraiInput)
     (r1 rd : regidx) (shamt : BitVec 6)
     -- (b) decode pins
@@ -1414,7 +1414,7 @@ theorem shift_m32_1_imm_shift_pin_row_of_facts
 theorem construction_sllw_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (sllw_input : PureSpec.SllwInput)
     (r1 r2 rd : regidx)
     -- (b) decode pins
@@ -1481,7 +1481,7 @@ theorem construction_sllw_sound_claimed_dead
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable with hm
   set state := binding.stateAt i with hstate
   let bus := busSub trace binding i execRow
-  -- (a) op-bus provider match, derived from `trace.balanced`. SLLW = 4th
+  -- (a) op-bus provider match, derived from `trace.channels_balanced`. SLLW = 4th
   -- disjunct of the shared shift Layer-A wrapper.
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
@@ -1568,7 +1568,7 @@ theorem construction_sllw_sound_claimed_dead
 theorem construction_srlw_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (srlw_input : PureSpec.SrlwInput)
     (r1 r2 rd : regidx)
     (h_main_op :
@@ -1708,7 +1708,7 @@ theorem construction_srlw_sound_claimed_dead
 theorem construction_sraw_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (sraw_input : PureSpec.SrawInput)
     (r1 r2 rd : regidx)
     (h_main_op :
@@ -1859,7 +1859,7 @@ theorem construction_sraw_sound_claimed_dead
 theorem construction_slliw_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (slliw_input : PureSpec.SlliwInput)
     (r1 rd : regidx)
     -- (b) decode pins
@@ -1990,7 +1990,7 @@ theorem construction_slliw_sound_claimed_dead
 theorem construction_srliw_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (srliw_input : PureSpec.SrliwInput)
     (r1 rd : regidx)
     (h_main_op :
@@ -2117,7 +2117,7 @@ theorem construction_srliw_sound_claimed_dead
 theorem construction_sraiw_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (sraiw_input : PureSpec.SraiwInput)
     (r1 rd : regidx)
     (h_main_op :

--- a/ZiskFv/Compliance/ConstructionStore.lean
+++ b/ZiskFv/Compliance/ConstructionStore.lean
@@ -20,7 +20,7 @@ side** instead of the operation bus.
 ALU/M-ext ops READ their operands off register-bus MemBus entries and write
 `rd`; their op-bus `equiv_<OP>` is resolved against a *separate* provider AIR
 (Binary / Arith / …) via a Layer-A `exists_*_provider_row_matches_*_from_binding`
-wrapper that consumes `trace.balanced`.
+wrapper that consumes `trace.channels_balanced`.
 
 Stores WRITE memory. The store's memory-bus write entry (`bus.e2`, address-space
 `as = 2`) is the Main row's **own** c/store emission `cMemMessage`. The
@@ -50,7 +50,7 @@ the structural counterpart, derived from the real trace row.
 
 * **(a) derived inside the body** (NOT binders): the Main row provenance
   (`mainRowWithRomSt.core = rowAt …`), the per-row `Main.Spec` (from
-  `trace.spec`, via `mainSpec_at`), `store_pc = 0` lifted to the row, and the
+  `trace.spec_holds`, via `mainSpec_at`), `store_pc = 0` lifted to the row, and the
   self-referential `main_c_match` (`matches_memory_entry_refl`).
 
 * **(b) named residual** — explicit top-level binders:
@@ -101,7 +101,7 @@ set_option maxHeartbeats 2000000
     the real Main table. Its `.core` equals `rowAt (mainOfTable …) i`. -/
 @[reducible]
 def mainRowWithRomSt
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) :
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) :
     ZiskFv.AirsClean.Main.MainRowWithRom FGL :=
   ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
     trace.program binding.mainTable i.val
@@ -112,7 +112,7 @@ def mainRowWithRomSt
     `S*CleanWitness.main_c_match` is then `matches_memory_entry_refl`. -/
 @[reducible]
 def eRdSt
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) :
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) :
     Interaction.MemoryBusEntry FGL :=
   ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
     (ZiskFv.AirsClean.Main.cMemMessage (mainRowWithRomSt trace binding i)) 1 2
@@ -123,7 +123,7 @@ def eRdSt
     mult/as shape facts are then `rfl`. -/
 @[reducible]
 def busSt
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (execRow : List (Interaction.ExecutionBusEntry FGL)) :
     ZiskFv.Compliance.BusRows where
   exec_row := execRow
@@ -136,7 +136,7 @@ def busSt
 /-- The Main row provenance at trace index `i`: `mainRowWithRomSt`'s `.core`
     equals the honest `rowAt (mainOfTable …) i`. Shared by all four stores. -/
 theorem mainRowWithRomSt_core
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) :
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) :
     (mainRowWithRomSt trace binding i).core =
       ZiskFv.AirsClean.Main.rowAt
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
@@ -157,7 +157,7 @@ theorem mainRowWithRomSt_core
 theorem construction_sb_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (sb_input : PureSpec.SbInput)
     (regs : ZiskFv.Compliance.ModeRegsFull)
     -- (b) decode pins
@@ -291,7 +291,7 @@ theorem construction_sb_sound_claimed_dead
 theorem construction_sh_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (sh_input : PureSpec.ShInput)
     (regs : ZiskFv.Compliance.ModeRegsFull)
     -- (b) decode pins
@@ -414,7 +414,7 @@ theorem construction_sh_sound_claimed_dead
 theorem construction_sw_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (sw_input : PureSpec.SwInput)
     (regs : ZiskFv.Compliance.ModeRegsFull)
     -- (b) decode pins
@@ -532,7 +532,7 @@ theorem construction_sw_sound_claimed_dead
 theorem construction_sd_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (sd_input : PureSpec.SdInput)
     (regs : ZiskFv.Compliance.ModeRegsFull)
     -- (b) decode pins

--- a/ZiskFv/Compliance/ConstructionSub.lean
+++ b/ZiskFv/Compliance/ConstructionSub.lean
@@ -20,7 +20,7 @@ A SUB envelope's content splits into three buckets against the live Clean
 ensemble (channels = OpBus + MemBus only; per-row component model):
 
 * **(a) derived** — proven inside the body, NOT a binder:
-  - op-bus provider match (from `trace.balanced`, via the salvaged Layer-A
+  - op-bus provider match (from `trace.channels_balanced`, via the salvaged Layer-A
     `exists_staticBinary_provider_row_matches_sub_from_binding`, bottoming in an
     axiom-free Layer-B permutation theorem),
   - row shape (`mainOfTable` / `rowAt_mainOfTable`),
@@ -119,7 +119,7 @@ theorem allByteMatchesOfStaticOut64_local
     real Main table.  Its `.core` equals `rowAt (mainOfTable …) i`. -/
 @[reducible]
 def mainRowWithRomSub
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) :
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) :
     ZiskFv.AirsClean.Main.MainRowWithRom FGL :=
   ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
     trace.program binding.mainTable i.val
@@ -129,7 +129,7 @@ def mainRowWithRomSub
     `m0..m2` shape facts are then `rfl`. -/
 @[reducible]
 def busSub
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (execRow : List (Interaction.ExecutionBusEntry FGL)) :
     ZiskFv.Compliance.BusRows where
   exec_row := execRow
@@ -155,12 +155,12 @@ def busSub
       not vacuous).
 
     Derived inside the body (NOT binders): op-bus provider match (from
-    `trace.balanced`), row shape, circuit-internal rd arithmetic, the MemBus
+    `trace.channels_balanced`), row shape, circuit-internal rd arithmetic, the MemBus
     `m0..m2` shape, `h_lane_rd`, and the lane→Sail binding facts. -/
 theorem construction_sub_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (sub_input : PureSpec.SubInput)
     (r1 r2 rd : regidx)
     -- (b) decode pins
@@ -234,7 +234,7 @@ theorem construction_sub_sound_claimed_dead
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable with hm
   set state := binding.stateAt i with hstate
   let bus := busSub trace binding i execRow
-  -- (a) op-bus provider match, derived from `trace.balanced`
+  -- (a) op-bus provider match, derived from `trace.channels_balanced`
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
     exists_staticBinary_provider_row_matches_sub_from_binding

--- a/ZiskFv/Compliance/ConstructionWAlu.lean
+++ b/ZiskFv/Compliance/ConstructionWAlu.lean
@@ -80,7 +80,7 @@ set_option maxHeartbeats 2000000
 theorem construction_subw_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (subw_input : PureSpec.SubwInput)
     (r1 r2 rd : regidx)
     -- (b) decode pins
@@ -150,7 +150,7 @@ theorem construction_subw_sound_claimed_dead
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable with hm
   set state := binding.stateAt i with hstate
   let bus := busSub trace binding i execRow
-  -- (a) op-bus provider match, derived from `trace.balanced`. SUBW = `Or.inr`.
+  -- (a) op-bus provider match, derived from `trace.channels_balanced`. SUBW = `Or.inr`.
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
     exists_staticBinary_provider_row_matches_w_from_binding
@@ -260,7 +260,7 @@ theorem construction_subw_sound_claimed_dead
 theorem construction_addw_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (addw_input : PureSpec.AddwInput)
     (r1 r2 rd : regidx)
     (h_main_op :
@@ -439,7 +439,7 @@ theorem construction_addw_sound_claimed_dead
 theorem construction_addiw_sound_claimed_dead
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (addiw_input : PureSpec.AddiwInput)
     (r1 rd : regidx)
     (imm : BitVec 12)

--- a/ZiskFv/Compliance/ProgramBinding/Basic.lean
+++ b/ZiskFv/Compliance/ProgramBinding/Basic.lean
@@ -1,4 +1,4 @@
-import ZiskFv.Compliance.AcceptedTrace
+import ZiskFv.Compliance.AcceptedTrace.Spec
 import ZiskFv.SailSpec.Auxiliaries
 
 /-!

--- a/ZiskFv/Compliance/ProgramBinding/Basic.lean
+++ b/ZiskFv/Compliance/ProgramBinding/Basic.lean
@@ -20,14 +20,14 @@ It supplies the Sail state sequence, the selected Main table, and the table's
 membership / component / index facts. -/
 structure ProgramBinding (trace : AcceptedTrace) where
   stateAt :
-    Fin trace.length →
+    Fin trace.numInstructions →
       PreSail.SequentialState RegisterType Sail.trivialChoiceSource
   mainTable : Air.Flat.Table FGL
   mainTable_mem : mainTable ∈ trace.witness.allTables
   mainTable_component :
     mainTable.component =
       ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-        trace.length trace.program
-  mainTable_index : ∀ i : Fin trace.length, i.val < mainTable.table.length
+        trace.numInstructions trace.program
+  mainTable_index : ∀ i : Fin trace.numInstructions, i.val < mainTable.table.length
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/ProgramBinding/Wrappers.lean
+++ b/ZiskFv/Compliance/ProgramBinding/Wrappers.lean
@@ -10,7 +10,7 @@ op row selected by a `ProgramBinding`, they build the Main op-bus interaction,
 prove its membership and `mult = -1`, and discharge the op-bus provider match by
 delegating to the axiom-free Layer-B permutation theorems in
 `AirsClean/FullEnsemble/{Balance,ArithBalance}.lean`. They are the only consumers
-of `trace.balanced` in the construction spine; the honest sound construction
+of `trace.channels_balanced` in the construction spine; the honest sound construction
 built on top lives in `ZiskFv/Compliance/ConstructionSub.lean`.
 -/
 
@@ -21,7 +21,7 @@ open ZiskFv.AirsClean.FullEnsemble
 theorem exists_staticBinary_provider_row_matches_logic_from_binding
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
@@ -56,17 +56,17 @@ theorem exists_staticBinary_provider_row_matches_logic_from_binding
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core.is_external_op)
+          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core)).toRaw).eval
+          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (binding.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ binding.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core =
+          trace.numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
           i.val := by
@@ -79,33 +79,33 @@ theorem exists_staticBinary_provider_row_matches_logic_from_binding
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         binding.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core.is_external_op)
+              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core)).toRaw).eval
+              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (binding.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         (binding.mainTable.environment mainRow) h_active_row
   exact
     exists_staticBinary_provider_row_matches_legacy_main_of_logic_active_main_row_interaction
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
-        i.val trace.witness trace.constraints trace.balanced trace.spec
+        i.val trace.witness trace.constraints_hold trace.channels_balanced trace.spec_holds
         binding.mainTable_mem binding.mainTable_component h_mainRow_mem
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
@@ -113,7 +113,7 @@ theorem exists_staticBinary_provider_row_matches_logic_from_binding
 theorem exists_staticBinary_provider_row_matches_sub_from_binding
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
@@ -142,17 +142,17 @@ theorem exists_staticBinary_provider_row_matches_sub_from_binding
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core.is_external_op)
+          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core)).toRaw).eval
+          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (binding.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ binding.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core =
+          trace.numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
           i.val := by
@@ -165,33 +165,33 @@ theorem exists_staticBinary_provider_row_matches_sub_from_binding
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         binding.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core.is_external_op)
+              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core)).toRaw).eval
+              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (binding.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         (binding.mainTable.environment mainRow) h_active_row
   exact
     exists_staticBinary_provider_row_matches_legacy_main_of_sub_active_main_row_interaction
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
-        i.val trace.witness trace.constraints trace.balanced trace.spec
+        i.val trace.witness trace.constraints_hold trace.channels_balanced trace.spec_holds
         binding.mainTable_mem binding.mainTable_component h_mainRow_mem
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
@@ -199,7 +199,7 @@ theorem exists_staticBinary_provider_row_matches_sub_from_binding
 theorem exists_add_provider_row_matches_from_binding
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
@@ -245,17 +245,17 @@ theorem exists_add_provider_row_matches_from_binding
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core.is_external_op)
+          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core)).toRaw).eval
+          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (binding.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ binding.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core =
+          trace.numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
           i.val := by
@@ -268,34 +268,34 @@ theorem exists_add_provider_row_matches_from_binding
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         binding.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core.is_external_op)
+              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core)).toRaw).eval
+              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (binding.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         (binding.mainTable.environment mainRow) h_active_row
   have h_main_component_spec :
       binding.mainTable.component.Spec
         (binding.mainTable.environment (binding.mainTable.table.get mainIdx)) := by
     simpa [mainRow] using
-      trace.spec binding.mainTable binding.mainTable_mem mainRow h_mainRow_mem
+      trace.spec_holds binding.mainTable binding.mainTable_mem mainRow h_mainRow_mem
   have h_main_spec :
       ZiskFv.AirsClean.Main.Spec
         (ZiskFv.AirsClean.Main.rowAt
@@ -315,7 +315,7 @@ theorem exists_add_provider_row_matches_from_binding
   exact ⟨h_main_subset,
     exists_add_provider_row_matches_legacy_main_of_add_active_main_row_interaction
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
-        i.val trace.witness trace.constraints trace.balanced trace.spec
+        i.val trace.witness trace.constraints_hold trace.channels_balanced trace.spec_holds
         binding.mainTable_mem binding.mainTable_component h_mainRow_mem
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op⟩
@@ -323,7 +323,7 @@ theorem exists_add_provider_row_matches_from_binding
 theorem exists_staticBinary_provider_row_matches_compare_from_binding
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
@@ -355,17 +355,17 @@ theorem exists_staticBinary_provider_row_matches_compare_from_binding
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core.is_external_op)
+          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core)).toRaw).eval
+          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (binding.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ binding.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core =
+          trace.numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
           i.val := by
@@ -378,33 +378,33 @@ theorem exists_staticBinary_provider_row_matches_compare_from_binding
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         binding.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core.is_external_op)
+              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core)).toRaw).eval
+              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (binding.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         (binding.mainTable.environment mainRow) h_active_row
   exact
     exists_staticBinary_provider_row_matches_legacy_main_of_compare_active_main_row_interaction
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
-        i.val trace.witness trace.constraints trace.balanced trace.spec
+        i.val trace.witness trace.constraints_hold trace.channels_balanced trace.spec_holds
         binding.mainTable_mem binding.mainTable_component h_mainRow_mem
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
@@ -412,7 +412,7 @@ theorem exists_staticBinary_provider_row_matches_compare_from_binding
 theorem exists_staticBinary_provider_row_matches_w_from_binding
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
@@ -444,17 +444,17 @@ theorem exists_staticBinary_provider_row_matches_w_from_binding
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core.is_external_op)
+          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core)).toRaw).eval
+          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (binding.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ binding.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core =
+          trace.numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
           i.val := by
@@ -467,33 +467,33 @@ theorem exists_staticBinary_provider_row_matches_w_from_binding
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         binding.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core.is_external_op)
+              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core)).toRaw).eval
+              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (binding.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         (binding.mainTable.environment mainRow) h_active_row
   exact
     exists_staticBinary_provider_row_matches_legacy_main_of_w_active_main_row_interaction
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
-        i.val trace.witness trace.constraints trace.balanced trace.spec
+        i.val trace.witness trace.constraints_hold trace.channels_balanced trace.spec_holds
         binding.mainTable_mem binding.mainTable_component h_mainRow_mem
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
@@ -501,7 +501,7 @@ theorem exists_staticBinary_provider_row_matches_w_from_binding
 theorem exists_binaryExtension_provider_row_matches_shift_from_binding
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
@@ -546,17 +546,17 @@ theorem exists_binaryExtension_provider_row_matches_shift_from_binding
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core.is_external_op)
+          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core)).toRaw).eval
+          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (binding.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ binding.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core =
+          trace.numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
           i.val := by
@@ -569,33 +569,33 @@ theorem exists_binaryExtension_provider_row_matches_shift_from_binding
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         binding.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core.is_external_op)
+              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core)).toRaw).eval
+              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (binding.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         (binding.mainTable.environment mainRow) h_active_row
   exact
     exists_binaryExtension_provider_row_matches_legacy_main_of_shift_active_main_row_interaction
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
-        i.val trace.witness trace.constraints trace.balanced trace.spec
+        i.val trace.witness trace.constraints_hold trace.channels_balanced trace.spec_holds
         binding.mainTable_mem binding.mainTable_component h_mainRow_mem
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
@@ -614,7 +614,7 @@ theorem exists_binaryExtension_provider_row_matches_shift_from_binding
 theorem exists_arithMul_provider_row_matches_primary_of_mulw_from_binding
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
@@ -643,17 +643,17 @@ theorem exists_arithMul_provider_row_matches_primary_of_mulw_from_binding
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core.is_external_op)
+          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core)).toRaw).eval
+          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (binding.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ binding.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core =
+          trace.numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
           i.val := by
@@ -666,33 +666,33 @@ theorem exists_arithMul_provider_row_matches_primary_of_mulw_from_binding
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         binding.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core.is_external_op)
+              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core)).toRaw).eval
+              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (binding.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         (binding.mainTable.environment mainRow) h_active_row
   exact
     ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_primary_of_mulw_active_main_row_interaction
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
-        i.val trace.witness trace.constraints trace.balanced trace.spec
+        i.val trace.witness trace.constraints_hold trace.channels_balanced trace.spec_holds
         binding.mainTable_mem binding.mainTable_component h_mainRow_mem
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
@@ -709,7 +709,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_mulw_from_binding
 theorem exists_arithMul_provider_row_matches_secondary_of_mulhu_from_binding
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
@@ -738,17 +738,17 @@ theorem exists_arithMul_provider_row_matches_secondary_of_mulhu_from_binding
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core.is_external_op)
+          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core)).toRaw).eval
+          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (binding.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ binding.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core =
+          trace.numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
           i.val := by
@@ -761,33 +761,33 @@ theorem exists_arithMul_provider_row_matches_secondary_of_mulhu_from_binding
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         binding.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core.is_external_op)
+              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core)).toRaw).eval
+              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (binding.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         (binding.mainTable.environment mainRow) h_active_row
   exact
     ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_secondary_of_mulhu_active_main_row_interaction
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
-        i.val trace.witness trace.constraints trace.balanced trace.spec
+        i.val trace.witness trace.constraints_hold trace.channels_balanced trace.spec_holds
         binding.mainTable_mem binding.mainTable_component h_mainRow_mem
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
@@ -806,7 +806,7 @@ theorem exists_arithMul_provider_row_matches_secondary_of_mulhu_from_binding
 theorem exists_arithMul_provider_row_matches_primary_of_divu_from_binding
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
@@ -835,17 +835,17 @@ theorem exists_arithMul_provider_row_matches_primary_of_divu_from_binding
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core.is_external_op)
+          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core)).toRaw).eval
+          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (binding.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ binding.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core =
+          trace.numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
           i.val := by
@@ -858,33 +858,33 @@ theorem exists_arithMul_provider_row_matches_primary_of_divu_from_binding
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         binding.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core.is_external_op)
+              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core)).toRaw).eval
+              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (binding.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         (binding.mainTable.environment mainRow) h_active_row
   exact
     ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_primary_of_divu_active_main_row_interaction
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
-        i.val trace.witness trace.constraints trace.balanced trace.spec
+        i.val trace.witness trace.constraints_hold trace.channels_balanced trace.spec_holds
         binding.mainTable_mem binding.mainTable_component h_mainRow_mem
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
@@ -902,7 +902,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_divu_from_binding
 theorem exists_arithMul_provider_row_matches_primary_of_divuw_from_binding
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
@@ -931,17 +931,17 @@ theorem exists_arithMul_provider_row_matches_primary_of_divuw_from_binding
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core.is_external_op)
+          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core)).toRaw).eval
+          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (binding.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ binding.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core =
+          trace.numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
           i.val := by
@@ -954,33 +954,33 @@ theorem exists_arithMul_provider_row_matches_primary_of_divuw_from_binding
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         binding.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core.is_external_op)
+              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core)).toRaw).eval
+              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (binding.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         (binding.mainTable.environment mainRow) h_active_row
   exact
     ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_primary_of_divuw_active_main_row_interaction
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
-        i.val trace.witness trace.constraints trace.balanced trace.spec
+        i.val trace.witness trace.constraints_hold trace.channels_balanced trace.spec_holds
         binding.mainTable_mem binding.mainTable_component h_mainRow_mem
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
@@ -999,7 +999,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_divuw_from_binding
 theorem exists_arithMul_provider_row_matches_primary_of_remu_from_binding
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
@@ -1028,17 +1028,17 @@ theorem exists_arithMul_provider_row_matches_primary_of_remu_from_binding
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core.is_external_op)
+          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core)).toRaw).eval
+          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (binding.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ binding.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core =
+          trace.numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
           i.val := by
@@ -1051,33 +1051,33 @@ theorem exists_arithMul_provider_row_matches_primary_of_remu_from_binding
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         binding.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core.is_external_op)
+              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core)).toRaw).eval
+              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (binding.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         (binding.mainTable.environment mainRow) h_active_row
   exact
     ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_primary_of_remu_active_main_row_interaction
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
-        i.val trace.witness trace.constraints trace.balanced trace.spec
+        i.val trace.witness trace.constraints_hold trace.channels_balanced trace.spec_holds
         binding.mainTable_mem binding.mainTable_component h_mainRow_mem
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
@@ -1097,7 +1097,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_remu_from_binding
 theorem exists_arithMul_provider_row_matches_primary_of_remuw_from_binding
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (i : Fin trace.length)
+    (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
@@ -1126,17 +1126,17 @@ theorem exists_arithMul_provider_row_matches_primary_of_remuw_from_binding
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core.is_external_op)
+          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core)).toRaw).eval
+          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (binding.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ binding.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core =
+          trace.numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
           i.val := by
@@ -1149,33 +1149,33 @@ theorem exists_arithMul_provider_row_matches_primary_of_remuw_from_binding
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         binding.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core.is_external_op)
+              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.length trace.program).rowInputVar.core)).toRaw).eval
+              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (binding.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (binding.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.length trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.length) (program := trace.program)
+        (length := trace.numInstructions) (program := trace.program)
         (binding.mainTable.environment mainRow) h_active_row
   exact
     ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_primary_of_remuw_active_main_row_interaction
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable)
-        i.val trace.witness trace.constraints trace.balanced trace.spec
+        i.val trace.witness trace.constraints_hold trace.channels_balanced trace.spec_holds
         binding.mainTable_mem binding.mainTable_component h_mainRow_mem
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op

--- a/ZiskFv/Compliance/TraceLevelExport.lean
+++ b/ZiskFv/Compliance/TraceLevelExport.lean
@@ -50,7 +50,7 @@ that construction's genuinely-irreducible residual binders (decode pins, Sail
 reads, operand/lane bridges, the `execRow` ∀-binder + exec facts,
 `h_nextPC_matches`; for loads also `MemoryTimelineEvidence` + the Mem-AIR
 provider linkage).  It does NOT package the bucket-(a) op-bus provider-match
-evidence: that is derived INSIDE each construction from `trace.balanced` (via the
+evidence: that is derived INSIDE each construction from `trace.channels_balanced` (via the
 `exists_*_from_binding` Layer-A wrappers).
 
 ## Coverage (stated explicitly — NOT hidden)
@@ -390,7 +390,7 @@ noncomputable def loadMemMsg (memRow : ZiskFv.AirsClean.Mem.MemRow FGL) :
 /-- Irreducible per-row residuals for the `sub` archetype — the binders of
     `construction_sub_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sub
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   sub_input : PureSpec.SubInput
   r1 : regidx
   r2 : regidx
@@ -450,7 +450,7 @@ structure RowData_sub
 /-- Irreducible per-row residuals for the `and` archetype — the binders of
     `construction_and_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_and
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   and_input : PureSpec.AndInput
   r1 : regidx
   r2 : regidx
@@ -510,7 +510,7 @@ structure RowData_and
 /-- Irreducible per-row residuals for the `or` archetype — the binders of
     `construction_or_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_or
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   or_input : PureSpec.OrInput
   r1 : regidx
   r2 : regidx
@@ -570,7 +570,7 @@ structure RowData_or
 /-- Irreducible per-row residuals for the `xor` archetype — the binders of
     `construction_xor_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_xor
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   xor_input : PureSpec.XorInput
   r1 : regidx
   r2 : regidx
@@ -630,7 +630,7 @@ structure RowData_xor
 /-- Irreducible per-row residuals for the `slt` archetype — the binders of
     `construction_slt_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_slt
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   slt_input : PureSpec.SltInput
   r1 : regidx
   r2 : regidx
@@ -690,7 +690,7 @@ structure RowData_slt
 /-- Irreducible per-row residuals for the `sltu` archetype — the binders of
     `construction_sltu_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sltu
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   sltu_input : PureSpec.SltuInput
   r1 : regidx
   r2 : regidx
@@ -750,7 +750,7 @@ structure RowData_sltu
 /-- Irreducible per-row residuals for the `andi` archetype — the binders of
     `construction_andi_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_andi
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   andi_input : PureSpec.AndiInput
   r1 : regidx
   rd : regidx
@@ -801,7 +801,7 @@ structure RowData_andi
 /-- Irreducible per-row residuals for the `ori` archetype — the binders of
     `construction_ori_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_ori
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   ori_input : PureSpec.OriInput
   r1 : regidx
   rd : regidx
@@ -852,7 +852,7 @@ structure RowData_ori
 /-- Irreducible per-row residuals for the `xori` archetype — the binders of
     `construction_xori_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_xori
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   xori_input : PureSpec.XoriInput
   r1 : regidx
   rd : regidx
@@ -903,7 +903,7 @@ structure RowData_xori
 /-- Irreducible per-row residuals for the `slti` archetype — the binders of
     `construction_slti_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_slti
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   slti_input : PureSpec.SltiInput
   r1 : regidx
   rd : regidx
@@ -954,7 +954,7 @@ structure RowData_slti
 /-- Irreducible per-row residuals for the `sltiu` archetype — the binders of
     `construction_sltiu_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sltiu
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   sltiu_input : PureSpec.SltiuInput
   r1 : regidx
   rd : regidx
@@ -1005,7 +1005,7 @@ structure RowData_sltiu
 /-- Irreducible per-row residuals for the `sll` archetype — the binders of
     `construction_sll_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sll
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   sll_input : PureSpec.SllInput
   r1 : regidx
   r2 : regidx
@@ -1065,7 +1065,7 @@ structure RowData_sll
 /-- Irreducible per-row residuals for the `srl` archetype — the binders of
     `construction_srl_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_srl
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   srl_input : PureSpec.SrlInput
   r1 : regidx
   r2 : regidx
@@ -1125,7 +1125,7 @@ structure RowData_srl
 /-- Irreducible per-row residuals for the `sra` archetype — the binders of
     `construction_sra_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sra
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   sra_input : PureSpec.SraInput
   r1 : regidx
   r2 : regidx
@@ -1185,7 +1185,7 @@ structure RowData_sra
 /-- Irreducible per-row residuals for the `slli` archetype — the binders of
     `construction_slli_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_slli
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   slli_input : PureSpec.SlliInput
   r1 : regidx
   rd : regidx
@@ -1236,7 +1236,7 @@ structure RowData_slli
 /-- Irreducible per-row residuals for the `srli` archetype — the binders of
     `construction_srli_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_srli
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   srli_input : PureSpec.SrliInput
   r1 : regidx
   rd : regidx
@@ -1287,7 +1287,7 @@ structure RowData_srli
 /-- Irreducible per-row residuals for the `srai` archetype — the binders of
     `construction_srai_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_srai
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   srai_input : PureSpec.SraiInput
   r1 : regidx
   rd : regidx
@@ -1338,7 +1338,7 @@ structure RowData_srai
 /-- Irreducible per-row residuals for the `sllw` archetype — the binders of
     `construction_sllw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sllw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   sllw_input : PureSpec.SllwInput
   r1 : regidx
   r2 : regidx
@@ -1398,7 +1398,7 @@ structure RowData_sllw
 /-- Irreducible per-row residuals for the `srlw` archetype — the binders of
     `construction_srlw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_srlw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   srlw_input : PureSpec.SrlwInput
   r1 : regidx
   r2 : regidx
@@ -1458,7 +1458,7 @@ structure RowData_srlw
 /-- Irreducible per-row residuals for the `sraw` archetype — the binders of
     `construction_sraw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sraw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   sraw_input : PureSpec.SrawInput
   r1 : regidx
   r2 : regidx
@@ -1518,7 +1518,7 @@ structure RowData_sraw
 /-- Irreducible per-row residuals for the `slliw` archetype — the binders of
     `construction_slliw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_slliw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   slliw_input : PureSpec.SlliwInput
   r1 : regidx
   rd : regidx
@@ -1567,7 +1567,7 @@ structure RowData_slliw
 /-- Irreducible per-row residuals for the `srliw` archetype — the binders of
     `construction_srliw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_srliw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   srliw_input : PureSpec.SrliwInput
   r1 : regidx
   rd : regidx
@@ -1616,7 +1616,7 @@ structure RowData_srliw
 /-- Irreducible per-row residuals for the `sraiw` archetype — the binders of
     `construction_sraiw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sraiw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   sraiw_input : PureSpec.SraiwInput
   r1 : regidx
   rd : regidx
@@ -1665,7 +1665,7 @@ structure RowData_sraiw
 /-- Irreducible per-row residuals for the `add` archetype — the binders of
     `construction_add_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_add
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   add_input : PureSpec.AddInput
   r1 : regidx
   r2 : regidx
@@ -1725,7 +1725,7 @@ structure RowData_add
 /-- Irreducible per-row residuals for the `addi` archetype — the binders of
     `construction_addi_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_addi
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   addi_input : PureSpec.AddiInput
   r1 : regidx
   rd : regidx
@@ -1779,7 +1779,7 @@ structure RowData_addi
 /-- Irreducible per-row residuals for the `subw` archetype — the binders of
     `construction_subw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_subw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   subw_input : PureSpec.SubwInput
   r1 : regidx
   r2 : regidx
@@ -1839,7 +1839,7 @@ structure RowData_subw
 /-- Irreducible per-row residuals for the `addw` archetype — the binders of
     `construction_addw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_addw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   addw_input : PureSpec.AddwInput
   r1 : regidx
   r2 : regidx
@@ -1899,7 +1899,7 @@ structure RowData_addw
 /-- Irreducible per-row residuals for the `addiw` archetype — the binders of
     `construction_addiw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_addiw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   addiw_input : PureSpec.AddiwInput
   r1 : regidx
   rd : regidx
@@ -1950,7 +1950,7 @@ structure RowData_addiw
 /-- Irreducible per-row residuals for the `lui` archetype — the binders of
     `construction_lui_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_lui
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   lui_input : PureSpec.LuiInput
   imm : BitVec 20
   rd : regidx
@@ -1992,7 +1992,7 @@ structure RowData_lui
 /-- Irreducible per-row residuals for the `auipc` archetype — the binders of
     `construction_auipc_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_auipc
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   auipc_input : PureSpec.AuipcInput
   imm : BitVec 20
   rd : regidx
@@ -2041,7 +2041,7 @@ structure RowData_auipc
 /-- Irreducible per-row residuals for the `mulw` archetype — the binders of
     `construction_mulw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_mulw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   mulw_input : PureSpec.MulwInput
   r1 : regidx
   r2 : regidx
@@ -2132,7 +2132,7 @@ structure RowData_mulw
     contradictory `False`-binder.  Non-vacuous: a real trace with an honest signed
     MUL row supplies all binders. -/
 structure RowData_mul
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   mul_input : PureSpec.MulInput
   r1 : regidx
   r2 : regidx
@@ -2198,7 +2198,7 @@ structure RowData_mul
     Non-vacuous: a real trace with an honest signed MULH row supplies all
     binders (`h_not_forge` holds, `h_sign_*` are the true operand MSBs). -/
 structure RowData_mulh
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   mulh_input : PureSpec.MulhInput
   r1 : regidx
   r2 : regidx
@@ -2259,7 +2259,7 @@ structure RowData_mulh
     high half, op 179).  Mirror of `RowData_mulh` but the table pins `nb = 0`
     (op2 unsigned), so only ONE sign-range residual `h_sign_a` is carried. -/
 structure RowData_mulhsu
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   mulhsu_input : PureSpec.MulhsuInput
   r1 : regidx
   r2 : regidx
@@ -2341,7 +2341,7 @@ structure RowData_mulhsu
     Non-vacuous: a real trace with an honest signed DIV row supplies all binders
     (anti-vacuity witness `honest_div_witness_not_forge`). -/
 structure RowData_div
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   div_input : PureSpec.DivInput
   r1 : regidx
   r2 : regidx
@@ -2438,7 +2438,7 @@ structure RowData_div
     remainder lane (`opBus_row_ArithDivSecondary`).  Carries the narrowed honest
     shape `|r| ≠ |op2|`; the divisor-zero residual stays carried. -/
 structure RowData_rem
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   rem_input : PureSpec.RemInput
   r1 : regidx
   r2 : regidx
@@ -2527,7 +2527,7 @@ structure RowData_rem
     narrowed W honest shape excluding the nonzero-divisor `|r₃₂| = |op2₃₂|`
     false positive. -/
 structure RowData_divw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   divw_input : PureSpec.DivwInput
   r1 : regidx
   r2 : regidx
@@ -2632,7 +2632,7 @@ structure RowData_divw
     remainder (op `189`, `m32 = 1`, secondary ArithDiv lane).  W-mode analogue of
     `RowData_rem`; mirror of `RowData_divw` on the secondary (remainder) lane. -/
 structure RowData_remw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   remw_input : PureSpec.RemwInput
   r1 : regidx
   r2 : regidx
@@ -2733,7 +2733,7 @@ structure RowData_remw
 /-- Irreducible per-row residuals for the `mulhu` archetype — the binders of
     `construction_mulhu_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_mulhu
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   mulhu_input : PureSpec.MulhuInput
   r1 : regidx
   r2 : regidx
@@ -2788,7 +2788,7 @@ structure RowData_mulhu
 /-- Irreducible per-row residuals for the `divu` archetype — the binders of
     `construction_divu_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_divu
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   divu_input : PureSpec.DivuInput
   r1 : regidx
   r2 : regidx
@@ -2846,7 +2846,7 @@ structure RowData_divu
 /-- Irreducible per-row residuals for the `divuw` archetype — the binders of
     `construction_divuw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_divuw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   divuw_input : PureSpec.DivuwInput
   r1 : regidx
   r2 : regidx
@@ -2919,7 +2919,7 @@ structure RowData_divuw
 /-- Irreducible per-row residuals for the `remu` archetype — the binders of
     `construction_remu_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_remu
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   remu_input : PureSpec.RemuInput
   r1 : regidx
   r2 : regidx
@@ -2977,7 +2977,7 @@ structure RowData_remu
 /-- Irreducible per-row residuals for the `remuw` archetype — the binders of
     `construction_remuw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_remuw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   remuw_input : PureSpec.RemuwInput
   r1 : regidx
   r2 : regidx
@@ -3050,7 +3050,7 @@ structure RowData_remuw
 /-- Irreducible per-row residuals for the `sb` archetype — the binders of
     `construction_sb_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sb
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   sb_input : PureSpec.SbInput
   regs : ZiskFv.Compliance.ModeRegsFull
   h_main_active :
@@ -3103,7 +3103,7 @@ structure RowData_sb
 /-- Irreducible per-row residuals for the `sh` archetype — the binders of
     `construction_sh_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sh
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   sh_input : PureSpec.ShInput
   regs : ZiskFv.Compliance.ModeRegsFull
   h_main_active :
@@ -3154,7 +3154,7 @@ structure RowData_sh
 /-- Irreducible per-row residuals for the `sw` archetype — the binders of
     `construction_sw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   sw_input : PureSpec.SwInput
   regs : ZiskFv.Compliance.ModeRegsFull
   h_main_active :
@@ -3201,7 +3201,7 @@ structure RowData_sw
 /-- Irreducible per-row residuals for the `sd` archetype — the binders of
     `construction_sd_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sd
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   sd_input : PureSpec.SdInput
   regs : ZiskFv.Compliance.ModeRegsFull
   h_main_active :
@@ -3237,7 +3237,7 @@ structure RowData_sd
 /-- Irreducible per-row residuals for the `ld` archetype — the binders of
     `construction_ld_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_ld
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   ld_input : PureSpec.LdInput
   regs : ZiskFv.Compliance.ModeRegsFull
   mem : Valid_Mem FGL FGL
@@ -3286,7 +3286,7 @@ structure RowData_ld
 /-- Irreducible per-row residuals for the `lbu` archetype — the binders of
     `construction_lbu_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_lbu
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   lbu_input : PureSpec.LbuInput
   regs : ZiskFv.Compliance.ModeRegsFull
   mem : Valid_Mem FGL FGL
@@ -3338,7 +3338,7 @@ structure RowData_lbu
 /-- Irreducible per-row residuals for the `lhu` archetype — the binders of
     `construction_lhu_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_lhu
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   lhu_input : PureSpec.LhuInput
   regs : ZiskFv.Compliance.ModeRegsFull
   mem : Valid_Mem FGL FGL
@@ -3390,7 +3390,7 @@ structure RowData_lhu
 /-- Irreducible per-row residuals for the `lwu` archetype — the binders of
     `construction_lwu_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_lwu
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   lwu_input : PureSpec.LwuInput
   regs : ZiskFv.Compliance.ModeRegsFull
   mem : Valid_Mem FGL FGL
@@ -3442,7 +3442,7 @@ structure RowData_lwu
 /-- Irreducible per-row residuals for the `lb` archetype — the binders of
     `construction_lb_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_lb
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   lb_input : PureSpec.LbInput
   regs : ZiskFv.Compliance.ModeRegsFull
   mem : Valid_Mem FGL FGL
@@ -3502,7 +3502,7 @@ structure RowData_lb
 /-- Irreducible per-row residuals for the `lh` archetype — the binders of
     `construction_lh_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_lh
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   lh_input : PureSpec.LhInput
   regs : ZiskFv.Compliance.ModeRegsFull
   mem : Valid_Mem FGL FGL
@@ -3562,7 +3562,7 @@ structure RowData_lh
 /-- Irreducible per-row residuals for the `lw` archetype — the binders of
     `construction_lw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_lw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   lw_input : PureSpec.LwInput
   regs : ZiskFv.Compliance.ModeRegsFull
   mem : Valid_Mem FGL FGL
@@ -3622,7 +3622,7 @@ structure RowData_lw
 /-- Irreducible per-row residuals for the `beq` archetype — the binders of
     `construction_beq_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_beq
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   beq_input : PureSpec.BeqInput
   imm : BitVec 13
   r1 : regidx
@@ -3668,7 +3668,7 @@ structure RowData_beq
 /-- Irreducible per-row residuals for the `bne` archetype — the binders of
     `construction_bne_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_bne
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   bne_input : PureSpec.BneInput
   imm : BitVec 13
   r1 : regidx
@@ -3714,7 +3714,7 @@ structure RowData_bne
 /-- Irreducible per-row residuals for the `blt` archetype — the binders of
     `construction_blt_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_blt
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   blt_input : PureSpec.BltInput
   imm : BitVec 13
   r1 : regidx
@@ -3760,7 +3760,7 @@ structure RowData_blt
 /-- Irreducible per-row residuals for the `bge` archetype — the binders of
     `construction_bge_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_bge
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   bge_input : PureSpec.BgeInput
   imm : BitVec 13
   r1 : regidx
@@ -3806,7 +3806,7 @@ structure RowData_bge
 /-- Irreducible per-row residuals for the `bltu` archetype — the binders of
     `construction_bltu_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_bltu
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   bltu_input : PureSpec.BltuInput
   imm : BitVec 13
   r1 : regidx
@@ -3852,7 +3852,7 @@ structure RowData_bltu
 /-- Irreducible per-row residuals for the `bgeu` archetype — the binders of
     `construction_bgeu_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_bgeu
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   bgeu_input : PureSpec.BgeuInput
   imm : BitVec 13
   r1 : regidx
@@ -3898,7 +3898,7 @@ structure RowData_bgeu
 /-- Irreducible per-row residuals for the `jal` archetype — the binders of
     `construction_jal_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_jal
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   jal_input : PureSpec.JalInput
   imm : BitVec 21
   rd : regidx
@@ -3947,7 +3947,7 @@ structure RowData_jal
 /-- Irreducible per-row residuals for the `jalr` archetype — the binders of
     `construction_jalr_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_jalr
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   jalr_input : PureSpec.JalrInput
   imm : BitVec 12
   rs1 : regidx
@@ -4018,7 +4018,7 @@ structure RowData_jalr
     documents.  Non-vacuous: a real trace with a generic `fm=0,rs1=x0,rd=x0` FENCE
     row supplies all binders and proves the `NoKnownDefect` obligation. -/
 structure RowData_fence
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   fence_input : PureSpec.FenceInput
   fm : BitVec 4
   fenceP : BitVec 4
@@ -4054,7 +4054,7 @@ structure RowData_fence
     so the threaded `NoKnownDefect` obligation is the genuine `NoKnownDefect` of the
     exact env the proof feeds to `zisk_riscv_compliant_program_bus`. -/
 noncomputable def fenceEnvOf
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_fence trace binding i) :
     OpEnvelope (binding.stateAt i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable) i.val :=
@@ -4073,7 +4073,7 @@ noncomputable def fenceEnvOf
     exact env the proof feeds to `zisk_riscv_compliant_program_bus`.  (Mirrors
     `fenceEnvOf`: a specific-env obligation, SATISFIABLE for an honest row.) -/
 noncomputable def mulEnvOf
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_mul trace binding i) :
     OpEnvelope (binding.stateAt i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable) i.val :=
@@ -4094,7 +4094,7 @@ noncomputable def mulEnvOf
     is NON-VACUOUS (it is not discharged by a contradictory binder).  This lemma is
     the Lean-checked anti-vacuity guard for the strong-export MUL arm. -/
 theorem mul_noKnownDefect_of_rowData
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_mul trace binding i) :
     Defects.NoKnownDefect (mulEnvOf trace binding i d) := by
   intro id
@@ -4111,7 +4111,7 @@ theorem mul_noKnownDefect_of_rowData
     `mulEnvOf`: a specific-env obligation, SATISFIABLE for an honest signed MULH
     row.  Carries the SIGN-RANGE RESIDUAL `h_sign_a`/`h_sign_b`. -/
 noncomputable def mulhEnvOf
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_mulh trace binding i) :
     OpEnvelope (binding.stateAt i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable) i.val :=
@@ -4124,7 +4124,7 @@ noncomputable def mulhEnvOf
 /-- The `OpEnvelope.mulhsu` env CONSTRUCTED from a `RowData_mulhsu`.  Only ONE
     sign-range residual `h_sign_a` (op2 unsigned, table-pinned `nb = 0`). -/
 noncomputable def mulhsuEnvOf
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_mulhsu trace binding i) :
     OpEnvelope (binding.stateAt i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable) i.val :=
@@ -4139,7 +4139,7 @@ noncomputable def mulhsuEnvOf
     narrowed `MaliciousSignedMulWitnessShape` admits for op 181, so
     `NoKnownDefect (mulhEnvOf …)` is TRUE — the `.mulh` strong arm is NON-VACUOUS. -/
 theorem mulh_noKnownDefect_of_rowData
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_mulh trace binding i) :
     Defects.NoKnownDefect (mulhEnvOf trace binding i d) := by
   intro id
@@ -4155,7 +4155,7 @@ theorem mulh_noKnownDefect_of_rowData
 /-- Satisfiability witness for the threaded MULHSU obligation (companion of
     `mulh_noKnownDefect_of_rowData`). -/
 theorem mulhsu_noKnownDefect_of_rowData
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_mulhsu trace binding i) :
     Defects.NoKnownDefect (mulhsuEnvOf trace binding i d) := by
   intro id
@@ -4175,7 +4175,7 @@ theorem mulhsu_noKnownDefect_of_rowData
     `mulEnvOf`: a specific-env obligation, SATISFIABLE for an honest signed DIV
     row whose `|r| ≠ |op2|`.) -/
 noncomputable def divEnvOf
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_div trace binding i) :
     OpEnvelope (binding.stateAt i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable) i.val :=
@@ -4187,7 +4187,7 @@ noncomputable def divEnvOf
 
 /-- The `OpEnvelope.rem` env CONSTRUCTED from a `RowData_rem` (secondary lane). -/
 noncomputable def remEnvOf
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_rem trace binding i) :
     OpEnvelope (binding.stateAt i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable) i.val :=
@@ -4199,7 +4199,7 @@ noncomputable def remEnvOf
 
 /-- The `OpEnvelope.divw` env CONSTRUCTED from a `RowData_divw` (W-mode primary). -/
 noncomputable def divwEnvOf
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_divw trace binding i) :
     OpEnvelope (binding.stateAt i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable) i.val :=
@@ -4212,7 +4212,7 @@ noncomputable def divwEnvOf
 
 /-- The `OpEnvelope.remw` env CONSTRUCTED from a `RowData_remw` (W-mode secondary). -/
 noncomputable def remwEnvOf
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_remw trace binding i) :
     OpEnvelope (binding.stateAt i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program binding.mainTable) i.val :=
@@ -4235,7 +4235,7 @@ noncomputable def remwEnvOf
     including divisor-zero rows handled by the boundary constraints.  This is the
     Lean-checked anti-vacuity guard for the strong-export DIV arm. -/
 theorem div_noKnownDefect_of_rowData
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_div trace binding i) :
     Defects.NoKnownDefect (divEnvOf trace binding i d) := by
   intro id
@@ -4251,7 +4251,7 @@ theorem div_noKnownDefect_of_rowData
 /-- Satisfiability witness for the threaded REM obligation (companion of
     `div_noKnownDefect_of_rowData`; secondary remainder lane). -/
 theorem rem_noKnownDefect_of_rowData
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_rem trace binding i) :
     Defects.NoKnownDefect (remEnvOf trace binding i d) := by
   intro id
@@ -4269,7 +4269,7 @@ theorem rem_noKnownDefect_of_rowData
 /-- Satisfiability witness for the threaded DIVW obligation (W-mode analogue of
     `div_noKnownDefect_of_rowData`; narrowed shape `|r₃₂| ≠ |op2₃₂|`). -/
 theorem divw_noKnownDefect_of_rowData
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_divw trace binding i) :
     Defects.NoKnownDefect (divwEnvOf trace binding i d) := by
   intro id
@@ -4285,7 +4285,7 @@ theorem divw_noKnownDefect_of_rowData
 /-- Satisfiability witness for the threaded REMW obligation (companion of
     `divw_noKnownDefect_of_rowData`; W-mode secondary remainder lane). -/
 theorem remw_noKnownDefect_of_rowData
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_remw trace binding i) :
     Defects.NoKnownDefect (remwEnvOf trace binding i d) := by
   intro id
@@ -4325,7 +4325,7 @@ no `False.elim` or contradictory pair is used.
     derivations) and invoking `zisk_riscv_compliant_program_bus`. Dominates the
     `bus_effect`-form `StepCompliance.sub`. -/
 theorem stepStrong_sub
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_sub trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -4461,7 +4461,7 @@ theorem stepStrong_sub
     derivations) and invoking `zisk_riscv_compliant_program_bus`. Dominates the
     `bus_effect`-form `StepCompliance.and`. -/
 theorem stepStrong_and
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_and trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -4597,7 +4597,7 @@ theorem stepStrong_and
     derivations) and invoking `zisk_riscv_compliant_program_bus`. Dominates the
     `bus_effect`-form `StepCompliance.or`. -/
 theorem stepStrong_or
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_or trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -4733,7 +4733,7 @@ theorem stepStrong_or
     derivations) and invoking `zisk_riscv_compliant_program_bus`. Dominates the
     `bus_effect`-form `StepCompliance.xor`. -/
 theorem stepStrong_xor
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_xor trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -4870,7 +4870,7 @@ theorem stepStrong_xor
     derivations) and invoking `zisk_riscv_compliant_program_bus`. Dominates the
     `bus_effect`-form `StepCompliance.slt`. -/
 theorem stepStrong_slt
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_slt trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -5006,7 +5006,7 @@ theorem stepStrong_slt
     derivations) and invoking `zisk_riscv_compliant_program_bus`. Dominates the
     `bus_effect`-form `StepCompliance.sltu`. -/
 theorem stepStrong_sltu
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_sltu trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -5141,7 +5141,7 @@ theorem stepStrong_sltu
     `OpEnvelope.andi` + `zisk_riscv_compliant_program_bus`. Dominates
     `StepCompliance.andi`. -/
 theorem stepStrong_andi
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_andi trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -5276,7 +5276,7 @@ theorem stepStrong_andi
     `OpEnvelope.ori` + `zisk_riscv_compliant_program_bus`. Dominates
     `StepCompliance.ori`. -/
 theorem stepStrong_ori
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_ori trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -5411,7 +5411,7 @@ theorem stepStrong_ori
     `OpEnvelope.xori` + `zisk_riscv_compliant_program_bus`. Dominates
     `StepCompliance.xori`. -/
 theorem stepStrong_xori
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_xori trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -5544,7 +5544,7 @@ theorem stepStrong_xori
     `OpEnvelope.slti` + `zisk_riscv_compliant_program_bus`. Dominates
     `StepCompliance.slti`. -/
 theorem stepStrong_slti
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_slti trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -5672,7 +5672,7 @@ theorem stepStrong_slti
     `OpEnvelope.sltiu` + `zisk_riscv_compliant_program_bus`. Dominates
     `StepCompliance.sltiu`. -/
 theorem stepStrong_sltiu
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_sltiu trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -5801,7 +5801,7 @@ theorem stepStrong_sltiu
 /-- Strengthened `sll` step: channel-balance via constructed `OpEnvelope.sll`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.sll`. -/
 theorem stepStrong_sll
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_sll trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -5900,7 +5900,7 @@ theorem stepStrong_sll
 /-- Strengthened `srl` step: channel-balance via constructed `OpEnvelope.srl`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.srl`. -/
 theorem stepStrong_srl
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_srl trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -5999,7 +5999,7 @@ theorem stepStrong_srl
 /-- Strengthened `sra` step: channel-balance via constructed `OpEnvelope.sra`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.sra`. -/
 theorem stepStrong_sra
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_sra trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -6098,7 +6098,7 @@ theorem stepStrong_sra
 /-- Strengthened `slli` step: channel-balance via constructed `OpEnvelope.slli`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.slli`. -/
 theorem stepStrong_slli
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_slli trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -6197,7 +6197,7 @@ theorem stepStrong_slli
 /-- Strengthened `srli` step: channel-balance via constructed `OpEnvelope.srli`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.srli`. -/
 theorem stepStrong_srli
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_srli trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -6296,7 +6296,7 @@ theorem stepStrong_srli
 /-- Strengthened `srai` step: channel-balance via constructed `OpEnvelope.srai`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.srai`. -/
 theorem stepStrong_srai
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_srai trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -6397,7 +6397,7 @@ theorem stepStrong_srai
 /-- Strengthened `subw` step: channel-balance via constructed `OpEnvelope.subw`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.subw`. -/
 theorem stepStrong_subw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_subw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -6527,7 +6527,7 @@ theorem stepStrong_subw
 /-- Strengthened `addw` step: channel-balance via constructed `OpEnvelope.addw`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.addw`. -/
 theorem stepStrong_addw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_addw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -6657,7 +6657,7 @@ theorem stepStrong_addw
 /-- Strengthened `addiw` step: channel-balance via constructed `OpEnvelope.addiw`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.addiw`. -/
 theorem stepStrong_addiw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_addiw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -6767,7 +6767,7 @@ theorem stepStrong_addiw
 
 OpEnvelope route, mirroring the base-shift arms (`stepStrong_sll` etc.) but on the
 m32 = 1 register/immediate W-shift route.  Each arm builds `OpEnvelope.<op>` from
-the trace's BinaryExtension shift provider row (derived from `trace.balanced`),
+the trace's BinaryExtension shift provider row (derived from `trace.channels_balanced`),
 invokes `zisk_riscv_compliant_program_bus`, and projects `exec_eq_remaining` (the
 12th conjunct).  The promise/provider plumbing is the m32 = 1 variant of the base
 shift (`shift_m32_1_*_of_facts`); the conclusion is the `RTYPEW`/`SHIFTIWOP`
@@ -6777,7 +6777,7 @@ real BinaryExtension Spec row from the committed trace. -/
 /-- Strengthened `sllw` step: channel-balance via constructed `OpEnvelope.sllw`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.sllw`. -/
 theorem stepStrong_sllw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_sllw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -6875,7 +6875,7 @@ theorem stepStrong_sllw
 /-- Strengthened `srlw` step: channel-balance via constructed `OpEnvelope.srlw`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.srlw`. -/
 theorem stepStrong_srlw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_srlw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -6973,7 +6973,7 @@ theorem stepStrong_srlw
 /-- Strengthened `sraw` step: channel-balance via constructed `OpEnvelope.sraw`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.sraw`. -/
 theorem stepStrong_sraw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_sraw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -7072,7 +7072,7 @@ theorem stepStrong_sraw
 /-- Strengthened `slliw` step: channel-balance via constructed `OpEnvelope.slliw`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.slliw`. -/
 theorem stepStrong_slliw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_slliw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -7166,7 +7166,7 @@ theorem stepStrong_slliw
 /-- Strengthened `srliw` step: channel-balance via constructed `OpEnvelope.srliw`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.srliw`. -/
 theorem stepStrong_srliw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_srliw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -7260,7 +7260,7 @@ theorem stepStrong_srliw
 /-- Strengthened `sraiw` step: channel-balance via constructed `OpEnvelope.sraiw`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.sraiw`. -/
 theorem stepStrong_sraiw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_sraiw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -7359,7 +7359,7 @@ theorem stepStrong_sraiw
     BinaryAdd provider) + `zisk_riscv_compliant_program_bus`. Dominates
     `StepCompliance.add`. -/
 theorem stepStrong_add
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_add trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -7511,7 +7511,7 @@ theorem stepStrong_add
     (`addi_via_binary` / `addi_via_binaryadd`) + `zisk_riscv_compliant_program_bus`.
     Dominates `StepCompliance.addi`. -/
 theorem stepStrong_addi
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_addi trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -7687,7 +7687,7 @@ the corresponding `bus_effect`-form arms (channel-balance form, same data). -/
     conjunct.  `aeneasBridgeTrust` is flat decode pins carried as `RowData_beq`
     residuals; `NoKnownDefect` comes from the threaded `h_known_arm`. -/
 theorem stepStrong_beq
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_beq trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -7728,7 +7728,7 @@ theorem stepStrong_beq
 
 /-- Strengthened `bne` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_bne
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_bne trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -7769,7 +7769,7 @@ theorem stepStrong_bne
 
 /-- Strengthened `blt` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_blt
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_blt trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -7810,7 +7810,7 @@ theorem stepStrong_blt
 
 /-- Strengthened `bge` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_bge
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_bge trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -7851,7 +7851,7 @@ theorem stepStrong_bge
 
 /-- Strengthened `bltu` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_bltu
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_bltu trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -7892,7 +7892,7 @@ theorem stepStrong_bltu
 
 /-- Strengthened `bgeu` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_bgeu
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_bgeu trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -7944,7 +7944,7 @@ theorem stepStrong_bgeu
     `⟨⟨provenance⟩, row_mode, h_imm_lo_nat, h_imm_hi_nat⟩`; `memoryTimeline`
     trivially; `NoKnownDefect` from the threaded `h_known_arm` (non-defect). -/
 theorem stepStrong_lui
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_lui trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -8032,7 +8032,7 @@ theorem stepStrong_lui
     `⟨⟨provenance⟩, row_mode, h_offset_bridge, h_pc_bridge⟩`; `NoKnownDefect` from
     the threaded `h_known_arm` (non-defect). -/
 theorem stepStrong_auipc
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_auipc trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -8120,7 +8120,7 @@ theorem stepStrong_auipc
     `⟨⟨provenance⟩, row_mode, h_jmp2, h_pc_bridge⟩`; `NoKnownDefect` from the
     threaded `h_known_arm` (non-defect). -/
 theorem stepStrong_jal
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_jal trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -8208,7 +8208,7 @@ theorem stepStrong_jal
     `NoKnownDefect`.  JALR's `aeneasBridgeTrust` is flat decode pins already in
     `RowData_jalr` (no `MainRowProvenance`). -/
 theorem stepStrong_jalr
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_jalr trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -8317,7 +8317,7 @@ private def emptyMainEnv : Environment FGL :=
 
 /-- Strengthened `sb` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_sb
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_sb trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -8383,7 +8383,7 @@ theorem stepStrong_sb
 
 /-- Strengthened `sh` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_sh
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_sh trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -8449,7 +8449,7 @@ theorem stepStrong_sh
 
 /-- Strengthened `sw` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_sw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_sw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -8515,7 +8515,7 @@ theorem stepStrong_sw
 
 /-- Strengthened `sd` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_sd
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_sd trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -8598,7 +8598,7 @@ records are real `Valid_Mem`/`Valid_BinaryExtension` rows. -/
 
 /-- Strengthened `ld` step (channel-balance form). -/
 theorem stepStrong_ld
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_ld trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -8676,7 +8676,7 @@ theorem stepStrong_ld
 
 /-- Strengthened `lbu` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_lbu
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_lbu trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -8754,7 +8754,7 @@ theorem stepStrong_lbu
 
 /-- Strengthened `lhu` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_lhu
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_lhu trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -8832,7 +8832,7 @@ theorem stepStrong_lhu
 
 /-- Strengthened `lwu` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_lwu
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_lwu trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -8910,7 +8910,7 @@ theorem stepStrong_lwu
 
 /-- Strengthened `lb` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_lb
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_lb trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -8989,7 +8989,7 @@ theorem stepStrong_lb
 
 /-- Strengthened `lh` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_lh
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_lh trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -9068,7 +9068,7 @@ theorem stepStrong_lh
 
 /-- Strengthened `lw` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_lw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_lw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -9174,7 +9174,7 @@ the real `busSub` row.  These are strictly stronger than the corresponding
     pins carried as `RowData_mulw` residuals (`m32 = 1` for W-mode); `NoKnownDefect`
     comes from the threaded `h_known_arm`.  Non-vacuous (real provider FullSpec). -/
 theorem stepStrong_mulw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_mulw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -9277,10 +9277,10 @@ theorem stepStrong_mulw
     `NoKnownDefect` comes from the threaded `h_known_arm`.
 
     Non-vacuous: the envelope's witnesses are the REAL provider row's FullSpec
-    projections derived from `trace.balanced` / `trace.spec`, not a fabricated
+    projections derived from `trace.channels_balanced` / `trace.spec_holds`, not a fabricated
     environment; `execRow` remains a genuine ∀-binder. -/
 theorem stepStrong_mulhu
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_mulhu trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -9392,7 +9392,7 @@ theorem stepStrong_mulhu
     `NoKnownDefect` comes from the threaded `h_known_arm`.  Non-vacuous (real
     provider FullSpec; the witnesses' substance is the balance-derived facts). -/
 theorem stepStrong_divu
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_divu trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -9500,7 +9500,7 @@ theorem stepStrong_divu
     (`equiv_DIVUW`).  Adds the W-mode residuals `h_b23`/`h_c23`/`h_sext_choice`
     carried by `RowData_divuw`.  Non-vacuous (real provider FullSpec). -/
 theorem stepStrong_divuw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_divuw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -9603,7 +9603,7 @@ theorem stepStrong_divuw
     secondary d-lane (`opBus_row_ArithDivSecondary`, REMU mode `main_div = 0`).
     Non-vacuous (real provider FullSpec; witnesses' substance is balance-derived). -/
 theorem stepStrong_remu
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_remu trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -9705,7 +9705,7 @@ theorem stepStrong_remu
     (`m32 = 1`), secondary d-lane match (`opBus_row_ArithDivSecondary`), routing
     to the `exec_eq_remaining` conjunct (`equiv_REMUW`).  Non-vacuous. -/
 theorem stepStrong_remuw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_remuw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -9822,7 +9822,7 @@ theorem stepStrong_remuw
     the two exceptional product-sign shapes the ArithTable admits for op 180, so an
     honest signed MUL row supplies all binders. -/
 theorem stepStrong_mul
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_mul trace binding i)
     (h_known : Defects.NoKnownDefect (mulEnvOf trace binding i d)) :
     (do
@@ -9855,7 +9855,7 @@ theorem stepStrong_mul
     consumes the documented SIGN-RANGE RESIDUAL `h_sign_a`/`h_sign_b` carried by
     `RowData_mulh`.  Non-vacuous. -/
 theorem stepStrong_mulh
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_mulh trace binding i)
     (h_known : Defects.NoKnownDefect (mulhEnvOf trace binding i d)) :
     (do
@@ -9881,7 +9881,7 @@ theorem stepStrong_mulh
     Companion of `stepStrong_mulh` for the signed × unsigned high multiply
     (op 179).  Carries ONE sign-range residual `h_sign_a` (op2 unsigned). -/
 theorem stepStrong_mulhsu
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_mulhsu trace binding i)
     (h_known : Defects.NoKnownDefect (mulhsuEnvOf trace binding i d)) :
     (do
@@ -9924,7 +9924,7 @@ theorem stepStrong_mulhsu
     forge (codygunton/zisk#5), and divisor-zero rows are handled by
     `h_boundary`; signed overflow is handled by the signed DIV bridge. -/
 theorem stepStrong_div
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_div trace binding i)
     (h_known : Defects.NoKnownDefect (divEnvOf trace binding i d)) :
     (do
@@ -9947,7 +9947,7 @@ theorem stepStrong_div
     `h_known` is the GENUINE `NoKnownDefect (remEnvOf …)`, SATISFIABLE for an honest
     signed REM row (`RowData_rem.h_not_forge`).  Non-vacuous. -/
 theorem stepStrong_rem
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_rem trace binding i)
     (h_known : Defects.NoKnownDefect (remEnvOf trace binding i d)) :
     (do
@@ -9971,7 +9971,7 @@ theorem stepStrong_rem
     `NoKnownDefect (divwEnvOf …)`, SATISFIABLE for an honest signed DIVW row
     (`RowData_divw.h_not_forge`, `|r₃₂| ≠ |op2₃₂|`).  Non-vacuous. -/
 theorem stepStrong_divw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_divw trace binding i)
     (h_known : Defects.NoKnownDefect (divwEnvOf trace binding i d)) :
     (do
@@ -9992,7 +9992,7 @@ theorem stepStrong_divw
     W-mode analogue of `stepStrong_rem` (signed 32-bit remainder, op `189`,
     `m32 = 1`, secondary lane).  Non-vacuous (`RowData_remw.h_not_forge`). -/
 theorem stepStrong_remw
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_remw trace binding i)
     (h_known : Defects.NoKnownDefect (remwEnvOf trace binding i d)) :
     (do
@@ -10026,7 +10026,7 @@ theorem stepStrong_remw
     proves it.  Non-vacuous: the malicious FENCE shapes are excluded exactly by the
     honest-shape pins the caller supplies, as the FENCE defect ledger documents. -/
 theorem stepStrong_fence
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : RowData_fence trace binding i)
     (h_known : Defects.NoKnownDefect (fenceEnvOf trace binding i d)) :
     execute_instruction (instruction.FENCE (d.fm, d.fenceP, d.fenceS, d.rs, d.rd)) (binding.stateAt i)
@@ -10050,7 +10050,7 @@ theorem stepStrong_fence
     the exact forge witness (so honest rows are never excluded).  No arm is omitted —
     the export is 63/63 on the OpEnvelope route. -/
 inductive StrongRowConstructionData
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) where
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) where
   | sub (d : RowData_sub trace binding i) : StrongRowConstructionData trace binding i
   | and (d : RowData_and trace binding i) : StrongRowConstructionData trace binding i
   | or (d : RowData_or trace binding i) : StrongRowConstructionData trace binding i
@@ -10130,7 +10130,7 @@ inductive StrongRowConstructionData
     obligation is SATISFIABLE for an honest FENCE row (see `RowData_fence` /
     `stepStrong_fence`). -/
 def StepNoKnownDefect
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) :
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) :
     StrongRowConstructionData trace binding i → Prop
   | .sub _ => EnvNoKnownDefectFor
       (state := binding.stateAt i)
@@ -10375,7 +10375,7 @@ def StepNoKnownDefect
     (`state_effect_via_channels`) form — the OLD global theorem's per-arm
     conclusion — keyed on the row archetype. -/
 def StepComplianceStrong
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length) :
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions) :
     StrongRowConstructionData trace binding i → Prop
   | .sub d =>
       (do
@@ -10856,7 +10856,7 @@ def StepComplianceStrong
     `zisk_riscv_compliant_program_bus`.  For the direct-lift arms (which never call
     the old theorem) the obligation is `True` and is ignored. -/
 theorem stepComplianceStrong_of_rowData
-    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.length)
+    (trace : AcceptedTrace) (binding : ProgramBinding trace) (i : Fin trace.numInstructions)
     (d : StrongRowConstructionData trace binding i)
     (h_known : StepNoKnownDefect trace binding i d) :
     StepComplianceStrong trace binding i d := by

--- a/ZiskFv/Soundness.lean
+++ b/ZiskFv/Soundness.lean
@@ -21,9 +21,9 @@ namespace ZiskFv.Compliance
 theorem root_soundness
     (trace : AcceptedTrace)
     (binding : ProgramBinding trace)
-    (rowData : ∀ i : Fin trace.length, StrongRowConstructionData trace binding i)
-    (h_known_bugs : ∀ i : Fin trace.length, StepNoKnownDefect trace binding i (rowData i)) :
-    ∀ i : Fin trace.length, StepComplianceStrong trace binding i (rowData i) :=
+    (rowData : ∀ i : Fin trace.numInstructions, StrongRowConstructionData trace binding i)
+    (h_known_bugs : ∀ i : Fin trace.numInstructions, StepNoKnownDefect trace binding i (rowData i)) :
+    ∀ i : Fin trace.numInstructions, StepComplianceStrong trace binding i (rowData i) :=
   fun i => stepComplianceStrong_of_rowData trace binding i (rowData i) (h_known_bugs i)
 
 end ZiskFv.Compliance

--- a/ZiskFv/Soundness.lean
+++ b/ZiskFv/Soundness.lean
@@ -4,13 +4,26 @@ import ZiskFv.Compliance.TraceLevelExport
 # Root soundness
 
 The headline soundness statement of the project, factored out of the
-trace-level export development for visibility.  It sits parallel to
+trace-level export development for visibility. It sits parallel to
 `ZiskFv.Compliance` and re-exports the single endpoint theorem.
 -/
 
 namespace ZiskFv.Compliance
 
-/-- **Root soundness — trace-level export (#61).**
+/-- ** The top-level global soundness theorem: given a satisfying assignment of circuits
+    that does not involve any explicitly enumerated bugs, the zisk machine state transition
+    agrees with the Sail machine state transition.
+
+    An AcceptedTrace is a set of constraints, and a witness that satisfies those constraints and the
+    channel balancing constraint enfoced in the proving system through a lookup argument.
+
+    A ProgramBinding is a choice of which table in the witness is the Main execution table, together
+    with the sequence of Sail machine states the program steps through and the facts that pin that
+    table into the witness : that it really occurs in it, that it really is the Main component, and
+    that it has one row per instruction.
+
+    rowData is the assumption that, for each instruction, ZisK's inputs match the Sail model's
+    inputs — same opcode, same operand and PC values.
 
     From an accepted full-ensemble trace, a program binding, a per-row
     classification of all 63 RV64IM archetypes, and a per-row defect-exclusion

--- a/trust/generated/baseline-construction-theorem-binders.txt
+++ b/trust/generated/baseline-construction-theorem-binders.txt
@@ -1,16 +1,16 @@
 # ZiskFv.Compliance.construction_sub_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 sub_input :: PureSpec.SubInput
 r1 :: regidx
 r2 :: regidx
@@ -35,18 +35,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq sub_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_and_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 and_input :: PureSpec.AndInput
 r1 :: regidx
 r2 :: regidx
@@ -71,18 +71,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq and_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_or_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 or_input :: PureSpec.OrInput
 r1 :: regidx
 r2 :: regidx
@@ -107,18 +107,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq or_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_xor_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 xor_input :: PureSpec.XorInput
 r1 :: regidx
 r2 :: regidx
@@ -143,18 +143,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq xor_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_slt_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 slt_input :: PureSpec.SltInput
 r1 :: regidx
 r2 :: regidx
@@ -179,18 +179,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq slt_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_sltu_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 sltu_input :: PureSpec.SltuInput
 r1 :: regidx
 r2 :: regidx
@@ -215,18 +215,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq sltu_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_andi_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 andi_input :: PureSpec.AndiInput
 r1 :: regidx
 rd :: regidx
@@ -250,18 +250,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq andi_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_ori_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 ori_input :: PureSpec.OriInput
 r1 :: regidx
 rd :: regidx
@@ -285,18 +285,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq ori_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_xori_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 xori_input :: PureSpec.XoriInput
 r1 :: regidx
 rd :: regidx
@@ -320,18 +320,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq xori_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_slti_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 slti_input :: PureSpec.SltiInput
 r1 :: regidx
 rd :: regidx
@@ -355,18 +355,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq slti_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_sltiu_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 sltiu_input :: PureSpec.SltiuInput
 r1 :: regidx
 rd :: regidx
@@ -390,18 +390,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq sltiu_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_sll_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 sll_input :: PureSpec.SllInput
 r1 :: regidx
 r2 :: regidx
@@ -426,18 +426,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq sll_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_srl_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 srl_input :: PureSpec.SrlInput
 r1 :: regidx
 r2 :: regidx
@@ -462,18 +462,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq srl_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_sra_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 sra_input :: PureSpec.SraInput
 r1 :: regidx
 r2 :: regidx
@@ -498,18 +498,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq sra_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_slli_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 slli_input :: PureSpec.SlliInput
 r1 :: regidx
 rd :: regidx
@@ -533,18 +533,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq slli_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_srli_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 srli_input :: PureSpec.SrliInput
 r1 :: regidx
 rd :: regidx
@@ -568,18 +568,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq srli_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_srai_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 srai_input :: PureSpec.SraiInput
 r1 :: regidx
 rd :: regidx
@@ -603,18 +603,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq srai_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_sllw_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 sllw_input :: PureSpec.SllwInput
 r1 :: regidx
 r2 :: regidx
@@ -639,18 +639,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq sllw_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_srlw_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 srlw_input :: PureSpec.SrlwInput
 r1 :: regidx
 r2 :: regidx
@@ -675,18 +675,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq srlw_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_sraw_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 sraw_input :: PureSpec.SrawInput
 r1 :: regidx
 r2 :: regidx
@@ -711,18 +711,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq sraw_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_slliw_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 slliw_input :: PureSpec.SlliwInput
 r1 :: regidx
 rd :: regidx
@@ -744,18 +744,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq slliw_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_srliw_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 srliw_input :: PureSpec.SrliwInput
 r1 :: regidx
 rd :: regidx
@@ -777,18 +777,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq srliw_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_sraiw_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 sraiw_input :: PureSpec.SraiwInput
 r1 :: regidx
 rd :: regidx
@@ -810,18 +810,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq sraiw_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_add_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 add_input :: PureSpec.AddInput
 r1 :: regidx
 r2 :: regidx
@@ -846,18 +846,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq add_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_addi_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 addi_input :: PureSpec.AddiInput
 r1 :: regidx
 rd :: regidx
@@ -882,18 +882,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq addi_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_subw_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 subw_input :: PureSpec.SubwInput
 r1 :: regidx
 r2 :: regidx
@@ -918,18 +918,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq subw_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_addw_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 addw_input :: PureSpec.AddwInput
 r1 :: regidx
 r2 :: regidx
@@ -954,18 +954,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq addw_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_addiw_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 addiw_input :: PureSpec.AddiwInput
 r1 :: regidx
 rd :: regidx
@@ -989,18 +989,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq addiw_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.busSub trace binding i execRow).e2.ptr)
 
 # ZiskFv.Compliance.construction_lui_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 lui_input :: PureSpec.LuiInput
 imm :: BitVec 20
 rd :: regidx
@@ -1022,18 +1022,18 @@ h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.ge
 h_rd_idx :: Eq lui_input.rd (Transpiler.wrap_to_regidx (ZiskFv.Compliance.eRdLui trace binding i).ptr)
 
 # ZiskFv.Compliance.construction_auipc_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 auipc_input :: PureSpec.AuipcInput
 imm :: BitVec 20
 rd :: regidx
@@ -1057,18 +1057,18 @@ h_no_wrap :: instLTNat.lt (instHAdd.hAdd auipc_input.PC.toNat (BitVec.signExtend
 h_pc_offset_lt_2_32 :: instLTNat.lt (instHAdd.hAdd auipc_input.PC (BitVec.signExtend 64 (BitVec.instHAppendHAddNat.hAppend auipc_input.imm 0))).toNat 4294967296
 
 # ZiskFv.Compliance.construction_mulw_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 mulw_input :: PureSpec.MulwInput
 r1 :: regidx
 r2 :: regidx
@@ -1093,18 +1093,18 @@ h_rs1_value :: Eq (Sail.BitVec.extractLsb mulw_input.r1_val 31 0).toInt (instHSu
 h_rs2_value :: Eq (Sail.BitVec.extractLsb mulw_input.r2_val 31 0).toInt (instHSub.hSub (instHAdd.hAdd ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).b_0 0).val.cast (instHMul.hMul ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).b_1 0).val.cast 65536)) (instHMul.hMul ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulwArow trace binding i h_main_active h_main_op)).nb 0).val.cast (instHPow.hPow 2 32)))
 
 # ZiskFv.Compliance.construction_mulhu_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 mulhu_input :: PureSpec.MulhuInput
 r1 :: regidx
 r2 :: regidx
@@ -1134,18 +1134,18 @@ h_rs1_value :: Eq mulhu_input.r1_val.toNat (ZiskFv.PackedBitVec.MulNoWrap.packed
 h_rs2_value :: Eq mulhu_input.r2_val.toNat (ZiskFv.PackedBitVec.MulNoWrap.packed4 ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulhuArow trace binding i h_main_active h_main_op)).b_0 0).val ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulhuArow trace binding i h_main_active h_main_op)).b_1 0).val ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulhuArow trace binding i h_main_active h_main_op)).b_2 0).val ((ZiskFv.Compliance.vOfMulwRow (ZiskFv.Compliance.mulhuArow trace binding i h_main_active h_main_op)).b_3 0).val)
 
 # ZiskFv.Compliance.construction_divu_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 divu_input :: PureSpec.DivuInput
 r1 :: regidx
 r2 :: regidx
@@ -1254,18 +1254,18 @@ h_rs1_value :: Eq divu_input.r1_val.toNat (ZiskFv.PackedBitVec.MulNoWrap.packed4
 h_rs2_value :: Eq divu_input.r2_val.toNat (ZiskFv.PackedBitVec.MulNoWrap.packed4 (ZiskFv.Compliance.divuArow trace binding i h_main_active h_main_op).chunks.b_0.val (ZiskFv.Compliance.divuArow trace binding i h_main_active h_main_op).chunks.b_1.val (ZiskFv.Compliance.divuArow trace binding i h_main_active h_main_op).chunks.b_2.val (ZiskFv.Compliance.divuArow trace binding i h_main_active h_main_op).chunks.b_3.val)
 
 # ZiskFv.Compliance.construction_divuw_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 divuw_input :: PureSpec.DivuwInput
 r1 :: regidx
 r2 :: regidx
@@ -1377,18 +1377,18 @@ h_rs1_value :: Eq (Sail.BitVec.extractLsb divuw_input.r1_val 31 0).toNat (instHA
 h_rs2_value :: Eq (Sail.BitVec.extractLsb divuw_input.r2_val 31 0).toNat (instHAdd.hAdd (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op).chunks.b_0.val (instHMul.hMul (ZiskFv.Compliance.divuwArow trace binding i h_main_active h_main_op).chunks.b_1.val 65536))
 
 # ZiskFv.Compliance.construction_remu_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 remu_input :: PureSpec.RemuInput
 r1 :: regidx
 r2 :: regidx
@@ -1497,18 +1497,18 @@ h_rs1_value :: Eq remu_input.r1_val.toNat (ZiskFv.PackedBitVec.MulNoWrap.packed4
 h_rs2_value :: Eq remu_input.r2_val.toNat (ZiskFv.PackedBitVec.MulNoWrap.packed4 (ZiskFv.Compliance.remuArow trace binding i h_main_active h_main_op).chunks.b_0.val (ZiskFv.Compliance.remuArow trace binding i h_main_active h_main_op).chunks.b_1.val (ZiskFv.Compliance.remuArow trace binding i h_main_active h_main_op).chunks.b_2.val (ZiskFv.Compliance.remuArow trace binding i h_main_active h_main_op).chunks.b_3.val)
 
 # ZiskFv.Compliance.construction_remuw_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 remuw_input :: PureSpec.RemuwInput
 r1 :: regidx
 r2 :: regidx
@@ -1620,18 +1620,18 @@ h_rs1_value :: Eq (Sail.BitVec.extractLsb remuw_input.r1_val 31 0).toNat (instHA
 h_rs2_value :: Eq (Sail.BitVec.extractLsb remuw_input.r2_val 31 0).toNat (instHAdd.hAdd (ZiskFv.Compliance.remuwArow trace binding i h_main_active h_main_op).chunks.b_0.val (instHMul.hMul (ZiskFv.Compliance.remuwArow trace binding i h_main_active h_main_op).chunks.b_1.val 65536))
 
 # ZiskFv.Compliance.construction_sb_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 sb_input :: PureSpec.SbInput
 regs.mstatus :: RegisterType Register.mstatus
 regs.pmaRegion :: PMA_Region
@@ -1660,18 +1660,18 @@ h_m6 :: Eq (Std.ExtHashMap.instGetElem?Mem.getElem? (binding.stateAt i).mem (ins
 h_m7 :: Eq (Std.ExtHashMap.instGetElem?Mem.getElem? (binding.stateAt i).mem (instHAdd.hAdd (ZiskFv.Compliance.busSt trace binding i execRow).e2.ptr.toNat 7)) (Option.some { toFin := ⟨instHMod.hMod (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSt trace binding i execRow).e2 7).val 256, ⋯⟩ })
 
 # ZiskFv.Compliance.construction_sh_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 sh_input :: PureSpec.ShInput
 regs.mstatus :: RegisterType Register.mstatus
 regs.pmaRegion :: PMA_Region
@@ -1699,18 +1699,18 @@ h_m6 :: Eq (Std.ExtHashMap.instGetElem?Mem.getElem? (binding.stateAt i).mem (ins
 h_m7 :: Eq (Std.ExtHashMap.instGetElem?Mem.getElem? (binding.stateAt i).mem (instHAdd.hAdd (ZiskFv.Compliance.busSt trace binding i execRow).e2.ptr.toNat 7)) (Option.some { toFin := ⟨instHMod.hMod (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSt trace binding i execRow).e2 7).val 256, ⋯⟩ })
 
 # ZiskFv.Compliance.construction_sw_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 sw_input :: PureSpec.SwInput
 regs.mstatus :: RegisterType Register.mstatus
 regs.pmaRegion :: PMA_Region
@@ -1736,18 +1736,18 @@ h_m6 :: Eq (Std.ExtHashMap.instGetElem?Mem.getElem? (binding.stateAt i).mem (ins
 h_m7 :: Eq (Std.ExtHashMap.instGetElem?Mem.getElem? (binding.stateAt i).mem (instHAdd.hAdd (ZiskFv.Compliance.busSt trace binding i execRow).e2.ptr.toNat 7)) (Option.some { toFin := ⟨instHMod.hMod (ZiskFv.Channels.MemoryBusBytes.byteAt (ZiskFv.Compliance.busSt trace binding i execRow).e2 7).val 256, ⋯⟩ })
 
 # ZiskFv.Compliance.construction_sd_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 sd_input :: PureSpec.SdInput
 regs.mstatus :: RegisterType Register.mstatus
 regs.pmaRegion :: PMA_Region
@@ -1768,18 +1768,18 @@ h_e1_mult :: Eq (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSt 
 h_nextPC_matches :: Eq (Eq.rec (BitVec.ofNat 64 (List.instGetElem?NatLtLength.getElem! (ZiskFv.Compliance.busSt trace binding i execRow).exec_row 1).pc.val) register_type_pc_equiv) (PureSpec.execute_STORED_pure sd_input).nextPC
 
 # ZiskFv.Compliance.construction_ld_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 ld_input :: PureSpec.LdInput
 regs.mstatus :: RegisterType Register.mstatus
 regs.pmaRegion :: PMA_Region
@@ -1828,18 +1828,18 @@ h_mem_sel :: Eq (mem.sel r_mem) 1
 h_mem_wr :: Eq (mem.wr r_mem) 0
 
 # ZiskFv.Compliance.construction_lbu_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 lbu_input :: PureSpec.LbuInput
 regs.mstatus :: RegisterType Register.mstatus
 regs.pmaRegion :: PMA_Region
@@ -1950,18 +1950,18 @@ h_mem_sel :: Eq (mem.sel r_mem) 1
 h_mem_wr :: Eq (mem.wr r_mem) 0
 
 # ZiskFv.Compliance.construction_lhu_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 lhu_input :: PureSpec.LhuInput
 regs.mstatus :: RegisterType Register.mstatus
 regs.pmaRegion :: PMA_Region
@@ -2072,18 +2072,18 @@ h_mem_sel :: Eq (mem.sel r_mem) 1
 h_mem_wr :: Eq (mem.wr r_mem) 0
 
 # ZiskFv.Compliance.construction_lwu_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 lwu_input :: PureSpec.LwuInput
 regs.mstatus :: RegisterType Register.mstatus
 regs.pmaRegion :: PMA_Region
@@ -2194,18 +2194,18 @@ h_mem_sel :: Eq (mem.sel r_mem) 1
 h_mem_wr :: Eq (mem.wr r_mem) 0
 
 # ZiskFv.Compliance.construction_lb_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 lb_input :: PureSpec.LbInput
 regs.mstatus :: RegisterType Register.mstatus
 regs.pmaRegion :: PMA_Region
@@ -2294,18 +2294,18 @@ h_mem_sel :: Eq (mem.sel r_mem) 1
 h_mem_wr :: Eq (mem.wr r_mem) 0
 
 # ZiskFv.Compliance.construction_lh_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 lh_input :: PureSpec.LhInput
 regs.mstatus :: RegisterType Register.mstatus
 regs.pmaRegion :: PMA_Region
@@ -2394,18 +2394,18 @@ h_mem_sel :: Eq (mem.sel r_mem) 1
 h_mem_wr :: Eq (mem.wr r_mem) 0
 
 # ZiskFv.Compliance.construction_lw_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 lw_input :: PureSpec.LwInput
 regs.mstatus :: RegisterType Register.mstatus
 regs.pmaRegion :: PMA_Region
@@ -2494,18 +2494,18 @@ h_mem_sel :: Eq (mem.sel r_mem) 1
 h_mem_wr :: Eq (mem.wr r_mem) 0
 
 # ZiskFv.Compliance.construction_beq_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 beq_input :: PureSpec.BeqInput
 imm :: BitVec 13
 r1 :: regidx
@@ -2526,18 +2526,18 @@ h_not_throws :: Eq (PureSpec.execute_BEQ_pure beq_input).throws Bool.false
 h_success :: Eq (PureSpec.execute_BEQ_pure beq_input).success Bool.true
 
 # ZiskFv.Compliance.construction_bne_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 bne_input :: PureSpec.BneInput
 imm :: BitVec 13
 r1 :: regidx
@@ -2558,18 +2558,18 @@ h_not_throws :: Eq (PureSpec.execute_BNE_pure bne_input).throws Bool.false
 h_success :: Eq (PureSpec.execute_BNE_pure bne_input).success Bool.true
 
 # ZiskFv.Compliance.construction_blt_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 blt_input :: PureSpec.BltInput
 imm :: BitVec 13
 r1 :: regidx
@@ -2590,18 +2590,18 @@ h_not_throws :: Eq (PureSpec.execute_BLT_pure blt_input).throws Bool.false
 h_success :: Eq (PureSpec.execute_BLT_pure blt_input).success Bool.true
 
 # ZiskFv.Compliance.construction_bge_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 bge_input :: PureSpec.BgeInput
 imm :: BitVec 13
 r1 :: regidx
@@ -2622,18 +2622,18 @@ h_not_throws :: Eq (PureSpec.execute_BGE_pure bge_input).throws Bool.false
 h_success :: Eq (PureSpec.execute_BGE_pure bge_input).success Bool.true
 
 # ZiskFv.Compliance.construction_bltu_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 bltu_input :: PureSpec.BltuInput
 imm :: BitVec 13
 r1 :: regidx
@@ -2654,18 +2654,18 @@ h_not_throws :: Eq (PureSpec.execute_BLTU_pure bltu_input).throws Bool.false
 h_success :: Eq (PureSpec.execute_BLTU_pure bltu_input).success Bool.true
 
 # ZiskFv.Compliance.construction_bgeu_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 bgeu_input :: PureSpec.BgeuInput
 imm :: BitVec 13
 r1 :: regidx
@@ -2686,18 +2686,18 @@ h_not_throws :: Eq (PureSpec.execute_BGEU_pure bgeu_input).throws Bool.false
 h_success :: Eq (PureSpec.execute_BGEU_pure bgeu_input).success Bool.true
 
 # ZiskFv.Compliance.construction_jal_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 jal_input :: PureSpec.JalInput
 imm :: BitVec 21
 rd :: regidx
@@ -2728,18 +2728,18 @@ h_pc_bound :: instLTNat.lt jal_input.PC.toNat (instHSub.hSub 1844674406941458432
 h_pc_offset_lt_2_32 :: instLTNat.lt (instHAdd.hAdd jal_input.PC (BitVec.ofNat 64 4)).toNat 4294967296
 
 # ZiskFv.Compliance.construction_jalr_sound_claimed_dead
-trace.length :: Nat
+trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
-trace.constraints :: trace.3.Constraints
-trace.spec :: trace.3.Spec
-trace.balanced :: trace.3.BalancedChannels
-binding.stateAt :: Fin trace.length → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+trace.constraints_hold :: trace.3.Constraints
+trace.spec_holds :: trace.3.Spec
+trace.channels_balanced :: trace.3.BalancedChannels
+binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
 binding.mainTable_mem :: List.instMembership.mem trace.witness.allTables binding.2
-binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.length trace.program)
-binding.mainTable_index :: ∀ (i : Fin trace.length), instLTNat.lt i.val binding.2.table.length
-i :: Fin trace.length
+binding.mainTable_component :: Eq binding.2.component (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.numInstructions trace.program)
+binding.mainTable_index :: ∀ (i : Fin trace.numInstructions), instLTNat.lt i.val binding.2.table.length
+i :: Fin trace.numInstructions
 jalr_input :: PureSpec.JalrInput
 imm :: BitVec 12
 rs1 :: regidx

--- a/trust/generated/baseline-construction-theorem-binders.txt
+++ b/trust/generated/baseline-construction-theorem-binders.txt
@@ -3,7 +3,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -39,7 +38,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -75,7 +73,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -111,7 +108,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -147,7 +143,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -183,7 +178,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -219,7 +213,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -254,7 +247,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -289,7 +281,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -324,7 +315,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -359,7 +349,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -394,7 +383,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -430,7 +418,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -466,7 +453,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -502,7 +488,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -537,7 +522,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -572,7 +556,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -607,7 +590,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -643,7 +625,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -679,7 +660,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -715,7 +695,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -748,7 +727,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -781,7 +759,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -814,7 +791,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -850,7 +826,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -886,7 +861,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -922,7 +896,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -958,7 +931,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -993,7 +965,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1026,7 +997,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1061,7 +1031,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1097,7 +1066,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1138,7 +1106,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1258,7 +1225,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1381,7 +1347,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1501,7 +1466,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1624,7 +1588,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1664,7 +1627,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1703,7 +1665,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1740,7 +1701,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1772,7 +1732,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1832,7 +1791,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1954,7 +1912,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2076,7 +2033,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2198,7 +2154,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2298,7 +2253,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2398,7 +2352,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2498,7 +2451,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2530,7 +2482,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2562,7 +2513,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2594,7 +2544,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2626,7 +2575,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2658,7 +2606,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2690,7 +2637,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2732,7 +2678,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)

--- a/trust/generated/baseline-strong-export-binders.txt
+++ b/trust/generated/baseline-strong-export-binders.txt
@@ -1,5 +1,5 @@
 0 :: trace :: ZiskFv.Compliance.AcceptedTrace
 1 :: binding :: ZiskFv.Compliance.ProgramBinding trace
-2 :: rowData :: (i : Fin trace.length) → ZiskFv.Compliance.StrongRowConstructionData trace binding i
-3 :: h_known_bugs :: ∀ (i : Fin trace.length), ZiskFv.Compliance.StepNoKnownDefect trace binding i (rowData i)
-4 :: i :: Fin trace.length
+2 :: rowData :: (i : Fin trace.numInstructions) → ZiskFv.Compliance.StrongRowConstructionData trace binding i
+3 :: h_known_bugs :: ∀ (i : Fin trace.numInstructions), ZiskFv.Compliance.StepNoKnownDefect trace binding i (rowData i)
+4 :: i :: Fin trace.numInstructions


### PR DESCRIPTION
Stacked on `top_down_clarity_00` (#122).

Scope: refactor of `ZiskFv/Compliance/AcceptedTrace.lean`. Starts with a rewrite of the module head comment to explain what an Air.Flat ensemble vs. its filled-in witness is, what the per-table `spec` field means, and that `balanced` is a *proposition* (channels balance / logUp), not a boolean. Further AcceptedTrace cleanup will accumulate here until the next boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)