### PR TITLE
Re-express known-defect predicates over row data; collapse StepNoKnownDefect (off OpEnvelope)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,44 +1,38 @@
-Stream: root_soundness signature refactor (legible 3-way split).
-Branch: clarity/root-soundness-shape. Plan: docs/ai/plan/PLAN_ROOT_SOUNDNESS_SHAPE.md
+Stream: lift known-defect predicates off OpEnvelope onto row data.
+Branch: clarity/defects-on-rowdata. Plan: docs/ai/plan/PLAN_DEFECTS_ON_ROWDATA.md
 
-Goal: replace root_soundness's single `rowData` hypothesis with three named,
-honest binders — ziskStep / rowDecodes / inputsAgree — and rename the conclusion
-(StepComplianceStrong→StepFaithful) and derivation (…_of_rowData→
-stepFaithful_of_evidence). The split surfaces, in the signature itself, the
-dischargeable circuit facts (rowDecodes, owed by #141) vs the fundamental
-cross-world assumption (inputsAgree).
+Goal: re-express the three known-defect predicates over the Inputs_<op>/Claim_<op>
+row data instead of the legacy OpEnvelope sum, collapsing StepNoKnownDefect to one
+8-arm + wildcard `match`. Semantics-preserving re-expression — trust footprint
+byte-identical (NOT a discharge).
 
-Target signature:
-  (ziskStep    : ∀ i, ZiskStep    ziskTrace          i)
-  (rowDecodes  : ∀ i, RowDecode   ziskTrace          i (ziskStep i))
-  (inputsAgree : ∀ i, InputsAgree ziskTrace sailTrace i (ziskStep i))
-  (h_known_bugs: ∀ i, StepNoKnownDefect ziskTrace sailTrace i (ziskStep i) (rowDecodes i) (inputsAgree i))
-  : ∀ i, StepFaithful ziskTrace sailTrace i (ziskStep i)
+Status: COMPLETE. Committed 97b3841e, pushed origin/clarity/defects-on-rowdata
+(no PR). Steps A–F all done.
 
-Decisions:
-- StepNoKnownDefect TAKES THE EVIDENCE (user-confirmed). The 8 signed-M/FENCE
-  defect arms build their env from arith-witness/operand data (see mulEnvOf), so
-  claim-only is an endpoint property (defects→empty), not achievable now.
-- nextPC fact is cross-world → lives in inputsAgree, keeping rowDecodes
-  sailTrace-free. Circuit-only nextPC (→ rowDecodes) is a #141 follow-up.
+- A Defects.lean: SignedMulForge / DivRemForge / DivRemForgeW / FenceKnownGood
+  (same conditions as the OpEnvelope shapes).
+- B EnvOf.lean: 8 PROVED `Iff.rfl` bridge lemmas (faithfulness audit).
+- C Dispatcher.lean: StepNoKnownDefect = direct `match zs, ia`; deleted
+  EnvNoKnownDefectFor / envNoKnownDefectFor_of_nondefect / toFull /
+  StrongRowConstructionData / StepNoKnownDefectOn + 55 selector arms.
+  Base.lean: added general `noKnownDefect_of_shapes` helper.
+- D 63 stepStrong rewired: 55 non-defect take (_h_known : True) + build
+  NoKnownDefect locally; 8 defect consume row-data forge-negation via the helper.
+- E Soundness.lean: h_known_bugs drops (rowDecodes i). Sole sanctioned baseline
+  churn = the h_known_bugs binder line in baseline-strong-export-binders.txt.
+- F TraceLevelExport.lean module doc + dead-code-entry-points.txt comment refreshed.
 
-Stages:
-- A (rename): StepComplianceStrong→StepFaithful, …_of_rowData→
-  stepFaithful_of_evidence. DONE — committed 4555d095, pushed, build+V1 green.
-- B (structural split): DONE. RowDataSplit.lean (63× Claim/Decode/Inputs/
-  toRowData, workflow wwvvvytoj). Dispatcher rewritten: ZiskStep inductive +
-  RowDecode/InputsAgree + toFull; StrongRowConstructionData kept internal; old
-  StepNoKnownDefect body kept verbatim as StepNoKnownDefectOn; new
-  StepNoKnownDefect routes through toFull; StepFaithful transformed d→c over the
-  claim; stepFaithful_of_evidence dispatches to the UNTOUCHED stepStrong_<op>.
-  root_soundness rewritten with the 3 binders. 63 stepStrong proofs unchanged.
-- C: DONE. baselines regenerated; full build 8760; V1 15/15; V2 13/13; 0 axioms.
-  KEY: baseline-equiv-axiom-deps.txt + baseline-axioms.txt UNCHANGED → trust
-  footprint byte-identical (pure re-packaging, no proof-strategy change).
+Verification: lake build green (8760); V1 (incl. RowData-partition check 16) +
+V2 both PASS; 0 project axioms; no axiom/sorry/native_decide/bare decide added.
+baseline-equiv-axiom-deps.txt + baseline-axioms.txt byte-identical to origin/main.
 
-Blocking: none.
-Next step: commit + push Stage B; then update #141 / docs as wanted.
+Open questions (resolved empirically):
+- 55 non-defect proofs needed no content change beyond binder/`have` rewiring —
+  noKnownDefect_of_shapes closes the vacuous shapes definitionally.
+- Dropping rowDecodes from h_known_bugs threads cleanly through the 8 defect
+  proofs (they take rowDecodes from their own `d` binder to build the env).
 
-Digression: motivated by issue #141 (placement assumed, not derived from Main AIR).
-Note: a prior GitHub-issue-refresh (codex) stream's uncommitted STATUS/PLAN
-notes were reset by this branch switch; per user, discarded (not restored).
+Blocking: none. Next: the metaprogramming/macro pass is a separate later phase.
+
+Env note: build/ symlinked to /home/cody/zisk-fv/build; zisk submodule inited.
+Both are env-only, never committed.

--- a/ZiskFv/Compliance/Defects.lean
+++ b/ZiskFv/Compliance/Defects.lean
@@ -146,6 +146,47 @@ def ArithDivDynamicWitnessShape
           = (Sail.BitVec.extractLsb remw_input.r2_val 31 0).toInt.natAbs
   | _ => False
 
+/-! ### Row-data forms of the three defect shapes
+
+The four predicates below state the SAME conditions as the `OpEnvelope`-based
+shapes above (`MaliciousSignedMulWitnessShape`, `ArithDivDynamicWitnessShape`,
+`FenceKnownGoodShape`), re-expressed directly over the arith witness / claim
+fields that live in the `Inputs_<op>` / `Claim_<op>` row data.  This lets the
+threaded `StepNoKnownDefect` obligation read the defect condition off the row
+data without the `OpEnvelope` detour.  The faithfulness of the re-expression is
+the content of the bridge lemmas `signedMulForge_iff_shape` /
+`divRemForge_iff_shape` / `divRemForgeW_iff_shape` / `fenceKnownGood_iff_shape`
+in `ZiskFv.Compliance.TraceLevelExport.EnvOf`, each proved by `Iff.rfl`. -/
+
+/-- Row-data form of the malicious signed-MUL forge shape (ops 179/180/181):
+    the two exceptional product-sign witnesses the shared ArithTable admits.
+    Same condition as the `.mul`/`.mulh`/`.mulhsu` arms of
+    `MaliciousSignedMulWitnessShape`. -/
+def SignedMulForge (v : ZiskFv.Airs.ArithMul.Valid_ArithMul FGL FGL) (r_a : ℕ) : Prop :=
+  (v.na r_a = 1 ∧ v.nb r_a = 0 ∧ v.np r_a = 0)
+  ∨ (v.na r_a = 0 ∧ v.nb r_a = 1 ∧ v.np r_a = 0)
+
+/-- Row-data form of the signed DIV/REM 64-bit remainder-bound false positive
+    (`divisor ≠ 0 ∧ |remainder| = |divisor|` on the nonzero-divisor path).
+    Same condition as the `.div`/`.rem` arms of `ArithDivDynamicWitnessShape`. -/
+def DivRemForge (op2 : BitVec 64)
+    (v : ZiskFv.Airs.ArithDiv.Valid_ArithDiv FGL FGL) (r_a : ℕ) : Prop :=
+  op2.toInt ≠ 0 ∧ (signedRemainderInt v r_a).natAbs = op2.toInt.natAbs
+
+/-- W-mode (DIVW/REMW) analogue of `DivRemForge`: the 32-bit
+    `|r₃₂| = |op2₃₂|` false positive on the nonzero-divisor path.  Same
+    condition as the `.divw`/`.remw` arms of `ArithDivDynamicWitnessShape`. -/
+def DivRemForgeW (op2 : BitVec 64)
+    (v : ZiskFv.Airs.ArithDiv.Valid_ArithDiv FGL FGL) (r_a : ℕ) : Prop :=
+  Sail.BitVec.extractLsb op2 31 0 ≠ 0#32
+    ∧ (signedRemainderIntW v r_a).natAbs = (Sail.BitVec.extractLsb op2 31 0).toInt.natAbs
+
+/-- Row-data form of ZisK's currently accepted known-good FENCE subset
+    (`fm = 0 ∧ rs1 = x0 ∧ rd = x0`).  Same condition as the `.fence` arm of
+    `FenceKnownGoodShape`. -/
+def FenceKnownGood (fm : BitVec 4) (rs rd : regidx) : Prop :=
+  fm = 0#4 ∧ IsX0Reg rs ∧ IsX0Reg rd
+
 /-- `Blocks id env` means defect `id` excludes this envelope from the
     defect-qualified compliance theorem. -/
 def Blocks (id : DefectId) (env : OpEnvelope state m r_main) : Prop :=

--- a/ZiskFv/Compliance/TraceLevelExport.lean
+++ b/ZiskFv/Compliance/TraceLevelExport.lean
@@ -13,15 +13,18 @@ import ZiskFv.Compliance.TraceLevelExport.Dispatcher
 # TraceLevelExport.lean — P5 trace-level export (channel-balance form)
 
 This is the achievable closure of #61.  It exports the per-opcode
-`construction_<op>_sound` theorems to a single trace-level statement in the
-channel-balance form: given an accepted full-ensemble trace, a program binding,
-and a per-row CLASSIFICATION (`rowData : ∀ i, StrongRowConstructionData …`), plus
-the per-row defect-exclusion obligation `h_known_bugs`, EVERY row of the trace
-satisfies the canonical per-step channel-balance conclusion
-(`= state_effect_via_channels …`) — the SAME conclusion the OLD global theorem
-`zisk_riscv_compliant_program_bus` produces — with NO caller-supplied
-`OpEnvelope`.  The envelope for each row is constructed/lifted INSIDE, per row,
-from `rowData i` to the matching `stepStrong_<op>`.
+`construction_<op>_sound` theorems to a single trace-level statement
+(`root_soundness`, in `ZiskFv/Soundness.lean`) in the channel-balance form:
+given an accepted full-ensemble trace and a program binding, with each row's
+residual split three ways — `ziskStep i : ZiskStep` (which op decoded + its
+`Claim_<op>`), `rowDecodes i : RowDecode` (the circuit-checkable `Decode_<op>`),
+`inputsAgree i : InputsAgree` (the cross-world `Inputs_<op>`) — plus the per-row
+defect-exclusion obligation `h_known_bugs`, EVERY row of the trace satisfies the
+canonical per-step channel-balance conclusion (`= state_effect_via_channels …`)
+— the SAME conclusion the OLD global theorem `zisk_riscv_compliant_program_bus`
+produces — with NO caller-supplied `OpEnvelope`.  The envelope for each row is
+constructed/lifted INSIDE, per row, by `stepFaithful_of_evidence` dispatching the
+reassembled `RowData_<op>` to the matching `stepStrong_<op>`.
 
 > The earlier, weaker `bus_effect`-form export (`RowConstructionData` /
 > `StepCompliance` / `stepCompliance_of_rowData` /
@@ -30,16 +33,18 @@ from `rowData i` to the matching `stepStrong_<op>`.
 > form via `state_effect_via_channels_eq_bus_effect_2`) and nothing depended on
 > the weaker form.
 
-## What `StrongRowConstructionData` is (and is NOT)
+## The per-row split (`ZiskStep` / `RowDecode` / `InputsAgree`)
 
-`StrongRowConstructionData trace binding i` is a sum type — one arm per RV64IM
-opcode.  Each arm carries a single `RowData_<op>` payload that packages EXACTLY
-that construction's genuinely-irreducible residual binders (decode pins, Sail
-reads, operand/lane bridges, the `execRow` ∀-binder + exec facts,
+`ZiskStep trace i` is a sum type — one arm per RV64IM opcode — carrying that op's
+`Claim_<op>` (decoded operand / destination indices + committed bus row).
+`RowDecode`/`InputsAgree` then compute the matching `Decode_<op>` / `Inputs_<op>`
+residual.  Together (`RowData_<op>`, reassembled by `toRowData_<op>`) they package
+EXACTLY each construction's genuinely-irreducible residual binders (decode pins,
+Sail reads, operand/lane bridges, the `execRow` ∀-binder + exec facts,
 `h_nextPC_matches`; for loads also `MemoryTimelineEvidence` + the Mem-AIR
-provider linkage).  It does NOT package the bucket-(a) op-bus provider-match
-evidence: that is derived INSIDE each construction from `trace.channels_balanced` (via the
-`exists_*_provider_row_matches_*` Layer-A lemmas).
+provider linkage).  They do NOT package the bucket-(a) op-bus provider-match
+evidence: that is derived INSIDE each construction from `trace.channels_balanced`
+(via the `exists_*_provider_row_matches_*` Layer-A lemmas).
 
 ## Coverage (stated explicitly — NOT hidden)
 
@@ -55,8 +60,9 @@ global theorem produces:
    `zisk_riscv_compliant_program_bus`.  Its three hypotheses are discharged in
    place: `aeneasBridgeTrust` from the derived row-binding facts,
    `memoryTimelineConstructionEvidence` trivially (non-load arms), and
-   `NoKnownDefect` from the threaded `h_known_bugs` (non-defect ops — TRUE, not a
-   contradictory hypothesis).
+   `NoKnownDefect` assembled locally via `noKnownDefect_of_shapes` (the three
+   defect shapes are vacuous for a non-defect constructor — `False` / `False` /
+   `True` — so the threaded `h_known_bugs` obligation for these arms is `True`).
 
 2. **Direct-lift route (27 control-flow + U-type + store + load + M-ext-unsigned
    arms)** — `BEQ BNE BLT BGE BLTU BGEU`, `LUI AUIPC`, `JAL JALR`,
@@ -72,37 +78,41 @@ global theorem produces:
 
 3. **Env-constructed defect-narrowed route (7 signed-M arms + FENCE)** —
    `MUL MULH MULHSU DIV REM DIVW REMW` and `FENCE`.  Each CONSTRUCTS its
-   `OpEnvelope.<op>` (= `<op>EnvOf`) from the trace row and asks for the GENUINE
-   `NoKnownDefect (<op>EnvOf …)` of that SPECIFIC env (NOT the `EnvNoKnownDefectFor`
+   `OpEnvelope.<op>` (= `<op>EnvOf`) from the trace row and assembles
+   `NoKnownDefect (<op>EnvOf …)` of that SPECIFIC env via `noKnownDefect_of_shapes`,
+   feeding its threaded row-data forge-negation into the one matching slot (NOT a
    selector-∀, NOT a contradictory `False`-binder).  The signed-M defect predicates
-   were NARROWED from the old opcode-wide `| .mul .. => True` form to the EXACT
-   witness-conditional forge shapes — MUL/MULH/MULHSU exclude only the np-forge
-   `np=0 ∧ na⊕nb=1` (`MaliciousSignedMulWitnessShape`); DIV/REM/DIVW/REMW exclude only
-   the `|r|=|d|` `LT_ABS_NP` false positive (`ArithDivDynamicWitnessShape`,
+   are the EXACT witness-conditional forge shapes — MUL/MULH/MULHSU exclude only
+   the np-forge `np=0 ∧ na⊕nb=1` (`SignedMulForge`, defeq `MaliciousSignedMulWitnessShape`);
+   DIV/REM/DIVW/REMW exclude only the `|r|=|d|` `LT_ABS_NP` false positive
+   (`DivRemForge` / `DivRemForgeW`, defeq `ArithDivDynamicWitnessShape`,
    codygunton/zisk#5).  Honest rows are NEVER excluded, so every arm is SATISFIABLE
-   for a real honest signed-M row (anti-vacuity witnesses
-   `honest_<op>_witness_not_forge`); FENCE is likewise satisfiable for an honest FENCE
-   row (`fm=0, rs1=x0, rd=x0`).  A documented sign-range residual `na = MSB` is carried
-   per signed-M row (the real circuit enforces it via the arith.pil indexed range
-   lookup; the FV model collapsed it to FULL — dischargeable, issue #114).
+   for a real honest signed-M row (the row's own `h_not_forge` field witnesses the
+   obligation; anti-vacuity guards `honest_<op>_witness_not_forge`); FENCE is likewise
+   satisfiable for an honest FENCE row (`fm=0, rs1=x0, rd=x0`).  A documented
+   sign-range residual `na = MSB` is carried per signed-M row (the real circuit
+   enforces it via the arith.pil indexed range lookup; the FV model collapsed it to
+   FULL — dischargeable, issue #114).
 
 ## Threaded defect-exclusion hypothesis (`h_known_bugs`)
 
 The `h_known_bugs` premise is the per-row defect-exclusion obligation
-(`StepNoKnownDefect`).  It is threaded — via `stepFaithful_of_evidence` —
-to each OpEnvelope-route `stepStrong_<op>`, which feeds it to the old global
-theorem in place of an internally-proved `NoKnownDefect`.  It takes three shapes
-across the 63 arms, all SATISFIABLE for an honest row (so this export is NOT
-vacuous):
+(`StepNoKnownDefect`), stated DIRECTLY over the row data (no `OpEnvelope`
+detour).  It is threaded — via `stepFaithful_of_evidence` — to each
+`stepStrong_<op>`.  It takes two shapes across the 63 arms, all SATISFIABLE for
+an honest row (so this export is NOT vacuous):
   * **Non-defect arms** (op-bus ALU + M-ext-unsigned + control-flow / U-type /
-    store / load): `EnvNoKnownDefectFor` on the arm's non-defect constructor,
-    TRIVIALLY true — see `envNoKnownDefectFor_of_nondefect`.
-  * **7 signed-M arms** (MUL/MULH/MULHSU/DIV/REM/DIVW/REMW): the GENUINE
-    `NoKnownDefect (<op>EnvOf …)` of the SPECIFIC env, true for any honest row
-    because the defect predicates were narrowed to the exact forge shapes (the
-    np-forge / `|r|=|d|` witnesses) that an honest row never matches.
-  * **FENCE**: the GENUINE `NoKnownDefect (fenceEnvOf …)` of the honest FENCE env,
-    true for an honest FENCE row (`fm=0, rs1=x0, rd=x0`).
+    store / load): no defect obligation — the arm is `True`.  Each `stepStrong_<op>`
+    builds `NoKnownDefect` of its own env locally via `noKnownDefect_of_shapes`
+    (the three defect shapes are vacuous for a non-defect constructor).
+  * **8 defect-capable arms** (MUL/MULH/MULHSU/DIV/REM/DIVW/REMW + FENCE): the
+    row-data forge-negation (`¬ SignedMulForge` / `¬ DivRemForge` /
+    `¬ DivRemForgeW`) or FENCE-known-good (`FenceKnownGood`), read off the arith
+    witness / claim fields.  Each is DEFINITIONALLY equal to the corresponding
+    `<op>EnvOf` `OpEnvelope` defect shape (the `Iff.rfl` bridge lemmas
+    `signedMulForge_iff_*` / `divRemForge*_iff_*` / `fenceKnownGood_iff_fenceShape`
+    in `EnvOf`), and is true for any honest row (the row's `h_not_forge` field /
+    honest FENCE pins `fm=0, rs1=x0, rd=x0`).
 
 ## Non-vacuity
 

--- a/ZiskFv/Compliance/TraceLevelExport/Base.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/Base.lean
@@ -47,47 +47,34 @@ set_option maxHeartbeats 8000000
 noncomputable def zeroValidBinary : ZiskFv.Airs.Binary.Valid_Binary FGL FGL := by
   constructor <;> exact fun _ => 0
 
-/-- `EnvNoKnownDefectFor sel` is the defect-exclusion fact for *every* `OpEnvelope`
-    in the family carved out by the selector `sel`: every such env is outside all
-    known-defect regions.  An OpEnvelope-route `stepStrong_<op>` proof instantiates
-    this with the specific env it constructs (`sel` selecting exactly that arm's
-    `OpEnvelope` constructor), feeding the result to
-    `zisk_riscv_compliant_program_bus` instead of re-proving `NoKnownDefect`.
+/-- `NoKnownDefect env` is exactly the conjunction of its three per-defect
+    components: the env is outside the signed-MUL forge shape, outside the
+    DIV/REM forge shape, and inside the FENCE known-good shape.  This is the
+    `∀ id, ¬ Blocks id env` unfolding, packaged so every OpEnvelope-route
+    `stepStrong_<op>` proof can assemble `NoKnownDefect` from the three facts of
+    the specific env it constructs.
 
-    For the non-defect OpEnvelope-route arms the selected constructor is never a
-    defect constructor, so this is TRIVIALLY satisfiable (proved by `cases`/`simp`
-    on the defect predicates) — the threaded hypothesis is non-vacuous.  The 7
-    signed-M arms and FENCE do NOT use this selector-∀ shape (it would be FALSE for
-    them — a malicious env matches the selector but is not `NoKnownDefect`); they
-    instead ask `StepNoKnownDefect` for the GENUINE `NoKnownDefect (<op>EnvOf …)` of
-    the SPECIFIC honest env they construct, satisfiable for any honest row because
-    the defect predicates are narrowed to the exact forge witnesses (see
-    `StepNoKnownDefect`). -/
-def EnvNoKnownDefectFor
+    * Non-defect arms discharge all three definitionally: the MUL and DIV/REM
+      shapes are `False` (`fun h => h`) and the FENCE shape is `True`
+      (`trivial`).
+    * A defect arm (the 7 signed-M arms + FENCE) supplies its threaded
+      row-data forge-negation in the one matching slot (`¬ SignedMulForge` /
+      `¬ DivRemForge` / `FenceKnownGood`, definitionally equal to the
+      corresponding `Shape` of the `<op>EnvOf` env via the bridge lemmas in
+      `EnvOf`) and discharges the other two definitionally. -/
+theorem noKnownDefect_of_shapes
     {state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource}
     {m : ZiskFv.Airs.Main.Valid_Main FGL FGL} {r : ℕ}
-    (sel : OpEnvelope state m r → Prop) : Prop :=
-  ∀ env : OpEnvelope state m r, sel env → Defects.NoKnownDefect env
-
-/-- The defect-constructor selector for an OpEnvelope-route arm is non-defect: every
-    `OpEnvelope` it selects is `NoKnownDefect`.  This is the trivial discharge used
-    to satisfy the threaded `StepNoKnownDefect` obligation for the 22 current
-    non-defect arms (non-vacuous: the selected env exists and the fact is TRUE). -/
-theorem envNoKnownDefectFor_of_nondefect
-    {state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource}
-    {m : ZiskFv.Airs.Main.Valid_Main FGL FGL} {r : ℕ}
-    (sel : OpEnvelope state m r → Prop)
-    (h : ∀ env, sel env →
-      ¬ Defects.MaliciousSignedMulWitnessShape env ∧
-      ¬ Defects.ArithDivDynamicWitnessShape env ∧
-      Defects.FenceKnownGoodShape env) :
-    EnvNoKnownDefectFor sel := by
-  intro env hsel id
-  obtain ⟨h1, h2, h3⟩ := h env hsel
+    (env : OpEnvelope state m r)
+    (h_mul : ¬ Defects.MaliciousSignedMulWitnessShape env)
+    (h_div : ¬ Defects.ArithDivDynamicWitnessShape env)
+    (h_fence : Defects.FenceKnownGoodShape env) :
+    Defects.NoKnownDefect env := by
+  intro id
   cases id with
-  | arithMulSignedWitnessSoundness => exact h1
-  | arithDivDynamicWitnessSoundness => exact h2
-  | fenceIncomplete => simpa [Defects.Blocks] using h3
+  | arithMulSignedWitnessSoundness => exact h_mul
+  | arithDivDynamicWitnessSoundness => exact h_div
+  | fenceIncomplete => exact not_not_intro h_fence
 
 /-- Build a `MainRowProvenance m r` from the FIVE Main-row mode/control pins
     (`op`, `is_external_op`, `m32`, `set_pc`, `store_pc`) that the LUI/AUIPC/JAL

--- a/ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean
@@ -52,96 +52,10 @@ set_option maxHeartbeats 8000000
 
 /-! ## Strong sum + dispatcher + top-level strengthened export -/
 
-/-- A per-row classification carrying the honest residual binders for ALL 63 RV64IM
-    arms, each strengthened to the channel-balance / env-constructed form.  Three
-    routes feed the identical channel-balance proposition: the 22 op-bus ALU arms via
-    the env-constructed route; the control-flow / U-type / store / load /
-    M-ext-unsigned arms via the direct-lift route; and the 7 signed-M arms
-    (MUL/MULH/MULHSU/DIV/REM/DIVW/REMW) plus FENCE via the env-constructed route with
-    a GENUINE per-row `NoKnownDefect` obligation whose defect predicate is narrowed to
-    the exact forge witness (so honest rows are never excluded).  No arm is omitted —
-    the export is 63/63 on the OpEnvelope route. -/
 
-inductive StrongRowConstructionData
-    (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions) (i : Fin ziskTrace.numInstructions) where
-  | sub (d : RowData_sub ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | and (d : RowData_and ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | or (d : RowData_or ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | xor (d : RowData_xor ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | slt (d : RowData_slt ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | sltu (d : RowData_sltu ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | andi (d : RowData_andi ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | ori (d : RowData_ori ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | xori (d : RowData_xori ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | slti (d : RowData_slti ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | sltiu (d : RowData_sltiu ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | sll (d : RowData_sll ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | srl (d : RowData_srl ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | sra (d : RowData_sra ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | slli (d : RowData_slli ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | srli (d : RowData_srli ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | srai (d : RowData_srai ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | add (d : RowData_add ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | addi (d : RowData_addi ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | subw (d : RowData_subw ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | addw (d : RowData_addw ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | addiw (d : RowData_addiw ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | sllw (d : RowData_sllw ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | srlw (d : RowData_srlw ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | sraw (d : RowData_sraw ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | slliw (d : RowData_slliw ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | srliw (d : RowData_srliw ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | sraiw (d : RowData_sraiw ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | mul (d : RowData_mul ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | mulh (d : RowData_mulh ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | mulhsu (d : RowData_mulhsu ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | mulw (d : RowData_mulw ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | mulhu (d : RowData_mulhu ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | div (d : RowData_div ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | rem (d : RowData_rem ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | divw (d : RowData_divw ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | remw (d : RowData_remw ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | divu (d : RowData_divu ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | divuw (d : RowData_divuw ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | remu (d : RowData_remu ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | remuw (d : RowData_remuw ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | beq (d : RowData_beq ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | bne (d : RowData_bne ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | blt (d : RowData_blt ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | bge (d : RowData_bge ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | bltu (d : RowData_bltu ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | bgeu (d : RowData_bgeu ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | lui (d : RowData_lui ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | auipc (d : RowData_auipc ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | jal (d : RowData_jal ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | jalr (d : RowData_jalr ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | sb (d : RowData_sb ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | sh (d : RowData_sh ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | sw (d : RowData_sw ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | sd (d : RowData_sd ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | ld (d : RowData_ld ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | lbu (d : RowData_lbu ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | lhu (d : RowData_lhu ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | lwu (d : RowData_lwu ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | lb (d : RowData_lb ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | lh (d : RowData_lh ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | lw (d : RowData_lw ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-  | fence (d : RowData_fence ziskTrace sailTrace i) : StrongRowConstructionData ziskTrace sailTrace i
-
-/-- Per-row defect-exclusion obligation supplied to (and threaded into) the
-    strengthened ziskTrace-level export.  For each OpEnvelope-route arm it is the
-    `EnvNoKnownDefectFor` fact restricted to that arm's `OpEnvelope` constructor;
-    for the direct-lift arms (which never invoke `zisk_riscv_compliant_program_bus`)
-    it is `True`.  See `EnvNoKnownDefectFor` for the non-vacuity / generalization
-    rationale.
-
-    The `fence` arm is the EXCEPTION to the `EnvNoKnownDefectFor` selector-∀ shape:
-    that shape (`∀ env, sel env → NoKnownDefect env`) is FALSE for FENCE (a
-    malicious `fm≠0` FENCE matches the `.fence` selector but is NOT `NoKnownDefect`),
-    so the fence arm instead asks for the GENUINE `NoKnownDefect` of the SPECIFIC
-    honest `OpEnvelope.fence` env built from the row's honest-shape pins.  That
-    obligation is SATISFIABLE for an honest FENCE row (see `RowData_fence` /
-    `stepStrong_fence`). -/
+/-- The ZisK side of one trace step: which RV64IM op the row decoded to,
+    together with that op's `Claim_<op>` (decoded operand / destination
+    indices + committed bus row).  One constructor per RV64IM archetype. -/
 
 inductive ZiskStep (ziskTrace : AcceptedZiskTrace numInstructions) (i : Fin ziskTrace.numInstructions) where
   | sub (c : Claim_sub ziskTrace i) : ZiskStep ziskTrace i
@@ -340,325 +254,35 @@ def InputsAgree (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : Sai
   | .lw c => Inputs_lw ziskTrace sailTrace i c
   | .fence c => Inputs_fence ziskTrace sailTrace i c
 
-def toFull (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions)
-    (i : Fin ziskTrace.numInstructions) (zs : ZiskStep ziskTrace i)
-    (rd : RowDecode ziskTrace i zs) (ia : InputsAgree ziskTrace sailTrace i zs) :
-    StrongRowConstructionData ziskTrace sailTrace i :=
-  match zs, rd, ia with
-  | .sub c, rd, ia => .sub (toRowData_sub c rd ia)
-  | .and c, rd, ia => .and (toRowData_and c rd ia)
-  | .or c, rd, ia => .or (toRowData_or c rd ia)
-  | .xor c, rd, ia => .xor (toRowData_xor c rd ia)
-  | .slt c, rd, ia => .slt (toRowData_slt c rd ia)
-  | .sltu c, rd, ia => .sltu (toRowData_sltu c rd ia)
-  | .andi c, rd, ia => .andi (toRowData_andi c rd ia)
-  | .ori c, rd, ia => .ori (toRowData_ori c rd ia)
-  | .xori c, rd, ia => .xori (toRowData_xori c rd ia)
-  | .slti c, rd, ia => .slti (toRowData_slti c rd ia)
-  | .sltiu c, rd, ia => .sltiu (toRowData_sltiu c rd ia)
-  | .sll c, rd, ia => .sll (toRowData_sll c rd ia)
-  | .srl c, rd, ia => .srl (toRowData_srl c rd ia)
-  | .sra c, rd, ia => .sra (toRowData_sra c rd ia)
-  | .slli c, rd, ia => .slli (toRowData_slli c rd ia)
-  | .srli c, rd, ia => .srli (toRowData_srli c rd ia)
-  | .srai c, rd, ia => .srai (toRowData_srai c rd ia)
-  | .add c, rd, ia => .add (toRowData_add c rd ia)
-  | .addi c, rd, ia => .addi (toRowData_addi c rd ia)
-  | .subw c, rd, ia => .subw (toRowData_subw c rd ia)
-  | .addw c, rd, ia => .addw (toRowData_addw c rd ia)
-  | .addiw c, rd, ia => .addiw (toRowData_addiw c rd ia)
-  | .sllw c, rd, ia => .sllw (toRowData_sllw c rd ia)
-  | .srlw c, rd, ia => .srlw (toRowData_srlw c rd ia)
-  | .sraw c, rd, ia => .sraw (toRowData_sraw c rd ia)
-  | .slliw c, rd, ia => .slliw (toRowData_slliw c rd ia)
-  | .srliw c, rd, ia => .srliw (toRowData_srliw c rd ia)
-  | .sraiw c, rd, ia => .sraiw (toRowData_sraiw c rd ia)
-  | .mul c, rd, ia => .mul (toRowData_mul c rd ia)
-  | .mulh c, rd, ia => .mulh (toRowData_mulh c rd ia)
-  | .mulhsu c, rd, ia => .mulhsu (toRowData_mulhsu c rd ia)
-  | .mulw c, rd, ia => .mulw (toRowData_mulw c rd ia)
-  | .mulhu c, rd, ia => .mulhu (toRowData_mulhu c rd ia)
-  | .div c, rd, ia => .div (toRowData_div c rd ia)
-  | .rem c, rd, ia => .rem (toRowData_rem c rd ia)
-  | .divw c, rd, ia => .divw (toRowData_divw c rd ia)
-  | .remw c, rd, ia => .remw (toRowData_remw c rd ia)
-  | .divu c, rd, ia => .divu (toRowData_divu c rd ia)
-  | .divuw c, rd, ia => .divuw (toRowData_divuw c rd ia)
-  | .remu c, rd, ia => .remu (toRowData_remu c rd ia)
-  | .remuw c, rd, ia => .remuw (toRowData_remuw c rd ia)
-  | .beq c, rd, ia => .beq (toRowData_beq c rd ia)
-  | .bne c, rd, ia => .bne (toRowData_bne c rd ia)
-  | .blt c, rd, ia => .blt (toRowData_blt c rd ia)
-  | .bge c, rd, ia => .bge (toRowData_bge c rd ia)
-  | .bltu c, rd, ia => .bltu (toRowData_bltu c rd ia)
-  | .bgeu c, rd, ia => .bgeu (toRowData_bgeu c rd ia)
-  | .lui c, rd, ia => .lui (toRowData_lui c rd ia)
-  | .auipc c, rd, ia => .auipc (toRowData_auipc c rd ia)
-  | .jal c, rd, ia => .jal (toRowData_jal c rd ia)
-  | .jalr c, rd, ia => .jalr (toRowData_jalr c rd ia)
-  | .sb c, rd, ia => .sb (toRowData_sb c rd ia)
-  | .sh c, rd, ia => .sh (toRowData_sh c rd ia)
-  | .sw c, rd, ia => .sw (toRowData_sw c rd ia)
-  | .sd c, rd, ia => .sd (toRowData_sd c rd ia)
-  | .ld c, rd, ia => .ld (toRowData_ld c rd ia)
-  | .lbu c, rd, ia => .lbu (toRowData_lbu c rd ia)
-  | .lhu c, rd, ia => .lhu (toRowData_lhu c rd ia)
-  | .lwu c, rd, ia => .lwu (toRowData_lwu c rd ia)
-  | .lb c, rd, ia => .lb (toRowData_lb c rd ia)
-  | .lh c, rd, ia => .lh (toRowData_lh c rd ia)
-  | .lw c, rd, ia => .lw (toRowData_lw c rd ia)
-  | .fence c, rd, ia => .fence (toRowData_fence c rd ia)
 
-def StepNoKnownDefectOn
-    (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions) (i : Fin ziskTrace.numInstructions) :
-    StrongRowConstructionData ziskTrace sailTrace i → Prop
-  | .sub _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .sub .. => True | _ => False)
-  | .and _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .and .. => True | _ => False)
-  | .or _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .or .. => True | _ => False)
-  | .xor _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .xor .. => True | _ => False)
-  | .slt _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .slt .. => True | _ => False)
-  | .sltu _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .sltu .. => True | _ => False)
-  | .andi _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .andi .. => True | _ => False)
-  | .ori _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .ori .. => True | _ => False)
-  | .xori _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .xori .. => True | _ => False)
-  | .slti _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .slti .. => True | _ => False)
-  | .sltiu _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .sltiu .. => True | _ => False)
-  | .sll _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .sll .. => True | _ => False)
-  | .srl _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .srl .. => True | _ => False)
-  | .sra _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .sra .. => True | _ => False)
-  | .slli _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .slli .. => True | _ => False)
-  | .srli _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .srli .. => True | _ => False)
-  | .srai _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .srai .. => True | _ => False)
-  | .add _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val)
-      (fun env => match env with | .add_via_binary .. => True | .add_via_binaryadd .. => True | _ => False)
-  | .addi _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val)
-      (fun env => match env with | .addi_via_binary .. => True | .addi_via_binaryadd .. => True | _ => False)
-  | .subw _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .subw .. => True | _ => False)
-  | .addw _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .addw .. => True | _ => False)
-  | .addiw _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .addiw .. => True | _ => False)
-  | .sllw _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .sllw .. => True | _ => False)
-  | .srlw _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .srlw .. => True | _ => False)
-  | .sraw _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .sraw .. => True | _ => False)
-  | .slliw _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .slliw .. => True | _ => False)
-  | .srliw _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .srliw .. => True | _ => False)
-  | .sraiw _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .sraiw .. => True | _ => False)
-  | .jalr _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .jalr .. => True | _ => False)
-  | .beq _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .beq .. => True | _ => False)
-  | .bne _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .bne .. => True | _ => False)
-  | .blt _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .blt .. => True | _ => False)
-  | .bge _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .bge .. => True | _ => False)
-  | .bltu _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .bltu .. => True | _ => False)
-  | .bgeu _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .bgeu .. => True | _ => False)
-  | .mul d => Defects.NoKnownDefect (mulEnvOf ziskTrace sailTrace i d)
-  | .mulh d => Defects.NoKnownDefect (mulhEnvOf ziskTrace sailTrace i d)
-  | .mulhsu d => Defects.NoKnownDefect (mulhsuEnvOf ziskTrace sailTrace i d)
-  -- Signed DIV/REM/DIVW/REMW: the GENUINE `NoKnownDefect` of the SPECIFIC env,
-  -- NOT the (false) selector-∀ shape.  Satisfiable for an honest signed row
-  -- (`|r| ≠ |op2|`); see `RowData_div` / `stepStrong_div`.
-  | .div d => Defects.NoKnownDefect (divEnvOf ziskTrace sailTrace i d)
-  | .rem d => Defects.NoKnownDefect (remEnvOf ziskTrace sailTrace i d)
-  | .divw d => Defects.NoKnownDefect (divwEnvOf ziskTrace sailTrace i d)
-  | .remw d => Defects.NoKnownDefect (remwEnvOf ziskTrace sailTrace i d)
-  | .mulw _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .mulw .. => True | _ => False)
-  | .mulhu _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .mulhu .. => True | _ => False)
-  | .divu _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .divu .. => True | _ => False)
-  | .divuw _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .divuw .. => True | _ => False)
-  | .remu _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .remu .. => True | _ => False)
-  | .remuw _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .remuw .. => True | _ => False)
-  | .lui _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .lui .. => True | _ => False)
-  | .auipc _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .auipc .. => True | _ => False)
-  | .jal _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .jal .. => True | _ => False)
-  | .sb _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .sb .. => True | _ => False)
-  | .sh _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .sh .. => True | _ => False)
-  | .sw _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .sw .. => True | _ => False)
-  | .sd _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .sd .. => True | _ => False)
-  | .ld _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .ld .. => True | _ => False)
-  | .lbu _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .lbu .. => True | _ => False)
-  | .lhu _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .lhu .. => True | _ => False)
-  | .lwu _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val) (fun env => match env with | .lwu .. => True | _ => False)
-  | .lb _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val)
-      (fun env => match env with | .lb_via_static_match .. => True | _ => False)
-  | .lh _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val)
-      (fun env => match env with | .lh_via_static_match .. => True | _ => False)
-  | .lw _ => EnvNoKnownDefectFor
-      (state := sailTrace i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable)
-      (r := i.val)
-      (fun env => match env with | .lw_via_static_match .. => True | _ => False)
-  -- FENCE: the GENUINE `NoKnownDefect` of the SPECIFIC honest env, NOT the
-  -- (false) selector-∀ shape.  Satisfiable for an honest FENCE row.
-  | .fence d => Defects.NoKnownDefect (fenceEnvOf ziskTrace sailTrace i d)
 
-/-- The strengthened per-step conclusion: the channel-balance
-    (`state_effect_via_channels`) form — the OLD global theorem's per-arm
-    conclusion — keyed on the row archetype. -/
+/-- Per-row known-defect exclusion obligation, stated DIRECTLY over the row data
+    (no `OpEnvelope` detour).
 
+    The 8 defect-capable arms carry the genuine forge exclusion, read off the
+    arith witness / claim fields that live in `ia` (the `inputsAgree` half) or in
+    the matched `ZiskStep` claim payload:
+      * MUL / MULH / MULHSU → `¬ SignedMulForge` of the ArithMul sign witnesses;
+      * DIV / REM → `¬ DivRemForge` of the 64-bit remainder/divisor magnitudes;
+      * DIVW / REMW → `¬ DivRemForgeW` of the 32-bit remainder/divisor magnitudes;
+      * FENCE → `FenceKnownGood` of the claim's `fm` / `rs` / `rd`.
+    Each is DEFINITIONALLY the same proposition as the corresponding `<op>EnvOf`
+    `OpEnvelope` defect shape (the `Iff.rfl` bridge lemmas in `EnvOf`), so the
+    re-expression off `OpEnvelope` carries no change of meaning.  Every other
+    (non-defect) arm carries no defect obligation (`True`). -/
 def StepNoKnownDefect (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions)
     (i : Fin ziskTrace.numInstructions) (zs : ZiskStep ziskTrace i)
-    (rd : RowDecode ziskTrace i zs) (ia : InputsAgree ziskTrace sailTrace i zs) : Prop :=
-  StepNoKnownDefectOn ziskTrace sailTrace i (toFull ziskTrace sailTrace i zs rd ia)
+    (ia : InputsAgree ziskTrace sailTrace i zs) : Prop :=
+  match zs, ia with
+  | .mul _, ia => ¬ Defects.SignedMulForge ia.v ia.r_a
+  | .mulh _, ia => ¬ Defects.SignedMulForge ia.v ia.r_a
+  | .mulhsu _, ia => ¬ Defects.SignedMulForge ia.v ia.r_a
+  | .div _, ia => ¬ Defects.DivRemForge ia.div_input.r2_val ia.v ia.r_a
+  | .rem _, ia => ¬ Defects.DivRemForge ia.rem_input.r2_val ia.v ia.r_a
+  | .divw _, ia => ¬ Defects.DivRemForgeW ia.divw_input.r2_val ia.v ia.r_a
+  | .remw _, ia => ¬ Defects.DivRemForgeW ia.remw_input.r2_val ia.v ia.r_a
+  | .fence c, _ => Defects.FenceKnownGood c.fm c.rs c.rd
+  | _, _ => True
 
 def StepFaithful
     (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions) (i : Fin ziskTrace.numInstructions) :
@@ -1136,16 +760,18 @@ def StepFaithful
 /-- Per-row dispatch to the matching strengthened step theorem.
 
     The `h_known` parameter carries the per-row defect-exclusion obligation
-    (`StepNoKnownDefect`).  For the 22 OpEnvelope-route arms it is the
-    `EnvNoKnownDefectFor` fact for that arm's constructor; the dispatcher hands it
-    straight to the corresponding `stepStrong_<op>`, which feeds it to
-    `zisk_riscv_compliant_program_bus`.  For the direct-lift arms (which never call
-    the old theorem) the obligation is `True` and is ignored. -/
+    (`StepNoKnownDefect`), stated directly over the row data.  For the 8
+    defect-capable arms it is the row-data forge-negation / FENCE-known-good
+    fact; the dispatcher hands it straight to the corresponding `stepStrong_<op>`,
+    which assembles `NoKnownDefect (<op>EnvOf …)` from it (via
+    `noKnownDefect_of_shapes`) and feeds that to
+    `zisk_riscv_compliant_program_bus`.  For every other (non-defect) arm the
+    obligation is `True` and is ignored — the arm builds its own `NoKnownDefect`. -/
 
 theorem stepFaithful_of_evidence (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions)
     (i : Fin ziskTrace.numInstructions) (zs : ZiskStep ziskTrace i)
     (rd : RowDecode ziskTrace i zs) (ia : InputsAgree ziskTrace sailTrace i zs)
-    (h_known : StepNoKnownDefect ziskTrace sailTrace i zs rd ia) :
+    (h_known : StepNoKnownDefect ziskTrace sailTrace i zs ia) :
     StepFaithful ziskTrace sailTrace i zs := by
   cases zs with
   | sub c => exact stepStrong_sub ziskTrace sailTrace i (toRowData_sub c rd ia) h_known

--- a/ZiskFv/Compliance/TraceLevelExport/EnvOf.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/EnvOf.lean
@@ -293,5 +293,64 @@ theorem remw_noKnownDefect_of_rowData
   | fenceIncomplete =>
       simp [Defects.Blocks, Defects.FenceKnownGoodShape, remwEnvOf]
 
+/-! ### Bridge lemmas: row-data forge predicates ≡ OpEnvelope defect shapes
+
+Each bridge is `Iff.rfl`: the row-data predicate (over the `Inputs_<op>` arith
+witness / `Claim_<op>` fields) and the `OpEnvelope`-based defect shape at the
+corresponding `<op>EnvOf` env are DEFINITIONALLY the same proposition.  These are
+the faithfulness audit for the `StepNoKnownDefect` re-expression (plan step B):
+they witness that lifting the three known-defect conditions off `OpEnvelope`
+onto the row data changed no meaning — the `Iff.rfl` proofs would fail if the
+re-expressed predicate were even slightly weaker or stronger than the original
+`OpEnvelope` shape. -/
+
+theorem signedMulForge_iff_mulShape
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (d : RowData_mul trace binding i) :
+    Defects.SignedMulForge d.toInputs.v d.toInputs.r_a
+      ↔ Defects.MaliciousSignedMulWitnessShape (mulEnvOf trace binding i d) := Iff.rfl
+
+theorem signedMulForge_iff_mulhShape
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (d : RowData_mulh trace binding i) :
+    Defects.SignedMulForge d.toInputs.v d.toInputs.r_a
+      ↔ Defects.MaliciousSignedMulWitnessShape (mulhEnvOf trace binding i d) := Iff.rfl
+
+theorem signedMulForge_iff_mulhsuShape
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (d : RowData_mulhsu trace binding i) :
+    Defects.SignedMulForge d.toInputs.v d.toInputs.r_a
+      ↔ Defects.MaliciousSignedMulWitnessShape (mulhsuEnvOf trace binding i d) := Iff.rfl
+
+theorem divRemForge_iff_divShape
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (d : RowData_div trace binding i) :
+    Defects.DivRemForge d.toInputs.div_input.r2_val d.toInputs.v d.toInputs.r_a
+      ↔ Defects.ArithDivDynamicWitnessShape (divEnvOf trace binding i d) := Iff.rfl
+
+theorem divRemForge_iff_remShape
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (d : RowData_rem trace binding i) :
+    Defects.DivRemForge d.toInputs.rem_input.r2_val d.toInputs.v d.toInputs.r_a
+      ↔ Defects.ArithDivDynamicWitnessShape (remEnvOf trace binding i d) := Iff.rfl
+
+theorem divRemForgeW_iff_divwShape
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (d : RowData_divw trace binding i) :
+    Defects.DivRemForgeW d.toInputs.divw_input.r2_val d.toInputs.v d.toInputs.r_a
+      ↔ Defects.ArithDivDynamicWitnessShape (divwEnvOf trace binding i d) := Iff.rfl
+
+theorem divRemForgeW_iff_remwShape
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (d : RowData_remw trace binding i) :
+    Defects.DivRemForgeW d.toInputs.remw_input.r2_val d.toInputs.v d.toInputs.r_a
+      ↔ Defects.ArithDivDynamicWitnessShape (remwEnvOf trace binding i d) := Iff.rfl
+
+theorem fenceKnownGood_iff_fenceShape
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (d : RowData_fence trace binding i) :
+    Defects.FenceKnownGood d.toClaim.fm d.toClaim.rs d.toClaim.rd
+      ↔ Defects.FenceKnownGoodShape (fenceEnvOf trace binding i d) := Iff.rfl
+
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongAluArith.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongAluArith.lean
@@ -74,10 +74,7 @@ no `False.elim` or contradictory pair is used.
 theorem stepStrong_sub
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sub trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .sub .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -199,7 +196,7 @@ theorem stepStrong_sub
     exact ⟨h_input_r1_row, h_input_r2_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.1
 
 /-- Strengthened `and` step: the channel-balance conclusion (the OLD global
@@ -210,10 +207,7 @@ theorem stepStrong_sub
 theorem stepStrong_and
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_and trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .and .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -335,7 +329,7 @@ theorem stepStrong_and
     exact ⟨h_input_r1_row, h_input_r2_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.1
 
 /-- Strengthened `or` step: the channel-balance conclusion (the OLD global
@@ -346,10 +340,7 @@ theorem stepStrong_and
 theorem stepStrong_or
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_or trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .or .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -471,7 +462,7 @@ theorem stepStrong_or
     exact ⟨h_input_r1_row, h_input_r2_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.1
 
 /-- Strengthened `xor` step: the channel-balance conclusion (the OLD global
@@ -482,10 +473,7 @@ theorem stepStrong_or
 theorem stepStrong_xor
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_xor trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .xor .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -608,7 +596,7 @@ theorem stepStrong_xor
     exact ⟨h_input_r1_row, h_input_r2_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.1
 
 /-- Strengthened `slt` step: the channel-balance conclusion (the OLD global
@@ -619,10 +607,7 @@ theorem stepStrong_xor
 theorem stepStrong_slt
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_slt trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .slt .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -744,7 +729,7 @@ theorem stepStrong_slt
     exact ⟨h_input_r1_row, h_input_r2_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.1
 
 /-- Strengthened `sltu` step: the channel-balance conclusion (the OLD global
@@ -755,10 +740,7 @@ theorem stepStrong_slt
 theorem stepStrong_sltu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sltu trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .sltu .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -880,7 +862,7 @@ theorem stepStrong_sltu
     exact ⟨h_input_r1_row, h_input_r2_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.1
 
 
@@ -890,10 +872,7 @@ theorem stepStrong_sltu
 theorem stepStrong_andi
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_andi trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .andi .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -1016,7 +995,7 @@ theorem stepStrong_andi
     exact ⟨h_input_r1_row, h_input_imm_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.1
 
 /-- Strengthened `ori` step: channel-balance conclusion via constructed
@@ -1025,10 +1004,7 @@ theorem stepStrong_andi
 theorem stepStrong_ori
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_ori trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .ori .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -1151,7 +1127,7 @@ theorem stepStrong_ori
     exact ⟨h_input_r1_row, h_input_imm_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.1
 
 /-- Strengthened `xori` step: channel-balance conclusion via constructed
@@ -1160,10 +1136,7 @@ theorem stepStrong_ori
 theorem stepStrong_xori
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_xori trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .xori .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -1284,7 +1257,7 @@ theorem stepStrong_xori
     exact ⟨h_input_r1_row, h_input_imm_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.1
 
 /-- Strengthened `slti` step: channel-balance conclusion via constructed
@@ -1293,10 +1266,7 @@ theorem stepStrong_xori
 theorem stepStrong_slti
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_slti trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .slti .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -1412,7 +1382,7 @@ theorem stepStrong_slti
     exact ⟨h_m32_zero, h_input_r1_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.1
 
 /-- Strengthened `sltiu` step: channel-balance conclusion via constructed
@@ -1421,10 +1391,7 @@ theorem stepStrong_slti
 theorem stepStrong_sltiu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sltiu trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .sltiu .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -1540,7 +1507,7 @@ theorem stepStrong_sltiu
     exact ⟨h_m32_zero, h_input_r1_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.1
 
 
@@ -1550,10 +1517,7 @@ theorem stepStrong_sltiu
 theorem stepStrong_sll
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sll trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .sll .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -1641,7 +1605,7 @@ theorem stepStrong_sll
     exact ⟨h_input_r1_row, h_shift_pin_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.1
 
 /-- Strengthened `srl` step: channel-balance via constructed `OpEnvelope.srl`
@@ -1649,10 +1613,7 @@ theorem stepStrong_sll
 theorem stepStrong_srl
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_srl trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .srl .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -1740,7 +1701,7 @@ theorem stepStrong_srl
     exact ⟨h_input_r1_row, h_shift_pin_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.1
 
 /-- Strengthened `sra` step: channel-balance via constructed `OpEnvelope.sra`
@@ -1748,10 +1709,7 @@ theorem stepStrong_srl
 theorem stepStrong_sra
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sra trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .sra .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -1839,7 +1797,7 @@ theorem stepStrong_sra
     exact ⟨h_input_r1_row, h_shift_pin_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.1
 
 /-- Strengthened `slli` step: channel-balance via constructed `OpEnvelope.slli`
@@ -1847,10 +1805,7 @@ theorem stepStrong_sra
 theorem stepStrong_slli
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_slli trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .slli .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.SHIFTIOP (d.toClaim.shamt, d.toClaim.r1, d.toClaim.rd, sop.SLLI)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨(busSub trace i d.toClaim.execRow).exec_row,
@@ -1938,7 +1893,7 @@ theorem stepStrong_slli
     exact ⟨h_input_r1_row, h_shift_pin_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.1
 
 /-- Strengthened `srli` step: channel-balance via constructed `OpEnvelope.srli`
@@ -1946,10 +1901,7 @@ theorem stepStrong_slli
 theorem stepStrong_srli
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_srli trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .srli .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.SHIFTIOP (d.toClaim.shamt, d.toClaim.r1, d.toClaim.rd, sop.SRLI)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨(busSub trace i d.toClaim.execRow).exec_row,
@@ -2037,7 +1989,7 @@ theorem stepStrong_srli
     exact ⟨h_input_r1_row, h_shift_pin_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.1
 
 /-- Strengthened `srai` step: channel-balance via constructed `OpEnvelope.srai`
@@ -2045,10 +1997,7 @@ theorem stepStrong_srli
 theorem stepStrong_srai
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_srai trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .srai .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.SHIFTIOP (d.toClaim.shamt, d.toClaim.r1, d.toClaim.rd, sop.SRAI)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨(busSub trace i d.toClaim.execRow).exec_row,
@@ -2136,7 +2085,7 @@ theorem stepStrong_srai
     exact ⟨h_input_r1_row, h_shift_pin_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.1
 
 
@@ -2146,10 +2095,7 @@ theorem stepStrong_srai
 theorem stepStrong_subw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_subw trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .subw .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -2268,7 +2214,7 @@ theorem stepStrong_subw
     exact ⟨h_input_r1_extract, h_input_r2_extract⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.1
 
 /-- Strengthened `addw` step: channel-balance via constructed `OpEnvelope.addw`
@@ -2276,10 +2222,7 @@ theorem stepStrong_subw
 theorem stepStrong_addw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_addw trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .addw .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -2398,7 +2341,7 @@ theorem stepStrong_addw
     exact ⟨h_input_r1_extract, h_input_r2_extract⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.1
 
 /-- Strengthened `addiw` step: channel-balance via constructed `OpEnvelope.addiw`
@@ -2406,10 +2349,7 @@ theorem stepStrong_addw
 theorem stepStrong_addiw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_addiw trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .addiw .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -2507,7 +2447,7 @@ theorem stepStrong_addiw
   have h_bridge : env.aeneasBridgeTrust := h_input_r1_extract
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.1
 
 /-! ## Strengthened W-shift arms (SLLW/SRLW/SRAW/SLLIW/SRLIW/SRAIW, channel-balance form)
@@ -2526,10 +2466,7 @@ real BinaryExtension Spec row from the committed trace. -/
 theorem stepStrong_sllw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sllw trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .sllw .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.RTYPEW (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, ropw.SLLW)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨(busSub trace i d.toClaim.execRow).exec_row,
@@ -2616,7 +2553,7 @@ theorem stepStrong_sllw
     exact ⟨h_input_r1_row, h_shift_pin_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `srlw` step: channel-balance via constructed `OpEnvelope.srlw`
@@ -2624,10 +2561,7 @@ theorem stepStrong_sllw
 theorem stepStrong_srlw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_srlw trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .srlw .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.RTYPEW (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, ropw.SRLW)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨(busSub trace i d.toClaim.execRow).exec_row,
@@ -2714,7 +2648,7 @@ theorem stepStrong_srlw
     exact ⟨h_input_r1_row, h_shift_pin_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `sraw` step: channel-balance via constructed `OpEnvelope.sraw`
@@ -2722,10 +2656,7 @@ theorem stepStrong_srlw
 theorem stepStrong_sraw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sraw trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .sraw .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.RTYPEW (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, ropw.SRAW)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨(busSub trace i d.toClaim.execRow).exec_row,
@@ -2813,7 +2744,7 @@ theorem stepStrong_sraw
     exact ⟨h_input_r1_row, h_shift_pin_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `slliw` step: channel-balance via constructed `OpEnvelope.slliw`
@@ -2821,10 +2752,7 @@ theorem stepStrong_sraw
 theorem stepStrong_slliw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_slliw trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .slliw .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction
       (instruction.SHIFTIWOP (d.toClaim.slliw_input.shamt, d.toClaim.r1, d.toClaim.rd, sopw.SLLIW)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
@@ -2907,7 +2835,7 @@ theorem stepStrong_slliw
     exact ⟨h_input_r1_row, h_shift_pin_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `srliw` step: channel-balance via constructed `OpEnvelope.srliw`
@@ -2915,10 +2843,7 @@ theorem stepStrong_slliw
 theorem stepStrong_srliw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_srliw trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .srliw .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction
       (instruction.SHIFTIWOP (d.toClaim.srliw_input.shamt, d.toClaim.r1, d.toClaim.rd, sopw.SRLIW)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
@@ -3001,7 +2926,7 @@ theorem stepStrong_srliw
     exact ⟨h_input_r1_row, h_shift_pin_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `sraiw` step: channel-balance via constructed `OpEnvelope.sraiw`
@@ -3009,10 +2934,7 @@ theorem stepStrong_srliw
 theorem stepStrong_sraiw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sraiw trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .sraiw .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction
       (instruction.SHIFTIWOP (d.toClaim.sraiw_input.shamt, d.toClaim.r1, d.toClaim.rd, sopw.SRAIW)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
@@ -3096,7 +3018,7 @@ theorem stepStrong_sraiw
     exact ⟨h_input_r1_row, h_shift_pin_row⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 
@@ -3108,12 +3030,7 @@ theorem stepStrong_sraiw
 theorem stepStrong_add
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_add trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val)
-      (fun env => match env with
-        | .add_via_binary .. => True | .add_via_binaryadd .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -3237,7 +3154,7 @@ theorem stepStrong_add
       exact ⟨h_input_r1_row, h_input_r2_row⟩
     have h_mem : env.memoryTimelineConstructionEvidence := by trivial
     have h_known : Defects.NoKnownDefect env :=
-      h_known_arm env trivial
+      noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
     exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.1
   · obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
         h_component, h_table_spec, h_match⟩ := h_binaryadd
@@ -3251,7 +3168,7 @@ theorem stepStrong_add
       exact ⟨d.toInputs.h_a_lo_t, d.toInputs.h_a_hi_t, d.toInputs.h_b_lo_t, d.toInputs.h_b_hi_t, h_m32_zero⟩
     have h_mem : env.memoryTimelineConstructionEvidence := by trivial
     have h_known : Defects.NoKnownDefect env :=
-      h_known_arm env trivial
+      noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
     exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.1
 
 /-- Strengthened `addi` step: channel-balance via a constructed `OpEnvelope` arm
@@ -3260,12 +3177,7 @@ theorem stepStrong_add
 theorem stepStrong_addi
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_addi trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val)
-      (fun env => match env with
-        | .addi_via_binary .. => True | .addi_via_binaryadd .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -3391,7 +3303,7 @@ theorem stepStrong_addi
       exact ⟨h_input_r1_row, h_input_imm_row⟩
     have h_mem : env.memoryTimelineConstructionEvidence := by trivial
     have h_known : Defects.NoKnownDefect env :=
-      h_known_arm env trivial
+      noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
     exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.1
   · obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
         h_component, h_table_spec, h_match⟩ := h_binaryadd
@@ -3405,7 +3317,7 @@ theorem stepStrong_addi
       exact ⟨d.toInputs.h_a_lo_t, d.toInputs.h_a_hi_t, h_m32_zero, h_set_pc_zero⟩
     have h_mem : env.memoryTimelineConstructionEvidence := by trivial
     have h_known : Defects.NoKnownDefect env :=
-      h_known_arm env trivial
+      noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
     exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.1
 
 

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
@@ -68,14 +68,11 @@ the corresponding `bus_effect`-form arms (channel-balance form, same data). -/
     `BranchInstrOperands` + `BranchPromises` `construction_beq_sound` builds) and
     invoke `zisk_riscv_compliant_program_bus`, projecting the `exec_eq_branch`
     conjunct.  `aeneasBridgeTrust` is flat decode pins carried as `RowData_beq`
-    residuals; `NoKnownDefect` comes from the threaded `h_known_arm`. -/
+    residuals; `NoKnownDefect` comes from the locally-assembled `NoKnownDefect`. -/
 theorem stepStrong_beq
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_beq trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .beq .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BEQ)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨d.toClaim.exec_row, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -106,17 +103,14 @@ theorem stepStrong_beq
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc, d.toDecode.h_jmp_offset2⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.1
 
 /-- Strengthened `bne` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_bne
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_bne trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .bne .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BNE)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨d.toClaim.exec_row, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -147,17 +141,14 @@ theorem stepStrong_bne
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc, d.toDecode.h_jmp_offset1⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.1
 
 /-- Strengthened `blt` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_blt
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_blt trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .blt .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BLT)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨d.toClaim.exec_row, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -188,17 +179,14 @@ theorem stepStrong_blt
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc, d.toDecode.h_jmp_offset2⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.1
 
 /-- Strengthened `bge` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_bge
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_bge trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .bge .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BGE)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨d.toClaim.exec_row, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -229,17 +217,14 @@ theorem stepStrong_bge
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc, d.toDecode.h_jmp_offset1⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.1
 
 /-- Strengthened `bltu` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_bltu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_bltu trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .bltu .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BLTU)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨d.toClaim.exec_row, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -270,17 +255,14 @@ theorem stepStrong_bltu
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc, d.toDecode.h_jmp_offset2⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.1
 
 /-- Strengthened `bgeu` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_bgeu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_bgeu trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .bgeu .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BGEU)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨d.toClaim.exec_row, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -311,7 +293,7 @@ theorem stepStrong_bgeu
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc, d.toDecode.h_jmp_offset1⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.1
 
 /-- Strengthened `lui` step (channel-balance form), via the OpEnvelope route:
@@ -325,14 +307,11 @@ theorem stepStrong_bgeu
     honest decode residuals, so the conversion adds no trust over the prior
     direct-lift arm.  `aeneasBridgeTrust` is the LUI tuple
     `⟨⟨provenance⟩, row_mode, h_imm_lo_nat, h_imm_hi_nat⟩`; `memoryTimeline`
-    trivially; `NoKnownDefect` from the threaded `h_known_arm` (non-defect). -/
+    trivially; `NoKnownDefect` from the locally-assembled `NoKnownDefect` (non-defect). -/
 theorem stepStrong_lui
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lui trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .lui .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.UTYPE (d.toClaim.imm, d.toClaim.rd, uop.LUI)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨d.toClaim.execRow, [eRdLui trace i]⟩ (binding i) := by
@@ -401,7 +380,7 @@ theorem stepStrong_lui
     ⟨⟨provenance⟩, row_mode, d.toDecode.h_imm_lo_nat, d.toDecode.h_imm_hi_nat⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.1
 
 /-- Strengthened `auipc` step (channel-balance form), via the OpEnvelope route:
@@ -413,14 +392,11 @@ theorem stepStrong_lui
     (`mainRowProvenance_of_pins` + `auipcRowMode_of_extracted_shape`-shape record).
     `aeneasBridgeTrust` is the AUIPC tuple
     `⟨⟨provenance⟩, row_mode, h_offset_bridge, h_pc_bridge⟩`; `NoKnownDefect` from
-    the threaded `h_known_arm` (non-defect). -/
+    the locally-assembled `NoKnownDefect` (non-defect). -/
 theorem stepStrong_auipc
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_auipc trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .auipc .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.UTYPE (d.toClaim.imm, d.toClaim.rd, uop.AUIPC)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨d.toClaim.execRow, [eRdLui trace i]⟩ (binding i) := by
@@ -489,7 +465,7 @@ theorem stepStrong_auipc
     ⟨⟨provenance⟩, row_mode, d.toInputs.h_offset_bridge, d.toInputs.h_pc_bridge⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.1
 
 /-- Strengthened `jal` step (channel-balance form), via the OpEnvelope route:
@@ -501,14 +477,11 @@ theorem stepStrong_auipc
     the JAL `provenance`/`row_mode` are BUILT from the five mode pins
     (`mainRowProvenance_of_pins`).  `aeneasBridgeTrust` is the JAL tuple
     `⟨⟨provenance⟩, row_mode, h_jmp2, h_pc_bridge⟩`; `NoKnownDefect` from the
-    threaded `h_known_arm` (non-defect). -/
+    locally-assembled `NoKnownDefect` (non-defect). -/
 theorem stepStrong_jal
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_jal trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .jal .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.JAL (d.toClaim.imm, d.toClaim.rd)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨d.toClaim.execRow, [eRdLui trace i]⟩ (binding i) := by
@@ -579,7 +552,7 @@ theorem stepStrong_jal
     ⟨⟨provenance⟩, row_mode, d.toDecode.h_jmp2, d.toInputs.h_pc_bridge⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `jalr` step (channel-balance form), via the OpEnvelope route:
@@ -587,16 +560,14 @@ theorem stepStrong_jal
     `construction_jalr_sound`'s internal `next_pc` / `e_rd` / `store_pc_mem` /
     `pins` / `h_jalr_subset` / `promises` derivations) and invoke
     `zisk_riscv_compliant_program_bus`, projecting the `exec_eq_remaining`
-    conjunct.  The threaded `h_known_arm : EnvNoKnownDefectFor …` discharges
-    `NoKnownDefect`.  JALR's `aeneasBridgeTrust` is flat decode pins already in
+    conjunct.  The non-defect arm carries no defect obligation (`True`);
+    `NoKnownDefect` is assembled locally via `noKnownDefect_of_shapes`.  JALR's
+    `aeneasBridgeTrust` is flat decode pins already in
     `RowData_jalr` (no `MainRowProvenance`). -/
 theorem stepStrong_jalr
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_jalr trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .jalr .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.JALR (d.toClaim.imm, d.toClaim.rs1, d.toClaim.rd))) (binding i)
@@ -665,7 +636,7 @@ theorem stepStrong_jalr
     ⟨d.toDecode.h_flag, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc, d.toInputs.h_link_bridge⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-! ## Strengthened store arms (SB/SH/SW/SD, channel-balance form) — OpEnvelope route
@@ -702,10 +673,7 @@ private def emptyMainEnv : Environment FGL :=
 theorem stepStrong_sb
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sb trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .sb .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.STORE
         (d.toClaim.sb_input.imm, regidx.Regidx d.toClaim.sb_input.r2, regidx.Regidx d.toClaim.sb_input.r1, 1))
         (binding i)
@@ -761,17 +729,14 @@ theorem stepStrong_sb
       h_b0' h_b1' d.toInputs.h_m1 d.toInputs.h_m2 d.toInputs.h_m3 d.toInputs.h_m4 d.toInputs.h_m5 d.toInputs.h_m6 d.toInputs.h_m7
   have h_bridge : env.aeneasBridgeTrust := ⟨d.toDecode.h_main_ind_width, h_b0', h_b1'⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
-  have h_known : Defects.NoKnownDefect env := h_known_arm env trivial
+  have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `sh` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_sh
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sh trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .sh .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.STORE
         (d.toClaim.sh_input.imm, regidx.Regidx d.toClaim.sh_input.r2, regidx.Regidx d.toClaim.sh_input.r1, 2))
         (binding i)
@@ -827,17 +792,14 @@ theorem stepStrong_sh
       h_b0' h_b1' d.toInputs.h_m2 d.toInputs.h_m3 d.toInputs.h_m4 d.toInputs.h_m5 d.toInputs.h_m6 d.toInputs.h_m7
   have h_bridge : env.aeneasBridgeTrust := ⟨d.toDecode.h_main_ind_width, h_b0', h_b1'⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
-  have h_known : Defects.NoKnownDefect env := h_known_arm env trivial
+  have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `sw` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_sw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sw trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .sw .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.STORE
         (d.toClaim.sw_input.imm, regidx.Regidx d.toClaim.sw_input.r2, regidx.Regidx d.toClaim.sw_input.r1, 4))
         (binding i)
@@ -893,17 +855,14 @@ theorem stepStrong_sw
       h_b0' h_b1' d.toInputs.h_m4 d.toInputs.h_m5 d.toInputs.h_m6 d.toInputs.h_m7
   have h_bridge : env.aeneasBridgeTrust := ⟨d.toDecode.h_main_ind_width, h_b0', h_b1'⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
-  have h_known : Defects.NoKnownDefect env := h_known_arm env trivial
+  have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `sd` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_sd
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sd trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .sd .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.STORE
         (d.toClaim.sd_input.imm, regidx.Regidx d.toClaim.sd_input.r2, regidx.Regidx d.toClaim.sd_input.r1, 8))
         (binding i)
@@ -959,7 +918,7 @@ theorem stepStrong_sd
       h_b0' h_b1'
   have h_bridge : env.aeneasBridgeTrust := ⟨h_b0', h_b1'⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
-  have h_known : Defects.NoKnownDefect env := h_known_arm env trivial
+  have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.1
 
 

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongLoadMext.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongLoadMext.lean
@@ -66,10 +66,7 @@ records are real `Valid_Mem`/`Valid_BinaryExtension` rows. -/
 theorem stepStrong_ld
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_ld trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .ld .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.LOAD
         (d.toClaim.ld_input.imm, regidx.Regidx d.toClaim.ld_input.r1, regidx.Regidx d.toClaim.ld_input.rd, false, 8))
         (binding i)
@@ -137,17 +134,14 @@ theorem stepStrong_ld
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
   have h_bridge : env.aeneasBridgeTrust := d.toDecode.h_width
   have h_mem : env.memoryTimelineConstructionEvidence := d.toInputs.h_memory_timeline
-  have h_known : Defects.NoKnownDefect env := h_known_arm env trivial
+  have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.1
 
 /-- Strengthened `lbu` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_lbu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lbu trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .lbu .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lbu_input.imm, regidx.Regidx d.toClaim.lbu_input.r1, regidx.Regidx d.toClaim.lbu_input.rd, true, 1))
         (binding i)
@@ -215,17 +209,14 @@ theorem stepStrong_lbu
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
   have h_bridge : env.aeneasBridgeTrust := d.toDecode.h_width
   have h_mem : env.memoryTimelineConstructionEvidence := d.toInputs.h_memory_timeline
-  have h_known : Defects.NoKnownDefect env := h_known_arm env trivial
+  have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `lhu` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_lhu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lhu trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .lhu .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lhu_input.imm, regidx.Regidx d.toClaim.lhu_input.r1, regidx.Regidx d.toClaim.lhu_input.rd, true, 2))
         (binding i)
@@ -293,17 +284,14 @@ theorem stepStrong_lhu
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
   have h_bridge : env.aeneasBridgeTrust := d.toDecode.h_width
   have h_mem : env.memoryTimelineConstructionEvidence := d.toInputs.h_memory_timeline
-  have h_known : Defects.NoKnownDefect env := h_known_arm env trivial
+  have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `lwu` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_lwu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lwu trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .lwu .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lwu_input.imm, regidx.Regidx d.toClaim.lwu_input.r1, regidx.Regidx d.toClaim.lwu_input.rd, true, 4))
         (binding i)
@@ -371,17 +359,14 @@ theorem stepStrong_lwu
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
   have h_bridge : env.aeneasBridgeTrust := d.toDecode.h_width
   have h_mem : env.memoryTimelineConstructionEvidence := d.toInputs.h_memory_timeline
-  have h_known : Defects.NoKnownDefect env := h_known_arm env trivial
+  have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `lb` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_lb
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lb trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .lb_via_static_match .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lb_input.imm, regidx.Regidx d.toClaim.lb_input.r1, regidx.Regidx d.toClaim.lb_input.rd, false, 1))
         (binding i)
@@ -450,17 +435,14 @@ theorem stepStrong_lb
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
   have h_bridge : env.aeneasBridgeTrust := d.toDecode.h_width
   have h_mem : env.memoryTimelineConstructionEvidence := d.toInputs.h_memory_timeline
-  have h_known : Defects.NoKnownDefect env := h_known_arm env trivial
+  have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.1
 
 /-- Strengthened `lh` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_lh
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lh trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .lh_via_static_match .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lh_input.imm, regidx.Regidx d.toClaim.lh_input.r1, regidx.Regidx d.toClaim.lh_input.rd, false, 2))
         (binding i)
@@ -529,17 +511,14 @@ theorem stepStrong_lh
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
   have h_bridge : env.aeneasBridgeTrust := d.toDecode.h_width
   have h_mem : env.memoryTimelineConstructionEvidence := d.toInputs.h_memory_timeline
-  have h_known : Defects.NoKnownDefect env := h_known_arm env trivial
+  have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.1
 
 /-- Strengthened `lw` step (channel-balance form), via the OpEnvelope route. -/
 theorem stepStrong_lw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lw trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .lw_via_static_match .. => True | _ => False)) :
+    (_h_known : True) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lw_input.imm, regidx.Regidx d.toClaim.lw_input.r1, regidx.Regidx d.toClaim.lw_input.rd, false, 4))
         (binding i)
@@ -608,7 +587,7 @@ theorem stepStrong_lw
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
   have h_bridge : env.aeneasBridgeTrust := d.toDecode.h_width
   have h_mem : env.memoryTimelineConstructionEvidence := d.toInputs.h_memory_timeline
-  have h_known : Defects.NoKnownDefect env := h_known_arm env trivial
+  have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.1
 
 /-! ## Strengthened M-ext-unsigned arms (MULW/MULHU/DIVU/DIVUW/REMU/REMUW)
@@ -638,14 +617,11 @@ the real `busSub` row.  These are strictly stronger than the corresponding
     conjunct.  The lookup-witness structures are BUILT from `mulwArow_fullSpec` via
     the `*_of_fullSpec` / `*_of_spec` builders; `aeneasBridgeTrust` is flat decode
     pins carried as `RowData_mulw` residuals (`m32 = 1` for W-mode); `NoKnownDefect`
-    comes from the threaded `h_known_arm`.  Non-vacuous (real provider FullSpec). -/
+    comes from the locally-assembled `NoKnownDefect`.  Non-vacuous (real provider FullSpec). -/
 theorem stepStrong_mulw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mulw trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .mulw .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.MULW (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd))) (binding i)
@@ -728,7 +704,7 @@ theorem stepStrong_mulw
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `mulhu` step (channel-balance form), via the OpEnvelope route:
@@ -740,7 +716,7 @@ theorem stepStrong_mulw
     `ArithMulSignedCarryRangeWitness`) are BUILT from the trace's `FullSpec`
     (`mulhuArow_fullSpec`) via the `*_of_fullSpec` / `*_of_spec` builders;
     `aeneasBridgeTrust` is flat decode pins carried as `RowData_mulhu` residuals;
-    `NoKnownDefect` comes from the threaded `h_known_arm`.
+    `NoKnownDefect` comes from the locally-assembled `NoKnownDefect`.
 
     Non-vacuous: the envelope's witnesses are the REAL provider row's FullSpec
     projections derived from `trace.channels_balanced` / `trace.spec_holds`, not a fabricated
@@ -748,10 +724,7 @@ theorem stepStrong_mulw
 theorem stepStrong_mulhu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mulhu trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .mulhu .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute
@@ -843,7 +816,7 @@ theorem stepStrong_mulhu
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `divu` step (channel-balance form), via the OpEnvelope route:
@@ -855,15 +828,12 @@ theorem stepStrong_mulhu
     `arithDiv_fullSpec_of_arithMul_fullSpec` view bridge + the ArithDiv
     `*_of_fullSpec` / `*_of_spec` builders; `remainder_bound` is the explicit
     residual carried by `RowData_divu`; `aeneasBridgeTrust` is flat decode pins;
-    `NoKnownDefect` comes from the threaded `h_known_arm`.  Non-vacuous (real
+    `NoKnownDefect` comes from the locally-assembled `NoKnownDefect`.  Non-vacuous (real
     provider FullSpec; the witnesses' substance is the balance-derived facts). -/
 theorem stepStrong_divu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_divu trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .divu .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.DIV (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, true))) (binding i)
@@ -956,7 +926,7 @@ theorem stepStrong_divu
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   -- DIVU is the dedicated `exec_eq_divu` conjunct (10th), not `exec_eq_remaining`.
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.1
 
@@ -968,10 +938,7 @@ theorem stepStrong_divu
 theorem stepStrong_divuw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_divuw trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .divuw .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.DIVW (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, true))) (binding i)
@@ -1060,7 +1027,7 @@ theorem stepStrong_divuw
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `remu` step (channel-balance form), via the OpEnvelope route:
@@ -1071,10 +1038,7 @@ theorem stepStrong_divuw
 theorem stepStrong_remu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_remu trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .remu .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.REM (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, true))) (binding i)
@@ -1163,7 +1127,7 @@ theorem stepStrong_remu
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `remuw` step (channel-balance form), via the OpEnvelope route:
@@ -1173,10 +1137,7 @@ theorem stepStrong_remu
 theorem stepStrong_remuw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_remuw trace binding i)
-    (h_known_arm : EnvNoKnownDefectFor
-      (state := binding i)
-      (m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-      (r := i.val) (fun env => match env with | .remuw .. => True | _ => False)) :
+    (_h_known : True) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.REMW (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, true))) (binding i)
@@ -1265,7 +1226,7 @@ theorem stepStrong_remuw
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
-    h_known_arm env trivial
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongSignedM.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongSignedM.lean
@@ -67,7 +67,7 @@ set_option maxHeartbeats 8000000
 theorem stepStrong_mul
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mul trace binding i)
-    (h_known : Defects.NoKnownDefect (mulEnvOf trace binding i d)) :
+    (h_known : ¬ Defects.SignedMulForge d.toInputs.v d.toInputs.r_a) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute
@@ -85,6 +85,11 @@ theorem stepStrong_mul
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc,
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
+  -- The threaded `¬ SignedMulForge` obligation is (defeq, via
+  -- `signedMulForge_iff_mulShape`) `¬ MaliciousSignedMulWitnessShape env`; the
+  -- DIV/REM and FENCE shapes are vacuous for a `.mul` env.
+  have h_known : Defects.NoKnownDefect env :=
+    noKnownDefect_of_shapes env h_known (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `mulh` step (channel-balance form), via the OpEnvelope route.
@@ -100,7 +105,7 @@ theorem stepStrong_mul
 theorem stepStrong_mulh
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mulh trace binding i)
-    (h_known : Defects.NoKnownDefect (mulhEnvOf trace binding i d)) :
+    (h_known : ¬ Defects.SignedMulForge d.toInputs.v d.toInputs.r_a) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute
@@ -118,6 +123,8 @@ theorem stepStrong_mulh
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc,
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
+  have h_known : Defects.NoKnownDefect env :=
+    noKnownDefect_of_shapes env h_known (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `mulhsu` step (channel-balance form), via the OpEnvelope route.
@@ -126,7 +133,7 @@ theorem stepStrong_mulh
 theorem stepStrong_mulhsu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mulhsu trace binding i)
-    (h_known : Defects.NoKnownDefect (mulhsuEnvOf trace binding i d)) :
+    (h_known : ¬ Defects.SignedMulForge d.toInputs.v d.toInputs.r_a) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute
@@ -144,6 +151,8 @@ theorem stepStrong_mulhsu
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc,
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
+  have h_known : Defects.NoKnownDefect env :=
+    noKnownDefect_of_shapes env h_known (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `div` step (channel-balance form), via the OpEnvelope route.
@@ -169,7 +178,7 @@ theorem stepStrong_mulhsu
 theorem stepStrong_div
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_div trace binding i)
-    (h_known : Defects.NoKnownDefect (divEnvOf trace binding i d)) :
+    (h_known : ¬ Defects.DivRemForge d.toInputs.div_input.r2_val d.toInputs.v d.toInputs.r_a) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.DIV (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, false))) (binding i)
@@ -182,6 +191,11 @@ theorem stepStrong_div
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc,
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
+  -- The threaded `¬ DivRemForge` obligation is (defeq, via
+  -- `divRemForge_iff_divShape`) `¬ ArithDivDynamicWitnessShape env`; the
+  -- signed-MUL and FENCE shapes are vacuous for a `.div` env.
+  have h_known : Defects.NoKnownDefect env :=
+    noKnownDefect_of_shapes env (fun h => h) h_known trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `rem` step (channel-balance form), via the OpEnvelope route.
@@ -192,7 +206,7 @@ theorem stepStrong_div
 theorem stepStrong_rem
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_rem trace binding i)
-    (h_known : Defects.NoKnownDefect (remEnvOf trace binding i d)) :
+    (h_known : ¬ Defects.DivRemForge d.toInputs.rem_input.r2_val d.toInputs.v d.toInputs.r_a) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.REM (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, false))) (binding i)
@@ -205,6 +219,8 @@ theorem stepStrong_rem
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc,
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
+  have h_known : Defects.NoKnownDefect env :=
+    noKnownDefect_of_shapes env (fun h => h) h_known trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `divw` step (channel-balance form), via the OpEnvelope route.
@@ -216,7 +232,7 @@ theorem stepStrong_rem
 theorem stepStrong_divw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_divw trace binding i)
-    (h_known : Defects.NoKnownDefect (divwEnvOf trace binding i d)) :
+    (h_known : ¬ Defects.DivRemForgeW d.toInputs.divw_input.r2_val d.toInputs.v d.toInputs.r_a) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.DIVW (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, false))) (binding i)
@@ -229,6 +245,8 @@ theorem stepStrong_divw
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc,
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
+  have h_known : Defects.NoKnownDefect env :=
+    noKnownDefect_of_shapes env (fun h => h) h_known trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `remw` step (channel-balance form), via the OpEnvelope route.
@@ -237,7 +255,7 @@ theorem stepStrong_divw
 theorem stepStrong_remw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_remw trace binding i)
-    (h_known : Defects.NoKnownDefect (remwEnvOf trace binding i d)) :
+    (h_known : ¬ Defects.DivRemForgeW d.toInputs.remw_input.r2_val d.toInputs.v d.toInputs.r_a) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.REMW (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, false))) (binding i)
@@ -250,6 +268,8 @@ theorem stepStrong_remw
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc,
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
+  have h_known : Defects.NoKnownDefect env :=
+    noKnownDefect_of_shapes env (fun h => h) h_known trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-- Strengthened `fence` step (channel-balance form), via the OpEnvelope route.
@@ -271,7 +291,7 @@ theorem stepStrong_remw
 theorem stepStrong_fence
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_fence trace binding i)
-    (h_known : Defects.NoKnownDefect (fenceEnvOf trace binding i d)) :
+    (h_known : Defects.FenceKnownGood d.toClaim.fm d.toClaim.rs d.toClaim.rd) :
     execute_instruction (instruction.FENCE (d.toClaim.fm, d.toClaim.fenceP, d.toClaim.fenceS, d.toClaim.rs, d.toClaim.rd)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨d.toClaim.exec_row, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -279,6 +299,11 @@ theorem stepStrong_fence
   let env : OpEnvelope state m i.val := fenceEnvOf trace binding i d
   have h_bridge : env.aeneasBridgeTrust := ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
+  -- The threaded `FenceKnownGood` obligation is (defeq, via
+  -- `fenceKnownGood_iff_fenceShape`) `FenceKnownGoodShape env`; the signed-MUL
+  -- and DIV/REM shapes are vacuous for a `.fence` env.
+  have h_known : Defects.NoKnownDefect env :=
+    noKnownDefect_of_shapes env (fun h => h) (fun h => h) h_known
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.1
 
 

--- a/ZiskFv/Soundness.lean
+++ b/ZiskFv/Soundness.lean
@@ -41,7 +41,7 @@ theorem root_soundness
     (rowDecodes : ∀ i : Fin numInstructions, RowDecode ziskTrace i (ziskStep i))
     (inputsAgree : ∀ i : Fin numInstructions, InputsAgree ziskTrace sailTrace i (ziskStep i))
     (hAvoidKnownBugs : ∀ i : Fin numInstructions,
-      StepNoKnownDefect ziskTrace sailTrace i (ziskStep i) (rowDecodes i) (inputsAgree i)) :
+      StepNoKnownDefect ziskTrace sailTrace i (ziskStep i) (inputsAgree i)) :
     ∀ i : Fin numInstructions, StepFaithful ziskTrace sailTrace i (ziskStep i) :=
   fun i =>
     stepFaithful_of_evidence ziskTrace sailTrace i (ziskStep i) (rowDecodes i) (inputsAgree i) (hAvoidKnownBugs i)

--- a/trust/dead-code-entry-points.txt
+++ b/trust/dead-code-entry-points.txt
@@ -10,9 +10,10 @@
 ZiskFv.Compliance.zisk_riscv_compliant_program_bus
 #
 # Group 1b: the P5 trace-level export theorem (#61). The env-constructed
-# channel-balance export over the 56 strengthened archetypes. Reaches
-# StrongRowConstructionData / RowData_<op> / StepFaithful /
-# stepFaithful_of_evidence / stepStrong_<op> / zeroValidBinary.
+# channel-balance export over the 63 strengthened archetypes. Reaches
+# ZiskStep / RowDecode / InputsAgree / RowData_<op> / StepNoKnownDefect /
+# StepFaithful / stepFaithful_of_evidence / stepStrong_<op> /
+# noKnownDefect_of_shapes / zeroValidBinary.
 ZiskFv.Compliance.root_soundness
 #
 # Group 2: the 63 canonical `equiv_<OP>` theorems (one per RV64IM

--- a/trust/generated/baseline-strong-export-binders.txt
+++ b/trust/generated/baseline-strong-export-binders.txt
@@ -4,5 +4,5 @@
 3 :: ziskStep :: (i : Fin numInstructions) → ZiskFv.Compliance.ZiskStep ziskTrace i
 4 :: rowDecodes :: (i : Fin numInstructions) → ZiskFv.Compliance.RowDecode ziskTrace i (ziskStep i)
 5 :: inputsAgree :: (i : Fin numInstructions) → ZiskFv.Compliance.InputsAgree ziskTrace sailTrace i (ziskStep i)
-6 :: hAvoidKnownBugs :: ∀ (i : Fin numInstructions), ZiskFv.Compliance.StepNoKnownDefect ziskTrace sailTrace i (ziskStep i) (rowDecodes i) (inputsAgree i)
+6 :: hAvoidKnownBugs :: ∀ (i : Fin numInstructions), ZiskFv.Compliance.StepNoKnownDefect ziskTrace sailTrace i (ziskStep i) (inputsAgree i)
 7 :: i :: Fin numInstructions


### PR DESCRIPTION
**Stacked on #148** (base `clarity/rename-known-bugs`). Merge after #148.

Re-states the three known-defect predicates over the `Inputs_<op>`/`Claim_<op>` row data instead of the legacy `OpEnvelope` sum, collapsing `StepNoKnownDefect` to one 8-arm + wildcard `match` (no `OpEnvelope`, no `rd` param). `hAvoidKnownBugs` drops `rowDecodes` (a forge is a witness property, not a decode fact).

Deleted: `EnvNoKnownDefectFor`, `toFull`, `StrongRowConstructionData`, `StepNoKnownDefectOn`, and the 55 selector arms. **Net −425 lines.**

**Faithfulness audit:** 8 bridge lemmas, each `:= Iff.rfl` — the row-data shapes are *definitionally* the old `OpEnvelope` shapes, so the re-expression provably changed no meaning.

**Verified:** full build green (8760); V1 16/16 (incl. partition check); V2 13/13; 0 axioms; no `sorry`/`axiom`/`decide`; `baseline-equiv-axiom-deps.txt` + `baseline-axioms.txt` byte-identical (only the `hAvoidKnownBugs` binder line moved — lost `rowDecodes`).

Follow-on (separate): re-root the shapes onto `ziskTrace` directly to drop `inputsAgree`/`sailTrace` + the `RowOutsideDefectRegion`/`StepSound` renames (PLAN_DEFECTS_TRACE_LOCAL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)