### PR TITLE
Rename defect/soundness decls (RowOutsideDefectRegion / StepSound); defer trace-local re-rooting

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,38 +1,50 @@
-Stream: lift known-defect predicates off OpEnvelope onto row data.
-Branch: clarity/defects-on-rowdata. Plan: docs/ai/plan/PLAN_DEFECTS_ON_ROWDATA.md
+Stream: re-root known-defect predicates onto ziskTrace (drop inputsAgree) + rename trio.
+Branch: clarity/defects-trace-local (off clarity/defects-on-rowdata = PR #149).
+Plan: docs/ai/plan/PLAN_DEFECTS_TRACE_LOCAL.md
 
-Goal: re-express the three known-defect predicates over the Inputs_<op>/Claim_<op>
-row data instead of the legacy OpEnvelope sum, collapsing StepNoKnownDefect to one
-8-arm + wildcard `match`. Semantics-preserving re-expression — trust footprint
-byte-identical (NOT a discharge).
+Goal: make the per-step defect predicate row-local (read the forge witness off
+ziskTrace, not inputsAgree), drop inputsAgree/sailTrace from the defect path, and
+apply the rename trio.
 
-Status: COMPLETE. Committed 97b3841e, pushed origin/clarity/defects-on-rowdata
-(no PR). Steps A–F all done.
+Status: PARTIAL. Step 3 (renames) DONE; steps 1/2 (trace projection, drop
+inputsAgree) DEFERRED — genuine blocker, see below.
 
-- A Defects.lean: SignedMulForge / DivRemForge / DivRemForgeW / FenceKnownGood
-  (same conditions as the OpEnvelope shapes).
-- B EnvOf.lean: 8 PROVED `Iff.rfl` bridge lemmas (faithfulness audit).
-- C Dispatcher.lean: StepNoKnownDefect = direct `match zs, ia`; deleted
-  EnvNoKnownDefectFor / envNoKnownDefectFor_of_nondefect / toFull /
-  StrongRowConstructionData / StepNoKnownDefectOn + 55 selector arms.
-  Base.lean: added general `noKnownDefect_of_shapes` helper.
-- D 63 stepStrong rewired: 55 non-defect take (_h_known : True) + build
-  NoKnownDefect locally; 8 defect consume row-data forge-negation via the helper.
-- E Soundness.lean: h_known_bugs drops (rowDecodes i). Sole sanctioned baseline
-  churn = the h_known_bugs binder line in baseline-strong-export-binders.txt.
-- F TraceLevelExport.lean module doc + dead-code-entry-points.txt comment refreshed.
+Done (step 3 — decl renames, pure):
+- StepNoKnownDefect    → RowOutsideDefectRegion
+- StepFaithful         → StepSound
+- stepFaithful_of_evidence → stepSound_of_evidence
+- root_soundness binder hAvoidKnownBugs → rowsOutsideDefects
+  Files: Dispatcher.lean, Soundness.lean, Defects.lean (doc), TraceLevelExport.lean
+  (doc), EnvOf.lean (doc), StepStrongSignedM.lean (doc), dead-code-entry-points.txt.
+  Sole baseline churn: baseline-strong-export-binders.txt line 6 (binder/type rename;
+  still retains sailTrace+inputsAgree → confirms the deferred removal).
 
-Verification: lake build green (8760); V1 (incl. RowData-partition check 16) +
-V2 both PASS; 0 project axioms; no axiom/sorry/native_decide/bare decide added.
-baseline-equiv-axiom-deps.txt + baseline-axioms.txt byte-identical to origin/main.
+DEFERRED (steps 1/2 — drop inputsAgree/sailTrace from the defect path): BLOCKED.
+The forge shapes read v.na/nb/np (signed-MUL) and v.nr/v.d_* (DIV/REM) — committed
+Arith WITNESS columns that are NOT carried on the operation-bus message. See
+ZiskFv/Airs/Arith/Mul.lean:199-242 (opBus_row_Arith / opBus_row_ArithMulSecondary
+expose only op, a/b/c lanes, mult, flag — no na/nb/np). So h_match_primary /
+h_match_secondary (op-bus matches_entry) cannot pin na/nb/np. Further, NO
+main_request_<op>_provided / exists_arithMul_provider_row_matches_* derivation
+exists for the 7 defect ops (only the 6 non-defect M-ext ops mulw/mulhu/divu/
+divuw/remu/remuw — OpBusProviderMatch.lean / ArithBalance.lean), and
+Inputs_<op>.h_match_* is a caller-supplied field. Bridging a trace-projected
+witness's ¬shape back to the env's caller-supplied ia.v (as stepStrong_<op> needs)
+would require an Arith-provider-table accessor reading the committed sign columns
+PLUS a uniqueness argument the op bus does not supply — i.e. exactly the
+Arith-fidelity / na=MSB infrastructure the plan declares out of scope and
+footprint-neutral. The plan's premise ("values already tied to the matched Arith
+row by h_match_*") is false for the na/nb/np / nr portion.
 
-Open questions (resolved empirically):
-- 55 non-defect proofs needed no content change beyond binder/`have` rewiring —
-  noKnownDefect_of_shapes closes the vacuous shapes definitionally.
-- Dropping rowDecodes from h_known_bugs threads cleanly through the 8 defect
-  proofs (they take rowDecodes from their own `d` binder to build the env).
-
-Blocking: none. Next: the metaprogramming/macro pass is a separate later phase.
+Verification: lake build green (8768); V1 16/16 (incl. partition check 16) + V2
+13/13 PASS; 0 project axioms; no axiom/sorry/native_decide/bare decide added.
+baseline-equiv-axiom-deps.txt + baseline-axioms.txt byte-identical to
+origin/clarity/defects-on-rowdata (footprint-neutral, as intended).
 
 Env note: build/ symlinked to /home/cody/zisk-fv/build; zisk submodule inited.
-Both are env-only, never committed.
+Both env-only, never committed.
+
+Next: steps 1/2 require building the defect-op Arith provider-match derivations
++ an Arith-provider-table witness accessor (committed na/nb/np), which is the
+#114-cat-D / arith-fidelity workstream — not footprint-neutral. Re-scope before
+attempting.

--- a/ZiskFv/Compliance/Defects.lean
+++ b/ZiskFv/Compliance/Defects.lean
@@ -152,7 +152,7 @@ The four predicates below state the SAME conditions as the `OpEnvelope`-based
 shapes above (`MaliciousSignedMulWitnessShape`, `ArithDivDynamicWitnessShape`,
 `FenceKnownGoodShape`), re-expressed directly over the arith witness / claim
 fields that live in the `Inputs_<op>` / `Claim_<op>` row data.  This lets the
-threaded `StepNoKnownDefect` obligation read the defect condition off the row
+threaded `RowOutsideDefectRegion` obligation read the defect condition off the row
 data without the `OpEnvelope` detour.  The faithfulness of the re-expression is
 the content of the bridge lemmas `signedMulForge_iff_shape` /
 `divRemForge_iff_shape` / `divRemForgeW_iff_shape` / `fenceKnownGood_iff_shape`

--- a/ZiskFv/Compliance/TraceLevelExport.lean
+++ b/ZiskFv/Compliance/TraceLevelExport.lean
@@ -23,7 +23,7 @@ defect-exclusion obligation `h_known_bugs`, EVERY row of the trace satisfies the
 canonical per-step channel-balance conclusion (`= state_effect_via_channels …`)
 — the SAME conclusion the OLD global theorem `zisk_riscv_compliant_program_bus`
 produces — with NO caller-supplied `OpEnvelope`.  The envelope for each row is
-constructed/lifted INSIDE, per row, by `stepFaithful_of_evidence` dispatching the
+constructed/lifted INSIDE, per row, by `stepSound_of_evidence` dispatching the
 reassembled `RowData_<op>` to the matching `stepStrong_<op>`.
 
 > The earlier, weaker `bus_effect`-form export (`RowConstructionData` /
@@ -97,8 +97,8 @@ global theorem produces:
 ## Threaded defect-exclusion hypothesis (`h_known_bugs`)
 
 The `h_known_bugs` premise is the per-row defect-exclusion obligation
-(`StepNoKnownDefect`), stated DIRECTLY over the row data (no `OpEnvelope`
-detour).  It is threaded — via `stepFaithful_of_evidence` — to each
+(`RowOutsideDefectRegion`), stated DIRECTLY over the row data (no `OpEnvelope`
+detour).  It is threaded — via `stepSound_of_evidence` — to each
 `stepStrong_<op>`.  It takes two shapes across the 63 arms, all SATISFIABLE for
 an honest row (so this export is NOT vacuous):
   * **Non-defect arms** (op-bus ALU + M-ext-unsigned + control-flow / U-type /

--- a/ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean
@@ -270,7 +270,7 @@ def InputsAgree (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : Sai
     `OpEnvelope` defect shape (the `Iff.rfl` bridge lemmas in `EnvOf`), so the
     re-expression off `OpEnvelope` carries no change of meaning.  Every other
     (non-defect) arm carries no defect obligation (`True`). -/
-def StepNoKnownDefect (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions)
+def RowOutsideDefectRegion (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions)
     (i : Fin ziskTrace.numInstructions) (zs : ZiskStep ziskTrace i)
     (ia : InputsAgree ziskTrace sailTrace i zs) : Prop :=
   match zs, ia with
@@ -284,7 +284,7 @@ def StepNoKnownDefect (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace
   | .fence c, _ => Defects.FenceKnownGood c.fm c.rs c.rd
   | _, _ => True
 
-def StepFaithful
+def StepSound
     (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions) (i : Fin ziskTrace.numInstructions) :
     ZiskStep ziskTrace i → Prop
   | .sub c =>
@@ -760,7 +760,7 @@ def StepFaithful
 /-- Per-row dispatch to the matching strengthened step theorem.
 
     The `h_known` parameter carries the per-row defect-exclusion obligation
-    (`StepNoKnownDefect`), stated directly over the row data.  For the 8
+    (`RowOutsideDefectRegion`), stated directly over the row data.  For the 8
     defect-capable arms it is the row-data forge-negation / FENCE-known-good
     fact; the dispatcher hands it straight to the corresponding `stepStrong_<op>`,
     which assembles `NoKnownDefect (<op>EnvOf …)` from it (via
@@ -768,11 +768,11 @@ def StepFaithful
     `zisk_riscv_compliant_program_bus`.  For every other (non-defect) arm the
     obligation is `True` and is ignored — the arm builds its own `NoKnownDefect`. -/
 
-theorem stepFaithful_of_evidence (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions)
+theorem stepSound_of_evidence (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions)
     (i : Fin ziskTrace.numInstructions) (zs : ZiskStep ziskTrace i)
     (rd : RowDecode ziskTrace i zs) (ia : InputsAgree ziskTrace sailTrace i zs)
-    (h_known : StepNoKnownDefect ziskTrace sailTrace i zs ia) :
-    StepFaithful ziskTrace sailTrace i zs := by
+    (h_known : RowOutsideDefectRegion ziskTrace sailTrace i zs ia) :
+    StepSound ziskTrace sailTrace i zs := by
   cases zs with
   | sub c => exact stepStrong_sub ziskTrace sailTrace i (toRowData_sub c rd ia) h_known
   | and c => exact stepStrong_and ziskTrace sailTrace i (toRowData_and c rd ia) h_known

--- a/ZiskFv/Compliance/TraceLevelExport/EnvOf.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/EnvOf.lean
@@ -45,7 +45,7 @@ seal mulwArow mulhuArow divuArow divuwArow remuArow remuwArow
 set_option maxHeartbeats 8000000
 
 /-- The `OpEnvelope.fence` env CONSTRUCTED from a `RowData_fence`.  Both the
-    `StepNoKnownDefect` fence obligation AND `stepStrong_fence` reference THIS env,
+    `RowOutsideDefectRegion` fence obligation AND `stepStrong_fence` reference THIS env,
     so the threaded `NoKnownDefect` obligation is the genuine `NoKnownDefect` of the
     exact env the proof feeds to `zisk_riscv_compliant_program_bus`. -/
 noncomputable def fenceEnvOf
@@ -63,7 +63,7 @@ noncomputable def fenceEnvOf
       nextPC_matches := d.toInputs.h_nextPC_matches }
 
 /-- The `OpEnvelope.mul` env CONSTRUCTED from a `RowData_mul`.  Both the
-    `StepNoKnownDefect` mul obligation AND `stepStrong_mul` reference THIS env, so
+    `RowOutsideDefectRegion` mul obligation AND `stepStrong_mul` reference THIS env, so
     the threaded `NoKnownDefect` obligation is the genuine `NoKnownDefect` of the
     exact env the proof feeds to `zisk_riscv_compliant_program_bus`.  (Mirrors
     `fenceEnvOf`: a specific-env obligation, SATISFIABLE for an honest row.) -/
@@ -79,7 +79,7 @@ noncomputable def mulEnvOf
 
 /-- **Satisfiability / non-vacuity witness for the threaded MUL obligation.**
 
-    The `StepNoKnownDefect (.mul d)` obligation — `Defects.NoKnownDefect (mulEnvOf
+    The `RowOutsideDefectRegion (.mul d)` obligation — `Defects.NoKnownDefect (mulEnvOf
     …)` — is DISCHARGED from `RowData_mul.h_not_forge` (the honest product-sign
     shape).  Concretely: for the `.mul` env, the arith-div defect predicate is
     `False` and the FENCE defect predicate's negation is `True`, while the
@@ -164,7 +164,7 @@ theorem mulhsu_noKnownDefect_of_rowData
       simp [Defects.Blocks, Defects.FenceKnownGoodShape, mulhsuEnvOf]
 
 /-- The `OpEnvelope.div` env CONSTRUCTED from a `RowData_div`.  Both the
-    `StepNoKnownDefect` div obligation AND `stepStrong_div` reference THIS env, so
+    `RowOutsideDefectRegion` div obligation AND `stepStrong_div` reference THIS env, so
     the threaded `NoKnownDefect` obligation is the genuine `NoKnownDefect` of the
     exact env the proof feeds to `zisk_riscv_compliant_program_bus`.  (Mirrors
     `mulEnvOf`: a specific-env obligation, SATISFIABLE for an honest signed DIV
@@ -220,7 +220,7 @@ noncomputable def remwEnvOf
 
 /-- **Non-vacuity / satisfiability witness for the threaded DIV obligation.**
 
-    The `StepNoKnownDefect (.div d)` obligation — `Defects.NoKnownDefect (divEnvOf
+    The `RowOutsideDefectRegion (.div d)` obligation — `Defects.NoKnownDefect (divEnvOf
     …)` — is DISCHARGED from `RowData_div.h_not_forge` (the narrowed honest shape
     nonzero-divisor `|r| ≠ |op2|` shape).  Concretely: for the `.div` env the
     arith-MUL defect predicate is `False` (not a mul env) and the FENCE defect
@@ -298,7 +298,7 @@ theorem remw_noKnownDefect_of_rowData
 Each bridge is `Iff.rfl`: the row-data predicate (over the `Inputs_<op>` arith
 witness / `Claim_<op>` fields) and the `OpEnvelope`-based defect shape at the
 corresponding `<op>EnvOf` env are DEFINITIONALLY the same proposition.  These are
-the faithfulness audit for the `StepNoKnownDefect` re-expression (plan step B):
+the faithfulness audit for the `RowOutsideDefectRegion` re-expression (plan step B):
 they witness that lifting the three known-defect conditions off `OpEnvelope`
 onto the row data changed no meaning — the `Iff.rfl` proofs would fail if the
 re-expressed predicate were even slightly weaker or stronger than the original

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongSignedM.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongSignedM.lean
@@ -56,7 +56,7 @@ set_option maxHeartbeats 8000000
     witnessed by `arith_mem`).
 
     The `NoKnownDefect` obligation is supplied DIRECTLY by the caller as
-    `h_known : Defects.NoKnownDefect (mulEnvOf …)` (= `StepNoKnownDefect`'s mul
+    `h_known : Defects.NoKnownDefect (mulEnvOf …)` (= `RowOutsideDefectRegion`'s mul
     arm) — the GENUINE `NoKnownDefect` of the SPECIFIC env this proof feeds to the
     global theorem, NOT a selector-∀ and NOT a contradictory `False`-binder.  It is
     SATISFIABLE: for an honest MUL row (`RowData_mul.h_not_forge`, i.e.
@@ -166,7 +166,7 @@ theorem stepStrong_mulhsu
     witnessed by `arith_mem`).
 
     The `NoKnownDefect` obligation is supplied DIRECTLY by the caller as
-    `h_known : Defects.NoKnownDefect (divEnvOf …)` (= `StepNoKnownDefect`'s div
+    `h_known : Defects.NoKnownDefect (divEnvOf …)` (= `RowOutsideDefectRegion`'s div
     arm) — the GENUINE `NoKnownDefect` of the SPECIFIC env this proof feeds to the
     global theorem, NOT a selector-∀ and NOT a contradictory `False`-binder.  It is
     SATISFIABLE: for an honest signed DIV row (`RowData_div.h_not_forge`, i.e.
@@ -281,7 +281,7 @@ theorem stepStrong_remw
     memory-timeline obligation is trivial (FENCE has no memory entry).
 
     The `NoKnownDefect` obligation is supplied DIRECTLY by the caller as
-    `h_known : Defects.NoKnownDefect (fenceEnvOf …)` (= `StepNoKnownDefect`'s fence
+    `h_known : Defects.NoKnownDefect (fenceEnvOf …)` (= `RowOutsideDefectRegion`'s fence
     arm) — the GENUINE `NoKnownDefect` of the SPECIFIC env this proof feeds to the
     old theorem, NOT a selector-∀ and NOT a contradictory `False`-binder.  It is
     SATISFIABLE: for an honest FENCE row (`RowData_fence.h_fm_zero` / `h_rs_x0` /

--- a/ZiskFv/Soundness.lean
+++ b/ZiskFv/Soundness.lean
@@ -27,7 +27,7 @@ namespace ZiskFv.Compliance
     indices + committed bus row); `rowDecodes` is the circuit-checkable fact that
     the row is a well-formed instance of that op; and `inputsAgree` is the
     cross-world fact that ZisK's inputs equal the Sail model's register / PC /
-    memory state. `hAvoidKnownBugs` excludes the enumerated forge defects.
+    memory state. `rowsOutsideDefects` excludes the enumerated forge defects.
 
     Every row then satisfies the canonical channel-balance conclusion
     (`= state_effect_via_channels …`). The per-row `OpEnvelope` is constructed
@@ -40,10 +40,10 @@ theorem root_soundness
     (ziskStep : ∀ i : Fin numInstructions, ZiskStep ziskTrace i)
     (rowDecodes : ∀ i : Fin numInstructions, RowDecode ziskTrace i (ziskStep i))
     (inputsAgree : ∀ i : Fin numInstructions, InputsAgree ziskTrace sailTrace i (ziskStep i))
-    (hAvoidKnownBugs : ∀ i : Fin numInstructions,
-      StepNoKnownDefect ziskTrace sailTrace i (ziskStep i) (inputsAgree i)) :
-    ∀ i : Fin numInstructions, StepFaithful ziskTrace sailTrace i (ziskStep i) :=
+    (rowsOutsideDefects : ∀ i : Fin numInstructions,
+      RowOutsideDefectRegion ziskTrace sailTrace i (ziskStep i) (inputsAgree i)) :
+    ∀ i : Fin numInstructions, StepSound ziskTrace sailTrace i (ziskStep i) :=
   fun i =>
-    stepFaithful_of_evidence ziskTrace sailTrace i (ziskStep i) (rowDecodes i) (inputsAgree i) (hAvoidKnownBugs i)
+    stepSound_of_evidence ziskTrace sailTrace i (ziskStep i) (rowDecodes i) (inputsAgree i) (rowsOutsideDefects i)
 
 end ZiskFv.Compliance

--- a/trust/dead-code-entry-points.txt
+++ b/trust/dead-code-entry-points.txt
@@ -11,8 +11,8 @@ ZiskFv.Compliance.zisk_riscv_compliant_program_bus
 #
 # Group 1b: the P5 trace-level export theorem (#61). The env-constructed
 # channel-balance export over the 63 strengthened archetypes. Reaches
-# ZiskStep / RowDecode / InputsAgree / RowData_<op> / StepNoKnownDefect /
-# StepFaithful / stepFaithful_of_evidence / stepStrong_<op> /
+# ZiskStep / RowDecode / InputsAgree / RowData_<op> / RowOutsideDefectRegion /
+# StepSound / stepSound_of_evidence / stepStrong_<op> /
 # noKnownDefect_of_shapes / zeroValidBinary.
 ZiskFv.Compliance.root_soundness
 #

--- a/trust/generated/baseline-strong-export-binders.txt
+++ b/trust/generated/baseline-strong-export-binders.txt
@@ -4,5 +4,5 @@
 3 :: ziskStep :: (i : Fin numInstructions) → ZiskFv.Compliance.ZiskStep ziskTrace i
 4 :: rowDecodes :: (i : Fin numInstructions) → ZiskFv.Compliance.RowDecode ziskTrace i (ziskStep i)
 5 :: inputsAgree :: (i : Fin numInstructions) → ZiskFv.Compliance.InputsAgree ziskTrace sailTrace i (ziskStep i)
-6 :: hAvoidKnownBugs :: ∀ (i : Fin numInstructions), ZiskFv.Compliance.StepNoKnownDefect ziskTrace sailTrace i (ziskStep i) (inputsAgree i)
+6 :: rowsOutsideDefects :: ∀ (i : Fin numInstructions), ZiskFv.Compliance.RowOutsideDefectRegion ziskTrace sailTrace i (ziskStep i) (inputsAgree i)
 7 :: i :: Fin numInstructions


### PR DESCRIPTION
**Stacked on #149** (base `clarity/defects-on-rowdata`).

Pure decl renames:
- `StepNoKnownDefect → RowOutsideDefectRegion` (matches the `Blocks` "defect region" vocabulary)
- `StepFaithful → StepSound` (this is the soundness axis; completeness is separate)
- `stepFaithful_of_evidence → stepSound_of_evidence`
- binder `hAvoidKnownBugs → rowsOutsideDefects`

**Deferred (genuine blocker, not done here):** dropping `inputsAgree`/`sailTrace` from `RowOutsideDefectRegion` (the row-local re-rooting). It is **blocked on #114-cat-D**: the forge witness columns (`na/nb/np`, `nr`, `d_*`) are not on the operation bus (`Airs/Arith/Mul.lean:199-242`), and there is no provider-row derivation for the 7 defect ops (only the 6 non-defect M-ext ops). Reading them off the trace needs the Arith-table-fidelity + uniqueness infrastructure of #114-cat-D, so `RowOutsideDefectRegion` still takes `inputsAgree`/`sailTrace` (its docstring says so honestly). FENCE alone is already trace-local.

**Verified:** build green (8760); V1 16/16; V2 13/13; 0 axioms; no `sorry`/`axiom`/`decide`; `equiv-axiom-deps`/`axioms` byte-identical (renames only; just the binder-baseline line moved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)