### PR TITLE
Tighten CI coverage for trust gate changes

### DIFF
--- a/.github/workflows/proofs.yml
+++ b/.github/workflows/proofs.yml
@@ -14,6 +14,7 @@ on:
     branches: [main]
     paths:
       - 'ZiskFv/**'
+      - 'bin/TrustGate/**'
       - 'tools/pil-extract/**'
       - 'scripts/aeneas-production-extract.sh'
       - 'zisk'

--- a/trust/scripts/check-no-sorry.sh
+++ b/trust/scripts/check-no-sorry.sh
@@ -16,15 +16,15 @@
 set -uo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
-# grep for `sorry` as a Lean tactic / term, excluding:
+# grep for `sorry` as a Lean tactic / term in all non-generated project
+# sources, excluding:
 #   - `-- sorry`             (line comments)
 #   - ``sorry``              (backtick prose in doc comments)
 #   - `"sorry"`              (string literals)
-hits=$(grep -rnE '(^|[^a-zA-Z_`])sorry([^a-zA-Z_`]|$)' \
-  --include='*.lean' \
-  ZiskFv/Fundamentals ZiskFv/Airs ZiskFv/ZiskCircuit ZiskFv/Equivalence \
-  ZiskFv/EquivCore ZiskFv/Compliance ZiskFv/Completeness ZiskFv/Tactics \
-  ZiskFv/SailSpec 2>/dev/null \
+hits=$(find ZiskFv \
+  -path 'ZiskFv/Extraction' -prune -o \
+  -name '*.lean' -print0 \
+  | xargs -0 grep -nE '(^|[^a-zA-Z_`])sorry([^a-zA-Z_`]|$)' 2>/dev/null \
   | grep -v ':[[:space:]]*--' \
   | grep -v ':[[:space:]]*///' \
   | grep -v '"sorry"' \
@@ -36,4 +36,4 @@ if [ -n "$hits" ]; then
   exit 1
 fi
 
-echo "trust-gate: zero sorry — every proof in Fundamentals/Airs/Circuit/Equivalence/EquivCore/Compliance/Completeness/Tactics/SailSpec is complete."
+echo "trust-gate: zero sorry — every non-generated ZiskFv Lean source is complete."


### PR DESCRIPTION
## Summary

- Run the full `proofs` workflow when `bin/TrustGate/**` changes, since that directory builds the semantic `trust-gate` Lake executable.
- Broaden `trust/scripts/check-no-sorry.sh` from a hand-maintained directory list to all non-generated `ZiskFv/**/*.lean`, pruning `ZiskFv/Extraction`.

The stale disabled `aeneas extraction` workflow is GitHub Actions metadata for a deleted workflow file, so there is no source-file deletion for this PR to carry.

## Verification

- `bash -n trust/scripts/check-no-sorry.sh`
- `trust/scripts/check-no-sorry.sh`
- `trust/scripts/check-all.sh` (15/15 passed after initializing the pinned `zisk` submodule in the fresh worktree)
- `git diff --check`
