### PR TITLE
Reduce store RMW memory residual

### DIFF
--- a/ZiskFv/Compliance.lean
+++ b/ZiskFv/Compliance.lean
@@ -55,6 +55,11 @@ construction residual for load arms: the generated replay trace contains the
 selected load row, and the load Sail state aligns with the selected replay
 prefix. Non-load arms impose no memory-timeline obligation.
 
+Sub-doubleword store arms carry their RMW memory residual separately as
+`StoreRmwMemoryCoherenceEvidence` in the store envelope/rowData split. Dispatch
+projects the old preserved-byte facts from that named evidence before calling
+the internal clean store cores.
+
 `zisk_riscv_compliant_program_bus` is the single public global theorem. It is
 defect-aware while `trust/defects.md` contains open claim-weakening defects:
 the `h_known_bugs` binder is orthogonal to the validity witnesses already

--- a/ZiskFv/Compliance/AeneasBridgeTrust/Stores.lean
+++ b/ZiskFv/Compliance/AeneasBridgeTrust/Stores.lean
@@ -41,13 +41,7 @@ def OpEnvelope.sbOfExtractedShape
         (sb_input.r1_val + BitVec.signExtend 64 sb_input.imm).toNat)
     (h_b0_value : m.b_0 r_main = ZiskFv.Trusted.lane_lo sb_input.r2_val)
     (h_b1_value : m.b_1 r_main = ZiskFv.Trusted.lane_hi sb_input.r2_val)
-    (h_m1 : state.mem[bus.e2.ptr.toNat + 1]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 1 : BitVec 8))
-    (h_m2 : state.mem[bus.e2.ptr.toNat + 2]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 2 : BitVec 8))
-    (h_m3 : state.mem[bus.e2.ptr.toNat + 3]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 3 : BitVec 8))
-    (h_m4 : state.mem[bus.e2.ptr.toNat + 4]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 4 : BitVec 8))
-    (h_m5 : state.mem[bus.e2.ptr.toNat + 5]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 5 : BitVec 8))
-    (h_m6 : state.mem[bus.e2.ptr.toNat + 6]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 6 : BitVec 8))
-    (h_m7 : state.mem[bus.e2.ptr.toNat + 7]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 7 : BitVec 8)) :
+    (h_store_rmw : StoreRmwMemoryCoherenceEvidence state bus.e2 1) :
     OpEnvelope state m r_main :=
   OpEnvelope.sb sb_input regs bus
     (MainRowProvenance.copybPins_of_extracted_shape provenance h_op h_internal)
@@ -56,7 +50,7 @@ def OpEnvelope.sbOfExtractedShape
     h_opcode_assumptions promises h_main_row h_main_spec
     (MainRowProvenance.cleanStorePcZero_of_extracted_shape provenance
       h_store_pc_shape h_main_row)
-    h_main_c_match h_addr2 h_b0_value h_b1_value h_m1 h_m2 h_m3 h_m4 h_m5 h_m6 h_m7
+    h_main_c_match h_addr2 h_b0_value h_b1_value h_store_rmw
 
 /-- Construct the SH store envelope while deriving its Main store shape fields
 from extracted row-shape equalities. -/
@@ -90,12 +84,7 @@ def OpEnvelope.shOfExtractedShape
         (sh_input.r1_val + BitVec.signExtend 64 sh_input.imm).toNat)
     (h_b0_value : m.b_0 r_main = ZiskFv.Trusted.lane_lo sh_input.r2_val)
     (h_b1_value : m.b_1 r_main = ZiskFv.Trusted.lane_hi sh_input.r2_val)
-    (h_m2 : state.mem[bus.e2.ptr.toNat + 2]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 2 : BitVec 8))
-    (h_m3 : state.mem[bus.e2.ptr.toNat + 3]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 3 : BitVec 8))
-    (h_m4 : state.mem[bus.e2.ptr.toNat + 4]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 4 : BitVec 8))
-    (h_m5 : state.mem[bus.e2.ptr.toNat + 5]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 5 : BitVec 8))
-    (h_m6 : state.mem[bus.e2.ptr.toNat + 6]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 6 : BitVec 8))
-    (h_m7 : state.mem[bus.e2.ptr.toNat + 7]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 7 : BitVec 8)) :
+    (h_store_rmw : StoreRmwMemoryCoherenceEvidence state bus.e2 2) :
     OpEnvelope state m r_main :=
   OpEnvelope.sh sh_input regs bus
     (MainRowProvenance.copybPins_of_extracted_shape provenance h_op h_internal)
@@ -104,7 +93,7 @@ def OpEnvelope.shOfExtractedShape
     h_opcode_assumptions promises h_main_row h_main_spec
     (MainRowProvenance.cleanStorePcZero_of_extracted_shape provenance
       h_store_pc_shape h_main_row)
-    h_main_c_match h_addr2 h_b0_value h_b1_value h_m2 h_m3 h_m4 h_m5 h_m6 h_m7
+    h_main_c_match h_addr2 h_b0_value h_b1_value h_store_rmw
 
 /-- Construct the SW store envelope while deriving its Main store shape fields
 from extracted row-shape equalities. -/
@@ -138,10 +127,7 @@ def OpEnvelope.swOfExtractedShape
         (sw_input.r1_val + BitVec.signExtend 64 sw_input.imm).toNat)
     (h_b0_value : m.b_0 r_main = ZiskFv.Trusted.lane_lo sw_input.r2_val)
     (h_b1_value : m.b_1 r_main = ZiskFv.Trusted.lane_hi sw_input.r2_val)
-    (h_m4 : state.mem[bus.e2.ptr.toNat + 4]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 4 : BitVec 8))
-    (h_m5 : state.mem[bus.e2.ptr.toNat + 5]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 5 : BitVec 8))
-    (h_m6 : state.mem[bus.e2.ptr.toNat + 6]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 6 : BitVec 8))
-    (h_m7 : state.mem[bus.e2.ptr.toNat + 7]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 7 : BitVec 8)) :
+    (h_store_rmw : StoreRmwMemoryCoherenceEvidence state bus.e2 4) :
     OpEnvelope state m r_main :=
   OpEnvelope.sw sw_input regs bus
     (MainRowProvenance.copybPins_of_extracted_shape provenance h_op h_internal)
@@ -150,7 +136,7 @@ def OpEnvelope.swOfExtractedShape
     h_opcode_assumptions promises h_main_row h_main_spec
     (MainRowProvenance.cleanStorePcZero_of_extracted_shape provenance
       h_store_pc_shape h_main_row)
-    h_main_c_match h_addr2 h_b0_value h_b1_value h_m4 h_m5 h_m6 h_m7
+    h_main_c_match h_addr2 h_b0_value h_b1_value h_store_rmw
 
 /-- Construct the SD store envelope while deriving its Main `OP_COPYB` pins and
 Clean `store_pc` fact from extracted row-shape equalities. -/
@@ -223,19 +209,12 @@ theorem OpEnvelope.aeneasBridgeTrust_sbOfExtractedShape
         (sb_input.r1_val + BitVec.signExtend 64 sb_input.imm).toNat)
     (h_b0_value : m.b_0 r_main = ZiskFv.Trusted.lane_lo sb_input.r2_val)
     (h_b1_value : m.b_1 r_main = ZiskFv.Trusted.lane_hi sb_input.r2_val)
-    (h_m1 : state.mem[bus.e2.ptr.toNat + 1]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 1 : BitVec 8))
-    (h_m2 : state.mem[bus.e2.ptr.toNat + 2]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 2 : BitVec 8))
-    (h_m3 : state.mem[bus.e2.ptr.toNat + 3]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 3 : BitVec 8))
-    (h_m4 : state.mem[bus.e2.ptr.toNat + 4]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 4 : BitVec 8))
-    (h_m5 : state.mem[bus.e2.ptr.toNat + 5]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 5 : BitVec 8))
-    (h_m6 : state.mem[bus.e2.ptr.toNat + 6]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 6 : BitVec 8))
-    (h_m7 : state.mem[bus.e2.ptr.toNat + 7]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 7 : BitVec 8)) :
+    (h_store_rmw : StoreRmwMemoryCoherenceEvidence state bus.e2 1) :
     (OpEnvelope.sbOfExtractedShape
       (state := state) (m := m) (r_main := r_main)
       sb_input regs bus provenance h_op h_internal h_width h_store_pc_shape
       h_opcode_assumptions promises h_main_row h_main_spec h_main_c_match
-      h_addr2 h_b0_value h_b1_value h_m1 h_m2 h_m3 h_m4 h_m5 h_m6
-      h_m7).aeneasBridgeTrust := by
+      h_addr2 h_b0_value h_b1_value h_store_rmw).aeneasBridgeTrust := by
   unfold OpEnvelope.sbOfExtractedShape OpEnvelope.aeneasBridgeTrust
   exact ⟨by simpa [natF] using
     MainRowProvenance.indWidth_of_extracted_shape provenance h_width,
@@ -273,18 +252,12 @@ theorem OpEnvelope.aeneasBridgeTrust_shOfExtractedShape
         (sh_input.r1_val + BitVec.signExtend 64 sh_input.imm).toNat)
     (h_b0_value : m.b_0 r_main = ZiskFv.Trusted.lane_lo sh_input.r2_val)
     (h_b1_value : m.b_1 r_main = ZiskFv.Trusted.lane_hi sh_input.r2_val)
-    (h_m2 : state.mem[bus.e2.ptr.toNat + 2]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 2 : BitVec 8))
-    (h_m3 : state.mem[bus.e2.ptr.toNat + 3]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 3 : BitVec 8))
-    (h_m4 : state.mem[bus.e2.ptr.toNat + 4]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 4 : BitVec 8))
-    (h_m5 : state.mem[bus.e2.ptr.toNat + 5]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 5 : BitVec 8))
-    (h_m6 : state.mem[bus.e2.ptr.toNat + 6]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 6 : BitVec 8))
-    (h_m7 : state.mem[bus.e2.ptr.toNat + 7]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 7 : BitVec 8)) :
+    (h_store_rmw : StoreRmwMemoryCoherenceEvidence state bus.e2 2) :
     (OpEnvelope.shOfExtractedShape
       (state := state) (m := m) (r_main := r_main)
       sh_input regs bus provenance h_op h_internal h_width h_store_pc_shape
       h_opcode_assumptions promises h_main_row h_main_spec h_main_c_match
-      h_addr2 h_b0_value h_b1_value h_m2 h_m3 h_m4 h_m5 h_m6
-      h_m7).aeneasBridgeTrust := by
+      h_addr2 h_b0_value h_b1_value h_store_rmw).aeneasBridgeTrust := by
   unfold OpEnvelope.shOfExtractedShape OpEnvelope.aeneasBridgeTrust
   exact ⟨by simpa [natF] using
     MainRowProvenance.indWidth_of_extracted_shape provenance h_width,
@@ -322,15 +295,12 @@ theorem OpEnvelope.aeneasBridgeTrust_swOfExtractedShape
         (sw_input.r1_val + BitVec.signExtend 64 sw_input.imm).toNat)
     (h_b0_value : m.b_0 r_main = ZiskFv.Trusted.lane_lo sw_input.r2_val)
     (h_b1_value : m.b_1 r_main = ZiskFv.Trusted.lane_hi sw_input.r2_val)
-    (h_m4 : state.mem[bus.e2.ptr.toNat + 4]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 4 : BitVec 8))
-    (h_m5 : state.mem[bus.e2.ptr.toNat + 5]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 5 : BitVec 8))
-    (h_m6 : state.mem[bus.e2.ptr.toNat + 6]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 6 : BitVec 8))
-    (h_m7 : state.mem[bus.e2.ptr.toNat + 7]? = some (ZiskFv.Channels.MemoryBusBytes.byteAt bus.e2 7 : BitVec 8)) :
+    (h_store_rmw : StoreRmwMemoryCoherenceEvidence state bus.e2 4) :
     (OpEnvelope.swOfExtractedShape
       (state := state) (m := m) (r_main := r_main)
       sw_input regs bus provenance h_op h_internal h_width h_store_pc_shape
       h_opcode_assumptions promises h_main_row h_main_spec h_main_c_match
-      h_addr2 h_b0_value h_b1_value h_m4 h_m5 h_m6 h_m7).aeneasBridgeTrust := by
+      h_addr2 h_b0_value h_b1_value h_store_rmw).aeneasBridgeTrust := by
   unfold OpEnvelope.swOfExtractedShape OpEnvelope.aeneasBridgeTrust
   exact ⟨by simpa [natF] using
     MainRowProvenance.indWidth_of_extracted_shape provenance h_width,

--- a/ZiskFv/Compliance/ConstructionLoad.lean
+++ b/ZiskFv/Compliance/ConstructionLoad.lean
@@ -21,8 +21,10 @@ binders — mirroring `construction_sb_sound` but on the **MemoryBus read side**
 ## Why loads differ from stores (and what is honestly irreducible)
 
 Stores WRITE memory: the store's write entry (`bus.e2`, as = 2) is the Main
-row's own `c` emission, so its match is `matches_memory_entry_refl` and the
-memory-side residual is only the high-byte RMW preservation reads.
+row's own `c` emission, so its match is `matches_memory_entry_refl`; the
+trace-level store interface carries the remaining high-byte RMW obligation as
+`StoreRmwMemoryCoherenceEvidence`, with byte facts projected only for the
+internal clean store cores.
 
 Loads READ memory. Two facts are genuinely irreducible at the per-row Clean
 layer and are carried as **named residuals** (the `#76` memory-timeline

--- a/ZiskFv/Compliance/ConstructionStore.lean
+++ b/ZiskFv/Compliance/ConstructionStore.lean
@@ -16,6 +16,11 @@ full-ensemble trace plus an explicit, named, top-level set of residual
 binders — mirroring `construction_add_sound` but on the **MemoryBus write
 side** instead of the operation bus.
 
+These `*_claimed_dead` helpers are lower-level construction witnesses. The
+current trace-level rowData/`OpEnvelope` store interface carries the RMW memory
+obligation as `StoreRmwMemoryCoherenceEvidence`; dispatch then projects the
+byte facts consumed by these clean store witnesses.
+
 ## Why stores differ from the ALU/M-ext constructions
 
 ALU/M-ext ops READ their operands off register-bus MemBus entries and write
@@ -62,14 +67,13 @@ the structural counterpart, derived from the real trace row.
   - Sail-side: `regs : ModeRegsFull`, `h_opcode_assumptions`
     (`s*_state_assumptions`), and the `RISC_V_assumptions` / exec / next-PC
     fields carried inside the `StorePromises` bundle.
-  - **memory-side residual** (SB/SH/SW only): the high-byte RMW reads
-    `m1..m7` / `m2..m7` / `m4..m7`. These read the bytes OUTSIDE the written
-    width from current memory and assert they equal the bus entry's preserved
-    bytes. They are the genuinely-irreducible store residual: the byte-local
-    read-modify-write preservation is NOT balance-derivable from the store
-    Main row alone (it is a fact about the memory state at the store, the
-    load / replay-side `#76` timeline). SD writes the full doubleword, so it
-    carries NO `m*` residual.
+  - **memory-side residual** (SB/SH/SW only): these low-level helpers still
+    consume the projected high-byte RMW reads `m1..m7` / `m2..m7` / `m4..m7`.
+    The live trace-level interface names the source obligation once as
+    `StoreRmwMemoryCoherenceEvidence`. The byte-local read-modify-write
+    preservation is NOT balance-derivable from the store Main row alone; it is
+    a fact about the memory state at the store, via the replay-side `#76`
+    timeline. SD writes the full doubleword, so it carries NO `m*` residual.
 
 * **(c) artifact**: the `execRow : List (ExecutionBusEntry FGL)` **∀-binder**
   plus its length/multiplicity fields inside `StorePromises`.
@@ -153,8 +157,8 @@ theorem mainRowWithRomSt_core
     The memory-bus write entry `bus.e2` is the Main row's own `c` emission
     (`busSt`/`eRdSt`), so the `SbCleanWitness.main_c_match` is
     `matches_memory_entry_refl` (derived, NOT a balance/provider fact). The
-    high-byte RMW preservation reads `m1..m7` are the genuinely-irreducible
-    memory-side residual (named binders). -/
+    legacy clean witness below still consumes the projected high-byte RMW
+    preservation reads `m1..m7`. -/
 theorem construction_sb_sound_claimed_dead
     (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)

--- a/ZiskFv/Compliance/Dispatch/Remaining.lean
+++ b/ZiskFv/Compliance/Dispatch/Remaining.lean
@@ -252,10 +252,24 @@ theorem zisk_riscv_compliant_program_bus_remaining
       state lwu_input regs m mem r_main bus align pins h_width promises' w
   | sb sb_input regs bus pins h_main_ind_width h_opcode_assumptions promises
       h_main_row h_main_spec h_store_pc h_main_c_match h_addr2
-      h_b0_value h_b1_value h_m1 h_m2 h_m3 h_m4 h_m5 h_m6 h_m7 =>
+      h_b0_value h_b1_value h_store_rmw =>
     change execute_instruction (instruction.STORE (
         sb_input.imm, regidx.Regidx sb_input.r2, regidx.Regidx sb_input.r1, 1
       )) state = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
+    have h_m1 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 1) (by norm_num) (by norm_num)
+    have h_m2 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 2) (by norm_num) (by norm_num)
+    have h_m3 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 3) (by norm_num) (by norm_num)
+    have h_m4 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 4) (by norm_num) (by norm_num)
+    have h_m5 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 5) (by norm_num) (by norm_num)
+    have h_m6 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 6) (by norm_num) (by norm_num)
+    have h_m7 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 7) (by norm_num) (by norm_num)
     let w :=
       ZiskFv.EquivCore.Bridge.MemClean.sbCleanWitness_of_full_ensemble_main_c
       m r_main bus state sb_input h_main_row h_main_spec h_store_pc
@@ -266,10 +280,22 @@ theorem zisk_riscv_compliant_program_bus_remaining
       h_opcode_assumptions promises w
   | sh sh_input regs bus pins h_main_ind_width h_opcode_assumptions promises
       h_main_row h_main_spec h_store_pc h_main_c_match h_addr2
-      h_b0_value h_b1_value h_m2 h_m3 h_m4 h_m5 h_m6 h_m7 =>
+      h_b0_value h_b1_value h_store_rmw =>
     change execute_instruction (instruction.STORE (
         sh_input.imm, regidx.Regidx sh_input.r2, regidx.Regidx sh_input.r1, 2
       )) state = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
+    have h_m2 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 2) (by norm_num) (by norm_num)
+    have h_m3 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 3) (by norm_num) (by norm_num)
+    have h_m4 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 4) (by norm_num) (by norm_num)
+    have h_m5 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 5) (by norm_num) (by norm_num)
+    have h_m6 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 6) (by norm_num) (by norm_num)
+    have h_m7 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 7) (by norm_num) (by norm_num)
     let w :=
       ZiskFv.EquivCore.Bridge.MemClean.shCleanWitness_of_full_ensemble_main_c
       m r_main bus state sh_input h_main_row h_main_spec h_store_pc
@@ -280,10 +306,18 @@ theorem zisk_riscv_compliant_program_bus_remaining
       h_opcode_assumptions promises w
   | sw sw_input regs bus pins h_main_ind_width h_opcode_assumptions promises
       h_main_row h_main_spec h_store_pc h_main_c_match h_addr2
-      h_b0_value h_b1_value h_m4 h_m5 h_m6 h_m7 =>
+      h_b0_value h_b1_value h_store_rmw =>
     change execute_instruction (instruction.STORE (
         sw_input.imm, regidx.Regidx sw_input.r2, regidx.Regidx sw_input.r1, 4
       )) state = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
+    have h_m4 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 4) (by norm_num) (by norm_num)
+    have h_m5 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 5) (by norm_num) (by norm_num)
+    have h_m6 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 6) (by norm_num) (by norm_num)
+    have h_m7 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 7) (by norm_num) (by norm_num)
     let w :=
       ZiskFv.EquivCore.Bridge.MemClean.swCleanWitness_of_full_ensemble_main_c
       m r_main bus state sw_input h_main_row h_main_spec h_store_pc
@@ -685,10 +719,24 @@ theorem zisk_riscv_compliant_program_bus_remaining_except_known_defects
       h_addr2_idx h_mem_sel h_mem_wr
   | sb sb_input regs bus pins h_main_ind_width h_opcode_assumptions promises
       h_main_row h_main_spec h_store_pc h_main_c_match h_addr2
-      h_b0_value h_b1_value h_m1 h_m2 h_m3 h_m4 h_m5 h_m6 h_m7 =>
+      h_b0_value h_b1_value h_store_rmw =>
     change execute_instruction (instruction.STORE (
         sb_input.imm, regidx.Regidx sb_input.r2, regidx.Regidx sb_input.r1, 1
       )) state = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
+    have h_m1 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 1) (by norm_num) (by norm_num)
+    have h_m2 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 2) (by norm_num) (by norm_num)
+    have h_m3 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 3) (by norm_num) (by norm_num)
+    have h_m4 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 4) (by norm_num) (by norm_num)
+    have h_m5 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 5) (by norm_num) (by norm_num)
+    have h_m6 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 6) (by norm_num) (by norm_num)
+    have h_m7 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 7) (by norm_num) (by norm_num)
     exact ZiskFv.Compliance.sb_eq_of_full_ensemble_main_c
       state sb_input regs m r_main bus pins h_main_ind_width
       h_opcode_assumptions promises h_main_row h_main_spec h_store_pc
@@ -696,10 +744,22 @@ theorem zisk_riscv_compliant_program_bus_remaining_except_known_defects
       h_m1 h_m2 h_m3 h_m4 h_m5 h_m6 h_m7
   | sh sh_input regs bus pins h_main_ind_width h_opcode_assumptions promises
       h_main_row h_main_spec h_store_pc h_main_c_match h_addr2
-      h_b0_value h_b1_value h_m2 h_m3 h_m4 h_m5 h_m6 h_m7 =>
+      h_b0_value h_b1_value h_store_rmw =>
     change execute_instruction (instruction.STORE (
         sh_input.imm, regidx.Regidx sh_input.r2, regidx.Regidx sh_input.r1, 2
       )) state = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
+    have h_m2 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 2) (by norm_num) (by norm_num)
+    have h_m3 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 3) (by norm_num) (by norm_num)
+    have h_m4 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 4) (by norm_num) (by norm_num)
+    have h_m5 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 5) (by norm_num) (by norm_num)
+    have h_m6 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 6) (by norm_num) (by norm_num)
+    have h_m7 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 7) (by norm_num) (by norm_num)
     exact ZiskFv.Compliance.sh_eq_of_full_ensemble_main_c
       state sh_input regs m r_main bus pins h_main_ind_width
       h_opcode_assumptions promises h_main_row h_main_spec h_store_pc
@@ -707,10 +767,18 @@ theorem zisk_riscv_compliant_program_bus_remaining_except_known_defects
       h_m2 h_m3 h_m4 h_m5 h_m6 h_m7
   | sw sw_input regs bus pins h_main_ind_width h_opcode_assumptions promises
       h_main_row h_main_spec h_store_pc h_main_c_match h_addr2
-      h_b0_value h_b1_value h_m4 h_m5 h_m6 h_m7 =>
+      h_b0_value h_b1_value h_store_rmw =>
     change execute_instruction (instruction.STORE (
         sw_input.imm, regidx.Regidx sw_input.r2, regidx.Regidx sw_input.r1, 4
       )) state = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
+    have h_m4 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 4) (by norm_num) (by norm_num)
+    have h_m5 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 5) (by norm_num) (by norm_num)
+    have h_m6 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 6) (by norm_num) (by norm_num)
+    have h_m7 := storeRmwPreservedByte_of_coherenceEvidence h_store_rmw
+      (i := 7) (by norm_num) (by norm_num)
     exact ZiskFv.Compliance.sw_eq_of_full_ensemble_main_c
       state sw_input regs m r_main bus pins h_main_ind_width
       h_opcode_assumptions promises h_main_row h_main_spec h_store_pc

--- a/ZiskFv/Compliance/OpEnvelope.lean
+++ b/ZiskFv/Compliance/OpEnvelope.lean
@@ -145,6 +145,67 @@ open ZiskFv.Tactics.UTypeArchetype
 open ZiskFv.Tactics.ALUITypeArchetype
 open ZiskFv.Compliance
 
+/-! ## Store RMW memory evidence -/
+
+/-- Replay-prefix fact for the bytes a narrow store must preserve.
+
+For `SB`, `firstPreserved = 1`; for `SH`, `firstPreserved = 2`; for `SW`,
+`firstPreserved = 4`. This is stated over replay memory, not directly over the
+Sail state; `storeRmwPreservedByte_of_coherenceEvidence` composes it with the
+Fold-B `RowTraceCoherence` route to recover the byte facts consumed by the
+existing store cores. -/
+@[reducible]
+def StoreRmwPreservedBytesAtPrefix
+    (mem : Std.ExtHashMap Nat (BitVec 8))
+    (entry : Interaction.MemoryBusEntry FGL)
+    (firstPreserved : Nat) : Prop :=
+  ∀ i : Nat, firstPreserved ≤ i → i < 8 →
+    mem[entry.ptr.toNat + i]? = some (byteAt entry i : BitVec 8)
+
+/-- Named store-side memory residual for sub-doubleword RMW stores.
+
+This is the store analogue of `LoadMemoryTimelineCoherenceEvidence`: it exposes
+the seed-relative replay/coherence boundary once, then keeps the old per-byte
+preservation facts as derived projections. Full derivation of this evidence from
+accepted trace replay remains the #115/#185 follow-on. -/
+@[reducible]
+def StoreRmwMemoryCoherenceEvidence
+    (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
+    (entry : Interaction.MemoryBusEntry FGL)
+    (firstPreserved : Nat) : Prop :=
+  ∃ (initialState : ZiskFv.ZiskCircuit.MemTrace.SailState)
+    (rows : List (Interaction.MemoryBusEntry FGL))
+    (facts : ZiskFv.AirsClean.Mem.GeneratedMemReplayFacts initialState rows)
+    (stateAt : List (Interaction.MemoryBusEntry FGL) →
+      ZiskFv.ZiskCircuit.MemTrace.SailState)
+    (priorRows laterRows : List (Interaction.MemoryBusEntry FGL)),
+      rows = priorRows ++ entry :: laterRows
+        ∧ stateAt [] = initialState
+        ∧ stateAt priorRows = state
+        ∧ ZiskFv.ZiskCircuit.MemTimeline.Spike.RowTraceCoherence stateAt [] priorRows
+        ∧ StoreRmwPreservedBytesAtPrefix
+            (ZiskFv.ZiskCircuit.MemTrace.replayMemoryAfterBusRows
+              facts.initialMemory priorRows)
+            entry firstPreserved
+
+/-- Project one preserved byte from named store RMW evidence. -/
+theorem storeRmwPreservedByte_of_coherenceEvidence
+    {state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource}
+    {entry : Interaction.MemoryBusEntry FGL}
+    {firstPreserved i : Nat}
+    (h_coherence : StoreRmwMemoryCoherenceEvidence state entry firstPreserved)
+    (h_first : firstPreserved ≤ i)
+    (h_i : i < 8) :
+    state.mem[entry.ptr.toNat + i]? = some (byteAt entry i : BitVec 8) := by
+  obtain ⟨initialState, rows, facts, stateAt, priorRows, laterRows,
+    _h_traceSplit, h_seed, h_storeState, h_rowCoherence, h_prefix⟩ := h_coherence
+  have h_bytes :=
+    ZiskFv.ZiskCircuit.MemTimeline.Spike.stateBytesAtPrefix_of_rowTraceCoherence
+      (entry := entry) facts stateAt priorRows h_seed h_rowCoherence
+  rw [h_storeState] at h_bytes
+  have h_state_replay := h_bytes i h_i
+  rw [h_prefix i h_first h_i] at h_state_replay
+  exact h_state_replay
 
 /-! ## The `OpEnvelope` sum type
 
@@ -1376,13 +1437,7 @@ inductive OpEnvelope
         (sb_input.r1_val + BitVec.signExtend 64 sb_input.imm).toNat)
     (h_b0_value : m.b_0 r_main = ZiskFv.Trusted.lane_lo sb_input.r2_val)
     (h_b1_value : m.b_1 r_main = ZiskFv.Trusted.lane_hi sb_input.r2_val)
-    (h_m1 : state.mem[bus.e2.ptr.toNat + 1]? = some (byteAt bus.e2 1 : BitVec 8))
-    (h_m2 : state.mem[bus.e2.ptr.toNat + 2]? = some (byteAt bus.e2 2 : BitVec 8))
-    (h_m3 : state.mem[bus.e2.ptr.toNat + 3]? = some (byteAt bus.e2 3 : BitVec 8))
-    (h_m4 : state.mem[bus.e2.ptr.toNat + 4]? = some (byteAt bus.e2 4 : BitVec 8))
-    (h_m5 : state.mem[bus.e2.ptr.toNat + 5]? = some (byteAt bus.e2 5 : BitVec 8))
-    (h_m6 : state.mem[bus.e2.ptr.toNat + 6]? = some (byteAt bus.e2 6 : BitVec 8))
-    (h_m7 : state.mem[bus.e2.ptr.toNat + 7]? = some (byteAt bus.e2 7 : BitVec 8)) :
+    (h_store_rmw : StoreRmwMemoryCoherenceEvidence state bus.e2 1) :
       OpEnvelope state m r_main
   -- ============================ SH (store, Main-only) ===================
   | sh
@@ -1413,12 +1468,7 @@ inductive OpEnvelope
         (sh_input.r1_val + BitVec.signExtend 64 sh_input.imm).toNat)
     (h_b0_value : m.b_0 r_main = ZiskFv.Trusted.lane_lo sh_input.r2_val)
     (h_b1_value : m.b_1 r_main = ZiskFv.Trusted.lane_hi sh_input.r2_val)
-    (h_m2 : state.mem[bus.e2.ptr.toNat + 2]? = some (byteAt bus.e2 2 : BitVec 8))
-    (h_m3 : state.mem[bus.e2.ptr.toNat + 3]? = some (byteAt bus.e2 3 : BitVec 8))
-    (h_m4 : state.mem[bus.e2.ptr.toNat + 4]? = some (byteAt bus.e2 4 : BitVec 8))
-    (h_m5 : state.mem[bus.e2.ptr.toNat + 5]? = some (byteAt bus.e2 5 : BitVec 8))
-    (h_m6 : state.mem[bus.e2.ptr.toNat + 6]? = some (byteAt bus.e2 6 : BitVec 8))
-    (h_m7 : state.mem[bus.e2.ptr.toNat + 7]? = some (byteAt bus.e2 7 : BitVec 8)) :
+    (h_store_rmw : StoreRmwMemoryCoherenceEvidence state bus.e2 2) :
       OpEnvelope state m r_main
   -- ============================ SW (store, Main-only) ===================
   | sw
@@ -1449,10 +1499,7 @@ inductive OpEnvelope
         (sw_input.r1_val + BitVec.signExtend 64 sw_input.imm).toNat)
     (h_b0_value : m.b_0 r_main = ZiskFv.Trusted.lane_lo sw_input.r2_val)
     (h_b1_value : m.b_1 r_main = ZiskFv.Trusted.lane_hi sw_input.r2_val)
-    (h_m4 : state.mem[bus.e2.ptr.toNat + 4]? = some (byteAt bus.e2 4 : BitVec 8))
-    (h_m5 : state.mem[bus.e2.ptr.toNat + 5]? = some (byteAt bus.e2 5 : BitVec 8))
-    (h_m6 : state.mem[bus.e2.ptr.toNat + 6]? = some (byteAt bus.e2 6 : BitVec 8))
-    (h_m7 : state.mem[bus.e2.ptr.toNat + 7]? = some (byteAt bus.e2 7 : BitVec 8)) :
+    (h_store_rmw : StoreRmwMemoryCoherenceEvidence state bus.e2 4) :
       OpEnvelope state m r_main
   -- ============================ SD (store, Main-only) ===================
   | sd

--- a/ZiskFv/Compliance/OpEnvelope.lean
+++ b/ZiskFv/Compliance/OpEnvelope.lean
@@ -164,10 +164,12 @@ def StoreRmwPreservedBytesAtPrefix
 
 /-- Named store-side memory residual for sub-doubleword RMW stores.
 
-This is the store analogue of `LoadMemoryTimelineCoherenceEvidence`: it exposes
-the seed-relative replay/coherence boundary once, then keeps the old per-byte
-preservation facts as derived projections. Full derivation of this evidence from
-accepted trace replay remains the #115/#185 follow-on. -/
+This is the store analogue of `LoadMemoryTimelineCoherenceEvidence`, but with
+one extra posited store-specific conjunct: the replay memory at the store prefix
+already contains the bytes that the narrow RMW store must preserve. The
+projection theorem below turns that named prefix fact into the old per-byte
+state facts. Full derivation of this evidence from accepted trace replay remains
+the #115/#185 follow-on. -/
 @[reducible]
 def StoreRmwMemoryCoherenceEvidence
     (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)

--- a/ZiskFv/Compliance/TraceLevelExport.lean
+++ b/ZiskFv/Compliance/TraceLevelExport.lean
@@ -127,8 +127,9 @@ a contradictory hypothesis pair; no `False.elim` is used.
 
 The irreducible residuals carried per arm bottom out in the existing project
 residuals — none introduces a new `ZiskFv.*` axiom:
-* loads/stores `h_memory_timeline` / RMW-preservation reads → **#76** (memory
-  timeline), plus the Mem-AIR `h_mem_*` provider linkage;
+* loads `h_memory_timeline` and sub-doubleword store
+  `StoreRmwMemoryCoherenceEvidence` → **#76** (memory timeline), plus the
+  Mem-AIR `h_mem_*` provider linkage on loads;
 * `h_nextPC_matches` (conditional next-PC) → **#100 — now DISCHARGED** for ALL 63
   opcodes: derived from the `AcceptedZiskTrace.transitions_hold` PC-handshake
   certificate (`Compliance/MainTransition.lean`, `Compliance/Pilot/*NextPC.lean`),

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
@@ -2005,20 +2005,9 @@ structure Inputs_sb (trace : AcceptedZiskTrace numInstructions) (binding : SailT
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.sb_input.PC.toNat
   h_pc_bound : c.sb_input.PC.toNat < GL_prime - 4
-  h_m1 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 1]?
-    = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 1 : BitVec 8)
-  h_m2 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 2]?
-    = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 2 : BitVec 8)
-  h_m3 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 3]?
-    = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 3 : BitVec 8)
-  h_m4 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 4]?
-    = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 4 : BitVec 8)
-  h_m5 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 5]?
-    = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 5 : BitVec 8)
-  h_m6 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 6]?
-    = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 6 : BitVec 8)
-  h_m7 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 7]?
-    = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 7 : BitVec 8)
+  h_store_rmw :
+    StoreRmwMemoryCoherenceEvidence (binding i)
+      (busSt trace i (Pilot.execRowOf trace i)).e2 1
 
 /-- Per-op residual bundle for the `sb` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sb` bundles them. -/
@@ -2087,18 +2076,9 @@ structure Inputs_sh (trace : AcceptedZiskTrace numInstructions) (binding : SailT
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.sh_input.PC.toNat
   h_pc_bound : c.sh_input.PC.toNat < GL_prime - 4
-  h_m2 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 2]?
-    = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 2 : BitVec 8)
-  h_m3 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 3]?
-    = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 3 : BitVec 8)
-  h_m4 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 4]?
-    = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 4 : BitVec 8)
-  h_m5 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 5]?
-    = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 5 : BitVec 8)
-  h_m6 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 6]?
-    = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 6 : BitVec 8)
-  h_m7 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 7]?
-    = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 7 : BitVec 8)
+  h_store_rmw :
+    StoreRmwMemoryCoherenceEvidence (binding i)
+      (busSt trace i (Pilot.execRowOf trace i)).e2 2
 
 /-- Per-op residual bundle for the `sh` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sh` bundles them. -/
@@ -2167,14 +2147,9 @@ structure Inputs_sw (trace : AcceptedZiskTrace numInstructions) (binding : SailT
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.sw_input.PC.toNat
   h_pc_bound : c.sw_input.PC.toNat < GL_prime - 4
-  h_m4 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 4]?
-    = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 4 : BitVec 8)
-  h_m5 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 5]?
-    = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 5 : BitVec 8)
-  h_m6 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 6]?
-    = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 6 : BitVec 8)
-  h_m7 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 7]?
-    = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 7 : BitVec 8)
+  h_store_rmw :
+    StoreRmwMemoryCoherenceEvidence (binding i)
+      (busSt trace i (Pilot.execRowOf trace i)).e2 4
 
 /-- Per-op residual bundle for the `sw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sw` bundles them. -/

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
@@ -1269,9 +1269,8 @@ whnf BLOWUP (the `Eq.mpr` cast over a free `MainRowWithRom` motive) because the 
 is a `.const` literal of the committed trace row, not an opaque eval-binder.
 
 Non-vacuous: `execRow` is a genuine ∀-binder; the `c`-emission match is
-`matches_memory_entry_refl` over the real `busSt` row; the high-byte RMW residuals
-(`h_m*`, the #76 sub-doubleword preservation reads) are carried verbatim as
-`RowData_<store>` binders, NOT laundered. -/
+`matches_memory_entry_refl` over the real `busSt` row; the high-byte RMW residual
+is carried as named store memory evidence and projected inside store dispatch. -/
 
 /-- Empty environment used only to instantiate the store `OpEnvelope` arms'
     `{mainEnv}` implicit binder; `eval_mainConstVar` makes the choice irrelevant. -/
@@ -1338,7 +1337,7 @@ theorem stepStrong_sb
       (by simpa only [eval_mainConstVar] using h_core_store_pc)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
       (by simpa only [eval_mainConstVar] using d.toInputs.h_addr2)
-      h_b0' h_b1' d.toInputs.h_m1 d.toInputs.h_m2 d.toInputs.h_m3 d.toInputs.h_m4 d.toInputs.h_m5 d.toInputs.h_m6 d.toInputs.h_m7
+      h_b0' h_b1' d.toInputs.h_store_rmw
   have h_bridge : env.aeneasBridgeTrust := ⟨d.toDecode.h_main_ind_width, h_b0', h_b1'⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
@@ -1404,7 +1403,7 @@ theorem stepStrong_sh
       (by simpa only [eval_mainConstVar] using h_core_store_pc)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
       (by simpa only [eval_mainConstVar] using d.toInputs.h_addr2)
-      h_b0' h_b1' d.toInputs.h_m2 d.toInputs.h_m3 d.toInputs.h_m4 d.toInputs.h_m5 d.toInputs.h_m6 d.toInputs.h_m7
+      h_b0' h_b1' d.toInputs.h_store_rmw
   have h_bridge : env.aeneasBridgeTrust := ⟨d.toDecode.h_main_ind_width, h_b0', h_b1'⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
@@ -1470,7 +1469,7 @@ theorem stepStrong_sw
       (by simpa only [eval_mainConstVar] using h_core_store_pc)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
       (by simpa only [eval_mainConstVar] using d.toInputs.h_addr2)
-      h_b0' h_b1' d.toInputs.h_m4 d.toInputs.h_m5 d.toInputs.h_m6 d.toInputs.h_m7
+      h_b0' h_b1' d.toInputs.h_store_rmw
   have h_bridge : env.aeneasBridgeTrust := ⟨d.toDecode.h_main_ind_width, h_b0', h_b1'⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial


### PR DESCRIPTION
Closes #119.

## Summary
- replace raw SB/SH/SW `h_m*` rowData/envelope fields with `StoreRmwMemoryCoherenceEvidence`
- project preserved-byte facts internally in store dispatch before calling existing clean store witnesses
- update Aeneas bridge-trust store helpers and trust/comment text for the new residual shape

## Verification
- `rtk lake build`
- `rtk trust/scripts/check-all.sh`
- `rtk trust/scripts/check-all-semantic.sh`
- `rtk git diff --check`
- `rtk lake exe trust-gate print-axiom-closure ZiskFv.Compliance.storeRmwPreservedByte_of_coherenceEvidence`