### PR TITLE
OpBusProviderMatch cleanup: drop dead SailTrace param, rename file + lemmas

### DIFF
--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -135,7 +135,7 @@ import ZiskFv.Compliance.RowProvenance
 import ZiskFv.Compliance.AcceptedZiskTrace
 import ZiskFv.Compliance.AcceptedZiskTrace.Spec
 import ZiskFv.Compliance.SailTrace
-import ZiskFv.Compliance.ProviderFromBinding
+import ZiskFv.Compliance.OpBusProviderMatch
 import ZiskFv.Compliance.ConstructionSub
 import ZiskFv.Compliance.ConstructionAnd
 import ZiskFv.Compliance.ConstructionLogic

--- a/ZiskFv/Compliance/ConstructionAdd.lean
+++ b/ZiskFv/Compliance/ConstructionAdd.lean
@@ -15,7 +15,7 @@ EITHER of two distinct providers with two distinct `opBusMessage` shapes:
 * the lookup-aware Binary provider (`staticLookupComponent`), or
 * the dedicated `BinaryAdd` provider (`BinaryAdd.component`).
 
-The salvaged Layer-A wrapper `exists_add_provider_row_matches_from_binding`
+The salvaged Layer-A wrapper `exists_add_provider_row_matches`
 (`AcceptedZiskTrace.lean`) RESOLVES the op-bus from `trace.channels_balanced` into the
 conjunction
 
@@ -176,8 +176,8 @@ theorem construction_add_sound_claimed_dead
   -- (a) op-bus provider RESOLUTION, derived from `trace.channels_balanced`: the
   -- `add_subset_holds` conjunct + a `staticLookup ∨ BinaryAdd` DISJUNCTION.
   obtain ⟨h_add_subset, h_disj⟩ :=
-    exists_add_provider_row_matches_from_binding
-      trace binding i h_main_active h_main_op
+    exists_add_provider_row_matches
+      trace i h_main_active h_main_op
   -- decode pins bundle (shared by both arms)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD :=
     ⟨h_main_active, h_main_op⟩
@@ -381,8 +381,8 @@ theorem construction_addi_sound_claimed_dead
   -- `add_subset_holds` conjunct + a `staticLookup ∨ BinaryAdd` DISJUNCTION
   -- (the op-bus match is operand-source-agnostic, so the SAME wrapper serves ADDI).
   obtain ⟨h_add_subset, h_disj⟩ :=
-    exists_add_provider_row_matches_from_binding
-      trace binding i h_main_active h_main_op
+    exists_add_provider_row_matches
+      trace i h_main_active h_main_op
   -- decode pins bundle (shared by both arms)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD :=
     ⟨h_main_active, h_main_op⟩

--- a/ZiskFv/Compliance/ConstructionAdd.lean
+++ b/ZiskFv/Compliance/ConstructionAdd.lean
@@ -15,7 +15,7 @@ EITHER of two distinct providers with two distinct `opBusMessage` shapes:
 * the lookup-aware Binary provider (`staticLookupComponent`), or
 * the dedicated `BinaryAdd` provider (`BinaryAdd.component`).
 
-The salvaged Layer-A wrapper `exists_add_provider_row_matches`
+The salvaged Layer-A wrapper `main_request_add_provided`
 (`AcceptedZiskTrace.lean`) RESOLVES the op-bus from `trace.channels_balanced` into the
 conjunction
 
@@ -176,7 +176,7 @@ theorem construction_add_sound_claimed_dead
   -- (a) op-bus provider RESOLUTION, derived from `trace.channels_balanced`: the
   -- `add_subset_holds` conjunct + a `staticLookup ∨ BinaryAdd` DISJUNCTION.
   obtain ⟨h_add_subset, h_disj⟩ :=
-    exists_add_provider_row_matches
+    main_request_add_provided
       trace i h_main_active h_main_op
   -- decode pins bundle (shared by both arms)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD :=
@@ -381,7 +381,7 @@ theorem construction_addi_sound_claimed_dead
   -- `add_subset_holds` conjunct + a `staticLookup ∨ BinaryAdd` DISJUNCTION
   -- (the op-bus match is operand-source-agnostic, so the SAME wrapper serves ADDI).
   obtain ⟨h_add_subset, h_disj⟩ :=
-    exists_add_provider_row_matches
+    main_request_add_provided
       trace i h_main_active h_main_op
   -- decode pins bundle (shared by both arms)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD :=

--- a/ZiskFv/Compliance/ConstructionAnd.lean
+++ b/ZiskFv/Compliance/ConstructionAnd.lean
@@ -14,7 +14,7 @@ plus an explicit, named, top-level set of residual binders — with **no**
 The only structural differences from `construction_sub_sound` are:
 
 * the op-bus provider match is derived from the **salvaged logic Layer-A**
-  wrapper `exists_staticBinary_provider_row_matches_logic_from_binding`
+  wrapper `exists_staticBinary_provider_row_matches_logic`
   (which serves AND / OR / XOR; it takes the op pin as the disjunction
   `op = OP_AND ∨ op = OP_OR ∨ op = OP_XOR`, here discharged by `Or.inl`),
 * the op literal is `OP_AND` (`14`, still `< 16`, so the same
@@ -186,8 +186,8 @@ theorem construction_and_sound_claimed_dead
   -- logic wrapper (serves AND / OR / XOR; op pin given as the AND disjunct).
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic_from_binding
-      trace binding i h_main_active (Or.inl h_main_op)
+    exists_staticBinary_provider_row_matches_logic
+      trace i h_main_active (Or.inl h_main_op)
   -- decode pins bundle
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_AND :=
     ⟨h_main_active, h_main_op⟩

--- a/ZiskFv/Compliance/ConstructionAnd.lean
+++ b/ZiskFv/Compliance/ConstructionAnd.lean
@@ -14,7 +14,7 @@ plus an explicit, named, top-level set of residual binders — with **no**
 The only structural differences from `construction_sub_sound` are:
 
 * the op-bus provider match is derived from the **salvaged logic Layer-A**
-  wrapper `exists_staticBinary_provider_row_matches_logic`
+  wrapper `main_request_logic_provided`
   (which serves AND / OR / XOR; it takes the op pin as the disjunction
   `op = OP_AND ∨ op = OP_OR ∨ op = OP_XOR`, here discharged by `Or.inl`),
 * the op literal is `OP_AND` (`14`, still `< 16`, so the same
@@ -186,7 +186,7 @@ theorem construction_and_sound_claimed_dead
   -- logic wrapper (serves AND / OR / XOR; op pin given as the AND disjunct).
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic
+    main_request_logic_provided
       trace i h_main_active (Or.inl h_main_op)
   -- decode pins bundle
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_AND :=

--- a/ZiskFv/Compliance/ConstructionBranch.lean
+++ b/ZiskFv/Compliance/ConstructionBranch.lean
@@ -1,4 +1,5 @@
-import ZiskFv.Compliance.ProviderFromBinding
+import ZiskFv.Compliance.OpBusProviderMatch
+import ZiskFv.Compliance.SailTrace
 import ZiskFv.Compliance.Wrappers.Beq
 import ZiskFv.Compliance.Wrappers.Bne
 import ZiskFv.Compliance.Wrappers.Blt

--- a/ZiskFv/Compliance/ConstructionCompare.lean
+++ b/ZiskFv/Compliance/ConstructionCompare.lean
@@ -14,7 +14,7 @@ any fact.
 
 Both reuse the op-agnostic infra `busSub` / `mainRowWithRomSub`
 (`ZiskFv/Compliance/ConstructionSub.lean`) and the salvaged compare Layer-A wrapper
-`exists_staticBinary_provider_row_matches_compare` (which serves
+`main_request_compare_provided` (which serves
 SLT / SLTU, taking the op pin as the disjunction `op = OP_LT ∨ op = OP_LTU`).
 The residual budget is identical to SUB/AND: EXACTLY `4 + 5 + 4 + 1 + 3 = 17`
 hypothesis binders plus the genuine `execRow` ∀-binder.
@@ -157,7 +157,7 @@ theorem construction_slt_sound_claimed_dead
   -- compare wrapper (serves SLT / SLTU; op pin given as the SLT disjunct).
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_compare
+    main_request_compare_provided
       trace i h_main_active (Or.inl h_main_op)
   -- decode pins bundle
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_LT :=
@@ -352,7 +352,7 @@ theorem construction_sltu_sound_claimed_dead
   -- compare wrapper (serves SLT / SLTU; op pin given as the SLTU disjunct).
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_compare
+    main_request_compare_provided
       trace i h_main_active (Or.inr h_main_op)
   -- decode pins bundle
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_LTU :=

--- a/ZiskFv/Compliance/ConstructionCompare.lean
+++ b/ZiskFv/Compliance/ConstructionCompare.lean
@@ -14,7 +14,7 @@ any fact.
 
 Both reuse the op-agnostic infra `busSub` / `mainRowWithRomSub`
 (`ZiskFv/Compliance/ConstructionSub.lean`) and the salvaged compare Layer-A wrapper
-`exists_staticBinary_provider_row_matches_compare_from_binding` (which serves
+`exists_staticBinary_provider_row_matches_compare` (which serves
 SLT / SLTU, taking the op pin as the disjunction `op = OP_LT ∨ op = OP_LTU`).
 The residual budget is identical to SUB/AND: EXACTLY `4 + 5 + 4 + 1 + 3 = 17`
 hypothesis binders plus the genuine `execRow` ∀-binder.
@@ -157,8 +157,8 @@ theorem construction_slt_sound_claimed_dead
   -- compare wrapper (serves SLT / SLTU; op pin given as the SLT disjunct).
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_compare_from_binding
-      trace binding i h_main_active (Or.inl h_main_op)
+    exists_staticBinary_provider_row_matches_compare
+      trace i h_main_active (Or.inl h_main_op)
   -- decode pins bundle
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_LT :=
     ⟨h_main_active, h_main_op⟩
@@ -352,8 +352,8 @@ theorem construction_sltu_sound_claimed_dead
   -- compare wrapper (serves SLT / SLTU; op pin given as the SLTU disjunct).
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_compare_from_binding
-      trace binding i h_main_active (Or.inr h_main_op)
+    exists_staticBinary_provider_row_matches_compare
+      trace i h_main_active (Or.inr h_main_op)
   -- decode pins bundle
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_LTU :=
     ⟨h_main_active, h_main_op⟩

--- a/ZiskFv/Compliance/ConstructionDivu.lean
+++ b/ZiskFv/Compliance/ConstructionDivu.lean
@@ -1,4 +1,5 @@
-import ZiskFv.Compliance.ProviderFromBinding
+import ZiskFv.Compliance.OpBusProviderMatch
+import ZiskFv.Compliance.SailTrace
 import ZiskFv.Compliance.ConstructionMulw
 import ZiskFv.Compliance.ConstructionMulhu
 import ZiskFv.EquivCore.Divu
@@ -434,7 +435,7 @@ private lemma divu_carry_bounds_claimed_dead
     operation, as a concrete `ArithMulRow`.  It is the
     `componentWithArithTable.rowInput` of the provider row chosen by the DIVU
     keep-arithMul balance wrapper
-    `exists_arithMul_provider_row_matches_primary_of_divu_from_binding`.
+    `exists_arithMul_provider_row_matches_primary_of_divu`.
     Mirrors `mulwArow`. -/
 noncomputable def divuArow
     (trace : AcceptedZiskTrace) (binding : SailTrace trace) (i : Fin trace.numInstructions)
@@ -443,8 +444,8 @@ noncomputable def divuArow
     (h_main_op :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU) :
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
-  let h := exists_arithMul_provider_row_matches_primary_of_divu_from_binding
-    trace binding i h_main_active h_main_op
+  let h := exists_arithMul_provider_row_matches_primary_of_divu
+    trace i h_main_active h_main_op
   componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
 
 /-- `FullSpec` of the balance-selected DIVU provider row, derived from the
@@ -457,8 +458,8 @@ theorem divuArow_fullSpec_row
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU) :
     ZiskFv.AirsClean.ArithMul.FullSpec (divuArow trace binding i h_main_active h_main_op) := by
   unfold divuArow
-  set H := exists_arithMul_provider_row_matches_primary_of_divu_from_binding
-    trace binding i h_main_active h_main_op with hH
+  set H := exists_arithMul_provider_row_matches_primary_of_divu
+    trace i h_main_active h_main_op with hH
   obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
   obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
   exact ZiskFv.AirsClean.FullEnsemble.arithMul_fullSpec_of_component_spec
@@ -479,8 +480,8 @@ theorem divuArow_match_row
         (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
           (divuArow trace binding i h_main_active h_main_op)) 1) := by
   unfold divuArow
-  set H := exists_arithMul_provider_row_matches_primary_of_divu_from_binding
-    trace binding i h_main_active h_main_op with hH
+  set H := exists_arithMul_provider_row_matches_primary_of_divu
+    trace i h_main_active h_main_op with hH
   exact H.choose_spec.2.choose_spec.2.2.2
 
 /-- DIVU mode pins on the balance-selected provider row, DERIVED from its

--- a/ZiskFv/Compliance/ConstructionDivu.lean
+++ b/ZiskFv/Compliance/ConstructionDivu.lean
@@ -435,7 +435,7 @@ private lemma divu_carry_bounds_claimed_dead
     operation, as a concrete `ArithMulRow`.  It is the
     `componentWithArithTable.rowInput` of the provider row chosen by the DIVU
     keep-arithMul balance wrapper
-    `main_request_divu_limb1_provided`.
+    `main_request_divu_provided`.
     Mirrors `mulwArow`. -/
 noncomputable def divuArow
     (trace : AcceptedZiskTrace) (binding : SailTrace trace) (i : Fin trace.numInstructions)
@@ -444,7 +444,7 @@ noncomputable def divuArow
     (h_main_op :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU) :
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
-  let h := main_request_divu_limb1_provided
+  let h := main_request_divu_provided
     trace i h_main_active h_main_op
   componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
 
@@ -458,7 +458,7 @@ theorem divuArow_fullSpec_row
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU) :
     ZiskFv.AirsClean.ArithMul.FullSpec (divuArow trace binding i h_main_active h_main_op) := by
   unfold divuArow
-  set H := main_request_divu_limb1_provided
+  set H := main_request_divu_provided
     trace i h_main_active h_main_op with hH
   obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
   obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
@@ -480,7 +480,7 @@ theorem divuArow_match_row
         (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
           (divuArow trace binding i h_main_active h_main_op)) 1) := by
   unfold divuArow
-  set H := main_request_divu_limb1_provided
+  set H := main_request_divu_provided
     trace i h_main_active h_main_op with hH
   exact H.choose_spec.2.choose_spec.2.2.2
 

--- a/ZiskFv/Compliance/ConstructionDivu.lean
+++ b/ZiskFv/Compliance/ConstructionDivu.lean
@@ -435,7 +435,7 @@ private lemma divu_carry_bounds_claimed_dead
     operation, as a concrete `ArithMulRow`.  It is the
     `componentWithArithTable.rowInput` of the provider row chosen by the DIVU
     keep-arithMul balance wrapper
-    `exists_arithMul_provider_row_matches_primary_of_divu`.
+    `main_request_divu_limb1_provided`.
     Mirrors `mulwArow`. -/
 noncomputable def divuArow
     (trace : AcceptedZiskTrace) (binding : SailTrace trace) (i : Fin trace.numInstructions)
@@ -444,7 +444,7 @@ noncomputable def divuArow
     (h_main_op :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU) :
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
-  let h := exists_arithMul_provider_row_matches_primary_of_divu
+  let h := main_request_divu_limb1_provided
     trace i h_main_active h_main_op
   componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
 
@@ -458,7 +458,7 @@ theorem divuArow_fullSpec_row
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU) :
     ZiskFv.AirsClean.ArithMul.FullSpec (divuArow trace binding i h_main_active h_main_op) := by
   unfold divuArow
-  set H := exists_arithMul_provider_row_matches_primary_of_divu
+  set H := main_request_divu_limb1_provided
     trace i h_main_active h_main_op with hH
   obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
   obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
@@ -480,7 +480,7 @@ theorem divuArow_match_row
         (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
           (divuArow trace binding i h_main_active h_main_op)) 1) := by
   unfold divuArow
-  set H := exists_arithMul_provider_row_matches_primary_of_divu
+  set H := main_request_divu_limb1_provided
     trace i h_main_active h_main_op with hH
   exact H.choose_spec.2.choose_spec.2.2.2
 

--- a/ZiskFv/Compliance/ConstructionDivuw.lean
+++ b/ZiskFv/Compliance/ConstructionDivuw.lean
@@ -299,7 +299,7 @@ private lemma divuw_carry_bounds_claimed_dead
     operation, as a concrete `ArithMulRow`.  It is the
     `componentWithArithTable.rowInput` of the provider row chosen by the DIVUW
     keep-arithMul balance wrapper
-    `exists_arithMul_provider_row_matches_primary_of_divuw`.
+    `main_request_divuw_limb1_provided`.
     Mirrors `divuArow`. -/
 noncomputable def divuwArow
     (trace : AcceptedZiskTrace) (binding : SailTrace trace) (i : Fin trace.numInstructions)
@@ -308,7 +308,7 @@ noncomputable def divuwArow
     (h_main_op :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU_W) :
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
-  let h := exists_arithMul_provider_row_matches_primary_of_divuw
+  let h := main_request_divuw_limb1_provided
     trace i h_main_active h_main_op
   componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
 
@@ -323,7 +323,7 @@ theorem divuwArow_fullSpec_row
     ZiskFv.AirsClean.ArithMul.FullSpec
       (divuwArow trace binding i h_main_active h_main_op) := by
   unfold divuwArow
-  set H := exists_arithMul_provider_row_matches_primary_of_divuw
+  set H := main_request_divuw_limb1_provided
     trace i h_main_active h_main_op with hH
   obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
   obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
@@ -344,7 +344,7 @@ theorem divuwArow_match_row
         (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
           (divuwArow trace binding i h_main_active h_main_op)) 1) := by
   unfold divuwArow
-  set H := exists_arithMul_provider_row_matches_primary_of_divuw
+  set H := main_request_divuw_limb1_provided
     trace i h_main_active h_main_op with hH
   exact H.choose_spec.2.choose_spec.2.2.2
 

--- a/ZiskFv/Compliance/ConstructionDivuw.lean
+++ b/ZiskFv/Compliance/ConstructionDivuw.lean
@@ -1,4 +1,5 @@
-import ZiskFv.Compliance.ProviderFromBinding
+import ZiskFv.Compliance.OpBusProviderMatch
+import ZiskFv.Compliance.SailTrace
 import ZiskFv.Compliance.ConstructionMulw
 import ZiskFv.Compliance.ConstructionMulhu
 import ZiskFv.Compliance.ConstructionDivu
@@ -298,7 +299,7 @@ private lemma divuw_carry_bounds_claimed_dead
     operation, as a concrete `ArithMulRow`.  It is the
     `componentWithArithTable.rowInput` of the provider row chosen by the DIVUW
     keep-arithMul balance wrapper
-    `exists_arithMul_provider_row_matches_primary_of_divuw_from_binding`.
+    `exists_arithMul_provider_row_matches_primary_of_divuw`.
     Mirrors `divuArow`. -/
 noncomputable def divuwArow
     (trace : AcceptedZiskTrace) (binding : SailTrace trace) (i : Fin trace.numInstructions)
@@ -307,8 +308,8 @@ noncomputable def divuwArow
     (h_main_op :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU_W) :
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
-  let h := exists_arithMul_provider_row_matches_primary_of_divuw_from_binding
-    trace binding i h_main_active h_main_op
+  let h := exists_arithMul_provider_row_matches_primary_of_divuw
+    trace i h_main_active h_main_op
   componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
 
 /-- `FullSpec` of the balance-selected DIVUW provider row, derived from the
@@ -322,8 +323,8 @@ theorem divuwArow_fullSpec_row
     ZiskFv.AirsClean.ArithMul.FullSpec
       (divuwArow trace binding i h_main_active h_main_op) := by
   unfold divuwArow
-  set H := exists_arithMul_provider_row_matches_primary_of_divuw_from_binding
-    trace binding i h_main_active h_main_op with hH
+  set H := exists_arithMul_provider_row_matches_primary_of_divuw
+    trace i h_main_active h_main_op with hH
   obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
   obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
   exact ZiskFv.AirsClean.FullEnsemble.arithMul_fullSpec_of_component_spec
@@ -343,8 +344,8 @@ theorem divuwArow_match_row
         (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
           (divuwArow trace binding i h_main_active h_main_op)) 1) := by
   unfold divuwArow
-  set H := exists_arithMul_provider_row_matches_primary_of_divuw_from_binding
-    trace binding i h_main_active h_main_op with hH
+  set H := exists_arithMul_provider_row_matches_primary_of_divuw
+    trace i h_main_active h_main_op with hH
   exact H.choose_spec.2.choose_spec.2.2.2
 
 /-- DIVUW mode pins on the balance-selected provider row, DERIVED from its

--- a/ZiskFv/Compliance/ConstructionDivuw.lean
+++ b/ZiskFv/Compliance/ConstructionDivuw.lean
@@ -299,7 +299,7 @@ private lemma divuw_carry_bounds_claimed_dead
     operation, as a concrete `ArithMulRow`.  It is the
     `componentWithArithTable.rowInput` of the provider row chosen by the DIVUW
     keep-arithMul balance wrapper
-    `main_request_divuw_limb1_provided`.
+    `main_request_divuw_provided`.
     Mirrors `divuArow`. -/
 noncomputable def divuwArow
     (trace : AcceptedZiskTrace) (binding : SailTrace trace) (i : Fin trace.numInstructions)
@@ -308,7 +308,7 @@ noncomputable def divuwArow
     (h_main_op :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU_W) :
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
-  let h := main_request_divuw_limb1_provided
+  let h := main_request_divuw_provided
     trace i h_main_active h_main_op
   componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
 
@@ -323,7 +323,7 @@ theorem divuwArow_fullSpec_row
     ZiskFv.AirsClean.ArithMul.FullSpec
       (divuwArow trace binding i h_main_active h_main_op) := by
   unfold divuwArow
-  set H := main_request_divuw_limb1_provided
+  set H := main_request_divuw_provided
     trace i h_main_active h_main_op with hH
   obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
   obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
@@ -344,7 +344,7 @@ theorem divuwArow_match_row
         (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
           (divuwArow trace binding i h_main_active h_main_op)) 1) := by
   unfold divuwArow
-  set H := main_request_divuw_limb1_provided
+  set H := main_request_divuw_provided
     trace i h_main_active h_main_op with hH
   exact H.choose_spec.2.choose_spec.2.2.2
 

--- a/ZiskFv/Compliance/ConstructionIType.lean
+++ b/ZiskFv/Compliance/ConstructionIType.lean
@@ -37,8 +37,8 @@ program binding. So relative to the R-type sibling each construction:
 
 The op-bus provider match is operand-source-agnostic, so the SAME salvaged
 Layer-A wrapper as the R-type sibling is reused verbatim
-(`exists_staticBinary_provider_row_matches_logic_from_binding` for ANDI/ORI/XORI,
-`exists_staticBinary_provider_row_matches_compare_from_binding` for SLTI/SLTIU,
+(`exists_staticBinary_provider_row_matches_logic` for ANDI/ORI/XORI,
+`exists_staticBinary_provider_row_matches_compare` for SLTI/SLTIU,
 with the SAME op-pin disjunct shape). The op-agnostic infra `busSub` /
 `mainRowWithRomSub` (`ConstructionSub.lean`) and the lane-rd / row-shape / MemBus
 derivations are reused verbatim.
@@ -194,8 +194,8 @@ theorem construction_andi_sound_claimed_dead
   -- logic wrapper (serves AND/ANDI / OR/ORI / XOR/XORI; op pin = AND disjunct).
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic_from_binding
-      trace binding i h_main_active (Or.inl h_main_op)
+    exists_staticBinary_provider_row_matches_logic
+      trace i h_main_active (Or.inl h_main_op)
   -- decode pins bundle
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_AND :=
     ⟨h_main_active, h_main_op⟩
@@ -381,8 +381,8 @@ theorem construction_ori_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic_from_binding
-      trace binding i h_main_active (Or.inr (Or.inl h_main_op))
+    exists_staticBinary_provider_row_matches_logic
+      trace i h_main_active (Or.inr (Or.inl h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_OR :=
     ⟨h_main_active, h_main_op⟩
   have h_core_store_pc :
@@ -562,8 +562,8 @@ theorem construction_xori_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic_from_binding
-      trace binding i h_main_active (Or.inr (Or.inr h_main_op))
+    exists_staticBinary_provider_row_matches_logic
+      trace i h_main_active (Or.inr (Or.inr h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_XOR :=
     ⟨h_main_active, h_main_op⟩
   have h_core_store_pc :
@@ -670,7 +670,7 @@ theorem construction_xori_sound_claimed_dead
 
     Residual budget identical to ANDI/ORI/XORI (16 + `imm` + `execRow`). Mirrors
     `construction_slt_sound` (compare Layer-A wrapper
-    `exists_staticBinary_provider_row_matches_compare_from_binding`, `OP_LT = 7 < 16`
+    `exists_staticBinary_provider_row_matches_compare`, `OP_LT = 7 < 16`
     so the in-body `h_matches` reuses the `_op_lt_16` + `_64` route) through the
     uniform I-type immediate DELTA. `equiv_SLTI` consumes the Main-form
     `h_slti_subset` + `m32 = 0` directly and re-derives the 8-byte immediate form
@@ -744,8 +744,8 @@ theorem construction_slti_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_compare_from_binding
-      trace binding i h_main_active (Or.inl h_main_op)
+    exists_staticBinary_provider_row_matches_compare
+      trace i h_main_active (Or.inl h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_LT :=
     ⟨h_main_active, h_main_op⟩
   have h_core_store_pc :
@@ -919,8 +919,8 @@ theorem construction_sltiu_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_compare_from_binding
-      trace binding i h_main_active (Or.inr h_main_op)
+    exists_staticBinary_provider_row_matches_compare
+      trace i h_main_active (Or.inr h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_LTU :=
     ⟨h_main_active, h_main_op⟩
   have h_core_store_pc :

--- a/ZiskFv/Compliance/ConstructionIType.lean
+++ b/ZiskFv/Compliance/ConstructionIType.lean
@@ -37,8 +37,8 @@ program binding. So relative to the R-type sibling each construction:
 
 The op-bus provider match is operand-source-agnostic, so the SAME salvaged
 Layer-A wrapper as the R-type sibling is reused verbatim
-(`exists_staticBinary_provider_row_matches_logic` for ANDI/ORI/XORI,
-`exists_staticBinary_provider_row_matches_compare` for SLTI/SLTIU,
+(`main_request_logic_provided` for ANDI/ORI/XORI,
+`main_request_compare_provided` for SLTI/SLTIU,
 with the SAME op-pin disjunct shape). The op-agnostic infra `busSub` /
 `mainRowWithRomSub` (`ConstructionSub.lean`) and the lane-rd / row-shape / MemBus
 derivations are reused verbatim.
@@ -194,7 +194,7 @@ theorem construction_andi_sound_claimed_dead
   -- logic wrapper (serves AND/ANDI / OR/ORI / XOR/XORI; op pin = AND disjunct).
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic
+    main_request_logic_provided
       trace i h_main_active (Or.inl h_main_op)
   -- decode pins bundle
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_AND :=
@@ -381,7 +381,7 @@ theorem construction_ori_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic
+    main_request_logic_provided
       trace i h_main_active (Or.inr (Or.inl h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_OR :=
     ⟨h_main_active, h_main_op⟩
@@ -562,7 +562,7 @@ theorem construction_xori_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic
+    main_request_logic_provided
       trace i h_main_active (Or.inr (Or.inr h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_XOR :=
     ⟨h_main_active, h_main_op⟩
@@ -670,7 +670,7 @@ theorem construction_xori_sound_claimed_dead
 
     Residual budget identical to ANDI/ORI/XORI (16 + `imm` + `execRow`). Mirrors
     `construction_slt_sound` (compare Layer-A wrapper
-    `exists_staticBinary_provider_row_matches_compare`, `OP_LT = 7 < 16`
+    `main_request_compare_provided`, `OP_LT = 7 < 16`
     so the in-body `h_matches` reuses the `_op_lt_16` + `_64` route) through the
     uniform I-type immediate DELTA. `equiv_SLTI` consumes the Main-form
     `h_slti_subset` + `m32 = 0` directly and re-derives the 8-byte immediate form
@@ -744,7 +744,7 @@ theorem construction_slti_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_compare
+    main_request_compare_provided
       trace i h_main_active (Or.inl h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_LT :=
     ⟨h_main_active, h_main_op⟩
@@ -919,7 +919,7 @@ theorem construction_sltiu_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_compare
+    main_request_compare_provided
       trace i h_main_active (Or.inr h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_LTU :=
     ⟨h_main_active, h_main_op⟩

--- a/ZiskFv/Compliance/ConstructionLoad.lean
+++ b/ZiskFv/Compliance/ConstructionLoad.lean
@@ -1,4 +1,5 @@
-import ZiskFv.Compliance.ProviderFromBinding
+import ZiskFv.Compliance.OpBusProviderMatch
+import ZiskFv.Compliance.SailTrace
 import ZiskFv.Compliance.Wrappers.Lb
 import ZiskFv.Compliance.Wrappers.Lh
 import ZiskFv.Compliance.Wrappers.Lw

--- a/ZiskFv/Compliance/ConstructionLogic.lean
+++ b/ZiskFv/Compliance/ConstructionLogic.lean
@@ -14,7 +14,7 @@ any fact.
 
 Both reuse the op-agnostic infra `busSub` / `mainRowWithRomSub`
 (`ZiskFv/Compliance/ConstructionSub.lean`) and the salvaged logic Layer-A wrapper
-`exists_staticBinary_provider_row_matches_logic_from_binding` (which serves
+`exists_staticBinary_provider_row_matches_logic` (which serves
 AND / OR / XOR, taking the op pin as the disjunction
 `op = OP_AND ∨ op = OP_OR ∨ op = OP_XOR`). The residual budget is identical to
 SUB/AND: EXACTLY `4 + 5 + 4 + 1 + 3 = 17` hypothesis binders plus the genuine
@@ -165,8 +165,8 @@ theorem construction_or_sound_claimed_dead
   -- logic wrapper (serves AND / OR / XOR; op pin given as the OR disjunct).
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic_from_binding
-      trace binding i h_main_active (Or.inr (Or.inl h_main_op))
+    exists_staticBinary_provider_row_matches_logic
+      trace i h_main_active (Or.inr (Or.inl h_main_op))
   -- decode pins bundle
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_OR :=
     ⟨h_main_active, h_main_op⟩
@@ -360,8 +360,8 @@ theorem construction_xor_sound_claimed_dead
   -- logic wrapper (serves AND / OR / XOR; op pin given as the XOR disjunct).
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic_from_binding
-      trace binding i h_main_active (Or.inr (Or.inr h_main_op))
+    exists_staticBinary_provider_row_matches_logic
+      trace i h_main_active (Or.inr (Or.inr h_main_op))
   -- decode pins bundle
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_XOR :=
     ⟨h_main_active, h_main_op⟩

--- a/ZiskFv/Compliance/ConstructionLogic.lean
+++ b/ZiskFv/Compliance/ConstructionLogic.lean
@@ -14,7 +14,7 @@ any fact.
 
 Both reuse the op-agnostic infra `busSub` / `mainRowWithRomSub`
 (`ZiskFv/Compliance/ConstructionSub.lean`) and the salvaged logic Layer-A wrapper
-`exists_staticBinary_provider_row_matches_logic` (which serves
+`main_request_logic_provided` (which serves
 AND / OR / XOR, taking the op pin as the disjunction
 `op = OP_AND ∨ op = OP_OR ∨ op = OP_XOR`). The residual budget is identical to
 SUB/AND: EXACTLY `4 + 5 + 4 + 1 + 3 = 17` hypothesis binders plus the genuine
@@ -165,7 +165,7 @@ theorem construction_or_sound_claimed_dead
   -- logic wrapper (serves AND / OR / XOR; op pin given as the OR disjunct).
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic
+    main_request_logic_provided
       trace i h_main_active (Or.inr (Or.inl h_main_op))
   -- decode pins bundle
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_OR :=
@@ -360,7 +360,7 @@ theorem construction_xor_sound_claimed_dead
   -- logic wrapper (serves AND / OR / XOR; op pin given as the XOR disjunct).
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic
+    main_request_logic_provided
       trace i h_main_active (Or.inr (Or.inr h_main_op))
   -- decode pins bundle
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_XOR :=

--- a/ZiskFv/Compliance/ConstructionLui.lean
+++ b/ZiskFv/Compliance/ConstructionLui.lean
@@ -1,4 +1,5 @@
-import ZiskFv.Compliance.ProviderFromBinding
+import ZiskFv.Compliance.OpBusProviderMatch
+import ZiskFv.Compliance.SailTrace
 import ZiskFv.Compliance.Wrappers.Lui
 
 /-!

--- a/ZiskFv/Compliance/ConstructionMulhu.lean
+++ b/ZiskFv/Compliance/ConstructionMulhu.lean
@@ -1,4 +1,5 @@
-import ZiskFv.Compliance.ProviderFromBinding
+import ZiskFv.Compliance.OpBusProviderMatch
+import ZiskFv.Compliance.SailTrace
 import ZiskFv.Compliance.ConstructionMulw
 import ZiskFv.EquivCore.MulHU
 import ZiskFv.EquivCore.Promises.ArithHelpers
@@ -613,7 +614,7 @@ lemma equiv_MULHU_of_fullSpec_claimed_dead
     operation, as a concrete `ArithMulRow`.  It is the
     `componentWithArithTable.rowInput` of the provider row chosen by the MULHU
     keep-arithMul balance wrapper
-    `exists_arithMul_provider_row_matches_secondary_of_mulhu_from_binding`.
+    `exists_arithMul_provider_row_matches_secondary_of_mulhu`.
     Mirrors `mulwArow`. -/
 noncomputable def mulhuArow
     (trace : AcceptedZiskTrace) (binding : SailTrace trace) (i : Fin trace.numInstructions)
@@ -622,8 +623,8 @@ noncomputable def mulhuArow
     (h_main_op :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_MULUH) :
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
-  let h := exists_arithMul_provider_row_matches_secondary_of_mulhu_from_binding
-    trace binding i h_main_active h_main_op
+  let h := exists_arithMul_provider_row_matches_secondary_of_mulhu
+    trace i h_main_active h_main_op
   componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
 
 /-- `FullSpec` of the balance-selected MULHU provider row, derived from the
@@ -636,8 +637,8 @@ theorem mulhuArow_fullSpec_row
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_MULUH) :
     ZiskFv.AirsClean.ArithMul.FullSpec (mulhuArow trace binding i h_main_active h_main_op) := by
   unfold mulhuArow
-  set H := exists_arithMul_provider_row_matches_secondary_of_mulhu_from_binding
-    trace binding i h_main_active h_main_op with hH
+  set H := exists_arithMul_provider_row_matches_secondary_of_mulhu
+    trace i h_main_active h_main_op with hH
   obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
   obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
   exact ZiskFv.AirsClean.FullEnsemble.arithMul_fullSpec_of_component_spec
@@ -690,8 +691,8 @@ theorem mulhuArow_match_row
         (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
           (mulhuArow trace binding i h_main_active h_main_op)) 1) := by
   unfold mulhuArow
-  set H := exists_arithMul_provider_row_matches_secondary_of_mulhu_from_binding
-    trace binding i h_main_active h_main_op with hH
+  set H := exists_arithMul_provider_row_matches_secondary_of_mulhu
+    trace i h_main_active h_main_op with hH
   exact H.choose_spec.2.choose_spec.2.2.2
 
 /-- MULHU secondary mode pins on the balance-selected provider row, DERIVED from

--- a/ZiskFv/Compliance/ConstructionMulhu.lean
+++ b/ZiskFv/Compliance/ConstructionMulhu.lean
@@ -614,7 +614,7 @@ lemma equiv_MULHU_of_fullSpec_claimed_dead
     operation, as a concrete `ArithMulRow`.  It is the
     `componentWithArithTable.rowInput` of the provider row chosen by the MULHU
     keep-arithMul balance wrapper
-    `exists_arithMul_provider_row_matches_secondary_of_mulhu`.
+    `main_request_mulhu_limb2_provided`.
     Mirrors `mulwArow`. -/
 noncomputable def mulhuArow
     (trace : AcceptedZiskTrace) (binding : SailTrace trace) (i : Fin trace.numInstructions)
@@ -623,7 +623,7 @@ noncomputable def mulhuArow
     (h_main_op :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_MULUH) :
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
-  let h := exists_arithMul_provider_row_matches_secondary_of_mulhu
+  let h := main_request_mulhu_limb2_provided
     trace i h_main_active h_main_op
   componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
 
@@ -637,7 +637,7 @@ theorem mulhuArow_fullSpec_row
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_MULUH) :
     ZiskFv.AirsClean.ArithMul.FullSpec (mulhuArow trace binding i h_main_active h_main_op) := by
   unfold mulhuArow
-  set H := exists_arithMul_provider_row_matches_secondary_of_mulhu
+  set H := main_request_mulhu_limb2_provided
     trace i h_main_active h_main_op with hH
   obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
   obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
@@ -691,7 +691,7 @@ theorem mulhuArow_match_row
         (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
           (mulhuArow trace binding i h_main_active h_main_op)) 1) := by
   unfold mulhuArow
-  set H := exists_arithMul_provider_row_matches_secondary_of_mulhu
+  set H := main_request_mulhu_limb2_provided
     trace i h_main_active h_main_op with hH
   exact H.choose_spec.2.choose_spec.2.2.2
 

--- a/ZiskFv/Compliance/ConstructionMulhu.lean
+++ b/ZiskFv/Compliance/ConstructionMulhu.lean
@@ -614,7 +614,7 @@ lemma equiv_MULHU_of_fullSpec_claimed_dead
     operation, as a concrete `ArithMulRow`.  It is the
     `componentWithArithTable.rowInput` of the provider row chosen by the MULHU
     keep-arithMul balance wrapper
-    `main_request_mulhu_limb2_provided`.
+    `main_request_mulhu_provided`.
     Mirrors `mulwArow`. -/
 noncomputable def mulhuArow
     (trace : AcceptedZiskTrace) (binding : SailTrace trace) (i : Fin trace.numInstructions)
@@ -623,7 +623,7 @@ noncomputable def mulhuArow
     (h_main_op :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_MULUH) :
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
-  let h := main_request_mulhu_limb2_provided
+  let h := main_request_mulhu_provided
     trace i h_main_active h_main_op
   componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
 
@@ -637,7 +637,7 @@ theorem mulhuArow_fullSpec_row
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_MULUH) :
     ZiskFv.AirsClean.ArithMul.FullSpec (mulhuArow trace binding i h_main_active h_main_op) := by
   unfold mulhuArow
-  set H := main_request_mulhu_limb2_provided
+  set H := main_request_mulhu_provided
     trace i h_main_active h_main_op with hH
   obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
   obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
@@ -691,7 +691,7 @@ theorem mulhuArow_match_row
         (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
           (mulhuArow trace binding i h_main_active h_main_op)) 1) := by
   unfold mulhuArow
-  set H := main_request_mulhu_limb2_provided
+  set H := main_request_mulhu_provided
     trace i h_main_active h_main_op with hH
   exact H.choose_spec.2.choose_spec.2.2.2
 

--- a/ZiskFv/Compliance/ConstructionMulw.lean
+++ b/ZiskFv/Compliance/ConstructionMulw.lean
@@ -26,7 +26,7 @@ construction reads that `FullSpec` straight off the balance-derived provider row
 
 * **(a) derived** — proven inside the body, NOT a binder:
   - op-bus provider match (from `trace.channels_balanced`, via the Layer-A wrapper
-    `main_request_mulw_limb1_provided`,
+    `main_request_mulw_provided`,
     bottoming in the axiom-free keep-arithMul balance theorem),
   - the row-native `Valid_ArithMul` view `vOfMulwRow (mulwArow …)` of the
     balance-selected provider row,
@@ -138,7 +138,7 @@ def vOfMulwRow (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL) :
 /-- The balance-selected Arith-Mul provider row at trace index `i`, as a concrete
     `ArithMulRow`. It is the `componentWithArithTable.rowInput` of the provider
     row chosen by the keep-arithMul balance wrapper
-    `main_request_mulw_limb1_provided`.
+    `main_request_mulw_provided`.
 
     This is a deterministic handle on the balance-selected row, used to phrase
     the residual operand bridges over its row-native view
@@ -151,7 +151,7 @@ noncomputable def mulwArow
     (h_main_op :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_MUL_W) :
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
-  let h := main_request_mulw_limb1_provided
+  let h := main_request_mulw_provided
     trace i h_main_active h_main_op
   componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
 
@@ -178,7 +178,7 @@ theorem mulwArow_fullSpec_row
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_MUL_W) :
     ZiskFv.AirsClean.ArithMul.FullSpec (mulwArow trace binding i h_main_active h_main_op) := by
   unfold mulwArow
-  set H := main_request_mulw_limb1_provided
+  set H := main_request_mulw_provided
     trace i h_main_active h_main_op with hH
   obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
   obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
@@ -242,7 +242,7 @@ theorem mulwArow_match_row
         (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
           (mulwArow trace binding i h_main_active h_main_op)) 1) := by
   unfold mulwArow
-  set H := main_request_mulw_limb1_provided
+  set H := main_request_mulw_provided
     trace i h_main_active h_main_op with hH
   -- Use direct `.choose_spec` projections (NOT `obtain`, which introduces a
   -- fresh fvar for the row that the muxed message would force `exact` to

--- a/ZiskFv/Compliance/ConstructionMulw.lean
+++ b/ZiskFv/Compliance/ConstructionMulw.lean
@@ -1,4 +1,5 @@
-import ZiskFv.Compliance.ProviderFromBinding
+import ZiskFv.Compliance.OpBusProviderMatch
+import ZiskFv.Compliance.SailTrace
 import ZiskFv.Compliance.ConstructionSub
 import ZiskFv.Compliance.Wrappers.MulW
 
@@ -25,7 +26,7 @@ construction reads that `FullSpec` straight off the balance-derived provider row
 
 * **(a) derived** — proven inside the body, NOT a binder:
   - op-bus provider match (from `trace.channels_balanced`, via the Layer-A wrapper
-    `exists_arithMul_provider_row_matches_primary_of_mulw_from_binding`,
+    `exists_arithMul_provider_row_matches_primary_of_mulw`,
     bottoming in the axiom-free keep-arithMul balance theorem),
   - the row-native `Valid_ArithMul` view `vOfMulwRow (mulwArow …)` of the
     balance-selected provider row,
@@ -137,7 +138,7 @@ def vOfMulwRow (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL) :
 /-- The balance-selected Arith-Mul provider row at trace index `i`, as a concrete
     `ArithMulRow`. It is the `componentWithArithTable.rowInput` of the provider
     row chosen by the keep-arithMul balance wrapper
-    `exists_arithMul_provider_row_matches_primary_of_mulw_from_binding`.
+    `exists_arithMul_provider_row_matches_primary_of_mulw`.
 
     This is a deterministic handle on the balance-selected row, used to phrase
     the residual operand bridges over its row-native view
@@ -150,8 +151,8 @@ noncomputable def mulwArow
     (h_main_op :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_MUL_W) :
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
-  let h := exists_arithMul_provider_row_matches_primary_of_mulw_from_binding
-    trace binding i h_main_active h_main_op
+  let h := exists_arithMul_provider_row_matches_primary_of_mulw
+    trace i h_main_active h_main_op
   componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
 
 /-- `FullSpec` transports along the row-native view: a `FullSpec` for a concrete
@@ -177,8 +178,8 @@ theorem mulwArow_fullSpec_row
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_MUL_W) :
     ZiskFv.AirsClean.ArithMul.FullSpec (mulwArow trace binding i h_main_active h_main_op) := by
   unfold mulwArow
-  set H := exists_arithMul_provider_row_matches_primary_of_mulw_from_binding
-    trace binding i h_main_active h_main_op with hH
+  set H := exists_arithMul_provider_row_matches_primary_of_mulw
+    trace i h_main_active h_main_op with hH
   obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
   obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
   -- Cheap projection of the provider component's generic `Spec` to `FullSpec`
@@ -241,8 +242,8 @@ theorem mulwArow_match_row
         (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
           (mulwArow trace binding i h_main_active h_main_op)) 1) := by
   unfold mulwArow
-  set H := exists_arithMul_provider_row_matches_primary_of_mulw_from_binding
-    trace binding i h_main_active h_main_op with hH
+  set H := exists_arithMul_provider_row_matches_primary_of_mulw
+    trace i h_main_active h_main_op with hH
   -- Use direct `.choose_spec` projections (NOT `obtain`, which introduces a
   -- fresh fvar for the row that the muxed message would force `exact` to
   -- whnf-reconcile against the goal's `H.choose_spec.2.choose`).

--- a/ZiskFv/Compliance/ConstructionMulw.lean
+++ b/ZiskFv/Compliance/ConstructionMulw.lean
@@ -26,7 +26,7 @@ construction reads that `FullSpec` straight off the balance-derived provider row
 
 * **(a) derived** — proven inside the body, NOT a binder:
   - op-bus provider match (from `trace.channels_balanced`, via the Layer-A wrapper
-    `exists_arithMul_provider_row_matches_primary_of_mulw`,
+    `main_request_mulw_limb1_provided`,
     bottoming in the axiom-free keep-arithMul balance theorem),
   - the row-native `Valid_ArithMul` view `vOfMulwRow (mulwArow …)` of the
     balance-selected provider row,
@@ -138,7 +138,7 @@ def vOfMulwRow (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL) :
 /-- The balance-selected Arith-Mul provider row at trace index `i`, as a concrete
     `ArithMulRow`. It is the `componentWithArithTable.rowInput` of the provider
     row chosen by the keep-arithMul balance wrapper
-    `exists_arithMul_provider_row_matches_primary_of_mulw`.
+    `main_request_mulw_limb1_provided`.
 
     This is a deterministic handle on the balance-selected row, used to phrase
     the residual operand bridges over its row-native view
@@ -151,7 +151,7 @@ noncomputable def mulwArow
     (h_main_op :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_MUL_W) :
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
-  let h := exists_arithMul_provider_row_matches_primary_of_mulw
+  let h := main_request_mulw_limb1_provided
     trace i h_main_active h_main_op
   componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
 
@@ -178,7 +178,7 @@ theorem mulwArow_fullSpec_row
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_MUL_W) :
     ZiskFv.AirsClean.ArithMul.FullSpec (mulwArow trace binding i h_main_active h_main_op) := by
   unfold mulwArow
-  set H := exists_arithMul_provider_row_matches_primary_of_mulw
+  set H := main_request_mulw_limb1_provided
     trace i h_main_active h_main_op with hH
   obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
   obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
@@ -242,7 +242,7 @@ theorem mulwArow_match_row
         (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
           (mulwArow trace binding i h_main_active h_main_op)) 1) := by
   unfold mulwArow
-  set H := exists_arithMul_provider_row_matches_primary_of_mulw
+  set H := main_request_mulw_limb1_provided
     trace i h_main_active h_main_op with hH
   -- Use direct `.choose_spec` projections (NOT `obtain`, which introduces a
   -- fresh fvar for the row that the muxed message would force `exact` to

--- a/ZiskFv/Compliance/ConstructionRemu.lean
+++ b/ZiskFv/Compliance/ConstructionRemu.lean
@@ -135,7 +135,7 @@ theorem match_opBus_row_ArithDivSecondary_vOfDivuRow
     operation, as a concrete `ArithMulRow`.  It is the
     `componentWithArithTable.rowInput` of the provider row chosen by the REMU
     keep-arithMul balance wrapper
-    `exists_arithMul_provider_row_matches_primary_of_remu`.
+    `main_request_remu_limb1_provided`.
     Mirrors `divuArow`. -/
 noncomputable def remuArow
     (trace : AcceptedZiskTrace) (binding : SailTrace trace) (i : Fin trace.numInstructions)
@@ -144,7 +144,7 @@ noncomputable def remuArow
     (h_main_op :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_REMU) :
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
-  let h := exists_arithMul_provider_row_matches_primary_of_remu
+  let h := main_request_remu_limb1_provided
     trace i h_main_active h_main_op
   componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
 
@@ -159,7 +159,7 @@ theorem remuArow_fullSpec_row
     ZiskFv.AirsClean.ArithMul.FullSpec
       (remuArow trace binding i h_main_active h_main_op) := by
   unfold remuArow
-  set H := exists_arithMul_provider_row_matches_primary_of_remu
+  set H := main_request_remu_limb1_provided
     trace i h_main_active h_main_op with hH
   obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
   obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
@@ -180,7 +180,7 @@ theorem remuArow_match_row
         (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
           (remuArow trace binding i h_main_active h_main_op)) 1) := by
   unfold remuArow
-  set H := exists_arithMul_provider_row_matches_primary_of_remu
+  set H := main_request_remu_limb1_provided
     trace i h_main_active h_main_op with hH
   exact H.choose_spec.2.choose_spec.2.2.2
 

--- a/ZiskFv/Compliance/ConstructionRemu.lean
+++ b/ZiskFv/Compliance/ConstructionRemu.lean
@@ -135,7 +135,7 @@ theorem match_opBus_row_ArithDivSecondary_vOfDivuRow
     operation, as a concrete `ArithMulRow`.  It is the
     `componentWithArithTable.rowInput` of the provider row chosen by the REMU
     keep-arithMul balance wrapper
-    `main_request_remu_limb1_provided`.
+    `main_request_remu_provided`.
     Mirrors `divuArow`. -/
 noncomputable def remuArow
     (trace : AcceptedZiskTrace) (binding : SailTrace trace) (i : Fin trace.numInstructions)
@@ -144,7 +144,7 @@ noncomputable def remuArow
     (h_main_op :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_REMU) :
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
-  let h := main_request_remu_limb1_provided
+  let h := main_request_remu_provided
     trace i h_main_active h_main_op
   componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
 
@@ -159,7 +159,7 @@ theorem remuArow_fullSpec_row
     ZiskFv.AirsClean.ArithMul.FullSpec
       (remuArow trace binding i h_main_active h_main_op) := by
   unfold remuArow
-  set H := main_request_remu_limb1_provided
+  set H := main_request_remu_provided
     trace i h_main_active h_main_op with hH
   obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
   obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
@@ -180,7 +180,7 @@ theorem remuArow_match_row
         (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
           (remuArow trace binding i h_main_active h_main_op)) 1) := by
   unfold remuArow
-  set H := main_request_remu_limb1_provided
+  set H := main_request_remu_provided
     trace i h_main_active h_main_op with hH
   exact H.choose_spec.2.choose_spec.2.2.2
 

--- a/ZiskFv/Compliance/ConstructionRemu.lean
+++ b/ZiskFv/Compliance/ConstructionRemu.lean
@@ -1,4 +1,5 @@
-import ZiskFv.Compliance.ProviderFromBinding
+import ZiskFv.Compliance.OpBusProviderMatch
+import ZiskFv.Compliance.SailTrace
 import ZiskFv.Compliance.ConstructionMulw
 import ZiskFv.Compliance.ConstructionMulhu
 import ZiskFv.Compliance.ConstructionDivu
@@ -134,7 +135,7 @@ theorem match_opBus_row_ArithDivSecondary_vOfDivuRow
     operation, as a concrete `ArithMulRow`.  It is the
     `componentWithArithTable.rowInput` of the provider row chosen by the REMU
     keep-arithMul balance wrapper
-    `exists_arithMul_provider_row_matches_primary_of_remu_from_binding`.
+    `exists_arithMul_provider_row_matches_primary_of_remu`.
     Mirrors `divuArow`. -/
 noncomputable def remuArow
     (trace : AcceptedZiskTrace) (binding : SailTrace trace) (i : Fin trace.numInstructions)
@@ -143,8 +144,8 @@ noncomputable def remuArow
     (h_main_op :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_REMU) :
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
-  let h := exists_arithMul_provider_row_matches_primary_of_remu_from_binding
-    trace binding i h_main_active h_main_op
+  let h := exists_arithMul_provider_row_matches_primary_of_remu
+    trace i h_main_active h_main_op
   componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
 
 /-- `FullSpec` of the balance-selected REMU provider row, derived from the
@@ -158,8 +159,8 @@ theorem remuArow_fullSpec_row
     ZiskFv.AirsClean.ArithMul.FullSpec
       (remuArow trace binding i h_main_active h_main_op) := by
   unfold remuArow
-  set H := exists_arithMul_provider_row_matches_primary_of_remu_from_binding
-    trace binding i h_main_active h_main_op with hH
+  set H := exists_arithMul_provider_row_matches_primary_of_remu
+    trace i h_main_active h_main_op with hH
   obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
   obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
   exact ZiskFv.AirsClean.FullEnsemble.arithMul_fullSpec_of_component_spec
@@ -179,8 +180,8 @@ theorem remuArow_match_row
         (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
           (remuArow trace binding i h_main_active h_main_op)) 1) := by
   unfold remuArow
-  set H := exists_arithMul_provider_row_matches_primary_of_remu_from_binding
-    trace binding i h_main_active h_main_op with hH
+  set H := exists_arithMul_provider_row_matches_primary_of_remu
+    trace i h_main_active h_main_op with hH
   exact H.choose_spec.2.choose_spec.2.2.2
 
 /-- REMU mode pins on the balance-selected provider row, DERIVED from its

--- a/ZiskFv/Compliance/ConstructionRemuw.lean
+++ b/ZiskFv/Compliance/ConstructionRemuw.lean
@@ -297,7 +297,7 @@ private lemma remuw_carry_bounds_claimed_dead
     operation, as a concrete `ArithMulRow`.  It is the
     `componentWithArithTable.rowInput` of the provider row chosen by the REMUW
     keep-arithMul balance wrapper
-    `main_request_remuw_limb1_provided`.
+    `main_request_remuw_provided`.
     Mirrors `remuArow` / `divuwArow`. -/
 noncomputable def remuwArow
     (trace : AcceptedZiskTrace) (binding : SailTrace trace) (i : Fin trace.numInstructions)
@@ -306,7 +306,7 @@ noncomputable def remuwArow
     (h_main_op :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_REMU_W) :
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
-  let h := main_request_remuw_limb1_provided
+  let h := main_request_remuw_provided
     trace i h_main_active h_main_op
   componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
 
@@ -321,7 +321,7 @@ theorem remuwArow_fullSpec_row
     ZiskFv.AirsClean.ArithMul.FullSpec
       (remuwArow trace binding i h_main_active h_main_op) := by
   unfold remuwArow
-  set H := main_request_remuw_limb1_provided
+  set H := main_request_remuw_provided
     trace i h_main_active h_main_op with hH
   obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
   obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
@@ -342,7 +342,7 @@ theorem remuwArow_match_row
         (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
           (remuwArow trace binding i h_main_active h_main_op)) 1) := by
   unfold remuwArow
-  set H := main_request_remuw_limb1_provided
+  set H := main_request_remuw_provided
     trace i h_main_active h_main_op with hH
   exact H.choose_spec.2.choose_spec.2.2.2
 

--- a/ZiskFv/Compliance/ConstructionRemuw.lean
+++ b/ZiskFv/Compliance/ConstructionRemuw.lean
@@ -297,7 +297,7 @@ private lemma remuw_carry_bounds_claimed_dead
     operation, as a concrete `ArithMulRow`.  It is the
     `componentWithArithTable.rowInput` of the provider row chosen by the REMUW
     keep-arithMul balance wrapper
-    `exists_arithMul_provider_row_matches_primary_of_remuw`.
+    `main_request_remuw_limb1_provided`.
     Mirrors `remuArow` / `divuwArow`. -/
 noncomputable def remuwArow
     (trace : AcceptedZiskTrace) (binding : SailTrace trace) (i : Fin trace.numInstructions)
@@ -306,7 +306,7 @@ noncomputable def remuwArow
     (h_main_op :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_REMU_W) :
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
-  let h := exists_arithMul_provider_row_matches_primary_of_remuw
+  let h := main_request_remuw_limb1_provided
     trace i h_main_active h_main_op
   componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
 
@@ -321,7 +321,7 @@ theorem remuwArow_fullSpec_row
     ZiskFv.AirsClean.ArithMul.FullSpec
       (remuwArow trace binding i h_main_active h_main_op) := by
   unfold remuwArow
-  set H := exists_arithMul_provider_row_matches_primary_of_remuw
+  set H := main_request_remuw_limb1_provided
     trace i h_main_active h_main_op with hH
   obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
   obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
@@ -342,7 +342,7 @@ theorem remuwArow_match_row
         (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
           (remuwArow trace binding i h_main_active h_main_op)) 1) := by
   unfold remuwArow
-  set H := exists_arithMul_provider_row_matches_primary_of_remuw
+  set H := main_request_remuw_limb1_provided
     trace i h_main_active h_main_op with hH
   exact H.choose_spec.2.choose_spec.2.2.2
 

--- a/ZiskFv/Compliance/ConstructionRemuw.lean
+++ b/ZiskFv/Compliance/ConstructionRemuw.lean
@@ -1,4 +1,5 @@
-import ZiskFv.Compliance.ProviderFromBinding
+import ZiskFv.Compliance.OpBusProviderMatch
+import ZiskFv.Compliance.SailTrace
 import ZiskFv.Compliance.ConstructionMulw
 import ZiskFv.Compliance.ConstructionMulhu
 import ZiskFv.Compliance.ConstructionDivu
@@ -296,7 +297,7 @@ private lemma remuw_carry_bounds_claimed_dead
     operation, as a concrete `ArithMulRow`.  It is the
     `componentWithArithTable.rowInput` of the provider row chosen by the REMUW
     keep-arithMul balance wrapper
-    `exists_arithMul_provider_row_matches_primary_of_remuw_from_binding`.
+    `exists_arithMul_provider_row_matches_primary_of_remuw`.
     Mirrors `remuArow` / `divuwArow`. -/
 noncomputable def remuwArow
     (trace : AcceptedZiskTrace) (binding : SailTrace trace) (i : Fin trace.numInstructions)
@@ -305,8 +306,8 @@ noncomputable def remuwArow
     (h_main_op :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_REMU_W) :
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
-  let h := exists_arithMul_provider_row_matches_primary_of_remuw_from_binding
-    trace binding i h_main_active h_main_op
+  let h := exists_arithMul_provider_row_matches_primary_of_remuw
+    trace i h_main_active h_main_op
   componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
 
 /-- `FullSpec` of the balance-selected REMUW provider row, derived from the
@@ -320,8 +321,8 @@ theorem remuwArow_fullSpec_row
     ZiskFv.AirsClean.ArithMul.FullSpec
       (remuwArow trace binding i h_main_active h_main_op) := by
   unfold remuwArow
-  set H := exists_arithMul_provider_row_matches_primary_of_remuw_from_binding
-    trace binding i h_main_active h_main_op with hH
+  set H := exists_arithMul_provider_row_matches_primary_of_remuw
+    trace i h_main_active h_main_op with hH
   obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
   obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
   exact ZiskFv.AirsClean.FullEnsemble.arithMul_fullSpec_of_component_spec
@@ -341,8 +342,8 @@ theorem remuwArow_match_row
         (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
           (remuwArow trace binding i h_main_active h_main_op)) 1) := by
   unfold remuwArow
-  set H := exists_arithMul_provider_row_matches_primary_of_remuw_from_binding
-    trace binding i h_main_active h_main_op with hH
+  set H := exists_arithMul_provider_row_matches_primary_of_remuw
+    trace i h_main_active h_main_op with hH
   exact H.choose_spec.2.choose_spec.2.2.2
 
 /-- REMUW mode pins on the balance-selected provider row, DERIVED from its

--- a/ZiskFv/Compliance/ConstructionShift.lean
+++ b/ZiskFv/Compliance/ConstructionShift.lean
@@ -29,7 +29,7 @@ The shifts are a **separate template instantiation**, not the
 
 1. **BinaryExtension provider, not staticBinary.** The op-bus provider match is
    derived from the salvaged shift Layer-A wrapper
-   `exists_binaryExtension_provider_row_matches_shift` (which serves
+   `main_request_shift_provided` (which serves
    all twelve shifts; it takes the op pin as the 6-way disjunction
    `OP_SLL ∨ OP_SRL ∨ OP_SRA ∨ OP_SLL_W ∨ OP_SRL_W ∨ OP_SRA_W`, here discharged
    by the appropriate disjunct per family). The provider is
@@ -384,7 +384,7 @@ theorem construction_sll_sound_claimed_dead
   -- (a) op-bus provider match, derived from `trace.channels_balanced`
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i h_main_active (Or.inl h_main_op)
   -- decode pins bundle
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SLL :=
@@ -550,7 +550,7 @@ theorem construction_srl_sound_claimed_dead
   -- (a) op-bus provider match, derived from `trace.channels_balanced`
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i h_main_active (Or.inr (Or.inl h_main_op))
   -- decode pins bundle
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRL :=
@@ -716,7 +716,7 @@ theorem construction_sra_sound_claimed_dead
   -- (a) op-bus provider match, derived from `trace.channels_balanced`
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i h_main_active (Or.inr (Or.inr (Or.inl h_main_op)))
   -- decode pins bundle
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRA :=
@@ -867,7 +867,7 @@ theorem construction_slli_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i h_main_active (Or.inl h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SLL :=
     ⟨h_main_active, h_main_op⟩
@@ -1013,7 +1013,7 @@ theorem construction_srli_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i h_main_active (Or.inr (Or.inl h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRL :=
     ⟨h_main_active, h_main_op⟩
@@ -1159,7 +1159,7 @@ theorem construction_srai_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i h_main_active (Or.inr (Or.inr (Or.inl h_main_op)))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRA :=
     ⟨h_main_active, h_main_op⟩
@@ -1485,7 +1485,7 @@ theorem construction_sllw_sound_claimed_dead
   -- disjunct of the shared shift Layer-A wrapper.
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i h_main_active (Or.inr (Or.inr (Or.inr (Or.inl h_main_op))))
   -- decode pins bundle
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SLL_W :=
@@ -1632,7 +1632,7 @@ theorem construction_srlw_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i h_main_active (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl h_main_op)))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRL_W :=
     ⟨h_main_active, h_main_op⟩
@@ -1772,7 +1772,7 @@ theorem construction_sraw_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i h_main_active
       (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr h_main_op)))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRA_W :=
@@ -1918,7 +1918,7 @@ theorem construction_slliw_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i h_main_active (Or.inr (Or.inr (Or.inr (Or.inl h_main_op))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SLL_W :=
     ⟨h_main_active, h_main_op⟩
@@ -2045,7 +2045,7 @@ theorem construction_srliw_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i h_main_active (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl h_main_op)))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRL_W :=
     ⟨h_main_active, h_main_op⟩
@@ -2172,7 +2172,7 @@ theorem construction_sraiw_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i h_main_active
       (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr h_main_op)))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRA_W :=

--- a/ZiskFv/Compliance/ConstructionShift.lean
+++ b/ZiskFv/Compliance/ConstructionShift.lean
@@ -29,7 +29,7 @@ The shifts are a **separate template instantiation**, not the
 
 1. **BinaryExtension provider, not staticBinary.** The op-bus provider match is
    derived from the salvaged shift Layer-A wrapper
-   `exists_binaryExtension_provider_row_matches_shift_from_binding` (which serves
+   `exists_binaryExtension_provider_row_matches_shift` (which serves
    all twelve shifts; it takes the op pin as the 6-way disjunction
    `OP_SLL ∨ OP_SRL ∨ OP_SRA ∨ OP_SLL_W ∨ OP_SRL_W ∨ OP_SRA_W`, here discharged
    by the appropriate disjunct per family). The provider is
@@ -384,8 +384,8 @@ theorem construction_sll_sound_claimed_dead
   -- (a) op-bus provider match, derived from `trace.channels_balanced`
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i h_main_active (Or.inl h_main_op)
+    exists_binaryExtension_provider_row_matches_shift
+      trace i h_main_active (Or.inl h_main_op)
   -- decode pins bundle
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SLL :=
     ⟨h_main_active, h_main_op⟩
@@ -550,8 +550,8 @@ theorem construction_srl_sound_claimed_dead
   -- (a) op-bus provider match, derived from `trace.channels_balanced`
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i h_main_active (Or.inr (Or.inl h_main_op))
+    exists_binaryExtension_provider_row_matches_shift
+      trace i h_main_active (Or.inr (Or.inl h_main_op))
   -- decode pins bundle
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRL :=
     ⟨h_main_active, h_main_op⟩
@@ -716,8 +716,8 @@ theorem construction_sra_sound_claimed_dead
   -- (a) op-bus provider match, derived from `trace.channels_balanced`
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i h_main_active (Or.inr (Or.inr (Or.inl h_main_op)))
+    exists_binaryExtension_provider_row_matches_shift
+      trace i h_main_active (Or.inr (Or.inr (Or.inl h_main_op)))
   -- decode pins bundle
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRA :=
     ⟨h_main_active, h_main_op⟩
@@ -867,8 +867,8 @@ theorem construction_slli_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i h_main_active (Or.inl h_main_op)
+    exists_binaryExtension_provider_row_matches_shift
+      trace i h_main_active (Or.inl h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SLL :=
     ⟨h_main_active, h_main_op⟩
   have h_core_store_pc :
@@ -1013,8 +1013,8 @@ theorem construction_srli_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i h_main_active (Or.inr (Or.inl h_main_op))
+    exists_binaryExtension_provider_row_matches_shift
+      trace i h_main_active (Or.inr (Or.inl h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRL :=
     ⟨h_main_active, h_main_op⟩
   have h_core_store_pc :
@@ -1159,8 +1159,8 @@ theorem construction_srai_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i h_main_active (Or.inr (Or.inr (Or.inl h_main_op)))
+    exists_binaryExtension_provider_row_matches_shift
+      trace i h_main_active (Or.inr (Or.inr (Or.inl h_main_op)))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRA :=
     ⟨h_main_active, h_main_op⟩
   have h_core_store_pc :
@@ -1485,8 +1485,8 @@ theorem construction_sllw_sound_claimed_dead
   -- disjunct of the shared shift Layer-A wrapper.
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i h_main_active (Or.inr (Or.inr (Or.inr (Or.inl h_main_op))))
+    exists_binaryExtension_provider_row_matches_shift
+      trace i h_main_active (Or.inr (Or.inr (Or.inr (Or.inl h_main_op))))
   -- decode pins bundle
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SLL_W :=
     ⟨h_main_active, h_main_op⟩
@@ -1632,8 +1632,8 @@ theorem construction_srlw_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i h_main_active (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl h_main_op)))))
+    exists_binaryExtension_provider_row_matches_shift
+      trace i h_main_active (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl h_main_op)))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRL_W :=
     ⟨h_main_active, h_main_op⟩
   have h_core_store_pc :
@@ -1772,8 +1772,8 @@ theorem construction_sraw_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i h_main_active
+    exists_binaryExtension_provider_row_matches_shift
+      trace i h_main_active
       (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr h_main_op)))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRA_W :=
     ⟨h_main_active, h_main_op⟩
@@ -1918,8 +1918,8 @@ theorem construction_slliw_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i h_main_active (Or.inr (Or.inr (Or.inr (Or.inl h_main_op))))
+    exists_binaryExtension_provider_row_matches_shift
+      trace i h_main_active (Or.inr (Or.inr (Or.inr (Or.inl h_main_op))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SLL_W :=
     ⟨h_main_active, h_main_op⟩
   have h_core_store_pc :
@@ -2045,8 +2045,8 @@ theorem construction_srliw_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i h_main_active (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl h_main_op)))))
+    exists_binaryExtension_provider_row_matches_shift
+      trace i h_main_active (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl h_main_op)))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRL_W :=
     ⟨h_main_active, h_main_op⟩
   have h_core_store_pc :
@@ -2172,8 +2172,8 @@ theorem construction_sraiw_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i h_main_active
+    exists_binaryExtension_provider_row_matches_shift
+      trace i h_main_active
       (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr h_main_op)))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRA_W :=
     ⟨h_main_active, h_main_op⟩

--- a/ZiskFv/Compliance/ConstructionStore.lean
+++ b/ZiskFv/Compliance/ConstructionStore.lean
@@ -1,4 +1,5 @@
-import ZiskFv.Compliance.ProviderFromBinding
+import ZiskFv.Compliance.OpBusProviderMatch
+import ZiskFv.Compliance.SailTrace
 import ZiskFv.Compliance.Wrappers.Sb
 import ZiskFv.Compliance.Wrappers.Sh
 import ZiskFv.Compliance.Wrappers.Sw
@@ -19,8 +20,8 @@ side** instead of the operation bus.
 
 ALU/M-ext ops READ their operands off register-bus MemBus entries and write
 `rd`; their op-bus `equiv_<OP>` is resolved against a *separate* provider AIR
-(Binary / Arith / …) via a Layer-A `exists_*_provider_row_matches_*_from_binding`
-wrapper that consumes `trace.channels_balanced`.
+(Binary / Arith / …) via a Layer-A `exists_*_provider_row_matches_*`
+lemma that consumes `trace.channels_balanced`.
 
 Stores WRITE memory. The store's memory-bus write entry (`bus.e2`, address-space
 `as = 2`) is the Main row's **own** c/store emission `cMemMessage`. The

--- a/ZiskFv/Compliance/ConstructionSub.lean
+++ b/ZiskFv/Compliance/ConstructionSub.lean
@@ -1,4 +1,5 @@
-import ZiskFv.Compliance.ProviderFromBinding
+import ZiskFv.Compliance.OpBusProviderMatch
+import ZiskFv.Compliance.SailTrace
 import ZiskFv.Compliance.Wrappers.Sub
 
 /-!
@@ -21,7 +22,7 @@ ensemble (channels = OpBus + MemBus only; per-row component model):
 
 * **(a) derived** — proven inside the body, NOT a binder:
   - op-bus provider match (from `trace.channels_balanced`, via the salvaged Layer-A
-    `exists_staticBinary_provider_row_matches_sub_from_binding`, bottoming in an
+    `exists_staticBinary_provider_row_matches_sub`, bottoming in an
     axiom-free Layer-B permutation theorem),
   - row shape (`mainOfTable` / `rowAt_mainOfTable`),
   - circuit-internal rd arithmetic (the already-proven packed byte-chain lemmas),
@@ -237,8 +238,8 @@ theorem construction_sub_sound_claimed_dead
   -- (a) op-bus provider match, derived from `trace.channels_balanced`
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_sub_from_binding
-      trace binding i h_main_active h_main_op
+    exists_staticBinary_provider_row_matches_sub
+      trace i h_main_active h_main_op
   -- decode pins bundle
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SUB :=
     ⟨h_main_active, h_main_op⟩

--- a/ZiskFv/Compliance/ConstructionSub.lean
+++ b/ZiskFv/Compliance/ConstructionSub.lean
@@ -22,7 +22,7 @@ ensemble (channels = OpBus + MemBus only; per-row component model):
 
 * **(a) derived** — proven inside the body, NOT a binder:
   - op-bus provider match (from `trace.channels_balanced`, via the salvaged Layer-A
-    `exists_staticBinary_provider_row_matches_sub`, bottoming in an
+    `main_request_sub_provided`, bottoming in an
     axiom-free Layer-B permutation theorem),
   - row shape (`mainOfTable` / `rowAt_mainOfTable`),
   - circuit-internal rd arithmetic (the already-proven packed byte-chain lemmas),
@@ -238,7 +238,7 @@ theorem construction_sub_sound_claimed_dead
   -- (a) op-bus provider match, derived from `trace.channels_balanced`
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_sub
+    main_request_sub_provided
       trace i h_main_active h_main_op
   -- decode pins bundle
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SUB :=

--- a/ZiskFv/Compliance/ConstructionWAlu.lean
+++ b/ZiskFv/Compliance/ConstructionWAlu.lean
@@ -1,4 +1,5 @@
-import ZiskFv.Compliance.ProviderFromBinding
+import ZiskFv.Compliance.OpBusProviderMatch
+import ZiskFv.Compliance.SailTrace
 import ZiskFv.Compliance.ConstructionSub
 import ZiskFv.Compliance.Wrappers.Addw
 import ZiskFv.Compliance.Wrappers.Subw
@@ -26,7 +27,7 @@ The W families differ from the 64-bit SUB construction on exactly these points:
    lanes collapse to `0` (provider high bytes pinned zero); the 32-bit operand is
    sourced from the `a_lo`/`b_lo` conjunct only.
 2. **op-bus provider match** via the salvaged W Layer-A wrapper
-   `exists_staticBinary_provider_row_matches_w_from_binding` (op pin disjunction
+   `exists_staticBinary_provider_row_matches_w` (op pin disjunction
    `OP_ADD_W ∨ OP_SUB_W`).
 3. **lane → Sail binding** via the new m32 = 1 lane lemmas, producing the 32-bit
    `extractLsb _ 31 0` form `binaryRowA32 row % 2^32` (NOT the 64-bit
@@ -153,8 +154,8 @@ theorem construction_subw_sound_claimed_dead
   -- (a) op-bus provider match, derived from `trace.channels_balanced`. SUBW = `Or.inr`.
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_w_from_binding
-      trace binding i h_main_active (Or.inr h_main_op)
+    exists_staticBinary_provider_row_matches_w
+      trace i h_main_active (Or.inr h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SUB_W :=
     ⟨h_main_active, h_main_op⟩
   have h_core_store_pc :
@@ -328,8 +329,8 @@ theorem construction_addw_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_w_from_binding
-      trace binding i h_main_active (Or.inl h_main_op)
+    exists_staticBinary_provider_row_matches_w
+      trace i h_main_active (Or.inl h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD_W :=
     ⟨h_main_active, h_main_op⟩
   have h_core_store_pc :
@@ -500,8 +501,8 @@ theorem construction_addiw_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_w_from_binding
-      trace binding i h_main_active (Or.inl h_main_op)
+    exists_staticBinary_provider_row_matches_w
+      trace i h_main_active (Or.inl h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD_W :=
     ⟨h_main_active, h_main_op⟩
   have h_core_store_pc :

--- a/ZiskFv/Compliance/ConstructionWAlu.lean
+++ b/ZiskFv/Compliance/ConstructionWAlu.lean
@@ -27,7 +27,7 @@ The W families differ from the 64-bit SUB construction on exactly these points:
    lanes collapse to `0` (provider high bytes pinned zero); the 32-bit operand is
    sourced from the `a_lo`/`b_lo` conjunct only.
 2. **op-bus provider match** via the salvaged W Layer-A wrapper
-   `exists_staticBinary_provider_row_matches_w` (op pin disjunction
+   `main_request_w_provided` (op pin disjunction
    `OP_ADD_W ∨ OP_SUB_W`).
 3. **lane → Sail binding** via the new m32 = 1 lane lemmas, producing the 32-bit
    `extractLsb _ 31 0` form `binaryRowA32 row % 2^32` (NOT the 64-bit
@@ -154,7 +154,7 @@ theorem construction_subw_sound_claimed_dead
   -- (a) op-bus provider match, derived from `trace.channels_balanced`. SUBW = `Or.inr`.
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_w
+    main_request_w_provided
       trace i h_main_active (Or.inr h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SUB_W :=
     ⟨h_main_active, h_main_op⟩
@@ -329,7 +329,7 @@ theorem construction_addw_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_w
+    main_request_w_provided
       trace i h_main_active (Or.inl h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD_W :=
     ⟨h_main_active, h_main_op⟩
@@ -501,7 +501,7 @@ theorem construction_addiw_sound_claimed_dead
   let bus := busSub trace binding i execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_w
+    main_request_w_provided
       trace i h_main_active (Or.inl h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD_W :=
     ⟨h_main_active, h_main_op⟩

--- a/ZiskFv/Compliance/OpBusProviderMatch.lean
+++ b/ZiskFv/Compliance/OpBusProviderMatch.lean
@@ -3,12 +3,13 @@ import ZiskFv.AirsClean.FullEnsemble.Balance
 import ZiskFv.AirsClean.FullEnsemble.ArithBalance
 
 /-!
-# Layer-A op-bus provider-match existence lemmas
+# Layer-A op-bus request lemmas
 
-The `exists_*_provider_row_matches_*` lemmas: for an active Main op row, they
-build the Main op-bus interaction, prove its membership and `mult = -1`, and
-discharge the op-bus provider match by delegating to the axiom-free Layer-B
-permutation theorems in `AirsClean/FullEnsemble/{Balance,ArithBalance}.lean`.
+The `main_request_<op>_provided` lemmas: for an active Main op row, they prove
+Main's op-bus request (the interaction with `mult = -1`) is matched by a provider
+push in the witness — building the Main interaction, proving its membership and
+`mult = -1`, and discharging the match via the axiom-free Layer-B permutation
+theorems in `AirsClean/FullEnsemble/{Balance,ArithBalance}.lean`.
 They are the only consumers of `trace.channels_balanced` in the construction
 spine; the honest sound construction built on top lives in
 `ZiskFv/Compliance/ConstructionSub.lean`.
@@ -18,7 +19,7 @@ namespace ZiskFv.Compliance
 
 open ZiskFv.AirsClean.FullEnsemble
 
-theorem exists_staticBinary_provider_row_matches_logic
+theorem main_request_logic_provided
     (trace : AcceptedZiskTrace)
     (i : Fin trace.numInstructions)
     (h_main_active :
@@ -109,7 +110,7 @@ theorem exists_staticBinary_provider_row_matches_logic
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
 
-theorem exists_staticBinary_provider_row_matches_sub
+theorem main_request_sub_provided
     (trace : AcceptedZiskTrace)
     (i : Fin trace.numInstructions)
     (h_main_active :
@@ -194,7 +195,7 @@ theorem exists_staticBinary_provider_row_matches_sub
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
 
-theorem exists_add_provider_row_matches
+theorem main_request_add_provided
     (trace : AcceptedZiskTrace)
     (i : Fin trace.numInstructions)
     (h_main_active :
@@ -317,7 +318,7 @@ theorem exists_add_provider_row_matches
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op⟩
 
-theorem exists_staticBinary_provider_row_matches_compare
+theorem main_request_compare_provided
     (trace : AcceptedZiskTrace)
     (i : Fin trace.numInstructions)
     (h_main_active :
@@ -405,7 +406,7 @@ theorem exists_staticBinary_provider_row_matches_compare
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
 
-theorem exists_staticBinary_provider_row_matches_w
+theorem main_request_w_provided
     (trace : AcceptedZiskTrace)
     (i : Fin trace.numInstructions)
     (h_main_active :
@@ -493,7 +494,7 @@ theorem exists_staticBinary_provider_row_matches_w
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
 
-theorem exists_binaryExtension_provider_row_matches_shift
+theorem main_request_shift_provided
     (trace : AcceptedZiskTrace)
     (i : Fin trace.numInstructions)
     (h_main_active :
@@ -596,7 +597,7 @@ theorem exists_binaryExtension_provider_row_matches_shift
 
 /-- Layer-A op-bus provider-match wrapper for the Arith MULW operation
     (`OP_MUL_W = 182`).  Mirrors
-    `exists_staticBinary_provider_row_matches_sub`: it builds the
+    `main_request_sub_provided`: it builds the
     Main op-bus interaction, proves membership + `mult = -1`, and delegates to
     the keep-arithMul balance theorem
     `exists_arithMul_provider_row_matches_primary_of_mulw_active_main_row_interaction`.
@@ -605,7 +606,7 @@ theorem exists_binaryExtension_provider_row_matches_shift
     `arithMulProviderComponent` (= `ArithMul.componentWithArithTable`), so
     `providerTable.Spec` is `FullSpec (rowInput …)` and the match is against the
     ArithMul primary op-bus message. -/
-theorem exists_arithMul_provider_row_matches_primary_of_mulw
+theorem main_request_mulw_limb1_provided
     (trace : AcceptedZiskTrace)
     (i : Fin trace.numInstructions)
     (h_main_active :
@@ -692,14 +693,14 @@ theorem exists_arithMul_provider_row_matches_primary_of_mulw
 
 /-- Layer-A op-bus provider-match wrapper for the Arith MULHU operation
     (`OP_MULUH = 177`).  Mirrors
-    `exists_arithMul_provider_row_matches_primary_of_mulw`, but
+    `main_request_mulw_limb1_provided`, but
     delegates to the MULHU keep-arithMul balance theorem
     `exists_arithMul_provider_row_matches_secondary_of_mulhu_active_main_row_interaction`.
 
     The returned match is still against the muxed `primaryOpBusMessage`; the
     MULHU-mode bridge in `ArithMul/Bridge.lean` later reduces it to the
     secondary d-lane `opBus_row_ArithMulSecondary`. -/
-theorem exists_arithMul_provider_row_matches_secondary_of_mulhu
+theorem main_request_mulhu_limb2_provided
     (trace : AcceptedZiskTrace)
     (i : Fin trace.numInstructions)
     (h_main_active :
@@ -786,7 +787,7 @@ theorem exists_arithMul_provider_row_matches_secondary_of_mulhu
 
 /-- Layer-A op-bus provider-match wrapper for the Arith DIVU operation
     (`OP_DIVU = 184`).  Mirrors
-    `exists_arithMul_provider_row_matches_primary_of_mulw`, but
+    `main_request_mulw_limb1_provided`, but
     delegates to the DIVU keep-arithMul balance theorem
     `exists_arithMul_provider_row_matches_primary_of_divu_active_main_row_interaction`.
 
@@ -795,7 +796,7 @@ theorem exists_arithMul_provider_row_matches_secondary_of_mulhu
     against the muxed `primaryOpBusMessage`.  The DIVU-mode bridge in
     `ArithMul/Bridge.lean` later reduces it to the div quotient-lane
     `opBus_row_ArithDiv`. -/
-theorem exists_arithMul_provider_row_matches_primary_of_divu
+theorem main_request_divu_limb1_provided
     (trace : AcceptedZiskTrace)
     (i : Fin trace.numInstructions)
     (h_main_active :
@@ -882,7 +883,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_divu
 
 /-- Layer-A op-bus provider-match wrapper for the Arith DIVUW operation
     (`OP_DIVU_W = 188`, W-mode `m32 = 1`).  Mirrors
-    `exists_arithMul_provider_row_matches_primary_of_divu`, but
+    `main_request_divu_limb1_provided`, but
     delegates to the DIVUW keep-arithMul balance theorem
     `exists_arithMul_provider_row_matches_primary_of_divuw_active_main_row_interaction`.
 
@@ -890,7 +891,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_divu
     ArithDiv component carries no op-bus in the ensemble); the returned match is
     against the muxed `primaryOpBusMessage`.  The DIVU-mode op-bus bridge later
     reduces it to the div quotient-lane `opBus_row_ArithDiv`. -/
-theorem exists_arithMul_provider_row_matches_primary_of_divuw
+theorem main_request_divuw_limb1_provided
     (trace : AcceptedZiskTrace)
     (i : Fin trace.numInstructions)
     (h_main_active :
@@ -977,7 +978,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_divuw
 
 /-- Layer-A op-bus provider-match wrapper for the Arith REMU operation
     (`OP_REMU = 185`).  Mirrors
-    `exists_arithMul_provider_row_matches_primary_of_divu`, but
+    `main_request_divu_limb1_provided`, but
     delegates to the REMU keep-arithMul balance theorem
     `exists_arithMul_provider_row_matches_primary_of_remu_active_main_row_interaction`.
 
@@ -986,7 +987,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_divuw
     against the muxed `primaryOpBusMessage`.  The REMU-mode bridge in
     `ConstructionRemu.lean` later reduces it (at `div = 1`, `main_div = 0`,
     `main_mul = 0`) to the div remainder-lane `opBus_row_ArithDivSecondary`. -/
-theorem exists_arithMul_provider_row_matches_primary_of_remu
+theorem main_request_remu_limb1_provided
     (trace : AcceptedZiskTrace)
     (i : Fin trace.numInstructions)
     (h_main_active :
@@ -1073,7 +1074,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_remu
 
 /-- Layer-A op-bus provider-match wrapper for the Arith REMUW operation
     (`OP_REMU_W = 189`, W-mode `m32 = 1`).  Mirrors
-    `exists_arithMul_provider_row_matches_primary_of_remu`, but
+    `main_request_remu_limb1_provided`, but
     delegates to the REMUW keep-arithMul balance theorem
     `exists_arithMul_provider_row_matches_primary_of_remuw_active_main_row_interaction`.
 
@@ -1083,7 +1084,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_remu
     `ConstructionRemu.lean` later reduces it (at `div = 1`, `main_div = 0`,
     `main_mul = 0`) to the div remainder-lane `opBus_row_ArithDivSecondary`; the
     `m32` flag plays no role in the mux. -/
-theorem exists_arithMul_provider_row_matches_primary_of_remuw
+theorem main_request_remuw_limb1_provided
     (trace : AcceptedZiskTrace)
     (i : Fin trace.numInstructions)
     (h_main_active :

--- a/ZiskFv/Compliance/OpBusProviderMatch.lean
+++ b/ZiskFv/Compliance/OpBusProviderMatch.lean
@@ -1,26 +1,25 @@
-import ZiskFv.Compliance.SailTrace
+import ZiskFv.Compliance.AcceptedZiskTrace.MainTable
 import ZiskFv.AirsClean.FullEnsemble.Balance
 import ZiskFv.AirsClean.FullEnsemble.ArithBalance
 
 /-!
-# Layer-A op-bus provider-match wrappers
+# Layer-A op-bus provider-match existence lemmas
 
-The `exists_*_provider_row_matches_*_from_binding` wrappers: for an active Main
-op row selected by a `SailTrace`, they build the Main op-bus interaction,
-prove its membership and `mult = -1`, and discharge the op-bus provider match by
-delegating to the axiom-free Layer-B permutation theorems in
-`AirsClean/FullEnsemble/{Balance,ArithBalance}.lean`. They are the only consumers
-of `trace.channels_balanced` in the construction spine; the honest sound construction
-built on top lives in `ZiskFv/Compliance/ConstructionSub.lean`.
+The `exists_*_provider_row_matches_*` lemmas: for an active Main op row, they
+build the Main op-bus interaction, prove its membership and `mult = -1`, and
+discharge the op-bus provider match by delegating to the axiom-free Layer-B
+permutation theorems in `AirsClean/FullEnsemble/{Balance,ArithBalance}.lean`.
+They are the only consumers of `trace.channels_balanced` in the construction
+spine; the honest sound construction built on top lives in
+`ZiskFv/Compliance/ConstructionSub.lean`.
 -/
 
 namespace ZiskFv.Compliance
 
 open ZiskFv.AirsClean.FullEnsemble
 
-theorem exists_staticBinary_provider_row_matches_logic_from_binding
+theorem exists_staticBinary_provider_row_matches_logic
     (trace : AcceptedZiskTrace)
-    (binding : SailTrace trace)
     (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
@@ -110,9 +109,8 @@ theorem exists_staticBinary_provider_row_matches_logic_from_binding
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
 
-theorem exists_staticBinary_provider_row_matches_sub_from_binding
+theorem exists_staticBinary_provider_row_matches_sub
     (trace : AcceptedZiskTrace)
-    (binding : SailTrace trace)
     (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
@@ -196,9 +194,8 @@ theorem exists_staticBinary_provider_row_matches_sub_from_binding
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
 
-theorem exists_add_provider_row_matches_from_binding
+theorem exists_add_provider_row_matches
     (trace : AcceptedZiskTrace)
-    (binding : SailTrace trace)
     (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
@@ -320,9 +317,8 @@ theorem exists_add_provider_row_matches_from_binding
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op⟩
 
-theorem exists_staticBinary_provider_row_matches_compare_from_binding
+theorem exists_staticBinary_provider_row_matches_compare
     (trace : AcceptedZiskTrace)
-    (binding : SailTrace trace)
     (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
@@ -409,9 +405,8 @@ theorem exists_staticBinary_provider_row_matches_compare_from_binding
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
 
-theorem exists_staticBinary_provider_row_matches_w_from_binding
+theorem exists_staticBinary_provider_row_matches_w
     (trace : AcceptedZiskTrace)
-    (binding : SailTrace trace)
     (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
@@ -498,9 +493,8 @@ theorem exists_staticBinary_provider_row_matches_w_from_binding
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
 
-theorem exists_binaryExtension_provider_row_matches_shift_from_binding
+theorem exists_binaryExtension_provider_row_matches_shift
     (trace : AcceptedZiskTrace)
-    (binding : SailTrace trace)
     (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
@@ -602,7 +596,7 @@ theorem exists_binaryExtension_provider_row_matches_shift_from_binding
 
 /-- Layer-A op-bus provider-match wrapper for the Arith MULW operation
     (`OP_MUL_W = 182`).  Mirrors
-    `exists_staticBinary_provider_row_matches_sub_from_binding`: it builds the
+    `exists_staticBinary_provider_row_matches_sub`: it builds the
     Main op-bus interaction, proves membership + `mult = -1`, and delegates to
     the keep-arithMul balance theorem
     `exists_arithMul_provider_row_matches_primary_of_mulw_active_main_row_interaction`.
@@ -611,9 +605,8 @@ theorem exists_binaryExtension_provider_row_matches_shift_from_binding
     `arithMulProviderComponent` (= `ArithMul.componentWithArithTable`), so
     `providerTable.Spec` is `FullSpec (rowInput …)` and the match is against the
     ArithMul primary op-bus message. -/
-theorem exists_arithMul_provider_row_matches_primary_of_mulw_from_binding
+theorem exists_arithMul_provider_row_matches_primary_of_mulw
     (trace : AcceptedZiskTrace)
-    (binding : SailTrace trace)
     (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
@@ -699,16 +692,15 @@ theorem exists_arithMul_provider_row_matches_primary_of_mulw_from_binding
 
 /-- Layer-A op-bus provider-match wrapper for the Arith MULHU operation
     (`OP_MULUH = 177`).  Mirrors
-    `exists_arithMul_provider_row_matches_primary_of_mulw_from_binding`, but
+    `exists_arithMul_provider_row_matches_primary_of_mulw`, but
     delegates to the MULHU keep-arithMul balance theorem
     `exists_arithMul_provider_row_matches_secondary_of_mulhu_active_main_row_interaction`.
 
     The returned match is still against the muxed `primaryOpBusMessage`; the
     MULHU-mode bridge in `ArithMul/Bridge.lean` later reduces it to the
     secondary d-lane `opBus_row_ArithMulSecondary`. -/
-theorem exists_arithMul_provider_row_matches_secondary_of_mulhu_from_binding
+theorem exists_arithMul_provider_row_matches_secondary_of_mulhu
     (trace : AcceptedZiskTrace)
-    (binding : SailTrace trace)
     (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
@@ -794,7 +786,7 @@ theorem exists_arithMul_provider_row_matches_secondary_of_mulhu_from_binding
 
 /-- Layer-A op-bus provider-match wrapper for the Arith DIVU operation
     (`OP_DIVU = 184`).  Mirrors
-    `exists_arithMul_provider_row_matches_primary_of_mulw_from_binding`, but
+    `exists_arithMul_provider_row_matches_primary_of_mulw`, but
     delegates to the DIVU keep-arithMul balance theorem
     `exists_arithMul_provider_row_matches_primary_of_divu_active_main_row_interaction`.
 
@@ -803,9 +795,8 @@ theorem exists_arithMul_provider_row_matches_secondary_of_mulhu_from_binding
     against the muxed `primaryOpBusMessage`.  The DIVU-mode bridge in
     `ArithMul/Bridge.lean` later reduces it to the div quotient-lane
     `opBus_row_ArithDiv`. -/
-theorem exists_arithMul_provider_row_matches_primary_of_divu_from_binding
+theorem exists_arithMul_provider_row_matches_primary_of_divu
     (trace : AcceptedZiskTrace)
-    (binding : SailTrace trace)
     (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
@@ -891,7 +882,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_divu_from_binding
 
 /-- Layer-A op-bus provider-match wrapper for the Arith DIVUW operation
     (`OP_DIVU_W = 188`, W-mode `m32 = 1`).  Mirrors
-    `exists_arithMul_provider_row_matches_primary_of_divu_from_binding`, but
+    `exists_arithMul_provider_row_matches_primary_of_divu`, but
     delegates to the DIVUW keep-arithMul balance theorem
     `exists_arithMul_provider_row_matches_primary_of_divuw_active_main_row_interaction`.
 
@@ -899,9 +890,8 @@ theorem exists_arithMul_provider_row_matches_primary_of_divu_from_binding
     ArithDiv component carries no op-bus in the ensemble); the returned match is
     against the muxed `primaryOpBusMessage`.  The DIVU-mode op-bus bridge later
     reduces it to the div quotient-lane `opBus_row_ArithDiv`. -/
-theorem exists_arithMul_provider_row_matches_primary_of_divuw_from_binding
+theorem exists_arithMul_provider_row_matches_primary_of_divuw
     (trace : AcceptedZiskTrace)
-    (binding : SailTrace trace)
     (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
@@ -987,7 +977,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_divuw_from_binding
 
 /-- Layer-A op-bus provider-match wrapper for the Arith REMU operation
     (`OP_REMU = 185`).  Mirrors
-    `exists_arithMul_provider_row_matches_primary_of_divu_from_binding`, but
+    `exists_arithMul_provider_row_matches_primary_of_divu`, but
     delegates to the REMU keep-arithMul balance theorem
     `exists_arithMul_provider_row_matches_primary_of_remu_active_main_row_interaction`.
 
@@ -996,9 +986,8 @@ theorem exists_arithMul_provider_row_matches_primary_of_divuw_from_binding
     against the muxed `primaryOpBusMessage`.  The REMU-mode bridge in
     `ConstructionRemu.lean` later reduces it (at `div = 1`, `main_div = 0`,
     `main_mul = 0`) to the div remainder-lane `opBus_row_ArithDivSecondary`. -/
-theorem exists_arithMul_provider_row_matches_primary_of_remu_from_binding
+theorem exists_arithMul_provider_row_matches_primary_of_remu
     (trace : AcceptedZiskTrace)
-    (binding : SailTrace trace)
     (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
@@ -1084,7 +1073,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_remu_from_binding
 
 /-- Layer-A op-bus provider-match wrapper for the Arith REMUW operation
     (`OP_REMU_W = 189`, W-mode `m32 = 1`).  Mirrors
-    `exists_arithMul_provider_row_matches_primary_of_remu_from_binding`, but
+    `exists_arithMul_provider_row_matches_primary_of_remu`, but
     delegates to the REMUW keep-arithMul balance theorem
     `exists_arithMul_provider_row_matches_primary_of_remuw_active_main_row_interaction`.
 
@@ -1094,9 +1083,8 @@ theorem exists_arithMul_provider_row_matches_primary_of_remu_from_binding
     `ConstructionRemu.lean` later reduces it (at `div = 1`, `main_div = 0`,
     `main_mul = 0`) to the div remainder-lane `opBus_row_ArithDivSecondary`; the
     `m32` flag plays no role in the mux. -/
-theorem exists_arithMul_provider_row_matches_primary_of_remuw_from_binding
+theorem exists_arithMul_provider_row_matches_primary_of_remuw
     (trace : AcceptedZiskTrace)
-    (binding : SailTrace trace)
     (i : Fin trace.numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op

--- a/ZiskFv/Compliance/OpBusProviderMatch.lean
+++ b/ZiskFv/Compliance/OpBusProviderMatch.lean
@@ -606,7 +606,7 @@ theorem main_request_shift_provided
     `arithMulProviderComponent` (= `ArithMul.componentWithArithTable`), so
     `providerTable.Spec` is `FullSpec (rowInput …)` and the match is against the
     ArithMul primary op-bus message. -/
-theorem main_request_mulw_limb1_provided
+theorem main_request_mulw_provided
     (trace : AcceptedZiskTrace)
     (i : Fin trace.numInstructions)
     (h_main_active :
@@ -693,14 +693,14 @@ theorem main_request_mulw_limb1_provided
 
 /-- Layer-A op-bus provider-match wrapper for the Arith MULHU operation
     (`OP_MULUH = 177`).  Mirrors
-    `main_request_mulw_limb1_provided`, but
+    `main_request_mulw_provided`, but
     delegates to the MULHU keep-arithMul balance theorem
     `exists_arithMul_provider_row_matches_secondary_of_mulhu_active_main_row_interaction`.
 
     The returned match is still against the muxed `primaryOpBusMessage`; the
     MULHU-mode bridge in `ArithMul/Bridge.lean` later reduces it to the
     secondary d-lane `opBus_row_ArithMulSecondary`. -/
-theorem main_request_mulhu_limb2_provided
+theorem main_request_mulhu_provided
     (trace : AcceptedZiskTrace)
     (i : Fin trace.numInstructions)
     (h_main_active :
@@ -787,7 +787,7 @@ theorem main_request_mulhu_limb2_provided
 
 /-- Layer-A op-bus provider-match wrapper for the Arith DIVU operation
     (`OP_DIVU = 184`).  Mirrors
-    `main_request_mulw_limb1_provided`, but
+    `main_request_mulw_provided`, but
     delegates to the DIVU keep-arithMul balance theorem
     `exists_arithMul_provider_row_matches_primary_of_divu_active_main_row_interaction`.
 
@@ -796,7 +796,7 @@ theorem main_request_mulhu_limb2_provided
     against the muxed `primaryOpBusMessage`.  The DIVU-mode bridge in
     `ArithMul/Bridge.lean` later reduces it to the div quotient-lane
     `opBus_row_ArithDiv`. -/
-theorem main_request_divu_limb1_provided
+theorem main_request_divu_provided
     (trace : AcceptedZiskTrace)
     (i : Fin trace.numInstructions)
     (h_main_active :
@@ -883,7 +883,7 @@ theorem main_request_divu_limb1_provided
 
 /-- Layer-A op-bus provider-match wrapper for the Arith DIVUW operation
     (`OP_DIVU_W = 188`, W-mode `m32 = 1`).  Mirrors
-    `main_request_divu_limb1_provided`, but
+    `main_request_divu_provided`, but
     delegates to the DIVUW keep-arithMul balance theorem
     `exists_arithMul_provider_row_matches_primary_of_divuw_active_main_row_interaction`.
 
@@ -891,7 +891,7 @@ theorem main_request_divu_limb1_provided
     ArithDiv component carries no op-bus in the ensemble); the returned match is
     against the muxed `primaryOpBusMessage`.  The DIVU-mode op-bus bridge later
     reduces it to the div quotient-lane `opBus_row_ArithDiv`. -/
-theorem main_request_divuw_limb1_provided
+theorem main_request_divuw_provided
     (trace : AcceptedZiskTrace)
     (i : Fin trace.numInstructions)
     (h_main_active :
@@ -978,7 +978,7 @@ theorem main_request_divuw_limb1_provided
 
 /-- Layer-A op-bus provider-match wrapper for the Arith REMU operation
     (`OP_REMU = 185`).  Mirrors
-    `main_request_divu_limb1_provided`, but
+    `main_request_divu_provided`, but
     delegates to the REMU keep-arithMul balance theorem
     `exists_arithMul_provider_row_matches_primary_of_remu_active_main_row_interaction`.
 
@@ -987,7 +987,7 @@ theorem main_request_divuw_limb1_provided
     against the muxed `primaryOpBusMessage`.  The REMU-mode bridge in
     `ConstructionRemu.lean` later reduces it (at `div = 1`, `main_div = 0`,
     `main_mul = 0`) to the div remainder-lane `opBus_row_ArithDivSecondary`. -/
-theorem main_request_remu_limb1_provided
+theorem main_request_remu_provided
     (trace : AcceptedZiskTrace)
     (i : Fin trace.numInstructions)
     (h_main_active :
@@ -1074,7 +1074,7 @@ theorem main_request_remu_limb1_provided
 
 /-- Layer-A op-bus provider-match wrapper for the Arith REMUW operation
     (`OP_REMU_W = 189`, W-mode `m32 = 1`).  Mirrors
-    `main_request_remu_limb1_provided`, but
+    `main_request_remu_provided`, but
     delegates to the REMUW keep-arithMul balance theorem
     `exists_arithMul_provider_row_matches_primary_of_remuw_active_main_row_interaction`.
 
@@ -1084,7 +1084,7 @@ theorem main_request_remu_limb1_provided
     `ConstructionRemu.lean` later reduces it (at `div = 1`, `main_div = 0`,
     `main_mul = 0`) to the div remainder-lane `opBus_row_ArithDivSecondary`; the
     `m32` flag plays no role in the mux. -/
-theorem main_request_remuw_limb1_provided
+theorem main_request_remuw_provided
     (trace : AcceptedZiskTrace)
     (i : Fin trace.numInstructions)
     (h_main_active :

--- a/ZiskFv/Compliance/TraceLevelExport.lean
+++ b/ZiskFv/Compliance/TraceLevelExport.lean
@@ -39,7 +39,7 @@ reads, operand/lane bridges, the `execRow` ∀-binder + exec facts,
 `h_nextPC_matches`; for loads also `MemoryTimelineEvidence` + the Mem-AIR
 provider linkage).  It does NOT package the bucket-(a) op-bus provider-match
 evidence: that is derived INSIDE each construction from `trace.channels_balanced` (via the
-`exists_*_from_binding` Layer-A wrappers).
+`exists_*_provider_row_matches_*` Layer-A lemmas).
 
 ## Coverage (stated explicitly — NOT hidden)
 
@@ -50,8 +50,8 @@ global theorem produces:
 1. **Env-constructed route (22 op-bus ALU arms)** — `SUB AND OR XOR SLT SLTU`,
    `ANDI ORI XORI SLTI SLTIU`, `SLL SRL SRA SLLI SRLI SRAI`, `ADD ADDI`,
    `SUBW ADDW ADDIW`.  The matching `OpEnvelope.<op>` arm is **constructed from
-   the accepted trace** per row (re-running each construction's `*_from_binding`
-   provider-match + input-packing derivations) and fed to
+   the accepted trace** per row (re-running each construction's
+   `exists_*_provider_row_matches_*` + input-packing derivations) and fed to
    `zisk_riscv_compliant_program_bus`.  Its three hypotheses are discharged in
    place: `aeneasBridgeTrust` from the derived row-binding facts,
    `memoryTimelineConstructionEvidence` trivially (non-load arms), and

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongAluArith.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongAluArith.lean
@@ -93,7 +93,7 @@ theorem stepStrong_sub
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_sub
+    main_request_sub_provided
       trace i d.h_main_active d.h_main_op
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SUB :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -229,7 +229,7 @@ theorem stepStrong_and
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic
+    main_request_logic_provided
       trace i d.h_main_active (Or.inl d.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_AND :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -365,7 +365,7 @@ theorem stepStrong_or
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic
+    main_request_logic_provided
       trace i d.h_main_active (Or.inr (Or.inl d.h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_OR :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -501,7 +501,7 @@ theorem stepStrong_xor
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic
+    main_request_logic_provided
       trace i d.h_main_active (Or.inr (Or.inr d.h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_XOR :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -638,7 +638,7 @@ theorem stepStrong_slt
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_compare
+    main_request_compare_provided
       trace i d.h_main_active (Or.inl d.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_LT :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -774,7 +774,7 @@ theorem stepStrong_sltu
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_compare
+    main_request_compare_provided
       trace i d.h_main_active (Or.inr d.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_LTU :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -909,7 +909,7 @@ theorem stepStrong_andi
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic
+    main_request_logic_provided
       trace i d.h_main_active (Or.inl d.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_AND :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -1044,7 +1044,7 @@ theorem stepStrong_ori
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic
+    main_request_logic_provided
       trace i d.h_main_active (Or.inr (Or.inl d.h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_OR :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -1179,7 +1179,7 @@ theorem stepStrong_xori
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic
+    main_request_logic_provided
       trace i d.h_main_active (Or.inr (Or.inr d.h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_XOR :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -1312,7 +1312,7 @@ theorem stepStrong_slti
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_compare
+    main_request_compare_provided
       trace i d.h_main_active (Or.inl d.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_LT :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -1440,7 +1440,7 @@ theorem stepStrong_sltiu
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_compare
+    main_request_compare_provided
       trace i d.h_main_active (Or.inr d.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_LTU :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -1569,7 +1569,7 @@ theorem stepStrong_sll
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i d.h_main_active (Or.inl d.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SLL :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -1668,7 +1668,7 @@ theorem stepStrong_srl
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i d.h_main_active (Or.inr (Or.inl d.h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRL :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -1767,7 +1767,7 @@ theorem stepStrong_sra
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i d.h_main_active (Or.inr (Or.inr (Or.inl d.h_main_op)))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRA :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -1862,7 +1862,7 @@ theorem stepStrong_slli
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i d.h_main_active (Or.inl d.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SLL :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -1961,7 +1961,7 @@ theorem stepStrong_srli
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i d.h_main_active (Or.inr (Or.inl d.h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRL :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -2060,7 +2060,7 @@ theorem stepStrong_srai
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i d.h_main_active (Or.inr (Or.inr (Or.inl d.h_main_op)))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRA :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -2165,7 +2165,7 @@ theorem stepStrong_subw
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_w
+    main_request_w_provided
       trace i d.h_main_active (Or.inr d.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SUB_W :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -2295,7 +2295,7 @@ theorem stepStrong_addw
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_w
+    main_request_w_provided
       trace i d.h_main_active (Or.inl d.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD_W :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -2425,7 +2425,7 @@ theorem stepStrong_addiw
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_w
+    main_request_w_provided
       trace i d.h_main_active (Or.inl d.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD_W :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -2541,7 +2541,7 @@ theorem stepStrong_sllw
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i d.h_main_active (Or.inr (Or.inr (Or.inr (Or.inl d.h_main_op))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SLL_W :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -2639,7 +2639,7 @@ theorem stepStrong_srlw
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i d.h_main_active (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl d.h_main_op)))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRL_W :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -2737,7 +2737,7 @@ theorem stepStrong_sraw
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i d.h_main_active
       (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr d.h_main_op)))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRA_W :=
@@ -2837,7 +2837,7 @@ theorem stepStrong_slliw
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i d.h_main_active (Or.inr (Or.inr (Or.inr (Or.inl d.h_main_op))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SLL_W :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -2931,7 +2931,7 @@ theorem stepStrong_srliw
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i d.h_main_active (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl d.h_main_op)))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRL_W :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -3025,7 +3025,7 @@ theorem stepStrong_sraiw
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift
+    main_request_shift_provided
       trace i d.h_main_active
       (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr d.h_main_op)))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRA_W :=
@@ -3128,7 +3128,7 @@ theorem stepStrong_add
   set state := binding i with hstate
   let bus := busSub trace binding i d.execRow
   obtain ⟨h_add_subset, h_disj⟩ :=
-    exists_add_provider_row_matches
+    main_request_add_provided
       trace i d.h_main_active d.h_main_op
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -3280,7 +3280,7 @@ theorem stepStrong_addi
   set state := binding i with hstate
   let bus := busSub trace binding i d.execRow
   obtain ⟨h_add_subset, h_disj⟩ :=
-    exists_add_provider_row_matches
+    main_request_add_provided
       trace i d.h_main_active d.h_main_op
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD :=
     ⟨d.h_main_active, d.h_main_op⟩

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongAluArith.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongAluArith.lean
@@ -93,8 +93,8 @@ theorem stepStrong_sub
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_sub_from_binding
-      trace binding i d.h_main_active d.h_main_op
+    exists_staticBinary_provider_row_matches_sub
+      trace i d.h_main_active d.h_main_op
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SUB :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -229,8 +229,8 @@ theorem stepStrong_and
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic_from_binding
-      trace binding i d.h_main_active (Or.inl d.h_main_op)
+    exists_staticBinary_provider_row_matches_logic
+      trace i d.h_main_active (Or.inl d.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_AND :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -365,8 +365,8 @@ theorem stepStrong_or
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic_from_binding
-      trace binding i d.h_main_active (Or.inr (Or.inl d.h_main_op))
+    exists_staticBinary_provider_row_matches_logic
+      trace i d.h_main_active (Or.inr (Or.inl d.h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_OR :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -501,8 +501,8 @@ theorem stepStrong_xor
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic_from_binding
-      trace binding i d.h_main_active (Or.inr (Or.inr d.h_main_op))
+    exists_staticBinary_provider_row_matches_logic
+      trace i d.h_main_active (Or.inr (Or.inr d.h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_XOR :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -638,8 +638,8 @@ theorem stepStrong_slt
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_compare_from_binding
-      trace binding i d.h_main_active (Or.inl d.h_main_op)
+    exists_staticBinary_provider_row_matches_compare
+      trace i d.h_main_active (Or.inl d.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_LT :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -774,8 +774,8 @@ theorem stepStrong_sltu
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_compare_from_binding
-      trace binding i d.h_main_active (Or.inr d.h_main_op)
+    exists_staticBinary_provider_row_matches_compare
+      trace i d.h_main_active (Or.inr d.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_LTU :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -909,8 +909,8 @@ theorem stepStrong_andi
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic_from_binding
-      trace binding i d.h_main_active (Or.inl d.h_main_op)
+    exists_staticBinary_provider_row_matches_logic
+      trace i d.h_main_active (Or.inl d.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_AND :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -1044,8 +1044,8 @@ theorem stepStrong_ori
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic_from_binding
-      trace binding i d.h_main_active (Or.inr (Or.inl d.h_main_op))
+    exists_staticBinary_provider_row_matches_logic
+      trace i d.h_main_active (Or.inr (Or.inl d.h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_OR :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -1179,8 +1179,8 @@ theorem stepStrong_xori
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_logic_from_binding
-      trace binding i d.h_main_active (Or.inr (Or.inr d.h_main_op))
+    exists_staticBinary_provider_row_matches_logic
+      trace i d.h_main_active (Or.inr (Or.inr d.h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_XOR :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -1312,8 +1312,8 @@ theorem stepStrong_slti
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_compare_from_binding
-      trace binding i d.h_main_active (Or.inl d.h_main_op)
+    exists_staticBinary_provider_row_matches_compare
+      trace i d.h_main_active (Or.inl d.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_LT :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -1440,8 +1440,8 @@ theorem stepStrong_sltiu
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_compare_from_binding
-      trace binding i d.h_main_active (Or.inr d.h_main_op)
+    exists_staticBinary_provider_row_matches_compare
+      trace i d.h_main_active (Or.inr d.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_LTU :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -1569,8 +1569,8 @@ theorem stepStrong_sll
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i d.h_main_active (Or.inl d.h_main_op)
+    exists_binaryExtension_provider_row_matches_shift
+      trace i d.h_main_active (Or.inl d.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SLL :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -1668,8 +1668,8 @@ theorem stepStrong_srl
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i d.h_main_active (Or.inr (Or.inl d.h_main_op))
+    exists_binaryExtension_provider_row_matches_shift
+      trace i d.h_main_active (Or.inr (Or.inl d.h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRL :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -1767,8 +1767,8 @@ theorem stepStrong_sra
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i d.h_main_active (Or.inr (Or.inr (Or.inl d.h_main_op)))
+    exists_binaryExtension_provider_row_matches_shift
+      trace i d.h_main_active (Or.inr (Or.inr (Or.inl d.h_main_op)))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRA :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -1862,8 +1862,8 @@ theorem stepStrong_slli
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i d.h_main_active (Or.inl d.h_main_op)
+    exists_binaryExtension_provider_row_matches_shift
+      trace i d.h_main_active (Or.inl d.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SLL :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -1961,8 +1961,8 @@ theorem stepStrong_srli
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i d.h_main_active (Or.inr (Or.inl d.h_main_op))
+    exists_binaryExtension_provider_row_matches_shift
+      trace i d.h_main_active (Or.inr (Or.inl d.h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRL :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -2060,8 +2060,8 @@ theorem stepStrong_srai
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i d.h_main_active (Or.inr (Or.inr (Or.inl d.h_main_op)))
+    exists_binaryExtension_provider_row_matches_shift
+      trace i d.h_main_active (Or.inr (Or.inr (Or.inl d.h_main_op)))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRA :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -2165,8 +2165,8 @@ theorem stepStrong_subw
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_w_from_binding
-      trace binding i d.h_main_active (Or.inr d.h_main_op)
+    exists_staticBinary_provider_row_matches_w
+      trace i d.h_main_active (Or.inr d.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SUB_W :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -2295,8 +2295,8 @@ theorem stepStrong_addw
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_w_from_binding
-      trace binding i d.h_main_active (Or.inl d.h_main_op)
+    exists_staticBinary_provider_row_matches_w
+      trace i d.h_main_active (Or.inl d.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD_W :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -2425,8 +2425,8 @@ theorem stepStrong_addiw
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_staticBinary_provider_row_matches_w_from_binding
-      trace binding i d.h_main_active (Or.inl d.h_main_op)
+    exists_staticBinary_provider_row_matches_w
+      trace i d.h_main_active (Or.inl d.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD_W :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -2541,8 +2541,8 @@ theorem stepStrong_sllw
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i d.h_main_active (Or.inr (Or.inr (Or.inr (Or.inl d.h_main_op))))
+    exists_binaryExtension_provider_row_matches_shift
+      trace i d.h_main_active (Or.inr (Or.inr (Or.inr (Or.inl d.h_main_op))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SLL_W :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -2639,8 +2639,8 @@ theorem stepStrong_srlw
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i d.h_main_active (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl d.h_main_op)))))
+    exists_binaryExtension_provider_row_matches_shift
+      trace i d.h_main_active (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl d.h_main_op)))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRL_W :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -2737,8 +2737,8 @@ theorem stepStrong_sraw
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i d.h_main_active
+    exists_binaryExtension_provider_row_matches_shift
+      trace i d.h_main_active
       (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr d.h_main_op)))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRA_W :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -2837,8 +2837,8 @@ theorem stepStrong_slliw
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i d.h_main_active (Or.inr (Or.inr (Or.inr (Or.inl d.h_main_op))))
+    exists_binaryExtension_provider_row_matches_shift
+      trace i d.h_main_active (Or.inr (Or.inr (Or.inr (Or.inl d.h_main_op))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SLL_W :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -2931,8 +2931,8 @@ theorem stepStrong_srliw
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i d.h_main_active (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl d.h_main_op)))))
+    exists_binaryExtension_provider_row_matches_shift
+      trace i d.h_main_active (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl d.h_main_op)))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRL_W :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -3025,8 +3025,8 @@ theorem stepStrong_sraiw
   let bus := busSub trace binding i d.execRow
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    exists_binaryExtension_provider_row_matches_shift_from_binding
-      trace binding i d.h_main_active
+    exists_binaryExtension_provider_row_matches_shift
+      trace i d.h_main_active
       (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr d.h_main_op)))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRA_W :=
     ⟨d.h_main_active, d.h_main_op⟩
@@ -3128,8 +3128,8 @@ theorem stepStrong_add
   set state := binding i with hstate
   let bus := busSub trace binding i d.execRow
   obtain ⟨h_add_subset, h_disj⟩ :=
-    exists_add_provider_row_matches_from_binding
-      trace binding i d.h_main_active d.h_main_op
+    exists_add_provider_row_matches
+      trace i d.h_main_active d.h_main_op
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :
@@ -3280,8 +3280,8 @@ theorem stepStrong_addi
   set state := binding i with hstate
   let bus := busSub trace binding i d.execRow
   obtain ⟨h_add_subset, h_disj⟩ :=
-    exists_add_provider_row_matches_from_binding
-      trace binding i d.h_main_active d.h_main_op
+    exists_add_provider_row_matches
+      trace i d.h_main_active d.h_main_op
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD :=
     ⟨d.h_main_active, d.h_main_op⟩
   have h_core_store_pc :


### PR DESCRIPTION
Cleanup of the op-bus provider-match file (was `ProviderFromBinding.lean`).

### 1. Drop dead `SailTrace` param + rename file
The 12 `exists_*_provider_row_matches_*_from_binding` theorems carried a `(binding : SailTrace trace)` param that was **provably dead** (12/12 binder-only, never in a body) — these proofs are pure op-bus bookkeeping consuming `trace.channels_balanced`, never a Sail state. Dropped the param + the false `_from_binding` suffix; renamed `ProviderFromBinding.lean → OpBusProviderMatch.lean`; updated callers and made 12 transitive `SailTrace` imports explicit.

### 2. Rename the lemmas to the Clean channel vocabulary
`main_request_<op>_provided`: Main posts an op-bus **request** (`mult = -1`, the pull side, per Clean's `Channel.lean`); the lemma proves a matching **provider push** (`mult = +1`) exists in the witness. The `arithMul`/`staticBinary` provider and the old `primary`/`secondary` qualifier are dropped — the op token already determines both (e.g. `mulhu` is the only one consuming the secondary d-lane message). E.g.:
```
exists_arithMul_provider_row_matches_secondary_of_mulhu  →  main_request_mulhu_provided
exists_staticBinary_provider_row_matches_logic           →  main_request_logic_provided
```

Internal plumbing only — not canonical `equiv_<OP>`, not in any kept baseline. Build green (8759), trust gate V1 15/15 + V2 13/13, **no baseline shifted, 0 new axioms**. Based on `main` (post-#137).

🤖 Generated with [Claude Code](https://claude.com/claude-code)