### PR TITLE
Derive store addr2 placement

### DIFF
--- a/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
@@ -1220,6 +1220,7 @@ structure ProgramDecode_sb {numInstructions : Nat}
   h_bits_ieo : bits.is_external_op = false
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
+  h_bits_store_ind : bits.store_ind = true
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -1240,6 +1241,7 @@ structure ProgramDecode_sh {numInstructions : Nat}
   h_bits_ieo : bits.is_external_op = false
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
+  h_bits_store_ind : bits.store_ind = true
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -1260,6 +1262,7 @@ structure ProgramDecode_sw {numInstructions : Nat}
   h_bits_ieo : bits.is_external_op = false
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
+  h_bits_store_ind : bits.store_ind = true
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -1280,6 +1283,7 @@ structure ProgramDecode_sd {numInstructions : Nat}
   h_bits_ieo : bits.is_external_op = false
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
+  h_bits_store_ind : bits.store_ind = true
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -1654,10 +1658,10 @@ noncomputable def rowDecode_of_programDecode (ziskTrace : AcceptedZiskTrace numI
   | auipc c => exact RomDecodeBinding.Decode_auipc_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | jal c => exact RomDecodeBinding.Decode_jal_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | jalr c => exact RomDecodeBinding.Decode_jalr_of_program ziskTrace i c pd.h_idx pd.h_flag pd.h_a_mask_lo pd.h_a_mask_hi pd.h_c1_zero pd.h_offset_bridge pd.h_offset_even pd.h_no_fgl_wrap pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
-  | sb c => exact RomDecodeBinding.Decode_sb_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
-  | sh c => exact RomDecodeBinding.Decode_sh_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
-  | sw c => exact RomDecodeBinding.Decode_sw_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
-  | sd c => exact RomDecodeBinding.Decode_sd_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
+  | sb c => exact RomDecodeBinding.Decode_sb_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
+  | sh c => exact RomDecodeBinding.Decode_sh_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
+  | sw c => exact RomDecodeBinding.Decode_sw_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
+  | sd c => exact RomDecodeBinding.Decode_sd_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | ld c => exact RomDecodeBinding.Decode_ld_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_store_reg pd.h_prog
   | lbu c => exact RomDecodeBinding.Decode_lbu_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_store_reg pd.h_prog
   | lhu c => exact RomDecodeBinding.Decode_lhu_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_store_reg pd.h_prog

--- a/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
@@ -3015,6 +3015,7 @@ def Decode_sb_of_program
     (h_bits_ieo : bits.is_external_op = false)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
+    (h_bits_store_ind : bits.store_ind = true)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -3039,6 +3040,13 @@ def Decode_sb_of_program
     obtain ⟨p_ieo, _, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1, hiw.symm.trans hpiw⟩
+  have h_store_ind : (mainRowWithRomSt trace i).rom.store_ind = 1 := by
+    obtain ⟨j, hline, _hop, _hiw, _hj1, _hj2, hflags⟩ :=
+      mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpf⟩ := h_prog j hline
+    obtain ⟨p_store_ind, _, _⟩ :=
+      mainSelectorColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
+    simpa [mainRowWithRomSt, h_bits_store_ind, ZiskFv.AirsClean.boolF_true] using p_store_ind
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -3047,6 +3055,7 @@ def Decode_sb_of_program
       h_jmp1 := key.2.2.2.2.1
       h_jmp2 := key.2.2.2.2.2.1
       h_main_ind_width := key.2.2.2.2.2.2
+      h_store_ind := h_store_ind
       h_idx := h_idx }
 
 /-- `Decode_sh` rebuilt from the committed program via the ROM lookup
@@ -3062,6 +3071,7 @@ def Decode_sh_of_program
     (h_bits_ieo : bits.is_external_op = false)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
+    (h_bits_store_ind : bits.store_ind = true)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -3086,6 +3096,13 @@ def Decode_sh_of_program
     obtain ⟨p_ieo, _, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1, hiw.symm.trans hpiw⟩
+  have h_store_ind : (mainRowWithRomSt trace i).rom.store_ind = 1 := by
+    obtain ⟨j, hline, _hop, _hiw, _hj1, _hj2, hflags⟩ :=
+      mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpf⟩ := h_prog j hline
+    obtain ⟨p_store_ind, _, _⟩ :=
+      mainSelectorColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
+    simpa [mainRowWithRomSt, h_bits_store_ind, ZiskFv.AirsClean.boolF_true] using p_store_ind
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -3094,6 +3111,7 @@ def Decode_sh_of_program
       h_jmp1 := key.2.2.2.2.1
       h_jmp2 := key.2.2.2.2.2.1
       h_main_ind_width := key.2.2.2.2.2.2
+      h_store_ind := h_store_ind
       h_idx := h_idx }
 
 /-- `Decode_sw` rebuilt from the committed program via the ROM lookup
@@ -3109,6 +3127,7 @@ def Decode_sw_of_program
     (h_bits_ieo : bits.is_external_op = false)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
+    (h_bits_store_ind : bits.store_ind = true)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -3133,6 +3152,13 @@ def Decode_sw_of_program
     obtain ⟨p_ieo, _, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1, hiw.symm.trans hpiw⟩
+  have h_store_ind : (mainRowWithRomSt trace i).rom.store_ind = 1 := by
+    obtain ⟨j, hline, _hop, _hiw, _hj1, _hj2, hflags⟩ :=
+      mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpf⟩ := h_prog j hline
+    obtain ⟨p_store_ind, _, _⟩ :=
+      mainSelectorColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
+    simpa [mainRowWithRomSt, h_bits_store_ind, ZiskFv.AirsClean.boolF_true] using p_store_ind
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -3141,6 +3167,7 @@ def Decode_sw_of_program
       h_jmp1 := key.2.2.2.2.1
       h_jmp2 := key.2.2.2.2.2.1
       h_main_ind_width := key.2.2.2.2.2.2
+      h_store_ind := h_store_ind
       h_idx := h_idx }
 
 /-- `Decode_sd` rebuilt from the committed program via the ROM lookup
@@ -3156,6 +3183,7 @@ def Decode_sd_of_program
     (h_bits_ieo : bits.is_external_op = false)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
+    (h_bits_store_ind : bits.store_ind = true)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -3178,6 +3206,13 @@ def Decode_sd_of_program
     obtain ⟨p_ieo, _, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1⟩
+  have h_store_ind : (mainRowWithRomSt trace i).rom.store_ind = 1 := by
+    obtain ⟨j, hline, _hop, _hiw, _hj1, _hj2, hflags⟩ :=
+      mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, _hpj1, hpf⟩ := h_prog j hline
+    obtain ⟨p_store_ind, _, _⟩ :=
+      mainSelectorColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
+    simpa [mainRowWithRomSt, h_bits_store_ind, ZiskFv.AirsClean.boolF_true] using p_store_ind
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -3185,6 +3220,7 @@ def Decode_sd_of_program
       h_store_pc := key.2.2.2.1
       h_jmp1 := key.2.2.2.2.1
       h_jmp2 := key.2.2.2.2.2
+      h_store_ind := h_store_ind
       h_idx := h_idx }
 
 

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
@@ -1997,6 +1997,8 @@ structure Decode_sb (trace : AcceptedZiskTrace numInstructions)
   h_main_ind_width :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).ind_width
       i.val = 1
+  h_store_ind :
+    (mainRowWithRomSt trace i).rom.store_ind = 1
   -- #100 next-PC transition inputs (replace the exec artifacts): the next row
   -- exists, plus the COPYB store-row decode pins `set_pc = 0`,
   -- `jmp_offset1 = jmp_offset2 = 4` (Rust lowerer `zib.j(4, 4)`, no `set_pc()`;
@@ -2016,8 +2018,8 @@ structure Inputs_sb (trace : AcceptedZiskTrace numInstructions) (binding : SailT
     (i : Fin trace.numInstructions) (c : Claim_sb trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   h_opcode_assumptions : PureSpec.sb_state_assumptions c.sb_input (binding i)
-  h_addr2 :
-    (mainRowWithRomSt trace i).rom.addr2.toNat =
+  h_store_addr_arith :
+    ((mainRowWithRomSt trace i).rom.store_offset + (mainRowWithRomSt trace i).core.a_0).toNat =
       (c.sb_input.r1_val + BitVec.signExtend 64 c.sb_input.imm).toNat
   h_b0_value :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).b_0 i.val =
@@ -2079,6 +2081,8 @@ structure Decode_sh (trace : AcceptedZiskTrace numInstructions)
   h_main_ind_width :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).ind_width
       i.val = 2
+  h_store_ind :
+    (mainRowWithRomSt trace i).rom.store_ind = 1
   -- #100 next-PC transition inputs (replace the exec artifacts): the next row
   -- exists, plus the COPYB store-row decode pins `set_pc = 0`,
   -- `jmp_offset1 = jmp_offset2 = 4` (Rust lowerer `zib.j(4, 4)`, no `set_pc()`;
@@ -2098,8 +2102,8 @@ structure Inputs_sh (trace : AcceptedZiskTrace numInstructions) (binding : SailT
     (i : Fin trace.numInstructions) (c : Claim_sh trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   h_opcode_assumptions : PureSpec.sh_state_assumptions c.sh_input (binding i)
-  h_addr2 :
-    (mainRowWithRomSt trace i).rom.addr2.toNat =
+  h_store_addr_arith :
+    ((mainRowWithRomSt trace i).rom.store_offset + (mainRowWithRomSt trace i).core.a_0).toNat =
       (c.sh_input.r1_val + BitVec.signExtend 64 c.sh_input.imm).toNat
   h_b0_value :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).b_0 i.val =
@@ -2159,6 +2163,8 @@ structure Decode_sw (trace : AcceptedZiskTrace numInstructions)
   h_main_ind_width :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).ind_width
       i.val = 4
+  h_store_ind :
+    (mainRowWithRomSt trace i).rom.store_ind = 1
   -- #100 next-PC transition inputs (replace the exec artifacts): the next row
   -- exists, plus the COPYB store-row decode pins `set_pc = 0`,
   -- `jmp_offset1 = jmp_offset2 = 4` (Rust lowerer `zib.j(4, 4)`, no `set_pc()`;
@@ -2178,8 +2184,8 @@ structure Inputs_sw (trace : AcceptedZiskTrace numInstructions) (binding : SailT
     (i : Fin trace.numInstructions) (c : Claim_sw trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   h_opcode_assumptions : PureSpec.sw_state_assumptions c.sw_input (binding i)
-  h_addr2 :
-    (mainRowWithRomSt trace i).rom.addr2.toNat =
+  h_store_addr_arith :
+    ((mainRowWithRomSt trace i).rom.store_offset + (mainRowWithRomSt trace i).core.a_0).toNat =
       (c.sw_input.r1_val + BitVec.signExtend 64 c.sw_input.imm).toNat
   h_b0_value :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).b_0 i.val =
@@ -2232,6 +2238,8 @@ structure Decode_sd (trace : AcceptedZiskTrace numInstructions)
   h_store_pc :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).store_pc
       i.val = 0
+  h_store_ind :
+    (mainRowWithRomSt trace i).rom.store_ind = 1
   -- #100 next-PC transition inputs (replace the exec artifacts): the next row
   -- exists, plus the COPYB store-row decode pins `set_pc = 0`,
   -- `jmp_offset1 = jmp_offset2 = 4` (Rust lowerer `zib.j(4, 4)`, no `set_pc()`;
@@ -2251,8 +2259,8 @@ structure Inputs_sd (trace : AcceptedZiskTrace numInstructions) (binding : SailT
     (i : Fin trace.numInstructions) (c : Claim_sd trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   h_opcode_assumptions : PureSpec.sd_state_assumptions c.sd_input (binding i)
-  h_addr2 :
-    (mainRowWithRomSt trace i).rom.addr2.toNat =
+  h_store_addr_arith :
+    ((mainRowWithRomSt trace i).rom.store_offset + (mainRowWithRomSt trace i).core.a_0).toNat =
       (c.sd_input.r1_val + BitVec.signExtend 64 c.sd_input.imm).toNat
   h_b0_value :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).b_0 i.val =

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
@@ -68,6 +68,25 @@ theorem eRdLui_rd_idx_of_decode
   rw [h_addr2, h_store_offset, h_store_ind]
   simp [Transpiler.wrap_to_regidx_ind]
 
+/-- Store `addr2` placement derived from `AddressSpec` and the decoded store selector.
+
+The remaining arithmetic premise is deliberately over the `AddressSpec` right-hand
+side, not over `addr2`: it is the residual Sail/field address representation bridge,
+while this theorem discharges the Main-row address-placement part. -/
+theorem store_addr2_of_decode
+    {numInstructions : Nat}
+    {trace : AcceptedZiskTrace numInstructions}
+    {i : Fin trace.numInstructions}
+    {target : Nat}
+    (h_store_ind : (mainRowWithRomSt trace i).rom.store_ind = 1)
+    (h_store_addr_arith :
+      ((mainRowWithRomSt trace i).rom.store_offset
+        + (mainRowWithRomSt trace i).core.a_0).toNat = target) :
+    (mainRowWithRomSt trace i).rom.addr2.toNat = target := by
+  have h_addr2 := (RomDecodeBinding.mainRowWithRomSt_addressSpec trace i).2.2.1
+  rw [h_addr2, h_store_ind]
+  simpa using h_store_addr_arith
+
 /-! ## Strengthened control-flow + U-type arms (branches, JAL/JALR, LUI/AUIPC)
 
 These arms reach the same channel-balance conclusion as the 22 above, but via a
@@ -1287,8 +1306,9 @@ mainRowVar` appears in five hypotheses (`h_main_row`/`h_main_spec`/`h_store_pc`/
 `eval` reduces to the concrete trace row `mainRowWithRomSt trace i`, so the
 five hypotheses become exactly the facts `construction_<store>_sound` already
 proves (Spec at the row, `store_pc = 0`, the self-referential `c`-emission match,
-the `addr2` bridge).  This `mainConstVar`-of-the-real-row pattern is the analogue
-of the M-ext/control "placeholder-env + real row" build and sidesteps the prior
+and the derived `addr2` placement bridge).  This `mainConstVar`-of-the-real-row
+pattern is the analogue of the M-ext/control "placeholder-env + real row" build
+and sidesteps the prior
 whnf BLOWUP (the `Eq.mpr` cast over a free `MainRowWithRom` motive) because the row
 is a `.const` literal of the committed trace row, not an opaque eval-binder.
 
@@ -1361,7 +1381,9 @@ theorem stepStrong_sb
       (by simpa only [eval_mainConstVar] using h_main_spec)
       (by simpa only [eval_mainConstVar] using h_core_store_pc)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
-      (by simpa only [eval_mainConstVar] using d.toInputs.h_addr2)
+      (by
+        simpa only [eval_mainConstVar] using
+          store_addr2_of_decode d.toDecode.h_store_ind d.toInputs.h_store_addr_arith)
       h_b0' h_b1' d.toInputs.h_m1 d.toInputs.h_m2 d.toInputs.h_m3 d.toInputs.h_m4 d.toInputs.h_m5 d.toInputs.h_m6 d.toInputs.h_m7
   have h_bridge : env.aeneasBridgeTrust := ⟨d.toDecode.h_main_ind_width, h_b0', h_b1'⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
@@ -1427,7 +1449,9 @@ theorem stepStrong_sh
       (by simpa only [eval_mainConstVar] using h_main_spec)
       (by simpa only [eval_mainConstVar] using h_core_store_pc)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
-      (by simpa only [eval_mainConstVar] using d.toInputs.h_addr2)
+      (by
+        simpa only [eval_mainConstVar] using
+          store_addr2_of_decode d.toDecode.h_store_ind d.toInputs.h_store_addr_arith)
       h_b0' h_b1' d.toInputs.h_m2 d.toInputs.h_m3 d.toInputs.h_m4 d.toInputs.h_m5 d.toInputs.h_m6 d.toInputs.h_m7
   have h_bridge : env.aeneasBridgeTrust := ⟨d.toDecode.h_main_ind_width, h_b0', h_b1'⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
@@ -1493,7 +1517,9 @@ theorem stepStrong_sw
       (by simpa only [eval_mainConstVar] using h_main_spec)
       (by simpa only [eval_mainConstVar] using h_core_store_pc)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
-      (by simpa only [eval_mainConstVar] using d.toInputs.h_addr2)
+      (by
+        simpa only [eval_mainConstVar] using
+          store_addr2_of_decode d.toDecode.h_store_ind d.toInputs.h_store_addr_arith)
       h_b0' h_b1' d.toInputs.h_m4 d.toInputs.h_m5 d.toInputs.h_m6 d.toInputs.h_m7
   have h_bridge : env.aeneasBridgeTrust := ⟨d.toDecode.h_main_ind_width, h_b0', h_b1'⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
@@ -1559,7 +1585,9 @@ theorem stepStrong_sd
       (by simpa only [eval_mainConstVar] using h_main_spec)
       (by simpa only [eval_mainConstVar] using h_core_store_pc)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
-      (by simpa only [eval_mainConstVar] using d.toInputs.h_addr2)
+      (by
+        simpa only [eval_mainConstVar] using
+          store_addr2_of_decode d.toDecode.h_store_ind d.toInputs.h_store_addr_arith)
       h_b0' h_b1'
   have h_bridge : env.aeneasBridgeTrust := ⟨h_b0', h_b1'⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial


### PR DESCRIPTION
Part of #141.

This PR removes the direct store `Inputs_* .h_addr2` placement premise for SB/SH/SW/SD. The store decode records now expose `store_ind = 1` from committed-program ROM flags, and `StepStrongControlStore` derives `addr2` from `AddressSpec` plus that decoded selector.

The residual address arithmetic bridge is deliberately kept over `store_offset + core.a_0`, not over `addr2`, so this discharges the Main-row placement part without hiding the remaining Sail/field representation obligation.

Verification:
- `lake build ZiskFv.Compliance.TraceLevelExport.RowDataArithMem ZiskFv.Compliance.TraceLevelExport.RomDecodeBindingOps ZiskFv.Compliance.TraceLevelExport.ProgramDecode ZiskFv.Compliance.TraceLevelExport.StepStrongControlStore`
- `lake build`
- `trust/scripts/check-all.sh`
- `trust/scripts/check-all-semantic.sh`