### PR TITLE
ci: refresh issue dependency graph hourly

### DIFF
--- a/.github/workflows/issue-deps-graph.yml
+++ b/.github/workflows/issue-deps-graph.yml
@@ -7,7 +7,7 @@ on:
   schedule:
     # Dependency-sidebar edits do not always produce a useful workflow event.
     # This cheap, no-commit refresh catches drift without triggering proof CI.
-    - cron: '17 9 * * *'
+    - cron: '17 * * * *'
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,9 @@ itself.
 
 When creating an issue, decide whether it has a strict prerequisite before
 leaving the task. If it does, set the GitHub `blockedBy` relationship immediately
-after creation and refresh the canonical graph issue.
+after creation. The canonical graph issue is refreshed automatically by the
+workflow; run the manual updater only when you need an immediate refresh or are
+repairing/debugging the automation.
 
 ## GitHub Issue Structure
 
@@ -75,7 +77,7 @@ mutation($blocked:ID!, $blocker:ID!) {
   GitHub labels (`soundness`, `completeness`, both, neither).
 - List parent/sub-issue relationships separately from the Mermaid dependency
   graph unless they also have structured blocker edges.
-- Refresh the graph issue with:
+- For an immediate refresh, run:
 
 ```bash
 python3 scripts/update_issue_deps_graph.py \
@@ -85,5 +87,6 @@ python3 scripts/update_issue_deps_graph.py \
   --update
 ```
 
-- The workflow `.github/workflows/issue-deps-graph.yml` runs the same updater
-  without committing generated Markdown, so it does not trigger push/PR proof CI.
+- The workflow `.github/workflows/issue-deps-graph.yml` runs the same updater on
+  issue events and on an hourly schedule, without committing generated Markdown,
+  so it does not trigger push/PR proof CI.


### PR DESCRIPTION
## Summary
- change the canonical issue dependency graph scheduled refresh from daily to hourly
- clarify AGENTS.md that normal graph maintenance is automatic and the manual updater is only for immediate refreshes/debugging

## Notes
The graph remains derived from GitHub issue metadata and rendered only in the canonical `Issue dependency graph` issue. The workflow edits that issue body; it does not commit generated Mermaid or trigger proof CI from graph refreshes.

## Verification
- `git diff --check -- .github/workflows/issue-deps-graph.yml AGENTS.md`