### PR TITLE
Rename root_soundness binder h_known_bugs → hAvoidKnownBugs

### DIFF
--- a/ZiskFv/Soundness.lean
+++ b/ZiskFv/Soundness.lean
@@ -27,7 +27,7 @@ namespace ZiskFv.Compliance
     indices + committed bus row); `rowDecodes` is the circuit-checkable fact that
     the row is a well-formed instance of that op; and `inputsAgree` is the
     cross-world fact that ZisK's inputs equal the Sail model's register / PC /
-    memory state. `h_known_bugs` excludes the enumerated forge defects.
+    memory state. `hAvoidKnownBugs` excludes the enumerated forge defects.
 
     Every row then satisfies the canonical channel-balance conclusion
     (`= state_effect_via_channels …`). The per-row `OpEnvelope` is constructed
@@ -40,10 +40,10 @@ theorem root_soundness
     (ziskStep : ∀ i : Fin numInstructions, ZiskStep ziskTrace i)
     (rowDecodes : ∀ i : Fin numInstructions, RowDecode ziskTrace i (ziskStep i))
     (inputsAgree : ∀ i : Fin numInstructions, InputsAgree ziskTrace sailTrace i (ziskStep i))
-    (h_known_bugs : ∀ i : Fin numInstructions,
+    (hAvoidKnownBugs : ∀ i : Fin numInstructions,
       StepNoKnownDefect ziskTrace sailTrace i (ziskStep i) (rowDecodes i) (inputsAgree i)) :
     ∀ i : Fin numInstructions, StepFaithful ziskTrace sailTrace i (ziskStep i) :=
   fun i =>
-    stepFaithful_of_evidence ziskTrace sailTrace i (ziskStep i) (rowDecodes i) (inputsAgree i) (h_known_bugs i)
+    stepFaithful_of_evidence ziskTrace sailTrace i (ziskStep i) (rowDecodes i) (inputsAgree i) (hAvoidKnownBugs i)
 
 end ZiskFv.Compliance

--- a/trust/generated/baseline-strong-export-binders.txt
+++ b/trust/generated/baseline-strong-export-binders.txt
@@ -4,5 +4,5 @@
 3 :: ziskStep :: (i : Fin numInstructions) → ZiskFv.Compliance.ZiskStep ziskTrace i
 4 :: rowDecodes :: (i : Fin numInstructions) → ZiskFv.Compliance.RowDecode ziskTrace i (ziskStep i)
 5 :: inputsAgree :: (i : Fin numInstructions) → ZiskFv.Compliance.InputsAgree ziskTrace sailTrace i (ziskStep i)
-6 :: h_known_bugs :: ∀ (i : Fin numInstructions), ZiskFv.Compliance.StepNoKnownDefect ziskTrace sailTrace i (ziskStep i) (rowDecodes i) (inputsAgree i)
+6 :: hAvoidKnownBugs :: ∀ (i : Fin numInstructions), ZiskFv.Compliance.StepNoKnownDefect ziskTrace sailTrace i (ziskStep i) (rowDecodes i) (inputsAgree i)
 7 :: i :: Fin numInstructions


### PR DESCRIPTION
Pure binder rename on the headline `root_soundness` theorem. Build green (8741); V1 + V2 pass; `baseline-equiv-axiom-deps.txt`/`baseline-axioms.txt` byte-unchanged (only the strong-export binder baseline records the new name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)