### PR TITLE
Parameterize AcceptedZiskTrace by numInstructions — clean root_soundness signature

### DIFF
--- a/ZiskFv/AirsClean/FullEnsemble/Balance/TableProjections.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/TableProjections.lean
@@ -78,8 +78,15 @@ def mainTableRowAtOrZero
   else
     zeroMainRowWithRom
 
-/-- Named-column Main view obtained from the concrete Clean unified Main table. -/
-@[reducible]
+/-- Named-column Main view obtained from the concrete Clean unified Main table.
+
+    **Semireducible (not `@[reducible]`).** Marking it reducible used to make
+    elaboration whnf-expand this 16-field `Valid_Main` structure instance over
+    the heavy noncomputable `mainTable`, which tips into a non-terminating
+    `whnf` once `AcceptedZiskTrace` is parameterized by `numInstructions`
+    (issue #144). Consumers rewrite via the `@[simp]` projection lemmas below
+    (`mainOfTable_op`, `mainOfTable_is_external_op`, …) instead of unfolding the
+    instance directly. -/
 def mainOfTable
     {length : ℕ}
     (program : Program length)
@@ -107,6 +114,85 @@ def mainOfTable
   store_pc := fun row => (mainTableRowAtOrZero program table row).core.store_pc
   im_high_degree_2 := fun row => (mainTableRowAtOrZero program table row).core.im_high_degree_2
   segment_l1 := fun row => (mainTableRowAtOrZero program table row).core.segment_l1
+
+section MainOfTableProjections
+
+variable {length : ℕ} (program : Program length) (table : Table FGL)
+
+/-! ### `mainOfTable` field projections
+
+Since `mainOfTable` is no longer `@[reducible]`, every `Valid_Main` field
+access on it goes through these `@[simp]` lemmas instead of whnf-unfolding the
+16-field structure instance. Each is a definitional `rfl`. -/
+
+@[simp] theorem mainOfTable_a_0 :
+    (mainOfTable program table).a_0 =
+      fun row => (mainTableRowAtOrZero program table row).core.a_0 := rfl
+@[simp] theorem mainOfTable_a_1 :
+    (mainOfTable program table).a_1 =
+      fun row => (mainTableRowAtOrZero program table row).core.a_1 := rfl
+@[simp] theorem mainOfTable_b_0 :
+    (mainOfTable program table).b_0 =
+      fun row => (mainTableRowAtOrZero program table row).core.b_0 := rfl
+@[simp] theorem mainOfTable_b_1 :
+    (mainOfTable program table).b_1 =
+      fun row => (mainTableRowAtOrZero program table row).core.b_1 := rfl
+@[simp] theorem mainOfTable_c_0 :
+    (mainOfTable program table).c_0 =
+      fun row => (mainTableRowAtOrZero program table row).core.c_0 := rfl
+@[simp] theorem mainOfTable_c_1 :
+    (mainOfTable program table).c_1 =
+      fun row => (mainTableRowAtOrZero program table row).core.c_1 := rfl
+@[simp] theorem mainOfTable_flag :
+    (mainOfTable program table).flag =
+      fun row => (mainTableRowAtOrZero program table row).core.flag := rfl
+@[simp] theorem mainOfTable_pc :
+    (mainOfTable program table).pc =
+      fun row => (mainTableRowAtOrZero program table row).core.pc := rfl
+@[simp] theorem mainOfTable_is_external_op :
+    (mainOfTable program table).is_external_op =
+      fun row => (mainTableRowAtOrZero program table row).core.is_external_op := rfl
+@[simp] theorem mainOfTable_op :
+    (mainOfTable program table).op =
+      fun row => (mainTableRowAtOrZero program table row).core.op := rfl
+@[simp] theorem mainOfTable_b_src_imm :
+    (mainOfTable program table).b_src_imm =
+      fun row => (mainTableRowAtOrZero program table row).rom.b_src_imm := rfl
+@[simp] theorem mainOfTable_b_src_mem :
+    (mainOfTable program table).b_src_mem =
+      fun row => (mainTableRowAtOrZero program table row).rom.b_src_mem := rfl
+@[simp] theorem mainOfTable_b_src_ind :
+    (mainOfTable program table).b_src_ind =
+      fun row => (mainTableRowAtOrZero program table row).rom.b_src_ind := rfl
+@[simp] theorem mainOfTable_b_src_reg :
+    (mainOfTable program table).b_src_reg =
+      fun row => (mainTableRowAtOrZero program table row).rom.b_src_reg := rfl
+@[simp] theorem mainOfTable_m32 :
+    (mainOfTable program table).m32 =
+      fun row => (mainTableRowAtOrZero program table row).core.m32 := rfl
+@[simp] theorem mainOfTable_ind_width :
+    (mainOfTable program table).ind_width =
+      fun row => (mainTableRowAtOrZero program table row).core.ind_width := rfl
+@[simp] theorem mainOfTable_set_pc :
+    (mainOfTable program table).set_pc =
+      fun row => (mainTableRowAtOrZero program table row).core.set_pc := rfl
+@[simp] theorem mainOfTable_jmp_offset1 :
+    (mainOfTable program table).jmp_offset1 =
+      fun row => (mainTableRowAtOrZero program table row).core.jmp_offset1 := rfl
+@[simp] theorem mainOfTable_jmp_offset2 :
+    (mainOfTable program table).jmp_offset2 =
+      fun row => (mainTableRowAtOrZero program table row).core.jmp_offset2 := rfl
+@[simp] theorem mainOfTable_store_pc :
+    (mainOfTable program table).store_pc =
+      fun row => (mainTableRowAtOrZero program table row).core.store_pc := rfl
+@[simp] theorem mainOfTable_im_high_degree_2 :
+    (mainOfTable program table).im_high_degree_2 =
+      fun row => (mainTableRowAtOrZero program table row).core.im_high_degree_2 := rfl
+@[simp] theorem mainOfTable_segment_l1 :
+    (mainOfTable program table).segment_l1 =
+      fun row => (mainTableRowAtOrZero program table row).core.segment_l1 := rfl
+
+end MainOfTableProjections
 
 /-- In-range concrete table projection agrees with `List.get`. -/
 theorem mainTableRowAtOrZero_get

--- a/ZiskFv/Compliance/AcceptedZiskTrace.lean
+++ b/ZiskFv/Compliance/AcceptedZiskTrace.lean
@@ -34,9 +34,14 @@ constructions) is built relative to one of these.
 
 namespace ZiskFv.Compliance
 
-/-- Accepted committed trace for the full RV64IM Clean ensemble. -/
-structure AcceptedZiskTrace where
-  numInstructions : Nat
+/-- Accepted committed trace for the full RV64IM Clean ensemble.
+
+    `numInstructions` is a **structure parameter** (not a field) so that
+    `root_soundness` can share one instruction count across the ZisK and Sail
+    sides (issue #144). The `AcceptedZiskTrace.numInstructions` accessor below
+    recovers it, so the many `trace.numInstructions` uses keep working
+    unchanged. -/
+structure AcceptedZiskTrace (numInstructions : Nat) where
   program : ZiskFv.AirsClean.ZiskInstructionRom.Program numInstructions
   witness :
     Air.Flat.EnsembleWitness
@@ -51,5 +56,14 @@ structure AcceptedZiskTrace where
       table.component =
           ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus numInstructions program →
         ∀ i : Fin numInstructions, i.val < table.table.length
+
+/-- Recover the instruction count from a parameterized `AcceptedZiskTrace`.
+    `numInstructions` is now a structure parameter rather than a field; this
+    accessor keeps the many value-level `trace.numInstructions` projections
+    working. Type-level uses inside the heavy provider-match lemmas instead
+    reference the structure parameter directly (the autobound `numInstructions`
+    / `n`), so this accessor never has to unfold into the heavy
+    `componentWithRomMemAndOpBus …` subterms during `whnf` (issue #144). -/
+def AcceptedZiskTrace.numInstructions {n : Nat} (_ : AcceptedZiskTrace n) : Nat := n
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/AcceptedZiskTrace/MainTable.lean
+++ b/ZiskFv/Compliance/AcceptedZiskTrace/MainTable.lean
@@ -17,18 +17,18 @@ namespace ZiskFv.Compliance
 /-- The Main execution table selected from the witness. **Non-reducible** so it
     behaves opaquely, exactly like the former `SailTrace.mainTable` struct
     field: proofs that treat the Main table abstractly keep working unchanged. -/
-noncomputable def AcceptedZiskTrace.mainTable (trace : AcceptedZiskTrace) : Air.Flat.Table FGL :=
+noncomputable def AcceptedZiskTrace.mainTable (trace : AcceptedZiskTrace n) : Air.Flat.Table FGL :=
   (ZiskFv.AirsClean.FullEnsemble.exists_main_table_of_fullRv64im_witness
     trace.witness).choose
 
 /-- The derived Main table really occurs in the witness. -/
-theorem AcceptedZiskTrace.mainTable_mem (trace : AcceptedZiskTrace) :
+theorem AcceptedZiskTrace.mainTable_mem (trace : AcceptedZiskTrace n) :
     trace.mainTable ∈ trace.witness.allTables :=
   (ZiskFv.AirsClean.FullEnsemble.exists_main_table_of_fullRv64im_witness
     trace.witness).choose_spec.1
 
 /-- The derived Main table really is the Main component for this program. -/
-theorem AcceptedZiskTrace.mainTable_component (trace : AcceptedZiskTrace) :
+theorem AcceptedZiskTrace.mainTable_component (trace : AcceptedZiskTrace n) :
     trace.mainTable.component =
       ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
         trace.numInstructions trace.program :=
@@ -37,7 +37,7 @@ theorem AcceptedZiskTrace.mainTable_component (trace : AcceptedZiskTrace) :
 
 /-- The derived Main table has a row for every instruction — `main_height`
     specialized to `mainTable` via its membership and component facts. -/
-theorem AcceptedZiskTrace.mainTable_index (trace : AcceptedZiskTrace) :
+theorem AcceptedZiskTrace.mainTable_index (trace : AcceptedZiskTrace n) :
     ∀ i : Fin trace.numInstructions, i.val < trace.mainTable.table.length :=
   trace.main_height trace.mainTable trace.mainTable_mem trace.mainTable_component
 

--- a/ZiskFv/Compliance/AcceptedZiskTrace/Spec.lean
+++ b/ZiskFv/Compliance/AcceptedZiskTrace/Spec.lean
@@ -16,7 +16,7 @@ namespace ZiskFv.Compliance
     ensemble's table-soundness (`witness_spec_of_constraints`). It is
     `@[reducible]` so every consumer (and the trust gate's `whnfR`) sees through
     it exactly as it did the former struct field. -/
-@[reducible] def AcceptedZiskTrace.spec_holds (trace : AcceptedZiskTrace) : trace.witness.Spec :=
+@[reducible] def AcceptedZiskTrace.spec_holds (trace : AcceptedZiskTrace n) : trace.witness.Spec :=
   ZiskFv.AirsClean.FullEnsemble.witness_spec_of_constraints
     trace.witness trace.constraints_hold trace.channels_balanced
 

--- a/ZiskFv/Compliance/ConstructionAdd.lean
+++ b/ZiskFv/Compliance/ConstructionAdd.lean
@@ -190,7 +190,7 @@ theorem construction_add_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -204,7 +204,7 @@ theorem construction_add_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -395,7 +395,7 @@ theorem construction_addi_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -409,7 +409,7 @@ theorem construction_addi_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h

--- a/ZiskFv/Compliance/ConstructionAdd.lean
+++ b/ZiskFv/Compliance/ConstructionAdd.lean
@@ -100,7 +100,7 @@ set_option maxHeartbeats 2000000
     * (c) exec artifacts (3): `h_exec_len`, `h_e0_mult`, `h_e1_mult`, PLUS the
       genuine `execRow` ∀-binder. -/
 theorem construction_add_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (add_input : PureSpec.AddInput)
@@ -308,7 +308,7 @@ theorem construction_add_sound_claimed_dead
     Residual budget = ADD's, minus the 2 r2 lane bridges (`h_b_lo_t`/`h_b_hi_t`)
     and `h_input_r2`, plus `imm`, `h_input_imm`, `h_addi_subset`, `h_set_pc`. -/
 theorem construction_addi_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (addi_input : PureSpec.AddiInput)

--- a/ZiskFv/Compliance/ConstructionAnd.lean
+++ b/ZiskFv/Compliance/ConstructionAnd.lean
@@ -106,7 +106,7 @@ set_option maxHeartbeats 2000000
     circuit-internal rd arithmetic, the MemBus `m0..m2` shape, `h_lane_rd`, and
     the lane→Sail binding facts. -/
 theorem construction_and_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (and_input : PureSpec.AndInput)

--- a/ZiskFv/Compliance/ConstructionAnd.lean
+++ b/ZiskFv/Compliance/ConstructionAnd.lean
@@ -200,7 +200,7 @@ theorem construction_and_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -214,7 +214,7 @@ theorem construction_and_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h

--- a/ZiskFv/Compliance/ConstructionAuipc.lean
+++ b/ZiskFv/Compliance/ConstructionAuipc.lean
@@ -77,7 +77,7 @@ set_option maxHeartbeats 2000000
     AUIPC constraint subset, the `StorePcMemoryWitness`, the rd-write MemBus
     shape, the pure-spec `nextPC_eq`, and the circuit-internal rd arithmetic. -/
 theorem construction_auipc_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (auipc_input : PureSpec.AuipcInput)

--- a/ZiskFv/Compliance/ConstructionAuipc.lean
+++ b/ZiskFv/Compliance/ConstructionAuipc.lean
@@ -164,7 +164,7 @@ theorem construction_auipc_sound_claimed_dead
     have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
       trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
     simpa [mainRowWithRomLui, m,
-      ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+      ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
   let store_pc_mem : ZiskFv.Compliance.StorePcMemoryWitness m i.val e_rd :=
     { row := mainRowWithRomLui trace binding i
       row_eq := h_row_core

--- a/ZiskFv/Compliance/ConstructionBranch.lean
+++ b/ZiskFv/Compliance/ConstructionBranch.lean
@@ -107,7 +107,7 @@ set_option maxHeartbeats 2000000
     * (c) exec artifacts (3): `h_exec_len`, `h_e0_mult`, `h_e1_mult`, PLUS the
       genuine `exec_row` ∀-binder (with `misa_val`). -/
 theorem construction_beq_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (beq_input : PureSpec.BeqInput)
@@ -168,7 +168,7 @@ theorem construction_beq_sound_claimed_dead
     The conditional next-PC residual `h_nextPC_matches` is the #100 cross-row
     obligation. -/
 theorem construction_bne_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (bne_input : PureSpec.BneInput)
@@ -220,7 +220,7 @@ theorem construction_bne_sound_claimed_dead
 
 /-- Sound BLT construction (signed less-than). See `construction_beq_sound`. -/
 theorem construction_blt_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (blt_input : PureSpec.BltInput)
@@ -272,7 +272,7 @@ theorem construction_blt_sound_claimed_dead
 
 /-- Sound BGE construction (signed greater-or-equal). See `construction_beq_sound`. -/
 theorem construction_bge_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (bge_input : PureSpec.BgeInput)
@@ -324,7 +324,7 @@ theorem construction_bge_sound_claimed_dead
 
 /-- Sound BLTU construction (unsigned less-than). See `construction_beq_sound`. -/
 theorem construction_bltu_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (bltu_input : PureSpec.BltuInput)
@@ -376,7 +376,7 @@ theorem construction_bltu_sound_claimed_dead
 
 /-- Sound BGEU construction (unsigned greater-or-equal). See `construction_beq_sound`. -/
 theorem construction_bgeu_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (bgeu_input : PureSpec.BgeuInput)

--- a/ZiskFv/Compliance/ConstructionCompare.lean
+++ b/ZiskFv/Compliance/ConstructionCompare.lean
@@ -80,7 +80,7 @@ set_option maxHeartbeats 2000000
     rd arithmetic (incl. the signed-compare polarity, inside `equiv_SLT`), the
     MemBus `m0..m2` shape, `h_lane_rd`, and the lane→Sail binding facts. -/
 theorem construction_slt_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (slt_input : PureSpec.SltInput)
@@ -275,7 +275,7 @@ theorem construction_slt_sound_claimed_dead
     same `_op_lt_16` + `_64` route applies; the unsigned-compare polarity lives
     inside `equiv_SLTU`. -/
 theorem construction_sltu_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (sltu_input : PureSpec.SltuInput)

--- a/ZiskFv/Compliance/ConstructionCompare.lean
+++ b/ZiskFv/Compliance/ConstructionCompare.lean
@@ -171,7 +171,7 @@ theorem construction_slt_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -185,7 +185,7 @@ theorem construction_slt_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -366,7 +366,7 @@ theorem construction_sltu_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -380,7 +380,7 @@ theorem construction_sltu_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h

--- a/ZiskFv/Compliance/ConstructionDivu.lean
+++ b/ZiskFv/Compliance/ConstructionDivu.lean
@@ -821,7 +821,7 @@ theorem construction_divu_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   let arith_mem :
@@ -833,7 +833,7 @@ theorem construction_divu_sound_claimed_dead
         have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
           trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
         simpa [mainRowWithRomSub,
-          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
       store_pc_zero := h_core_store_pc
       rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
   -- promises bundle: Sail reads + exec artifacts as binders; MemBus shape by rfl.

--- a/ZiskFv/Compliance/ConstructionDivu.lean
+++ b/ZiskFv/Compliance/ConstructionDivu.lean
@@ -438,7 +438,7 @@ private lemma divu_carry_bounds_claimed_dead
     `main_request_divu_provided`.
     Mirrors `mulwArow`. -/
 noncomputable def divuArow
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -451,7 +451,7 @@ noncomputable def divuArow
 /-- `FullSpec` of the balance-selected DIVU provider row, derived from the
     provider component's proven soundness (`componentWithArithTable.Spec`). -/
 theorem divuArow_fullSpec_row
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -469,7 +469,7 @@ theorem divuArow_fullSpec_row
     row's emission, in `toEntry (primaryOpBusMessage …) 1` form (cheap: free
     `ArithMulRow`, no view whnf). -/
 theorem divuArow_match_row
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -490,7 +490,7 @@ theorem divuArow_match_row
     off the BARE provider `ArithMulRow` via `divu_mode_pins_of_row`, never
     forcing the heavy `Classical.choose` row's whnf. -/
 theorem divuArow_mode_pins
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -520,7 +520,7 @@ theorem divuArow_mode_pins
     Main row's emission, in `opBus_row_ArithDiv` form.  The DIVU mode pins
     needed to reduce the faithful mux are DERIVED via `divuArow_mode_pins`. -/
 theorem divuArow_match
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -733,7 +733,7 @@ lemma equiv_DIVU_of_fullSpec_claimed_dead
     `arithDiv_table_interactionsWith_opBus_nil`), so it is carried explicitly,
     exactly as the canonical `equiv_DIVU` carries it. -/
 theorem construction_divu_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (divu_input : PureSpec.DivuInput)

--- a/ZiskFv/Compliance/ConstructionDivuw.lean
+++ b/ZiskFv/Compliance/ConstructionDivuw.lean
@@ -742,7 +742,7 @@ theorem construction_divuw_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   let arith_mem :
@@ -754,7 +754,7 @@ theorem construction_divuw_sound_claimed_dead
         have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
           trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
         simpa [mainRowWithRomSub,
-          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
       store_pc_zero := h_core_store_pc
       rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
   -- promises bundle: Sail reads + exec artifacts as binders; MemBus shape by rfl.

--- a/ZiskFv/Compliance/ConstructionDivuw.lean
+++ b/ZiskFv/Compliance/ConstructionDivuw.lean
@@ -302,7 +302,7 @@ private lemma divuw_carry_bounds_claimed_dead
     `main_request_divuw_provided`.
     Mirrors `divuArow`. -/
 noncomputable def divuwArow
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -315,7 +315,7 @@ noncomputable def divuwArow
 /-- `FullSpec` of the balance-selected DIVUW provider row, derived from the
     provider component's proven soundness (`componentWithArithTable.Spec`). -/
 theorem divuwArow_fullSpec_row
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -333,7 +333,7 @@ theorem divuwArow_fullSpec_row
 /-- The op-bus match of the balance-selected DIVUW provider row against the Main
     row's emission, in `toEntry (primaryOpBusMessage …) 1` form. -/
 theorem divuwArow_match_row
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -354,7 +354,7 @@ theorem divuwArow_match_row
     off the BARE provider `ArithMulRow` via `divuw_mode_pins_of_row`, never
     forcing the heavy `Classical.choose` row's whnf. -/
 theorem divuwArow_mode_pins
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -385,7 +385,7 @@ theorem divuwArow_mode_pins
     faithful mux are DERIVED via `divuwArow_mode_pins` (they are `m32`-agnostic,
     so the DIVU-mode bridge `match_opBus_row_ArithDiv_vOfDivuRow` applies). -/
 theorem divuwArow_match
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -635,7 +635,7 @@ lemma equiv_DIVUW_of_fullSpec_claimed_dead
     SEXT_00/SEXT_FF bus encoding on bytes 4..7, class #4 — the same residuals
     the canonical `equiv_DIVUW` carries). -/
 theorem construction_divuw_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (divuw_input : PureSpec.DivuwInput)

--- a/ZiskFv/Compliance/ConstructionIType.lean
+++ b/ZiskFv/Compliance/ConstructionIType.lean
@@ -124,7 +124,7 @@ set_option maxHeartbeats 2000000
     circuit-internal rd arithmetic, the MemBus `m0..m2` shape, `h_lane_rd`, and
     the r1 lane→Sail binding fact. -/
 theorem construction_andi_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (andi_input : PureSpec.AndiInput)
@@ -314,7 +314,7 @@ theorem construction_andi_sound_claimed_dead
     `execute_ITYPE_andi_pure → execute_ITYPE_ori_pure`. `OP_OR = 15 < 16`, so the
     same `_op_lt_16` + `_64` data-effect route applies. -/
 theorem construction_ori_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (ori_input : PureSpec.OriInput)
@@ -495,7 +495,7 @@ theorem construction_ori_sound_claimed_dead
     NOT the `_op_lt_16` + `_64` pair. The I-type immediate DELTA is identical to
     ANDI/ORI; route via `equiv_XORI`. -/
 theorem construction_xori_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (xori_input : PureSpec.XoriInput)
@@ -677,7 +677,7 @@ theorem construction_xori_sound_claimed_dead
     internally, so NO `h_input_imm_row` is passed; the signed-compare polarity lives
     inside the wrapper. -/
 theorem construction_slti_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (slti_input : PureSpec.SltiInput)
@@ -852,7 +852,7 @@ theorem construction_slti_sound_claimed_dead
     unsigned) lives inside `equiv_SLTIU`. The imm packing is the uniform
     `BitVec.signExtend 64 imm` Main-form pin. -/
 theorem construction_sltiu_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (sltiu_input : PureSpec.SltiuInput)

--- a/ZiskFv/Compliance/ConstructionIType.lean
+++ b/ZiskFv/Compliance/ConstructionIType.lean
@@ -208,7 +208,7 @@ theorem construction_andi_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -222,7 +222,7 @@ theorem construction_andi_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -393,7 +393,7 @@ theorem construction_ori_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -407,7 +407,7 @@ theorem construction_ori_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -574,7 +574,7 @@ theorem construction_xori_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -588,7 +588,7 @@ theorem construction_xori_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -756,7 +756,7 @@ theorem construction_slti_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -770,7 +770,7 @@ theorem construction_slti_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -931,7 +931,7 @@ theorem construction_sltiu_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -945,7 +945,7 @@ theorem construction_sltiu_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h

--- a/ZiskFv/Compliance/ConstructionJump.lean
+++ b/ZiskFv/Compliance/ConstructionJump.lean
@@ -79,7 +79,7 @@ set_option maxHeartbeats 2000000
     * (b) RANGE pins (2): `h_pc_bound`, `h_pc_offset_lt_2_32`
     * (c) exec artifacts: the `execRow` ∀-binder + its shape fields. -/
 theorem construction_jal_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (jal_input : PureSpec.JalInput)
@@ -209,7 +209,7 @@ theorem construction_jal_sound_claimed_dead
     * (b) RANGE pins (2): `h_pc_bound`, `h_pc_offset_lt_2_32`
     * (c) exec artifacts: the `execRow` ∀-binder + its shape fields. -/
 theorem construction_jalr_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (jalr_input : PureSpec.JalrInput)

--- a/ZiskFv/Compliance/ConstructionJump.lean
+++ b/ZiskFv/Compliance/ConstructionJump.lean
@@ -162,7 +162,7 @@ theorem construction_jal_sound_claimed_dead
     have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
       trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
     simpa [mainRowWithRomLui, m,
-      ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+      ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
   let store_pc_mem : ZiskFv.Compliance.StorePcMemoryWitness m i.val e_rd :=
     { row := mainRowWithRomLui trace binding i
       row_eq := h_row_core
@@ -304,7 +304,7 @@ theorem construction_jalr_sound_claimed_dead
     have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
       trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
     simpa [mainRowWithRomLui, m,
-      ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+      ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
   let store_pc_mem : ZiskFv.Compliance.StorePcMemoryWitness m i.val e_rd :=
     { row := mainRowWithRomLui trace binding i
       row_eq := h_row_core

--- a/ZiskFv/Compliance/ConstructionLoad.lean
+++ b/ZiskFv/Compliance/ConstructionLoad.lean
@@ -101,7 +101,7 @@ set_option maxHeartbeats 2000000
     the real Main table. Its `.core` equals `rowAt (mainOfTable …) i`. -/
 @[reducible]
 noncomputable def mainRowWithRomLd
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) :
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) :
     ZiskFv.AirsClean.Main.MainRowWithRom FGL :=
   ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
     trace.program trace.mainTable i.val
@@ -113,7 +113,7 @@ noncomputable def mainRowWithRomLd
     `matches_memory_entry_refl`. -/
 @[reducible]
 noncomputable def busLd
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (execRow : List (Interaction.ExecutionBusEntry FGL)) :
     ZiskFv.Compliance.BusRows where
   exec_row := execRow
@@ -127,7 +127,7 @@ noncomputable def busLd
 /-- The Main row provenance at trace index `i`: `mainRowWithRomLd`'s `.core`
     equals the honest `rowAt (mainOfTable …) i`. Shared by all seven loads. -/
 theorem mainRowWithRomLd_core
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) :
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) :
     (mainRowWithRomLd trace binding i).core =
       ZiskFv.AirsClean.Main.rowAt
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
@@ -153,7 +153,7 @@ theorem mainRowWithRomLd_core
       provider row backing the read. Not balance-derivable here (the
       Mem-channel balance leaves a 5-way provider disjunction). -/
 theorem construction_ld_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (ld_input : PureSpec.LdInput)
@@ -297,7 +297,7 @@ theorem construction_ld_sound_claimed_dead
       backing the narrow read (3 MemAlign validators + core/lookup + the
       `SubdoublewordLoadProviderWitness`). Not balance-derivable here. -/
 theorem construction_lbu_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (lbu_input : PureSpec.LbuInput)
@@ -431,7 +431,7 @@ theorem construction_lbu_sound_claimed_dead
     `construction_lbu_sound`: width literal `2`; `h_width = 2`; `LbuInput →
     LhuInput`; `LOADBU → LOADHU`. Same #76 residual budget. -/
 theorem construction_lhu_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (lhu_input : PureSpec.LhuInput)
@@ -557,7 +557,7 @@ theorem construction_lhu_sound_claimed_dead
     `construction_lhu_sound`: width literal `4`; `h_width = 4`; `LhuInput →
     LwuInput`; `LOADHU → LOADWU`. Same #76 residual budget. -/
 theorem construction_lwu_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (lwu_input : PureSpec.LwuInput)
@@ -694,7 +694,7 @@ theorem construction_lwu_sound_claimed_dead
     exists; not derivable at this layer — FLAGGED):**
     * `v`, `r_binary`, `offset`, `env`, `h_static`, `h_match`. -/
 theorem construction_lb_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (lb_input : PureSpec.LbInput)
@@ -832,7 +832,7 @@ theorem construction_lb_sound_claimed_dead
     `construction_lb_sound`: `OP_SIGNEXTEND_H`; `LbInput → LhInput`; width
     literal `2`; `LOADB → LOADH`. Same residual budget. -/
 theorem construction_lh_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (lh_input : PureSpec.LhInput)
@@ -962,7 +962,7 @@ theorem construction_lh_sound_claimed_dead
     `OP_SIGNEXTEND_W`; `LhInput → LwInput`; width literal `4`; `LOADH → LOADW`.
     Same residual budget. -/
 theorem construction_lw_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (lw_input : PureSpec.LwInput)

--- a/ZiskFv/Compliance/ConstructionLoad.lean
+++ b/ZiskFv/Compliance/ConstructionLoad.lean
@@ -135,7 +135,7 @@ theorem mainRowWithRomLd_core
   have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
     trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
   simpa [mainRowWithRomLd,
-    ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+    ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
 
 /-- Sound LD construction: the doubleword load, the cleanest of the seven (no
     sub-doubleword width pin, no BinaryExtension sign chain). From the accepted

--- a/ZiskFv/Compliance/ConstructionLogic.lean
+++ b/ZiskFv/Compliance/ConstructionLogic.lean
@@ -179,7 +179,7 @@ theorem construction_or_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -193,7 +193,7 @@ theorem construction_or_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -374,7 +374,7 @@ theorem construction_xor_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -388,7 +388,7 @@ theorem construction_xor_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h

--- a/ZiskFv/Compliance/ConstructionLogic.lean
+++ b/ZiskFv/Compliance/ConstructionLogic.lean
@@ -88,7 +88,7 @@ set_option maxHeartbeats 2000000
     rd arithmetic, the MemBus `m0..m2` shape, `h_lane_rd`, and the lane→Sail
     binding facts. -/
 theorem construction_or_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (or_input : PureSpec.OrInput)
@@ -283,7 +283,7 @@ theorem construction_or_sound_claimed_dead
     `byte_chain_discharge_logic_of_static_row` (mirroring `EquivCore/Xor.lean`),
     NOT the `_op_lt_16` + `_64` pair. -/
 theorem construction_xor_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (xor_input : PureSpec.XorInput)

--- a/ZiskFv/Compliance/ConstructionLui.lean
+++ b/ZiskFv/Compliance/ConstructionLui.lean
@@ -197,7 +197,7 @@ theorem construction_lui_sound_claimed_dead
     have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
       trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
     simpa [mainRowWithRomLui, m,
-      ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+      ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
   let store_pc_mem : ZiskFv.Compliance.StorePcMemoryWitness m i.val e_rd :=
     { row := mainRowWithRomLui trace binding i
       row_eq := h_row_core

--- a/ZiskFv/Compliance/ConstructionLui.lean
+++ b/ZiskFv/Compliance/ConstructionLui.lean
@@ -65,7 +65,7 @@ set_option maxHeartbeats 2000000
     table.  Its `.core` equals `rowAt (mainOfTable …) i`. -/
 @[reducible]
 noncomputable def mainRowWithRomLui
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) :
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) :
     ZiskFv.AirsClean.Main.MainRowWithRom FGL :=
   ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
     trace.program trace.mainTable i.val
@@ -75,7 +75,7 @@ noncomputable def mainRowWithRomLui
     match is then `matches_memory_entry_refl`. -/
 @[reducible]
 noncomputable def eRdLui
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) :
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) :
     Interaction.MemoryBusEntry FGL :=
   ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
     (ZiskFv.AirsClean.Main.cMemMessage (mainRowWithRomLui trace binding i)) 1 1
@@ -83,7 +83,7 @@ noncomputable def eRdLui
 /-- The Main per-row `Spec` at trace index `i`, derived from `trace.spec_holds`.
     (Standalone version of the in-wrapper `h_main_spec` derivation.) -/
 theorem mainSpec_at
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) :
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) :
     ZiskFv.AirsClean.Main.Spec
       (ZiskFv.AirsClean.Main.rowAt
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
@@ -118,7 +118,7 @@ theorem mainSpec_at
     LUI constraint subset, the `StorePcMemoryWitness`, the rd-write MemBus shape,
     the pure-spec `nextPC_eq`, and the circuit-internal rd arithmetic. -/
 theorem construction_lui_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (lui_input : PureSpec.LuiInput)

--- a/ZiskFv/Compliance/ConstructionMulhu.lean
+++ b/ZiskFv/Compliance/ConstructionMulhu.lean
@@ -835,7 +835,7 @@ theorem construction_mulhu_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   let arith_mem :
@@ -847,7 +847,7 @@ theorem construction_mulhu_sound_claimed_dead
         have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
           trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
         simpa [mainRowWithRomSub,
-          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
       store_pc_zero := h_core_store_pc
       rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
   -- promises bundle: Sail reads + exec artifacts as binders; MemBus shape by rfl.

--- a/ZiskFv/Compliance/ConstructionMulhu.lean
+++ b/ZiskFv/Compliance/ConstructionMulhu.lean
@@ -617,7 +617,7 @@ lemma equiv_MULHU_of_fullSpec_claimed_dead
     `main_request_mulhu_provided`.
     Mirrors `mulwArow`. -/
 noncomputable def mulhuArow
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -630,7 +630,7 @@ noncomputable def mulhuArow
 /-- `FullSpec` of the balance-selected MULHU provider row, derived from the
     provider component's proven soundness (`componentWithArithTable.Spec`). -/
 theorem mulhuArow_fullSpec_row
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -646,7 +646,7 @@ theorem mulhuArow_fullSpec_row
 
 /-- `FullSpec` of the balance-selected MULHU provider row view. -/
 theorem mulhuArow_fullSpec
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -680,7 +680,7 @@ theorem match_opBus_row_ArithMulSecondary_vOfMulwRow
     row's emission, in `toEntry (primaryOpBusMessage …) 1` form (cheap: free
     `ArithMulRow`, no `vOfMulwRow`/`opBus_row_*` whnf). -/
 theorem mulhuArow_match_row
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -701,7 +701,7 @@ theorem mulhuArow_match_row
     off the BARE provider `ArithMulRow` via `mulhu_mode_pins_of_row`, never
     forcing the heavy `Classical.choose` row's whnf. -/
 theorem mulhuArow_mode_pins
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -725,7 +725,7 @@ theorem mulhuArow_mode_pins
     Main row's emission, in `opBus_row_ArithMulSecondary` form.  The MULHU mode
     pins needed to reduce the faithful mux are DERIVED via `mulhuArow_mode_pins`. -/
 theorem mulhuArow_match
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -748,7 +748,7 @@ theorem mulhuArow_match
     `trace.channels_balanced` / `trace.spec_holds` via the provider's lookup-aware
     `componentWithArithTable.Spec = FullSpec`, NOT supplied as binders. -/
 theorem construction_mulhu_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (mulhu_input : PureSpec.MulhuInput)

--- a/ZiskFv/Compliance/ConstructionMulw.lean
+++ b/ZiskFv/Compliance/ConstructionMulw.lean
@@ -145,7 +145,7 @@ def vOfMulwRow (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL) :
     `vOfMulwRow (mulwArow …)`. The Arith witnesses for this row are derived
     inside `construction_mulw_sound`; nothing about the row is caller-supplied. -/
 noncomputable def mulwArow
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -171,7 +171,7 @@ theorem fullSpec_rowAt_vOfMulwRow
     underlying `mulwArow` matches the one this proof picks — keeping the defeq
     cheap for the construction body. -/
 theorem mulwArow_fullSpec_row
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -189,7 +189,7 @@ theorem mulwArow_fullSpec_row
 
 /-- `FullSpec` of the balance-selected MULW provider row view. -/
 theorem mulwArow_fullSpec
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -231,7 +231,7 @@ theorem match_opBus_row_Arith_vOfMulwRow
     row's emission, in `toEntry (primaryOpBusMessage …) 1` form. Cheap: the row
     is a free `ArithMulRow`, so no `vOfMulwRow`/`opBus_row_Arith` whnf. -/
 theorem mulwArow_match_row
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -262,7 +262,7 @@ theorem mulwArow_match_row
     op-bus match via the CHEAP `rfl`-projection lemma `primaryOpBusMessage_toEntry_op`
     (a rewrite, not a reduction). -/
 theorem mulwArow_mode_pins
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -291,7 +291,7 @@ theorem mulwArow_mode_pins
     Main row's emission, in `opBus_row_Arith` form. The MUL/MULW mode pins
     needed to reduce the faithful mux are DERIVED via `mulwArow_mode_pins`. -/
 theorem mulwArow_match
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -313,7 +313,7 @@ theorem mulwArow_match
     `trace.channels_balanced` / `trace.spec_holds` via the provider's lookup-aware
     `componentWithArithTable.Spec = FullSpec`, NOT supplied as binders. -/
 theorem construction_mulw_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (mulw_input : PureSpec.MulwInput)

--- a/ZiskFv/Compliance/ConstructionMulw.lean
+++ b/ZiskFv/Compliance/ConstructionMulw.lean
@@ -419,7 +419,7 @@ theorem construction_mulw_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   let arith_mem :
@@ -431,7 +431,7 @@ theorem construction_mulw_sound_claimed_dead
         have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
           trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
         simpa [mainRowWithRomSub,
-          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
       store_pc_zero := h_core_store_pc
       rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
   -- promises bundle: Sail reads + exec artifacts as binders; MemBus shape by rfl.

--- a/ZiskFv/Compliance/ConstructionRemu.lean
+++ b/ZiskFv/Compliance/ConstructionRemu.lean
@@ -705,7 +705,7 @@ theorem construction_remu_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   let arith_mem :
@@ -717,7 +717,7 @@ theorem construction_remu_sound_claimed_dead
         have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
           trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
         simpa [mainRowWithRomSub,
-          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
       store_pc_zero := h_core_store_pc
       rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
   -- promises bundle: Sail reads + exec artifacts as binders; MemBus shape by rfl.

--- a/ZiskFv/Compliance/ConstructionRemu.lean
+++ b/ZiskFv/Compliance/ConstructionRemu.lean
@@ -138,7 +138,7 @@ theorem match_opBus_row_ArithDivSecondary_vOfDivuRow
     `main_request_remu_provided`.
     Mirrors `divuArow`. -/
 noncomputable def remuArow
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -151,7 +151,7 @@ noncomputable def remuArow
 /-- `FullSpec` of the balance-selected REMU provider row, derived from the
     provider component's proven soundness (`componentWithArithTable.Spec`). -/
 theorem remuArow_fullSpec_row
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -169,7 +169,7 @@ theorem remuArow_fullSpec_row
 /-- The op-bus match of the balance-selected REMU provider row against the Main
     row's emission, in `toEntry (primaryOpBusMessage …) 1` form. -/
 theorem remuArow_match_row
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -190,7 +190,7 @@ theorem remuArow_match_row
     off the BARE provider `ArithMulRow` via `remu_mode_pins_of_row`, never
     forcing the heavy `Classical.choose` row's whnf. -/
 theorem remuArow_mode_pins
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -220,7 +220,7 @@ theorem remuArow_mode_pins
     Main row's emission, in `opBus_row_ArithDivSecondary` form.  The REMU mode
     pins needed to reduce the faithful mux are DERIVED via `remuArow_mode_pins`. -/
 theorem remuArow_match
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -617,7 +617,7 @@ lemma equiv_REMU_of_fullSpec_claimed_dead
     `arithDiv_table_interactionsWith_opBus_nil`), so it is carried explicitly,
     exactly as the canonical `equiv_REMU` carries it. -/
 theorem construction_remu_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (remu_input : PureSpec.RemuInput)

--- a/ZiskFv/Compliance/ConstructionRemuw.lean
+++ b/ZiskFv/Compliance/ConstructionRemuw.lean
@@ -300,7 +300,7 @@ private lemma remuw_carry_bounds_claimed_dead
     `main_request_remuw_provided`.
     Mirrors `remuArow` / `divuwArow`. -/
 noncomputable def remuwArow
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -313,7 +313,7 @@ noncomputable def remuwArow
 /-- `FullSpec` of the balance-selected REMUW provider row, derived from the
     provider component's proven soundness (`componentWithArithTable.Spec`). -/
 theorem remuwArow_fullSpec_row
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -331,7 +331,7 @@ theorem remuwArow_fullSpec_row
 /-- The op-bus match of the balance-selected REMUW provider row against the Main
     row's emission, in `toEntry (primaryOpBusMessage …) 1` form. -/
 theorem remuwArow_match_row
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -352,7 +352,7 @@ theorem remuwArow_match_row
     off the BARE provider `ArithMulRow` via `remuw_mode_pins_of_row`, never
     forcing the heavy `Classical.choose` row's whnf. -/
 theorem remuwArow_mode_pins
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -384,7 +384,7 @@ theorem remuwArow_mode_pins
     `m32`-agnostic, so the REMU secondary bridge
     `match_opBus_row_ArithDivSecondary_vOfDivuRow` applies verbatim). -/
 theorem remuwArow_match
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
     (h_main_op :
@@ -634,7 +634,7 @@ lemma equiv_REMUW_of_fullSpec_claimed_dead
     encoding on bytes 4..7, class #4 — the same residuals the canonical
     `equiv_REMUW` carries). -/
 theorem construction_remuw_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (remuw_input : PureSpec.RemuwInput)

--- a/ZiskFv/Compliance/ConstructionRemuw.lean
+++ b/ZiskFv/Compliance/ConstructionRemuw.lean
@@ -741,7 +741,7 @@ theorem construction_remuw_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   let arith_mem :
@@ -753,7 +753,7 @@ theorem construction_remuw_sound_claimed_dead
         have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
           trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
         simpa [mainRowWithRomSub,
-          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
       store_pc_zero := h_core_store_pc
       rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
   -- promises bundle: Sail reads + exec artifacts as binders; MemBus shape by rfl.

--- a/ZiskFv/Compliance/ConstructionShift.lean
+++ b/ZiskFv/Compliance/ConstructionShift.lean
@@ -398,7 +398,7 @@ theorem construction_sll_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -412,7 +412,7 @@ theorem construction_sll_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -564,7 +564,7 @@ theorem construction_srl_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -578,7 +578,7 @@ theorem construction_srl_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -730,7 +730,7 @@ theorem construction_sra_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -744,7 +744,7 @@ theorem construction_sra_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -879,7 +879,7 @@ theorem construction_slli_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -893,7 +893,7 @@ theorem construction_slli_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -1025,7 +1025,7 @@ theorem construction_srli_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -1039,7 +1039,7 @@ theorem construction_srli_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -1171,7 +1171,7 @@ theorem construction_srai_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -1185,7 +1185,7 @@ theorem construction_srai_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -1499,7 +1499,7 @@ theorem construction_sllw_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -1513,7 +1513,7 @@ theorem construction_sllw_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -1644,7 +1644,7 @@ theorem construction_srlw_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -1658,7 +1658,7 @@ theorem construction_srlw_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -1785,7 +1785,7 @@ theorem construction_sraw_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -1799,7 +1799,7 @@ theorem construction_sraw_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -1930,7 +1930,7 @@ theorem construction_slliw_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -1944,7 +1944,7 @@ theorem construction_slliw_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -2057,7 +2057,7 @@ theorem construction_srliw_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -2071,7 +2071,7 @@ theorem construction_srliw_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -2185,7 +2185,7 @@ theorem construction_sraiw_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -2199,7 +2199,7 @@ theorem construction_sraiw_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h

--- a/ZiskFv/Compliance/ConstructionShift.lean
+++ b/ZiskFv/Compliance/ConstructionShift.lean
@@ -312,7 +312,7 @@ theorem shift_imm_shift_pin_row_of_facts
     wf/byte facts, `op_is_shift = 1`, the MemBus `m0..m2` shape, `h_lane_rd`, and
     the lane→Sail bindings `h_input_r1_row` / `h_shift_pin_row` (m32 = 0 route). -/
 theorem construction_sll_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (sll_input : PureSpec.SllInput)
@@ -478,7 +478,7 @@ theorem construction_sll_sound_claimed_dead
     wf/byte facts, `op_is_shift = 1`, the MemBus `m0..m2` shape, `h_lane_rd`, and
     the lane→Sail bindings `h_input_r1_row` / `h_shift_pin_row` (m32 = 0 route). -/
 theorem construction_srl_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (srl_input : PureSpec.SrlInput)
@@ -644,7 +644,7 @@ theorem construction_srl_sound_claimed_dead
     wf/byte facts, `op_is_shift = 1`, the MemBus `m0..m2` shape, `h_lane_rd`, and
     the lane→Sail bindings `h_input_r1_row` / `h_shift_pin_row` (m32 = 0 route). -/
 theorem construction_sra_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (sra_input : PureSpec.SraInput)
@@ -806,7 +806,7 @@ theorem construction_sra_sound_claimed_dead
     variant's 17 + execRow): drop `h_input_r2`/`h_b_hi_t`, add `shamt` +
     `h_input_shamt`; the `b_0` decode pin replaces the register `h_b_lo_t`. -/
 theorem construction_slli_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (slli_input : PureSpec.SlliInput)
@@ -952,7 +952,7 @@ theorem construction_slli_sound_claimed_dead
     variant's 17 + execRow): drop `h_input_r2`/`h_b_hi_t`, add `shamt` +
     `h_input_shamt`; the `b_0` decode pin replaces the register `h_b_lo_t`. -/
 theorem construction_srli_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (srli_input : PureSpec.SrliInput)
@@ -1098,7 +1098,7 @@ theorem construction_srli_sound_claimed_dead
     variant's 17 + execRow): drop `h_input_r2`/`h_b_hi_t`, add `shamt` +
     `h_input_shamt`; the `b_0` decode pin replaces the register `h_b_lo_t`. -/
 theorem construction_srai_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (srai_input : PureSpec.SraiInput)
@@ -1412,7 +1412,7 @@ theorem shift_m32_1_imm_shift_pin_row_of_facts
     op pin pinned to `OP_SLL_W`, `h_m32` pinned to 1, and the next-PC against
     `execute_RTYPE_sllw_pure`. -/
 theorem construction_sllw_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (sllw_input : PureSpec.SllwInput)
@@ -1566,7 +1566,7 @@ theorem construction_sllw_sound_claimed_dead
     shared Layer-A wrapper), `ropw.SRLW`, `execute_RTYPE_srlw_pure`. Same
     m32 = 1 lane (`ring`) + `% 32` register shift-pin route. -/
 theorem construction_srlw_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (srlw_input : PureSpec.SrlwInput)
@@ -1706,7 +1706,7 @@ theorem construction_srlw_sound_claimed_dead
     the shared Layer-A wrapper), `ropw.SRAW`, `execute_RTYPE_sraw_pure`. Same
     m32 = 1 lane (`ring`) + `% 32` register shift-pin route. -/
 theorem construction_sraw_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (sraw_input : PureSpec.SrawInput)
@@ -1857,7 +1857,7 @@ theorem construction_sraw_sound_claimed_dead
     `slliw_input.shamt` replaces the register `h_b_lo_t`. The 5-bit immediate
     rides inside `slliw_input`, so it is NOT a separate top-level binder. -/
 theorem construction_slliw_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (slliw_input : PureSpec.SlliwInput)
@@ -1988,7 +1988,7 @@ theorem construction_slliw_sound_claimed_dead
     SLLIW). DELTA: op pin `OP_SRL_W` (5th disjunct), `sopw.SRLIW`,
     `execute_SHIFTIWOP_srliw_pure`. -/
 theorem construction_srliw_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (srliw_input : PureSpec.SrliwInput)
@@ -2115,7 +2115,7 @@ theorem construction_srliw_sound_claimed_dead
     of SLLIW). DELTA: op pin `OP_SRA_W` (6th disjunct), `sopw.SRAIW`,
     `execute_SHIFTIWOP_sraiw_pure`. -/
 theorem construction_sraiw_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (sraiw_input : PureSpec.SraiwInput)

--- a/ZiskFv/Compliance/ConstructionStore.lean
+++ b/ZiskFv/Compliance/ConstructionStore.lean
@@ -145,7 +145,7 @@ theorem mainRowWithRomSt_core
   have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
     trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
   simpa [mainRowWithRomSt,
-    ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+    ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
 
 /-- Sound SB construction: from the accepted trace + honest residual binders,
     conclude the canonical `execute_instruction (.STORE … width 1) = (bus_effect …).2`.

--- a/ZiskFv/Compliance/ConstructionStore.lean
+++ b/ZiskFv/Compliance/ConstructionStore.lean
@@ -102,7 +102,7 @@ set_option maxHeartbeats 2000000
     the real Main table. Its `.core` equals `rowAt (mainOfTable …) i`. -/
 @[reducible]
 noncomputable def mainRowWithRomSt
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) :
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) :
     ZiskFv.AirsClean.Main.MainRowWithRom FGL :=
   ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
     trace.program trace.mainTable i.val
@@ -113,7 +113,7 @@ noncomputable def mainRowWithRomSt
     `S*CleanWitness.main_c_match` is then `matches_memory_entry_refl`. -/
 @[reducible]
 noncomputable def eRdSt
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) :
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) :
     Interaction.MemoryBusEntry FGL :=
   ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
     (ZiskFv.AirsClean.Main.cMemMessage (mainRowWithRomSt trace binding i)) 1 2
@@ -124,7 +124,7 @@ noncomputable def eRdSt
     mult/as shape facts are then `rfl`. -/
 @[reducible]
 noncomputable def busSt
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (execRow : List (Interaction.ExecutionBusEntry FGL)) :
     ZiskFv.Compliance.BusRows where
   exec_row := execRow
@@ -137,7 +137,7 @@ noncomputable def busSt
 /-- The Main row provenance at trace index `i`: `mainRowWithRomSt`'s `.core`
     equals the honest `rowAt (mainOfTable …) i`. Shared by all four stores. -/
 theorem mainRowWithRomSt_core
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) :
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) :
     (mainRowWithRomSt trace binding i).core =
       ZiskFv.AirsClean.Main.rowAt
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
@@ -156,7 +156,7 @@ theorem mainRowWithRomSt_core
     high-byte RMW preservation reads `m1..m7` are the genuinely-irreducible
     memory-side residual (named binders). -/
 theorem construction_sb_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (sb_input : PureSpec.SbInput)
@@ -290,7 +290,7 @@ theorem construction_sb_sound_claimed_dead
     `SbInput → ShInput`; `STOREB → STOREH`; the high-byte RMW residual drops the
     written low half-word — `m2..m7` instead of `m1..m7`; width literal `2`. -/
 theorem construction_sh_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (sh_input : PureSpec.ShInput)
@@ -413,7 +413,7 @@ theorem construction_sh_sound_claimed_dead
     `ShInput → SwInput`; `STOREH → STOREW`; the high-byte RMW residual drops the
     written low word — `m4..m7` instead of `m2..m7`; width literal `4`. -/
 theorem construction_sw_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (sw_input : PureSpec.SwInput)
@@ -531,7 +531,7 @@ theorem construction_sw_sound_claimed_dead
     NO `ind_width` pin; the `SdCleanWitness` is `state`-free. `STOREB → STORED`;
     width literal `8`. -/
 theorem construction_sd_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (sd_input : PureSpec.SdInput)

--- a/ZiskFv/Compliance/ConstructionSub.lean
+++ b/ZiskFv/Compliance/ConstructionSub.lean
@@ -252,7 +252,7 @@ theorem construction_sub_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -266,7 +266,7 @@ theorem construction_sub_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h

--- a/ZiskFv/Compliance/ConstructionSub.lean
+++ b/ZiskFv/Compliance/ConstructionSub.lean
@@ -120,7 +120,7 @@ theorem allByteMatchesOfStaticOut64_local
     real Main table.  Its `.core` equals `rowAt (mainOfTable …) i`. -/
 @[reducible]
 noncomputable def mainRowWithRomSub
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) :
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) :
     ZiskFv.AirsClean.Main.MainRowWithRom FGL :=
   ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
     trace.program trace.mainTable i.val
@@ -130,7 +130,7 @@ noncomputable def mainRowWithRomSub
     `m0..m2` shape facts are then `rfl`. -/
 @[reducible]
 noncomputable def busSub
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (execRow : List (Interaction.ExecutionBusEntry FGL)) :
     ZiskFv.Compliance.BusRows where
   exec_row := execRow
@@ -159,7 +159,7 @@ noncomputable def busSub
     `trace.channels_balanced`), row shape, circuit-internal rd arithmetic, the MemBus
     `m0..m2` shape, `h_lane_rd`, and the lane→Sail binding facts. -/
 theorem construction_sub_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (sub_input : PureSpec.SubInput)

--- a/ZiskFv/Compliance/ConstructionWAlu.lean
+++ b/ZiskFv/Compliance/ConstructionWAlu.lean
@@ -166,7 +166,7 @@ theorem construction_subw_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -180,7 +180,7 @@ theorem construction_subw_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -341,7 +341,7 @@ theorem construction_addw_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -355,7 +355,7 @@ theorem construction_addw_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -513,7 +513,7 @@ theorem construction_addiw_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
   have h_lane_rd :
@@ -527,7 +527,7 @@ theorem construction_addiw_sound_claimed_dead
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h

--- a/ZiskFv/Compliance/ConstructionWAlu.lean
+++ b/ZiskFv/Compliance/ConstructionWAlu.lean
@@ -79,7 +79,7 @@ set_option maxHeartbeats 2000000
 /-- Sound SUBW construction (m32 = 1 word ALU). Unique opcode `OP_SUB_W`
     (`Or.inr` of the shared W Layer-A wrapper). -/
 theorem construction_subw_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (subw_input : PureSpec.SubwInput)
@@ -259,7 +259,7 @@ theorem construction_subw_sound_claimed_dead
     `construction_subw_sound`: op pin `OP_ADD_W` (`Or.inl` of the shared W
     Layer-A wrapper), `ropw.ADDW`, `execute_RTYPE_addw_pure`, `equiv_ADDW`. -/
 theorem construction_addw_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (addw_input : PureSpec.AddwInput)
@@ -438,7 +438,7 @@ theorem construction_addw_sound_claimed_dead
     derives the immediate byte decomposition internally from `h_addiw_subset` +
     `h_match`, so the construction supplies only the r1 lane extract. -/
 theorem construction_addiw_sound_claimed_dead
-    (trace : AcceptedZiskTrace)
+    (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions)
     (addiw_input : PureSpec.AddiwInput)

--- a/ZiskFv/Compliance/OpBusProviderMatch.lean
+++ b/ZiskFv/Compliance/OpBusProviderMatch.lean
@@ -20,8 +20,8 @@ namespace ZiskFv.Compliance
 open ZiskFv.AirsClean.FullEnsemble
 
 theorem main_request_logic_provided
-    (trace : AcceptedZiskTrace)
-    (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
@@ -56,17 +56,17 @@ theorem main_request_logic_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+          numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core =
+          numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -79,28 +79,28 @@ theorem main_request_logic_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+              numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     exists_staticBinary_provider_row_matches_legacy_main_of_logic_active_main_row_interaction
@@ -111,8 +111,8 @@ theorem main_request_logic_provided
         h_mainInteraction_eval h_active h_main_op
 
 theorem main_request_sub_provided
-    (trace : AcceptedZiskTrace)
-    (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
@@ -141,17 +141,17 @@ theorem main_request_sub_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+          numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core =
+          numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -164,28 +164,28 @@ theorem main_request_sub_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+              numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     exists_staticBinary_provider_row_matches_legacy_main_of_sub_active_main_row_interaction
@@ -196,8 +196,8 @@ theorem main_request_sub_provided
         h_mainInteraction_eval h_active h_main_op
 
 theorem main_request_add_provided
-    (trace : AcceptedZiskTrace)
-    (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
@@ -243,17 +243,17 @@ theorem main_request_add_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+          numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core =
+          numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -266,28 +266,28 @@ theorem main_request_add_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+              numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   have h_main_component_spec :
       trace.mainTable.component.Spec
@@ -319,8 +319,8 @@ theorem main_request_add_provided
         h_mainInteraction_eval h_active h_main_op⟩
 
 theorem main_request_compare_provided
-    (trace : AcceptedZiskTrace)
-    (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
@@ -352,17 +352,17 @@ theorem main_request_compare_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+          numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core =
+          numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -375,28 +375,28 @@ theorem main_request_compare_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+              numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     exists_staticBinary_provider_row_matches_legacy_main_of_compare_active_main_row_interaction
@@ -407,8 +407,8 @@ theorem main_request_compare_provided
         h_mainInteraction_eval h_active h_main_op
 
 theorem main_request_w_provided
-    (trace : AcceptedZiskTrace)
-    (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
@@ -440,17 +440,17 @@ theorem main_request_w_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+          numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core =
+          numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -463,28 +463,28 @@ theorem main_request_w_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+              numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     exists_staticBinary_provider_row_matches_legacy_main_of_w_active_main_row_interaction
@@ -495,8 +495,8 @@ theorem main_request_w_provided
         h_mainInteraction_eval h_active h_main_op
 
 theorem main_request_shift_provided
-    (trace : AcceptedZiskTrace)
-    (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
@@ -541,17 +541,17 @@ theorem main_request_shift_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+          numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core =
+          numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -564,28 +564,28 @@ theorem main_request_shift_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+              numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     exists_binaryExtension_provider_row_matches_legacy_main_of_shift_active_main_row_interaction
@@ -607,8 +607,8 @@ theorem main_request_shift_provided
     `providerTable.Spec` is `FullSpec (rowInput …)` and the match is against the
     ArithMul primary op-bus message. -/
 theorem main_request_mulw_provided
-    (trace : AcceptedZiskTrace)
-    (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
@@ -637,17 +637,17 @@ theorem main_request_mulw_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+          numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core =
+          numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -660,28 +660,28 @@ theorem main_request_mulw_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+              numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_primary_of_mulw_active_main_row_interaction
@@ -701,8 +701,8 @@ theorem main_request_mulw_provided
     MULHU-mode bridge in `ArithMul/Bridge.lean` later reduces it to the
     secondary d-lane `opBus_row_ArithMulSecondary`. -/
 theorem main_request_mulhu_provided
-    (trace : AcceptedZiskTrace)
-    (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
@@ -731,17 +731,17 @@ theorem main_request_mulhu_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+          numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core =
+          numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -754,28 +754,28 @@ theorem main_request_mulhu_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+              numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_secondary_of_mulhu_active_main_row_interaction
@@ -797,8 +797,8 @@ theorem main_request_mulhu_provided
     `ArithMul/Bridge.lean` later reduces it to the div quotient-lane
     `opBus_row_ArithDiv`. -/
 theorem main_request_divu_provided
-    (trace : AcceptedZiskTrace)
-    (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
@@ -827,17 +827,17 @@ theorem main_request_divu_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+          numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core =
+          numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -850,28 +850,28 @@ theorem main_request_divu_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+              numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_primary_of_divu_active_main_row_interaction
@@ -892,8 +892,8 @@ theorem main_request_divu_provided
     against the muxed `primaryOpBusMessage`.  The DIVU-mode op-bus bridge later
     reduces it to the div quotient-lane `opBus_row_ArithDiv`. -/
 theorem main_request_divuw_provided
-    (trace : AcceptedZiskTrace)
-    (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
@@ -922,17 +922,17 @@ theorem main_request_divuw_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+          numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core =
+          numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -945,28 +945,28 @@ theorem main_request_divuw_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+              numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_primary_of_divuw_active_main_row_interaction
@@ -988,8 +988,8 @@ theorem main_request_divuw_provided
     `ConstructionRemu.lean` later reduces it (at `div = 1`, `main_div = 0`,
     `main_mul = 0`) to the div remainder-lane `opBus_row_ArithDivSecondary`. -/
 theorem main_request_remu_provided
-    (trace : AcceptedZiskTrace)
-    (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
@@ -1018,17 +1018,17 @@ theorem main_request_remu_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+          numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core =
+          numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -1041,28 +1041,28 @@ theorem main_request_remu_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+              numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_primary_of_remu_active_main_row_interaction
@@ -1085,8 +1085,8 @@ theorem main_request_remu_provided
     `main_mul = 0`) to the div remainder-lane `opBus_row_ArithDivSecondary`; the
     `m32` flag plays no role in the mux. -/
 theorem main_request_remuw_provided
-    (trace : AcceptedZiskTrace)
-    (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin numInstructions)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
@@ -1115,17 +1115,17 @@ theorem main_request_remuw_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+          numInstructions trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          numInstructions trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core =
+          numInstructions trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -1138,28 +1138,28 @@ theorem main_request_remuw_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core.is_external_op)
+              numInstructions trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              numInstructions trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := trace.numInstructions) (program := trace.program)
+        (length := numInstructions) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_primary_of_remuw_active_main_row_interaction

--- a/ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean
@@ -63,7 +63,7 @@ set_option maxHeartbeats 8000000
     the export is 63/63 on the OpEnvelope route. -/
 
 inductive StrongRowConstructionData
-    (ziskTrace : AcceptedZiskTrace) (sailTrace : SailTrace ziskTrace.numInstructions) (i : Fin ziskTrace.numInstructions) where
+    (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions) (i : Fin ziskTrace.numInstructions) where
   | sub (d : RowData_sub ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
   | and (d : RowData_and ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
   | or (d : RowData_or ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
@@ -143,7 +143,7 @@ inductive StrongRowConstructionData
     obligation is SATISFIABLE for an honest FENCE row (see `RowData_fence` /
     `stepStrong_fence`). -/
 
-inductive ZiskStep (ziskTrace : AcceptedZiskTrace) (i : Fin ziskTrace.numInstructions) where
+inductive ZiskStep (ziskTrace : AcceptedZiskTrace numInstructions) (i : Fin ziskTrace.numInstructions) where
   | sub (c : Claim_sub ziskTrace i) : ZiskStep ziskTrace i
   | and (c : Claim_and ziskTrace i) : ZiskStep ziskTrace i
   | or (c : Claim_or ziskTrace i) : ZiskStep ziskTrace i
@@ -208,7 +208,7 @@ inductive ZiskStep (ziskTrace : AcceptedZiskTrace) (i : Fin ziskTrace.numInstruc
   | lw (c : Claim_lw ziskTrace i) : ZiskStep ziskTrace i
   | fence (c : Claim_fence ziskTrace i) : ZiskStep ziskTrace i
 
-def RowDecode (ziskTrace : AcceptedZiskTrace) (sailTrace : SailTrace ziskTrace.numInstructions)
+def RowDecode (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions)
     (i : Fin ziskTrace.numInstructions) : ZiskStep ziskTrace i → Type
   | .sub c => Decode_sub ziskTrace sailTrace i c
   | .and c => Decode_and ziskTrace sailTrace i c
@@ -274,7 +274,7 @@ def RowDecode (ziskTrace : AcceptedZiskTrace) (sailTrace : SailTrace ziskTrace.n
   | .lw c => Decode_lw ziskTrace sailTrace i c
   | .fence c => Decode_fence ziskTrace sailTrace i c
 
-def InputsAgree (ziskTrace : AcceptedZiskTrace) (sailTrace : SailTrace ziskTrace.numInstructions)
+def InputsAgree (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions)
     (i : Fin ziskTrace.numInstructions) : ZiskStep ziskTrace i → Type
   | .sub c => Inputs_sub ziskTrace sailTrace i c
   | .and c => Inputs_and ziskTrace sailTrace i c
@@ -340,7 +340,7 @@ def InputsAgree (ziskTrace : AcceptedZiskTrace) (sailTrace : SailTrace ziskTrace
   | .lw c => Inputs_lw ziskTrace sailTrace i c
   | .fence c => Inputs_fence ziskTrace sailTrace i c
 
-def toFull (ziskTrace : AcceptedZiskTrace) (sailTrace : SailTrace ziskTrace.numInstructions)
+def toFull (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions)
     (i : Fin ziskTrace.numInstructions) (zs : ZiskStep ziskTrace i)
     (rd : RowDecode ziskTrace sailTrace i zs) (ia : InputsAgree ziskTrace sailTrace i zs) :
     StrongRowConstructionData ziskTrace sailTrace i :=
@@ -410,7 +410,7 @@ def toFull (ziskTrace : AcceptedZiskTrace) (sailTrace : SailTrace ziskTrace.numI
   | .fence c, rd, ia => .fence (toRowData_fence c rd ia)
 
 def StepNoKnownDefectOn
-    (ziskTrace : AcceptedZiskTrace) (sailTrace : SailTrace ziskTrace.numInstructions) (i : Fin ziskTrace.numInstructions) :
+    (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions) (i : Fin ziskTrace.numInstructions) :
     StrongRowConstructionData ziskTrace sailTrace i → Prop
   | .sub _ => EnvNoKnownDefectFor
       (state := sailTrace i)
@@ -655,13 +655,13 @@ def StepNoKnownDefectOn
     (`state_effect_via_channels`) form — the OLD global theorem's per-arm
     conclusion — keyed on the row archetype. -/
 
-def StepNoKnownDefect (ziskTrace : AcceptedZiskTrace) (sailTrace : SailTrace ziskTrace.numInstructions)
+def StepNoKnownDefect (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions)
     (i : Fin ziskTrace.numInstructions) (zs : ZiskStep ziskTrace i)
     (rd : RowDecode ziskTrace sailTrace i zs) (ia : InputsAgree ziskTrace sailTrace i zs) : Prop :=
   StepNoKnownDefectOn ziskTrace sailTrace i (toFull ziskTrace sailTrace i zs rd ia)
 
 def StepFaithful
-    (ziskTrace : AcceptedZiskTrace) (sailTrace : SailTrace ziskTrace.numInstructions) (i : Fin ziskTrace.numInstructions) :
+    (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions) (i : Fin ziskTrace.numInstructions) :
     ZiskStep ziskTrace i → Prop
   | .sub c =>
       (do
@@ -1142,7 +1142,7 @@ def StepFaithful
     `zisk_riscv_compliant_program_bus`.  For the direct-lift arms (which never call
     the old theorem) the obligation is `True` and is ignored. -/
 
-theorem stepFaithful_of_evidence (ziskTrace : AcceptedZiskTrace) (sailTrace : SailTrace ziskTrace.numInstructions)
+theorem stepFaithful_of_evidence (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions)
     (i : Fin ziskTrace.numInstructions) (zs : ZiskStep ziskTrace i)
     (rd : RowDecode ziskTrace sailTrace i zs) (ia : InputsAgree ziskTrace sailTrace i zs)
     (h_known : StepNoKnownDefect ziskTrace sailTrace i zs rd ia) :

--- a/ZiskFv/Compliance/TraceLevelExport/EnvOf.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/EnvOf.lean
@@ -49,7 +49,7 @@ set_option maxHeartbeats 8000000
     so the threaded `NoKnownDefect` obligation is the genuine `NoKnownDefect` of the
     exact env the proof feeds to `zisk_riscv_compliant_program_bus`. -/
 noncomputable def fenceEnvOf
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_fence trace binding i) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
@@ -68,7 +68,7 @@ noncomputable def fenceEnvOf
     exact env the proof feeds to `zisk_riscv_compliant_program_bus`.  (Mirrors
     `fenceEnvOf`: a specific-env obligation, SATISFIABLE for an honest row.) -/
 noncomputable def mulEnvOf
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mul trace binding i) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
@@ -89,7 +89,7 @@ noncomputable def mulEnvOf
     is NON-VACUOUS (it is not discharged by a contradictory binder).  This lemma is
     the Lean-checked anti-vacuity guard for the strong-export MUL arm. -/
 theorem mul_noKnownDefect_of_rowData
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mul trace binding i) :
     Defects.NoKnownDefect (mulEnvOf trace binding i d) := by
   intro id
@@ -106,7 +106,7 @@ theorem mul_noKnownDefect_of_rowData
     `mulEnvOf`: a specific-env obligation, SATISFIABLE for an honest signed MULH
     row.  Carries the SIGN-RANGE RESIDUAL `h_sign_a`/`h_sign_b`. -/
 noncomputable def mulhEnvOf
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mulh trace binding i) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
@@ -119,7 +119,7 @@ noncomputable def mulhEnvOf
 /-- The `OpEnvelope.mulhsu` env CONSTRUCTED from a `RowData_mulhsu`.  Only ONE
     sign-range residual `h_sign_a` (op2 unsigned, table-pinned `nb = 0`). -/
 noncomputable def mulhsuEnvOf
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mulhsu trace binding i) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
@@ -134,7 +134,7 @@ noncomputable def mulhsuEnvOf
     narrowed `MaliciousSignedMulWitnessShape` admits for op 181, so
     `NoKnownDefect (mulhEnvOf …)` is TRUE — the `.mulh` strong arm is NON-VACUOUS. -/
 theorem mulh_noKnownDefect_of_rowData
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mulh trace binding i) :
     Defects.NoKnownDefect (mulhEnvOf trace binding i d) := by
   intro id
@@ -150,7 +150,7 @@ theorem mulh_noKnownDefect_of_rowData
 /-- Satisfiability witness for the threaded MULHSU obligation (companion of
     `mulh_noKnownDefect_of_rowData`). -/
 theorem mulhsu_noKnownDefect_of_rowData
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mulhsu trace binding i) :
     Defects.NoKnownDefect (mulhsuEnvOf trace binding i d) := by
   intro id
@@ -170,7 +170,7 @@ theorem mulhsu_noKnownDefect_of_rowData
     `mulEnvOf`: a specific-env obligation, SATISFIABLE for an honest signed DIV
     row whose `|r| ≠ |op2|`.) -/
 noncomputable def divEnvOf
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_div trace binding i) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
@@ -182,7 +182,7 @@ noncomputable def divEnvOf
 
 /-- The `OpEnvelope.rem` env CONSTRUCTED from a `RowData_rem` (secondary lane). -/
 noncomputable def remEnvOf
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_rem trace binding i) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
@@ -194,7 +194,7 @@ noncomputable def remEnvOf
 
 /-- The `OpEnvelope.divw` env CONSTRUCTED from a `RowData_divw` (W-mode primary). -/
 noncomputable def divwEnvOf
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_divw trace binding i) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
@@ -207,7 +207,7 @@ noncomputable def divwEnvOf
 
 /-- The `OpEnvelope.remw` env CONSTRUCTED from a `RowData_remw` (W-mode secondary). -/
 noncomputable def remwEnvOf
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_remw trace binding i) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
@@ -230,7 +230,7 @@ noncomputable def remwEnvOf
     including divisor-zero rows handled by the boundary constraints.  This is the
     Lean-checked anti-vacuity guard for the strong-export DIV arm. -/
 theorem div_noKnownDefect_of_rowData
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_div trace binding i) :
     Defects.NoKnownDefect (divEnvOf trace binding i d) := by
   intro id
@@ -246,7 +246,7 @@ theorem div_noKnownDefect_of_rowData
 /-- Satisfiability witness for the threaded REM obligation (companion of
     `div_noKnownDefect_of_rowData`; secondary remainder lane). -/
 theorem rem_noKnownDefect_of_rowData
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_rem trace binding i) :
     Defects.NoKnownDefect (remEnvOf trace binding i d) := by
   intro id
@@ -264,7 +264,7 @@ theorem rem_noKnownDefect_of_rowData
 /-- Satisfiability witness for the threaded DIVW obligation (W-mode analogue of
     `div_noKnownDefect_of_rowData`; narrowed shape `|r₃₂| ≠ |op2₃₂|`). -/
 theorem divw_noKnownDefect_of_rowData
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_divw trace binding i) :
     Defects.NoKnownDefect (divwEnvOf trace binding i d) := by
   intro id
@@ -280,7 +280,7 @@ theorem divw_noKnownDefect_of_rowData
 /-- Satisfiability witness for the threaded REMW obligation (companion of
     `divw_noKnownDefect_of_rowData`; W-mode secondary remainder lane). -/
 theorem remw_noKnownDefect_of_rowData
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_remw trace binding i) :
     Defects.NoKnownDefect (remwEnvOf trace binding i d) := by
   intro id

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataAluShift.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataAluShift.lean
@@ -44,7 +44,7 @@ set_option maxHeartbeats 8000000
 /-- Irreducible per-row residuals for the `sub` archetype — the binders of
     `construction_sub_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sub
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   sub_input : PureSpec.SubInput
   r1 : regidx
   r2 : regidx
@@ -104,7 +104,7 @@ structure RowData_sub
 /-- Irreducible per-row residuals for the `and` archetype — the binders of
     `construction_and_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_and
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   and_input : PureSpec.AndInput
   r1 : regidx
   r2 : regidx
@@ -164,7 +164,7 @@ structure RowData_and
 /-- Irreducible per-row residuals for the `or` archetype — the binders of
     `construction_or_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_or
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   or_input : PureSpec.OrInput
   r1 : regidx
   r2 : regidx
@@ -224,7 +224,7 @@ structure RowData_or
 /-- Irreducible per-row residuals for the `xor` archetype — the binders of
     `construction_xor_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_xor
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   xor_input : PureSpec.XorInput
   r1 : regidx
   r2 : regidx
@@ -284,7 +284,7 @@ structure RowData_xor
 /-- Irreducible per-row residuals for the `slt` archetype — the binders of
     `construction_slt_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_slt
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   slt_input : PureSpec.SltInput
   r1 : regidx
   r2 : regidx
@@ -344,7 +344,7 @@ structure RowData_slt
 /-- Irreducible per-row residuals for the `sltu` archetype — the binders of
     `construction_sltu_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sltu
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   sltu_input : PureSpec.SltuInput
   r1 : regidx
   r2 : regidx
@@ -404,7 +404,7 @@ structure RowData_sltu
 /-- Irreducible per-row residuals for the `andi` archetype — the binders of
     `construction_andi_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_andi
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   andi_input : PureSpec.AndiInput
   r1 : regidx
   rd : regidx
@@ -455,7 +455,7 @@ structure RowData_andi
 /-- Irreducible per-row residuals for the `ori` archetype — the binders of
     `construction_ori_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_ori
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   ori_input : PureSpec.OriInput
   r1 : regidx
   rd : regidx
@@ -506,7 +506,7 @@ structure RowData_ori
 /-- Irreducible per-row residuals for the `xori` archetype — the binders of
     `construction_xori_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_xori
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   xori_input : PureSpec.XoriInput
   r1 : regidx
   rd : regidx
@@ -557,7 +557,7 @@ structure RowData_xori
 /-- Irreducible per-row residuals for the `slti` archetype — the binders of
     `construction_slti_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_slti
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   slti_input : PureSpec.SltiInput
   r1 : regidx
   rd : regidx
@@ -608,7 +608,7 @@ structure RowData_slti
 /-- Irreducible per-row residuals for the `sltiu` archetype — the binders of
     `construction_sltiu_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sltiu
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   sltiu_input : PureSpec.SltiuInput
   r1 : regidx
   rd : regidx
@@ -659,7 +659,7 @@ structure RowData_sltiu
 /-- Irreducible per-row residuals for the `sll` archetype — the binders of
     `construction_sll_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sll
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   sll_input : PureSpec.SllInput
   r1 : regidx
   r2 : regidx
@@ -719,7 +719,7 @@ structure RowData_sll
 /-- Irreducible per-row residuals for the `srl` archetype — the binders of
     `construction_srl_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_srl
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   srl_input : PureSpec.SrlInput
   r1 : regidx
   r2 : regidx
@@ -779,7 +779,7 @@ structure RowData_srl
 /-- Irreducible per-row residuals for the `sra` archetype — the binders of
     `construction_sra_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sra
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   sra_input : PureSpec.SraInput
   r1 : regidx
   r2 : regidx
@@ -839,7 +839,7 @@ structure RowData_sra
 /-- Irreducible per-row residuals for the `slli` archetype — the binders of
     `construction_slli_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_slli
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   slli_input : PureSpec.SlliInput
   r1 : regidx
   rd : regidx
@@ -890,7 +890,7 @@ structure RowData_slli
 /-- Irreducible per-row residuals for the `srli` archetype — the binders of
     `construction_srli_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_srli
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   srli_input : PureSpec.SrliInput
   r1 : regidx
   rd : regidx
@@ -941,7 +941,7 @@ structure RowData_srli
 /-- Irreducible per-row residuals for the `srai` archetype — the binders of
     `construction_srai_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_srai
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   srai_input : PureSpec.SraiInput
   r1 : regidx
   rd : regidx
@@ -992,7 +992,7 @@ structure RowData_srai
 /-- Irreducible per-row residuals for the `sllw` archetype — the binders of
     `construction_sllw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sllw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   sllw_input : PureSpec.SllwInput
   r1 : regidx
   r2 : regidx
@@ -1052,7 +1052,7 @@ structure RowData_sllw
 /-- Irreducible per-row residuals for the `srlw` archetype — the binders of
     `construction_srlw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_srlw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   srlw_input : PureSpec.SrlwInput
   r1 : regidx
   r2 : regidx
@@ -1112,7 +1112,7 @@ structure RowData_srlw
 /-- Irreducible per-row residuals for the `sraw` archetype — the binders of
     `construction_sraw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sraw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   sraw_input : PureSpec.SrawInput
   r1 : regidx
   r2 : regidx
@@ -1172,7 +1172,7 @@ structure RowData_sraw
 /-- Irreducible per-row residuals for the `slliw` archetype — the binders of
     `construction_slliw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_slliw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   slliw_input : PureSpec.SlliwInput
   r1 : regidx
   rd : regidx
@@ -1221,7 +1221,7 @@ structure RowData_slliw
 /-- Irreducible per-row residuals for the `srliw` archetype — the binders of
     `construction_srliw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_srliw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   srliw_input : PureSpec.SrliwInput
   r1 : regidx
   rd : regidx
@@ -1270,7 +1270,7 @@ structure RowData_srliw
 /-- Irreducible per-row residuals for the `sraiw` archetype — the binders of
     `construction_sraiw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sraiw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   sraiw_input : PureSpec.SraiwInput
   r1 : regidx
   rd : regidx

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
@@ -44,7 +44,7 @@ set_option maxHeartbeats 8000000
 /-- Irreducible per-row residuals for the `add` archetype — the binders of
     `construction_add_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_add
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   add_input : PureSpec.AddInput
   r1 : regidx
   r2 : regidx
@@ -104,7 +104,7 @@ structure RowData_add
 /-- Irreducible per-row residuals for the `addi` archetype — the binders of
     `construction_addi_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_addi
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   addi_input : PureSpec.AddiInput
   r1 : regidx
   rd : regidx
@@ -158,7 +158,7 @@ structure RowData_addi
 /-- Irreducible per-row residuals for the `subw` archetype — the binders of
     `construction_subw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_subw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   subw_input : PureSpec.SubwInput
   r1 : regidx
   r2 : regidx
@@ -218,7 +218,7 @@ structure RowData_subw
 /-- Irreducible per-row residuals for the `addw` archetype — the binders of
     `construction_addw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_addw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   addw_input : PureSpec.AddwInput
   r1 : regidx
   r2 : regidx
@@ -278,7 +278,7 @@ structure RowData_addw
 /-- Irreducible per-row residuals for the `addiw` archetype — the binders of
     `construction_addiw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_addiw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   addiw_input : PureSpec.AddiwInput
   r1 : regidx
   rd : regidx
@@ -329,7 +329,7 @@ structure RowData_addiw
 /-- Irreducible per-row residuals for the `lui` archetype — the binders of
     `construction_lui_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_lui
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   lui_input : PureSpec.LuiInput
   imm : BitVec 20
   rd : regidx
@@ -371,7 +371,7 @@ structure RowData_lui
 /-- Irreducible per-row residuals for the `auipc` archetype — the binders of
     `construction_auipc_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_auipc
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   auipc_input : PureSpec.AuipcInput
   imm : BitVec 20
   rd : regidx
@@ -420,7 +420,7 @@ structure RowData_auipc
 /-- Irreducible per-row residuals for the `mulw` archetype — the binders of
     `construction_mulw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_mulw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   mulw_input : PureSpec.MulwInput
   r1 : regidx
   r2 : regidx
@@ -511,7 +511,7 @@ structure RowData_mulw
     contradictory `False`-binder.  Non-vacuous: a real trace with an honest signed
     MUL row supplies all binders. -/
 structure RowData_mul
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   mul_input : PureSpec.MulInput
   r1 : regidx
   r2 : regidx
@@ -577,7 +577,7 @@ structure RowData_mul
     Non-vacuous: a real trace with an honest signed MULH row supplies all
     binders (`h_not_forge` holds, `h_sign_*` are the true operand MSBs). -/
 structure RowData_mulh
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   mulh_input : PureSpec.MulhInput
   r1 : regidx
   r2 : regidx
@@ -638,7 +638,7 @@ structure RowData_mulh
     high half, op 179).  Mirror of `RowData_mulh` but the table pins `nb = 0`
     (op2 unsigned), so only ONE sign-range residual `h_sign_a` is carried. -/
 structure RowData_mulhsu
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   mulhsu_input : PureSpec.MulhsuInput
   r1 : regidx
   r2 : regidx
@@ -720,7 +720,7 @@ structure RowData_mulhsu
     Non-vacuous: a real trace with an honest signed DIV row supplies all binders
     (anti-vacuity witness `honest_div_witness_not_forge`). -/
 structure RowData_div
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   div_input : PureSpec.DivInput
   r1 : regidx
   r2 : regidx
@@ -817,7 +817,7 @@ structure RowData_div
     remainder lane (`opBus_row_ArithDivSecondary`).  Carries the narrowed honest
     shape `|r| ≠ |op2|`; the divisor-zero residual stays carried. -/
 structure RowData_rem
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   rem_input : PureSpec.RemInput
   r1 : regidx
   r2 : regidx
@@ -906,7 +906,7 @@ structure RowData_rem
     narrowed W honest shape excluding the nonzero-divisor `|r₃₂| = |op2₃₂|`
     false positive. -/
 structure RowData_divw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   divw_input : PureSpec.DivwInput
   r1 : regidx
   r2 : regidx
@@ -1011,7 +1011,7 @@ structure RowData_divw
     remainder (op `189`, `m32 = 1`, secondary ArithDiv lane).  W-mode analogue of
     `RowData_rem`; mirror of `RowData_divw` on the secondary (remainder) lane. -/
 structure RowData_remw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   remw_input : PureSpec.RemwInput
   r1 : regidx
   r2 : regidx
@@ -1112,7 +1112,7 @@ structure RowData_remw
 /-- Irreducible per-row residuals for the `mulhu` archetype — the binders of
     `construction_mulhu_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_mulhu
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   mulhu_input : PureSpec.MulhuInput
   r1 : regidx
   r2 : regidx
@@ -1167,7 +1167,7 @@ structure RowData_mulhu
 /-- Irreducible per-row residuals for the `divu` archetype — the binders of
     `construction_divu_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_divu
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   divu_input : PureSpec.DivuInput
   r1 : regidx
   r2 : regidx
@@ -1225,7 +1225,7 @@ structure RowData_divu
 /-- Irreducible per-row residuals for the `divuw` archetype — the binders of
     `construction_divuw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_divuw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   divuw_input : PureSpec.DivuwInput
   r1 : regidx
   r2 : regidx
@@ -1298,7 +1298,7 @@ structure RowData_divuw
 /-- Irreducible per-row residuals for the `remu` archetype — the binders of
     `construction_remu_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_remu
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   remu_input : PureSpec.RemuInput
   r1 : regidx
   r2 : regidx
@@ -1356,7 +1356,7 @@ structure RowData_remu
 /-- Irreducible per-row residuals for the `remuw` archetype — the binders of
     `construction_remuw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_remuw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   remuw_input : PureSpec.RemuwInput
   r1 : regidx
   r2 : regidx
@@ -1429,7 +1429,7 @@ structure RowData_remuw
 /-- Irreducible per-row residuals for the `sb` archetype — the binders of
     `construction_sb_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sb
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   sb_input : PureSpec.SbInput
   regs : ZiskFv.Compliance.ModeRegsFull
   h_main_active :
@@ -1482,7 +1482,7 @@ structure RowData_sb
 /-- Irreducible per-row residuals for the `sh` archetype — the binders of
     `construction_sh_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sh
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   sh_input : PureSpec.ShInput
   regs : ZiskFv.Compliance.ModeRegsFull
   h_main_active :
@@ -1533,7 +1533,7 @@ structure RowData_sh
 /-- Irreducible per-row residuals for the `sw` archetype — the binders of
     `construction_sw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   sw_input : PureSpec.SwInput
   regs : ZiskFv.Compliance.ModeRegsFull
   h_main_active :
@@ -1580,7 +1580,7 @@ structure RowData_sw
 /-- Irreducible per-row residuals for the `sd` archetype — the binders of
     `construction_sd_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_sd
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   sd_input : PureSpec.SdInput
   regs : ZiskFv.Compliance.ModeRegsFull
   h_main_active :
@@ -1616,7 +1616,7 @@ structure RowData_sd
 /-- Irreducible per-row residuals for the `ld` archetype — the binders of
     `construction_ld_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_ld
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   ld_input : PureSpec.LdInput
   regs : ZiskFv.Compliance.ModeRegsFull
   mem : Valid_Mem FGL FGL
@@ -1665,7 +1665,7 @@ structure RowData_ld
 /-- Irreducible per-row residuals for the `lbu` archetype — the binders of
     `construction_lbu_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_lbu
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   lbu_input : PureSpec.LbuInput
   regs : ZiskFv.Compliance.ModeRegsFull
   mem : Valid_Mem FGL FGL
@@ -1717,7 +1717,7 @@ structure RowData_lbu
 /-- Irreducible per-row residuals for the `lhu` archetype — the binders of
     `construction_lhu_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_lhu
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   lhu_input : PureSpec.LhuInput
   regs : ZiskFv.Compliance.ModeRegsFull
   mem : Valid_Mem FGL FGL
@@ -1769,7 +1769,7 @@ structure RowData_lhu
 /-- Irreducible per-row residuals for the `lwu` archetype — the binders of
     `construction_lwu_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_lwu
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   lwu_input : PureSpec.LwuInput
   regs : ZiskFv.Compliance.ModeRegsFull
   mem : Valid_Mem FGL FGL
@@ -1821,7 +1821,7 @@ structure RowData_lwu
 /-- Irreducible per-row residuals for the `lb` archetype — the binders of
     `construction_lb_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_lb
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   lb_input : PureSpec.LbInput
   regs : ZiskFv.Compliance.ModeRegsFull
   mem : Valid_Mem FGL FGL
@@ -1881,7 +1881,7 @@ structure RowData_lb
 /-- Irreducible per-row residuals for the `lh` archetype — the binders of
     `construction_lh_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_lh
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   lh_input : PureSpec.LhInput
   regs : ZiskFv.Compliance.ModeRegsFull
   mem : Valid_Mem FGL FGL
@@ -1941,7 +1941,7 @@ structure RowData_lh
 /-- Irreducible per-row residuals for the `lw` archetype — the binders of
     `construction_lw_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_lw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   lw_input : PureSpec.LwInput
   regs : ZiskFv.Compliance.ModeRegsFull
   mem : Valid_Mem FGL FGL

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
@@ -44,7 +44,7 @@ set_option maxHeartbeats 8000000
 /-- Irreducible per-row residuals for the `beq` archetype — the binders of
     `construction_beq_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_beq
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   beq_input : PureSpec.BeqInput
   imm : BitVec 13
   r1 : regidx
@@ -90,7 +90,7 @@ structure RowData_beq
 /-- Irreducible per-row residuals for the `bne` archetype — the binders of
     `construction_bne_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_bne
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   bne_input : PureSpec.BneInput
   imm : BitVec 13
   r1 : regidx
@@ -136,7 +136,7 @@ structure RowData_bne
 /-- Irreducible per-row residuals for the `blt` archetype — the binders of
     `construction_blt_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_blt
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   blt_input : PureSpec.BltInput
   imm : BitVec 13
   r1 : regidx
@@ -182,7 +182,7 @@ structure RowData_blt
 /-- Irreducible per-row residuals for the `bge` archetype — the binders of
     `construction_bge_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_bge
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   bge_input : PureSpec.BgeInput
   imm : BitVec 13
   r1 : regidx
@@ -228,7 +228,7 @@ structure RowData_bge
 /-- Irreducible per-row residuals for the `bltu` archetype — the binders of
     `construction_bltu_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_bltu
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   bltu_input : PureSpec.BltuInput
   imm : BitVec 13
   r1 : regidx
@@ -274,7 +274,7 @@ structure RowData_bltu
 /-- Irreducible per-row residuals for the `bgeu` archetype — the binders of
     `construction_bgeu_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_bgeu
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   bgeu_input : PureSpec.BgeuInput
   imm : BitVec 13
   r1 : regidx
@@ -320,7 +320,7 @@ structure RowData_bgeu
 /-- Irreducible per-row residuals for the `jal` archetype — the binders of
     `construction_jal_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_jal
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   jal_input : PureSpec.JalInput
   imm : BitVec 21
   rd : regidx
@@ -369,7 +369,7 @@ structure RowData_jal
 /-- Irreducible per-row residuals for the `jalr` archetype — the binders of
     `construction_jalr_sound` after `(trace) (binding) (i)`, verbatim. -/
 structure RowData_jalr
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   jalr_input : PureSpec.JalrInput
   imm : BitVec 12
   rs1 : regidx
@@ -440,7 +440,7 @@ structure RowData_jalr
     documents.  Non-vacuous: a real trace with a generic `fm=0,rs1=x0,rd=x0` FENCE
     row supplies all binders and proves the `NoKnownDefect` obligation. -/
 structure RowData_fence
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
   fence_input : PureSpec.FenceInput
   fm : BitVec 4
   fenceP : BitVec 4

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataSplit.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataSplit.lean
@@ -26,13 +26,13 @@ seal mulwArow mulhuArow divuArow divuwArow remuArow remuwArow
 
 set_option maxHeartbeats 8000000
 
-structure Claim_sub (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_sub (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_sub (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_sub (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sub trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -50,7 +50,7 @@ structure Decode_sub (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_sub (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_sub (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sub trace i) : Type where
   sub_input : PureSpec.SubInput
   h_input_r1 :
@@ -89,7 +89,7 @@ structure Inputs_sub (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
     sub_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_sub {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_sub {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_sub trace i) (dec : Decode_sub trace binding i c)
     (ia : Inputs_sub trace binding i c) : RowData_sub trace binding i where
@@ -116,13 +116,13 @@ def toRowData_sub {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInst
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_and (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_and (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_and (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_and (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_and trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -140,7 +140,7 @@ structure Decode_and (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_and (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_and (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_and trace i) : Type where
   and_input : PureSpec.AndInput
   h_input_r1 :
@@ -179,7 +179,7 @@ structure Inputs_and (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
     and_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_and {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_and {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_and trace i) (dec : Decode_and trace binding i c)
     (ia : Inputs_and trace binding i c) : RowData_and trace binding i where
@@ -206,13 +206,13 @@ def toRowData_and {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInst
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_or (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_or (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_or (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_or (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_or trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -230,7 +230,7 @@ structure Decode_or (trace : AcceptedZiskTrace) (binding : SailTrace trace.numIn
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_or (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_or (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_or trace i) : Type where
   or_input : PureSpec.OrInput
   h_input_r1 :
@@ -269,7 +269,7 @@ structure Inputs_or (trace : AcceptedZiskTrace) (binding : SailTrace trace.numIn
     or_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_or {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_or {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_or trace i) (dec : Decode_or trace binding i c)
     (ia : Inputs_or trace binding i c) : RowData_or trace binding i where
@@ -296,13 +296,13 @@ def toRowData_or {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstr
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_xor (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_xor (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_xor (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_xor (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_xor trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -320,7 +320,7 @@ structure Decode_xor (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_xor (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_xor (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_xor trace i) : Type where
   xor_input : PureSpec.XorInput
   h_input_r1 :
@@ -359,7 +359,7 @@ structure Inputs_xor (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
     xor_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_xor {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_xor {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_xor trace i) (dec : Decode_xor trace binding i c)
     (ia : Inputs_xor trace binding i c) : RowData_xor trace binding i where
@@ -386,13 +386,13 @@ def toRowData_xor {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInst
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_slt (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_slt (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_slt (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_slt (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_slt trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -410,7 +410,7 @@ structure Decode_slt (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_slt (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_slt (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_slt trace i) : Type where
   slt_input : PureSpec.SltInput
   h_input_r1 :
@@ -449,7 +449,7 @@ structure Inputs_slt (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
     slt_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_slt {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_slt {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_slt trace i) (dec : Decode_slt trace binding i c)
     (ia : Inputs_slt trace binding i c) : RowData_slt trace binding i where
@@ -476,13 +476,13 @@ def toRowData_slt {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInst
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_sltu (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_sltu (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_sltu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_sltu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sltu trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -500,7 +500,7 @@ structure Decode_sltu (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_sltu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_sltu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sltu trace i) : Type where
   sltu_input : PureSpec.SltuInput
   h_input_r1 :
@@ -539,7 +539,7 @@ structure Inputs_sltu (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
     sltu_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_sltu {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_sltu {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_sltu trace i) (dec : Decode_sltu trace binding i c)
     (ia : Inputs_sltu trace binding i c) : RowData_sltu trace binding i where
@@ -566,13 +566,13 @@ def toRowData_sltu {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIns
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_andi (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_andi (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   rd : regidx
   imm : BitVec 12
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_andi (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_andi (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_andi trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -590,7 +590,7 @@ structure Decode_andi (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_andi (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_andi (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_andi trace i) : Type where
   andi_input : PureSpec.AndiInput
   h_input_r1 :
@@ -620,7 +620,7 @@ structure Inputs_andi (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
     andi_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_andi {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_andi {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_andi trace i) (dec : Decode_andi trace binding i c)
     (ia : Inputs_andi trace binding i c) : RowData_andi trace binding i where
@@ -646,13 +646,13 @@ def toRowData_andi {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIns
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_ori (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_ori (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   rd : regidx
   imm : BitVec 12
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_ori (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_ori (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_ori trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -670,7 +670,7 @@ structure Decode_ori (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_ori (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_ori (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_ori trace i) : Type where
   ori_input : PureSpec.OriInput
   h_input_r1 :
@@ -700,7 +700,7 @@ structure Inputs_ori (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
     ori_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_ori {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_ori {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_ori trace i) (dec : Decode_ori trace binding i c)
     (ia : Inputs_ori trace binding i c) : RowData_ori trace binding i where
@@ -726,13 +726,13 @@ def toRowData_ori {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInst
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_xori (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_xori (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   rd : regidx
   imm : BitVec 12
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_xori (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_xori (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_xori trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -750,7 +750,7 @@ structure Decode_xori (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_xori (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_xori (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_xori trace i) : Type where
   xori_input : PureSpec.XoriInput
   h_input_r1 :
@@ -780,7 +780,7 @@ structure Inputs_xori (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
     xori_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_xori {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_xori {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_xori trace i) (dec : Decode_xori trace binding i c)
     (ia : Inputs_xori trace binding i c) : RowData_xori trace binding i where
@@ -806,13 +806,13 @@ def toRowData_xori {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIns
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_slti (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_slti (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   rd : regidx
   imm : BitVec 12
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_slti (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_slti (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_slti trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -830,7 +830,7 @@ structure Decode_slti (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_slti (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_slti (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_slti trace i) : Type where
   slti_input : PureSpec.SltiInput
   h_input_r1 :
@@ -860,7 +860,7 @@ structure Inputs_slti (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
     slti_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_slti {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_slti {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_slti trace i) (dec : Decode_slti trace binding i c)
     (ia : Inputs_slti trace binding i c) : RowData_slti trace binding i where
@@ -886,13 +886,13 @@ def toRowData_slti {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIns
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_sltiu (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_sltiu (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   rd : regidx
   imm : BitVec 12
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_sltiu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_sltiu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sltiu trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -910,7 +910,7 @@ structure Decode_sltiu (trace : AcceptedZiskTrace) (binding : SailTrace trace.nu
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_sltiu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_sltiu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sltiu trace i) : Type where
   sltiu_input : PureSpec.SltiuInput
   h_input_r1 :
@@ -940,7 +940,7 @@ structure Inputs_sltiu (trace : AcceptedZiskTrace) (binding : SailTrace trace.nu
     sltiu_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_sltiu {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_sltiu {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_sltiu trace i) (dec : Decode_sltiu trace binding i c)
     (ia : Inputs_sltiu trace binding i c) : RowData_sltiu trace binding i where
@@ -966,13 +966,13 @@ def toRowData_sltiu {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIn
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_add (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_add (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_add (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_add (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_add trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -990,7 +990,7 @@ structure Decode_add (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_add (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_add (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_add trace i) : Type where
   add_input : PureSpec.AddInput
   h_input_r1 :
@@ -1029,7 +1029,7 @@ structure Inputs_add (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
     add_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_add {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_add {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_add trace i) (dec : Decode_add trace binding i c)
     (ia : Inputs_add trace binding i c) : RowData_add trace binding i where
@@ -1056,13 +1056,13 @@ def toRowData_add {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInst
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_addi (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_addi (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   rd : regidx
   imm : BitVec 12
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_addi (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_addi (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_addi trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -1083,7 +1083,7 @@ structure Decode_addi (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_addi (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_addi (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_addi trace i) : Type where
   addi_input : PureSpec.AddiInput
   h_input_r1 :
@@ -1113,7 +1113,7 @@ structure Inputs_addi (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
     addi_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_addi {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_addi {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_addi trace i) (dec : Decode_addi trace binding i c)
     (ia : Inputs_addi trace binding i c) : RowData_addi trace binding i where
@@ -1140,13 +1140,13 @@ def toRowData_addi {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIns
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_sll (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_sll (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_sll (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_sll (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sll trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -1164,7 +1164,7 @@ structure Decode_sll (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_sll (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_sll (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sll trace i) : Type where
   sll_input : PureSpec.SllInput
   h_input_r1 :
@@ -1203,7 +1203,7 @@ structure Inputs_sll (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
     sll_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_sll {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_sll {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_sll trace i) (dec : Decode_sll trace binding i c)
     (ia : Inputs_sll trace binding i c) : RowData_sll trace binding i where
@@ -1230,13 +1230,13 @@ def toRowData_sll {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInst
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_srl (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_srl (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_srl (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_srl (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_srl trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -1254,7 +1254,7 @@ structure Decode_srl (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_srl (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_srl (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_srl trace i) : Type where
   srl_input : PureSpec.SrlInput
   h_input_r1 :
@@ -1293,7 +1293,7 @@ structure Inputs_srl (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
     srl_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_srl {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_srl {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_srl trace i) (dec : Decode_srl trace binding i c)
     (ia : Inputs_srl trace binding i c) : RowData_srl trace binding i where
@@ -1320,13 +1320,13 @@ def toRowData_srl {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInst
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_sra (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_sra (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_sra (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_sra (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sra trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -1344,7 +1344,7 @@ structure Decode_sra (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_sra (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_sra (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sra trace i) : Type where
   sra_input : PureSpec.SraInput
   h_input_r1 :
@@ -1383,7 +1383,7 @@ structure Inputs_sra (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
     sra_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_sra {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_sra {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_sra trace i) (dec : Decode_sra trace binding i c)
     (ia : Inputs_sra trace binding i c) : RowData_sra trace binding i where
@@ -1410,13 +1410,13 @@ def toRowData_sra {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInst
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_slli (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_slli (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   rd : regidx
   shamt : BitVec 6
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_slli (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_slli (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_slli trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -1437,7 +1437,7 @@ structure Decode_slli (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_slli (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_slli (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_slli trace i) : Type where
   slli_input : PureSpec.SlliInput
   h_input_r1 :
@@ -1464,7 +1464,7 @@ structure Inputs_slli (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
     slli_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_slli {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_slli {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_slli trace i) (dec : Decode_slli trace binding i c)
     (ia : Inputs_slli trace binding i c) : RowData_slli trace binding i where
@@ -1490,13 +1490,13 @@ def toRowData_slli {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIns
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_srli (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_srli (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   rd : regidx
   shamt : BitVec 6
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_srli (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_srli (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_srli trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -1517,7 +1517,7 @@ structure Decode_srli (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_srli (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_srli (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_srli trace i) : Type where
   srli_input : PureSpec.SrliInput
   h_input_r1 :
@@ -1544,7 +1544,7 @@ structure Inputs_srli (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
     srli_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_srli {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_srli {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_srli trace i) (dec : Decode_srli trace binding i c)
     (ia : Inputs_srli trace binding i c) : RowData_srli trace binding i where
@@ -1570,13 +1570,13 @@ def toRowData_srli {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIns
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_srai (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_srai (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   rd : regidx
   shamt : BitVec 6
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_srai (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_srai (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_srai trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -1597,7 +1597,7 @@ structure Decode_srai (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_srai (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_srai (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_srai trace i) : Type where
   srai_input : PureSpec.SraiInput
   h_input_r1 :
@@ -1624,7 +1624,7 @@ structure Inputs_srai (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
     srai_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_srai {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_srai {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_srai trace i) (dec : Decode_srai trace binding i c)
     (ia : Inputs_srai trace binding i c) : RowData_srai trace binding i where
@@ -1650,13 +1650,13 @@ def toRowData_srai {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIns
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_subw (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_subw (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_subw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_subw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_subw trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -1674,7 +1674,7 @@ structure Decode_subw (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_subw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_subw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_subw trace i) : Type where
   subw_input : PureSpec.SubwInput
   h_input_r1 :
@@ -1713,7 +1713,7 @@ structure Inputs_subw (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
     subw_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_subw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_subw {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_subw trace i) (dec : Decode_subw trace binding i c)
     (ia : Inputs_subw trace binding i c) : RowData_subw trace binding i where
@@ -1740,13 +1740,13 @@ def toRowData_subw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIns
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_addw (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_addw (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_addw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_addw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_addw trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -1764,7 +1764,7 @@ structure Decode_addw (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_addw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_addw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_addw trace i) : Type where
   addw_input : PureSpec.AddwInput
   h_input_r1 :
@@ -1803,7 +1803,7 @@ structure Inputs_addw (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
     addw_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_addw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_addw {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_addw trace i) (dec : Decode_addw trace binding i c)
     (ia : Inputs_addw trace binding i c) : RowData_addw trace binding i where
@@ -1830,13 +1830,13 @@ def toRowData_addw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIns
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_addiw (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_addiw (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   rd : regidx
   imm : BitVec 12
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_addiw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_addiw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_addiw trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -1854,7 +1854,7 @@ structure Decode_addiw (trace : AcceptedZiskTrace) (binding : SailTrace trace.nu
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_addiw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_addiw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_addiw trace i) : Type where
   addiw_input : PureSpec.AddiwInput
   h_input_r1 :
@@ -1884,7 +1884,7 @@ structure Inputs_addiw (trace : AcceptedZiskTrace) (binding : SailTrace trace.nu
     addiw_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_addiw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_addiw {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_addiw trace i) (dec : Decode_addiw trace binding i c)
     (ia : Inputs_addiw trace binding i c) : RowData_addiw trace binding i where
@@ -1910,13 +1910,13 @@ def toRowData_addiw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIn
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_sllw (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_sllw (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_sllw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_sllw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sllw trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -1934,7 +1934,7 @@ structure Decode_sllw (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_sllw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_sllw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sllw trace i) : Type where
   sllw_input : PureSpec.SllwInput
   h_input_r1 :
@@ -1973,7 +1973,7 @@ structure Inputs_sllw (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
     sllw_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_sllw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_sllw {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_sllw trace i) (dec : Decode_sllw trace binding i c)
     (ia : Inputs_sllw trace binding i c) : RowData_sllw trace binding i where
@@ -2000,13 +2000,13 @@ def toRowData_sllw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIns
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_srlw (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_srlw (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_srlw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_srlw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_srlw trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -2024,7 +2024,7 @@ structure Decode_srlw (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_srlw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_srlw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_srlw trace i) : Type where
   srlw_input : PureSpec.SrlwInput
   h_input_r1 :
@@ -2063,7 +2063,7 @@ structure Inputs_srlw (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
     srlw_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_srlw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_srlw {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_srlw trace i) (dec : Decode_srlw trace binding i c)
     (ia : Inputs_srlw trace binding i c) : RowData_srlw trace binding i where
@@ -2090,13 +2090,13 @@ def toRowData_srlw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIns
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_sraw (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_sraw (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_sraw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_sraw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sraw trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -2114,7 +2114,7 @@ structure Decode_sraw (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_sraw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_sraw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sraw trace i) : Type where
   sraw_input : PureSpec.SrawInput
   h_input_r1 :
@@ -2153,7 +2153,7 @@ structure Inputs_sraw (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
     sraw_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_sraw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_sraw {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_sraw trace i) (dec : Decode_sraw trace binding i c)
     (ia : Inputs_sraw trace binding i c) : RowData_sraw trace binding i where
@@ -2180,13 +2180,13 @@ def toRowData_sraw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIns
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_slliw (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_slliw (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   slliw_input : PureSpec.SlliwInput
   r1 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_slliw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_slliw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_slliw trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -2204,7 +2204,7 @@ structure Decode_slliw (trace : AcceptedZiskTrace) (binding : SailTrace trace.nu
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_slliw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_slliw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_slliw trace i) : Type where
   h_input_r1 :
     read_xreg (regidx_to_fin c.r1) (binding i)
@@ -2232,7 +2232,7 @@ structure Inputs_slliw (trace : AcceptedZiskTrace) (binding : SailTrace trace.nu
     c.slliw_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_slliw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_slliw {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_slliw trace i) (dec : Decode_slliw trace binding i c)
     (ia : Inputs_slliw trace binding i c) : RowData_slliw trace binding i where
@@ -2256,13 +2256,13 @@ def toRowData_slliw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIn
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_srliw (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_srliw (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   srliw_input : PureSpec.SrliwInput
   r1 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_srliw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_srliw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_srliw trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -2280,7 +2280,7 @@ structure Decode_srliw (trace : AcceptedZiskTrace) (binding : SailTrace trace.nu
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_srliw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_srliw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_srliw trace i) : Type where
   h_input_r1 :
     read_xreg (regidx_to_fin c.r1) (binding i)
@@ -2308,7 +2308,7 @@ structure Inputs_srliw (trace : AcceptedZiskTrace) (binding : SailTrace trace.nu
     c.srliw_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_srliw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_srliw {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_srliw trace i) (dec : Decode_srliw trace binding i c)
     (ia : Inputs_srliw trace binding i c) : RowData_srliw trace binding i where
@@ -2332,13 +2332,13 @@ def toRowData_srliw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIn
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_sraiw (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_sraiw (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   sraiw_input : PureSpec.SraiwInput
   r1 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_sraiw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_sraiw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sraiw trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -2356,7 +2356,7 @@ structure Decode_sraiw (trace : AcceptedZiskTrace) (binding : SailTrace trace.nu
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_sraiw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_sraiw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sraiw trace i) : Type where
   h_input_r1 :
     read_xreg (regidx_to_fin c.r1) (binding i)
@@ -2384,7 +2384,7 @@ structure Inputs_sraiw (trace : AcceptedZiskTrace) (binding : SailTrace trace.nu
     c.sraiw_input.rd =
       Transpiler.wrap_to_regidx (busSub trace binding i c.execRow).e2.ptr
 
-def toRowData_sraiw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_sraiw {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_sraiw trace i) (dec : Decode_sraiw trace binding i c)
     (ia : Inputs_sraiw trace binding i c) : RowData_sraiw trace binding i where
@@ -2408,7 +2408,7 @@ def toRowData_sraiw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIn
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_mul (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_mul (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
@@ -2416,7 +2416,7 @@ structure Claim_mul (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) 
   srs2 : Signedness
   bus : ZiskFv.Compliance.BusRows
 
-structure Decode_mul (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_mul (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_mul trace i) : Type where
   h_main_op :
     (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_MUL
@@ -2436,7 +2436,7 @@ structure Decode_mul (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
       (mainOfTable trace.program trace.mainTable) i.val c.bus.e2
   bounds : ZiskFv.Compliance.ByteBounds c.bus.e2
 
-structure Inputs_mul (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_mul (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_mul trace i) : Type where
   mul_input : PureSpec.MulInput
   v : ZiskFv.Airs.ArithMul.Valid_ArithMul FGL FGL
@@ -2465,7 +2465,7 @@ structure Inputs_mul (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
     ¬ ((v.na r_a = 1 ∧ v.nb r_a = 0 ∧ v.np r_a = 0)
       ∨ (v.na r_a = 0 ∧ v.nb r_a = 1 ∧ v.np r_a = 0))
 
-def toRowData_mul {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_mul {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_mul trace i) (dec : Decode_mul trace binding i c)
     (ia : Inputs_mul trace binding i c) : RowData_mul trace binding i where
@@ -2497,13 +2497,13 @@ def toRowData_mul {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInst
   h_rs2_value := ia.h_rs2_value
   h_not_forge := ia.h_not_forge
 
-structure Claim_mulh (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_mulh (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   bus : ZiskFv.Compliance.BusRows
 
-structure Decode_mulh (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_mulh (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_mulh trace i) : Type where
   h_main_op :
     (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_MULH
@@ -2523,7 +2523,7 @@ structure Decode_mulh (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
       (mainOfTable trace.program trace.mainTable) i.val c.bus.e2
   bounds : ZiskFv.Compliance.ByteBounds c.bus.e2
 
-structure Inputs_mulh (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_mulh (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_mulh trace i) : Type where
   mulh_input : PureSpec.MulhInput
   v : ZiskFv.Airs.ArithMul.Valid_ArithMul FGL FGL
@@ -2558,7 +2558,7 @@ structure Inputs_mulh (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
     = if 2 ^ 63 ≤ ZiskFv.PackedBitVec.MulNoWrap.packed4 (v.b_0 r_a).val (v.b_1 r_a).val
         (v.b_2 r_a).val (v.b_3 r_a).val then 1 else 0
 
-def toRowData_mulh {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_mulh {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_mulh trace i) (dec : Decode_mulh trace binding i c)
     (ia : Inputs_mulh trace binding i c) : RowData_mulh trace binding i where
@@ -2590,13 +2590,13 @@ def toRowData_mulh {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIns
   h_sign_a := ia.h_sign_a
   h_sign_b := ia.h_sign_b
 
-structure Claim_mulhsu (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_mulhsu (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   bus : ZiskFv.Compliance.BusRows
 
-structure Decode_mulhsu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_mulhsu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_mulhsu trace i) : Type where
   h_main_op :
     (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_MULSUH
@@ -2616,7 +2616,7 @@ structure Decode_mulhsu (trace : AcceptedZiskTrace) (binding : SailTrace trace.n
       (mainOfTable trace.program trace.mainTable) i.val c.bus.e2
   bounds : ZiskFv.Compliance.ByteBounds c.bus.e2
 
-structure Inputs_mulhsu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_mulhsu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_mulhsu trace i) : Type where
   mulhsu_input : PureSpec.MulhsuInput
   v : ZiskFv.Airs.ArithMul.Valid_ArithMul FGL FGL
@@ -2648,7 +2648,7 @@ structure Inputs_mulhsu (trace : AcceptedZiskTrace) (binding : SailTrace trace.n
     = if 2 ^ 63 ≤ ZiskFv.PackedBitVec.MulNoWrap.packed4 (v.a_0 r_a).val (v.a_1 r_a).val
         (v.a_2 r_a).val (v.a_3 r_a).val then 1 else 0
 
-def toRowData_mulhsu {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_mulhsu {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_mulhsu trace i) (dec : Decode_mulhsu trace binding i c)
     (ia : Inputs_mulhsu trace binding i c) : RowData_mulhsu trace binding i where
@@ -2679,13 +2679,13 @@ def toRowData_mulhsu {trace : AcceptedZiskTrace} {binding : SailTrace trace.numI
   h_not_forge := ia.h_not_forge
   h_sign_a := ia.h_sign_a
 
-structure Claim_div (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_div (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   bus : ZiskFv.Compliance.BusRows
 
-structure Decode_div (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_div (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_div trace i) : Type where
   h_main_op :
     (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_DIV
@@ -2707,7 +2707,7 @@ structure Decode_div (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
       (mainOfTable trace.program trace.mainTable) i.val c.bus.e2
   bounds : ZiskFv.Compliance.ByteBounds c.bus.e2
 
-structure Inputs_div (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_div (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_div trace i) : Type where
   div_input : PureSpec.DivInput
   v : ZiskFv.Airs.ArithDiv.Valid_ArithDiv FGL FGL
@@ -2770,7 +2770,7 @@ structure Inputs_div (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
         ∧ (ZiskFv.Compliance.Defects.signedRemainderInt v r_a).natAbs
           = div_input.r2_val.toInt.natAbs)
 
-def toRowData_div {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_div {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_div trace i) (dec : Decode_div trace binding i c)
     (ia : Inputs_div trace binding i c) : RowData_div trace binding i where
@@ -2809,13 +2809,13 @@ def toRowData_div {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInst
   h_r_sign := ia.h_r_sign
   h_not_forge := ia.h_not_forge
 
-structure Claim_rem (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_rem (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   bus : ZiskFv.Compliance.BusRows
 
-structure Decode_rem (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_rem (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_rem trace i) : Type where
   h_main_op :
     (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_REM
@@ -2837,7 +2837,7 @@ structure Decode_rem (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
       (mainOfTable trace.program trace.mainTable) i.val c.bus.e2
   bounds : ZiskFv.Compliance.ByteBounds c.bus.e2
 
-structure Inputs_rem (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_rem (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_rem trace i) : Type where
   rem_input : PureSpec.RemInput
   v : ZiskFv.Airs.ArithDiv.Valid_ArithDiv FGL FGL
@@ -2897,7 +2897,7 @@ structure Inputs_rem (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
     ¬ ((ZiskFv.Compliance.Defects.signedRemainderInt v r_a).natAbs
         = rem_input.r2_val.toInt.natAbs)
 
-def toRowData_rem {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_rem {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_rem trace i) (dec : Decode_rem trace binding i c)
     (ia : Inputs_rem trace binding i c) : RowData_rem trace binding i where
@@ -2935,13 +2935,13 @@ def toRowData_rem {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInst
   h_r_sign := ia.h_r_sign
   h_not_forge := ia.h_not_forge
 
-structure Claim_divw (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_divw (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   bus : ZiskFv.Compliance.BusRows
 
-structure Decode_divw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_divw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_divw trace i) : Type where
   h_main_op :
     (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_DIV_W
@@ -2963,7 +2963,7 @@ structure Decode_divw (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
       (mainOfTable trace.program trace.mainTable) i.val c.bus.e2
   bounds : ZiskFv.Compliance.ByteBounds c.bus.e2
 
-structure Inputs_divw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_divw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_divw trace i) : Type where
   divw_input : PureSpec.DivwInput
   v : ZiskFv.Airs.ArithDiv.Valid_ArithDiv FGL FGL
@@ -3041,7 +3041,7 @@ structure Inputs_divw (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
         ∧ (ZiskFv.Compliance.Defects.signedRemainderIntW v r_a).natAbs
           = (Sail.BitVec.extractLsb divw_input.r2_val 31 0).toInt.natAbs)
 
-def toRowData_divw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_divw {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_divw trace i) (dec : Decode_divw trace binding i c)
     (ia : Inputs_divw trace binding i c) : RowData_divw trace binding i where
@@ -3088,13 +3088,13 @@ def toRowData_divw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIns
   h_r_sign := ia.h_r_sign
   h_not_forge := ia.h_not_forge
 
-structure Claim_remw (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_remw (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   bus : ZiskFv.Compliance.BusRows
 
-structure Decode_remw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_remw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_remw trace i) : Type where
   h_main_op :
     (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_REM_W
@@ -3116,7 +3116,7 @@ structure Decode_remw (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
       (mainOfTable trace.program trace.mainTable) i.val c.bus.e2
   bounds : ZiskFv.Compliance.ByteBounds c.bus.e2
 
-structure Inputs_remw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_remw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_remw trace i) : Type where
   remw_input : PureSpec.RemwInput
   v : ZiskFv.Airs.ArithDiv.Valid_ArithDiv FGL FGL
@@ -3192,7 +3192,7 @@ structure Inputs_remw (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
         ∧ (ZiskFv.Compliance.Defects.signedRemainderIntW v r_a).natAbs
           = (Sail.BitVec.extractLsb remw_input.r2_val 31 0).toInt.natAbs)
 
-def toRowData_remw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_remw {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_remw trace i) (dec : Decode_remw trace binding i c)
     (ia : Inputs_remw trace binding i c) : RowData_remw trace binding i where
@@ -3238,13 +3238,13 @@ def toRowData_remw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIns
   h_r_sign := ia.h_r_sign
   h_not_forge := ia.h_not_forge
 
-structure Claim_mulw (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_mulw (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_mulw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_mulw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_mulw trace i) : Type where
   h_store_pc :
     (mainOfTable trace.program trace.mainTable).store_pc i.val = 0
@@ -3260,7 +3260,7 @@ structure Decode_mulw (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
   h_e0_mult : (busSub trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_mulw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_mulw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_mulw trace i) : Type where
   mulw_input : PureSpec.MulwInput
   h_main_op :
@@ -3314,7 +3314,7 @@ structure Inputs_mulw (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
             + ((vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)).b_1 0).val * 65536 : ℤ)
           - ((vOfMulwRow (mulwArow trace binding i h_main_active h_main_op)).nb 0).val * (2:ℤ)^32
 
-def toRowData_mulw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_mulw {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_mulw trace i) (dec : Decode_mulw trace binding i c)
     (ia : Inputs_mulw trace binding i c) : RowData_mulw trace binding i where
@@ -3345,13 +3345,13 @@ def toRowData_mulw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIns
   h_rs1_value := ia.h_rs1_value
   h_rs2_value := ia.h_rs2_value
 
-structure Claim_mulhu (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_mulhu (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_mulhu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_mulhu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_mulhu trace i) : Type where
   h_store_pc :
     (mainOfTable trace.program trace.mainTable).store_pc i.val = 0
@@ -3368,7 +3368,7 @@ structure Decode_mulhu (trace : AcceptedZiskTrace) (binding : SailTrace trace.nu
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
   bounds : ZiskFv.Compliance.ByteBounds (busSub trace binding i c.execRow).e2
 
-structure Inputs_mulhu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_mulhu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_mulhu trace i) : Type where
   mulhu_input : PureSpec.MulhuInput
   h_main_op :
@@ -3403,7 +3403,7 @@ structure Inputs_mulhu (trace : AcceptedZiskTrace) (binding : SailTrace trace.nu
         ((vOfMulwRow (mulhuArow trace binding i h_main_active h_main_op)).b_2 0).val
         ((vOfMulwRow (mulhuArow trace binding i h_main_active h_main_op)).b_3 0).val
 
-def toRowData_mulhu {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_mulhu {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_mulhu trace i) (dec : Decode_mulhu trace binding i c)
     (ia : Inputs_mulhu trace binding i c) : RowData_mulhu trace binding i where
@@ -3432,13 +3432,13 @@ def toRowData_mulhu {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIn
   h_rs1_value := ia.h_rs1_value
   h_rs2_value := ia.h_rs2_value
 
-structure Claim_divu (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_divu (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_divu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_divu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_divu trace i) : Type where
   h_store_pc :
     (mainOfTable trace.program trace.mainTable).store_pc i.val = 0
@@ -3455,7 +3455,7 @@ structure Decode_divu (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
   bounds : ZiskFv.Compliance.ByteBounds (busSub trace binding i c.execRow).e2
 
-structure Inputs_divu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_divu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_divu trace i) : Type where
   divu_input : PureSpec.DivuInput
   h_main_op :
@@ -3493,7 +3493,7 @@ structure Inputs_divu (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
         ((divuArow trace binding i h_main_active h_main_op).chunks.b_2).val
         ((divuArow trace binding i h_main_active h_main_op).chunks.b_3).val
 
-def toRowData_divu {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_divu {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_divu trace i) (dec : Decode_divu trace binding i c)
     (ia : Inputs_divu trace binding i c) : RowData_divu trace binding i where
@@ -3523,13 +3523,13 @@ def toRowData_divu {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIns
   h_rs1_value := ia.h_rs1_value
   h_rs2_value := ia.h_rs2_value
 
-structure Claim_divuw (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_divuw (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_divuw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_divuw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_divuw trace i) : Type where
   h_store_pc :
     (mainOfTable trace.program trace.mainTable).store_pc i.val = 0
@@ -3546,7 +3546,7 @@ structure Decode_divuw (trace : AcceptedZiskTrace) (binding : SailTrace trace.nu
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
   bounds : ZiskFv.Compliance.ByteBounds (busSub trace binding i c.execRow).e2
 
-structure Inputs_divuw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_divuw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_divuw trace i) : Type where
   divuw_input : PureSpec.DivuwInput
   h_main_op :
@@ -3599,7 +3599,7 @@ structure Inputs_divuw (trace : AcceptedZiskTrace) (binding : SailTrace trace.nu
     = ((divuwArow trace binding i h_main_active h_main_op).chunks.b_0).val
         + ((divuwArow trace binding i h_main_active h_main_op).chunks.b_1).val * 65536
 
-def toRowData_divuw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_divuw {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_divuw trace i) (dec : Decode_divuw trace binding i c)
     (ia : Inputs_divuw trace binding i c) : RowData_divuw trace binding i where
@@ -3632,13 +3632,13 @@ def toRowData_divuw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIn
   h_rs1_value := ia.h_rs1_value
   h_rs2_value := ia.h_rs2_value
 
-structure Claim_remu (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_remu (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_remu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_remu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_remu trace i) : Type where
   h_store_pc :
     (mainOfTable trace.program trace.mainTable).store_pc i.val = 0
@@ -3655,7 +3655,7 @@ structure Decode_remu (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
   bounds : ZiskFv.Compliance.ByteBounds (busSub trace binding i c.execRow).e2
 
-structure Inputs_remu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_remu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_remu trace i) : Type where
   remu_input : PureSpec.RemuInput
   h_main_op :
@@ -3693,7 +3693,7 @@ structure Inputs_remu (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
         ((remuArow trace binding i h_main_active h_main_op).chunks.b_2).val
         ((remuArow trace binding i h_main_active h_main_op).chunks.b_3).val
 
-def toRowData_remu {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_remu {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_remu trace i) (dec : Decode_remu trace binding i c)
     (ia : Inputs_remu trace binding i c) : RowData_remu trace binding i where
@@ -3723,13 +3723,13 @@ def toRowData_remu {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIns
   h_rs1_value := ia.h_rs1_value
   h_rs2_value := ia.h_rs2_value
 
-structure Claim_remuw (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_remuw (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
   r2 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_remuw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_remuw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_remuw trace i) : Type where
   h_store_pc :
     (mainOfTable trace.program trace.mainTable).store_pc i.val = 0
@@ -3746,7 +3746,7 @@ structure Decode_remuw (trace : AcceptedZiskTrace) (binding : SailTrace trace.nu
   h_e1_mult : (busSub trace binding i c.execRow).exec_row[1]!.multiplicity = 1
   bounds : ZiskFv.Compliance.ByteBounds (busSub trace binding i c.execRow).e2
 
-structure Inputs_remuw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_remuw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_remuw trace i) : Type where
   remuw_input : PureSpec.RemuwInput
   h_main_op :
@@ -3799,7 +3799,7 @@ structure Inputs_remuw (trace : AcceptedZiskTrace) (binding : SailTrace trace.nu
     = ((remuwArow trace binding i h_main_active h_main_op).chunks.b_0).val
         + ((remuwArow trace binding i h_main_active h_main_op).chunks.b_1).val * 65536
 
-def toRowData_remuw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_remuw {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_remuw trace i) (dec : Decode_remuw trace binding i c)
     (ia : Inputs_remuw trace binding i c) : RowData_remuw trace binding i where
@@ -3832,13 +3832,13 @@ def toRowData_remuw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIn
   h_rs1_value := ia.h_rs1_value
   h_rs2_value := ia.h_rs2_value
 
-structure Claim_beq (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_beq (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   imm : BitVec 13
   r1 : regidx
   r2 : regidx
   exec_row : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_beq (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_beq (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_beq trace i) : Type where
   h_main_active :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).is_external_op
@@ -3862,7 +3862,7 @@ structure Decode_beq (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_e0_mult : c.exec_row[0]!.multiplicity = -1
   h_e1_mult : c.exec_row[1]!.multiplicity = 1
 
-structure Inputs_beq (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_beq (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_beq trace i) : Type where
   beq_input : PureSpec.BeqInput
   misa_val : RegisterType Register.misa
@@ -3880,7 +3880,7 @@ structure Inputs_beq (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_not_throws : (PureSpec.execute_BEQ_pure beq_input).throws = false
   h_success : (PureSpec.execute_BEQ_pure beq_input).success = true
 
-def toRowData_beq {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_beq {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_beq trace i) (dec : Decode_beq trace binding i c)
     (ia : Inputs_beq trace binding i c) : RowData_beq trace binding i where
@@ -3909,13 +3909,13 @@ def toRowData_beq {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInst
   h_not_throws := ia.h_not_throws
   h_success := ia.h_success
 
-structure Claim_bne (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_bne (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   imm : BitVec 13
   r1 : regidx
   r2 : regidx
   exec_row : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_bne (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_bne (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_bne trace i) : Type where
   h_main_active :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).is_external_op
@@ -3939,7 +3939,7 @@ structure Decode_bne (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_e0_mult : c.exec_row[0]!.multiplicity = -1
   h_e1_mult : c.exec_row[1]!.multiplicity = 1
 
-structure Inputs_bne (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_bne (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_bne trace i) : Type where
   bne_input : PureSpec.BneInput
   misa_val : RegisterType Register.misa
@@ -3957,7 +3957,7 @@ structure Inputs_bne (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_not_throws : (PureSpec.execute_BNE_pure bne_input).throws = false
   h_success : (PureSpec.execute_BNE_pure bne_input).success = true
 
-def toRowData_bne {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_bne {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_bne trace i) (dec : Decode_bne trace binding i c)
     (ia : Inputs_bne trace binding i c) : RowData_bne trace binding i where
@@ -3986,13 +3986,13 @@ def toRowData_bne {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInst
   h_not_throws := ia.h_not_throws
   h_success := ia.h_success
 
-structure Claim_blt (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_blt (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   imm : BitVec 13
   r1 : regidx
   r2 : regidx
   exec_row : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_blt (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_blt (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_blt trace i) : Type where
   h_main_active :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).is_external_op
@@ -4016,7 +4016,7 @@ structure Decode_blt (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_e0_mult : c.exec_row[0]!.multiplicity = -1
   h_e1_mult : c.exec_row[1]!.multiplicity = 1
 
-structure Inputs_blt (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_blt (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_blt trace i) : Type where
   blt_input : PureSpec.BltInput
   misa_val : RegisterType Register.misa
@@ -4034,7 +4034,7 @@ structure Inputs_blt (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_not_throws : (PureSpec.execute_BLT_pure blt_input).throws = false
   h_success : (PureSpec.execute_BLT_pure blt_input).success = true
 
-def toRowData_blt {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_blt {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_blt trace i) (dec : Decode_blt trace binding i c)
     (ia : Inputs_blt trace binding i c) : RowData_blt trace binding i where
@@ -4063,13 +4063,13 @@ def toRowData_blt {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInst
   h_not_throws := ia.h_not_throws
   h_success := ia.h_success
 
-structure Claim_bge (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_bge (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   imm : BitVec 13
   r1 : regidx
   r2 : regidx
   exec_row : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_bge (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_bge (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_bge trace i) : Type where
   h_main_active :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).is_external_op
@@ -4093,7 +4093,7 @@ structure Decode_bge (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_e0_mult : c.exec_row[0]!.multiplicity = -1
   h_e1_mult : c.exec_row[1]!.multiplicity = 1
 
-structure Inputs_bge (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_bge (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_bge trace i) : Type where
   bge_input : PureSpec.BgeInput
   misa_val : RegisterType Register.misa
@@ -4111,7 +4111,7 @@ structure Inputs_bge (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_not_throws : (PureSpec.execute_BGE_pure bge_input).throws = false
   h_success : (PureSpec.execute_BGE_pure bge_input).success = true
 
-def toRowData_bge {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_bge {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_bge trace i) (dec : Decode_bge trace binding i c)
     (ia : Inputs_bge trace binding i c) : RowData_bge trace binding i where
@@ -4140,13 +4140,13 @@ def toRowData_bge {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInst
   h_not_throws := ia.h_not_throws
   h_success := ia.h_success
 
-structure Claim_bltu (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_bltu (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   imm : BitVec 13
   r1 : regidx
   r2 : regidx
   exec_row : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_bltu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_bltu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_bltu trace i) : Type where
   h_main_active :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).is_external_op
@@ -4170,7 +4170,7 @@ structure Decode_bltu (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
   h_e0_mult : c.exec_row[0]!.multiplicity = -1
   h_e1_mult : c.exec_row[1]!.multiplicity = 1
 
-structure Inputs_bltu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_bltu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_bltu trace i) : Type where
   bltu_input : PureSpec.BltuInput
   misa_val : RegisterType Register.misa
@@ -4188,7 +4188,7 @@ structure Inputs_bltu (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
   h_not_throws : (PureSpec.execute_BLTU_pure bltu_input).throws = false
   h_success : (PureSpec.execute_BLTU_pure bltu_input).success = true
 
-def toRowData_bltu {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_bltu {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_bltu trace i) (dec : Decode_bltu trace binding i c)
     (ia : Inputs_bltu trace binding i c) : RowData_bltu trace binding i where
@@ -4217,13 +4217,13 @@ def toRowData_bltu {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIns
   h_not_throws := ia.h_not_throws
   h_success := ia.h_success
 
-structure Claim_bgeu (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_bgeu (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   imm : BitVec 13
   r1 : regidx
   r2 : regidx
   exec_row : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_bgeu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_bgeu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_bgeu trace i) : Type where
   h_main_active :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).is_external_op
@@ -4247,7 +4247,7 @@ structure Decode_bgeu (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
   h_e0_mult : c.exec_row[0]!.multiplicity = -1
   h_e1_mult : c.exec_row[1]!.multiplicity = 1
 
-structure Inputs_bgeu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_bgeu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_bgeu trace i) : Type where
   bgeu_input : PureSpec.BgeuInput
   misa_val : RegisterType Register.misa
@@ -4265,7 +4265,7 @@ structure Inputs_bgeu (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
   h_not_throws : (PureSpec.execute_BGEU_pure bgeu_input).throws = false
   h_success : (PureSpec.execute_BGEU_pure bgeu_input).success = true
 
-def toRowData_bgeu {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_bgeu {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_bgeu trace i) (dec : Decode_bgeu trace binding i c)
     (ia : Inputs_bgeu trace binding i c) : RowData_bgeu trace binding i where
@@ -4294,12 +4294,12 @@ def toRowData_bgeu {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIns
   h_not_throws := ia.h_not_throws
   h_success := ia.h_success
 
-structure Claim_lui (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_lui (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   imm : BitVec 20
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_lui (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_lui (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lui trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -4326,7 +4326,7 @@ structure Decode_lui (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_e0_mult : c.execRow[0]!.multiplicity = -1
   h_e1_mult : c.execRow[1]!.multiplicity = 1
 
-structure Inputs_lui (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_lui (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lui trace i) : Type where
   lui_input : PureSpec.LuiInput
   h_input_imm : lui_input.imm = c.imm
@@ -4339,7 +4339,7 @@ structure Inputs_lui (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
     lui_input.rd =
       Transpiler.wrap_to_regidx (eRdLui trace binding i).ptr
 
-def toRowData_lui {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_lui {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_lui trace i) (dec : Decode_lui trace binding i c)
     (ia : Inputs_lui trace binding i c) : RowData_lui trace binding i where
@@ -4363,12 +4363,12 @@ def toRowData_lui {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInst
   h_nextPC_matches := ia.h_nextPC_matches
   h_rd_idx := ia.h_rd_idx
 
-structure Claim_auipc (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_auipc (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   imm : BitVec 20
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_auipc (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_auipc (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_auipc trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -4389,7 +4389,7 @@ structure Decode_auipc (trace : AcceptedZiskTrace) (binding : SailTrace trace.nu
   h_e0_mult : c.execRow[0]!.multiplicity = -1
   h_e1_mult : c.execRow[1]!.multiplicity = 1
 
-structure Inputs_auipc (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_auipc (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_auipc trace i) : Type where
   auipc_input : PureSpec.AuipcInput
   h_input_imm : auipc_input.imm = c.imm
@@ -4415,7 +4415,7 @@ structure Inputs_auipc (trace : AcceptedZiskTrace) (binding : SailTrace trace.nu
     (auipc_input.PC + BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
       < 4294967296
 
-def toRowData_auipc {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_auipc {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_auipc trace i) (dec : Decode_auipc trace binding i c)
     (ia : Inputs_auipc trace binding i c) : RowData_auipc trace binding i where
@@ -4441,12 +4441,12 @@ def toRowData_auipc {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIn
   h_no_wrap := ia.h_no_wrap
   h_pc_offset_lt_2_32 := ia.h_pc_offset_lt_2_32
 
-structure Claim_jal (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_jal (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   imm : BitVec 21
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_jal (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_jal (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_jal trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -4470,7 +4470,7 @@ structure Decode_jal (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_e0_mult : c.execRow[0]!.multiplicity = -1
   h_e1_mult : c.execRow[1]!.multiplicity = 1
 
-structure Inputs_jal (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_jal (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_jal trace i) : Type where
   jal_input : PureSpec.JalInput
   misa_val : RegisterType Register.misa
@@ -4493,7 +4493,7 @@ structure Inputs_jal (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_pc_bound : jal_input.PC.toNat < GL_prime - 4
   h_pc_offset_lt_2_32 : (jal_input.PC + 4#64).toNat < 4294967296
 
-def toRowData_jal {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_jal {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_jal trace i) (dec : Decode_jal trace binding i c)
     (ia : Inputs_jal trace binding i c) : RowData_jal trace binding i where
@@ -4526,13 +4526,13 @@ def toRowData_jal {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInst
   h_pc_bound := ia.h_pc_bound
   h_pc_offset_lt_2_32 := ia.h_pc_offset_lt_2_32
 
-structure Claim_jalr (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_jalr (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   imm : BitVec 12
   rs1 : regidx
   rd : regidx
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_jalr (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_jalr (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_jalr trace i) : Type where
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
@@ -4556,7 +4556,7 @@ structure Decode_jalr (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
   h_e0_mult : c.execRow[0]!.multiplicity = -1
   h_e1_mult : c.execRow[1]!.multiplicity = 1
 
-structure Inputs_jalr (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_jalr (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_jalr trace i) : Type where
   jalr_input : PureSpec.JalrInput
   misa_val : RegisterType Register.misa
@@ -4587,7 +4587,7 @@ structure Inputs_jalr (trace : AcceptedZiskTrace) (binding : SailTrace trace.num
   h_pc_bound : jalr_input.PC.toNat < GL_prime - 4
   h_pc_offset_lt_2_32 : (jalr_input.PC + 4#64).toNat < 4294967296
 
-def toRowData_jalr {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_jalr {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_jalr trace i) (dec : Decode_jalr trace binding i c)
     (ia : Inputs_jalr trace binding i c) : RowData_jalr trace binding i where
@@ -4624,7 +4624,7 @@ def toRowData_jalr {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIns
   h_pc_bound := ia.h_pc_bound
   h_pc_offset_lt_2_32 := ia.h_pc_offset_lt_2_32
 
-structure Claim_fence (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_fence (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   fm : BitVec 4
   fenceP : BitVec 4
   fenceS : BitVec 4
@@ -4632,7 +4632,7 @@ structure Claim_fence (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions
   rd : regidx
   exec_row : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_fence (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_fence (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_fence trace i) : Type where
   h_main_active :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).is_external_op
@@ -4647,7 +4647,7 @@ structure Decode_fence (trace : AcceptedZiskTrace) (binding : SailTrace trace.nu
   h_rs_x0 : ZiskFv.Compliance.Defects.IsX0Reg c.rs
   h_rd_x0 : ZiskFv.Compliance.Defects.IsX0Reg c.rd
 
-structure Inputs_fence (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_fence (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_fence trace i) : Type where
   fence_input : PureSpec.FenceInput
   h_input_pc : (binding i).regs.get? Register.PC = .some fence_input.PC
@@ -4657,7 +4657,7 @@ structure Inputs_fence (trace : AcceptedZiskTrace) (binding : SailTrace trace.nu
     (register_type_pc_equiv ▸ (BitVec.ofNat 64 (c.exec_row[1]!.pc).val))
       = (PureSpec.execute_FENCE_pure fence_input).nextPC
 
-def toRowData_fence {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_fence {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_fence trace i) (dec : Decode_fence trace binding i c)
     (ia : Inputs_fence trace binding i c) : RowData_fence trace binding i where
@@ -4680,11 +4680,11 @@ def toRowData_fence {trace : AcceptedZiskTrace} {binding : SailTrace trace.numIn
   h_rs_x0 := dec.h_rs_x0
   h_rd_x0 := dec.h_rd_x0
 
-structure Claim_sb (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_sb (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   sb_input : PureSpec.SbInput
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_sb (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_sb (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sb trace i) : Type where
   h_main_active :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).is_external_op
@@ -4702,7 +4702,7 @@ structure Decode_sb (trace : AcceptedZiskTrace) (binding : SailTrace trace.numIn
   h_e0_mult : (busSt trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSt trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_sb (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_sb (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sb trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   h_opcode_assumptions : PureSpec.sb_state_assumptions c.sb_input (binding i)
@@ -4736,7 +4736,7 @@ structure Inputs_sb (trace : AcceptedZiskTrace) (binding : SailTrace trace.numIn
   h_m7 : (binding i).mem[(busSt trace binding i c.execRow).e2.ptr.toNat + 7]?
     = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace binding i c.execRow).e2 7 : BitVec 8)
 
-def toRowData_sb {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_sb {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_sb trace i) (dec : Decode_sb trace binding i c)
     (ia : Inputs_sb trace binding i c) : RowData_sb trace binding i where
@@ -4764,11 +4764,11 @@ def toRowData_sb {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstr
   h_m6 := ia.h_m6
   h_m7 := ia.h_m7
 
-structure Claim_sh (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_sh (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   sh_input : PureSpec.ShInput
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_sh (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_sh (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sh trace i) : Type where
   h_main_active :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).is_external_op
@@ -4786,7 +4786,7 @@ structure Decode_sh (trace : AcceptedZiskTrace) (binding : SailTrace trace.numIn
   h_e0_mult : (busSt trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSt trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_sh (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_sh (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sh trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   h_opcode_assumptions : PureSpec.sh_state_assumptions c.sh_input (binding i)
@@ -4818,7 +4818,7 @@ structure Inputs_sh (trace : AcceptedZiskTrace) (binding : SailTrace trace.numIn
   h_m7 : (binding i).mem[(busSt trace binding i c.execRow).e2.ptr.toNat + 7]?
     = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace binding i c.execRow).e2 7 : BitVec 8)
 
-def toRowData_sh {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_sh {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_sh trace i) (dec : Decode_sh trace binding i c)
     (ia : Inputs_sh trace binding i c) : RowData_sh trace binding i where
@@ -4845,11 +4845,11 @@ def toRowData_sh {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstr
   h_m6 := ia.h_m6
   h_m7 := ia.h_m7
 
-structure Claim_sw (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_sw (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   sw_input : PureSpec.SwInput
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_sw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_sw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sw trace i) : Type where
   h_main_active :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).is_external_op
@@ -4867,7 +4867,7 @@ structure Decode_sw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numIn
   h_e0_mult : (busSt trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSt trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_sw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_sw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sw trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   h_opcode_assumptions : PureSpec.sw_state_assumptions c.sw_input (binding i)
@@ -4895,7 +4895,7 @@ structure Inputs_sw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numIn
   h_m7 : (binding i).mem[(busSt trace binding i c.execRow).e2.ptr.toNat + 7]?
     = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace binding i c.execRow).e2 7 : BitVec 8)
 
-def toRowData_sw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_sw {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_sw trace i) (dec : Decode_sw trace binding i c)
     (ia : Inputs_sw trace binding i c) : RowData_sw trace binding i where
@@ -4920,11 +4920,11 @@ def toRowData_sw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstr
   h_m6 := ia.h_m6
   h_m7 := ia.h_m7
 
-structure Claim_sd (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_sd (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   sd_input : PureSpec.SdInput
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_sd (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_sd (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sd trace i) : Type where
   h_main_active :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).is_external_op
@@ -4939,7 +4939,7 @@ structure Decode_sd (trace : AcceptedZiskTrace) (binding : SailTrace trace.numIn
   h_e0_mult : (busSt trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busSt trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_sd (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_sd (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sd trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   h_opcode_assumptions : PureSpec.sd_state_assumptions c.sd_input (binding i)
@@ -4959,7 +4959,7 @@ structure Inputs_sd (trace : AcceptedZiskTrace) (binding : SailTrace trace.numIn
         (BitVec.ofNat 64 ((busSt trace binding i c.execRow).exec_row[1]!.pc).val))
       = (PureSpec.execute_STORED_pure c.sd_input).nextPC
 
-def toRowData_sd {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_sd {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_sd trace i) (dec : Decode_sd trace binding i c)
     (ia : Inputs_sd trace binding i c) : RowData_sd trace binding i where
@@ -4979,11 +4979,11 @@ def toRowData_sd {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstr
   h_e1_mult := dec.h_e1_mult
   h_nextPC_matches := ia.h_nextPC_matches
 
-structure Claim_ld (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_ld (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   ld_input : PureSpec.LdInput
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_ld (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_ld (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_ld trace i) : Type where
   h_main_active :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).is_external_op
@@ -5001,7 +5001,7 @@ structure Decode_ld (trace : AcceptedZiskTrace) (binding : SailTrace trace.numIn
   h_e0_mult : (busLd trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busLd trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_ld (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_ld (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_ld trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   mem : Valid_Mem FGL FGL
@@ -5031,7 +5031,7 @@ structure Inputs_ld (trace : AcceptedZiskTrace) (binding : SailTrace trace.numIn
   h_mem_sel : mem.sel r_mem = 1
   h_mem_wr : mem.wr r_mem = 0
 
-def toRowData_ld {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_ld {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_ld trace i) (dec : Decode_ld trace binding i c)
     (ia : Inputs_ld trace binding i c) : RowData_ld trace binding i where
@@ -5058,11 +5058,11 @@ def toRowData_ld {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstr
   h_mem_sel := ia.h_mem_sel
   h_mem_wr := ia.h_mem_wr
 
-structure Claim_lbu (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_lbu (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   lbu_input : PureSpec.LbuInput
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_lbu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_lbu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lbu trace i) : Type where
   h_main_active :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).is_external_op
@@ -5080,7 +5080,7 @@ structure Decode_lbu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_e0_mult : (busLd trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busLd trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_lbu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_lbu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lbu trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   mem : Valid_Mem FGL FGL
@@ -5113,7 +5113,7 @@ structure Inputs_lbu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_mem_sel : mem.sel r_mem = 1
   h_mem_wr : mem.wr r_mem = 0
 
-def toRowData_lbu {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_lbu {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_lbu trace i) (dec : Decode_lbu trace binding i c)
     (ia : Inputs_lbu trace binding i c) : RowData_lbu trace binding i where
@@ -5141,11 +5141,11 @@ def toRowData_lbu {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInst
   h_mem_sel := ia.h_mem_sel
   h_mem_wr := ia.h_mem_wr
 
-structure Claim_lhu (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_lhu (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   lhu_input : PureSpec.LhuInput
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_lhu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_lhu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lhu trace i) : Type where
   h_main_active :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).is_external_op
@@ -5163,7 +5163,7 @@ structure Decode_lhu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_e0_mult : (busLd trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busLd trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_lhu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_lhu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lhu trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   mem : Valid_Mem FGL FGL
@@ -5196,7 +5196,7 @@ structure Inputs_lhu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_mem_sel : mem.sel r_mem = 1
   h_mem_wr : mem.wr r_mem = 0
 
-def toRowData_lhu {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_lhu {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_lhu trace i) (dec : Decode_lhu trace binding i c)
     (ia : Inputs_lhu trace binding i c) : RowData_lhu trace binding i where
@@ -5224,11 +5224,11 @@ def toRowData_lhu {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInst
   h_mem_sel := ia.h_mem_sel
   h_mem_wr := ia.h_mem_wr
 
-structure Claim_lwu (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_lwu (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   lwu_input : PureSpec.LwuInput
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_lwu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_lwu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lwu trace i) : Type where
   h_main_active :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).is_external_op
@@ -5246,7 +5246,7 @@ structure Decode_lwu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_e0_mult : (busLd trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busLd trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_lwu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_lwu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lwu trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   mem : Valid_Mem FGL FGL
@@ -5279,7 +5279,7 @@ structure Inputs_lwu (trace : AcceptedZiskTrace) (binding : SailTrace trace.numI
   h_mem_sel : mem.sel r_mem = 1
   h_mem_wr : mem.wr r_mem = 0
 
-def toRowData_lwu {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_lwu {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_lwu trace i) (dec : Decode_lwu trace binding i c)
     (ia : Inputs_lwu trace binding i c) : RowData_lwu trace binding i where
@@ -5307,11 +5307,11 @@ def toRowData_lwu {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInst
   h_mem_sel := ia.h_mem_sel
   h_mem_wr := ia.h_mem_wr
 
-structure Claim_lb (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_lb (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   lb_input : PureSpec.LbInput
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_lb (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_lb (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lb trace i) : Type where
   v : ZiskFv.Airs.BinaryExtension.Valid_BinaryExtension FGL FGL
   r_binary : ℕ
@@ -5340,7 +5340,7 @@ structure Decode_lb (trace : AcceptedZiskTrace) (binding : SailTrace trace.numIn
   h_e0_mult : (busLd trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busLd trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_lb (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_lb (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lb trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   mem : Valid_Mem FGL FGL
@@ -5370,7 +5370,7 @@ structure Inputs_lb (trace : AcceptedZiskTrace) (binding : SailTrace trace.numIn
   h_mem_sel : mem.sel r_mem = 1
   h_mem_wr : mem.wr r_mem = 0
 
-def toRowData_lb {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_lb {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_lb trace i) (dec : Decode_lb trace binding i c)
     (ia : Inputs_lb trace binding i c) : RowData_lb trace binding i where
@@ -5403,11 +5403,11 @@ def toRowData_lb {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstr
   h_mem_sel := ia.h_mem_sel
   h_mem_wr := ia.h_mem_wr
 
-structure Claim_lh (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_lh (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   lh_input : PureSpec.LhInput
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_lh (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_lh (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lh trace i) : Type where
   v : ZiskFv.Airs.BinaryExtension.Valid_BinaryExtension FGL FGL
   r_binary : ℕ
@@ -5436,7 +5436,7 @@ structure Decode_lh (trace : AcceptedZiskTrace) (binding : SailTrace trace.numIn
   h_e0_mult : (busLd trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busLd trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_lh (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_lh (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lh trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   mem : Valid_Mem FGL FGL
@@ -5466,7 +5466,7 @@ structure Inputs_lh (trace : AcceptedZiskTrace) (binding : SailTrace trace.numIn
   h_mem_sel : mem.sel r_mem = 1
   h_mem_wr : mem.wr r_mem = 0
 
-def toRowData_lh {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_lh {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_lh trace i) (dec : Decode_lh trace binding i c)
     (ia : Inputs_lh trace binding i c) : RowData_lh trace binding i where
@@ -5499,11 +5499,11 @@ def toRowData_lh {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstr
   h_mem_sel := ia.h_mem_sel
   h_mem_wr := ia.h_mem_wr
 
-structure Claim_lw (trace : AcceptedZiskTrace) (i : Fin trace.numInstructions) where
+structure Claim_lw (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   lw_input : PureSpec.LwInput
   execRow : List (Interaction.ExecutionBusEntry FGL)
 
-structure Decode_lw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Decode_lw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lw trace i) : Type where
   v : ZiskFv.Airs.BinaryExtension.Valid_BinaryExtension FGL FGL
   r_binary : ℕ
@@ -5532,7 +5532,7 @@ structure Decode_lw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numIn
   h_e0_mult : (busLd trace binding i c.execRow).exec_row[0]!.multiplicity = -1
   h_e1_mult : (busLd trace binding i c.execRow).exec_row[1]!.multiplicity = 1
 
-structure Inputs_lw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions)
+structure Inputs_lw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lw trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   mem : Valid_Mem FGL FGL
@@ -5562,7 +5562,7 @@ structure Inputs_lw (trace : AcceptedZiskTrace) (binding : SailTrace trace.numIn
   h_mem_sel : mem.sel r_mem = 1
   h_mem_wr : mem.wr r_mem = 0
 
-def toRowData_lw {trace : AcceptedZiskTrace} {binding : SailTrace trace.numInstructions}
+def toRowData_lw {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
     {i : Fin trace.numInstructions}
     (c : Claim_lw trace i) (dec : Decode_lw trace binding i c)
     (ia : Inputs_lw trace binding i c) : RowData_lw trace binding i where

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongAluArith.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongAluArith.lean
@@ -105,7 +105,7 @@ theorem stepStrong_sub
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -119,7 +119,7 @@ theorem stepStrong_sub
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -241,7 +241,7 @@ theorem stepStrong_and
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -255,7 +255,7 @@ theorem stepStrong_and
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -377,7 +377,7 @@ theorem stepStrong_or
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -391,7 +391,7 @@ theorem stepStrong_or
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -513,7 +513,7 @@ theorem stepStrong_xor
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -527,7 +527,7 @@ theorem stepStrong_xor
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -650,7 +650,7 @@ theorem stepStrong_slt
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -664,7 +664,7 @@ theorem stepStrong_slt
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -786,7 +786,7 @@ theorem stepStrong_sltu
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -800,7 +800,7 @@ theorem stepStrong_sltu
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -921,7 +921,7 @@ theorem stepStrong_andi
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -935,7 +935,7 @@ theorem stepStrong_andi
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -1056,7 +1056,7 @@ theorem stepStrong_ori
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -1070,7 +1070,7 @@ theorem stepStrong_ori
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -1191,7 +1191,7 @@ theorem stepStrong_xori
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -1205,7 +1205,7 @@ theorem stepStrong_xori
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -1324,7 +1324,7 @@ theorem stepStrong_slti
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -1338,7 +1338,7 @@ theorem stepStrong_slti
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -1452,7 +1452,7 @@ theorem stepStrong_sltiu
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -1466,7 +1466,7 @@ theorem stepStrong_sltiu
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -1581,7 +1581,7 @@ theorem stepStrong_sll
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -1595,7 +1595,7 @@ theorem stepStrong_sll
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -1680,7 +1680,7 @@ theorem stepStrong_srl
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -1694,7 +1694,7 @@ theorem stepStrong_srl
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -1779,7 +1779,7 @@ theorem stepStrong_sra
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -1793,7 +1793,7 @@ theorem stepStrong_sra
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -1874,7 +1874,7 @@ theorem stepStrong_slli
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -1888,7 +1888,7 @@ theorem stepStrong_slli
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -1973,7 +1973,7 @@ theorem stepStrong_srli
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -1987,7 +1987,7 @@ theorem stepStrong_srli
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -2072,7 +2072,7 @@ theorem stepStrong_srai
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -2086,7 +2086,7 @@ theorem stepStrong_srai
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -2177,7 +2177,7 @@ theorem stepStrong_subw
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -2191,7 +2191,7 @@ theorem stepStrong_subw
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -2307,7 +2307,7 @@ theorem stepStrong_addw
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -2321,7 +2321,7 @@ theorem stepStrong_addw
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -2437,7 +2437,7 @@ theorem stepStrong_addiw
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -2451,7 +2451,7 @@ theorem stepStrong_addiw
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -2553,7 +2553,7 @@ theorem stepStrong_sllw
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -2567,7 +2567,7 @@ theorem stepStrong_sllw
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -2651,7 +2651,7 @@ theorem stepStrong_srlw
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -2665,7 +2665,7 @@ theorem stepStrong_srlw
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -2750,7 +2750,7 @@ theorem stepStrong_sraw
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -2764,7 +2764,7 @@ theorem stepStrong_sraw
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -2849,7 +2849,7 @@ theorem stepStrong_slliw
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -2863,7 +2863,7 @@ theorem stepStrong_slliw
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -2943,7 +2943,7 @@ theorem stepStrong_srliw
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -2957,7 +2957,7 @@ theorem stepStrong_srliw
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -3038,7 +3038,7 @@ theorem stepStrong_sraiw
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -3052,7 +3052,7 @@ theorem stepStrong_sraiw
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -3140,7 +3140,7 @@ theorem stepStrong_add
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -3154,7 +3154,7 @@ theorem stepStrong_add
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h
@@ -3292,7 +3292,7 @@ theorem stepStrong_addi
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   have h_lane_rd :
@@ -3306,7 +3306,7 @@ theorem stepStrong_addi
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row] at h
     simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
       ZiskFv.AirsClean.Main.rowAt] using h

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongAluArith.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongAluArith.lean
@@ -72,7 +72,7 @@ no `False.elim` or contradictory pair is used.
     derivations) and invoking `zisk_riscv_compliant_program_bus`. Dominates the
     `bus_effect`-form `StepCompliance.sub`. -/
 theorem stepStrong_sub
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sub trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -208,7 +208,7 @@ theorem stepStrong_sub
     derivations) and invoking `zisk_riscv_compliant_program_bus`. Dominates the
     `bus_effect`-form `StepCompliance.and`. -/
 theorem stepStrong_and
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_and trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -344,7 +344,7 @@ theorem stepStrong_and
     derivations) and invoking `zisk_riscv_compliant_program_bus`. Dominates the
     `bus_effect`-form `StepCompliance.or`. -/
 theorem stepStrong_or
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_or trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -480,7 +480,7 @@ theorem stepStrong_or
     derivations) and invoking `zisk_riscv_compliant_program_bus`. Dominates the
     `bus_effect`-form `StepCompliance.xor`. -/
 theorem stepStrong_xor
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_xor trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -617,7 +617,7 @@ theorem stepStrong_xor
     derivations) and invoking `zisk_riscv_compliant_program_bus`. Dominates the
     `bus_effect`-form `StepCompliance.slt`. -/
 theorem stepStrong_slt
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_slt trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -753,7 +753,7 @@ theorem stepStrong_slt
     derivations) and invoking `zisk_riscv_compliant_program_bus`. Dominates the
     `bus_effect`-form `StepCompliance.sltu`. -/
 theorem stepStrong_sltu
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sltu trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -888,7 +888,7 @@ theorem stepStrong_sltu
     `OpEnvelope.andi` + `zisk_riscv_compliant_program_bus`. Dominates
     `StepCompliance.andi`. -/
 theorem stepStrong_andi
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_andi trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -1023,7 +1023,7 @@ theorem stepStrong_andi
     `OpEnvelope.ori` + `zisk_riscv_compliant_program_bus`. Dominates
     `StepCompliance.ori`. -/
 theorem stepStrong_ori
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_ori trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -1158,7 +1158,7 @@ theorem stepStrong_ori
     `OpEnvelope.xori` + `zisk_riscv_compliant_program_bus`. Dominates
     `StepCompliance.xori`. -/
 theorem stepStrong_xori
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_xori trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -1291,7 +1291,7 @@ theorem stepStrong_xori
     `OpEnvelope.slti` + `zisk_riscv_compliant_program_bus`. Dominates
     `StepCompliance.slti`. -/
 theorem stepStrong_slti
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_slti trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -1419,7 +1419,7 @@ theorem stepStrong_slti
     `OpEnvelope.sltiu` + `zisk_riscv_compliant_program_bus`. Dominates
     `StepCompliance.sltiu`. -/
 theorem stepStrong_sltiu
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sltiu trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -1548,7 +1548,7 @@ theorem stepStrong_sltiu
 /-- Strengthened `sll` step: channel-balance via constructed `OpEnvelope.sll`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.sll`. -/
 theorem stepStrong_sll
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sll trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -1647,7 +1647,7 @@ theorem stepStrong_sll
 /-- Strengthened `srl` step: channel-balance via constructed `OpEnvelope.srl`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.srl`. -/
 theorem stepStrong_srl
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_srl trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -1746,7 +1746,7 @@ theorem stepStrong_srl
 /-- Strengthened `sra` step: channel-balance via constructed `OpEnvelope.sra`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.sra`. -/
 theorem stepStrong_sra
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sra trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -1845,7 +1845,7 @@ theorem stepStrong_sra
 /-- Strengthened `slli` step: channel-balance via constructed `OpEnvelope.slli`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.slli`. -/
 theorem stepStrong_slli
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_slli trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -1944,7 +1944,7 @@ theorem stepStrong_slli
 /-- Strengthened `srli` step: channel-balance via constructed `OpEnvelope.srli`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.srli`. -/
 theorem stepStrong_srli
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_srli trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -2043,7 +2043,7 @@ theorem stepStrong_srli
 /-- Strengthened `srai` step: channel-balance via constructed `OpEnvelope.srai`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.srai`. -/
 theorem stepStrong_srai
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_srai trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -2144,7 +2144,7 @@ theorem stepStrong_srai
 /-- Strengthened `subw` step: channel-balance via constructed `OpEnvelope.subw`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.subw`. -/
 theorem stepStrong_subw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_subw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -2274,7 +2274,7 @@ theorem stepStrong_subw
 /-- Strengthened `addw` step: channel-balance via constructed `OpEnvelope.addw`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.addw`. -/
 theorem stepStrong_addw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_addw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -2404,7 +2404,7 @@ theorem stepStrong_addw
 /-- Strengthened `addiw` step: channel-balance via constructed `OpEnvelope.addiw`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.addiw`. -/
 theorem stepStrong_addiw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_addiw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -2524,7 +2524,7 @@ real BinaryExtension Spec row from the committed trace. -/
 /-- Strengthened `sllw` step: channel-balance via constructed `OpEnvelope.sllw`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.sllw`. -/
 theorem stepStrong_sllw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sllw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -2622,7 +2622,7 @@ theorem stepStrong_sllw
 /-- Strengthened `srlw` step: channel-balance via constructed `OpEnvelope.srlw`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.srlw`. -/
 theorem stepStrong_srlw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_srlw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -2720,7 +2720,7 @@ theorem stepStrong_srlw
 /-- Strengthened `sraw` step: channel-balance via constructed `OpEnvelope.sraw`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.sraw`. -/
 theorem stepStrong_sraw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sraw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -2819,7 +2819,7 @@ theorem stepStrong_sraw
 /-- Strengthened `slliw` step: channel-balance via constructed `OpEnvelope.slliw`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.slliw`. -/
 theorem stepStrong_slliw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_slliw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -2913,7 +2913,7 @@ theorem stepStrong_slliw
 /-- Strengthened `srliw` step: channel-balance via constructed `OpEnvelope.srliw`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.srliw`. -/
 theorem stepStrong_srliw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_srliw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -3007,7 +3007,7 @@ theorem stepStrong_srliw
 /-- Strengthened `sraiw` step: channel-balance via constructed `OpEnvelope.sraiw`
     + `zisk_riscv_compliant_program_bus`. Dominates `StepCompliance.sraiw`. -/
 theorem stepStrong_sraiw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sraiw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -3106,7 +3106,7 @@ theorem stepStrong_sraiw
     BinaryAdd provider) + `zisk_riscv_compliant_program_bus`. Dominates
     `StepCompliance.add`. -/
 theorem stepStrong_add
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_add trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -3258,7 +3258,7 @@ theorem stepStrong_add
     (`addi_via_binary` / `addi_via_binaryadd`) + `zisk_riscv_compliant_program_bus`.
     Dominates `StepCompliance.addi`. -/
 theorem stepStrong_addi
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_addi trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
@@ -70,7 +70,7 @@ the corresponding `bus_effect`-form arms (channel-balance form, same data). -/
     conjunct.  `aeneasBridgeTrust` is flat decode pins carried as `RowData_beq`
     residuals; `NoKnownDefect` comes from the threaded `h_known_arm`. -/
 theorem stepStrong_beq
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_beq trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -111,7 +111,7 @@ theorem stepStrong_beq
 
 /-- Strengthened `bne` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_bne
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_bne trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -152,7 +152,7 @@ theorem stepStrong_bne
 
 /-- Strengthened `blt` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_blt
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_blt trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -193,7 +193,7 @@ theorem stepStrong_blt
 
 /-- Strengthened `bge` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_bge
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_bge trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -234,7 +234,7 @@ theorem stepStrong_bge
 
 /-- Strengthened `bltu` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_bltu
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_bltu trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -275,7 +275,7 @@ theorem stepStrong_bltu
 
 /-- Strengthened `bgeu` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_bgeu
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_bgeu trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -327,7 +327,7 @@ theorem stepStrong_bgeu
     `⟨⟨provenance⟩, row_mode, h_imm_lo_nat, h_imm_hi_nat⟩`; `memoryTimeline`
     trivially; `NoKnownDefect` from the threaded `h_known_arm` (non-defect). -/
 theorem stepStrong_lui
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lui trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -415,7 +415,7 @@ theorem stepStrong_lui
     `⟨⟨provenance⟩, row_mode, h_offset_bridge, h_pc_bridge⟩`; `NoKnownDefect` from
     the threaded `h_known_arm` (non-defect). -/
 theorem stepStrong_auipc
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_auipc trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -503,7 +503,7 @@ theorem stepStrong_auipc
     `⟨⟨provenance⟩, row_mode, h_jmp2, h_pc_bridge⟩`; `NoKnownDefect` from the
     threaded `h_known_arm` (non-defect). -/
 theorem stepStrong_jal
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_jal trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -591,7 +591,7 @@ theorem stepStrong_jal
     `NoKnownDefect`.  JALR's `aeneasBridgeTrust` is flat decode pins already in
     `RowData_jalr` (no `MainRowProvenance`). -/
 theorem stepStrong_jalr
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_jalr trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -700,7 +700,7 @@ private def emptyMainEnv : Environment FGL :=
 
 /-- Strengthened `sb` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_sb
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sb trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -766,7 +766,7 @@ theorem stepStrong_sb
 
 /-- Strengthened `sh` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_sh
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sh trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -832,7 +832,7 @@ theorem stepStrong_sh
 
 /-- Strengthened `sw` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_sw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -898,7 +898,7 @@ theorem stepStrong_sw
 
 /-- Strengthened `sd` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_sd
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sd trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
@@ -374,7 +374,7 @@ theorem stepStrong_lui
     have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
       trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
     simpa [mainRowWithRomLui, m,
-      ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+      ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
   let store_pc_mem : ZiskFv.Compliance.StorePcMemoryWitness m i.val e_rd :=
     { row := mainRowWithRomLui trace binding i
       row_eq := h_row_core
@@ -460,7 +460,7 @@ theorem stepStrong_auipc
     have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
       trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
     simpa [mainRowWithRomLui, m,
-      ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+      ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
   let store_pc_mem : ZiskFv.Compliance.StorePcMemoryWitness m i.val e_rd :=
     { row := mainRowWithRomLui trace binding i
       row_eq := h_row_core
@@ -548,7 +548,7 @@ theorem stepStrong_jal
     have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
       trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
     simpa [mainRowWithRomLui, m,
-      ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+      ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
   let store_pc_mem : ZiskFv.Compliance.StorePcMemoryWitness m i.val e_rd :=
     { row := mainRowWithRomLui trace binding i
       row_eq := h_row_core
@@ -631,7 +631,7 @@ theorem stepStrong_jalr
     have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
       trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
     simpa [mainRowWithRomLui, m,
-      ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+      ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
   let store_pc_mem : ZiskFv.Compliance.StorePcMemoryWitness m i.val e_rd :=
     { row := mainRowWithRomLui trace binding i
       row_eq := h_row_core

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongLoadMext.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongLoadMext.lean
@@ -64,7 +64,7 @@ records are real `Valid_Mem`/`Valid_BinaryExtension` rows. -/
 
 /-- Strengthened `ld` step (channel-balance form). -/
 theorem stepStrong_ld
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_ld trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -142,7 +142,7 @@ theorem stepStrong_ld
 
 /-- Strengthened `lbu` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_lbu
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lbu trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -220,7 +220,7 @@ theorem stepStrong_lbu
 
 /-- Strengthened `lhu` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_lhu
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lhu trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -298,7 +298,7 @@ theorem stepStrong_lhu
 
 /-- Strengthened `lwu` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_lwu
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lwu trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -376,7 +376,7 @@ theorem stepStrong_lwu
 
 /-- Strengthened `lb` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_lb
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lb trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -455,7 +455,7 @@ theorem stepStrong_lb
 
 /-- Strengthened `lh` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_lh
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lh trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -534,7 +534,7 @@ theorem stepStrong_lh
 
 /-- Strengthened `lw` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_lw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -640,7 +640,7 @@ the real `busSub` row.  These are strictly stronger than the corresponding
     pins carried as `RowData_mulw` residuals (`m32 = 1` for W-mode); `NoKnownDefect`
     comes from the threaded `h_known_arm`.  Non-vacuous (real provider FullSpec). -/
 theorem stepStrong_mulw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mulw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -746,7 +746,7 @@ theorem stepStrong_mulw
     projections derived from `trace.channels_balanced` / `trace.spec_holds`, not a fabricated
     environment; `execRow` remains a genuine ∀-binder. -/
 theorem stepStrong_mulhu
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mulhu trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -858,7 +858,7 @@ theorem stepStrong_mulhu
     `NoKnownDefect` comes from the threaded `h_known_arm`.  Non-vacuous (real
     provider FullSpec; the witnesses' substance is the balance-derived facts). -/
 theorem stepStrong_divu
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_divu trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -966,7 +966,7 @@ theorem stepStrong_divu
     (`equiv_DIVUW`).  Adds the W-mode residuals `h_b23`/`h_c23`/`h_sext_choice`
     carried by `RowData_divuw`.  Non-vacuous (real provider FullSpec). -/
 theorem stepStrong_divuw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_divuw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -1069,7 +1069,7 @@ theorem stepStrong_divuw
     secondary d-lane (`opBus_row_ArithDivSecondary`, REMU mode `main_div = 0`).
     Non-vacuous (real provider FullSpec; witnesses' substance is balance-derived). -/
 theorem stepStrong_remu
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_remu trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)
@@ -1171,7 +1171,7 @@ theorem stepStrong_remu
     (`m32 = 1`), secondary d-lane match (`opBus_row_ArithDivSecondary`), routing
     to the `exec_eq_remaining` conjunct (`equiv_REMUW`).  Non-vacuous. -/
 theorem stepStrong_remuw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_remuw trace binding i)
     (h_known_arm : EnvNoKnownDefectFor
       (state := binding i)

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongLoadMext.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongLoadMext.lean
@@ -683,7 +683,7 @@ theorem stepStrong_mulw
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   let arith_mem :
@@ -694,7 +694,7 @@ theorem stepStrong_mulw
         have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
           trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
         simpa [mainRowWithRomSub, m,
-          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
       store_pc_zero := h_core_store_pc
       rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
   let promises : ZiskFv.EquivCore.Promises.RTypePromises
@@ -798,7 +798,7 @@ theorem stepStrong_mulhu
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   let arith_mem :
@@ -809,7 +809,7 @@ theorem stepStrong_mulhu
         have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
           trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
         simpa [mainRowWithRomSub, m,
-          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
       store_pc_zero := h_core_store_pc
       rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
   -- Promises bundle: Sail reads + exec artifacts as binders; MemBus shape by rfl.
@@ -911,7 +911,7 @@ theorem stepStrong_divu
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   let arith_mem :
@@ -922,7 +922,7 @@ theorem stepStrong_divu
         have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
           trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
         simpa [mainRowWithRomSub, m,
-          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
       store_pc_zero := h_core_store_pc
       rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
   let promises : ZiskFv.EquivCore.Promises.RTypePromises
@@ -1015,7 +1015,7 @@ theorem stepStrong_divuw
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   let arith_mem :
@@ -1026,7 +1026,7 @@ theorem stepStrong_divuw
         have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
           trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
         simpa [mainRowWithRomSub, m,
-          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
       store_pc_zero := h_core_store_pc
       rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
   let promises : ZiskFv.EquivCore.Promises.RTypePromises
@@ -1118,7 +1118,7 @@ theorem stepStrong_remu
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   let arith_mem :
@@ -1129,7 +1129,7 @@ theorem stepStrong_remu
         have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
           trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
         simpa [mainRowWithRomSub, m,
-          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
       store_pc_zero := h_core_store_pc
       rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
   let promises : ZiskFv.EquivCore.Promises.RTypePromises
@@ -1220,7 +1220,7 @@ theorem stepStrong_remuw
       have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
         trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
       simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
     rw [h_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using d.h_store_pc
   let arith_mem :
@@ -1231,7 +1231,7 @@ theorem stepStrong_remuw
         have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
           trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
         simpa [mainRowWithRomSub, m,
-          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get] using this.symm
+          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
       store_pc_zero := h_core_store_pc
       rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
   let promises : ZiskFv.EquivCore.Promises.RTypePromises

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongSignedM.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongSignedM.lean
@@ -65,7 +65,7 @@ set_option maxHeartbeats 8000000
     the two exceptional product-sign shapes the ArithTable admits for op 180, so an
     honest signed MUL row supplies all binders. -/
 theorem stepStrong_mul
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mul trace binding i)
     (h_known : Defects.NoKnownDefect (mulEnvOf trace binding i d)) :
     (do
@@ -98,7 +98,7 @@ theorem stepStrong_mul
     consumes the documented SIGN-RANGE RESIDUAL `h_sign_a`/`h_sign_b` carried by
     `RowData_mulh`.  Non-vacuous. -/
 theorem stepStrong_mulh
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mulh trace binding i)
     (h_known : Defects.NoKnownDefect (mulhEnvOf trace binding i d)) :
     (do
@@ -124,7 +124,7 @@ theorem stepStrong_mulh
     Companion of `stepStrong_mulh` for the signed × unsigned high multiply
     (op 179).  Carries ONE sign-range residual `h_sign_a` (op2 unsigned). -/
 theorem stepStrong_mulhsu
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mulhsu trace binding i)
     (h_known : Defects.NoKnownDefect (mulhsuEnvOf trace binding i d)) :
     (do
@@ -167,7 +167,7 @@ theorem stepStrong_mulhsu
     forge (codygunton/zisk#5), and divisor-zero rows are handled by
     `h_boundary`; signed overflow is handled by the signed DIV bridge. -/
 theorem stepStrong_div
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_div trace binding i)
     (h_known : Defects.NoKnownDefect (divEnvOf trace binding i d)) :
     (do
@@ -190,7 +190,7 @@ theorem stepStrong_div
     `h_known` is the GENUINE `NoKnownDefect (remEnvOf …)`, SATISFIABLE for an honest
     signed REM row (`RowData_rem.h_not_forge`).  Non-vacuous. -/
 theorem stepStrong_rem
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_rem trace binding i)
     (h_known : Defects.NoKnownDefect (remEnvOf trace binding i d)) :
     (do
@@ -214,7 +214,7 @@ theorem stepStrong_rem
     `NoKnownDefect (divwEnvOf …)`, SATISFIABLE for an honest signed DIVW row
     (`RowData_divw.h_not_forge`, `|r₃₂| ≠ |op2₃₂|`).  Non-vacuous. -/
 theorem stepStrong_divw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_divw trace binding i)
     (h_known : Defects.NoKnownDefect (divwEnvOf trace binding i d)) :
     (do
@@ -235,7 +235,7 @@ theorem stepStrong_divw
     W-mode analogue of `stepStrong_rem` (signed 32-bit remainder, op `189`,
     `m32 = 1`, secondary lane).  Non-vacuous (`RowData_remw.h_not_forge`). -/
 theorem stepStrong_remw
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_remw trace binding i)
     (h_known : Defects.NoKnownDefect (remwEnvOf trace binding i d)) :
     (do
@@ -269,7 +269,7 @@ theorem stepStrong_remw
     proves it.  Non-vacuous: the malicious FENCE shapes are excluded exactly by the
     honest-shape pins the caller supplies, as the FENCE defect ledger documents. -/
 theorem stepStrong_fence
-    (trace : AcceptedZiskTrace) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_fence trace binding i)
     (h_known : Defects.NoKnownDefect (fenceEnvOf trace binding i d)) :
     execute_instruction (instruction.FENCE (d.fm, d.fenceP, d.fenceS, d.rs, d.rd)) (binding i)

--- a/ZiskFv/Soundness.lean
+++ b/ZiskFv/Soundness.lean
@@ -34,17 +34,15 @@ namespace ZiskFv.Compliance
     from the trace inside each `stepStrong_<op>` — nothing is caller-supplied
     beyond the trace itself. -/
 theorem root_soundness
-    (ziskTrace : AcceptedZiskTrace)
-    -- Ideally `numInstructions` is a shared top-level arg so this reads
-    -- `SailTrace numInstructions` (and `ziskTrace : AcceptedZiskTrace numInstructions`);
-    -- blocked on a `mainOfTable` whnf runaway under structure parameterization — see #144.
-    (sailTrace : SailTrace ziskTrace.numInstructions)
-    (ziskStep : ∀ i : Fin ziskTrace.numInstructions, ZiskStep ziskTrace i)
-    (rowDecodes : ∀ i : Fin ziskTrace.numInstructions, RowDecode ziskTrace sailTrace i (ziskStep i))
-    (inputsAgree : ∀ i : Fin ziskTrace.numInstructions, InputsAgree ziskTrace sailTrace i (ziskStep i))
-    (h_known_bugs : ∀ i : Fin ziskTrace.numInstructions,
+    (numInstructions : Nat)
+    (ziskTrace : AcceptedZiskTrace numInstructions)
+    (sailTrace : SailTrace numInstructions)
+    (ziskStep : ∀ i : Fin numInstructions, ZiskStep ziskTrace i)
+    (rowDecodes : ∀ i : Fin numInstructions, RowDecode ziskTrace sailTrace i (ziskStep i))
+    (inputsAgree : ∀ i : Fin numInstructions, InputsAgree ziskTrace sailTrace i (ziskStep i))
+    (h_known_bugs : ∀ i : Fin numInstructions,
       StepNoKnownDefect ziskTrace sailTrace i (ziskStep i) (rowDecodes i) (inputsAgree i)) :
-    ∀ i : Fin ziskTrace.numInstructions, StepFaithful ziskTrace sailTrace i (ziskStep i) :=
+    ∀ i : Fin numInstructions, StepFaithful ziskTrace sailTrace i (ziskStep i) :=
   fun i =>
     stepFaithful_of_evidence ziskTrace sailTrace i (ziskStep i) (rowDecodes i) (inputsAgree i) (h_known_bugs i)
 

--- a/trust/generated/baseline-strong-export-binders.txt
+++ b/trust/generated/baseline-strong-export-binders.txt
@@ -1,7 +1,8 @@
-0 :: ziskTrace :: ZiskFv.Compliance.AcceptedZiskTrace
-1 :: sailTrace :: ZiskFv.Compliance.SailTrace ziskTrace.numInstructions
-2 :: ziskStep :: (i : Fin ziskTrace.numInstructions) → ZiskFv.Compliance.ZiskStep ziskTrace i
-3 :: rowDecodes :: (i : Fin ziskTrace.numInstructions) → ZiskFv.Compliance.RowDecode ziskTrace sailTrace i (ziskStep i)
-4 :: inputsAgree :: (i : Fin ziskTrace.numInstructions) → ZiskFv.Compliance.InputsAgree ziskTrace sailTrace i (ziskStep i)
-5 :: h_known_bugs :: ∀ (i : Fin ziskTrace.numInstructions), ZiskFv.Compliance.StepNoKnownDefect ziskTrace sailTrace i (ziskStep i) (rowDecodes i) (inputsAgree i)
-6 :: i :: Fin ziskTrace.numInstructions
+0 :: numInstructions :: Nat
+1 :: ziskTrace :: ZiskFv.Compliance.AcceptedZiskTrace numInstructions
+2 :: sailTrace :: ZiskFv.Compliance.SailTrace numInstructions
+3 :: ziskStep :: (i : Fin numInstructions) → ZiskFv.Compliance.ZiskStep ziskTrace i
+4 :: rowDecodes :: (i : Fin numInstructions) → ZiskFv.Compliance.RowDecode ziskTrace sailTrace i (ziskStep i)
+5 :: inputsAgree :: (i : Fin numInstructions) → ZiskFv.Compliance.InputsAgree ziskTrace sailTrace i (ziskStep i)
+6 :: h_known_bugs :: ∀ (i : Fin numInstructions), ZiskFv.Compliance.StepNoKnownDefect ziskTrace sailTrace i (ziskStep i) (rowDecodes i) (inputsAgree i)
+7 :: i :: Fin numInstructions

--- a/trust/generated/baseline-strong-export-closure.txt
+++ b/trust/generated/baseline-strong-export-closure.txt
@@ -23,7 +23,7 @@
 #     > trust/generated/baseline-strong-export-closure.txt  (body, below the header)
 #
 # Refresh via `trust/scripts/regenerate.sh` (requires `lake build`
-# artefacts under `.lake/build/`). Last regenerated: 2026-06-24.
+# artefacts under `.lake/build/`). Last regenerated: 2026-06-25.
 #
 # Total ZiskFv.* axiom entries: 0
 #

--- a/trust/generated/baseline-zisk-riscv-compliant.txt
+++ b/trust/generated/baseline-zisk-riscv-compliant.txt
@@ -25,7 +25,7 @@
 #     > trust/generated/baseline-zisk-riscv-compliant.txt
 #
 # Refresh via `trust/scripts/regenerate.sh` (requires `lake build`
-# artefacts under `.lake/build/`). Last regenerated: 2026-06-24.
+# artefacts under `.lake/build/`). Last regenerated: 2026-06-25.
 #
 # Total entries: 0
 #


### PR DESCRIPTION
Carries the content of #145 (auto-closed when #143's base branch was deleted during the stack merge). Rebased onto main. mainOfTable made semireducible + projection lemmas; AcceptedZiskTrace parameterized; clean `(numInstructions : Nat) … AcceptedZiskTrace numInstructions / SailTrace numInstructions` signature. Verified: build 8760, V1/V2 green, 0 axioms, trust footprint byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)