### PR TITLE
Discharge spec_holds: derive witness.Spec from constraints + channel balance

### DIFF
--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -133,6 +133,7 @@ import ZiskFv.ZiskCircuit.MemTimeline.Linkage
 import ZiskFv.ZiskCircuit.MemTimeline.Spike
 import ZiskFv.Compliance.RowProvenance
 import ZiskFv.Compliance.AcceptedTrace
+import ZiskFv.Compliance.AcceptedTrace.Spec
 import ZiskFv.Compliance.ProgramBinding.Basic
 import ZiskFv.Compliance.ProgramBinding.Wrappers
 import ZiskFv.Compliance.ConstructionSub

--- a/ZiskFv/AirsClean/FullEnsemble.lean
+++ b/ZiskFv/AirsClean/FullEnsemble.lean
@@ -43,13 +43,13 @@ open ZiskFv.Channels.OperationBus (OpBusChannel)
 open ZiskFv.Channels.MemoryBus (MemBusChannel)
 open ZiskFv.AirsClean.ZiskInstructionRom (Program)
 
-/-- The currently migrated full Clean ensemble for the supported RV64IM
-    surface. It finishes the operation and memory channels and includes
-    lookup-aware Binary/BinaryExtension providers. Main is represented by
-    one row-coherent component exposing both operation-bus and memory-bus
-    interactions. -/
-def fullRv64imEnsemble (length : ℕ) (program : Program length) :
-    FormalEnsemble FGL unit :=
+/-- The sound channel-balanced backbone of the full RV64IM Clean ensemble:
+    every migrated component added as a table, with the operation and memory
+    channels finished. This is the `SoundEnsemble` from which both the formal
+    ensemble (`fullRv64imEnsemble`) and the table-soundness discharge
+    (`witness_spec_of_constraints`) are derived. -/
+def fullRv64imSoundEnsemble (length : ℕ) (program : Program length) :
+    SoundEnsemble FGL unit :=
   SoundEnsemble.empty FGL unit
     |>.addTable (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program)
         (by simp [circuit_norm,
@@ -123,16 +123,50 @@ def fullRv64imEnsemble (length : ℕ) (program : Program length) :
           ZiskFv.AirsClean.MemAlignReadByte.memAlignReadByteElaborated])
     |>.addFinishedChannel OpBusChannel.toRaw
     |>.addFinishedChannel MemBusChannel.toRaw
-    |>.toFormal (fun _ => True) (fun _ => True)
-        (by
-          intro _ _ table h_mem row _
-          have h := EnsembleWitness.mem_allTables_component_of_mem_allTables h_mem
-          clear h_mem
-          simp only [circuit_norm, Ensemble.allTables] at h
-          rcases h with
-            h | h | h | h | h | h | h | h | h | h | h <;>
-            (rw [h]
-             trivial))
-        (by intro _ _; trivial)
+
+/-- Per-table assumptions discharge for the full ensemble: each migrated
+    component's per-row `Assumptions` reduce to `True`, so the ensemble-level
+    `AssumptionsConsistency` (and hence `EnsembleWitness.Assumptions`) holds
+    against the trivial `fun _ => True` ensemble assumptions. -/
+theorem fullRv64imSoundEnsemble_assumptionsConsistency (length : ℕ) (program : Program length) :
+    (fullRv64imSoundEnsemble length program).AssumptionsConsistency (fun _ => True) := by
+  intro _ _ table h_mem row _
+  have h := EnsembleWitness.mem_allTables_component_of_mem_allTables h_mem
+  clear h_mem
+  simp only [fullRv64imSoundEnsemble, circuit_norm, Ensemble.allTables] at h
+  rcases h with
+    h | h | h | h | h | h | h | h | h | h | h <;>
+    (rw [h]
+     trivial)
+
+/-- The currently migrated full Clean ensemble for the supported RV64IM
+    surface. It finishes the operation and memory channels and includes
+    lookup-aware Binary/BinaryExtension providers. Main is represented by
+    one row-coherent component exposing both operation-bus and memory-bus
+    interactions. -/
+def fullRv64imEnsemble (length : ℕ) (program : Program length) :
+    FormalEnsemble FGL unit :=
+  (fullRv64imSoundEnsemble length program).toFormal (fun _ => True) (fun _ => True)
+    (fullRv64imSoundEnsemble_assumptionsConsistency length program)
+    (by intro _ _; trivial)
+
+/-- **Discharge of `EnsembleWitness.Spec` from constraints + channel balance.**
+
+    The full ensemble's table-soundness — `witness.Assumptions →
+    witness.Constraints → witness.BalancedChannels → witness.Spec` — follows
+    from `SoundEnsemble`'s sound finished channels (`tableSoundness_of_soundChannels`).
+    The per-table `Assumptions` obligation is the trivial `fun _ => True`
+    discharge above. Hence the spec each AIR encodes is *derived* from the
+    accepted constraints and balanced channels, not assumed. -/
+theorem witness_spec_of_constraints {length : ℕ} {program : Program length}
+    (w : EnsembleWitness (fullRv64imEnsemble length program).ensemble)
+    (hc : w.Constraints) (hb : w.BalancedChannels) : w.Spec := by
+  have h_sound : (fullRv64imSoundEnsemble length program).ensemble.TableSoundness :=
+    Ensemble.tableSoundness_of_soundChannels
+      ⟨(fullRv64imSoundEnsemble length program).finished,
+       (fullRv64imSoundEnsemble length program).finished_subset,
+       (fullRv64imSoundEnsemble length program).soundChannels⟩
+  exact h_sound w
+    (fullRv64imSoundEnsemble_assumptionsConsistency length program w trivial) hc hb
 
 end ZiskFv.AirsClean.FullEnsemble

--- a/ZiskFv/AirsClean/FullEnsemble/Balance.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance.lean
@@ -53,7 +53,7 @@ theorem component_mem_fullRv64im_cases
       ∨ component = ZiskFv.AirsClean.BinaryAdd.component
       ∨ component =
         ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program := by
-  simp [fullRv64imEnsemble, SoundEnsemble.toFormal, Ensemble.allTables,
+  simp [fullRv64imEnsemble, fullRv64imSoundEnsemble, SoundEnsemble.toFormal, Ensemble.allTables,
     SoundEnsemble.addTable_tables, SoundEnsemble.addFinishedChannel_tables]
     at h_mem
   rcases h_mem with
@@ -84,7 +84,7 @@ theorem exists_mem_table_of_fullRv64im_witness
   have h_component_mem :
       ZiskFv.AirsClean.Mem.componentWithDualMemBus ∈
         (fullRv64imEnsemble length program).ensemble.allTables := by
-    simp [fullRv64imEnsemble, SoundEnsemble.toFormal, Ensemble.allTables,
+    simp [fullRv64imEnsemble, fullRv64imSoundEnsemble, SoundEnsemble.toFormal, Ensemble.allTables,
       SoundEnsemble.addTable_tables, SoundEnsemble.addFinishedChannel_tables]
   have h_in_map :
       ZiskFv.AirsClean.Mem.componentWithDualMemBus ∈
@@ -106,7 +106,7 @@ theorem exists_main_table_of_fullRv64im_witness
   have h_component_mem :
       ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program ∈
         (fullRv64imEnsemble length program).ensemble.allTables := by
-    simp [fullRv64imEnsemble, SoundEnsemble.toFormal, Ensemble.allTables,
+    simp [fullRv64imEnsemble, fullRv64imSoundEnsemble, SoundEnsemble.toFormal, Ensemble.allTables,
       SoundEnsemble.addTable_tables, SoundEnsemble.addFinishedChannel_tables]
   have h_in_map :
       ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program ∈
@@ -127,7 +127,7 @@ theorem exists_binary_table_of_fullRv64im_witness
   have h_component_mem :
       ZiskFv.AirsClean.Binary.staticLookupComponent ∈
         (fullRv64imEnsemble length program).ensemble.allTables := by
-    simp [fullRv64imEnsemble, SoundEnsemble.toFormal, Ensemble.allTables,
+    simp [fullRv64imEnsemble, fullRv64imSoundEnsemble, SoundEnsemble.toFormal, Ensemble.allTables,
       SoundEnsemble.addTable_tables, SoundEnsemble.addFinishedChannel_tables]
   have h_in_map :
       ZiskFv.AirsClean.Binary.staticLookupComponent ∈
@@ -149,7 +149,7 @@ theorem exists_binaryExtension_table_of_fullRv64im_witness
   have h_component_mem :
       shiftStaticLookupComponent ∈
         (fullRv64imEnsemble length program).ensemble.allTables := by
-    simp [fullRv64imEnsemble, SoundEnsemble.toFormal, Ensemble.allTables,
+    simp [fullRv64imEnsemble, fullRv64imSoundEnsemble, SoundEnsemble.toFormal, Ensemble.allTables,
       SoundEnsemble.addTable_tables, SoundEnsemble.addFinishedChannel_tables]
   have h_in_map :
       shiftStaticLookupComponent ∈
@@ -165,7 +165,7 @@ theorem verifierTable_interactionsWith_opBus_nil
     (length : ℕ) (program : Program length) :
     (fullRv64imEnsemble length program).ensemble.verifierTable.operations.interactionsWith
       OpBusChannel.toRaw = [] := by
-  simp [fullRv64imEnsemble, SoundEnsemble.toFormal,
+  simp [fullRv64imEnsemble, fullRv64imSoundEnsemble, SoundEnsemble.toFormal,
     Ensemble.verifierTable_interactionsWith, Ensemble.verifierOperations,
     GeneralFormalCircuit.empty, circuit_norm]
 
@@ -175,7 +175,7 @@ theorem verifierTable_interactionsWith_memBus_nil
     (length : ℕ) (program : Program length) :
     (fullRv64imEnsemble length program).ensemble.verifierTable.operations.interactionsWith
       MemBusChannel.toRaw = [] := by
-  simp [fullRv64imEnsemble, SoundEnsemble.toFormal,
+  simp [fullRv64imEnsemble, fullRv64imSoundEnsemble, SoundEnsemble.toFormal,
     Ensemble.verifierTable_interactionsWith, Ensemble.verifierOperations,
     GeneralFormalCircuit.empty, circuit_norm]
 

--- a/ZiskFv/Compliance/AcceptedTrace.lean
+++ b/ZiskFv/Compliance/AcceptedTrace.lean
@@ -13,21 +13,21 @@ plus the binary / arithmetic / memory / lookup tables) wired together by shared
 layouts and channels; it holds no data of its own.
 
 The `witness` is the ensemble *filled in* with concrete Goldilocks values: every
-AIR's grid of rows. The remaining three fields are the proofs that make the
+AIR's grid of rows. The remaining two fields are the proofs that make the
 witness "accepted" — exactly what a real ZisK proof certifies:
 
 * `constraints_hold : witness.Constraints` — every per-row algebraic gate of every
   table holds (the polynomial constraint equations are satisfied).
-* `spec_holds : witness.Spec` — every table additionally meets its higher-level *spec*
-  predicate: the semantic relation each AIR is meant to encode (e.g. a Binary
-  row really computes AND/OR/XOR; an ArithMul row's lanes are a correct
-  product). It is the meaning the constraints exist to enforce, stated directly
-  rather than as gate polynomials.
 * `channels_balanced : witness.BalancedChannels` — despite the name, **not a boolean**: it
   is the *proposition* that every cross-table channel balances, i.e. for each bus
   the multiset of messages sent equals the multiset received (the logUp /
   permutation argument). This is what stops a table from fabricating or dropping
   a bus message, gluing the otherwise-independent AIRs into one sound machine.
+
+The per-AIR *spec* (each table really computes its intended relation) is no
+longer an assumed field: `AcceptedTrace.spec_holds` *derives* `witness.Spec`
+from `constraints_hold` and `channels_balanced` via the ensemble's
+table-soundness.
 
 It is the single object the soundness development quantifies over; everything
 downstream (`ProgramBinding`, the provider-match wrappers, the per-op
@@ -44,7 +44,15 @@ structure AcceptedTrace where
     Air.Flat.EnsembleWitness
       (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble numInstructions program).ensemble
   constraints_hold : witness.Constraints
-  spec_holds : witness.Spec
   channels_balanced : witness.BalancedChannels
+
+/-- `spec_holds` is **derived**, not assumed: the spec each AIR encodes follows
+    from the accepted `constraints_hold` and `channels_balanced` via the
+    ensemble's table-soundness (`witness_spec_of_constraints`). It is
+    `@[reducible]` so every consumer (and the trust gate's `whnfR`) sees through
+    it exactly as it did the former struct field. -/
+@[reducible] def AcceptedTrace.spec_holds (trace : AcceptedTrace) : trace.witness.Spec :=
+  ZiskFv.AirsClean.FullEnsemble.witness_spec_of_constraints
+    trace.witness trace.constraints_hold trace.channels_balanced
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/AcceptedTrace.lean
+++ b/ZiskFv/Compliance/AcceptedTrace.lean
@@ -24,10 +24,8 @@ witness "accepted" — exactly what a real ZisK proof certifies:
   permutation argument). This is what stops a table from fabricating or dropping
   a bus message, gluing the otherwise-independent AIRs into one sound machine.
 
-The per-AIR *spec* (each table really computes its intended relation) is no
-longer an assumed field: `AcceptedTrace.spec_holds` *derives* `witness.Spec`
-from `constraints_hold` and `channels_balanced` via the ensemble's
-table-soundness.
+The per-AIR *spec* is not an assumed field: it is derived from these two by
+`AcceptedTrace.spec_holds` (in `AcceptedTrace/Spec.lean`).
 
 It is the single object the soundness development quantifies over; everything
 downstream (`ProgramBinding`, the provider-match wrappers, the per-op
@@ -45,14 +43,5 @@ structure AcceptedTrace where
       (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble numInstructions program).ensemble
   constraints_hold : witness.Constraints
   channels_balanced : witness.BalancedChannels
-
-/-- `spec_holds` is **derived**, not assumed: the spec each AIR encodes follows
-    from the accepted `constraints_hold` and `channels_balanced` via the
-    ensemble's table-soundness (`witness_spec_of_constraints`). It is
-    `@[reducible]` so every consumer (and the trust gate's `whnfR`) sees through
-    it exactly as it did the former struct field. -/
-@[reducible] def AcceptedTrace.spec_holds (trace : AcceptedTrace) : trace.witness.Spec :=
-  ZiskFv.AirsClean.FullEnsemble.witness_spec_of_constraints
-    trace.witness trace.constraints_hold trace.channels_balanced
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/AcceptedTrace/Spec.lean
+++ b/ZiskFv/Compliance/AcceptedTrace/Spec.lean
@@ -1,0 +1,23 @@
+import ZiskFv.Compliance.AcceptedTrace
+
+/-!
+# Derived per-AIR spec accessor
+
+`AcceptedTrace` carries only the two genuine accepted-trace fields
+(`constraints_hold`, `channels_balanced`). The per-AIR *spec* — that each table
+really computes its intended relation — is **derived**, not assumed, and lives
+here as the accessor `AcceptedTrace.spec_holds`.
+-/
+
+namespace ZiskFv.Compliance
+
+/-- `spec_holds` is **derived**, not assumed: the spec each AIR encodes follows
+    from the accepted `constraints_hold` and `channels_balanced` via the
+    ensemble's table-soundness (`witness_spec_of_constraints`). It is
+    `@[reducible]` so every consumer (and the trust gate's `whnfR`) sees through
+    it exactly as it did the former struct field. -/
+@[reducible] def AcceptedTrace.spec_holds (trace : AcceptedTrace) : trace.witness.Spec :=
+  ZiskFv.AirsClean.FullEnsemble.witness_spec_of_constraints
+    trace.witness trace.constraints_hold trace.channels_balanced
+
+end ZiskFv.Compliance

--- a/ZiskFv/Compliance/ProgramBinding/Basic.lean
+++ b/ZiskFv/Compliance/ProgramBinding/Basic.lean
@@ -1,4 +1,4 @@
-import ZiskFv.Compliance.AcceptedTrace
+import ZiskFv.Compliance.AcceptedTrace.Spec
 import ZiskFv.SailSpec.Auxiliaries
 
 /-!

--- a/ZiskFv/Soundness.lean
+++ b/ZiskFv/Soundness.lean
@@ -4,13 +4,26 @@ import ZiskFv.Compliance.TraceLevelExport
 # Root soundness
 
 The headline soundness statement of the project, factored out of the
-trace-level export development for visibility.  It sits parallel to
+trace-level export development for visibility. It sits parallel to
 `ZiskFv.Compliance` and re-exports the single endpoint theorem.
 -/
 
 namespace ZiskFv.Compliance
 
-/-- **Root soundness — trace-level export (#61).**
+/-- ** The top-level global soundness theorem: given a satisfying assignment of circuits
+    that does not involve any explicitly enumerated bugs, the zisk machine state transition
+    agrees with the Sail machine state transition.
+
+    An AcceptedTrace is a set of constraints, and a witness that satisfies those constraints and the
+    channel balancing constraint enfoced in the proving system through a lookup argument.
+
+    A ProgramBinding is a choice of which table in the witness is the Main execution table, together
+    with the sequence of Sail machine states the program steps through and the facts that pin that
+    table into the witness : that it really occurs in it, that it really is the Main component, and
+    that it has one row per instruction.
+
+    rowData is the assumption that, for each instruction, ZisK's inputs match the Sail model's
+    inputs — same opcode, same operand and PC values.
 
     From an accepted full-ensemble trace, a program binding, a per-row
     classification of all 63 RV64IM archetypes, and a per-row defect-exclusion

--- a/trust/generated/baseline-construction-theorem-binders.txt
+++ b/trust/generated/baseline-construction-theorem-binders.txt
@@ -3,7 +3,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -39,7 +38,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -75,7 +73,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -111,7 +108,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -147,7 +143,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -183,7 +178,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -219,7 +213,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -254,7 +247,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -289,7 +281,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -324,7 +315,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -359,7 +349,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -394,7 +383,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -430,7 +418,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -466,7 +453,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -502,7 +488,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -537,7 +522,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -572,7 +556,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -607,7 +590,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -643,7 +625,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -679,7 +660,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -715,7 +695,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -748,7 +727,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -781,7 +759,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -814,7 +791,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -850,7 +826,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -886,7 +861,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -922,7 +896,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -958,7 +931,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -993,7 +965,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1026,7 +997,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1061,7 +1031,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1097,7 +1066,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1138,7 +1106,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1258,7 +1225,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1381,7 +1347,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1501,7 +1466,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1624,7 +1588,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1664,7 +1627,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1703,7 +1665,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1740,7 +1701,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1772,7 +1732,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1832,7 +1791,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -1954,7 +1912,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2076,7 +2033,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2198,7 +2154,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2298,7 +2253,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2398,7 +2352,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2498,7 +2451,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2530,7 +2482,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2562,7 +2513,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2594,7 +2544,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2626,7 +2575,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2658,7 +2606,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2690,7 +2637,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)
@@ -2732,7 +2678,6 @@ trace.numInstructions :: Nat
 trace.program :: ZiskFv.AirsClean.ZiskInstructionRom.Program trace.1
 trace.witness :: Air.Flat.EnsembleWitness (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble trace.1 trace.2).ensemble
 trace.constraints_hold :: trace.3.Constraints
-trace.spec_holds :: trace.3.Spec
 trace.channels_balanced :: trace.3.BalancedChannels
 binding.stateAt :: Fin trace.numInstructions → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 binding.mainTable :: Air.Flat.Table (Fin 18446744069414584321)


### PR DESCRIPTION
Stacked on `top_down_clarity_01` (#124).

`AcceptedTrace` previously bundled `spec_holds : witness.Spec` as a third **assumed** proof field — even though every AIR already ships a proven `Constraints → Spec` soundness, just never assembled at the ensemble level. This wires that assembly and removes the assumption.

### What changed (`FullEnsemble.lean`)
- `fullRv64imSoundEnsemble : SoundEnsemble` — the pre-`.toFormal` chain factored into a named def.
- `fullRv64imSoundEnsemble_assumptionsConsistency` — the per-table `Assumptions := True` discharge lifted out of the inline `toFormal`.
- `fullRv64imEnsemble` redefined as `(fullRv64imSoundEnsemble …).toFormal …`; `.ensemble` stays `rfl`-defeq.
- `witness_spec_of_constraints (w) (hc : w.Constraints) (hb : w.BalancedChannels) : w.Spec` — proved straight from `Ensemble.tableSoundness_of_soundChannels`. No new framework lemmas, **no new axioms**.

### `AcceptedTrace`
- `spec_holds` struct field **removed**; replaced by `@[reducible] def AcceptedTrace.spec_holds := witness_spec_of_constraints …`, so the 14 consumption sites are literally zero-diff and the trust gate's `whnfR` still sees through it.

### Verification
- Full `lake build` green (8715 jobs).
- Trust gate **V1 (18/18)** and **V2 (14/14)** pass. Axiom-closure invariant holds: `witness_spec_of_constraints`, `AcceptedTrace.spec_holds`, and `zisk_riscv_compliant_program_bus` carry only kernel axioms; **0 `ZiskFv.*` axioms**, floor unchanged.
- One baseline regenerated (`baseline-construction-theorem-binders.txt`): a pure **removal** of 55 `trace.spec_holds` binder-leaf lines (trust-surface reduction), 0 additions, no new axiom/binder.

Net: `AcceptedTrace` now bundles only the two genuinely-independent verifier facts (`constraints_hold`, `channels_balanced`); the per-AIR spec is computed from them. `root_soundness`'s statement is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)