### PR TITLE
Derive U-type, jump, load, and store placement

### DIFF
--- a/ZiskFv/AirsClean/Main/Circuit.lean
+++ b/ZiskFv/AirsClean/Main/Circuit.lean
@@ -217,7 +217,8 @@ def packFlags (bits : RomFlagBits) : FGL :=
     and flag bits are copied from the selected program row and `RomFlagBits`;
     dependent `c_*`/`flag` columns are selected by `MainRomExecKind`. Address
     columns are computed by `mainRomRowOf` from the source PIL placement
-    equations, not supplied as free data. -/
+    equations, not supplied as free data. Immediate-selected operand lanes are
+    guarded by `MainRomSourceGuard`. -/
 structure MainRomFreeCols where
   a_0 : FGL
   a_1 : FGL
@@ -315,6 +316,18 @@ def mainRomRowOf (msg : ZiskFv.Channels.ZiskRomBus.ZiskRomMessage FGL)
 def MainRomAddressGuard (bits : RomFlagBits) (free : MainRomFreeCols) : Prop :=
   (boolF bits.store_ind + boolF bits.b_src_ind) * free.a_1 = 0
 
+/-- Immediate-source constructibility conditions from `main.pil:389-390`.
+
+When a ROM flag selects an immediate operand source, the honest row's operand
+limb must be the corresponding committed program immediate limb. -/
+def MainRomSourceGuard
+    (msg : ZiskFv.Channels.ZiskRomBus.ZiskRomMessage FGL)
+    (bits : RomFlagBits) (free : MainRomFreeCols) : Prop :=
+  boolF bits.a_src_imm * (free.a_0 + -1 * msg.a_offset_imm0) = 0
+  ∧ boolF bits.a_src_imm * (free.a_1 + -1 * msg.a_imm1) = 0
+  ∧ boolF bits.b_src_imm * (free.b_0 + -1 * msg.b_offset_imm0) = 0
+  ∧ boolF bits.b_src_imm * (free.b_1 + -1 * msg.b_imm1) = 0
+
 /-- The extra boolean obligations introduced by `mainWithRom`, beyond the
     original nine Main constraints. These are not part of Main's per-row
     soundness `Spec`; a future honest-prover completeness project may consume
@@ -348,8 +361,9 @@ theorem mainWithRomAndMemBus_soundness (length : ℕ) (program : Program length)
   · obtain ⟨h0, h1, h2, h3, h4, h5, h6, h7, h8, _h_m32, _h_set_pc,
       _h_store_pc, _h_a_src_imm, _h_a_src_mem, _h_is_precompiled,
       _h_b_src_imm, _h_b_src_mem, _h_store_mem, _h_store_ind, _h_b_src_ind,
-      _h_a_src_reg, _h_b_src_reg, _h_store_reg, _h_addr0, _h_addr1, _h_addr2,
-      _h_addr_guard, _h_rom⟩ := h_holds
+      _h_a_src_reg, _h_b_src_reg, _h_store_reg, _h_a_src_imm0, _h_a_src_imm1,
+      _h_b_src_imm0, _h_b_src_imm1, _h_addr0, _h_addr1, _h_addr2, _h_addr_guard,
+      _h_rom⟩ := h_holds
     exact ⟨ by simpa [sub_eq_add_neg] using h0
           , by simpa [sub_eq_add_neg] using h1
           , by simpa [sub_eq_add_neg] using h2
@@ -452,6 +466,49 @@ theorem addressSpec_of_mainWithRomAndMemBus_constraints
     ProvableType.eval_field]
   exact ⟨h_addr0, h_addr1, h_addr2, by simpa only [Expression.eval] using h_guard⟩
 
+/-- Project the source-PIL immediate-source constraints carried by
+`mainWithRomAndMemBus` to the evaluated Main row. -/
+theorem sourceSpec_of_mainWithRomAndMemBus_constraints
+    (length : ℕ) (program : Program length)
+    (row : Var MainRowWithRom FGL) (offset : ℕ) (env : Environment FGL)
+    (h_holds :
+      Operations.ConstraintsHold env
+        ((mainWithRomAndMemBus length program row).operations offset)) :
+    SourceSpec (eval env row) := by
+  simp only [mainWithRomAndMemBus, mainWithRom, main, circuit_norm] at h_holds
+  have h_a0 :
+      env (row.rom.a_src_imm * (row.core.a_0 - row.rom.a_offset_imm0)) = 0 :=
+    h_holds.1 (row.rom.a_src_imm * (row.core.a_0 - row.rom.a_offset_imm0)) (by simp)
+  have h_a1 :
+      env (row.rom.a_src_imm * (row.core.a_1 - row.rom.a_imm1)) = 0 :=
+    h_holds.1 (row.rom.a_src_imm * (row.core.a_1 - row.rom.a_imm1)) (by simp)
+  have h_b0 :
+      env (row.rom.b_src_imm * (row.core.b_0 - row.rom.b_offset_imm0)) = 0 :=
+    h_holds.1 (row.rom.b_src_imm * (row.core.b_0 - row.rom.b_offset_imm0)) (by simp)
+  have h_b1 :
+      env (row.rom.b_src_imm * (row.core.b_1 - row.rom.b_imm1)) = 0 :=
+    h_holds.1 (row.rom.b_src_imm * (row.core.b_1 - row.rom.b_imm1)) (by simp)
+  simp only [SourceSpec, ProvableStruct.eval_eq_eval, ProvableStruct.eval,
+    ProvableStruct.fromComponents, ProvableStruct.components,
+    ProvableStruct.toComponents, ProvableStruct.eval.go,
+    ProvableType.eval_field]
+  exact ⟨ by
+          have h := h_a0
+          simp only [Expression.eval] at h
+          simpa only [SourceSpec] using h
+        , by
+          have h := h_a1
+          simp only [Expression.eval] at h
+          simpa only [SourceSpec] using h
+        , by
+          have h := h_b0
+          simp only [Expression.eval] at h
+          simpa only [SourceSpec] using h
+        , by
+          have h := h_b1
+          simp only [Expression.eval] at h
+          simpa only [SourceSpec] using h ⟩
+
 /-- Project the ROM lookup carried by `mainWithRomAndMemBus` constraints to
     exact program-ROM membership for the evaluated row message. -/
 theorem romSpec_of_mainWithRomAndMemBus_constraints
@@ -485,6 +542,7 @@ theorem mainWithRomAndMemBus_completeness (length : ℕ) (program : Program leng
         ∃ i bits kind free,
           (program i).flags = packFlags bits
           ∧ MainRomExecKind.Coherent (program i) bits kind
+          ∧ MainRomSourceGuard (program i) bits free
           ∧ MainRomAddressGuard bits free
           ∧ row = mainRomRowOf (program i) bits kind free)
       (fun _ _ _ => True) := by
@@ -492,8 +550,10 @@ theorem mainWithRomAndMemBus_completeness (length : ℕ) (program : Program leng
   simp only [mainWithRomAndMemBus, mainWithRom, main, circuit_norm,
     romMessageExpr, romFlagsExpr, aMemMessageExpr, bMemMessageExpr,
     cMemMessageExpr, aMemOpExpr, bMemOpExpr, cMemOpExpr, storeValueLoExpr,
-    storeValueHiExpr, MemBusChannel, Lookup.completeness_def]
-  obtain ⟨i, bits, kind, free, h_flags, h_coherent, h_addr_guard, hrow⟩ := h_assumptions
+  storeValueHiExpr, MemBusChannel, Lookup.completeness_def]
+  obtain ⟨i, bits, kind, free, h_flags, h_coherent, h_source_guard, h_addr_guard, hrow⟩ :=
+    h_assumptions
+  rcases h_source_guard with ⟨h_src_a0, h_src_a1, h_src_b0, h_src_b1⟩
   rw [hrow] at h_input
   simp only [circuit_norm] at h_input
   cases kind with
@@ -550,6 +610,7 @@ def circuitWithRomAndMemBus
       ∃ i bits kind free,
         (program i).flags = packFlags bits
         ∧ MainRomExecKind.Coherent (program i) bits kind
+        ∧ MainRomSourceGuard (program i) bits free
         ∧ MainRomAddressGuard bits free
         ∧ row = mainRomRowOf (program i) bits kind free
     ProverSpec := fun _ _ _ => True
@@ -595,6 +656,7 @@ theorem mainWithRomMemAndOpBus_completeness (length : ℕ) (program : Program le
         ∃ i bits kind free,
           (program i).flags = packFlags bits
           ∧ MainRomExecKind.Coherent (program i) bits kind
+          ∧ MainRomSourceGuard (program i) bits free
           ∧ MainRomAddressGuard bits free
           ∧ row = mainRomRowOf (program i) bits kind free)
       (fun _ _ _ => True) := by
@@ -622,6 +684,7 @@ def circuitWithRomMemAndOpBus
       ∃ i bits kind free,
         (program i).flags = packFlags bits
         ∧ MainRomExecKind.Coherent (program i) bits kind
+        ∧ MainRomSourceGuard (program i) bits free
         ∧ MainRomAddressGuard bits free
         ∧ row = mainRomRowOf (program i) bits kind free
     ProverSpec := fun _ _ _ => True
@@ -745,6 +808,17 @@ theorem addressSpec_of_mainWithRomMemAndOpBus_constraints
   exact addressSpec_of_mainWithRomAndMemBus_constraints length program row offset env (by
     simpa only [mainWithRomMemAndOpBus] using h_holds)
 
+/-- Project source-PIL immediate-source placement from unified Main row constraints. -/
+theorem sourceSpec_of_mainWithRomMemAndOpBus_constraints
+    (length : ℕ) (program : Program length)
+    (row : Var MainRowWithRom FGL) (offset : ℕ) (env : Environment FGL)
+    (h_holds :
+      Operations.ConstraintsHold env
+        ((mainWithRomMemAndOpBus length program row).operations offset)) :
+    SourceSpec (eval env row) := by
+  exact sourceSpec_of_mainWithRomAndMemBus_constraints length program row offset env (by
+    simpa only [mainWithRomMemAndOpBus] using h_holds)
+
 theorem is_external_op_boolean_of_componentWithRomMemAndOpBus_constraints
     (length : ℕ) (program : Program length)
     (env : Environment FGL)
@@ -825,6 +899,25 @@ theorem addressSpec_of_componentWithRomAndMemBus_constraints
       simpa only [componentWithRomAndMemBus, circuitWithRomAndMemBus,
         Component.rowOperations] using h_row)
 
+/-- Component-level projection of source-PIL immediate-source placement for Main plus
+ROM/memory buses. -/
+theorem sourceSpec_of_componentWithRomAndMemBus_constraints
+    (length : ℕ) (program : Program length)
+    (env : Environment FGL)
+    (h_holds :
+      (componentWithRomAndMemBus length program).operations.ConstraintsHold env) :
+    SourceSpec (eval env (componentWithRomAndMemBus length program).rowInputVar) := by
+  have h_row :
+      (componentWithRomAndMemBus length program).rowOperations.ConstraintsHold env :=
+    (Component.constraintsHold_iff
+      (component := componentWithRomAndMemBus length program) env).mp h_holds
+  exact sourceSpec_of_mainWithRomAndMemBus_constraints
+    length program
+    (componentWithRomAndMemBus length program).rowInputVar
+    (componentWithRomAndMemBus length program).rowOffset env (by
+      simpa only [componentWithRomAndMemBus, circuitWithRomAndMemBus,
+        Component.rowOperations] using h_row)
+
 /-- Project the ROM lookup carried by the unified Main component's row
     constraints to exact program-ROM membership for the evaluated row message. -/
 theorem romSpec_of_componentWithRomMemAndOpBus_constraints
@@ -862,6 +955,26 @@ theorem addressSpec_of_componentWithRomMemAndOpBus_constraints
       (component := componentWithRomMemAndOpBus length program) env).mp h_holds
   exact
     addressSpec_of_mainWithRomMemAndOpBus_constraints
+      length program
+      (componentWithRomMemAndOpBus length program).rowInputVar
+      (componentWithRomMemAndOpBus length program).rowOffset env
+      (by
+        simpa only [componentWithRomMemAndOpBus, circuitWithRomMemAndOpBus,
+          Component.rowOperations] using h_row)
+
+/-- Component-level projection of source-PIL immediate-source placement for unified Main. -/
+theorem sourceSpec_of_componentWithRomMemAndOpBus_constraints
+    (length : ℕ) (program : Program length)
+    (env : Environment FGL)
+    (h_holds :
+      (componentWithRomMemAndOpBus length program).operations.ConstraintsHold env) :
+    SourceSpec (eval env (componentWithRomMemAndOpBus length program).rowInputVar) := by
+  have h_row :
+      (componentWithRomMemAndOpBus length program).rowOperations.ConstraintsHold env :=
+    (Component.constraintsHold_iff
+      (component := componentWithRomMemAndOpBus length program) env).mp h_holds
+  exact
+    sourceSpec_of_mainWithRomMemAndOpBus_constraints
       length program
       (componentWithRomMemAndOpBus length program).rowInputVar
       (componentWithRomMemAndOpBus length program).rowOffset env

--- a/ZiskFv/AirsClean/Main/Constraints.lean
+++ b/ZiskFv/AirsClean/Main/Constraints.lean
@@ -89,7 +89,14 @@ def mainWithOpBus (row : Var MainRow FGL) : Circuit FGL Unit := do
    store_offset, jmp_offset1, jmp_offset2, rom_flags]` tuple against
    the program-parameterised `romStaticTable`.
 
-3. The non-SP address-placement constraints at `main.pil:188-197`:
+3. The non-SP immediate-source constraints at `main.pil:389-390`,
+   unfolded across the two RV64 limbs:
+   `a_src_imm * (a[0] - a_offset_imm0) === 0`,
+   `a_src_imm * (a[1] - a_imm1) === 0`,
+   `b_src_imm * (b[0] - b_offset_imm0) === 0`, and
+   `b_src_imm * (b[1] - b_imm1) === 0`.
+
+4. The non-SP address-placement constraints at `main.pil:188-197`:
    `addr0 = a_offset_imm0`,
    `addr1 === b_offset_imm0 + b_src_ind * a[0]`,
    `addr2 = store_offset + store_ind * a[0]`, and
@@ -252,6 +259,11 @@ def mainWithRom (length : ℕ) (program : Program length)
   assertZero (row.rom.a_src_reg * (1 - row.rom.a_src_reg))
   assertZero (row.rom.b_src_reg * (1 - row.rom.b_src_reg))
   assertZero (row.rom.store_reg * (1 - row.rom.store_reg))
+  -- Immediate-source lane equations from `main.pil:389-390`.
+  assertZero (row.rom.a_src_imm * (row.core.a_0 - row.rom.a_offset_imm0))
+  assertZero (row.rom.a_src_imm * (row.core.a_1 - row.rom.a_imm1))
+  assertZero (row.rom.b_src_imm * (row.core.b_0 - row.rom.b_offset_imm0))
+  assertZero (row.rom.b_src_imm * (row.core.b_1 - row.rom.b_imm1))
   -- Non-SP address-placement equations from `main.pil:188-197`.
   assertZero (row.rom.addr0 - row.rom.a_offset_imm0)
   assertZero (row.rom.addr1 - (row.rom.b_offset_imm0 + row.rom.b_src_ind * row.core.a_0))

--- a/ZiskFv/AirsClean/Main/Spec.lean
+++ b/ZiskFv/AirsClean/Main/Spec.lean
@@ -20,11 +20,15 @@ set_pc, jmp_offset1, jmp_offset2 multiplexer with Nat.sub saturation
 at row 0; see `ZiskFv/Airs/Main/Main.lean:181-192`) is NOT in this
 per-row Spec — it lives in a separate adjacency theorem in Bridge.
 
-The ROM-backed row also has source-PIL address-placement constraints for
-the non-SP build (`main.pil:188-197`). These are kept as a separate
-`AddressSpec`: opcode soundness can project them when it needs
-memory/register-destination routing, while the older core `Spec` remains the
-nine local Main arithmetic/control constraints.
+The ROM-backed row also has source-PIL operand/address routing constraints for
+the non-SP build. These are kept as separate specs:
+
+* `SourceSpec` tracks immediate-source lane placement from `main.pil:389-390`;
+* `AddressSpec` tracks address-placement constraints from `main.pil:188-197`.
+
+Opcode soundness can project them when it needs operand, memory, or
+register-destination routing, while the older core `Spec` remains the nine
+local Main arithmetic/control constraints.
 
 ## Constructibility audit
 
@@ -66,5 +70,15 @@ def AddressSpec (row : MainRowWithRom FGL) : Prop :=
   ∧ row.rom.addr1 = row.rom.b_offset_imm0 + row.rom.b_src_ind * row.core.a_0
   ∧ row.rom.addr2 = row.rom.store_offset + row.rom.store_ind * row.core.a_0
   ∧ (row.rom.store_ind + row.rom.b_src_ind) * row.core.a_1 = 0
+
+/-- Non-SP Main immediate-source lane constraints from `main.pil:389-390`.
+
+When an operand source is the instruction immediate, the corresponding `a` or
+`b` low/high limbs must equal the ROM immediate limbs. -/
+def SourceSpec (row : MainRowWithRom FGL) : Prop :=
+  row.rom.a_src_imm * (row.core.a_0 + -1 * row.rom.a_offset_imm0) = 0
+  ∧ row.rom.a_src_imm * (row.core.a_1 + -1 * row.rom.a_imm1) = 0
+  ∧ row.rom.b_src_imm * (row.core.b_0 + -1 * row.rom.b_offset_imm0) = 0
+  ∧ row.rom.b_src_imm * (row.core.b_1 + -1 * row.rom.b_imm1) = 0
 
 end ZiskFv.AirsClean.Main

--- a/ZiskFv/Compliance/TraceLevelExport/Base.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/Base.lean
@@ -40,6 +40,15 @@ seal mulwArow mulhuArow divuArow divuwArow remuArow remuwArow
 
 set_option maxHeartbeats 8000000
 
+/-- Sequential next-PC theorem-domain range assumption.
+
+This is the explicit soundness-domain condition used by the sequential `PC + 4`
+cast. It is not Sail/ZisK state agreement and not a decoded placement fact, so
+`Inputs_<op>` records should not carry it once the opcode family has been
+factored to `RowOutsideDefectRegion`. -/
+def SequentialPcDomain (pc : BitVec 64) : Prop :=
+  pc.toNat < GL_prime - 4
+
 /-- All-zero `Valid_Binary` — pure data, never consumed by any dispatcher arm
     (the RTYPE/ITYPE/W binary `OpEnvelope` arms carry it as an unused field).
     Building it with `0` lanes is non-vacuous: it imposes no constraint and

--- a/ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean
@@ -259,30 +259,107 @@ def InputsAgree (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : Sai
 /-- Per-row known-defect exclusion obligation, stated DIRECTLY over the row data
     (no `OpEnvelope` detour).
 
-    The 8 defect-capable arms carry the genuine forge exclusion, read off the
+    The defect-capable arms carry the genuine forge exclusion, read off the
     arith witness / claim fields that live in `ia` (the `inputsAgree` half) or in
     the matched `ZiskStep` claim payload:
       * MUL / MULH / MULHSU → `¬ SignedMulForge` of the ArithMul sign witnesses;
       * DIV / REM → `¬ DivRemForge` of the 64-bit remainder/divisor magnitudes;
       * DIVW / REMW → `¬ DivRemForgeW` of the 32-bit remainder/divisor magnitudes;
       * FENCE → `FenceKnownGood` of the claim's `fm` / `rs` / `rd`.
-    Each is DEFINITIONALLY the same proposition as the corresponding `<op>EnvOf`
-    `OpEnvelope` defect shape (the `Iff.rfl` bridge lemmas in `EnvOf`), so the
-    re-expression off `OpEnvelope` carries no change of meaning.  Every other
-    (non-defect) arm carries no defect obligation (`True`). -/
+
+    The sequential, branch, and jump-like arms that have been factored carry
+    theorem-domain PC range assumptions separately from `InputsAgree`: these are
+    not state/value agreement facts, and they are not derived placement facts.
+    They preserve the old no-wrap / PC-bound obligations at the explicit
+    theorem-domain surface.
+    For defect-gated arms, the defect component is DEFINITIONALLY the same
+    proposition as the corresponding `<op>EnvOf` `OpEnvelope` defect shape (the
+    `Iff.rfl` bridge lemmas in `EnvOf`), so the re-expression off `OpEnvelope`
+    carries no change of meaning.  The separate sequential-domain component is
+    the old PC-bound obligation factored out of `InputsAgree`. -/
 def RowOutsideDefectRegion (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions)
     (i : Fin ziskTrace.numInstructions) (zs : ZiskStep ziskTrace i)
     (ia : InputsAgree ziskTrace sailTrace i zs) : Prop :=
   match zs, ia with
-  | .mul _, ia => ¬ Defects.SignedMulForge ia.v ia.r_a
-  | .mulh _, ia => ¬ Defects.SignedMulForge ia.v ia.r_a
-  | .mulhsu _, ia => ¬ Defects.SignedMulForge ia.v ia.r_a
-  | .div _, ia => ¬ Defects.DivRemForge ia.div_input.r2_val ia.v ia.r_a
-  | .rem _, ia => ¬ Defects.DivRemForge ia.rem_input.r2_val ia.v ia.r_a
-  | .divw _, ia => ¬ Defects.DivRemForgeW ia.divw_input.r2_val ia.v ia.r_a
-  | .remw _, ia => ¬ Defects.DivRemForgeW ia.remw_input.r2_val ia.v ia.r_a
-  | .fence c, _ => Defects.FenceKnownGood c.fm c.rs c.rd
-  | _, _ => True
+  | .mul _, ia => SequentialPcDomain ia.mul_input.PC ∧ ¬ Defects.SignedMulForge ia.v ia.r_a
+  | .mulh _, ia => SequentialPcDomain ia.mulh_input.PC ∧ ¬ Defects.SignedMulForge ia.v ia.r_a
+  | .mulhsu _, ia => SequentialPcDomain ia.mulhsu_input.PC ∧ ¬ Defects.SignedMulForge ia.v ia.r_a
+  | .div _, ia =>
+      SequentialPcDomain ia.div_input.PC ∧ ¬ Defects.DivRemForge ia.div_input.r2_val ia.v ia.r_a
+  | .rem _, ia =>
+      SequentialPcDomain ia.rem_input.PC ∧ ¬ Defects.DivRemForge ia.rem_input.r2_val ia.v ia.r_a
+  | .divw _, ia =>
+      SequentialPcDomain ia.divw_input.PC ∧ ¬ Defects.DivRemForgeW ia.divw_input.r2_val ia.v ia.r_a
+  | .remw _, ia =>
+      SequentialPcDomain ia.remw_input.PC ∧ ¬ Defects.DivRemForgeW ia.remw_input.r2_val ia.v ia.r_a
+  | .mulw _, ia => SequentialPcDomain ia.mulw_input.PC
+  | .mulhu _, ia => SequentialPcDomain ia.mulhu_input.PC
+  | .divu _, ia => SequentialPcDomain ia.divu_input.PC
+  | .divuw _, ia => SequentialPcDomain ia.divuw_input.PC
+  | .remu _, ia => SequentialPcDomain ia.remu_input.PC
+  | .remuw _, ia => SequentialPcDomain ia.remuw_input.PC
+  | .sub _, ia => SequentialPcDomain ia.sub_input.PC
+  | .and _, ia => SequentialPcDomain ia.and_input.PC
+  | .or _, ia => SequentialPcDomain ia.or_input.PC
+  | .xor _, ia => SequentialPcDomain ia.xor_input.PC
+  | .slt _, ia => SequentialPcDomain ia.slt_input.PC
+  | .sltu _, ia => SequentialPcDomain ia.sltu_input.PC
+  | .andi _, ia => SequentialPcDomain ia.andi_input.PC
+  | .ori _, ia => SequentialPcDomain ia.ori_input.PC
+  | .xori _, ia => SequentialPcDomain ia.xori_input.PC
+  | .slti _, ia => SequentialPcDomain ia.slti_input.PC
+  | .sltiu _, ia => SequentialPcDomain ia.sltiu_input.PC
+  | .sll _, ia => SequentialPcDomain ia.sll_input.PC
+  | .srl _, ia => SequentialPcDomain ia.srl_input.PC
+  | .sra _, ia => SequentialPcDomain ia.sra_input.PC
+  | .slli _, ia => SequentialPcDomain ia.slli_input.PC
+  | .srli _, ia => SequentialPcDomain ia.srli_input.PC
+  | .srai _, ia => SequentialPcDomain ia.srai_input.PC
+  | .add _, ia => SequentialPcDomain ia.add_input.PC
+  | .addi _, ia => SequentialPcDomain ia.addi_input.PC
+  | .subw _, ia => SequentialPcDomain ia.subw_input.PC
+  | .addw _, ia => SequentialPcDomain ia.addw_input.PC
+  | .addiw _, ia => SequentialPcDomain ia.addiw_input.PC
+  | .sllw _, ia => SequentialPcDomain ia.sllw_input.PC
+  | .srlw _, ia => SequentialPcDomain ia.srlw_input.PC
+  | .sraw _, ia => SequentialPcDomain ia.sraw_input.PC
+  | .slliw c, _ => SequentialPcDomain c.slliw_input.PC
+  | .srliw c, _ => SequentialPcDomain c.srliw_input.PC
+  | .sraiw c, _ => SequentialPcDomain c.sraiw_input.PC
+  | .beq _, ia =>
+      BranchRangeDomain ziskTrace i ia.beq_input.PC
+        ((mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset1 i.val)
+  | .bne _, ia =>
+      BranchRangeDomain ziskTrace i ia.bne_input.PC
+        ((mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset2 i.val)
+  | .blt _, ia =>
+      BranchRangeDomain ziskTrace i ia.blt_input.PC
+        ((mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset1 i.val)
+  | .bge _, ia =>
+      BranchRangeDomain ziskTrace i ia.bge_input.PC
+        ((mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset2 i.val)
+  | .bltu _, ia =>
+      BranchRangeDomain ziskTrace i ia.bltu_input.PC
+        ((mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset1 i.val)
+  | .bgeu _, ia =>
+      BranchRangeDomain ziskTrace i ia.bgeu_input.PC
+        ((mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset2 i.val)
+  | .auipc _, ia => AuipcRangeDomain ia.auipc_input
+  | .jal _, ia => JalRangeDomain ia.jal_input
+  | .jalr _, ia => JalrRangeDomain ia.jalr_input
+  | .lui _, ia => SequentialPcDomain ia.lui_input.PC
+  | .sb c, _ => SequentialPcDomain c.sb_input.PC
+  | .sh c, _ => SequentialPcDomain c.sh_input.PC
+  | .sw c, _ => SequentialPcDomain c.sw_input.PC
+  | .sd c, _ => SequentialPcDomain c.sd_input.PC
+  | .ld c, _ => SequentialPcDomain c.ld_input.PC
+  | .lbu c, _ => SequentialPcDomain c.lbu_input.PC
+  | .lhu c, _ => SequentialPcDomain c.lhu_input.PC
+  | .lwu c, _ => SequentialPcDomain c.lwu_input.PC
+  | .lb c, _ => SequentialPcDomain c.lb_input.PC
+  | .lh c, _ => SequentialPcDomain c.lh_input.PC
+  | .lw c, _ => SequentialPcDomain c.lw_input.PC
+  | .fence c, ia => SequentialPcDomain ia.fence_input.PC ∧ Defects.FenceKnownGood c.fm c.rs c.rd
 
 def StepSound
     (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions) (i : Fin ziskTrace.numInstructions) :
@@ -518,7 +595,9 @@ def StepSound
              signed_rs1 := c.srs1
              signed_rs2 := c.srs2 }))) (sailTrace i)
       = ZiskFv.Channels.state_effect_via_channels
-          ⟨c.bus.exec_row, [c.bus.e0, c.bus.e1, c.bus.e2]⟩ (sailTrace i)
+          ⟨(busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).exec_row,
+           [(busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).e0, (busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).e1,
+            (busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).e2]⟩ (sailTrace i)
   | .mulh c =>
       (do
       Sail.writeReg Register.nextPC
@@ -530,7 +609,9 @@ def StepSound
              signed_rs1 := .Signed
              signed_rs2 := .Signed }))) (sailTrace i)
       = ZiskFv.Channels.state_effect_via_channels
-          ⟨c.bus.exec_row, [c.bus.e0, c.bus.e1, c.bus.e2]⟩ (sailTrace i)
+          ⟨(busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).exec_row,
+           [(busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).e0, (busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).e1,
+            (busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).e2]⟩ (sailTrace i)
   | .mulhsu c =>
       (do
       Sail.writeReg Register.nextPC
@@ -542,35 +623,45 @@ def StepSound
              signed_rs1 := .Signed
              signed_rs2 := .Unsigned }))) (sailTrace i)
       = ZiskFv.Channels.state_effect_via_channels
-          ⟨c.bus.exec_row, [c.bus.e0, c.bus.e1, c.bus.e2]⟩ (sailTrace i)
+          ⟨(busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).exec_row,
+           [(busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).e0, (busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).e1,
+            (busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).e2]⟩ (sailTrace i)
   | .div c =>
       (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.DIV (c.r2, c.r1, c.rd, false))) (sailTrace i)
       = ZiskFv.Channels.state_effect_via_channels
-          ⟨c.bus.exec_row, [c.bus.e0, c.bus.e1, c.bus.e2]⟩ (sailTrace i)
+          ⟨(busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).exec_row,
+           [(busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).e0, (busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).e1,
+            (busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).e2]⟩ (sailTrace i)
   | .rem c =>
       (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.REM (c.r2, c.r1, c.rd, false))) (sailTrace i)
       = ZiskFv.Channels.state_effect_via_channels
-          ⟨c.bus.exec_row, [c.bus.e0, c.bus.e1, c.bus.e2]⟩ (sailTrace i)
+          ⟨(busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).exec_row,
+           [(busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).e0, (busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).e1,
+            (busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).e2]⟩ (sailTrace i)
   | .divw c =>
       (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.DIVW (c.r2, c.r1, c.rd, false))) (sailTrace i)
       = ZiskFv.Channels.state_effect_via_channels
-          ⟨c.bus.exec_row, [c.bus.e0, c.bus.e1, c.bus.e2]⟩ (sailTrace i)
+          ⟨(busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).exec_row,
+           [(busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).e0, (busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).e1,
+            (busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).e2]⟩ (sailTrace i)
   | .remw c =>
       (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.REMW (c.r2, c.r1, c.rd, false))) (sailTrace i)
       = ZiskFv.Channels.state_effect_via_channels
-          ⟨c.bus.exec_row, [c.bus.e0, c.bus.e1, c.bus.e2]⟩ (sailTrace i)
+          ⟨(busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).exec_row,
+           [(busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).e0, (busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).e1,
+            (busSub ziskTrace i (Pilot.execRowOf ziskTrace i)).e2]⟩ (sailTrace i)
   | .mulw c =>
       (do
       Sail.writeReg Register.nextPC
@@ -803,15 +894,15 @@ theorem stepSound_of_evidence (ziskTrace : AcceptedZiskTrace numInstructions) (s
   | slliw c => exact stepStrong_slliw ziskTrace sailTrace i (toRowData_slliw c rd ia) hAvoidKnownBugs
   | srliw c => exact stepStrong_srliw ziskTrace sailTrace i (toRowData_srliw c rd ia) hAvoidKnownBugs
   | sraiw c => exact stepStrong_sraiw ziskTrace sailTrace i (toRowData_sraiw c rd ia) hAvoidKnownBugs
-  | mul c => exact stepStrong_mul ziskTrace sailTrace i (toRowData_mul c rd ia) hAvoidKnownBugs
-  | mulh c => exact stepStrong_mulh ziskTrace sailTrace i (toRowData_mulh c rd ia) hAvoidKnownBugs
-  | mulhsu c => exact stepStrong_mulhsu ziskTrace sailTrace i (toRowData_mulhsu c rd ia) hAvoidKnownBugs
+  | mul c => exact stepStrong_mul ziskTrace sailTrace i (toRowData_mul c rd ia) hAvoidKnownBugs.1 hAvoidKnownBugs.2
+  | mulh c => exact stepStrong_mulh ziskTrace sailTrace i (toRowData_mulh c rd ia) hAvoidKnownBugs.1 hAvoidKnownBugs.2
+  | mulhsu c => exact stepStrong_mulhsu ziskTrace sailTrace i (toRowData_mulhsu c rd ia) hAvoidKnownBugs.1 hAvoidKnownBugs.2
   | mulw c => exact stepStrong_mulw ziskTrace sailTrace i (toRowData_mulw c rd ia) hAvoidKnownBugs
   | mulhu c => exact stepStrong_mulhu ziskTrace sailTrace i (toRowData_mulhu c rd ia) hAvoidKnownBugs
-  | div c => exact stepStrong_div ziskTrace sailTrace i (toRowData_div c rd ia) hAvoidKnownBugs
-  | rem c => exact stepStrong_rem ziskTrace sailTrace i (toRowData_rem c rd ia) hAvoidKnownBugs
-  | divw c => exact stepStrong_divw ziskTrace sailTrace i (toRowData_divw c rd ia) hAvoidKnownBugs
-  | remw c => exact stepStrong_remw ziskTrace sailTrace i (toRowData_remw c rd ia) hAvoidKnownBugs
+  | div c => exact stepStrong_div ziskTrace sailTrace i (toRowData_div c rd ia) hAvoidKnownBugs.1 hAvoidKnownBugs.2
+  | rem c => exact stepStrong_rem ziskTrace sailTrace i (toRowData_rem c rd ia) hAvoidKnownBugs.1 hAvoidKnownBugs.2
+  | divw c => exact stepStrong_divw ziskTrace sailTrace i (toRowData_divw c rd ia) hAvoidKnownBugs.1 hAvoidKnownBugs.2
+  | remw c => exact stepStrong_remw ziskTrace sailTrace i (toRowData_remw c rd ia) hAvoidKnownBugs.1 hAvoidKnownBugs.2
   | divu c => exact stepStrong_divu ziskTrace sailTrace i (toRowData_divu c rd ia) hAvoidKnownBugs
   | divuw c => exact stepStrong_divuw ziskTrace sailTrace i (toRowData_divuw c rd ia) hAvoidKnownBugs
   | remu c => exact stepStrong_remu ziskTrace sailTrace i (toRowData_remu c rd ia) hAvoidKnownBugs
@@ -837,6 +928,6 @@ theorem stepSound_of_evidence (ziskTrace : AcceptedZiskTrace numInstructions) (s
   | lb c => exact stepStrong_lb ziskTrace sailTrace i (toRowData_lb c rd ia) hAvoidKnownBugs
   | lh c => exact stepStrong_lh ziskTrace sailTrace i (toRowData_lh c rd ia) hAvoidKnownBugs
   | lw c => exact stepStrong_lw ziskTrace sailTrace i (toRowData_lw c rd ia) hAvoidKnownBugs
-  | fence c => exact stepStrong_fence ziskTrace sailTrace i (toRowData_fence c rd ia) hAvoidKnownBugs
+  | fence c => exact stepStrong_fence ziskTrace sailTrace i (toRowData_fence c rd ia) hAvoidKnownBugs.1 hAvoidKnownBugs.2
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/TraceLevelExport/EnvOf.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/EnvOf.lean
@@ -21,6 +21,7 @@ import ZiskFv.Compliance.ConstructionJump
 import ZiskFv.Compliance
 import ZiskFv.Compliance.Defects
 import ZiskFv.Compliance.TraceLevelExport.Base
+import ZiskFv.Compliance.TraceLevelExport.RomDecodeBinding
 import ZiskFv.Compliance.TraceLevelExport.RowDataAluShift
 import ZiskFv.Compliance.TraceLevelExport.RowDataArithMem
 import ZiskFv.Compliance.TraceLevelExport.RowDataControl
@@ -44,13 +45,33 @@ seal mulwArow mulhuArow divuArow divuwArow remuArow remuwArow
 
 set_option maxHeartbeats 8000000
 
+theorem busSub_rd_idx_of_decode
+    {numInstructions : Nat}
+    {trace : AcceptedZiskTrace numInstructions}
+    {i : Fin trace.numInstructions}
+    {execRow : List (Interaction.ExecutionBusEntry FGL)}
+    {rd : regidx}
+    (h_store_ind : (mainRowWithRomSub trace i).rom.store_ind = 0)
+    (h_store_offset :
+      (mainRowWithRomSub trace i).rom.store_offset =
+        Transpiler.ind (regidx_to_fin rd)) :
+    regidx_to_fin rd =
+      Transpiler.wrap_to_regidx (busSub trace i execRow).e2.ptr := by
+  have h_spec := RomDecodeBinding.mainAddressSpec_at trace ⟨i.val, trace.mainTable_index i⟩
+  have h_addr2 := h_spec.2.2.1
+  rw [busSub, ZiskFv.AirsClean.Main.cMemMessage,
+    ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry]
+  rw [h_addr2, h_store_offset, h_store_ind]
+  simp [Transpiler.wrap_to_regidx_ind]
+
 /-- The `OpEnvelope.fence` env CONSTRUCTED from a `RowData_fence`.  Both the
     `RowOutsideDefectRegion` fence obligation AND `stepStrong_fence` reference THIS env,
     so the threaded `NoKnownDefect` obligation is the genuine `NoKnownDefect` of the
     exact env the proof feeds to `zisk_riscv_compliant_program_bus`. -/
 noncomputable def fenceEnvOf
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_fence trace binding i) :
+    (d : RowData_fence trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.fence_input.PC) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
   OpEnvelope.fence d.toInputs.fence_input d.toClaim.fm d.toClaim.fenceP d.toClaim.fenceS d.toClaim.rs d.toClaim.rd (Pilot.execRowOf trace i)
@@ -63,7 +84,7 @@ noncomputable def fenceEnvOf
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound }
+          d.toInputs.h_pc_bridge h_domain }
 
 /-- The `OpEnvelope.mul` env CONSTRUCTED from a `RowData_mul`.  Both the
     `RowOutsideDefectRegion` mul obligation AND `stepStrong_mul` reference THIS env, so
@@ -72,10 +93,12 @@ noncomputable def fenceEnvOf
     `fenceEnvOf`: a specific-env obligation, SATISFIABLE for an honest row.) -/
 noncomputable def mulEnvOf
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_mul trace binding i) :
+    (d : RowData_mul trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mul_input.PC) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
-  OpEnvelope.mul d.toInputs.mul_input d.toClaim.r1 d.toClaim.r2 d.toClaim.rd d.toClaim.srs1 d.toClaim.srs2 d.toClaim.bus d.toInputs.v d.toInputs.r_a
+  let bus := busSub trace i (Pilot.execRowOf trace i)
+  OpEnvelope.mul d.toInputs.mul_input d.toClaim.r1 d.toClaim.r2 d.toClaim.rd d.toClaim.srs1 d.toClaim.srs2 bus d.toInputs.v d.toInputs.r_a
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
     d.toInputs.h_match_primary
     -- #100: DERIVE the bundled `nextPC_matches` from the in-circuit transition
@@ -83,10 +106,11 @@ noncomputable def mulEnvOf
     -- the 14 caller-supplied value/data promises. MUL's Sail nextPC = PC + 4#64.
     (d.toInputs.promises.withNextPC (PureSpec.execute_MULH_mul_pure d.toInputs.mul_input).nextPC
       (by
-        rw [d.toInputs.h_exec_row]
         exact Pilot.sequential_nextPC_discharged trace i d.toInputs.mul_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound))
+          d.toInputs.h_pc_bridge h_domain)
+      (d.toInputs.promises.input_rd_eq.trans
+        (busSub_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)))
     d.toDecode.arith_mem d.toDecode.bounds d.toInputs.h_row_constraints
     d.toInputs.arith_table d.toInputs.arith_chunk_ranges d.toInputs.arith_carry_ranges d.toInputs.h_rs1_value d.toInputs.h_rs2_value
 
@@ -103,8 +127,9 @@ noncomputable def mulEnvOf
     the Lean-checked anti-vacuity guard for the strong-export MUL arm. -/
 theorem mul_noKnownDefect_of_rowData
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_mul trace binding i) :
-    Defects.NoKnownDefect (mulEnvOf trace binding i d) := by
+    (d : RowData_mul trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mul_input.PC) :
+    Defects.NoKnownDefect (mulEnvOf trace binding i d h_domain) := by
   intro id
   cases id with
   | arithMulSignedWitnessSoundness =>
@@ -120,19 +145,22 @@ theorem mul_noKnownDefect_of_rowData
     row.  Carries the SIGN-RANGE RESIDUAL `h_sign_a`/`h_sign_b`. -/
 noncomputable def mulhEnvOf
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_mulh trace binding i) :
+    (d : RowData_mulh trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mulh_input.PC) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
-  OpEnvelope.mulh d.toInputs.mulh_input d.toClaim.r1 d.toClaim.r2 d.toClaim.rd d.toClaim.bus d.toInputs.v d.toInputs.r_a
+  let bus := busSub trace i (Pilot.execRowOf trace i)
+  OpEnvelope.mulh d.toInputs.mulh_input d.toClaim.r1 d.toClaim.r2 d.toClaim.rd bus d.toInputs.v d.toInputs.r_a
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
     d.toInputs.h_match_secondary
     -- #100: DERIVE the bundled `nextPC_matches` (MULH Sail nextPC = PC + 4#64); see `mulEnvOf`.
     (d.toInputs.promises.withNextPC (PureSpec.execute_MULH_mulh_pure d.toInputs.mulh_input).nextPC
       (by
-        rw [d.toInputs.h_exec_row]
         exact Pilot.sequential_nextPC_discharged trace i d.toInputs.mulh_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound))
+          d.toInputs.h_pc_bridge h_domain)
+      (d.toInputs.promises.input_rd_eq.trans
+        (busSub_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)))
     d.toDecode.arith_mem d.toDecode.bounds d.toInputs.h_row_constraints
     d.toInputs.arith_table d.toInputs.arith_chunk_ranges d.toInputs.arith_carry_ranges d.toInputs.h_rs1_value d.toInputs.h_rs2_value
     d.toInputs.h_sign_a d.toInputs.h_sign_b
@@ -141,19 +169,22 @@ noncomputable def mulhEnvOf
     sign-range residual `h_sign_a` (op2 unsigned, table-pinned `nb = 0`). -/
 noncomputable def mulhsuEnvOf
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_mulhsu trace binding i) :
+    (d : RowData_mulhsu trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mulhsu_input.PC) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
-  OpEnvelope.mulhsu d.toInputs.mulhsu_input d.toClaim.r1 d.toClaim.r2 d.toClaim.rd d.toClaim.bus d.toInputs.v d.toInputs.r_a
+  let bus := busSub trace i (Pilot.execRowOf trace i)
+  OpEnvelope.mulhsu d.toInputs.mulhsu_input d.toClaim.r1 d.toClaim.r2 d.toClaim.rd bus d.toInputs.v d.toInputs.r_a
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
     d.toInputs.h_match_secondary
     -- #100: DERIVE the bundled `nextPC_matches` (MULHSU Sail nextPC = PC + 4#64); see `mulEnvOf`.
     (d.toInputs.promises.withNextPC (PureSpec.execute_MULH_mulhsu_pure d.toInputs.mulhsu_input).nextPC
       (by
-        rw [d.toInputs.h_exec_row]
         exact Pilot.sequential_nextPC_discharged trace i d.toInputs.mulhsu_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound))
+          d.toInputs.h_pc_bridge h_domain)
+      (d.toInputs.promises.input_rd_eq.trans
+        (busSub_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)))
     d.toDecode.arith_mem d.toDecode.bounds d.toInputs.h_row_constraints
     d.toInputs.arith_table d.toInputs.arith_chunk_ranges d.toInputs.arith_carry_ranges d.toInputs.h_rs1_value d.toInputs.h_rs2_value
     d.toInputs.h_sign_a
@@ -164,8 +195,9 @@ noncomputable def mulhsuEnvOf
     `NoKnownDefect (mulhEnvOf …)` is TRUE — the `.mulh` strong arm is NON-VACUOUS. -/
 theorem mulh_noKnownDefect_of_rowData
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_mulh trace binding i) :
-    Defects.NoKnownDefect (mulhEnvOf trace binding i d) := by
+    (d : RowData_mulh trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mulh_input.PC) :
+    Defects.NoKnownDefect (mulhEnvOf trace binding i d h_domain) := by
   intro id
   cases id with
   | arithMulSignedWitnessSoundness =>
@@ -180,8 +212,9 @@ theorem mulh_noKnownDefect_of_rowData
     `mulh_noKnownDefect_of_rowData`). -/
 theorem mulhsu_noKnownDefect_of_rowData
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_mulhsu trace binding i) :
-    Defects.NoKnownDefect (mulhsuEnvOf trace binding i d) := by
+    (d : RowData_mulhsu trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mulhsu_input.PC) :
+    Defects.NoKnownDefect (mulhsuEnvOf trace binding i d h_domain) := by
   intro id
   cases id with
   | arithMulSignedWitnessSoundness =>
@@ -200,19 +233,22 @@ theorem mulhsu_noKnownDefect_of_rowData
     row whose `|r| ≠ |op2|`.) -/
 noncomputable def divEnvOf
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_div trace binding i) :
+    (d : RowData_div trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.div_input.PC) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
-  OpEnvelope.div d.toInputs.div_input d.toClaim.r1 d.toClaim.r2 d.toClaim.rd d.toClaim.bus d.toInputs.v d.toInputs.r_a d.toDecode.pins
+  let bus := busSub trace i (Pilot.execRowOf trace i)
+  OpEnvelope.div d.toInputs.div_input d.toClaim.r1 d.toClaim.r2 d.toClaim.rd bus d.toInputs.v d.toInputs.r_a d.toDecode.pins
     d.toInputs.h_match_primary
     -- #100: DERIVE the bundled `nextPC_matches` (DIV Sail nextPC = PC + 4#64); see `mulEnvOf`.
     -- The DivRemForge value-defect gate is untouched.
     (d.toInputs.promises.withNextPC (PureSpec.execute_DIVREM_div_pure d.toInputs.div_input).nextPC
       (by
-        rw [d.toInputs.h_exec_row]
         exact Pilot.sequential_nextPC_discharged trace i d.toInputs.div_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound))
+          d.toInputs.h_pc_bridge h_domain)
+      (d.toInputs.promises.input_rd_eq.trans
+        (busSub_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)))
     d.toDecode.arith_mem d.toDecode.bounds d.toInputs.h_row_constraints d.toInputs.h_boundary
     d.toInputs.arith_table d.toInputs.arith_chunk_ranges d.toInputs.arith_carry_ranges
     d.toInputs.h_na_bool d.toInputs.h_nb_bool d.toInputs.h_nr_bool d.toInputs.h_np_xor d.toInputs.h_nr_pin
@@ -221,18 +257,21 @@ noncomputable def divEnvOf
 /-- The `OpEnvelope.rem` env CONSTRUCTED from a `RowData_rem` (secondary lane). -/
 noncomputable def remEnvOf
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_rem trace binding i) :
+    (d : RowData_rem trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.rem_input.PC) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
-  OpEnvelope.rem d.toInputs.rem_input d.toClaim.r1 d.toClaim.r2 d.toClaim.rd d.toClaim.bus d.toInputs.v d.toInputs.r_a d.toDecode.pins
+  let bus := busSub trace i (Pilot.execRowOf trace i)
+  OpEnvelope.rem d.toInputs.rem_input d.toClaim.r1 d.toClaim.r2 d.toClaim.rd bus d.toInputs.v d.toInputs.r_a d.toDecode.pins
     d.toInputs.h_match_secondary
     -- #100: DERIVE the bundled `nextPC_matches` (REM Sail nextPC = PC + 4#64); see `mulEnvOf`.
     (d.toInputs.promises.withNextPC (PureSpec.execute_DIVREM_rem_pure d.toInputs.rem_input).nextPC
       (by
-        rw [d.toInputs.h_exec_row]
         exact Pilot.sequential_nextPC_discharged trace i d.toInputs.rem_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound))
+          d.toInputs.h_pc_bridge h_domain)
+      (d.toInputs.promises.input_rd_eq.trans
+        (busSub_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)))
     d.toDecode.arith_mem d.toDecode.bounds d.toInputs.h_row_constraints
     d.toInputs.arith_table d.toInputs.arith_chunk_ranges d.toInputs.arith_carry_ranges
     d.toInputs.h_na_bool d.toInputs.h_nb_bool d.toInputs.h_nr_bool d.toInputs.h_np_xor d.toInputs.h_nr_pin
@@ -241,18 +280,21 @@ noncomputable def remEnvOf
 /-- The `OpEnvelope.divw` env CONSTRUCTED from a `RowData_divw` (W-mode primary). -/
 noncomputable def divwEnvOf
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_divw trace binding i) :
+    (d : RowData_divw trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.divw_input.PC) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
-  OpEnvelope.divw d.toInputs.divw_input d.toClaim.r1 d.toClaim.r2 d.toClaim.rd d.toClaim.bus d.toInputs.v d.toInputs.r_a d.toDecode.pins
+  let bus := busSub trace i (Pilot.execRowOf trace i)
+  OpEnvelope.divw d.toInputs.divw_input d.toClaim.r1 d.toClaim.r2 d.toClaim.rd bus d.toInputs.v d.toInputs.r_a d.toDecode.pins
     d.toInputs.h_match_primary
     -- #100: DERIVE the bundled `nextPC_matches` (DIVW Sail nextPC = PC + 4#64); see `mulEnvOf`.
     (d.toInputs.promises.withNextPC (PureSpec.execute_DIVREM_divw_pure d.toInputs.divw_input).nextPC
       (by
-        rw [d.toInputs.h_exec_row]
         exact Pilot.sequential_nextPC_discharged trace i d.toInputs.divw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound))
+          d.toInputs.h_pc_bridge h_domain)
+      (d.toInputs.promises.input_rd_eq.trans
+        (busSub_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)))
     d.toDecode.arith_mem d.toDecode.bounds
     d.toInputs.h_row_constraints d.toInputs.h_boundary d.toInputs.arith_table d.toInputs.arith_chunk_ranges d.toInputs.arith_carry_ranges
     d.toInputs.h_na_bool d.toInputs.h_nb_bool d.toInputs.h_nr_bool d.toInputs.h_np_xor d.toInputs.h_nr_pin d.toInputs.h_m32_v d.toInputs.h_div_v
@@ -262,18 +304,21 @@ noncomputable def divwEnvOf
 /-- The `OpEnvelope.remw` env CONSTRUCTED from a `RowData_remw` (W-mode secondary). -/
 noncomputable def remwEnvOf
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_remw trace binding i) :
+    (d : RowData_remw trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.remw_input.PC) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
-  OpEnvelope.remw d.toInputs.remw_input d.toClaim.r1 d.toClaim.r2 d.toClaim.rd d.toClaim.bus d.toInputs.v d.toInputs.r_a d.toDecode.pins
+  let bus := busSub trace i (Pilot.execRowOf trace i)
+  OpEnvelope.remw d.toInputs.remw_input d.toClaim.r1 d.toClaim.r2 d.toClaim.rd bus d.toInputs.v d.toInputs.r_a d.toDecode.pins
     d.toInputs.h_match_secondary
     -- #100: DERIVE the bundled `nextPC_matches` (REMW Sail nextPC = PC + 4#64); see `mulEnvOf`.
     (d.toInputs.promises.withNextPC (PureSpec.execute_DIVREM_remw_pure d.toInputs.remw_input).nextPC
       (by
-        rw [d.toInputs.h_exec_row]
         exact Pilot.sequential_nextPC_discharged trace i d.toInputs.remw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound))
+          d.toInputs.h_pc_bridge h_domain)
+      (d.toInputs.promises.input_rd_eq.trans
+        (busSub_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)))
     d.toDecode.arith_mem d.toDecode.bounds
     d.toInputs.h_row_constraints d.toInputs.arith_table d.toInputs.arith_chunk_ranges d.toInputs.arith_carry_ranges
     d.toInputs.h_na_bool d.toInputs.h_nb_bool d.toInputs.h_nr_bool d.toInputs.h_np_xor d.toInputs.h_nr_pin d.toInputs.h_m32_v d.toInputs.h_div_v
@@ -293,8 +338,9 @@ noncomputable def remwEnvOf
     Lean-checked anti-vacuity guard for the strong-export DIV arm. -/
 theorem div_noKnownDefect_of_rowData
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_div trace binding i) :
-    Defects.NoKnownDefect (divEnvOf trace binding i d) := by
+    (d : RowData_div trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.div_input.PC) :
+    Defects.NoKnownDefect (divEnvOf trace binding i d h_domain) := by
   intro id
   cases id with
   | arithMulSignedWitnessSoundness =>
@@ -309,8 +355,9 @@ theorem div_noKnownDefect_of_rowData
     `div_noKnownDefect_of_rowData`; secondary remainder lane). -/
 theorem rem_noKnownDefect_of_rowData
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_rem trace binding i) :
-    Defects.NoKnownDefect (remEnvOf trace binding i d) := by
+    (d : RowData_rem trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.rem_input.PC) :
+    Defects.NoKnownDefect (remEnvOf trace binding i d h_domain) := by
   intro id
   cases id with
   | arithMulSignedWitnessSoundness =>
@@ -327,8 +374,9 @@ theorem rem_noKnownDefect_of_rowData
     `div_noKnownDefect_of_rowData`; narrowed shape `|r₃₂| ≠ |op2₃₂|`). -/
 theorem divw_noKnownDefect_of_rowData
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_divw trace binding i) :
-    Defects.NoKnownDefect (divwEnvOf trace binding i d) := by
+    (d : RowData_divw trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.divw_input.PC) :
+    Defects.NoKnownDefect (divwEnvOf trace binding i d h_domain) := by
   intro id
   cases id with
   | arithMulSignedWitnessSoundness =>
@@ -343,8 +391,9 @@ theorem divw_noKnownDefect_of_rowData
     `divw_noKnownDefect_of_rowData`; W-mode secondary remainder lane). -/
 theorem remw_noKnownDefect_of_rowData
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_remw trace binding i) :
-    Defects.NoKnownDefect (remwEnvOf trace binding i d) := by
+    (d : RowData_remw trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.remw_input.PC) :
+    Defects.NoKnownDefect (remwEnvOf trace binding i d h_domain) := by
   intro id
   cases id with
   | arithMulSignedWitnessSoundness =>
@@ -368,51 +417,59 @@ re-expressed predicate were even slightly weaker or stronger than the original
 
 theorem signedMulForge_iff_mulShape
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_mul trace binding i) :
+    (d : RowData_mul trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mul_input.PC) :
     Defects.SignedMulForge d.toInputs.v d.toInputs.r_a
-      ↔ Defects.MaliciousSignedMulWitnessShape (mulEnvOf trace binding i d) := Iff.rfl
+      ↔ Defects.MaliciousSignedMulWitnessShape (mulEnvOf trace binding i d h_domain) := Iff.rfl
 
 theorem signedMulForge_iff_mulhShape
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_mulh trace binding i) :
+    (d : RowData_mulh trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mulh_input.PC) :
     Defects.SignedMulForge d.toInputs.v d.toInputs.r_a
-      ↔ Defects.MaliciousSignedMulWitnessShape (mulhEnvOf trace binding i d) := Iff.rfl
+      ↔ Defects.MaliciousSignedMulWitnessShape (mulhEnvOf trace binding i d h_domain) := Iff.rfl
 
 theorem signedMulForge_iff_mulhsuShape
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_mulhsu trace binding i) :
+    (d : RowData_mulhsu trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mulhsu_input.PC) :
     Defects.SignedMulForge d.toInputs.v d.toInputs.r_a
-      ↔ Defects.MaliciousSignedMulWitnessShape (mulhsuEnvOf trace binding i d) := Iff.rfl
+      ↔ Defects.MaliciousSignedMulWitnessShape (mulhsuEnvOf trace binding i d h_domain) := Iff.rfl
 
 theorem divRemForge_iff_divShape
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_div trace binding i) :
+    (d : RowData_div trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.div_input.PC) :
     Defects.DivRemForge d.toInputs.div_input.r2_val d.toInputs.v d.toInputs.r_a
-      ↔ Defects.ArithDivDynamicWitnessShape (divEnvOf trace binding i d) := Iff.rfl
+      ↔ Defects.ArithDivDynamicWitnessShape (divEnvOf trace binding i d h_domain) := Iff.rfl
 
 theorem divRemForge_iff_remShape
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_rem trace binding i) :
+    (d : RowData_rem trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.rem_input.PC) :
     Defects.DivRemForge d.toInputs.rem_input.r2_val d.toInputs.v d.toInputs.r_a
-      ↔ Defects.ArithDivDynamicWitnessShape (remEnvOf trace binding i d) := Iff.rfl
+      ↔ Defects.ArithDivDynamicWitnessShape (remEnvOf trace binding i d h_domain) := Iff.rfl
 
 theorem divRemForgeW_iff_divwShape
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_divw trace binding i) :
+    (d : RowData_divw trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.divw_input.PC) :
     Defects.DivRemForgeW d.toInputs.divw_input.r2_val d.toInputs.v d.toInputs.r_a
-      ↔ Defects.ArithDivDynamicWitnessShape (divwEnvOf trace binding i d) := Iff.rfl
+      ↔ Defects.ArithDivDynamicWitnessShape (divwEnvOf trace binding i d h_domain) := Iff.rfl
 
 theorem divRemForgeW_iff_remwShape
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_remw trace binding i) :
+    (d : RowData_remw trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.remw_input.PC) :
     Defects.DivRemForgeW d.toInputs.remw_input.r2_val d.toInputs.v d.toInputs.r_a
-      ↔ Defects.ArithDivDynamicWitnessShape (remwEnvOf trace binding i d) := Iff.rfl
+      ↔ Defects.ArithDivDynamicWitnessShape (remwEnvOf trace binding i d h_domain) := Iff.rfl
 
 theorem fenceKnownGood_iff_fenceShape
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_fence trace binding i) :
+    (d : RowData_fence trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.fence_input.PC) :
     Defects.FenceKnownGood d.toClaim.fm d.toClaim.rs d.toClaim.rd
-      ↔ Defects.FenceKnownGoodShape (fenceEnvOf trace binding i d) := Iff.rfl
+      ↔ Defects.FenceKnownGoodShape (fenceEnvOf trace binding i d h_domain) := Iff.rfl
 
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
@@ -187,6 +187,7 @@ structure ProgramDecode_andi {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
+  h_bits_b_src_imm : bits.b_src_imm = true
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -194,6 +195,10 @@ structure ProgramDecode_andi {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
+        ∧ BitVec.signExtend 64 c.imm
+            = BitVec.ofNat 64
+                ((trace.program j).b_offset_imm0.val
+                  + (trace.program j).b_imm1.val * 4294967296)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `ori`: exactly the inputs
@@ -209,6 +214,7 @@ structure ProgramDecode_ori {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
+  h_bits_b_src_imm : bits.b_src_imm = true
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -216,6 +222,10 @@ structure ProgramDecode_ori {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
+        ∧ BitVec.signExtend 64 c.imm
+            = BitVec.ofNat 64
+                ((trace.program j).b_offset_imm0.val
+                  + (trace.program j).b_imm1.val * 4294967296)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `xori`: exactly the inputs
@@ -231,6 +241,7 @@ structure ProgramDecode_xori {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
+  h_bits_b_src_imm : bits.b_src_imm = true
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -238,6 +249,10 @@ structure ProgramDecode_xori {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
+        ∧ BitVec.signExtend 64 c.imm
+            = BitVec.ofNat 64
+                ((trace.program j).b_offset_imm0.val
+                  + (trace.program j).b_imm1.val * 4294967296)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `slti`: exactly the inputs
@@ -253,6 +268,7 @@ structure ProgramDecode_slti {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
+  h_bits_b_src_imm : bits.b_src_imm = true
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -260,6 +276,10 @@ structure ProgramDecode_slti {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
+        ∧ BitVec.signExtend 64 c.imm
+            = BitVec.ofNat 64
+                ((trace.program j).b_offset_imm0.val
+                  + (trace.program j).b_imm1.val * 4294967296)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `sltiu`: exactly the inputs
@@ -275,6 +295,7 @@ structure ProgramDecode_sltiu {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
+  h_bits_b_src_imm : bits.b_src_imm = true
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -282,6 +303,10 @@ structure ProgramDecode_sltiu {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
+        ∧ BitVec.signExtend 64 c.imm
+            = BitVec.ofNat 64
+                ((trace.program j).b_offset_imm0.val
+                  + (trace.program j).b_imm1.val * 4294967296)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `sll`: exactly the inputs
@@ -460,6 +485,7 @@ structure ProgramDecode_addi {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
+  h_bits_b_src_imm : bits.b_src_imm = true
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -467,6 +493,10 @@ structure ProgramDecode_addi {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
+        ∧ BitVec.signExtend 64 c.imm
+            = BitVec.ofNat 64
+                ((trace.program j).b_offset_imm0.val
+                  + (trace.program j).b_imm1.val * 4294967296)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `subw`: exactly the inputs
@@ -526,6 +556,7 @@ structure ProgramDecode_addiw {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
+  h_bits_b_src_imm : bits.b_src_imm = true
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -533,6 +564,10 @@ structure ProgramDecode_addiw {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
+        ∧ BitVec.signExtend 64 c.imm
+            = BitVec.ofNat 64
+                ((trace.program j).b_offset_imm0.val
+                  + (trace.program j).b_imm1.val * 4294967296)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `sllw`: exactly the inputs
@@ -676,20 +711,23 @@ structure ProgramDecode_mul {numInstructions : Nat}
   h_idx : i.val + 1 < trace.mainTable.table.length
   arith_mem :
     ZiskFv.Compliance.ExternalArithMemoryWitness
-      (mainOfTable trace.program trace.mainTable) i.val c.bus.e2
+      (mainOfTable trace.program trace.mainTable) i.val
+      (busSub trace i (Pilot.execRowOf trace i)).e2
   bounds :
-    ZiskFv.Compliance.ByteBounds c.bus.e2
+    ZiskFv.Compliance.ByteBounds (busSub trace i (Pilot.execRowOf trace i)).e2
   bits : RomFlagBits
   h_bits_ieo : bits.is_external_op = true
   h_bits_m32 : bits.m32 = false
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
+  h_bits_store_ind : bits.store_ind = false
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_MUL
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `mulh`: exactly the inputs
@@ -701,20 +739,23 @@ structure ProgramDecode_mulh {numInstructions : Nat}
   h_idx : i.val + 1 < trace.mainTable.table.length
   arith_mem :
     ZiskFv.Compliance.ExternalArithMemoryWitness
-      (mainOfTable trace.program trace.mainTable) i.val c.bus.e2
+      (mainOfTable trace.program trace.mainTable) i.val
+      (busSub trace i (Pilot.execRowOf trace i)).e2
   bounds :
-    ZiskFv.Compliance.ByteBounds c.bus.e2
+    ZiskFv.Compliance.ByteBounds (busSub trace i (Pilot.execRowOf trace i)).e2
   bits : RomFlagBits
   h_bits_ieo : bits.is_external_op = true
   h_bits_m32 : bits.m32 = false
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
+  h_bits_store_ind : bits.store_ind = false
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_MULH
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `mulhsu`: exactly the inputs
@@ -726,20 +767,23 @@ structure ProgramDecode_mulhsu {numInstructions : Nat}
   h_idx : i.val + 1 < trace.mainTable.table.length
   arith_mem :
     ZiskFv.Compliance.ExternalArithMemoryWitness
-      (mainOfTable trace.program trace.mainTable) i.val c.bus.e2
+      (mainOfTable trace.program trace.mainTable) i.val
+      (busSub trace i (Pilot.execRowOf trace i)).e2
   bounds :
-    ZiskFv.Compliance.ByteBounds c.bus.e2
+    ZiskFv.Compliance.ByteBounds (busSub trace i (Pilot.execRowOf trace i)).e2
   bits : RomFlagBits
   h_bits_ieo : bits.is_external_op = true
   h_bits_m32 : bits.m32 = false
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
+  h_bits_store_ind : bits.store_ind = false
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_MULSUH
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `mulw`: exactly the inputs
@@ -797,20 +841,23 @@ structure ProgramDecode_div {numInstructions : Nat}
   h_idx : i.val + 1 < trace.mainTable.table.length
   arith_mem :
     ZiskFv.Compliance.ExternalArithMemoryWitness
-      (mainOfTable trace.program trace.mainTable) i.val c.bus.e2
+      (mainOfTable trace.program trace.mainTable) i.val
+      (busSub trace i (Pilot.execRowOf trace i)).e2
   bounds :
-    ZiskFv.Compliance.ByteBounds c.bus.e2
+    ZiskFv.Compliance.ByteBounds (busSub trace i (Pilot.execRowOf trace i)).e2
   bits : RomFlagBits
   h_bits_ieo : bits.is_external_op = true
   h_bits_m32 : bits.m32 = false
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
+  h_bits_store_ind : bits.store_ind = false
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_DIV
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `rem`: exactly the inputs
@@ -822,20 +869,23 @@ structure ProgramDecode_rem {numInstructions : Nat}
   h_idx : i.val + 1 < trace.mainTable.table.length
   arith_mem :
     ZiskFv.Compliance.ExternalArithMemoryWitness
-      (mainOfTable trace.program trace.mainTable) i.val c.bus.e2
+      (mainOfTable trace.program trace.mainTable) i.val
+      (busSub trace i (Pilot.execRowOf trace i)).e2
   bounds :
-    ZiskFv.Compliance.ByteBounds c.bus.e2
+    ZiskFv.Compliance.ByteBounds (busSub trace i (Pilot.execRowOf trace i)).e2
   bits : RomFlagBits
   h_bits_ieo : bits.is_external_op = true
   h_bits_m32 : bits.m32 = false
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
+  h_bits_store_ind : bits.store_ind = false
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_REM
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `divw`: exactly the inputs
@@ -847,20 +897,23 @@ structure ProgramDecode_divw {numInstructions : Nat}
   h_idx : i.val + 1 < trace.mainTable.table.length
   arith_mem :
     ZiskFv.Compliance.ExternalArithMemoryWitness
-      (mainOfTable trace.program trace.mainTable) i.val c.bus.e2
+      (mainOfTable trace.program trace.mainTable) i.val
+      (busSub trace i (Pilot.execRowOf trace i)).e2
   bounds :
-    ZiskFv.Compliance.ByteBounds c.bus.e2
+    ZiskFv.Compliance.ByteBounds (busSub trace i (Pilot.execRowOf trace i)).e2
   bits : RomFlagBits
   h_bits_ieo : bits.is_external_op = true
   h_bits_m32 : bits.m32 = true
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
+  h_bits_store_ind : bits.store_ind = false
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_DIV_W
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `remw`: exactly the inputs
@@ -872,20 +925,23 @@ structure ProgramDecode_remw {numInstructions : Nat}
   h_idx : i.val + 1 < trace.mainTable.table.length
   arith_mem :
     ZiskFv.Compliance.ExternalArithMemoryWitness
-      (mainOfTable trace.program trace.mainTable) i.val c.bus.e2
+      (mainOfTable trace.program trace.mainTable) i.val
+      (busSub trace i (Pilot.execRowOf trace i)).e2
   bounds :
-    ZiskFv.Compliance.ByteBounds c.bus.e2
+    ZiskFv.Compliance.ByteBounds (busSub trace i (Pilot.execRowOf trace i)).e2
   bits : RomFlagBits
   h_bits_ieo : bits.is_external_op = true
   h_bits_m32 : bits.m32 = true
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
+  h_bits_store_ind : bits.store_ind = false
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_REM_W
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `divu`: exactly the inputs
@@ -1000,6 +1056,7 @@ structure ProgramDecode_beq {numInstructions : Nat}
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_EQ
+        ∧ ((trace.program j).jmp_offset1).val = (BitVec.signExtend 64 c.imm).toNat
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).flags = packFlags bits
 
@@ -1020,6 +1077,7 @@ structure ProgramDecode_bne {numInstructions : Nat}
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_EQ
         ∧ (trace.program j).jmp_offset1 = 4
+        ∧ ((trace.program j).jmp_offset2).val = (BitVec.signExtend 64 c.imm).toNat
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `blt`: exactly the inputs
@@ -1038,6 +1096,7 @@ structure ProgramDecode_blt {numInstructions : Nat}
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LT
+        ∧ ((trace.program j).jmp_offset1).val = (BitVec.signExtend 64 c.imm).toNat
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).flags = packFlags bits
 
@@ -1058,6 +1117,7 @@ structure ProgramDecode_bge {numInstructions : Nat}
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LT
         ∧ (trace.program j).jmp_offset1 = 4
+        ∧ ((trace.program j).jmp_offset2).val = (BitVec.signExtend 64 c.imm).toNat
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `bltu`: exactly the inputs
@@ -1076,6 +1136,7 @@ structure ProgramDecode_bltu {numInstructions : Nat}
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LTU
+        ∧ ((trace.program j).jmp_offset1).val = (BitVec.signExtend 64 c.imm).toNat
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).flags = packFlags bits
 
@@ -1096,6 +1157,7 @@ structure ProgramDecode_bgeu {numInstructions : Nat}
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LTU
         ∧ (trace.program j).jmp_offset1 = 4
+        ∧ ((trace.program j).jmp_offset2).val = (BitVec.signExtend 64 c.imm).toNat
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `lui`: exactly the inputs
@@ -1144,6 +1206,8 @@ structure ProgramDecode_auipc {numInstructions : Nat}
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_FLAG
         ∧ (trace.program j).jmp_offset1 = 4
+        ∧ ((trace.program j).jmp_offset2).val =
+          (BitVec.signExtend 64 (c.imm ++ (0 : BitVec 12))).toNat
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits
 
@@ -1164,6 +1228,7 @@ structure ProgramDecode_jal {numInstructions : Nat}
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_FLAG
+        ∧ ((trace.program j).jmp_offset1).val = (BitVec.signExtend 64 c.imm).toNat
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits
@@ -1206,6 +1271,7 @@ structure ProgramDecode_jalr {numInstructions : Nat}
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_AND
+        ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits
 
@@ -1228,6 +1294,8 @@ structure ProgramDecode_sb {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = 1
+        ∧ (trace.program j).store_offset =
+            ((BitVec.signExtend 64 c.sb_input.imm).toInt : FGL)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `sh`: exactly the inputs
@@ -1249,6 +1317,8 @@ structure ProgramDecode_sh {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = 2
+        ∧ (trace.program j).store_offset =
+            ((BitVec.signExtend 64 c.sh_input.imm).toInt : FGL)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `sw`: exactly the inputs
@@ -1270,6 +1340,8 @@ structure ProgramDecode_sw {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = 4
+        ∧ (trace.program j).store_offset =
+            ((BitVec.signExtend 64 c.sw_input.imm).toInt : FGL)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `sd`: exactly the inputs
@@ -1290,6 +1362,8 @@ structure ProgramDecode_sd {numInstructions : Nat}
           (trace.program j).op = ZiskFv.Trusted.OP_COPYB
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
+        ∧ (trace.program j).store_offset =
+            ((BitVec.signExtend 64 c.sd_input.imm).toInt : FGL)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `ld`: exactly the inputs
@@ -1313,6 +1387,8 @@ structure ProgramDecode_ld {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (8 : FGL)
+        ∧ (trace.program j).b_offset_imm0 =
+            ((BitVec.signExtend 64 c.ld_input.imm).toNat : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.ld_input.rd)
         ∧ (trace.program j).flags = packFlags bits
 
@@ -1337,6 +1413,8 @@ structure ProgramDecode_lbu {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (1 : FGL)
+        ∧ (trace.program j).b_offset_imm0 =
+            ((BitVec.signExtend 64 c.lbu_input.imm).toNat : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lbu_input.rd)
         ∧ (trace.program j).flags = packFlags bits
 
@@ -1361,6 +1439,8 @@ structure ProgramDecode_lhu {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (2 : FGL)
+        ∧ (trace.program j).b_offset_imm0 =
+            ((BitVec.signExtend 64 c.lhu_input.imm).toNat : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lhu_input.rd)
         ∧ (trace.program j).flags = packFlags bits
 
@@ -1385,6 +1465,8 @@ structure ProgramDecode_lwu {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (4 : FGL)
+        ∧ (trace.program j).b_offset_imm0 =
+            ((BitVec.signExtend 64 c.lwu_input.imm).toNat : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lwu_input.rd)
         ∧ (trace.program j).flags = packFlags bits
 
@@ -1425,6 +1507,8 @@ structure ProgramDecode_lb {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (1 : FGL)
+        ∧ (trace.program j).b_offset_imm0 =
+            ((BitVec.signExtend 64 c.lb_input.imm).toNat : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lb_input.rd)
         ∧ (trace.program j).flags = packFlags bits
 
@@ -1465,6 +1549,8 @@ structure ProgramDecode_lh {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (2 : FGL)
+        ∧ (trace.program j).b_offset_imm0 =
+            ((BitVec.signExtend 64 c.lh_input.imm).toNat : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lh_input.rd)
         ∧ (trace.program j).flags = packFlags bits
 
@@ -1505,6 +1591,8 @@ structure ProgramDecode_lw {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (4 : FGL)
+        ∧ (trace.program j).b_offset_imm0 =
+            ((BitVec.signExtend 64 c.lw_input.imm).toNat : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lw_input.rd)
         ∧ (trace.program j).flags = packFlags bits
 
@@ -1620,11 +1708,11 @@ noncomputable def rowDecode_of_programDecode (ziskTrace : AcceptedZiskTrace numI
   | xor c => exact RomDecodeBinding.Decode_xor_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | slt c => exact RomDecodeBinding.Decode_slt_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | sltu c => exact RomDecodeBinding.Decode_sltu_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
-  | andi c => exact RomDecodeBinding.Decode_andi_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
-  | ori c => exact RomDecodeBinding.Decode_ori_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
-  | xori c => exact RomDecodeBinding.Decode_xori_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
-  | slti c => exact RomDecodeBinding.Decode_slti_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
-  | sltiu c => exact RomDecodeBinding.Decode_sltiu_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
+  | andi c => exact RomDecodeBinding.Decode_andi_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_b_src_imm pd.h_prog
+  | ori c => exact RomDecodeBinding.Decode_ori_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_b_src_imm pd.h_prog
+  | xori c => exact RomDecodeBinding.Decode_xori_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_b_src_imm pd.h_prog
+  | slti c => exact RomDecodeBinding.Decode_slti_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_b_src_imm pd.h_prog
+  | sltiu c => exact RomDecodeBinding.Decode_sltiu_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_b_src_imm pd.h_prog
   | sll c => exact RomDecodeBinding.Decode_sll_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | srl c => exact RomDecodeBinding.Decode_srl_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | sra c => exact RomDecodeBinding.Decode_sra_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
@@ -1632,25 +1720,25 @@ noncomputable def rowDecode_of_programDecode (ziskTrace : AcceptedZiskTrace numI
   | srli c => exact RomDecodeBinding.Decode_srli_of_program ziskTrace i c pd.h_idx pd.h_b_lo_t pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | srai c => exact RomDecodeBinding.Decode_srai_of_program ziskTrace i c pd.h_idx pd.h_b_lo_t pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | add c => exact RomDecodeBinding.Decode_add_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
-  | addi c => exact RomDecodeBinding.Decode_addi_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
+  | addi c => exact RomDecodeBinding.Decode_addi_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_b_src_imm pd.h_prog
   | subw c => exact RomDecodeBinding.Decode_subw_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | addw c => exact RomDecodeBinding.Decode_addw_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
-  | addiw c => exact RomDecodeBinding.Decode_addiw_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
+  | addiw c => exact RomDecodeBinding.Decode_addiw_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_b_src_imm pd.h_prog
   | sllw c => exact RomDecodeBinding.Decode_sllw_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | srlw c => exact RomDecodeBinding.Decode_srlw_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | sraw c => exact RomDecodeBinding.Decode_sraw_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | slliw c => exact RomDecodeBinding.Decode_slliw_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | srliw c => exact RomDecodeBinding.Decode_srliw_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | sraiw c => exact RomDecodeBinding.Decode_sraiw_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
-  | mul c => exact RomDecodeBinding.Decode_mul_of_program ziskTrace i c pd.h_idx pd.arith_mem pd.bounds pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
-  | mulh c => exact RomDecodeBinding.Decode_mulh_of_program ziskTrace i c pd.h_idx pd.arith_mem pd.bounds pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
-  | mulhsu c => exact RomDecodeBinding.Decode_mulhsu_of_program ziskTrace i c pd.h_idx pd.arith_mem pd.bounds pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
+  | mul c => exact RomDecodeBinding.Decode_mul_of_program ziskTrace i c pd.h_idx pd.arith_mem pd.bounds pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
+  | mulh c => exact RomDecodeBinding.Decode_mulh_of_program ziskTrace i c pd.h_idx pd.arith_mem pd.bounds pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
+  | mulhsu c => exact RomDecodeBinding.Decode_mulhsu_of_program ziskTrace i c pd.h_idx pd.arith_mem pd.bounds pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | mulw c => exact RomDecodeBinding.Decode_mulw_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | mulhu c => exact RomDecodeBinding.Decode_mulhu_of_program ziskTrace i c pd.h_idx pd.bounds pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
-  | div c => exact RomDecodeBinding.Decode_div_of_program ziskTrace i c pd.h_idx pd.arith_mem pd.bounds pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
-  | rem c => exact RomDecodeBinding.Decode_rem_of_program ziskTrace i c pd.h_idx pd.arith_mem pd.bounds pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
-  | divw c => exact RomDecodeBinding.Decode_divw_of_program ziskTrace i c pd.h_idx pd.arith_mem pd.bounds pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
-  | remw c => exact RomDecodeBinding.Decode_remw_of_program ziskTrace i c pd.h_idx pd.arith_mem pd.bounds pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
+  | div c => exact RomDecodeBinding.Decode_div_of_program ziskTrace i c pd.h_idx pd.arith_mem pd.bounds pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
+  | rem c => exact RomDecodeBinding.Decode_rem_of_program ziskTrace i c pd.h_idx pd.arith_mem pd.bounds pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
+  | divw c => exact RomDecodeBinding.Decode_divw_of_program ziskTrace i c pd.h_idx pd.arith_mem pd.bounds pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
+  | remw c => exact RomDecodeBinding.Decode_remw_of_program ziskTrace i c pd.h_idx pd.arith_mem pd.bounds pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | divu c => exact RomDecodeBinding.Decode_divu_of_program ziskTrace i c pd.h_idx pd.bounds pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | divuw c => exact RomDecodeBinding.Decode_divuw_of_program ziskTrace i c pd.h_idx pd.bounds pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | remu c => exact RomDecodeBinding.Decode_remu_of_program ziskTrace i c pd.h_idx pd.bounds pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog

--- a/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
@@ -1220,6 +1220,7 @@ structure ProgramDecode_sb {numInstructions : Nat}
   h_bits_ieo : bits.is_external_op = false
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
+  h_bits_store_ind : bits.store_ind = true
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -1240,6 +1241,7 @@ structure ProgramDecode_sh {numInstructions : Nat}
   h_bits_ieo : bits.is_external_op = false
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
+  h_bits_store_ind : bits.store_ind = true
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -1260,6 +1262,7 @@ structure ProgramDecode_sw {numInstructions : Nat}
   h_bits_ieo : bits.is_external_op = false
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
+  h_bits_store_ind : bits.store_ind = true
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -1280,6 +1283,7 @@ structure ProgramDecode_sd {numInstructions : Nat}
   h_bits_ieo : bits.is_external_op = false
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
+  h_bits_store_ind : bits.store_ind = true
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -1654,10 +1658,10 @@ noncomputable def rowDecode_of_programDecode (ziskTrace : AcceptedZiskTrace numI
   | auipc c => exact RomDecodeBinding.Decode_auipc_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | jal c => exact RomDecodeBinding.Decode_jal_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | jalr c => exact RomDecodeBinding.Decode_jalr_of_program ziskTrace i c pd.h_idx pd.h_flag pd.h_a_mask_lo pd.h_a_mask_hi pd.h_c1_zero pd.h_offset_bridge pd.h_offset_even pd.h_no_fgl_wrap pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
-  | sb c => exact RomDecodeBinding.Decode_sb_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
-  | sh c => exact RomDecodeBinding.Decode_sh_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
-  | sw c => exact RomDecodeBinding.Decode_sw_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
-  | sd c => exact RomDecodeBinding.Decode_sd_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
+  | sb c => exact RomDecodeBinding.Decode_sb_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
+  | sh c => exact RomDecodeBinding.Decode_sh_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
+  | sw c => exact RomDecodeBinding.Decode_sw_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
+  | sd c => exact RomDecodeBinding.Decode_sd_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | ld c => exact RomDecodeBinding.Decode_ld_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_store_reg pd.h_prog
   | lbu c => exact RomDecodeBinding.Decode_lbu_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_store_reg pd.h_prog
   | lhu c => exact RomDecodeBinding.Decode_lhu_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_store_reg pd.h_prog

--- a/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
@@ -1116,12 +1116,14 @@ structure ProgramDecode_lui {numInstructions : Nat}
   h_bits_m32 : bits.m32 = false
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
+  h_bits_store_ind : bits.store_ind = false
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_COPYB
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `auipc`: exactly the inputs
@@ -1136,11 +1138,13 @@ structure ProgramDecode_auipc {numInstructions : Nat}
   h_bits_m32 : bits.m32 = false
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = true
+  h_bits_store_ind : bits.store_ind = false
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_FLAG
         ∧ (trace.program j).jmp_offset1 = 4
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `jal`: exactly the inputs
@@ -1155,11 +1159,13 @@ structure ProgramDecode_jal {numInstructions : Nat}
   h_bits_m32 : bits.m32 = false
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = true
+  h_bits_store_ind : bits.store_ind = false
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_FLAG
         ∧ (trace.program j).jmp_offset2 = 4
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `jalr`: exactly the inputs
@@ -1195,10 +1201,12 @@ structure ProgramDecode_jalr {numInstructions : Nat}
   h_bits_m32 : bits.m32 = false
   h_bits_set_pc : bits.set_pc = true
   h_bits_store_pc : bits.store_pc = true
+  h_bits_store_ind : bits.store_ind = false
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_AND
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `sb`: exactly the inputs
@@ -1642,10 +1650,10 @@ noncomputable def rowDecode_of_programDecode (ziskTrace : AcceptedZiskTrace numI
   | bge c => exact RomDecodeBinding.Decode_bge_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
   | bltu c => exact RomDecodeBinding.Decode_bltu_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
   | bgeu c => exact RomDecodeBinding.Decode_bgeu_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
-  | lui c => exact RomDecodeBinding.Decode_lui_of_program ziskTrace i c pd.h_idx pd.h_imm_lo_nat pd.h_imm_hi_nat pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
-  | auipc c => exact RomDecodeBinding.Decode_auipc_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
-  | jal c => exact RomDecodeBinding.Decode_jal_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
-  | jalr c => exact RomDecodeBinding.Decode_jalr_of_program ziskTrace i c pd.h_idx pd.h_flag pd.h_a_mask_lo pd.h_a_mask_hi pd.h_c1_zero pd.h_offset_bridge pd.h_offset_even pd.h_no_fgl_wrap pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
+  | lui c => exact RomDecodeBinding.Decode_lui_of_program ziskTrace i c pd.h_idx pd.h_imm_lo_nat pd.h_imm_hi_nat pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
+  | auipc c => exact RomDecodeBinding.Decode_auipc_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
+  | jal c => exact RomDecodeBinding.Decode_jal_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
+  | jalr c => exact RomDecodeBinding.Decode_jalr_of_program ziskTrace i c pd.h_idx pd.h_flag pd.h_a_mask_lo pd.h_a_mask_hi pd.h_c1_zero pd.h_offset_bridge pd.h_offset_even pd.h_no_fgl_wrap pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | sb c => exact RomDecodeBinding.Decode_sb_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
   | sh c => exact RomDecodeBinding.Decode_sh_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog
   | sw c => exact RomDecodeBinding.Decode_sw_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_prog

--- a/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
@@ -1305,6 +1305,7 @@ structure ProgramDecode_ld {numInstructions : Nat}
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
   h_bits_store_reg : bits.store_reg = true
+  h_bits_b_src_ind : bits.b_src_ind = true
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -1328,6 +1329,7 @@ structure ProgramDecode_lbu {numInstructions : Nat}
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
   h_bits_store_reg : bits.store_reg = true
+  h_bits_b_src_ind : bits.b_src_ind = true
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -1351,6 +1353,7 @@ structure ProgramDecode_lhu {numInstructions : Nat}
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
   h_bits_store_reg : bits.store_reg = true
+  h_bits_b_src_ind : bits.b_src_ind = true
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -1374,6 +1377,7 @@ structure ProgramDecode_lwu {numInstructions : Nat}
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
   h_bits_store_reg : bits.store_reg = true
+  h_bits_b_src_ind : bits.b_src_ind = true
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -1413,6 +1417,7 @@ structure ProgramDecode_lb {numInstructions : Nat}
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
   h_bits_store_reg : bits.store_reg = true
+  h_bits_b_src_ind : bits.b_src_ind = true
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -1452,6 +1457,7 @@ structure ProgramDecode_lh {numInstructions : Nat}
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
   h_bits_store_reg : bits.store_reg = true
+  h_bits_b_src_ind : bits.b_src_ind = true
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -1491,6 +1497,7 @@ structure ProgramDecode_lw {numInstructions : Nat}
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
   h_bits_store_reg : bits.store_reg = true
+  h_bits_b_src_ind : bits.b_src_ind = true
   h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -1662,13 +1669,37 @@ noncomputable def rowDecode_of_programDecode (ziskTrace : AcceptedZiskTrace numI
   | sh c => exact RomDecodeBinding.Decode_sh_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | sw c => exact RomDecodeBinding.Decode_sw_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | sd c => exact RomDecodeBinding.Decode_sd_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
-  | ld c => exact RomDecodeBinding.Decode_ld_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_store_reg pd.h_prog
-  | lbu c => exact RomDecodeBinding.Decode_lbu_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_store_reg pd.h_prog
-  | lhu c => exact RomDecodeBinding.Decode_lhu_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_store_reg pd.h_prog
-  | lwu c => exact RomDecodeBinding.Decode_lwu_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_store_reg pd.h_prog
-  | lb c => exact RomDecodeBinding.Decode_lb_of_program ziskTrace i c pd.h_idx pd.v pd.r_binary pd.offset pd.env pd.h_static pd.h_match pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_store_reg pd.h_prog
-  | lh c => exact RomDecodeBinding.Decode_lh_of_program ziskTrace i c pd.h_idx pd.v pd.r_binary pd.offset pd.env pd.h_static pd.h_match pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_store_reg pd.h_prog
-  | lw c => exact RomDecodeBinding.Decode_lw_of_program ziskTrace i c pd.h_idx pd.v pd.r_binary pd.offset pd.env pd.h_static pd.h_match pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_store_reg pd.h_prog
+  | ld c =>
+      exact RomDecodeBinding.Decode_ld_of_program ziskTrace i c pd.h_idx pd.bits
+        pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind
+        pd.h_bits_store_reg pd.h_bits_b_src_ind pd.h_prog
+  | lbu c =>
+      exact RomDecodeBinding.Decode_lbu_of_program ziskTrace i c pd.h_idx pd.bits
+        pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind
+        pd.h_bits_store_reg pd.h_bits_b_src_ind pd.h_prog
+  | lhu c =>
+      exact RomDecodeBinding.Decode_lhu_of_program ziskTrace i c pd.h_idx pd.bits
+        pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind
+        pd.h_bits_store_reg pd.h_bits_b_src_ind pd.h_prog
+  | lwu c =>
+      exact RomDecodeBinding.Decode_lwu_of_program ziskTrace i c pd.h_idx pd.bits
+        pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind
+        pd.h_bits_store_reg pd.h_bits_b_src_ind pd.h_prog
+  | lb c =>
+      exact RomDecodeBinding.Decode_lb_of_program ziskTrace i c pd.h_idx pd.v pd.r_binary
+        pd.offset pd.env pd.h_static pd.h_match pd.bits pd.h_bits_ieo pd.h_bits_set_pc
+        pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_store_reg pd.h_bits_b_src_ind
+        pd.h_prog
+  | lh c =>
+      exact RomDecodeBinding.Decode_lh_of_program ziskTrace i c pd.h_idx pd.v pd.r_binary
+        pd.offset pd.env pd.h_static pd.h_match pd.bits pd.h_bits_ieo pd.h_bits_set_pc
+        pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_store_reg pd.h_bits_b_src_ind
+        pd.h_prog
+  | lw c =>
+      exact RomDecodeBinding.Decode_lw_of_program ziskTrace i c pd.h_idx pd.v pd.r_binary
+        pd.offset pd.env pd.h_static pd.h_match pd.bits pd.h_bits_ieo pd.h_bits_set_pc
+        pd.h_bits_store_pc pd.h_bits_store_ind pd.h_bits_store_reg pd.h_bits_b_src_ind
+        pd.h_prog
   | fence c => exact RomDecodeBinding.Decode_fence_of_program ziskTrace i c pd.h_idx pd.h_fm_zero pd.h_rs_x0 pd.h_rd_x0 pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_prog
 
 /-- Lift `rowDecode_of_programDecode` over every instruction: given a per-row

--- a/ZiskFv/Compliance/TraceLevelExport/RomDecodeBinding.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RomDecodeBinding.lean
@@ -180,6 +180,21 @@ theorem mainAddressSpec_at
   rw [ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get trace.program trace.mainTable idx]
   exact h_spec
 
+/-- The source-PIL Main immediate-source equations hold for every in-range
+    concrete Main-table row, derived from accepted trace constraints. -/
+theorem mainSourceSpec_at
+    {numInstructions : Nat} (trace : AcceptedZiskTrace numInstructions)
+    (idx : Fin trace.mainTable.table.length) :
+    ZiskFv.AirsClean.Main.SourceSpec
+      (mainTableRowAtOrZero trace.program trace.mainTable idx.val) := by
+  have h_holds := mainOperationsConstraintsHold_at trace idx
+  have h_spec :=
+    ZiskFv.AirsClean.Main.sourceSpec_of_componentWithRomMemAndOpBus_constraints
+      numInstructions trace.program
+      (trace.mainTable.environment (trace.mainTable.table.get idx)) h_holds
+  rw [ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get trace.program trace.mainTable idx]
+  exact h_spec
+
 /-- Store-row alias of `mainAddressSpec_at`. -/
 theorem mainRowWithRomSt_addressSpec
     {numInstructions : Nat} (trace : AcceptedZiskTrace numInstructions)
@@ -195,6 +210,38 @@ theorem mainRowWithRomLd_addressSpec
     ZiskFv.AirsClean.Main.AddressSpec (mainRowWithRomLd trace i) := by
   simpa [mainRowWithRomLd] using
     mainAddressSpec_at trace ⟨i.val, trace.mainTable_index i⟩
+
+/-- ALU-row alias of `mainSourceSpec_at`. -/
+theorem mainRowWithRomSub_sourceSpec
+    {numInstructions : Nat} (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin trace.numInstructions) :
+    ZiskFv.AirsClean.Main.SourceSpec (mainRowWithRomSub trace i) := by
+  simpa [mainRowWithRomSub] using
+    mainSourceSpec_at trace ⟨i.val, trace.mainTable_index i⟩
+
+/-- Store-row alias of `mainSourceSpec_at`. -/
+theorem mainRowWithRomSt_sourceSpec
+    {numInstructions : Nat} (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin trace.numInstructions) :
+    ZiskFv.AirsClean.Main.SourceSpec (mainRowWithRomSt trace i) := by
+  simpa [mainRowWithRomSt] using
+    mainSourceSpec_at trace ⟨i.val, trace.mainTable_index i⟩
+
+/-- Load-row alias of `mainSourceSpec_at`. -/
+theorem mainRowWithRomLd_sourceSpec
+    {numInstructions : Nat} (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin trace.numInstructions) :
+    ZiskFv.AirsClean.Main.SourceSpec (mainRowWithRomLd trace i) := by
+  simpa [mainRowWithRomLd] using
+    mainSourceSpec_at trace ⟨i.val, trace.mainTable_index i⟩
+
+/-- eRdLui-row alias of `mainSourceSpec_at`. -/
+theorem mainRowWithRomLui_sourceSpec
+    {numInstructions : Nat} (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin trace.numInstructions) :
+    ZiskFv.AirsClean.Main.SourceSpec (mainRowWithRomLui trace i) := by
+  simpa [mainRowWithRomLui] using
+    mainSourceSpec_at trace ⟨i.val, trace.mainTable_index i⟩
 
 /-- **The reusable binding lemma (deliverable 1).**
 
@@ -540,6 +587,60 @@ theorem romSelectorColumns_of_romFlags_eq_packFlags
   have hbits := packFlags_inj (hpack.symm.trans h)
   subst hbits
   exact ⟨e_store_ind, e_b_src_ind, e_store_reg⟩
+
+/-- **Unpacking the immediate source selector from the packed `flags` slot.**
+
+This is the same `packFlags` injectivity argument as
+`romFlagColumns_of_romFlags_eq_packFlags`, but exposing the `b_src_imm` selector
+needed to turn `SourceSpec` into an I-type immediate-lane proof. -/
+theorem romBSourceImmColumn_of_romFlags_eq_packFlags
+    (row : MainRowWithRom FGL) (bits : RomFlagBits)
+    (hbool :
+      row.core.is_external_op * (1 - row.core.is_external_op) = 0
+    ∧ row.core.m32 * (1 - row.core.m32) = 0
+    ∧ row.core.set_pc * (1 - row.core.set_pc) = 0
+    ∧ row.core.store_pc * (1 - row.core.store_pc) = 0
+    ∧ row.rom.a_src_imm * (1 - row.rom.a_src_imm) = 0
+    ∧ row.rom.a_src_mem * (1 - row.rom.a_src_mem) = 0
+    ∧ row.rom.is_precompiled * (1 - row.rom.is_precompiled) = 0
+    ∧ row.rom.b_src_imm * (1 - row.rom.b_src_imm) = 0
+    ∧ row.rom.b_src_mem * (1 - row.rom.b_src_mem) = 0
+    ∧ row.rom.store_mem * (1 - row.rom.store_mem) = 0
+    ∧ row.rom.store_ind * (1 - row.rom.store_ind) = 0
+    ∧ row.rom.b_src_ind * (1 - row.rom.b_src_ind) = 0
+    ∧ row.rom.a_src_reg * (1 - row.rom.a_src_reg) = 0
+    ∧ row.rom.b_src_reg * (1 - row.rom.b_src_reg) = 0
+    ∧ row.rom.store_reg * (1 - row.rom.store_reg) = 0)
+    (h : romFlags row = packFlags bits) :
+    row.rom.b_src_imm = ZiskFv.AirsClean.boolF bits.b_src_imm := by
+  obtain ⟨hb_ieo, hb_m32, hb_set_pc, hb_store_pc, hb_a_src_imm, hb_a_src_mem,
+    hb_is_precompiled, hb_b_src_imm, hb_b_src_mem, hb_store_mem, hb_store_ind,
+    hb_b_src_ind, hb_a_src_reg, hb_b_src_reg, hb_store_reg⟩ := hbool
+  obtain ⟨d_ieo, e_ieo⟩ := bool_of_booleanity hb_ieo
+  obtain ⟨d_m32, e_m32⟩ := bool_of_booleanity hb_m32
+  obtain ⟨d_set_pc, e_set_pc⟩ := bool_of_booleanity hb_set_pc
+  obtain ⟨d_store_pc, e_store_pc⟩ := bool_of_booleanity hb_store_pc
+  obtain ⟨d_a_src_imm, e_a_src_imm⟩ := bool_of_booleanity hb_a_src_imm
+  obtain ⟨d_a_src_mem, e_a_src_mem⟩ := bool_of_booleanity hb_a_src_mem
+  obtain ⟨d_is_precompiled, e_is_precompiled⟩ := bool_of_booleanity hb_is_precompiled
+  obtain ⟨d_b_src_imm, e_b_src_imm⟩ := bool_of_booleanity hb_b_src_imm
+  obtain ⟨d_b_src_mem, e_b_src_mem⟩ := bool_of_booleanity hb_b_src_mem
+  obtain ⟨d_store_mem, e_store_mem⟩ := bool_of_booleanity hb_store_mem
+  obtain ⟨d_store_ind, e_store_ind⟩ := bool_of_booleanity hb_store_ind
+  obtain ⟨d_b_src_ind, e_b_src_ind⟩ := bool_of_booleanity hb_b_src_ind
+  obtain ⟨d_a_src_reg, e_a_src_reg⟩ := bool_of_booleanity hb_a_src_reg
+  obtain ⟨d_b_src_reg, e_b_src_reg⟩ := bool_of_booleanity hb_b_src_reg
+  obtain ⟨d_store_reg, e_store_reg⟩ := bool_of_booleanity hb_store_reg
+  have hpack : romFlags row =
+      packFlags ⟨d_a_src_imm, d_a_src_mem, d_is_precompiled, d_b_src_imm,
+        d_b_src_mem, d_ieo, d_store_pc, d_store_mem, d_store_ind, d_set_pc,
+        d_m32, d_b_src_ind, d_a_src_reg, d_b_src_reg, d_store_reg⟩ := by
+    simp only [romFlags, packFlags, e_ieo, e_m32, e_set_pc, e_store_pc,
+      e_a_src_imm, e_a_src_mem, e_is_precompiled, e_b_src_imm, e_b_src_mem,
+      e_store_mem, e_store_ind, e_b_src_ind, e_a_src_reg, e_b_src_reg, e_store_reg]
+  have hbits := packFlags_inj (hpack.symm.trans h)
+  subst hbits
+  exact e_b_src_imm
 
 /-! ## ADD pilot: reconstruct `Decode_add` from the committed program
 

--- a/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
@@ -73,6 +73,19 @@ theorem mainStoreOffset_at_eq_program
   refine ⟨j, ?_, ?_⟩ <;>
     simp only [← hj, romMessage, mainOfTable_pc]
 
+/-- **B-offset ROM-column binding.** Projects the load-address immediate slot
+    from the same Main↔ROM lookup used by `mainRomColumns_at_eq_program`. -/
+theorem mainBOffsetImm0_at_eq_program
+    {numInstructions : Nat} (trace : AcceptedZiskTrace numInstructions)
+    (idx : Fin trace.mainTable.table.length) :
+    ∃ j : Fin trace.numInstructions,
+      (trace.program j).line = (mainOfTable trace.program trace.mainTable).pc idx.val
+    ∧ (trace.program j).b_offset_imm0
+        = (mainTableRowAtOrZero trace.program trace.mainTable idx.val).rom.b_offset_imm0 := by
+  obtain ⟨j, hj⟩ := mainRomMessage_at_eq_program trace idx
+  refine ⟨j, ?_, ?_⟩ <;>
+    simp only [← hj, romMessage, mainOfTable_pc]
+
 /-- **Flag-column unpacking at a row.**  Given the row's packed `romFlags` equals
     `packFlags bits`, the four packed flag columns equal `boolF` of their bits.
     Wraps `romFlagColumns_of_romFlags_eq_packFlags` + `mainRow_flags_boolean` and
@@ -120,6 +133,111 @@ theorem mainSelectorColumns_of_packFlags
   exact romSelectorColumns_of_romFlags_eq_packFlags
     (mainTableRowAtOrZero trace.program trace.mainTable i.val) bits
     (mainRow_flags_boolean trace ⟨i.val, h_lt⟩) h
+
+/-- **Immediate-source selector unpacking at a row.** Given the row's packed
+    `romFlags` equals `packFlags bits`, the `b_src_imm` column equals `boolF` of
+    the committed-program bit. -/
+theorem mainBSourceImmColumn_of_packFlags
+    {numInstructions : Nat} (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin trace.numInstructions)
+    (h_lt : i.val < trace.mainTable.table.length)
+    (bits : RomFlagBits)
+    (h : romFlags (mainTableRowAtOrZero trace.program trace.mainTable i.val)
+        = packFlags bits) :
+    (mainTableRowAtOrZero trace.program trace.mainTable i.val).rom.b_src_imm
+        = ZiskFv.AirsClean.boolF bits.b_src_imm := by
+  exact romBSourceImmColumn_of_romFlags_eq_packFlags
+    (mainTableRowAtOrZero trace.program trace.mainTable i.val) bits
+    (mainRow_flags_boolean trace ⟨i.val, h_lt⟩) h
+
+/-- The committed program's `b` immediate limbs, transported through the
+    Main↔ROM lookup to the concrete row, together with `b_src_imm = 1`. -/
+theorem mainBImmediateSourceFacts_of_program
+    {numInstructions : Nat}
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin trace.numInstructions)
+    (h_lt : i.val < trace.mainTable.table.length)
+    (bits : RomFlagBits)
+    (imm : BitVec 12)
+    (h_bits_b_src_imm : bits.b_src_imm = true)
+    (h_prog : ∀ j : Fin numInstructions,
+        (trace.program j).line
+            = (mainOfTable trace.program trace.mainTable).pc i.val →
+          BitVec.signExtend 64 imm
+            = BitVec.ofNat 64
+                ((trace.program j).b_offset_imm0.val
+                  + (trace.program j).b_imm1.val * 4294967296)
+        ∧ (trace.program j).flags = packFlags bits) :
+    (mainTableRowAtOrZero trace.program trace.mainTable i.val).rom.b_src_imm = 1
+  ∧ BitVec.signExtend 64 imm
+      = BitVec.ofNat 64
+          (((mainTableRowAtOrZero trace.program trace.mainTable i.val).rom.b_offset_imm0).val
+            + ((mainTableRowAtOrZero trace.program trace.mainTable i.val).rom.b_imm1).val
+              * 4294967296) := by
+  obtain ⟨j, hj⟩ := mainRomMessage_at_eq_program trace ⟨i.val, h_lt⟩
+  have hline :
+      (trace.program j).line = (mainOfTable trace.program trace.mainTable).pc i.val := by
+    simp only [← hj, romMessage, mainOfTable_pc]
+  obtain ⟨h_imm, hpf⟩ := h_prog j hline
+  have hrom :
+      romFlags (mainTableRowAtOrZero trace.program trace.mainTable i.val) = packFlags bits := by
+    have hflags :
+        (trace.program j).flags =
+          romFlags (mainTableRowAtOrZero trace.program trace.mainTable i.val) := by
+      simp only [← hj, romMessage]
+    exact hflags.symm.trans hpf
+  have h_b_src_imm :=
+    mainBSourceImmColumn_of_packFlags trace i h_lt bits hrom
+  have h_b_src_imm_one :
+      (mainTableRowAtOrZero trace.program trace.mainTable i.val).rom.b_src_imm = 1 := by
+    simpa only [h_bits_b_src_imm, ZiskFv.AirsClean.boolF_true] using h_b_src_imm
+  have h_b_offset :
+      (trace.program j).b_offset_imm0 =
+        (mainTableRowAtOrZero trace.program trace.mainTable i.val).rom.b_offset_imm0 := by
+    simp only [← hj, romMessage]
+  have h_b_imm1 :
+      (trace.program j).b_imm1 =
+        (mainTableRowAtOrZero trace.program trace.mainTable i.val).rom.b_imm1 := by
+    simp only [← hj, romMessage]
+  exact ⟨h_b_src_imm_one, by simpa only [h_b_offset, h_b_imm1] using h_imm⟩
+
+/-- `SourceSpec` turns decoded immediate-source ROM limbs into the Main `b`
+    lanes used by the I-type archetype. -/
+theorem itypeImmSubset_of_sourceSpec
+    {numInstructions : Nat}
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin trace.numInstructions)
+    (imm : BitVec 12)
+    (h_source : ZiskFv.AirsClean.Main.SourceSpec (mainRowWithRomSub trace i))
+    (h_b_src_imm : (mainRowWithRomSub trace i).rom.b_src_imm = 1)
+    (h_rom_imm :
+      BitVec.signExtend 64 imm
+        = BitVec.ofNat 64
+            (((mainRowWithRomSub trace i).rom.b_offset_imm0).val
+              + ((mainRowWithRomSub trace i).rom.b_imm1).val * 4294967296)) :
+    ZiskFv.Tactics.ALUITypeArchetype.itype_imm_subset_holds_main
+      (mainOfTable trace.program trace.mainTable) i.val imm := by
+  obtain ⟨_, _, h_b0, h_b1⟩ := h_source
+  have h_b0_zero :
+      (mainRowWithRomSub trace i).core.b_0
+        + -1 * (mainRowWithRomSub trace i).rom.b_offset_imm0 = 0 := by
+    simpa only [h_b_src_imm, one_mul] using h_b0
+  have h_b1_zero :
+      (mainRowWithRomSub trace i).core.b_1
+        + -1 * (mainRowWithRomSub trace i).rom.b_imm1 = 0 := by
+    simpa only [h_b_src_imm, one_mul] using h_b1
+  have h_b0_eq :
+      (mainRowWithRomSub trace i).core.b_0 =
+        (mainRowWithRomSub trace i).rom.b_offset_imm0 := by
+    apply sub_eq_zero.mp
+    simpa [sub_eq_add_neg] using h_b0_zero
+  have h_b1_eq :
+      (mainRowWithRomSub trace i).core.b_1 =
+        (mainRowWithRomSub trace i).rom.b_imm1 := by
+    apply sub_eq_zero.mp
+    simpa [sub_eq_add_neg] using h_b1_zero
+  simpa [ZiskFv.Tactics.ALUITypeArchetype.itype_imm_subset_holds_main,
+    mainRowWithRomSub, mainOfTable_b_0, mainOfTable_b_1, h_b0_eq, h_b1_eq] using h_rom_imm
 
 /-- Writeback destination selector/offset facts derived from the committed
     program and packed ROM flags for the op-agnostic `mainRowWithRomSub` row. -/
@@ -551,6 +669,7 @@ def Decode_andi_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
+    (h_bits_b_src_imm : bits.b_src_imm = true)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -558,6 +677,10 @@ def Decode_andi_of_program
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
+        ∧ BitVec.signExtend 64 c.imm
+            = BitVec.ofNat 64
+                ((trace.program j).b_offset_imm0.val
+                  + (trace.program j).b_imm1.val * 4294967296)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_andi trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -571,15 +694,20 @@ def Decode_andi_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
     obtain ⟨j, hline, hop, _, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, _hp_store_offset, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, _hp_store_offset, _hp_imm, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1⟩
   have h_dest :=
     mainWritebackDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
       (fun j hline => by
-        obtain ⟨_, _, _, hp_store_offset, hpf⟩ := h_prog j hline
+        obtain ⟨_, _, _, hp_store_offset, _hp_imm, hpf⟩ := h_prog j hline
         exact ⟨hp_store_offset, hpf⟩)
+  have h_src :=
+    mainBImmediateSourceFacts_of_program trace i h_lt bits c.imm h_bits_b_src_imm
+      (fun j hline => by
+        obtain ⟨_, _, _, _, hp_imm, hpf⟩ := h_prog j hline
+        exact ⟨hp_imm, hpf⟩)
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -590,6 +718,8 @@ def Decode_andi_of_program
       h_jmp2 := key.2.2.2.2.2.2
       h_store_ind := h_dest.1
       h_store_offset := h_dest.2
+      h_b_src_imm := h_src.1
+      h_b_imm := h_src.2
       h_idx := h_idx }
 
 /-- `Decode_ori` rebuilt from the committed program via the ROM lookup
@@ -607,6 +737,7 @@ def Decode_ori_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
+    (h_bits_b_src_imm : bits.b_src_imm = true)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -614,6 +745,10 @@ def Decode_ori_of_program
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
+        ∧ BitVec.signExtend 64 c.imm
+            = BitVec.ofNat 64
+                ((trace.program j).b_offset_imm0.val
+                  + (trace.program j).b_imm1.val * 4294967296)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_ori trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -627,15 +762,20 @@ def Decode_ori_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
     obtain ⟨j, hline, hop, _, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, _hp_store_offset, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, _hp_store_offset, _hp_imm, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1⟩
   have h_dest :=
     mainWritebackDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
       (fun j hline => by
-        obtain ⟨_, _, _, hp_store_offset, hpf⟩ := h_prog j hline
+        obtain ⟨_, _, _, hp_store_offset, _hp_imm, hpf⟩ := h_prog j hline
         exact ⟨hp_store_offset, hpf⟩)
+  have h_src :=
+    mainBImmediateSourceFacts_of_program trace i h_lt bits c.imm h_bits_b_src_imm
+      (fun j hline => by
+        obtain ⟨_, _, _, _, hp_imm, hpf⟩ := h_prog j hline
+        exact ⟨hp_imm, hpf⟩)
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -646,6 +786,8 @@ def Decode_ori_of_program
       h_jmp2 := key.2.2.2.2.2.2
       h_store_ind := h_dest.1
       h_store_offset := h_dest.2
+      h_b_src_imm := h_src.1
+      h_b_imm := h_src.2
       h_idx := h_idx }
 
 /-- `Decode_xori` rebuilt from the committed program via the ROM lookup
@@ -663,6 +805,7 @@ def Decode_xori_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
+    (h_bits_b_src_imm : bits.b_src_imm = true)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -670,6 +813,10 @@ def Decode_xori_of_program
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
+        ∧ BitVec.signExtend 64 c.imm
+            = BitVec.ofNat 64
+                ((trace.program j).b_offset_imm0.val
+                  + (trace.program j).b_imm1.val * 4294967296)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_xori trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -683,15 +830,20 @@ def Decode_xori_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
     obtain ⟨j, hline, hop, _, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, _hp_store_offset, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, _hp_store_offset, _hp_imm, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1⟩
   have h_dest :=
     mainWritebackDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
       (fun j hline => by
-        obtain ⟨_, _, _, hp_store_offset, hpf⟩ := h_prog j hline
+        obtain ⟨_, _, _, hp_store_offset, _hp_imm, hpf⟩ := h_prog j hline
         exact ⟨hp_store_offset, hpf⟩)
+  have h_src :=
+    mainBImmediateSourceFacts_of_program trace i h_lt bits c.imm h_bits_b_src_imm
+      (fun j hline => by
+        obtain ⟨_, _, _, _, hp_imm, hpf⟩ := h_prog j hline
+        exact ⟨hp_imm, hpf⟩)
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -702,6 +854,8 @@ def Decode_xori_of_program
       h_jmp2 := key.2.2.2.2.2.2
       h_store_ind := h_dest.1
       h_store_offset := h_dest.2
+      h_b_src_imm := h_src.1
+      h_b_imm := h_src.2
       h_idx := h_idx }
 
 /-- `Decode_slti` rebuilt from the committed program via the ROM lookup
@@ -719,6 +873,7 @@ def Decode_slti_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
+    (h_bits_b_src_imm : bits.b_src_imm = true)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -726,6 +881,10 @@ def Decode_slti_of_program
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
+        ∧ BitVec.signExtend 64 c.imm
+            = BitVec.ofNat 64
+                ((trace.program j).b_offset_imm0.val
+                  + (trace.program j).b_imm1.val * 4294967296)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_slti trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -739,15 +898,20 @@ def Decode_slti_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
     obtain ⟨j, hline, hop, _, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, _hp_store_offset, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, _hp_store_offset, _hp_imm, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1⟩
   have h_dest :=
     mainWritebackDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
       (fun j hline => by
-        obtain ⟨_, _, _, hp_store_offset, hpf⟩ := h_prog j hline
+        obtain ⟨_, _, _, hp_store_offset, _hp_imm, hpf⟩ := h_prog j hline
         exact ⟨hp_store_offset, hpf⟩)
+  have h_src :=
+    mainBImmediateSourceFacts_of_program trace i h_lt bits c.imm h_bits_b_src_imm
+      (fun j hline => by
+        obtain ⟨_, _, _, _, hp_imm, hpf⟩ := h_prog j hline
+        exact ⟨hp_imm, hpf⟩)
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -758,6 +922,8 @@ def Decode_slti_of_program
       h_jmp2 := key.2.2.2.2.2.2
       h_store_ind := h_dest.1
       h_store_offset := h_dest.2
+      h_b_src_imm := h_src.1
+      h_b_imm := h_src.2
       h_idx := h_idx }
 
 /-- `Decode_sltiu` rebuilt from the committed program via the ROM lookup
@@ -775,6 +941,7 @@ def Decode_sltiu_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
+    (h_bits_b_src_imm : bits.b_src_imm = true)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -782,6 +949,10 @@ def Decode_sltiu_of_program
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
+        ∧ BitVec.signExtend 64 c.imm
+            = BitVec.ofNat 64
+                ((trace.program j).b_offset_imm0.val
+                  + (trace.program j).b_imm1.val * 4294967296)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_sltiu trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -795,15 +966,20 @@ def Decode_sltiu_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
     obtain ⟨j, hline, hop, _, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, _hp_store_offset, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, _hp_store_offset, _hp_imm, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1⟩
   have h_dest :=
     mainWritebackDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
       (fun j hline => by
-        obtain ⟨_, _, _, hp_store_offset, hpf⟩ := h_prog j hline
+        obtain ⟨_, _, _, hp_store_offset, _hp_imm, hpf⟩ := h_prog j hline
         exact ⟨hp_store_offset, hpf⟩)
+  have h_src :=
+    mainBImmediateSourceFacts_of_program trace i h_lt bits c.imm h_bits_b_src_imm
+      (fun j hline => by
+        obtain ⟨_, _, _, _, hp_imm, hpf⟩ := h_prog j hline
+        exact ⟨hp_imm, hpf⟩)
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -814,6 +990,8 @@ def Decode_sltiu_of_program
       h_jmp2 := key.2.2.2.2.2.2
       h_store_ind := h_dest.1
       h_store_offset := h_dest.2
+      h_b_src_imm := h_src.1
+      h_b_imm := h_src.2
       h_idx := h_idx }
 
 /-- `Decode_addi` rebuilt from the committed program via the ROM lookup
@@ -831,6 +1009,7 @@ def Decode_addi_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
+    (h_bits_b_src_imm : bits.b_src_imm = true)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -838,6 +1017,10 @@ def Decode_addi_of_program
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
+        ∧ BitVec.signExtend 64 c.imm
+            = BitVec.ofNat 64
+                ((trace.program j).b_offset_imm0.val
+                  + (trace.program j).b_imm1.val * 4294967296)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_addi trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -854,14 +1037,14 @@ def Decode_addi_of_program
         Transpiler.ind (regidx_to_fin c.rd) := by
     obtain ⟨j, hline, hop, _, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, _hp_store_offset, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, _hp_store_offset, _hp_imm, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     obtain ⟨p_store_ind, _p_b_src_ind, _p_store_reg⟩ :=
       mainSelectorColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     obtain ⟨j_store, hline_store, hstore⟩ :=
       mainStoreOffset_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨_, _, _, hp_store_offset, _⟩ := h_prog j_store hline_store
+    obtain ⟨_, _, _, hp_store_offset, _hp_imm, _⟩ := h_prog j_store hline_store
     refine ⟨hop.symm.trans hpo, ?_, ?_, ?_, ?_,
       hj1.symm.trans hpj0, hj2.symm.trans hpj1, ?_, hstore.symm.trans hp_store_offset⟩
     · rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true]
@@ -869,6 +1052,11 @@ def Decode_addi_of_program
     · rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false]
     · rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false]
     · rw [p_store_ind, h_bits_store_ind, ZiskFv.AirsClean.boolF_false]
+  have h_src :=
+    mainBImmediateSourceFacts_of_program trace i h_lt bits c.imm h_bits_b_src_imm
+      (fun j hline => by
+        obtain ⟨_, _, _, _, hp_imm, hpf⟩ := h_prog j hline
+        exact ⟨hp_imm, hpf⟩)
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -879,6 +1067,8 @@ def Decode_addi_of_program
       h_jmp2 := key.2.2.2.2.2.2.1
       h_store_ind := key.2.2.2.2.2.2.2.1
       h_store_offset := key.2.2.2.2.2.2.2.2
+      h_b_src_imm := h_src.1
+      h_b_imm := h_src.2
       h_idx := h_idx }
 
 
@@ -1362,6 +1552,7 @@ def Decode_addiw_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
+    (h_bits_b_src_imm : bits.b_src_imm = true)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -1369,6 +1560,10 @@ def Decode_addiw_of_program
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
+        ∧ BitVec.signExtend 64 c.imm
+            = BitVec.ofNat 64
+                ((trace.program j).b_offset_imm0.val
+                  + (trace.program j).b_imm1.val * 4294967296)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_addiw trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -1382,15 +1577,20 @@ def Decode_addiw_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
     obtain ⟨j, hline, hop, _, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, _hp_store_offset, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, _hp_store_offset, _hp_imm, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_true], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1⟩
   have h_dest :=
     mainWritebackDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
       (fun j hline => by
-        obtain ⟨_, _, _, hp_store_offset, hpf⟩ := h_prog j hline
+        obtain ⟨_, _, _, hp_store_offset, _hp_imm, hpf⟩ := h_prog j hline
         exact ⟨hp_store_offset, hpf⟩)
+  have h_src :=
+    mainBImmediateSourceFacts_of_program trace i h_lt bits c.imm h_bits_b_src_imm
+      (fun j hline => by
+        obtain ⟨_, _, _, _, hp_imm, hpf⟩ := h_prog j hline
+        exact ⟨hp_imm, hpf⟩)
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -1401,6 +1601,8 @@ def Decode_addiw_of_program
       h_jmp2 := key.2.2.2.2.2.2
       h_store_ind := h_dest.1
       h_store_offset := h_dest.2
+      h_b_src_imm := h_src.1
+      h_b_imm := h_src.2
       h_idx := h_idx }
 
 /-- `Decode_sllw` rebuilt from the committed program via the ROM lookup
@@ -1809,20 +2011,23 @@ def Decode_mul_of_program
     (h_idx : i.val + 1 < trace.mainTable.table.length)
     (arith_mem :
     ZiskFv.Compliance.ExternalArithMemoryWitness
-      (mainOfTable trace.program trace.mainTable) i.val c.bus.e2)
+      (mainOfTable trace.program trace.mainTable) i.val
+      (busSub trace i (Pilot.execRowOf trace i)).e2)
     (bounds :
-    ZiskFv.Compliance.ByteBounds c.bus.e2)
+    ZiskFv.Compliance.ByteBounds (busSub trace i (Pilot.execRowOf trace i)).e2)
     (bits : RomFlagBits)
     (h_bits_ieo : bits.is_external_op = true)
     (h_bits_m32 : bits.m32 = false)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
+    (h_bits_store_ind : bits.store_ind = false)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_MUL
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_mul trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -1836,10 +2041,15 @@ def Decode_mul_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
     obtain ⟨j, hline, hop, _, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, _hp_store_offset, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1⟩
+  have h_dest :=
+    mainWritebackDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
+      (fun j hline => by
+        obtain ⟨_, _, _, hp_store_offset, hpf⟩ := h_prog j hline
+        exact ⟨hp_store_offset, hpf⟩)
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -1848,6 +2058,8 @@ def Decode_mul_of_program
       h_store_pc := key.2.2.2.2.1
       h_jmp_offset1 := key.2.2.2.2.2.1
       h_jmp_offset2 := key.2.2.2.2.2.2
+      h_store_ind := h_dest.1
+      h_store_offset := h_dest.2
       h_idx := h_idx
       arith_mem := arith_mem
       bounds := bounds }
@@ -1863,20 +2075,23 @@ def Decode_mulh_of_program
     (h_idx : i.val + 1 < trace.mainTable.table.length)
     (arith_mem :
     ZiskFv.Compliance.ExternalArithMemoryWitness
-      (mainOfTable trace.program trace.mainTable) i.val c.bus.e2)
+      (mainOfTable trace.program trace.mainTable) i.val
+      (busSub trace i (Pilot.execRowOf trace i)).e2)
     (bounds :
-    ZiskFv.Compliance.ByteBounds c.bus.e2)
+    ZiskFv.Compliance.ByteBounds (busSub trace i (Pilot.execRowOf trace i)).e2)
     (bits : RomFlagBits)
     (h_bits_ieo : bits.is_external_op = true)
     (h_bits_m32 : bits.m32 = false)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
+    (h_bits_store_ind : bits.store_ind = false)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_MULH
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_mulh trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -1890,10 +2105,15 @@ def Decode_mulh_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
     obtain ⟨j, hline, hop, _, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, _hp_store_offset, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1⟩
+  have h_dest :=
+    mainWritebackDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
+      (fun j hline => by
+        obtain ⟨_, _, _, hp_store_offset, hpf⟩ := h_prog j hline
+        exact ⟨hp_store_offset, hpf⟩)
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -1902,6 +2122,8 @@ def Decode_mulh_of_program
       h_store_pc := key.2.2.2.2.1
       h_jmp_offset1 := key.2.2.2.2.2.1
       h_jmp_offset2 := key.2.2.2.2.2.2
+      h_store_ind := h_dest.1
+      h_store_offset := h_dest.2
       h_idx := h_idx
       arith_mem := arith_mem
       bounds := bounds }
@@ -1917,20 +2139,23 @@ def Decode_mulhsu_of_program
     (h_idx : i.val + 1 < trace.mainTable.table.length)
     (arith_mem :
     ZiskFv.Compliance.ExternalArithMemoryWitness
-      (mainOfTable trace.program trace.mainTable) i.val c.bus.e2)
+      (mainOfTable trace.program trace.mainTable) i.val
+      (busSub trace i (Pilot.execRowOf trace i)).e2)
     (bounds :
-    ZiskFv.Compliance.ByteBounds c.bus.e2)
+    ZiskFv.Compliance.ByteBounds (busSub trace i (Pilot.execRowOf trace i)).e2)
     (bits : RomFlagBits)
     (h_bits_ieo : bits.is_external_op = true)
     (h_bits_m32 : bits.m32 = false)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
+    (h_bits_store_ind : bits.store_ind = false)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_MULSUH
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_mulhsu trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -1944,10 +2169,15 @@ def Decode_mulhsu_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
     obtain ⟨j, hline, hop, _, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, _hp_store_offset, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1⟩
+  have h_dest :=
+    mainWritebackDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
+      (fun j hline => by
+        obtain ⟨_, _, _, hp_store_offset, hpf⟩ := h_prog j hline
+        exact ⟨hp_store_offset, hpf⟩)
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -1956,6 +2186,8 @@ def Decode_mulhsu_of_program
       h_store_pc := key.2.2.2.2.1
       h_jmp_offset1 := key.2.2.2.2.2.1
       h_jmp_offset2 := key.2.2.2.2.2.2
+      h_store_ind := h_dest.1
+      h_store_offset := h_dest.2
       h_idx := h_idx
       arith_mem := arith_mem
       bounds := bounds }
@@ -1971,20 +2203,23 @@ def Decode_div_of_program
     (h_idx : i.val + 1 < trace.mainTable.table.length)
     (arith_mem :
     ZiskFv.Compliance.ExternalArithMemoryWitness
-      (mainOfTable trace.program trace.mainTable) i.val c.bus.e2)
+      (mainOfTable trace.program trace.mainTable) i.val
+      (busSub trace i (Pilot.execRowOf trace i)).e2)
     (bounds :
-    ZiskFv.Compliance.ByteBounds c.bus.e2)
+    ZiskFv.Compliance.ByteBounds (busSub trace i (Pilot.execRowOf trace i)).e2)
     (bits : RomFlagBits)
     (h_bits_ieo : bits.is_external_op = true)
     (h_bits_m32 : bits.m32 = false)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
+    (h_bits_store_ind : bits.store_ind = false)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_DIV
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_div trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -1998,10 +2233,15 @@ def Decode_div_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
     obtain ⟨j, hline, hop, _, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, _hp_store_offset, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1⟩
+  have h_dest :=
+    mainWritebackDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
+      (fun j hline => by
+        obtain ⟨_, _, _, hp_store_offset, hpf⟩ := h_prog j hline
+        exact ⟨hp_store_offset, hpf⟩)
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -2010,6 +2250,8 @@ def Decode_div_of_program
       h_store_pc := key.2.2.2.2.1
       h_jmp_offset1 := key.2.2.2.2.2.1
       h_jmp_offset2 := key.2.2.2.2.2.2
+      h_store_ind := h_dest.1
+      h_store_offset := h_dest.2
       h_idx := h_idx
       pins := { main_active := key.2.1, main_op := key.1 }
       arith_mem := arith_mem
@@ -2026,20 +2268,23 @@ def Decode_rem_of_program
     (h_idx : i.val + 1 < trace.mainTable.table.length)
     (arith_mem :
     ZiskFv.Compliance.ExternalArithMemoryWitness
-      (mainOfTable trace.program trace.mainTable) i.val c.bus.e2)
+      (mainOfTable trace.program trace.mainTable) i.val
+      (busSub trace i (Pilot.execRowOf trace i)).e2)
     (bounds :
-    ZiskFv.Compliance.ByteBounds c.bus.e2)
+    ZiskFv.Compliance.ByteBounds (busSub trace i (Pilot.execRowOf trace i)).e2)
     (bits : RomFlagBits)
     (h_bits_ieo : bits.is_external_op = true)
     (h_bits_m32 : bits.m32 = false)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
+    (h_bits_store_ind : bits.store_ind = false)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_REM
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_rem trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -2053,10 +2298,15 @@ def Decode_rem_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
     obtain ⟨j, hline, hop, _, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, _hp_store_offset, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1⟩
+  have h_dest :=
+    mainWritebackDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
+      (fun j hline => by
+        obtain ⟨_, _, _, hp_store_offset, hpf⟩ := h_prog j hline
+        exact ⟨hp_store_offset, hpf⟩)
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -2065,6 +2315,8 @@ def Decode_rem_of_program
       h_store_pc := key.2.2.2.2.1
       h_jmp_offset1 := key.2.2.2.2.2.1
       h_jmp_offset2 := key.2.2.2.2.2.2
+      h_store_ind := h_dest.1
+      h_store_offset := h_dest.2
       h_idx := h_idx
       pins := { main_active := key.2.1, main_op := key.1 }
       arith_mem := arith_mem
@@ -2081,20 +2333,23 @@ def Decode_divw_of_program
     (h_idx : i.val + 1 < trace.mainTable.table.length)
     (arith_mem :
     ZiskFv.Compliance.ExternalArithMemoryWitness
-      (mainOfTable trace.program trace.mainTable) i.val c.bus.e2)
+      (mainOfTable trace.program trace.mainTable) i.val
+      (busSub trace i (Pilot.execRowOf trace i)).e2)
     (bounds :
-    ZiskFv.Compliance.ByteBounds c.bus.e2)
+    ZiskFv.Compliance.ByteBounds (busSub trace i (Pilot.execRowOf trace i)).e2)
     (bits : RomFlagBits)
     (h_bits_ieo : bits.is_external_op = true)
     (h_bits_m32 : bits.m32 = true)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
+    (h_bits_store_ind : bits.store_ind = false)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_DIV_W
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_divw trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -2108,10 +2363,15 @@ def Decode_divw_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
     obtain ⟨j, hline, hop, _, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, _hp_store_offset, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_true], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1⟩
+  have h_dest :=
+    mainWritebackDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
+      (fun j hline => by
+        obtain ⟨_, _, _, hp_store_offset, hpf⟩ := h_prog j hline
+        exact ⟨hp_store_offset, hpf⟩)
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -2120,6 +2380,8 @@ def Decode_divw_of_program
       h_store_pc := key.2.2.2.2.1
       h_jmp_offset1 := key.2.2.2.2.2.1
       h_jmp_offset2 := key.2.2.2.2.2.2
+      h_store_ind := h_dest.1
+      h_store_offset := h_dest.2
       h_idx := h_idx
       pins := { main_active := key.2.1, main_op := key.1 }
       arith_mem := arith_mem
@@ -2136,20 +2398,23 @@ def Decode_remw_of_program
     (h_idx : i.val + 1 < trace.mainTable.table.length)
     (arith_mem :
     ZiskFv.Compliance.ExternalArithMemoryWitness
-      (mainOfTable trace.program trace.mainTable) i.val c.bus.e2)
+      (mainOfTable trace.program trace.mainTable) i.val
+      (busSub trace i (Pilot.execRowOf trace i)).e2)
     (bounds :
-    ZiskFv.Compliance.ByteBounds c.bus.e2)
+    ZiskFv.Compliance.ByteBounds (busSub trace i (Pilot.execRowOf trace i)).e2)
     (bits : RomFlagBits)
     (h_bits_ieo : bits.is_external_op = true)
     (h_bits_m32 : bits.m32 = true)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
+    (h_bits_store_ind : bits.store_ind = false)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_REM_W
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_remw trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -2163,10 +2428,15 @@ def Decode_remw_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
     obtain ⟨j, hline, hop, _, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, _hp_store_offset, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_true], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1⟩
+  have h_dest :=
+    mainWritebackDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
+      (fun j hline => by
+        obtain ⟨_, _, _, hp_store_offset, hpf⟩ := h_prog j hline
+        exact ⟨hp_store_offset, hpf⟩)
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -2175,6 +2445,8 @@ def Decode_remw_of_program
       h_store_pc := key.2.2.2.2.1
       h_jmp_offset1 := key.2.2.2.2.2.1
       h_jmp_offset2 := key.2.2.2.2.2.2
+      h_store_ind := h_dest.1
+      h_store_offset := h_dest.2
       h_idx := h_idx
       pins := { main_active := key.2.1, main_op := key.1 }
       arith_mem := arith_mem
@@ -2564,6 +2836,8 @@ def Decode_ld_of_program
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (8 : FGL)
+        ∧ (trace.program j).b_offset_imm0 =
+            ((BitVec.signExtend 64 c.ld_input.imm).toNat : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.ld_input.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_ld trace i c := by
@@ -2578,34 +2852,40 @@ def Decode_ld_of_program
       (mainOfTable trace.program trace.mainTable).ind_width i.val = (8 : FGL) := by
     obtain ⟨j, hline, hop, hiw, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, hpiw, _hpso, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, hpiw, _hpbo, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, _, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1, hiw.symm.trans hpiw⟩
   have h_store_ind : (mainRowWithRomLd trace i).rom.store_ind = 0 := by
     obtain ⟨j, hline, _hop, _hiw, _hj1, _hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpso, hpf⟩ := h_prog j hline
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpbo, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_store_ind, _, _p_store_reg⟩ :=
       mainSelectorColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     simpa [mainRowWithRomLd, h_bits_store_ind, ZiskFv.AirsClean.boolF_false] using p_store_ind
   have h_store_reg : (mainRowWithRomLd trace i).rom.store_reg = 1 := by
     obtain ⟨j, hline, _hop, _hiw, _hj1, _hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpso, hpf⟩ := h_prog j hline
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpbo, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨_p_store_ind, _, p_store_reg⟩ :=
       mainSelectorColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     simpa [mainRowWithRomLd, h_bits_store_reg, ZiskFv.AirsClean.boolF_true] using p_store_reg
   have h_b_src_ind : (mainRowWithRomLd trace i).rom.b_src_ind = 1 :=
     mainLoadBsrcInd_of_program trace i h_lt bits h_bits_b_src_ind
       (fun j hline => by
-        obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpso, hpf⟩ := h_prog j hline
+        obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpbo, _hpso, hpf⟩ := h_prog j hline
         exact hpf)
   have h_store_offset :
       (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.ld_input.rd) := by
     obtain ⟨j, hline, hstore⟩ := mainStoreOffset_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpso, _hpf⟩ := h_prog j hline
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpbo, hpso, _hpf⟩ := h_prog j hline
     simpa [mainRowWithRomLd] using hstore.symm.trans hpso
+  have h_b_offset_imm0 :
+      (mainRowWithRomLd trace i).rom.b_offset_imm0 =
+        ((BitVec.signExtend 64 c.ld_input.imm).toNat : FGL) := by
+    obtain ⟨j, hline, hboff⟩ := mainBOffsetImm0_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpbo, _hpso, _hpf⟩ := h_prog j hline
+    simpa [mainRowWithRomLd] using hboff.symm.trans hpbo
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -2618,7 +2898,8 @@ def Decode_ld_of_program
       h_store_ind := h_store_ind
       h_store_reg := h_store_reg
       h_b_src_ind := h_b_src_ind
-      h_store_offset := h_store_offset }
+      h_store_offset := h_store_offset
+      h_b_offset_imm0 := h_b_offset_imm0 }
 
 /-- `Decode_lbu` rebuilt from the committed program via the ROM lookup
     (issue #159 block 1).  ROM-message-backed decode columns are DERIVED
@@ -2643,6 +2924,8 @@ def Decode_lbu_of_program
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (1 : FGL)
+        ∧ (trace.program j).b_offset_imm0 =
+            ((BitVec.signExtend 64 c.lbu_input.imm).toNat : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lbu_input.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_lbu trace i c := by
@@ -2657,19 +2940,25 @@ def Decode_lbu_of_program
       (mainOfTable trace.program trace.mainTable).ind_width i.val = (1 : FGL) := by
     obtain ⟨j, hline, hop, hiw, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, hpiw, _hpso, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, hpiw, _hpbo, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, _, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1, hiw.symm.trans hpiw⟩
   have h_dest := mainLoadDestinationFacts_of_program trace i h_lt bits c.lbu_input.rd
     h_bits_store_ind h_bits_store_reg (fun j hline => by
-      obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpso, hpf⟩ := h_prog j hline
+      obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpbo, hpso, hpf⟩ := h_prog j hline
       exact ⟨hpso, hpf⟩)
   have h_b_src_ind : (mainRowWithRomLd trace i).rom.b_src_ind = 1 :=
     mainLoadBsrcInd_of_program trace i h_lt bits h_bits_b_src_ind
       (fun j hline => by
-        obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpso, hpf⟩ := h_prog j hline
+        obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpbo, _hpso, hpf⟩ := h_prog j hline
         exact hpf)
+  have h_b_offset_imm0 :
+      (mainRowWithRomLd trace i).rom.b_offset_imm0 =
+        ((BitVec.signExtend 64 c.lbu_input.imm).toNat : FGL) := by
+    obtain ⟨j, hline, hboff⟩ := mainBOffsetImm0_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpbo, _hpso, _hpf⟩ := h_prog j hline
+    simpa [mainRowWithRomLd] using hboff.symm.trans hpbo
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -2682,7 +2971,8 @@ def Decode_lbu_of_program
       h_store_ind := h_dest.1
       h_store_reg := h_dest.2.1
       h_b_src_ind := h_b_src_ind
-      h_store_offset := h_dest.2.2 }
+      h_store_offset := h_dest.2.2
+      h_b_offset_imm0 := h_b_offset_imm0 }
 
 /-- `Decode_lhu` rebuilt from the committed program via the ROM lookup
     (issue #159 block 1).  ROM-message-backed decode columns are DERIVED
@@ -2707,6 +2997,8 @@ def Decode_lhu_of_program
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (2 : FGL)
+        ∧ (trace.program j).b_offset_imm0 =
+            ((BitVec.signExtend 64 c.lhu_input.imm).toNat : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lhu_input.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_lhu trace i c := by
@@ -2721,19 +3013,25 @@ def Decode_lhu_of_program
       (mainOfTable trace.program trace.mainTable).ind_width i.val = (2 : FGL) := by
     obtain ⟨j, hline, hop, hiw, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, hpiw, _hpso, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, hpiw, _hpbo, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, _, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1, hiw.symm.trans hpiw⟩
   have h_dest := mainLoadDestinationFacts_of_program trace i h_lt bits c.lhu_input.rd
     h_bits_store_ind h_bits_store_reg (fun j hline => by
-      obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpso, hpf⟩ := h_prog j hline
+      obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpbo, hpso, hpf⟩ := h_prog j hline
       exact ⟨hpso, hpf⟩)
   have h_b_src_ind : (mainRowWithRomLd trace i).rom.b_src_ind = 1 :=
     mainLoadBsrcInd_of_program trace i h_lt bits h_bits_b_src_ind
       (fun j hline => by
-        obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpso, hpf⟩ := h_prog j hline
+        obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpbo, _hpso, hpf⟩ := h_prog j hline
         exact hpf)
+  have h_b_offset_imm0 :
+      (mainRowWithRomLd trace i).rom.b_offset_imm0 =
+        ((BitVec.signExtend 64 c.lhu_input.imm).toNat : FGL) := by
+    obtain ⟨j, hline, hboff⟩ := mainBOffsetImm0_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpbo, _hpso, _hpf⟩ := h_prog j hline
+    simpa [mainRowWithRomLd] using hboff.symm.trans hpbo
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -2746,7 +3044,8 @@ def Decode_lhu_of_program
       h_store_ind := h_dest.1
       h_store_reg := h_dest.2.1
       h_b_src_ind := h_b_src_ind
-      h_store_offset := h_dest.2.2 }
+      h_store_offset := h_dest.2.2
+      h_b_offset_imm0 := h_b_offset_imm0 }
 
 /-- `Decode_lwu` rebuilt from the committed program via the ROM lookup
     (issue #159 block 1).  ROM-message-backed decode columns are DERIVED
@@ -2771,6 +3070,8 @@ def Decode_lwu_of_program
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (4 : FGL)
+        ∧ (trace.program j).b_offset_imm0 =
+            ((BitVec.signExtend 64 c.lwu_input.imm).toNat : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lwu_input.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_lwu trace i c := by
@@ -2785,19 +3086,25 @@ def Decode_lwu_of_program
       (mainOfTable trace.program trace.mainTable).ind_width i.val = (4 : FGL) := by
     obtain ⟨j, hline, hop, hiw, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, hpiw, _hpso, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, hpiw, _hpbo, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, _, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1, hiw.symm.trans hpiw⟩
   have h_dest := mainLoadDestinationFacts_of_program trace i h_lt bits c.lwu_input.rd
     h_bits_store_ind h_bits_store_reg (fun j hline => by
-      obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpso, hpf⟩ := h_prog j hline
+      obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpbo, hpso, hpf⟩ := h_prog j hline
       exact ⟨hpso, hpf⟩)
   have h_b_src_ind : (mainRowWithRomLd trace i).rom.b_src_ind = 1 :=
     mainLoadBsrcInd_of_program trace i h_lt bits h_bits_b_src_ind
       (fun j hline => by
-        obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpso, hpf⟩ := h_prog j hline
+        obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpbo, _hpso, hpf⟩ := h_prog j hline
         exact hpf)
+  have h_b_offset_imm0 :
+      (mainRowWithRomLd trace i).rom.b_offset_imm0 =
+        ((BitVec.signExtend 64 c.lwu_input.imm).toNat : FGL) := by
+    obtain ⟨j, hline, hboff⟩ := mainBOffsetImm0_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpbo, _hpso, _hpf⟩ := h_prog j hline
+    simpa [mainRowWithRomLd] using hboff.symm.trans hpbo
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -2810,7 +3117,8 @@ def Decode_lwu_of_program
       h_store_ind := h_dest.1
       h_store_reg := h_dest.2.1
       h_b_src_ind := h_b_src_ind
-      h_store_offset := h_dest.2.2 }
+      h_store_offset := h_dest.2.2
+      h_b_offset_imm0 := h_b_offset_imm0 }
 
 /-- `Decode_lb` rebuilt from the committed program via the ROM lookup
     (issue #159 block 1).  ROM-message-backed decode columns are DERIVED
@@ -2851,6 +3159,8 @@ def Decode_lb_of_program
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (1 : FGL)
+        ∧ (trace.program j).b_offset_imm0 =
+            ((BitVec.signExtend 64 c.lb_input.imm).toNat : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lb_input.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_lb trace i c := by
@@ -2865,19 +3175,25 @@ def Decode_lb_of_program
       (mainOfTable trace.program trace.mainTable).ind_width i.val = (1 : FGL) := by
     obtain ⟨j, hline, hop, hiw, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, hpiw, _hpso, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, hpiw, _hpbo, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, _, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1, hiw.symm.trans hpiw⟩
   have h_dest := mainLoadDestinationFacts_of_program trace i h_lt bits c.lb_input.rd
     h_bits_store_ind h_bits_store_reg (fun j hline => by
-      obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpso, hpf⟩ := h_prog j hline
+      obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpbo, hpso, hpf⟩ := h_prog j hline
       exact ⟨hpso, hpf⟩)
   have h_b_src_ind : (mainRowWithRomLd trace i).rom.b_src_ind = 1 :=
     mainLoadBsrcInd_of_program trace i h_lt bits h_bits_b_src_ind
       (fun j hline => by
-        obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpso, hpf⟩ := h_prog j hline
+        obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpbo, _hpso, hpf⟩ := h_prog j hline
         exact hpf)
+  have h_b_offset_imm0 :
+      (mainRowWithRomLd trace i).rom.b_offset_imm0 =
+        ((BitVec.signExtend 64 c.lb_input.imm).toNat : FGL) := by
+    obtain ⟨j, hline, hboff⟩ := mainBOffsetImm0_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpbo, _hpso, _hpf⟩ := h_prog j hline
+    simpa [mainRowWithRomLd] using hboff.symm.trans hpbo
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -2896,7 +3212,8 @@ def Decode_lb_of_program
       h_store_ind := h_dest.1
       h_store_reg := h_dest.2.1
       h_b_src_ind := h_b_src_ind
-      h_store_offset := h_dest.2.2 }
+      h_store_offset := h_dest.2.2
+      h_b_offset_imm0 := h_b_offset_imm0 }
 
 /-- `Decode_lh` rebuilt from the committed program via the ROM lookup
     (issue #159 block 1).  ROM-message-backed decode columns are DERIVED
@@ -2937,6 +3254,8 @@ def Decode_lh_of_program
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (2 : FGL)
+        ∧ (trace.program j).b_offset_imm0 =
+            ((BitVec.signExtend 64 c.lh_input.imm).toNat : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lh_input.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_lh trace i c := by
@@ -2951,19 +3270,25 @@ def Decode_lh_of_program
       (mainOfTable trace.program trace.mainTable).ind_width i.val = (2 : FGL) := by
     obtain ⟨j, hline, hop, hiw, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, hpiw, _hpso, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, hpiw, _hpbo, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, _, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1, hiw.symm.trans hpiw⟩
   have h_dest := mainLoadDestinationFacts_of_program trace i h_lt bits c.lh_input.rd
     h_bits_store_ind h_bits_store_reg (fun j hline => by
-      obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpso, hpf⟩ := h_prog j hline
+      obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpbo, hpso, hpf⟩ := h_prog j hline
       exact ⟨hpso, hpf⟩)
   have h_b_src_ind : (mainRowWithRomLd trace i).rom.b_src_ind = 1 :=
     mainLoadBsrcInd_of_program trace i h_lt bits h_bits_b_src_ind
       (fun j hline => by
-        obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpso, hpf⟩ := h_prog j hline
+        obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpbo, _hpso, hpf⟩ := h_prog j hline
         exact hpf)
+  have h_b_offset_imm0 :
+      (mainRowWithRomLd trace i).rom.b_offset_imm0 =
+        ((BitVec.signExtend 64 c.lh_input.imm).toNat : FGL) := by
+    obtain ⟨j, hline, hboff⟩ := mainBOffsetImm0_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpbo, _hpso, _hpf⟩ := h_prog j hline
+    simpa [mainRowWithRomLd] using hboff.symm.trans hpbo
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -2982,7 +3307,8 @@ def Decode_lh_of_program
       h_store_ind := h_dest.1
       h_store_reg := h_dest.2.1
       h_b_src_ind := h_b_src_ind
-      h_store_offset := h_dest.2.2 }
+      h_store_offset := h_dest.2.2
+      h_b_offset_imm0 := h_b_offset_imm0 }
 
 /-- `Decode_lw` rebuilt from the committed program via the ROM lookup
     (issue #159 block 1).  ROM-message-backed decode columns are DERIVED
@@ -3023,6 +3349,8 @@ def Decode_lw_of_program
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (4 : FGL)
+        ∧ (trace.program j).b_offset_imm0 =
+            ((BitVec.signExtend 64 c.lw_input.imm).toNat : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lw_input.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_lw trace i c := by
@@ -3037,19 +3365,25 @@ def Decode_lw_of_program
       (mainOfTable trace.program trace.mainTable).ind_width i.val = (4 : FGL) := by
     obtain ⟨j, hline, hop, hiw, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, hpiw, _hpso, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, hpiw, _hpbo, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, _, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1, hiw.symm.trans hpiw⟩
   have h_dest := mainLoadDestinationFacts_of_program trace i h_lt bits c.lw_input.rd
     h_bits_store_ind h_bits_store_reg (fun j hline => by
-      obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpso, hpf⟩ := h_prog j hline
+      obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpbo, hpso, hpf⟩ := h_prog j hline
       exact ⟨hpso, hpf⟩)
   have h_b_src_ind : (mainRowWithRomLd trace i).rom.b_src_ind = 1 :=
     mainLoadBsrcInd_of_program trace i h_lt bits h_bits_b_src_ind
       (fun j hline => by
-        obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpso, hpf⟩ := h_prog j hline
+        obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpbo, _hpso, hpf⟩ := h_prog j hline
         exact hpf)
+  have h_b_offset_imm0 :
+      (mainRowWithRomLd trace i).rom.b_offset_imm0 =
+        ((BitVec.signExtend 64 c.lw_input.imm).toNat : FGL) := by
+    obtain ⟨j, hline, hboff⟩ := mainBOffsetImm0_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpbo, _hpso, _hpf⟩ := h_prog j hline
+    simpa [mainRowWithRomLd] using hboff.symm.trans hpbo
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -3068,7 +3402,8 @@ def Decode_lw_of_program
       h_store_ind := h_dest.1
       h_store_reg := h_dest.2.1
       h_b_src_ind := h_b_src_ind
-      h_store_offset := h_dest.2.2 }
+      h_store_offset := h_dest.2.2
+      h_b_offset_imm0 := h_b_offset_imm0 }
 
 
 /-! ## Family: stores -/
@@ -3094,6 +3429,8 @@ def Decode_sb_of_program
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = 1
+        ∧ (trace.program j).store_offset =
+            ((BitVec.signExtend 64 c.sb_input.imm).toInt : FGL)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_sb trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -3107,17 +3444,23 @@ def Decode_sb_of_program
       (mainOfTable trace.program trace.mainTable).ind_width i.val = 1 := by
     obtain ⟨j, hline, hop, hiw, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, hpiw, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, hpiw, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, _, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1, hiw.symm.trans hpiw⟩
   have h_store_ind : (mainRowWithRomSt trace i).rom.store_ind = 1 := by
     obtain ⟨j, hline, _hop, _hiw, _hj1, _hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpf⟩ := h_prog j hline
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_store_ind, _, _⟩ :=
       mainSelectorColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     simpa [mainRowWithRomSt, h_bits_store_ind, ZiskFv.AirsClean.boolF_true] using p_store_ind
+  have h_store_offset_imm :
+      (mainRowWithRomSt trace i).rom.store_offset =
+        ((BitVec.signExtend 64 c.sb_input.imm).toInt : FGL) := by
+    obtain ⟨j, hline, hstore⟩ := mainStoreOffset_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpso, _hpf⟩ := h_prog j hline
+    simpa [mainRowWithRomSt] using hstore.symm.trans hpso
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -3127,6 +3470,7 @@ def Decode_sb_of_program
       h_jmp2 := key.2.2.2.2.2.1
       h_main_ind_width := key.2.2.2.2.2.2
       h_store_ind := h_store_ind
+      h_store_offset_imm := h_store_offset_imm
       h_idx := h_idx }
 
 /-- `Decode_sh` rebuilt from the committed program via the ROM lookup
@@ -3150,6 +3494,8 @@ def Decode_sh_of_program
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = 2
+        ∧ (trace.program j).store_offset =
+            ((BitVec.signExtend 64 c.sh_input.imm).toInt : FGL)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_sh trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -3163,17 +3509,23 @@ def Decode_sh_of_program
       (mainOfTable trace.program trace.mainTable).ind_width i.val = 2 := by
     obtain ⟨j, hline, hop, hiw, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, hpiw, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, hpiw, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, _, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1, hiw.symm.trans hpiw⟩
   have h_store_ind : (mainRowWithRomSt trace i).rom.store_ind = 1 := by
     obtain ⟨j, hline, _hop, _hiw, _hj1, _hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpf⟩ := h_prog j hline
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_store_ind, _, _⟩ :=
       mainSelectorColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     simpa [mainRowWithRomSt, h_bits_store_ind, ZiskFv.AirsClean.boolF_true] using p_store_ind
+  have h_store_offset_imm :
+      (mainRowWithRomSt trace i).rom.store_offset =
+        ((BitVec.signExtend 64 c.sh_input.imm).toInt : FGL) := by
+    obtain ⟨j, hline, hstore⟩ := mainStoreOffset_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpso, _hpf⟩ := h_prog j hline
+    simpa [mainRowWithRomSt] using hstore.symm.trans hpso
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -3183,6 +3535,7 @@ def Decode_sh_of_program
       h_jmp2 := key.2.2.2.2.2.1
       h_main_ind_width := key.2.2.2.2.2.2
       h_store_ind := h_store_ind
+      h_store_offset_imm := h_store_offset_imm
       h_idx := h_idx }
 
 /-- `Decode_sw` rebuilt from the committed program via the ROM lookup
@@ -3206,6 +3559,8 @@ def Decode_sw_of_program
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = 4
+        ∧ (trace.program j).store_offset =
+            ((BitVec.signExtend 64 c.sw_input.imm).toInt : FGL)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_sw trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -3219,17 +3574,23 @@ def Decode_sw_of_program
       (mainOfTable trace.program trace.mainTable).ind_width i.val = 4 := by
     obtain ⟨j, hline, hop, hiw, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, hpiw, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, hpiw, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, _, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1, hiw.symm.trans hpiw⟩
   have h_store_ind : (mainRowWithRomSt trace i).rom.store_ind = 1 := by
     obtain ⟨j, hline, _hop, _hiw, _hj1, _hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpf⟩ := h_prog j hline
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_store_ind, _, _⟩ :=
       mainSelectorColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     simpa [mainRowWithRomSt, h_bits_store_ind, ZiskFv.AirsClean.boolF_true] using p_store_ind
+  have h_store_offset_imm :
+      (mainRowWithRomSt trace i).rom.store_offset =
+        ((BitVec.signExtend 64 c.sw_input.imm).toInt : FGL) := by
+    obtain ⟨j, hline, hstore⟩ := mainStoreOffset_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpso, _hpf⟩ := h_prog j hline
+    simpa [mainRowWithRomSt] using hstore.symm.trans hpso
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -3239,6 +3600,7 @@ def Decode_sw_of_program
       h_jmp2 := key.2.2.2.2.2.1
       h_main_ind_width := key.2.2.2.2.2.2
       h_store_ind := h_store_ind
+      h_store_offset_imm := h_store_offset_imm
       h_idx := h_idx }
 
 /-- `Decode_sd` rebuilt from the committed program via the ROM lookup
@@ -3261,6 +3623,8 @@ def Decode_sd_of_program
           (trace.program j).op = ZiskFv.Trusted.OP_COPYB
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
+        ∧ (trace.program j).store_offset =
+            ((BitVec.signExtend 64 c.sd_input.imm).toInt : FGL)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_sd trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -3273,17 +3637,23 @@ def Decode_sd_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
     obtain ⟨j, hline, hop, _, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, _, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1⟩
   have h_store_ind : (mainRowWithRomSt trace i).rom.store_ind = 1 := by
     obtain ⟨j, hline, _hop, _hiw, _hj1, _hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨_hpo, _hpj0, _hpj1, hpf⟩ := h_prog j hline
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_store_ind, _, _⟩ :=
       mainSelectorColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     simpa [mainRowWithRomSt, h_bits_store_ind, ZiskFv.AirsClean.boolF_true] using p_store_ind
+  have h_store_offset_imm :
+      (mainRowWithRomSt trace i).rom.store_offset =
+        ((BitVec.signExtend 64 c.sd_input.imm).toInt : FGL) := by
+    obtain ⟨j, hline, hstore⟩ := mainStoreOffset_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, _hpj1, hpso, _hpf⟩ := h_prog j hline
+    simpa [mainRowWithRomSt] using hstore.symm.trans hpso
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -3292,6 +3662,7 @@ def Decode_sd_of_program
       h_jmp1 := key.2.2.2.2.1
       h_jmp2 := key.2.2.2.2.2
       h_store_ind := h_store_ind
+      h_store_offset_imm := h_store_offset_imm
       h_idx := h_idx }
 
 
@@ -3380,13 +3751,15 @@ def Decode_auipc_of_program
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_FLAG
         ∧ (trace.program j).jmp_offset1 = 4
+        ∧ ((trace.program j).jmp_offset2).val =
+          (BitVec.signExtend 64 (c.imm ++ (0 : BitVec 12))).toNat
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_auipc trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
   have h_dest := mainLuiDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
     (fun j hline => by
-      obtain ⟨_hpo, _hpj0, hpso, hpf⟩ := h_prog j hline
+      obtain ⟨_hpo, _hpj0, _hpj2_imm, hpso, hpf⟩ := h_prog j hline
       exact ⟨hpso, hpf⟩)
   have key :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_FLAG ∧
@@ -3397,10 +3770,17 @@ def Decode_auipc_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset1 i.val = 4 := by
     obtain ⟨j, hline, hop, _, hj1, _, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, _hpso, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, _hpj2_imm, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_true], hj1.symm.trans hpj0⟩
+  have h_jmp_offset2_imm :
+      ((mainOfTable trace.program trace.mainTable).jmp_offset2 i.val).val =
+        (BitVec.signExtend 64 (c.imm ++ (0 : BitVec 12))).toNat := by
+    obtain ⟨j, hline, _hop, _, _, hj2, _hflags⟩ :=
+      mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, hpj2_imm, _hpso, _hpf⟩ := h_prog j hline
+    simpa only [← hj2] using hpj2_imm
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -3409,6 +3789,7 @@ def Decode_auipc_of_program
       h_store_pc := key.2.2.2.2.1
       h_store_ind := h_dest.1
       h_store_offset := h_dest.2
+      h_jmp_offset2_imm := h_jmp_offset2_imm
       h_jmp1 := key.2.2.2.2.2
       h_idx := h_idx }
 
@@ -3433,6 +3814,7 @@ def Decode_beq_of_program
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_EQ
+        ∧ ((trace.program j).jmp_offset1).val = (BitVec.signExtend 64 c.imm).toNat
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_beq trace i c := by
@@ -3446,10 +3828,17 @@ def Decode_beq_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
     obtain ⟨j, hline, hop, _, _, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, _hpj1_imm, hpj0, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj2.symm.trans hpj0⟩
+  have h_jmp_offset1_imm :
+      ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val).val =
+        (BitVec.signExtend 64 c.imm).toNat := by
+    obtain ⟨j, hline, _hop, _, hj1, _, _hflags⟩ :=
+      mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, hpj1_imm, _hpj0, _hpf⟩ := h_prog j hline
+    simpa only [← hj1] using hpj1_imm
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -3457,6 +3846,7 @@ def Decode_beq_of_program
       h_set_pc := key.2.2.2.1
       h_store_pc := key.2.2.2.2.1
       h_jmp_offset2 := key.2.2.2.2.2
+      h_jmp_offset1_imm := h_jmp_offset1_imm
       h_idx := h_idx }
 
 /-- `Decode_bne` rebuilt from the committed program via the ROM lookup
@@ -3478,6 +3868,7 @@ def Decode_bne_of_program
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_EQ
         ∧ (trace.program j).jmp_offset1 = 4
+        ∧ ((trace.program j).jmp_offset2).val = (BitVec.signExtend 64 c.imm).toNat
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_bne trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -3490,10 +3881,17 @@ def Decode_bne_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset1 i.val = 4 := by
     obtain ⟨j, hline, hop, _, hj1, _, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, _hpj2_imm, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0⟩
+  have h_jmp_offset2_imm :
+      ((mainOfTable trace.program trace.mainTable).jmp_offset2 i.val).val =
+        (BitVec.signExtend 64 c.imm).toNat := by
+    obtain ⟨j, hline, _hop, _, _, hj2, _hflags⟩ :=
+      mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, hpj2_imm, _hpf⟩ := h_prog j hline
+    simpa only [← hj2] using hpj2_imm
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -3501,6 +3899,7 @@ def Decode_bne_of_program
       h_set_pc := key.2.2.2.1
       h_store_pc := key.2.2.2.2.1
       h_jmp_offset1 := key.2.2.2.2.2
+      h_jmp_offset2_imm := h_jmp_offset2_imm
       h_idx := h_idx }
 
 /-- `Decode_blt` rebuilt from the committed program via the ROM lookup
@@ -3521,6 +3920,7 @@ def Decode_blt_of_program
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LT
+        ∧ ((trace.program j).jmp_offset1).val = (BitVec.signExtend 64 c.imm).toNat
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_blt trace i c := by
@@ -3534,10 +3934,17 @@ def Decode_blt_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
     obtain ⟨j, hline, hop, _, _, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, _hpj1_imm, hpj0, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj2.symm.trans hpj0⟩
+  have h_jmp_offset1_imm :
+      ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val).val =
+        (BitVec.signExtend 64 c.imm).toNat := by
+    obtain ⟨j, hline, _hop, _, hj1, _, _hflags⟩ :=
+      mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, hpj1_imm, _hpj0, _hpf⟩ := h_prog j hline
+    simpa only [← hj1] using hpj1_imm
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -3545,6 +3952,7 @@ def Decode_blt_of_program
       h_set_pc := key.2.2.2.1
       h_store_pc := key.2.2.2.2.1
       h_jmp_offset2 := key.2.2.2.2.2
+      h_jmp_offset1_imm := h_jmp_offset1_imm
       h_idx := h_idx }
 
 /-- `Decode_bge` rebuilt from the committed program via the ROM lookup
@@ -3566,6 +3974,7 @@ def Decode_bge_of_program
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LT
         ∧ (trace.program j).jmp_offset1 = 4
+        ∧ ((trace.program j).jmp_offset2).val = (BitVec.signExtend 64 c.imm).toNat
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_bge trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -3578,10 +3987,17 @@ def Decode_bge_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset1 i.val = 4 := by
     obtain ⟨j, hline, hop, _, hj1, _, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, _hpj2_imm, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0⟩
+  have h_jmp_offset2_imm :
+      ((mainOfTable trace.program trace.mainTable).jmp_offset2 i.val).val =
+        (BitVec.signExtend 64 c.imm).toNat := by
+    obtain ⟨j, hline, _hop, _, _, hj2, _hflags⟩ :=
+      mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, hpj2_imm, _hpf⟩ := h_prog j hline
+    simpa only [← hj2] using hpj2_imm
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -3589,6 +4005,7 @@ def Decode_bge_of_program
       h_set_pc := key.2.2.2.1
       h_store_pc := key.2.2.2.2.1
       h_jmp_offset1 := key.2.2.2.2.2
+      h_jmp_offset2_imm := h_jmp_offset2_imm
       h_idx := h_idx }
 
 /-- `Decode_bltu` rebuilt from the committed program via the ROM lookup
@@ -3609,6 +4026,7 @@ def Decode_bltu_of_program
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LTU
+        ∧ ((trace.program j).jmp_offset1).val = (BitVec.signExtend 64 c.imm).toNat
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_bltu trace i c := by
@@ -3622,10 +4040,17 @@ def Decode_bltu_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
     obtain ⟨j, hline, hop, _, _, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, _hpj1_imm, hpj0, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj2.symm.trans hpj0⟩
+  have h_jmp_offset1_imm :
+      ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val).val =
+        (BitVec.signExtend 64 c.imm).toNat := by
+    obtain ⟨j, hline, _hop, _, hj1, _, _hflags⟩ :=
+      mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, hpj1_imm, _hpj0, _hpf⟩ := h_prog j hline
+    simpa only [← hj1] using hpj1_imm
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -3633,6 +4058,7 @@ def Decode_bltu_of_program
       h_set_pc := key.2.2.2.1
       h_store_pc := key.2.2.2.2.1
       h_jmp_offset2 := key.2.2.2.2.2
+      h_jmp_offset1_imm := h_jmp_offset1_imm
       h_idx := h_idx }
 
 /-- `Decode_bgeu` rebuilt from the committed program via the ROM lookup
@@ -3654,6 +4080,7 @@ def Decode_bgeu_of_program
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LTU
         ∧ (trace.program j).jmp_offset1 = 4
+        ∧ ((trace.program j).jmp_offset2).val = (BitVec.signExtend 64 c.imm).toNat
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_bgeu trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -3666,10 +4093,17 @@ def Decode_bgeu_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset1 i.val = 4 := by
     obtain ⟨j, hline, hop, _, hj1, _, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, _hpj2_imm, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0⟩
+  have h_jmp_offset2_imm :
+      ((mainOfTable trace.program trace.mainTable).jmp_offset2 i.val).val =
+        (BitVec.signExtend 64 c.imm).toNat := by
+    obtain ⟨j, hline, _hop, _, _, hj2, _hflags⟩ :=
+      mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, hpj2_imm, _hpf⟩ := h_prog j hline
+    simpa only [← hj2] using hpj2_imm
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -3677,6 +4111,7 @@ def Decode_bgeu_of_program
       h_set_pc := key.2.2.2.1
       h_store_pc := key.2.2.2.2.1
       h_jmp_offset1 := key.2.2.2.2.2
+      h_jmp_offset2_imm := h_jmp_offset2_imm
       h_idx := h_idx }
 
 
@@ -3701,6 +4136,7 @@ def Decode_jal_of_program
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_FLAG
+        ∧ ((trace.program j).jmp_offset1).val = (BitVec.signExtend 64 c.imm).toNat
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits) :
@@ -3708,7 +4144,7 @@ def Decode_jal_of_program
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
   have h_dest := mainLuiDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
     (fun j hline => by
-      obtain ⟨_hpo, _hpj0, hpso, hpf⟩ := h_prog j hline
+      obtain ⟨_hpo, _hpj1_imm, _hpj0, hpso, hpf⟩ := h_prog j hline
       exact ⟨hpso, hpf⟩)
   have key :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_FLAG ∧
@@ -3719,10 +4155,17 @@ def Decode_jal_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
     obtain ⟨j, hline, hop, _, _, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, _hpso, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, _hpj1_imm, hpj0, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_true], hj2.symm.trans hpj0⟩
+  have h_jmp_offset1_imm :
+      ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val).val =
+        (BitVec.signExtend 64 c.imm).toNat := by
+    obtain ⟨j, hline, _hop, _, hj1, _, _hflags⟩ :=
+      mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, hpj1_imm, _hpj0, _hpso, _hpf⟩ := h_prog j hline
+    simpa only [← hj1] using hpj1_imm
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -3731,6 +4174,7 @@ def Decode_jal_of_program
       h_store_pc := key.2.2.2.2.1
       h_store_ind := h_dest.1
       h_store_offset := h_dest.2
+      h_jmp_offset1_imm := h_jmp_offset1_imm
       h_jmp2 := key.2.2.2.2.2
       h_idx := h_idx }
 
@@ -3774,32 +4218,34 @@ def Decode_jalr_of_program
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_AND
+        ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_jalr trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
   have h_dest := mainLuiDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
     (fun j hline => by
-      obtain ⟨_hpo, hpso, hpf⟩ := h_prog j hline
+      obtain ⟨_hpo, _hpj2, hpso, hpf⟩ := h_prog j hline
       exact ⟨hpso, hpf⟩)
   have key :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_AND ∧
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1 ∧
       (mainOfTable trace.program trace.mainTable).m32 i.val = 0 ∧
       (mainOfTable trace.program trace.mainTable).set_pc i.val = 1 ∧
-      (mainOfTable trace.program trace.mainTable).store_pc i.val = 1 := by
-    obtain ⟨j, hline, hop, _, _, _, hflags⟩ :=
+      (mainOfTable trace.program trace.mainTable).store_pc i.val = 1 ∧
+      (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
+    obtain ⟨j, hline, hop, _, _, hjmp2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, _hpso, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj2, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
-    exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_true], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_true]⟩
+    exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_true], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_true], hjmp2.symm.trans hpj2⟩
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
       h_m32 := key.2.2.1
       h_set_pc := key.2.2.2.1
-      h_store_pc := key.2.2.2.2
+      h_store_pc := key.2.2.2.2.1
       h_store_ind := h_dest.1
       h_store_offset := h_dest.2
       h_idx := h_idx
@@ -3807,6 +4253,7 @@ def Decode_jalr_of_program
       h_a_mask_lo := h_a_mask_lo
       h_a_mask_hi := h_a_mask_hi
       h_c1_zero := h_c1_zero
+      h_jmp2 := key.2.2.2.2.2
       h_offset_bridge := h_offset_bridge
       h_offset_even := h_offset_even
       h_no_fgl_wrap := h_no_fgl_wrap }

--- a/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
@@ -3015,6 +3015,7 @@ def Decode_sb_of_program
     (h_bits_ieo : bits.is_external_op = false)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
+    (h_bits_store_ind : bits.store_ind = true)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -3039,6 +3040,13 @@ def Decode_sb_of_program
     obtain ⟨p_ieo, _, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1, hiw.symm.trans hpiw⟩
+  have h_store_ind : (mainRowWithRomSt trace i).rom.store_ind = 1 := by
+    obtain ⟨j, hline, _hop, _hiw, _hj1, _hj2, hflags⟩ :=
+      mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpf⟩ := h_prog j hline
+    obtain ⟨p_store_ind, _, _⟩ :=
+      mainSelectorColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
+    simpa [mainRowWithRomSt, h_bits_store_ind, ZiskFv.AirsClean.boolF_true] using p_store_ind
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -3047,6 +3055,7 @@ def Decode_sb_of_program
       h_jmp1 := key.2.2.2.2.1
       h_jmp2 := key.2.2.2.2.2.1
       h_main_ind_width := key.2.2.2.2.2.2
+      h_store_ind := h_store_ind
       h_idx := h_idx }
 
 /-- `Decode_sh` rebuilt from the committed program via the ROM lookup
@@ -3062,6 +3071,7 @@ def Decode_sh_of_program
     (h_bits_ieo : bits.is_external_op = false)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
+    (h_bits_store_ind : bits.store_ind = true)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -3086,6 +3096,13 @@ def Decode_sh_of_program
     obtain ⟨p_ieo, _, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1, hiw.symm.trans hpiw⟩
+  have h_store_ind : (mainRowWithRomSt trace i).rom.store_ind = 1 := by
+    obtain ⟨j, hline, _hop, _hiw, _hj1, _hj2, hflags⟩ :=
+      mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpf⟩ := h_prog j hline
+    obtain ⟨p_store_ind, _, _⟩ :=
+      mainSelectorColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
+    simpa [mainRowWithRomSt, h_bits_store_ind, ZiskFv.AirsClean.boolF_true] using p_store_ind
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -3094,6 +3111,7 @@ def Decode_sh_of_program
       h_jmp1 := key.2.2.2.2.1
       h_jmp2 := key.2.2.2.2.2.1
       h_main_ind_width := key.2.2.2.2.2.2
+      h_store_ind := h_store_ind
       h_idx := h_idx }
 
 /-- `Decode_sw` rebuilt from the committed program via the ROM lookup
@@ -3109,6 +3127,7 @@ def Decode_sw_of_program
     (h_bits_ieo : bits.is_external_op = false)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
+    (h_bits_store_ind : bits.store_ind = true)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -3133,6 +3152,13 @@ def Decode_sw_of_program
     obtain ⟨p_ieo, _, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1, hiw.symm.trans hpiw⟩
+  have h_store_ind : (mainRowWithRomSt trace i).rom.store_ind = 1 := by
+    obtain ⟨j, hline, _hop, _hiw, _hj1, _hj2, hflags⟩ :=
+      mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpf⟩ := h_prog j hline
+    obtain ⟨p_store_ind, _, _⟩ :=
+      mainSelectorColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
+    simpa [mainRowWithRomSt, h_bits_store_ind, ZiskFv.AirsClean.boolF_true] using p_store_ind
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -3141,6 +3167,7 @@ def Decode_sw_of_program
       h_jmp1 := key.2.2.2.2.1
       h_jmp2 := key.2.2.2.2.2.1
       h_main_ind_width := key.2.2.2.2.2.2
+      h_store_ind := h_store_ind
       h_idx := h_idx }
 
 /-- `Decode_sd` rebuilt from the committed program via the ROM lookup
@@ -3156,6 +3183,7 @@ def Decode_sd_of_program
     (h_bits_ieo : bits.is_external_op = false)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
+    (h_bits_store_ind : bits.store_ind = true)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -3178,6 +3206,13 @@ def Decode_sd_of_program
     obtain ⟨p_ieo, _, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1⟩
+  have h_store_ind : (mainRowWithRomSt trace i).rom.store_ind = 1 := by
+    obtain ⟨j, hline, _hop, _hiw, _hj1, _hj2, hflags⟩ :=
+      mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj0, _hpj1, hpf⟩ := h_prog j hline
+    obtain ⟨p_store_ind, _, _⟩ :=
+      mainSelectorColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
+    simpa [mainRowWithRomSt, h_bits_store_ind, ZiskFv.AirsClean.boolF_true] using p_store_ind
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -3185,6 +3220,7 @@ def Decode_sd_of_program
       h_store_pc := key.2.2.2.1
       h_jmp1 := key.2.2.2.2.1
       h_jmp2 := key.2.2.2.2.2
+      h_store_ind := h_store_ind
       h_idx := h_idx }
 
 

--- a/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
@@ -154,6 +154,40 @@ theorem mainWritebackDestinationFacts_of_program
     simpa [mainRowWithRomSub] using hstore.symm.trans hpso
   exact ⟨h_store_ind, h_store_offset⟩
 
+/-- Writeback destination selector/offset facts derived from the committed
+    program and packed ROM flags for the `mainRowWithRomLui` row used by
+    LUI/AUIPC/JAL/JALR rd writes. -/
+theorem mainLuiDestinationFacts_of_program
+    {numInstructions : Nat}
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin trace.numInstructions)
+    (h_lt : i.val < trace.mainTable.table.length)
+    (bits : RomFlagBits)
+    (rd : regidx)
+    (h_bits_store_ind : bits.store_ind = false)
+    (h_prog : ∀ j : Fin numInstructions,
+        (trace.program j).line
+            = (mainOfTable trace.program trace.mainTable).pc i.val →
+          (trace.program j).store_offset = Transpiler.ind (regidx_to_fin rd)
+        ∧ (trace.program j).flags = packFlags bits) :
+    (mainRowWithRomLui trace i).rom.store_ind = 0
+  ∧ (mainRowWithRomLui trace i).rom.store_offset =
+      Transpiler.ind (regidx_to_fin rd) := by
+  obtain ⟨j, hline, _hop, _hiw, _hj1, _hj2, hflags⟩ :=
+    mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
+  obtain ⟨_hpso, hpf⟩ := h_prog j hline
+  obtain ⟨p_store_ind, _, _⟩ :=
+    mainSelectorColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
+  have h_store_ind : (mainRowWithRomLui trace i).rom.store_ind = 0 := by
+    simpa [mainRowWithRomLui, h_bits_store_ind, ZiskFv.AirsClean.boolF_false] using p_store_ind
+  have h_store_offset :
+      (mainRowWithRomLui trace i).rom.store_offset =
+        Transpiler.ind (regidx_to_fin rd) := by
+    obtain ⟨j, hline, hstore⟩ := mainStoreOffset_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨hpso, _hpf⟩ := h_prog j hline
+    simpa [mainRowWithRomLui] using hstore.symm.trans hpso
+  exact ⟨h_store_ind, h_store_offset⟩
+
 
 /-! ## Family: R/I-type ALU -/
 
@@ -3176,15 +3210,21 @@ def Decode_lui_of_program
     (h_bits_m32 : bits.m32 = false)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
+    (h_bits_store_ind : bits.store_ind = false)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_COPYB
         ∧ (trace.program j).jmp_offset1 = 4
         ∧ (trace.program j).jmp_offset2 = 4
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_lui trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
+  have h_dest := mainLuiDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
+    (fun j hline => by
+      obtain ⟨_hpo, _hpj0, _hpj1, hpso, hpf⟩ := h_prog j hline
+      exact ⟨hpso, hpf⟩)
   have key :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_COPYB ∧
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 0 ∧
@@ -3195,7 +3235,7 @@ def Decode_lui_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
     obtain ⟨j, hline, hop, _, hj1, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpj1, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, hpj1, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0, hj2.symm.trans hpj1⟩
@@ -3205,6 +3245,8 @@ def Decode_lui_of_program
       h_m32 := key.2.2.1
       h_set_pc := key.2.2.2.1
       h_store_pc := key.2.2.2.2.1
+      h_store_ind := h_dest.1
+      h_store_offset := h_dest.2
       h_jmp1 := key.2.2.2.2.2.1
       h_jmp2 := key.2.2.2.2.2.2
       h_idx := h_idx
@@ -3225,14 +3267,20 @@ def Decode_auipc_of_program
     (h_bits_m32 : bits.m32 = false)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = true)
+    (h_bits_store_ind : bits.store_ind = false)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_FLAG
         ∧ (trace.program j).jmp_offset1 = 4
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_auipc trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
+  have h_dest := mainLuiDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
+    (fun j hline => by
+      obtain ⟨_hpo, _hpj0, hpso, hpf⟩ := h_prog j hline
+      exact ⟨hpso, hpf⟩)
   have key :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_FLAG ∧
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 0 ∧
@@ -3242,7 +3290,7 @@ def Decode_auipc_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset1 i.val = 4 := by
     obtain ⟨j, hline, hop, _, hj1, _, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_true], hj1.symm.trans hpj0⟩
@@ -3252,6 +3300,8 @@ def Decode_auipc_of_program
       h_m32 := key.2.2.1
       h_set_pc := key.2.2.2.1
       h_store_pc := key.2.2.2.2.1
+      h_store_ind := h_dest.1
+      h_store_offset := h_dest.2
       h_jmp1 := key.2.2.2.2.2
       h_idx := h_idx }
 
@@ -3539,14 +3589,20 @@ def Decode_jal_of_program
     (h_bits_m32 : bits.m32 = false)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = true)
+    (h_bits_store_ind : bits.store_ind = false)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_FLAG
         ∧ (trace.program j).jmp_offset2 = 4
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_jal trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
+  have h_dest := mainLuiDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
+    (fun j hline => by
+      obtain ⟨_hpo, _hpj0, hpso, hpf⟩ := h_prog j hline
+      exact ⟨hpso, hpf⟩)
   have key :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_FLAG ∧
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 0 ∧
@@ -3556,7 +3612,7 @@ def Decode_jal_of_program
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
     obtain ⟨j, hline, hop, _, _, hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj0, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj0, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_true], hj2.symm.trans hpj0⟩
@@ -3566,6 +3622,8 @@ def Decode_jal_of_program
       h_m32 := key.2.2.1
       h_set_pc := key.2.2.2.1
       h_store_pc := key.2.2.2.2.1
+      h_store_ind := h_dest.1
+      h_store_offset := h_dest.2
       h_jmp2 := key.2.2.2.2.2
       h_idx := h_idx }
 
@@ -3604,13 +3662,19 @@ def Decode_jalr_of_program
     (h_bits_m32 : bits.m32 = false)
     (h_bits_set_pc : bits.set_pc = true)
     (h_bits_store_pc : bits.store_pc = true)
+    (h_bits_store_ind : bits.store_ind = false)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_AND
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_jalr trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
+  have h_dest := mainLuiDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
+    (fun j hline => by
+      obtain ⟨_hpo, hpso, hpf⟩ := h_prog j hline
+      exact ⟨hpso, hpf⟩)
   have key :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_AND ∧
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1 ∧
@@ -3619,7 +3683,7 @@ def Decode_jalr_of_program
       (mainOfTable trace.program trace.mainTable).store_pc i.val = 1 := by
     obtain ⟨j, hline, hop, _, _, _, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_true], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_true]⟩
@@ -3629,6 +3693,8 @@ def Decode_jalr_of_program
       h_m32 := key.2.2.1
       h_set_pc := key.2.2.2.1
       h_store_pc := key.2.2.2.2
+      h_store_ind := h_dest.1
+      h_store_offset := h_dest.2
       h_idx := h_idx
       h_flag := h_flag
       h_a_mask_lo := h_a_mask_lo

--- a/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
@@ -2516,6 +2516,28 @@ theorem mainLoadDestinationFacts_of_program
     simpa [mainRowWithRomLd] using hstore.symm.trans hpso
   exact ⟨h_store_ind, h_store_reg, h_store_offset⟩
 
+/-- Load memory-address selector fact derived from the committed program and
+    packed ROM flags. This is the primitive decode fact needed to derive the
+    old `Inputs_*` `addr1` placement pins from `AddressSpec`. -/
+theorem mainLoadBsrcInd_of_program
+    {numInstructions : Nat}
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin trace.numInstructions)
+    (h_lt : i.val < trace.mainTable.table.length)
+    (bits : RomFlagBits)
+    (h_bits_b_src_ind : bits.b_src_ind = true)
+    (h_prog : ∀ j : Fin numInstructions,
+        (trace.program j).line
+            = (mainOfTable trace.program trace.mainTable).pc i.val →
+          (trace.program j).flags = packFlags bits) :
+    (mainRowWithRomLd trace i).rom.b_src_ind = 1 := by
+  obtain ⟨j, hline, _hop, _hiw, _hj1, _hj2, hflags⟩ :=
+    mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
+  have hpf := h_prog j hline
+  obtain ⟨_, p_b_src_ind, _⟩ :=
+    mainSelectorColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
+  simpa [mainRowWithRomLd, h_bits_b_src_ind, ZiskFv.AirsClean.boolF_true] using p_b_src_ind
+
 
 /-! ## Family: loads -/
 
@@ -2534,6 +2556,7 @@ def Decode_ld_of_program
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
     (h_bits_store_reg : bits.store_reg = true)
+    (h_bits_b_src_ind : bits.b_src_ind = true)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -2573,6 +2596,11 @@ def Decode_ld_of_program
     obtain ⟨_p_store_ind, _, p_store_reg⟩ :=
       mainSelectorColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     simpa [mainRowWithRomLd, h_bits_store_reg, ZiskFv.AirsClean.boolF_true] using p_store_reg
+  have h_b_src_ind : (mainRowWithRomLd trace i).rom.b_src_ind = 1 :=
+    mainLoadBsrcInd_of_program trace i h_lt bits h_bits_b_src_ind
+      (fun j hline => by
+        obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpso, hpf⟩ := h_prog j hline
+        exact hpf)
   have h_store_offset :
       (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.ld_input.rd) := by
     obtain ⟨j, hline, hstore⟩ := mainStoreOffset_at_eq_program trace ⟨i.val, h_lt⟩
@@ -2589,6 +2617,7 @@ def Decode_ld_of_program
       h_idx := h_idx
       h_store_ind := h_store_ind
       h_store_reg := h_store_reg
+      h_b_src_ind := h_b_src_ind
       h_store_offset := h_store_offset }
 
 /-- `Decode_lbu` rebuilt from the committed program via the ROM lookup
@@ -2606,6 +2635,7 @@ def Decode_lbu_of_program
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
     (h_bits_store_reg : bits.store_reg = true)
+    (h_bits_b_src_ind : bits.b_src_ind = true)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -2635,6 +2665,11 @@ def Decode_lbu_of_program
     h_bits_store_ind h_bits_store_reg (fun j hline => by
       obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpso, hpf⟩ := h_prog j hline
       exact ⟨hpso, hpf⟩)
+  have h_b_src_ind : (mainRowWithRomLd trace i).rom.b_src_ind = 1 :=
+    mainLoadBsrcInd_of_program trace i h_lt bits h_bits_b_src_ind
+      (fun j hline => by
+        obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpso, hpf⟩ := h_prog j hline
+        exact hpf)
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -2646,6 +2681,7 @@ def Decode_lbu_of_program
       h_idx := h_idx
       h_store_ind := h_dest.1
       h_store_reg := h_dest.2.1
+      h_b_src_ind := h_b_src_ind
       h_store_offset := h_dest.2.2 }
 
 /-- `Decode_lhu` rebuilt from the committed program via the ROM lookup
@@ -2663,6 +2699,7 @@ def Decode_lhu_of_program
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
     (h_bits_store_reg : bits.store_reg = true)
+    (h_bits_b_src_ind : bits.b_src_ind = true)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -2692,6 +2729,11 @@ def Decode_lhu_of_program
     h_bits_store_ind h_bits_store_reg (fun j hline => by
       obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpso, hpf⟩ := h_prog j hline
       exact ⟨hpso, hpf⟩)
+  have h_b_src_ind : (mainRowWithRomLd trace i).rom.b_src_ind = 1 :=
+    mainLoadBsrcInd_of_program trace i h_lt bits h_bits_b_src_ind
+      (fun j hline => by
+        obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpso, hpf⟩ := h_prog j hline
+        exact hpf)
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -2703,6 +2745,7 @@ def Decode_lhu_of_program
       h_idx := h_idx
       h_store_ind := h_dest.1
       h_store_reg := h_dest.2.1
+      h_b_src_ind := h_b_src_ind
       h_store_offset := h_dest.2.2 }
 
 /-- `Decode_lwu` rebuilt from the committed program via the ROM lookup
@@ -2720,6 +2763,7 @@ def Decode_lwu_of_program
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
     (h_bits_store_reg : bits.store_reg = true)
+    (h_bits_b_src_ind : bits.b_src_ind = true)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -2749,6 +2793,11 @@ def Decode_lwu_of_program
     h_bits_store_ind h_bits_store_reg (fun j hline => by
       obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpso, hpf⟩ := h_prog j hline
       exact ⟨hpso, hpf⟩)
+  have h_b_src_ind : (mainRowWithRomLd trace i).rom.b_src_ind = 1 :=
+    mainLoadBsrcInd_of_program trace i h_lt bits h_bits_b_src_ind
+      (fun j hline => by
+        obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpso, hpf⟩ := h_prog j hline
+        exact hpf)
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -2760,6 +2809,7 @@ def Decode_lwu_of_program
       h_idx := h_idx
       h_store_ind := h_dest.1
       h_store_reg := h_dest.2.1
+      h_b_src_ind := h_b_src_ind
       h_store_offset := h_dest.2.2 }
 
 /-- `Decode_lb` rebuilt from the committed program via the ROM lookup
@@ -2793,6 +2843,7 @@ def Decode_lb_of_program
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
     (h_bits_store_reg : bits.store_reg = true)
+    (h_bits_b_src_ind : bits.b_src_ind = true)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -2822,6 +2873,11 @@ def Decode_lb_of_program
     h_bits_store_ind h_bits_store_reg (fun j hline => by
       obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpso, hpf⟩ := h_prog j hline
       exact ⟨hpso, hpf⟩)
+  have h_b_src_ind : (mainRowWithRomLd trace i).rom.b_src_ind = 1 :=
+    mainLoadBsrcInd_of_program trace i h_lt bits h_bits_b_src_ind
+      (fun j hline => by
+        obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpso, hpf⟩ := h_prog j hline
+        exact hpf)
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -2839,6 +2895,7 @@ def Decode_lb_of_program
       h_match := h_match
       h_store_ind := h_dest.1
       h_store_reg := h_dest.2.1
+      h_b_src_ind := h_b_src_ind
       h_store_offset := h_dest.2.2 }
 
 /-- `Decode_lh` rebuilt from the committed program via the ROM lookup
@@ -2872,6 +2929,7 @@ def Decode_lh_of_program
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
     (h_bits_store_reg : bits.store_reg = true)
+    (h_bits_b_src_ind : bits.b_src_ind = true)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -2901,6 +2959,11 @@ def Decode_lh_of_program
     h_bits_store_ind h_bits_store_reg (fun j hline => by
       obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpso, hpf⟩ := h_prog j hline
       exact ⟨hpso, hpf⟩)
+  have h_b_src_ind : (mainRowWithRomLd trace i).rom.b_src_ind = 1 :=
+    mainLoadBsrcInd_of_program trace i h_lt bits h_bits_b_src_ind
+      (fun j hline => by
+        obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpso, hpf⟩ := h_prog j hline
+        exact hpf)
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -2918,6 +2981,7 @@ def Decode_lh_of_program
       h_match := h_match
       h_store_ind := h_dest.1
       h_store_reg := h_dest.2.1
+      h_b_src_ind := h_b_src_ind
       h_store_offset := h_dest.2.2 }
 
 /-- `Decode_lw` rebuilt from the committed program via the ROM lookup
@@ -2951,6 +3015,7 @@ def Decode_lw_of_program
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
     (h_bits_store_reg : bits.store_reg = true)
+    (h_bits_b_src_ind : bits.b_src_ind = true)
     (h_prog : ∀ j : Fin numInstructions,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
@@ -2980,6 +3045,11 @@ def Decode_lw_of_program
     h_bits_store_ind h_bits_store_reg (fun j hline => by
       obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpso, hpf⟩ := h_prog j hline
       exact ⟨hpso, hpf⟩)
+  have h_b_src_ind : (mainRowWithRomLd trace i).rom.b_src_ind = 1 :=
+    mainLoadBsrcInd_of_program trace i h_lt bits h_bits_b_src_ind
+      (fun j hline => by
+        obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpso, hpf⟩ := h_prog j hline
+        exact hpf)
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
@@ -2997,6 +3067,7 @@ def Decode_lw_of_program
       h_match := h_match
       h_store_ind := h_dest.1
       h_store_reg := h_dest.2.1
+      h_b_src_ind := h_b_src_ind
       h_store_offset := h_dest.2.2 }
 
 

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataAluShift.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataAluShift.lean
@@ -135,7 +135,6 @@ structure Inputs_sub (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = sub_input.PC.toNat
-  h_pc_bound : sub_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `sub` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sub` bundles them. -/
@@ -222,7 +221,6 @@ structure Inputs_and (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = and_input.PC.toNat
-  h_pc_bound : and_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `and` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_and` bundles them. -/
@@ -309,7 +307,6 @@ structure Inputs_or (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = or_input.PC.toNat
-  h_pc_bound : or_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `or` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_or` bundles them. -/
@@ -396,7 +393,6 @@ structure Inputs_xor (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = xor_input.PC.toNat
-  h_pc_bound : xor_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `xor` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_xor` bundles them. -/
@@ -483,7 +479,6 @@ structure Inputs_slt (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = slt_input.PC.toNat
-  h_pc_bound : slt_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `slt` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_slt` bundles them. -/
@@ -570,7 +565,6 @@ structure Inputs_sltu (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = sltu_input.PC.toNat
-  h_pc_bound : sltu_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `sltu` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sltu` bundles them. -/
@@ -622,6 +616,13 @@ structure Decode_andi (trace : AcceptedZiskTrace numInstructions)
   h_store_offset :
     (mainRowWithRomSub trace i).rom.store_offset =
       Transpiler.ind (regidx_to_fin c.rd)
+  h_b_src_imm :
+    (mainRowWithRomSub trace i).rom.b_src_imm = 1
+  h_b_imm :
+    BitVec.signExtend 64 c.imm =
+      BitVec.ofNat 64
+        (((mainRowWithRomSub trace i).rom.b_offset_imm0).val
+          + ((mainRowWithRomSub trace i).rom.b_imm1).val * 4294967296)
 
 structure Inputs_andi (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_andi trace i) : Type where
@@ -642,13 +643,9 @@ structure Inputs_andi (trace : AcceptedZiskTrace numInstructions) (binding : Sai
       ZiskFv.Trusted.lane_hi
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding i)).xreg
           (regidx_to_fin c.r1))
-  h_andi_subset : itype_imm_subset_holds_main
-    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-    i.val andi_input.imm
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = andi_input.PC.toNat
-  h_pc_bound : andi_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `andi` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_andi` bundles them. -/
@@ -700,6 +697,13 @@ structure Decode_ori (trace : AcceptedZiskTrace numInstructions)
   h_store_offset :
     (mainRowWithRomSub trace i).rom.store_offset =
       Transpiler.ind (regidx_to_fin c.rd)
+  h_b_src_imm :
+    (mainRowWithRomSub trace i).rom.b_src_imm = 1
+  h_b_imm :
+    BitVec.signExtend 64 c.imm =
+      BitVec.ofNat 64
+        (((mainRowWithRomSub trace i).rom.b_offset_imm0).val
+          + ((mainRowWithRomSub trace i).rom.b_imm1).val * 4294967296)
 
 structure Inputs_ori (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_ori trace i) : Type where
@@ -720,13 +724,9 @@ structure Inputs_ori (trace : AcceptedZiskTrace numInstructions) (binding : Sail
       ZiskFv.Trusted.lane_hi
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding i)).xreg
           (regidx_to_fin c.r1))
-  h_ori_subset : itype_imm_subset_holds_main
-    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-    i.val ori_input.imm
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = ori_input.PC.toNat
-  h_pc_bound : ori_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `ori` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_ori` bundles them. -/
@@ -778,6 +778,13 @@ structure Decode_xori (trace : AcceptedZiskTrace numInstructions)
   h_store_offset :
     (mainRowWithRomSub trace i).rom.store_offset =
       Transpiler.ind (regidx_to_fin c.rd)
+  h_b_src_imm :
+    (mainRowWithRomSub trace i).rom.b_src_imm = 1
+  h_b_imm :
+    BitVec.signExtend 64 c.imm =
+      BitVec.ofNat 64
+        (((mainRowWithRomSub trace i).rom.b_offset_imm0).val
+          + ((mainRowWithRomSub trace i).rom.b_imm1).val * 4294967296)
 
 structure Inputs_xori (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_xori trace i) : Type where
@@ -798,13 +805,9 @@ structure Inputs_xori (trace : AcceptedZiskTrace numInstructions) (binding : Sai
       ZiskFv.Trusted.lane_hi
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding i)).xreg
           (regidx_to_fin c.r1))
-  h_xori_subset : itype_imm_subset_holds_main
-    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-    i.val xori_input.imm
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = xori_input.PC.toNat
-  h_pc_bound : xori_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `xori` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_xori` bundles them. -/
@@ -856,6 +859,13 @@ structure Decode_slti (trace : AcceptedZiskTrace numInstructions)
   h_store_offset :
     (mainRowWithRomSub trace i).rom.store_offset =
       Transpiler.ind (regidx_to_fin c.rd)
+  h_b_src_imm :
+    (mainRowWithRomSub trace i).rom.b_src_imm = 1
+  h_b_imm :
+    BitVec.signExtend 64 c.imm =
+      BitVec.ofNat 64
+        (((mainRowWithRomSub trace i).rom.b_offset_imm0).val
+          + ((mainRowWithRomSub trace i).rom.b_imm1).val * 4294967296)
 
 structure Inputs_slti (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_slti trace i) : Type where
@@ -876,13 +886,9 @@ structure Inputs_slti (trace : AcceptedZiskTrace numInstructions) (binding : Sai
       ZiskFv.Trusted.lane_hi
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding i)).xreg
           (regidx_to_fin c.r1))
-  h_slti_subset : itype_imm_subset_holds_main
-    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-    i.val slti_input.imm
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = slti_input.PC.toNat
-  h_pc_bound : slti_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `slti` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_slti` bundles them. -/
@@ -934,6 +940,13 @@ structure Decode_sltiu (trace : AcceptedZiskTrace numInstructions)
   h_store_offset :
     (mainRowWithRomSub trace i).rom.store_offset =
       Transpiler.ind (regidx_to_fin c.rd)
+  h_b_src_imm :
+    (mainRowWithRomSub trace i).rom.b_src_imm = 1
+  h_b_imm :
+    BitVec.signExtend 64 c.imm =
+      BitVec.ofNat 64
+        (((mainRowWithRomSub trace i).rom.b_offset_imm0).val
+          + ((mainRowWithRomSub trace i).rom.b_imm1).val * 4294967296)
 
 structure Inputs_sltiu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_sltiu trace i) : Type where
@@ -954,13 +967,9 @@ structure Inputs_sltiu (trace : AcceptedZiskTrace numInstructions) (binding : Sa
       ZiskFv.Trusted.lane_hi
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding i)).xreg
           (regidx_to_fin c.r1))
-  h_sltiu_subset : itype_imm_subset_holds_main
-    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-    i.val sltiu_input.imm
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = sltiu_input.PC.toNat
-  h_pc_bound : sltiu_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `sltiu` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sltiu` bundles them. -/
@@ -1047,7 +1056,6 @@ structure Inputs_sll (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = sll_input.PC.toNat
-  h_pc_bound : sll_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `sll` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sll` bundles them. -/
@@ -1134,7 +1142,6 @@ structure Inputs_srl (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = srl_input.PC.toNat
-  h_pc_bound : srl_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `srl` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_srl` bundles them. -/
@@ -1221,7 +1228,6 @@ structure Inputs_sra (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = sra_input.PC.toNat
-  h_pc_bound : sra_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `sra` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sra` bundles them. -/
@@ -1299,7 +1305,6 @@ structure Inputs_slli (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = slli_input.PC.toNat
-  h_pc_bound : slli_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `slli` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_slli` bundles them. -/
@@ -1377,7 +1382,6 @@ structure Inputs_srli (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = srli_input.PC.toNat
-  h_pc_bound : srli_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `srli` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_srli` bundles them. -/
@@ -1455,7 +1459,6 @@ structure Inputs_srai (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = srai_input.PC.toNat
-  h_pc_bound : srai_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `srai` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_srai` bundles them. -/
@@ -1542,7 +1545,6 @@ structure Inputs_sllw (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = sllw_input.PC.toNat
-  h_pc_bound : sllw_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `sllw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sllw` bundles them. -/
@@ -1629,7 +1631,6 @@ structure Inputs_srlw (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = srlw_input.PC.toNat
-  h_pc_bound : srlw_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `srlw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_srlw` bundles them. -/
@@ -1716,7 +1717,6 @@ structure Inputs_sraw (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = sraw_input.PC.toNat
-  h_pc_bound : sraw_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `sraw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sraw` bundles them. -/
@@ -1792,7 +1792,6 @@ structure Inputs_slliw (trace : AcceptedZiskTrace numInstructions) (binding : Sa
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.slliw_input.PC.toNat
-  h_pc_bound : c.slliw_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `slliw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_slliw` bundles them. -/
@@ -1868,7 +1867,6 @@ structure Inputs_srliw (trace : AcceptedZiskTrace numInstructions) (binding : Sa
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.srliw_input.PC.toNat
-  h_pc_bound : c.srliw_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `srliw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_srliw` bundles them. -/
@@ -1944,7 +1942,6 @@ structure Inputs_sraiw (trace : AcceptedZiskTrace numInstructions) (binding : Sa
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.sraiw_input.PC.toNat
-  h_pc_bound : c.sraiw_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `sraiw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sraiw` bundles them. -/

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
@@ -2326,6 +2326,8 @@ structure Decode_ld (trace : AcceptedZiskTrace numInstructions)
     (mainRowWithRomLd trace i).rom.store_ind = 0
   h_store_reg :
     (mainRowWithRomLd trace i).rom.store_reg = 1
+  h_b_src_ind :
+    (mainRowWithRomLd trace i).rom.b_src_ind = 1
   h_store_offset :
     (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.ld_input.rd)
 
@@ -2335,8 +2337,8 @@ structure Inputs_ld (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   mem : Valid_Mem FGL FGL
   r_mem : ℕ
   h_opcode_assumptions : PureSpec.ld_state_assumptions c.ld_input (binding i)
-  h_addr1 :
-    (mainRowWithRomLd trace i).rom.addr1.toNat =
+  h_load_addr_arith :
+    ((mainRowWithRomLd trace i).rom.b_offset_imm0 + (mainRowWithRomLd trace i).core.a_0).toNat =
       c.ld_input.r1_val.toNat + (BitVec.signExtend 64 c.ld_input.imm).toNat
   h_risc_v_assumptions :
     RISC_V_assumptions (binding i) regs.mstatus regs.pmaRegion regs.misa regs.mseccfg
@@ -2404,6 +2406,8 @@ structure Decode_lbu (trace : AcceptedZiskTrace numInstructions)
     (mainRowWithRomLd trace i).rom.store_ind = 0
   h_store_reg :
     (mainRowWithRomLd trace i).rom.store_reg = 1
+  h_b_src_ind :
+    (mainRowWithRomLd trace i).rom.b_src_ind = 1
   h_store_offset :
     (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lbu_input.rd)
 
@@ -2416,8 +2420,8 @@ structure Inputs_lbu (trace : AcceptedZiskTrace numInstructions) (binding : Sail
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
     i.val (busLd trace i (Pilot.execRowOf trace i)).e1
   h_opcode_assumptions : PureSpec.lbu_state_assumptions c.lbu_input (binding i)
-  h_addr1 :
-    (mainRowWithRomLd trace i).rom.addr1.toNat =
+  h_load_addr_arith :
+    ((mainRowWithRomLd trace i).rom.b_offset_imm0 + (mainRowWithRomLd trace i).core.a_0).toNat =
       c.lbu_input.r1_val.toNat + (BitVec.signExtend 64 c.lbu_input.imm).toNat
   h_risc_v_assumptions :
     RISC_V_assumptions (binding i) regs.mstatus regs.pmaRegion regs.misa regs.mseccfg
@@ -2485,6 +2489,8 @@ structure Decode_lhu (trace : AcceptedZiskTrace numInstructions)
     (mainRowWithRomLd trace i).rom.store_ind = 0
   h_store_reg :
     (mainRowWithRomLd trace i).rom.store_reg = 1
+  h_b_src_ind :
+    (mainRowWithRomLd trace i).rom.b_src_ind = 1
   h_store_offset :
     (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lhu_input.rd)
 
@@ -2497,8 +2503,8 @@ structure Inputs_lhu (trace : AcceptedZiskTrace numInstructions) (binding : Sail
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
     i.val (busLd trace i (Pilot.execRowOf trace i)).e1
   h_opcode_assumptions : PureSpec.lhu_state_assumptions c.lhu_input (binding i)
-  h_addr1 :
-    (mainRowWithRomLd trace i).rom.addr1.toNat =
+  h_load_addr_arith :
+    ((mainRowWithRomLd trace i).rom.b_offset_imm0 + (mainRowWithRomLd trace i).core.a_0).toNat =
       c.lhu_input.r1_val.toNat + (BitVec.signExtend 64 c.lhu_input.imm).toNat
   h_risc_v_assumptions :
     RISC_V_assumptions (binding i) regs.mstatus regs.pmaRegion regs.misa regs.mseccfg
@@ -2566,6 +2572,8 @@ structure Decode_lwu (trace : AcceptedZiskTrace numInstructions)
     (mainRowWithRomLd trace i).rom.store_ind = 0
   h_store_reg :
     (mainRowWithRomLd trace i).rom.store_reg = 1
+  h_b_src_ind :
+    (mainRowWithRomLd trace i).rom.b_src_ind = 1
   h_store_offset :
     (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lwu_input.rd)
 
@@ -2578,8 +2586,8 @@ structure Inputs_lwu (trace : AcceptedZiskTrace numInstructions) (binding : Sail
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
     i.val (busLd trace i (Pilot.execRowOf trace i)).e1
   h_opcode_assumptions : PureSpec.lwu_state_assumptions c.lwu_input (binding i)
-  h_addr1 :
-    (mainRowWithRomLd trace i).rom.addr1.toNat =
+  h_load_addr_arith :
+    ((mainRowWithRomLd trace i).rom.b_offset_imm0 + (mainRowWithRomLd trace i).core.a_0).toNat =
       c.lwu_input.r1_val.toNat + (BitVec.signExtend 64 c.lwu_input.imm).toNat
   h_risc_v_assumptions :
     RISC_V_assumptions (binding i) regs.mstatus regs.pmaRegion regs.misa regs.mseccfg
@@ -2658,6 +2666,8 @@ structure Decode_lb (trace : AcceptedZiskTrace numInstructions)
     (mainRowWithRomLd trace i).rom.store_ind = 0
   h_store_reg :
     (mainRowWithRomLd trace i).rom.store_reg = 1
+  h_b_src_ind :
+    (mainRowWithRomLd trace i).rom.b_src_ind = 1
   h_store_offset :
     (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lb_input.rd)
 
@@ -2667,8 +2677,8 @@ structure Inputs_lb (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   mem : Valid_Mem FGL FGL
   r_mem : ℕ
   h_opcode_assumptions : PureSpec.lb_state_assumptions c.lb_input (binding i)
-  h_addr1 :
-    (mainRowWithRomLd trace i).rom.addr1.toNat =
+  h_load_addr_arith :
+    ((mainRowWithRomLd trace i).rom.b_offset_imm0 + (mainRowWithRomLd trace i).core.a_0).toNat =
       c.lb_input.r1_val.toNat + (BitVec.signExtend 64 c.lb_input.imm).toNat
   h_risc_v_assumptions :
     RISC_V_assumptions (binding i) regs.mstatus regs.pmaRegion regs.misa regs.mseccfg
@@ -2747,6 +2757,8 @@ structure Decode_lh (trace : AcceptedZiskTrace numInstructions)
     (mainRowWithRomLd trace i).rom.store_ind = 0
   h_store_reg :
     (mainRowWithRomLd trace i).rom.store_reg = 1
+  h_b_src_ind :
+    (mainRowWithRomLd trace i).rom.b_src_ind = 1
   h_store_offset :
     (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lh_input.rd)
 
@@ -2756,8 +2768,8 @@ structure Inputs_lh (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   mem : Valid_Mem FGL FGL
   r_mem : ℕ
   h_opcode_assumptions : PureSpec.lh_state_assumptions c.lh_input (binding i)
-  h_addr1 :
-    (mainRowWithRomLd trace i).rom.addr1.toNat =
+  h_load_addr_arith :
+    ((mainRowWithRomLd trace i).rom.b_offset_imm0 + (mainRowWithRomLd trace i).core.a_0).toNat =
       c.lh_input.r1_val.toNat + (BitVec.signExtend 64 c.lh_input.imm).toNat
   h_risc_v_assumptions :
     RISC_V_assumptions (binding i) regs.mstatus regs.pmaRegion regs.misa regs.mseccfg
@@ -2836,6 +2848,8 @@ structure Decode_lw (trace : AcceptedZiskTrace numInstructions)
     (mainRowWithRomLd trace i).rom.store_ind = 0
   h_store_reg :
     (mainRowWithRomLd trace i).rom.store_reg = 1
+  h_b_src_ind :
+    (mainRowWithRomLd trace i).rom.b_src_ind = 1
   h_store_offset :
     (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lw_input.rd)
 
@@ -2845,8 +2859,8 @@ structure Inputs_lw (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   mem : Valid_Mem FGL FGL
   r_mem : ℕ
   h_opcode_assumptions : PureSpec.lw_state_assumptions c.lw_input (binding i)
-  h_addr1 :
-    (mainRowWithRomLd trace i).rom.addr1.toNat =
+  h_load_addr_arith :
+    ((mainRowWithRomLd trace i).rom.b_offset_imm0 + (mainRowWithRomLd trace i).core.a_0).toNat =
       c.lw_input.r1_val.toNat + (BitVec.signExtend 64 c.lw_input.imm).toNat
   h_risc_v_assumptions :
     RISC_V_assumptions (binding i) regs.mstatus regs.pmaRegion regs.misa regs.mseccfg

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
@@ -1997,6 +1997,8 @@ structure Decode_sb (trace : AcceptedZiskTrace numInstructions)
   h_main_ind_width :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).ind_width
       i.val = 1
+  h_store_ind :
+    (mainRowWithRomSt trace i).rom.store_ind = 1
   -- #100 next-PC transition inputs (replace the exec artifacts): the next row
   -- exists, plus the COPYB store-row decode pins `set_pc = 0`,
   -- `jmp_offset1 = jmp_offset2 = 4` (Rust lowerer `zib.j(4, 4)`, no `set_pc()`;
@@ -2016,8 +2018,8 @@ structure Inputs_sb (trace : AcceptedZiskTrace numInstructions) (binding : SailT
     (i : Fin trace.numInstructions) (c : Claim_sb trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   h_opcode_assumptions : PureSpec.sb_state_assumptions c.sb_input (binding i)
-  h_addr2 :
-    (mainRowWithRomSt trace i).rom.addr2.toNat =
+  h_store_addr_arith :
+    ((mainRowWithRomSt trace i).rom.store_offset + (mainRowWithRomSt trace i).core.a_0).toNat =
       (c.sb_input.r1_val + BitVec.signExtend 64 c.sb_input.imm).toNat
   h_b0_value :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).b_0 i.val =
@@ -2079,6 +2081,8 @@ structure Decode_sh (trace : AcceptedZiskTrace numInstructions)
   h_main_ind_width :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).ind_width
       i.val = 2
+  h_store_ind :
+    (mainRowWithRomSt trace i).rom.store_ind = 1
   -- #100 next-PC transition inputs (replace the exec artifacts): the next row
   -- exists, plus the COPYB store-row decode pins `set_pc = 0`,
   -- `jmp_offset1 = jmp_offset2 = 4` (Rust lowerer `zib.j(4, 4)`, no `set_pc()`;
@@ -2098,8 +2102,8 @@ structure Inputs_sh (trace : AcceptedZiskTrace numInstructions) (binding : SailT
     (i : Fin trace.numInstructions) (c : Claim_sh trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   h_opcode_assumptions : PureSpec.sh_state_assumptions c.sh_input (binding i)
-  h_addr2 :
-    (mainRowWithRomSt trace i).rom.addr2.toNat =
+  h_store_addr_arith :
+    ((mainRowWithRomSt trace i).rom.store_offset + (mainRowWithRomSt trace i).core.a_0).toNat =
       (c.sh_input.r1_val + BitVec.signExtend 64 c.sh_input.imm).toNat
   h_b0_value :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).b_0 i.val =
@@ -2159,6 +2163,8 @@ structure Decode_sw (trace : AcceptedZiskTrace numInstructions)
   h_main_ind_width :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).ind_width
       i.val = 4
+  h_store_ind :
+    (mainRowWithRomSt trace i).rom.store_ind = 1
   -- #100 next-PC transition inputs (replace the exec artifacts): the next row
   -- exists, plus the COPYB store-row decode pins `set_pc = 0`,
   -- `jmp_offset1 = jmp_offset2 = 4` (Rust lowerer `zib.j(4, 4)`, no `set_pc()`;
@@ -2178,8 +2184,8 @@ structure Inputs_sw (trace : AcceptedZiskTrace numInstructions) (binding : SailT
     (i : Fin trace.numInstructions) (c : Claim_sw trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   h_opcode_assumptions : PureSpec.sw_state_assumptions c.sw_input (binding i)
-  h_addr2 :
-    (mainRowWithRomSt trace i).rom.addr2.toNat =
+  h_store_addr_arith :
+    ((mainRowWithRomSt trace i).rom.store_offset + (mainRowWithRomSt trace i).core.a_0).toNat =
       (c.sw_input.r1_val + BitVec.signExtend 64 c.sw_input.imm).toNat
   h_b0_value :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).b_0 i.val =
@@ -2232,6 +2238,8 @@ structure Decode_sd (trace : AcceptedZiskTrace numInstructions)
   h_store_pc :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).store_pc
       i.val = 0
+  h_store_ind :
+    (mainRowWithRomSt trace i).rom.store_ind = 1
   -- #100 next-PC transition inputs (replace the exec artifacts): the next row
   -- exists, plus the COPYB store-row decode pins `set_pc = 0`,
   -- `jmp_offset1 = jmp_offset2 = 4` (Rust lowerer `zib.j(4, 4)`, no `set_pc()`;
@@ -2251,8 +2259,8 @@ structure Inputs_sd (trace : AcceptedZiskTrace numInstructions) (binding : SailT
     (i : Fin trace.numInstructions) (c : Claim_sd trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   h_opcode_assumptions : PureSpec.sd_state_assumptions c.sd_input (binding i)
-  h_addr2 :
-    (mainRowWithRomSt trace i).rom.addr2.toNat =
+  h_store_addr_arith :
+    ((mainRowWithRomSt trace i).rom.store_offset + (mainRowWithRomSt trace i).core.a_0).toNat =
       (c.sd_input.r1_val + BitVec.signExtend 64 c.sd_input.imm).toNat
   h_b0_value :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).b_0 i.val =

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
@@ -42,21 +42,34 @@ seal mulwArow mulhuArow divuArow divuwArow remuArow remuwArow
 
 set_option maxHeartbeats 8000000
 
-/-- **`RTypePromises` minus its cross-world `nextPC_matches` field (#100).**
+/-- AUIPC theorem-domain range assumptions.
+
+These are explicit soundness-domain conditions, not decoded placement facts or Sail/ZisK value
+agreement. Keeping them separate from `Inputs_auipc` leaves the input record focused on state and
+value agreement while preserving the same AUIPC range obligations at the theorem boundary. -/
+structure AuipcRangeDomain (auipc_input : PureSpec.AuipcInput) : Prop where
+  h_pc_bound : auipc_input.PC.toNat < GL_prime - 4
+  h_no_wrap : auipc_input.PC.toNat
+    + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
+      < GL_prime
+  h_pc_offset_lt_2_32 :
+    (auipc_input.PC + BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
+      < 4294967296
+
+/-- **`RTypePromises` minus derived next-PC and rd-placement fields (#100/#141).**
 
     Identical to `ZiskFv.EquivCore.Promises.RTypePromises` except that the
     `pure_nextPC` parameter and the `nextPC_matches : (register_type_pc_equiv ▸
-    BitVec.ofNat 64 (exec_row[1]!.pc).val) = pure_nextPC` field are dropped.  The
-    fourteen value/data promises are unchanged, byte-for-byte.
+    BitVec.ofNat 64 (exec_row[1]!.pc).val) = pure_nextPC` field are dropped, and
+    the rd-write placement field `rd_idx` is also dropped.
 
     The next-PC promise is no longer caller-supplied for the bundle-shaped
     signed-M opcodes (MUL/MULH/MULHSU/DIV/REM/DIVW/REMW): it is DERIVED in the
     `<op>EnvOf` env-builder from the accepted trace's in-circuit `pcHandshakeBetween`
     transition certificate via `Pilot.sequential_nextPC_discharged` (the same
     kernel-only discharge the 56 already-rewired ops use) and re-attached through
-    `withNextPC`.  This is the bundle analogue of the bare-field `h_nextPC_matches`
-    removal performed on the 56 ops; it touches only the next-PC sub-fact and
-    leaves the value/data promises (and the separate value-defect gate) untouched.
+    `withNextPC`. The rd-placement promise is likewise DERIVED in `<op>EnvOf`
+    from the decoded ROM/Main `store_ind`/`store_offset` facts plus `AddressSpec`.
 
     Lives here, next to its only consumers (the signed-M `Inputs_<op>` /
     `<op>EnvOf`), rather than in `EquivCore/Promises/RType.lean`, to avoid a
@@ -83,12 +96,11 @@ structure RTypePromisesNoNextPC
   m1_as : e1.as.val = 1
   m2_mult : e2.multiplicity = 1
   m2_as : e2.as.val = 1
-  rd_idx : input_rd = Transpiler.wrap_to_regidx e2.ptr
 
-/-- Re-attach a discharged next-PC fact to a `RTypePromisesNoNextPC` bundle,
-    recovering the full `RTypePromises`.  The `h_nextPC` proof is sourced in the
-    `<op>EnvOf` env-builder from `Pilot.sequential_nextPC_discharged` (the
-    in-circuit transition certificate), so the caller never supplies it. -/
+/-- Re-attach discharged next-PC and rd-placement facts to a `RTypePromisesNoNextPC`
+    bundle, recovering the full `RTypePromises`. The `h_nextPC` proof is sourced in
+    `<op>EnvOf` from `Pilot.sequential_nextPC_discharged`; the `h_rd_idx` proof is
+    sourced there from the decoded writeback destination and `AddressSpec`. -/
 def RTypePromisesNoNextPC.withNextPC
     {state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource}
     {input_r1_val input_r2_val : BitVec 64} {input_rd : Fin 32}
@@ -99,7 +111,8 @@ def RTypePromisesNoNextPC.withNextPC
       r1 r2 rd exec_row e0 e1 e2)
     (pure_nextPC : BitVec 64)
     (h_nextPC :
-      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = pure_nextPC) :
+      (register_type_pc_equiv ▸ (BitVec.ofNat 64 (exec_row[1]!.pc).val)) = pure_nextPC)
+    (h_rd_idx : input_rd = Transpiler.wrap_to_regidx e2.ptr) :
     ZiskFv.EquivCore.Promises.RTypePromises state input_r1_val input_r2_val input_rd
       input_pc pure_nextPC r1 r2 rd exec_row e0 e1 e2 where
   input_r1_eq := p.input_r1_eq
@@ -116,7 +129,7 @@ def RTypePromisesNoNextPC.withNextPC
   m1_as := p.m1_as
   m2_mult := p.m2_mult
   m2_as := p.m2_as
-  rd_idx := p.rd_idx
+  rd_idx := h_rd_idx
 
 structure Claim_add (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   r1 : regidx
@@ -187,7 +200,6 @@ structure Inputs_add (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = add_input.PC.toNat
-  h_pc_bound : add_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `add` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_add` bundles them. -/
@@ -239,6 +251,13 @@ structure Decode_addi (trace : AcceptedZiskTrace numInstructions)
   h_store_offset :
     (mainRowWithRomSub trace i).rom.store_offset =
       Transpiler.ind (regidx_to_fin c.rd)
+  h_b_src_imm :
+    (mainRowWithRomSub trace i).rom.b_src_imm = 1
+  h_b_imm :
+    BitVec.signExtend 64 c.imm =
+      BitVec.ofNat 64
+        (((mainRowWithRomSub trace i).rom.b_offset_imm0).val
+          + ((mainRowWithRomSub trace i).rom.b_imm1).val * 4294967296)
 
 structure Inputs_addi (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_addi trace i) : Type where
@@ -259,13 +278,9 @@ structure Inputs_addi (trace : AcceptedZiskTrace numInstructions) (binding : Sai
       ZiskFv.Trusted.lane_hi
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding i)).xreg
           (regidx_to_fin c.r1))
-  h_addi_subset : ZiskFv.Tactics.ALUITypeArchetype.itype_imm_subset_holds_main
-    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-    i.val addi_input.imm
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = addi_input.PC.toNat
-  h_pc_bound : addi_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `addi` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_addi` bundles them. -/
@@ -352,7 +367,6 @@ structure Inputs_subw (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = subw_input.PC.toNat
-  h_pc_bound : subw_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `subw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_subw` bundles them. -/
@@ -439,7 +453,6 @@ structure Inputs_addw (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = addw_input.PC.toNat
-  h_pc_bound : addw_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `addw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_addw` bundles them. -/
@@ -491,6 +504,13 @@ structure Decode_addiw (trace : AcceptedZiskTrace numInstructions)
   h_store_offset :
     (mainRowWithRomSub trace i).rom.store_offset =
       Transpiler.ind (regidx_to_fin c.rd)
+  h_b_src_imm :
+    (mainRowWithRomSub trace i).rom.b_src_imm = 1
+  h_b_imm :
+    BitVec.signExtend 64 c.imm =
+      BitVec.ofNat 64
+        (((mainRowWithRomSub trace i).rom.b_offset_imm0).val
+          + ((mainRowWithRomSub trace i).rom.b_imm1).val * 4294967296)
 
 structure Inputs_addiw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_addiw trace i) : Type where
@@ -511,13 +531,9 @@ structure Inputs_addiw (trace : AcceptedZiskTrace numInstructions) (binding : Sa
       ZiskFv.Trusted.lane_hi
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding i)).xreg
           (regidx_to_fin c.r1))
-  h_addiw_subset : ZiskFv.Tactics.ALUITypeArchetype.itype_imm_subset_holds_main
-    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
-    i.val addiw_input.imm
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = addiw_input.PC.toNat
-  h_pc_bound : addiw_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `addiw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_addiw` bundles them. -/
@@ -589,7 +605,6 @@ structure Inputs_lui (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = lui_input.PC.toNat
-  h_pc_bound : lui_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `lui` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_lui` bundles them. -/
@@ -633,10 +648,14 @@ structure Decode_auipc (trace : AcceptedZiskTrace numInstructions)
   h_store_offset :
     (mainRowWithRomLui trace i).rom.store_offset =
       Transpiler.ind (regidx_to_fin c.rd)
+  h_jmp_offset2_imm :
+    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
+        i.val).val
+      = (BitVec.signExtend 64 (c.imm ++ (0 : BitVec 12))).toNat
   -- #100 next-PC transition inputs (replace the exec artifacts; AUIPC already
   -- carries h_set_pc above): the next row exists, plus the AUIPC FLAG-row jmp
-  -- pin `jmp_offset1 = 4` (Rust lowerer `zib.j(4, imm)`; cf.
-  -- `RowShape/Contract.lean` AUIPC arm, line 246). With set_pc=0 and flag=1
+  -- pin `jmp_offset1 = 4` and committed-program `jmp_offset2 = signExtend imm`
+  -- (Rust lowerer `zib.j(4, imm)`; cf. `RowShape/Contract.lean` AUIPC arm). With set_pc=0 and flag=1
   -- the handshake mux selects the taken offset `jmp_offset1 = 4`, so
   -- next_pc = pc + 4. `flag = 1` is NOT pinned here: it is derived in
   -- `stepStrong_auipc` from the OP_FLAG decode pins + `internal_op0_sets_flag`.
@@ -651,24 +670,11 @@ structure Inputs_auipc (trace : AcceptedZiskTrace numInstructions) (binding : Sa
   h_input_imm : auipc_input.imm = c.imm
   h_input_rd : auipc_input.rd = regidx_to_fin c.rd
   h_input_pc : (binding i).regs.get? Register.PC = .some auipc_input.PC
-  h_offset_bridge :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
-        i.val).val
-      = (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = auipc_input.PC.toNat
-  -- #100: the JAL/AUIPC-style PC-trajectory no-wrap bound on the `pc + 4`
-  -- sequential successor (mirrors `Pilot.ofNat_fgl_pc_plus_4_eq`'s precondition),
-  -- ruling out FGL wrap on the next PC. Replaces the cross-world `h_nextPC_matches`,
-  -- which is now derived via `Pilot.flag_path_nextPC_discharged`.
-  h_pc_bound : auipc_input.PC.toNat < GL_prime - 4
-  h_no_wrap : auipc_input.PC.toNat
-    + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
-      < GL_prime
-  h_pc_offset_lt_2_32 :
-    (auipc_input.PC + BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
-      < 4294967296
+  -- #100: PC bridge. The AUIPC range/domain facts live in `RowOutsideDefectRegion`
+  -- as `AuipcRangeDomain`.
 
 /-- Per-op residual bundle for the `auipc` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_auipc` bundles them. -/
@@ -728,7 +734,6 @@ structure Inputs_mulw (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = mulw_input.PC.toNat
-  h_pc_bound : mulw_input.PC.toNat < GL_prime - 4
   h_a23 :
     ∀ (ha : (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
       (ho : (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_MUL_W),
@@ -793,7 +798,6 @@ structure Claim_mul (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.n
   rd : regidx
   srs1 : Signedness
   srs2 : Signedness
-  bus : ZiskFv.Compliance.BusRows
 
 structure Decode_mul (trace : AcceptedZiskTrace numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_mul trace i) : Type where
@@ -817,9 +821,15 @@ structure Decode_mul (trace : AcceptedZiskTrace numInstructions)
   -- this lets `<op>EnvOf` DERIVE the bundled `nextPC_matches` rather than take it
   -- from the caller. Terminal row = #103 cross-segment boundary.
   h_idx : i.val + 1 < trace.mainTable.table.length
+  h_store_ind :
+    (mainRowWithRomSub trace i).rom.store_ind = 0
+  h_store_offset :
+    (mainRowWithRomSub trace i).rom.store_offset =
+      Transpiler.ind (regidx_to_fin c.rd)
   arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness
-      (mainOfTable trace.program trace.mainTable) i.val c.bus.e2
-  bounds : ZiskFv.Compliance.ByteBounds c.bus.e2
+      (mainOfTable trace.program trace.mainTable) i.val
+      (busSub trace i (Pilot.execRowOf trace i)).e2
+  bounds : ZiskFv.Compliance.ByteBounds (busSub trace i (Pilot.execRowOf trace i)).e2
 
 structure Inputs_mul (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_mul trace i) : Type where
@@ -835,7 +845,10 @@ structure Inputs_mul (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   -- no longer caller-supplied (DERIVED in `mulEnvOf` via `sequential_nextPC_discharged`).
   promises : RTypePromisesNoNextPC
       (binding i) mul_input.r1_val mul_input.r2_val mul_input.rd mul_input.PC
-      c.r1 c.r2 c.rd c.bus.exec_row c.bus.e0 c.bus.e1 c.bus.e2
+      c.r1 c.r2 c.rd (busSub trace i (Pilot.execRowOf trace i)).exec_row
+      (busSub trace i (Pilot.execRowOf trace i)).e0
+      (busSub trace i (Pilot.execRowOf trace i)).e1
+      (busSub trace i (Pilot.execRowOf trace i)).e2
   h_row_constraints :
     ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a
   arith_table : ZiskFv.Compliance.ArithMulTableWitness v r_a
@@ -857,8 +870,6 @@ structure Inputs_mul (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   -- derived from the transition certificate. The value-defect gate is untouched.
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val = mul_input.PC.toNat
-  h_pc_bound : mul_input.PC.toNat < GL_prime - 4
-  h_exec_row : c.bus.exec_row = Pilot.execRowOf trace i
 
 /-- Per-op residual bundle for the `mul` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_mul` bundles them. -/
@@ -880,7 +891,6 @@ structure Claim_mulh (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.
   r1 : regidx
   r2 : regidx
   rd : regidx
-  bus : ZiskFv.Compliance.BusRows
 
 structure Decode_mulh (trace : AcceptedZiskTrace numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_mulh trace i) : Type where
@@ -900,9 +910,15 @@ structure Decode_mulh (trace : AcceptedZiskTrace numInstructions)
     (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4
   -- #100 next-PC transition input (next Main row exists); see `Decode_mul.h_idx`.
   h_idx : i.val + 1 < trace.mainTable.table.length
+  h_store_ind :
+    (mainRowWithRomSub trace i).rom.store_ind = 0
+  h_store_offset :
+    (mainRowWithRomSub trace i).rom.store_offset =
+      Transpiler.ind (regidx_to_fin c.rd)
   arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness
-      (mainOfTable trace.program trace.mainTable) i.val c.bus.e2
-  bounds : ZiskFv.Compliance.ByteBounds c.bus.e2
+      (mainOfTable trace.program trace.mainTable) i.val
+      (busSub trace i (Pilot.execRowOf trace i)).e2
+  bounds : ZiskFv.Compliance.ByteBounds (busSub trace i (Pilot.execRowOf trace i)).e2
 
 structure Inputs_mulh (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_mulh trace i) : Type where
@@ -917,7 +933,10 @@ structure Inputs_mulh (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   -- #100: value/data promises only — `nextPC_matches` DERIVED in `mulhEnvOf`.
   promises : RTypePromisesNoNextPC
       (binding i) mulh_input.r1_val mulh_input.r2_val mulh_input.rd mulh_input.PC
-      c.r1 c.r2 c.rd c.bus.exec_row c.bus.e0 c.bus.e1 c.bus.e2
+      c.r1 c.r2 c.rd (busSub trace i (Pilot.execRowOf trace i)).exec_row
+      (busSub trace i (Pilot.execRowOf trace i)).e0
+      (busSub trace i (Pilot.execRowOf trace i)).e1
+      (busSub trace i (Pilot.execRowOf trace i)).e2
   h_row_constraints :
     ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a
   arith_table : ZiskFv.Compliance.ArithMulTableWitness v r_a
@@ -941,8 +960,6 @@ structure Inputs_mulh (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   -- #100 next-PC transition inputs (consumed by `mulhEnvOf`); see `Inputs_mul`.
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val = mulh_input.PC.toNat
-  h_pc_bound : mulh_input.PC.toNat < GL_prime - 4
-  h_exec_row : c.bus.exec_row = Pilot.execRowOf trace i
 
 /-- Per-op residual bundle for the `mulh` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_mulh` bundles them. -/
@@ -964,7 +981,6 @@ structure Claim_mulhsu (trace : AcceptedZiskTrace numInstructions) (i : Fin trac
   r1 : regidx
   r2 : regidx
   rd : regidx
-  bus : ZiskFv.Compliance.BusRows
 
 structure Decode_mulhsu (trace : AcceptedZiskTrace numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_mulhsu trace i) : Type where
@@ -984,9 +1000,15 @@ structure Decode_mulhsu (trace : AcceptedZiskTrace numInstructions)
     (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4
   -- #100 next-PC transition input (next Main row exists); see `Decode_mul.h_idx`.
   h_idx : i.val + 1 < trace.mainTable.table.length
+  h_store_ind :
+    (mainRowWithRomSub trace i).rom.store_ind = 0
+  h_store_offset :
+    (mainRowWithRomSub trace i).rom.store_offset =
+      Transpiler.ind (regidx_to_fin c.rd)
   arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness
-      (mainOfTable trace.program trace.mainTable) i.val c.bus.e2
-  bounds : ZiskFv.Compliance.ByteBounds c.bus.e2
+      (mainOfTable trace.program trace.mainTable) i.val
+      (busSub trace i (Pilot.execRowOf trace i)).e2
+  bounds : ZiskFv.Compliance.ByteBounds (busSub trace i (Pilot.execRowOf trace i)).e2
 
 structure Inputs_mulhsu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_mulhsu trace i) : Type where
@@ -1001,7 +1023,10 @@ structure Inputs_mulhsu (trace : AcceptedZiskTrace numInstructions) (binding : S
   -- #100: value/data promises only — `nextPC_matches` DERIVED in `mulhsuEnvOf`.
   promises : RTypePromisesNoNextPC
       (binding i) mulhsu_input.r1_val mulhsu_input.r2_val mulhsu_input.rd mulhsu_input.PC
-      c.r1 c.r2 c.rd c.bus.exec_row c.bus.e0 c.bus.e1 c.bus.e2
+      c.r1 c.r2 c.rd (busSub trace i (Pilot.execRowOf trace i)).exec_row
+      (busSub trace i (Pilot.execRowOf trace i)).e0
+      (busSub trace i (Pilot.execRowOf trace i)).e1
+      (busSub trace i (Pilot.execRowOf trace i)).e2
   h_row_constraints :
     ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a
   arith_table : ZiskFv.Compliance.ArithMulTableWitness v r_a
@@ -1022,8 +1047,6 @@ structure Inputs_mulhsu (trace : AcceptedZiskTrace numInstructions) (binding : S
   -- #100 next-PC transition inputs (consumed by `mulhsuEnvOf`); see `Inputs_mul`.
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val = mulhsu_input.PC.toNat
-  h_pc_bound : mulhsu_input.PC.toNat < GL_prime - 4
-  h_exec_row : c.bus.exec_row = Pilot.execRowOf trace i
 
 /-- Per-op residual bundle for the `mulhsu` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_mulhsu` bundles them. -/
@@ -1045,7 +1068,6 @@ structure Claim_div (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.n
   r1 : regidx
   r2 : regidx
   rd : regidx
-  bus : ZiskFv.Compliance.BusRows
 
 structure Decode_div (trace : AcceptedZiskTrace numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_div trace i) : Type where
@@ -1065,11 +1087,17 @@ structure Decode_div (trace : AcceptedZiskTrace numInstructions)
     (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4
   -- #100 next-PC transition input (next Main row exists); see `Decode_mul.h_idx`.
   h_idx : i.val + 1 < trace.mainTable.table.length
+  h_store_ind :
+    (mainRowWithRomSub trace i).rom.store_ind = 0
+  h_store_offset :
+    (mainRowWithRomSub trace i).rom.store_offset =
+      Transpiler.ind (regidx_to_fin c.rd)
   pins : ZiskFv.Compliance.MainRowPins
     (mainOfTable trace.program trace.mainTable) i.val 1 ZiskFv.Trusted.OP_DIV
   arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness
-      (mainOfTable trace.program trace.mainTable) i.val c.bus.e2
-  bounds : ZiskFv.Compliance.ByteBounds c.bus.e2
+      (mainOfTable trace.program trace.mainTable) i.val
+      (busSub trace i (Pilot.execRowOf trace i)).e2
+  bounds : ZiskFv.Compliance.ByteBounds (busSub trace i (Pilot.execRowOf trace i)).e2
 
 structure Inputs_div (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_div trace i) : Type where
@@ -1084,7 +1112,10 @@ structure Inputs_div (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   -- #100: value/data promises only — `nextPC_matches` DERIVED in `divEnvOf`.
   promises : RTypePromisesNoNextPC
       (binding i) div_input.r1_val div_input.r2_val div_input.rd div_input.PC
-      c.r1 c.r2 c.rd c.bus.exec_row c.bus.e0 c.bus.e1 c.bus.e2
+      c.r1 c.r2 c.rd (busSub trace i (Pilot.execRowOf trace i)).exec_row
+      (busSub trace i (Pilot.execRowOf trace i)).e0
+      (busSub trace i (Pilot.execRowOf trace i)).e1
+      (busSub trace i (Pilot.execRowOf trace i)).e2
   h_row_constraints :
     ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a
   h_boundary :
@@ -1137,8 +1168,6 @@ structure Inputs_div (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   -- These are next-PC plumbing only and leave the DivRemForge value gate untouched.
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val = div_input.PC.toNat
-  h_pc_bound : div_input.PC.toNat < GL_prime - 4
-  h_exec_row : c.bus.exec_row = Pilot.execRowOf trace i
 
 /-- Per-op residual bundle for the `div` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_div` bundles them. -/
@@ -1160,7 +1189,6 @@ structure Claim_rem (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.n
   r1 : regidx
   r2 : regidx
   rd : regidx
-  bus : ZiskFv.Compliance.BusRows
 
 structure Decode_rem (trace : AcceptedZiskTrace numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_rem trace i) : Type where
@@ -1180,11 +1208,17 @@ structure Decode_rem (trace : AcceptedZiskTrace numInstructions)
     (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4
   -- #100 next-PC transition input (next Main row exists); see `Decode_mul.h_idx`.
   h_idx : i.val + 1 < trace.mainTable.table.length
+  h_store_ind :
+    (mainRowWithRomSub trace i).rom.store_ind = 0
+  h_store_offset :
+    (mainRowWithRomSub trace i).rom.store_offset =
+      Transpiler.ind (regidx_to_fin c.rd)
   pins : ZiskFv.Compliance.MainRowPins
     (mainOfTable trace.program trace.mainTable) i.val 1 ZiskFv.Trusted.OP_REM
   arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness
-      (mainOfTable trace.program trace.mainTable) i.val c.bus.e2
-  bounds : ZiskFv.Compliance.ByteBounds c.bus.e2
+      (mainOfTable trace.program trace.mainTable) i.val
+      (busSub trace i (Pilot.execRowOf trace i)).e2
+  bounds : ZiskFv.Compliance.ByteBounds (busSub trace i (Pilot.execRowOf trace i)).e2
 
 structure Inputs_rem (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_rem trace i) : Type where
@@ -1199,7 +1233,10 @@ structure Inputs_rem (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   -- #100: value/data promises only — `nextPC_matches` DERIVED in `remEnvOf`.
   promises : RTypePromisesNoNextPC
       (binding i) rem_input.r1_val rem_input.r2_val rem_input.rd rem_input.PC
-      c.r1 c.r2 c.rd c.bus.exec_row c.bus.e0 c.bus.e1 c.bus.e2
+      c.r1 c.r2 c.rd (busSub trace i (Pilot.execRowOf trace i)).exec_row
+      (busSub trace i (Pilot.execRowOf trace i)).e0
+      (busSub trace i (Pilot.execRowOf trace i)).e1
+      (busSub trace i (Pilot.execRowOf trace i)).e2
   h_row_constraints :
     ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a
   arith_table : ZiskFv.Compliance.ArithDivTableWitness v r_a
@@ -1248,8 +1285,6 @@ structure Inputs_rem (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   -- #100 next-PC transition inputs (consumed by `remEnvOf`); see `Inputs_mul`.
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val = rem_input.PC.toNat
-  h_pc_bound : rem_input.PC.toNat < GL_prime - 4
-  h_exec_row : c.bus.exec_row = Pilot.execRowOf trace i
 
 /-- Per-op residual bundle for the `rem` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_rem` bundles them. -/
@@ -1271,7 +1306,6 @@ structure Claim_divw (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.
   r1 : regidx
   r2 : regidx
   rd : regidx
-  bus : ZiskFv.Compliance.BusRows
 
 structure Decode_divw (trace : AcceptedZiskTrace numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_divw trace i) : Type where
@@ -1291,11 +1325,17 @@ structure Decode_divw (trace : AcceptedZiskTrace numInstructions)
     (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4
   -- #100 next-PC transition input (next Main row exists); see `Decode_mul.h_idx`.
   h_idx : i.val + 1 < trace.mainTable.table.length
+  h_store_ind :
+    (mainRowWithRomSub trace i).rom.store_ind = 0
+  h_store_offset :
+    (mainRowWithRomSub trace i).rom.store_offset =
+      Transpiler.ind (regidx_to_fin c.rd)
   pins : ZiskFv.Compliance.MainRowPins
     (mainOfTable trace.program trace.mainTable) i.val 1 ZiskFv.Trusted.OP_DIV_W
   arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness
-      (mainOfTable trace.program trace.mainTable) i.val c.bus.e2
-  bounds : ZiskFv.Compliance.ByteBounds c.bus.e2
+      (mainOfTable trace.program trace.mainTable) i.val
+      (busSub trace i (Pilot.execRowOf trace i)).e2
+  bounds : ZiskFv.Compliance.ByteBounds (busSub trace i (Pilot.execRowOf trace i)).e2
 
 structure Inputs_divw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_divw trace i) : Type where
@@ -1310,7 +1350,10 @@ structure Inputs_divw (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   -- #100: value/data promises only — `nextPC_matches` DERIVED in `divwEnvOf`.
   promises : RTypePromisesNoNextPC
       (binding i) divw_input.r1_val divw_input.r2_val divw_input.rd divw_input.PC
-      c.r1 c.r2 c.rd c.bus.exec_row c.bus.e0 c.bus.e1 c.bus.e2
+      c.r1 c.r2 c.rd (busSub trace i (Pilot.execRowOf trace i)).exec_row
+      (busSub trace i (Pilot.execRowOf trace i)).e0
+      (busSub trace i (Pilot.execRowOf trace i)).e1
+      (busSub trace i (Pilot.execRowOf trace i)).e2
   h_row_constraints :
     ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a
   h_boundary :
@@ -1338,21 +1381,33 @@ structure Inputs_divw (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_d23 : (v.d_2 r_a).val = 0 ∧ (v.d_3 r_a).val = 0
   h_c23 : (v.c_2 r_a).val = 0 ∧ (v.c_3 r_a).val = 0
   h_byte_lo :
-    (ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 0).val
-        + (ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 1).val * 256
-        + (ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 2).val * 65536
-        + (ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 3).val * 16777216
+    (ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 0).val
+        + (ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 1).val * 256
+        + (ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 2).val * 65536
+        + (ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 3).val * 16777216
       = (v.a_0 r_a).val + (v.a_1 r_a).val * 65536
   h_sext_choice :
-    (((ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 4).val = 0
-        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 5).val = 0
-        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 6).val = 0
-        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 7).val = 0)
+    (((ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 4).val = 0
+        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 5).val = 0
+        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 6).val = 0
+        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 7).val = 0)
       ∧ (v.a_0 r_a).val + (v.a_1 r_a).val * 65536 < 2147483648)
-    ∨ (((ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 4).val = 255
-        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 5).val = 255
-        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 6).val = 255
-        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 7).val = 255)
+    ∨ (((ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 4).val = 255
+        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 5).val = 255
+        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 6).val = 255
+        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 7).val = 255)
       ∧ (v.a_0 r_a).val + (v.a_1 r_a).val * 65536 ≥ 2147483648)
   h_rs1_value :
     (Sail.BitVec.extractLsb divw_input.r1_val 31 0).toInt
@@ -1377,8 +1432,6 @@ structure Inputs_divw (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   -- #100 next-PC transition inputs (consumed by `divwEnvOf`); see `Inputs_mul`.
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val = divw_input.PC.toNat
-  h_pc_bound : divw_input.PC.toNat < GL_prime - 4
-  h_exec_row : c.bus.exec_row = Pilot.execRowOf trace i
 
 /-- Per-op residual bundle for the `divw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_divw` bundles them. -/
@@ -1400,7 +1453,6 @@ structure Claim_remw (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.
   r1 : regidx
   r2 : regidx
   rd : regidx
-  bus : ZiskFv.Compliance.BusRows
 
 structure Decode_remw (trace : AcceptedZiskTrace numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_remw trace i) : Type where
@@ -1420,11 +1472,17 @@ structure Decode_remw (trace : AcceptedZiskTrace numInstructions)
     (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4
   -- #100 next-PC transition input (next Main row exists); see `Decode_mul.h_idx`.
   h_idx : i.val + 1 < trace.mainTable.table.length
+  h_store_ind :
+    (mainRowWithRomSub trace i).rom.store_ind = 0
+  h_store_offset :
+    (mainRowWithRomSub trace i).rom.store_offset =
+      Transpiler.ind (regidx_to_fin c.rd)
   pins : ZiskFv.Compliance.MainRowPins
     (mainOfTable trace.program trace.mainTable) i.val 1 ZiskFv.Trusted.OP_REM_W
   arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness
-      (mainOfTable trace.program trace.mainTable) i.val c.bus.e2
-  bounds : ZiskFv.Compliance.ByteBounds c.bus.e2
+      (mainOfTable trace.program trace.mainTable) i.val
+      (busSub trace i (Pilot.execRowOf trace i)).e2
+  bounds : ZiskFv.Compliance.ByteBounds (busSub trace i (Pilot.execRowOf trace i)).e2
 
 structure Inputs_remw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_remw trace i) : Type where
@@ -1439,7 +1497,10 @@ structure Inputs_remw (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   -- #100: value/data promises only — `nextPC_matches` DERIVED in `remwEnvOf`.
   promises : RTypePromisesNoNextPC
       (binding i) remw_input.r1_val remw_input.r2_val remw_input.rd remw_input.PC
-      c.r1 c.r2 c.rd c.bus.exec_row c.bus.e0 c.bus.e1 c.bus.e2
+      c.r1 c.r2 c.rd (busSub trace i (Pilot.execRowOf trace i)).exec_row
+      (busSub trace i (Pilot.execRowOf trace i)).e0
+      (busSub trace i (Pilot.execRowOf trace i)).e1
+      (busSub trace i (Pilot.execRowOf trace i)).e2
   h_row_constraints :
     ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a
   arith_table : ZiskFv.Compliance.ArithDivTableWitness v r_a
@@ -1465,21 +1526,33 @@ structure Inputs_remw (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_d23 : (v.d_2 r_a).val = 0 ∧ (v.d_3 r_a).val = 0
   h_c23 : (v.c_2 r_a).val = 0 ∧ (v.c_3 r_a).val = 0
   h_byte_lo :
-    (ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 0).val
-        + (ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 1).val * 256
-        + (ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 2).val * 65536
-        + (ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 3).val * 16777216
+    (ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 0).val
+        + (ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 1).val * 256
+        + (ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 2).val * 65536
+        + (ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 3).val * 16777216
       = (v.d_0 r_a).val + (v.d_1 r_a).val * 65536
   h_sext_choice :
-    (((ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 4).val = 0
-        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 5).val = 0
-        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 6).val = 0
-        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 7).val = 0)
+    (((ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 4).val = 0
+        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 5).val = 0
+        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 6).val = 0
+        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 7).val = 0)
       ∧ (v.d_0 r_a).val + (v.d_1 r_a).val * 65536 < 2147483648)
-    ∨ (((ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 4).val = 255
-        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 5).val = 255
-        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 6).val = 255
-        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt c.bus.e2 7).val = 255)
+    ∨ (((ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 4).val = 255
+        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 5).val = 255
+        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 6).val = 255
+        ∧ (ZiskFv.Channels.MemoryBusBytes.byteAt
+          (busSub trace i (Pilot.execRowOf trace i)).e2 7).val = 255)
       ∧ (v.d_0 r_a).val + (v.d_1 r_a).val * 65536 ≥ 2147483648)
   h_rs1_value :
     (Sail.BitVec.extractLsb remw_input.r1_val 31 0).toInt
@@ -1504,8 +1577,6 @@ structure Inputs_remw (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   -- #100 next-PC transition inputs (consumed by `remwEnvOf`); see `Inputs_mul`.
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val = remw_input.PC.toNat
-  h_pc_bound : remw_input.PC.toNat < GL_prime - 4
-  h_exec_row : c.bus.exec_row = Pilot.execRowOf trace i
 
 /-- Per-op residual bundle for the `remw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_remw` bundles them. -/
@@ -1566,7 +1637,6 @@ structure Inputs_mulhu (trace : AcceptedZiskTrace numInstructions) (binding : Sa
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = mulhu_input.PC.toNat
-  h_pc_bound : mulhu_input.PC.toNat < GL_prime - 4
   h_rs1_value :
     ∀ (ha : (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
       (ho : (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_MULUH),
@@ -1645,7 +1715,6 @@ structure Inputs_divu (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = divu_input.PC.toNat
-  h_pc_bound : divu_input.PC.toNat < GL_prime - 4
   remainder_bound :
     ∀ (ha : (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
       (ho : (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU),
@@ -1729,7 +1798,6 @@ structure Inputs_divuw (trace : AcceptedZiskTrace numInstructions) (binding : Sa
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = divuw_input.PC.toNat
-  h_pc_bound : divuw_input.PC.toNat < GL_prime - 4
   remainder_bound :
     ∀ (ha : (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
       (ho : (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU_W),
@@ -1834,7 +1902,6 @@ structure Inputs_remu (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = remu_input.PC.toNat
-  h_pc_bound : remu_input.PC.toNat < GL_prime - 4
   remainder_bound :
     ∀ (ha : (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
       (ho : (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_REMU),
@@ -1918,7 +1985,6 @@ structure Inputs_remuw (trace : AcceptedZiskTrace numInstructions) (binding : Sa
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = remuw_input.PC.toNat
-  h_pc_bound : remuw_input.PC.toNat < GL_prime - 4
   remainder_bound :
     ∀ (ha : (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
       (ho : (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_REMU_W),
@@ -1999,6 +2065,9 @@ structure Decode_sb (trace : AcceptedZiskTrace numInstructions)
       i.val = 1
   h_store_ind :
     (mainRowWithRomSt trace i).rom.store_ind = 1
+  h_store_offset_imm :
+    (mainRowWithRomSt trace i).rom.store_offset =
+      ((BitVec.signExtend 64 c.sb_input.imm).toInt : FGL)
   -- #100 next-PC transition inputs (replace the exec artifacts): the next row
   -- exists, plus the COPYB store-row decode pins `set_pc = 0`,
   -- `jmp_offset1 = jmp_offset2 = 4` (Rust lowerer `zib.j(4, 4)`, no `set_pc()`;
@@ -2018,9 +2087,12 @@ structure Inputs_sb (trace : AcceptedZiskTrace numInstructions) (binding : SailT
     (i : Fin trace.numInstructions) (c : Claim_sb trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   h_opcode_assumptions : PureSpec.sb_state_assumptions c.sb_input (binding i)
-  h_store_addr_arith :
-    ((mainRowWithRomSt trace i).rom.store_offset + (mainRowWithRomSt trace i).core.a_0).toNat =
-      (c.sb_input.r1_val + BitVec.signExtend 64 c.sb_input.imm).toNat
+  h_a0_value :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_0 i.val =
+      ZiskFv.Trusted.lane_lo c.sb_input.r1_val
+  h_a1_value :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_1 i.val =
+      ZiskFv.Trusted.lane_hi c.sb_input.r1_val
   h_b0_value :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).b_0 i.val =
       ZiskFv.Trusted.lane_lo c.sb_input.r2_val
@@ -2032,7 +2104,6 @@ structure Inputs_sb (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.sb_input.PC.toNat
-  h_pc_bound : c.sb_input.PC.toNat < GL_prime - 4
   h_m1 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 1]?
     = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 1 : BitVec 8)
   h_m2 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 2]?
@@ -2083,6 +2154,9 @@ structure Decode_sh (trace : AcceptedZiskTrace numInstructions)
       i.val = 2
   h_store_ind :
     (mainRowWithRomSt trace i).rom.store_ind = 1
+  h_store_offset_imm :
+    (mainRowWithRomSt trace i).rom.store_offset =
+      ((BitVec.signExtend 64 c.sh_input.imm).toInt : FGL)
   -- #100 next-PC transition inputs (replace the exec artifacts): the next row
   -- exists, plus the COPYB store-row decode pins `set_pc = 0`,
   -- `jmp_offset1 = jmp_offset2 = 4` (Rust lowerer `zib.j(4, 4)`, no `set_pc()`;
@@ -2102,9 +2176,12 @@ structure Inputs_sh (trace : AcceptedZiskTrace numInstructions) (binding : SailT
     (i : Fin trace.numInstructions) (c : Claim_sh trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   h_opcode_assumptions : PureSpec.sh_state_assumptions c.sh_input (binding i)
-  h_store_addr_arith :
-    ((mainRowWithRomSt trace i).rom.store_offset + (mainRowWithRomSt trace i).core.a_0).toNat =
-      (c.sh_input.r1_val + BitVec.signExtend 64 c.sh_input.imm).toNat
+  h_a0_value :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_0 i.val =
+      ZiskFv.Trusted.lane_lo c.sh_input.r1_val
+  h_a1_value :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_1 i.val =
+      ZiskFv.Trusted.lane_hi c.sh_input.r1_val
   h_b0_value :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).b_0 i.val =
       ZiskFv.Trusted.lane_lo c.sh_input.r2_val
@@ -2116,7 +2193,6 @@ structure Inputs_sh (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.sh_input.PC.toNat
-  h_pc_bound : c.sh_input.PC.toNat < GL_prime - 4
   h_m2 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 2]?
     = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 2 : BitVec 8)
   h_m3 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 3]?
@@ -2165,6 +2241,9 @@ structure Decode_sw (trace : AcceptedZiskTrace numInstructions)
       i.val = 4
   h_store_ind :
     (mainRowWithRomSt trace i).rom.store_ind = 1
+  h_store_offset_imm :
+    (mainRowWithRomSt trace i).rom.store_offset =
+      ((BitVec.signExtend 64 c.sw_input.imm).toInt : FGL)
   -- #100 next-PC transition inputs (replace the exec artifacts): the next row
   -- exists, plus the COPYB store-row decode pins `set_pc = 0`,
   -- `jmp_offset1 = jmp_offset2 = 4` (Rust lowerer `zib.j(4, 4)`, no `set_pc()`;
@@ -2184,9 +2263,12 @@ structure Inputs_sw (trace : AcceptedZiskTrace numInstructions) (binding : SailT
     (i : Fin trace.numInstructions) (c : Claim_sw trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   h_opcode_assumptions : PureSpec.sw_state_assumptions c.sw_input (binding i)
-  h_store_addr_arith :
-    ((mainRowWithRomSt trace i).rom.store_offset + (mainRowWithRomSt trace i).core.a_0).toNat =
-      (c.sw_input.r1_val + BitVec.signExtend 64 c.sw_input.imm).toNat
+  h_a0_value :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_0 i.val =
+      ZiskFv.Trusted.lane_lo c.sw_input.r1_val
+  h_a1_value :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_1 i.val =
+      ZiskFv.Trusted.lane_hi c.sw_input.r1_val
   h_b0_value :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).b_0 i.val =
       ZiskFv.Trusted.lane_lo c.sw_input.r2_val
@@ -2198,7 +2280,6 @@ structure Inputs_sw (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.sw_input.PC.toNat
-  h_pc_bound : c.sw_input.PC.toNat < GL_prime - 4
   h_m4 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 4]?
     = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 4 : BitVec 8)
   h_m5 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 5]?
@@ -2240,6 +2321,9 @@ structure Decode_sd (trace : AcceptedZiskTrace numInstructions)
       i.val = 0
   h_store_ind :
     (mainRowWithRomSt trace i).rom.store_ind = 1
+  h_store_offset_imm :
+    (mainRowWithRomSt trace i).rom.store_offset =
+      ((BitVec.signExtend 64 c.sd_input.imm).toInt : FGL)
   -- #100 next-PC transition inputs (replace the exec artifacts): the next row
   -- exists, plus the COPYB store-row decode pins `set_pc = 0`,
   -- `jmp_offset1 = jmp_offset2 = 4` (Rust lowerer `zib.j(4, 4)`, no `set_pc()`;
@@ -2259,9 +2343,12 @@ structure Inputs_sd (trace : AcceptedZiskTrace numInstructions) (binding : SailT
     (i : Fin trace.numInstructions) (c : Claim_sd trace i) : Type where
   regs : ZiskFv.Compliance.ModeRegsFull
   h_opcode_assumptions : PureSpec.sd_state_assumptions c.sd_input (binding i)
-  h_store_addr_arith :
-    ((mainRowWithRomSt trace i).rom.store_offset + (mainRowWithRomSt trace i).core.a_0).toNat =
-      (c.sd_input.r1_val + BitVec.signExtend 64 c.sd_input.imm).toNat
+  h_a0_value :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_0 i.val =
+      ZiskFv.Trusted.lane_lo c.sd_input.r1_val
+  h_a1_value :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_1 i.val =
+      ZiskFv.Trusted.lane_hi c.sd_input.r1_val
   h_b0_value :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).b_0 i.val =
       ZiskFv.Trusted.lane_lo c.sd_input.r2_val
@@ -2273,7 +2360,6 @@ structure Inputs_sd (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.sd_input.PC.toNat
-  h_pc_bound : c.sd_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `sd` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sd` bundles them. -/
@@ -2330,6 +2416,9 @@ structure Decode_ld (trace : AcceptedZiskTrace numInstructions)
     (mainRowWithRomLd trace i).rom.b_src_ind = 1
   h_store_offset :
     (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.ld_input.rd)
+  h_b_offset_imm0 :
+    (mainRowWithRomLd trace i).rom.b_offset_imm0 =
+      ((BitVec.signExtend 64 c.ld_input.imm).toNat : FGL)
 
 structure Inputs_ld (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_ld trace i) : Type where
@@ -2337,15 +2426,14 @@ structure Inputs_ld (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   mem : Valid_Mem FGL FGL
   r_mem : ℕ
   h_opcode_assumptions : PureSpec.ld_state_assumptions c.ld_input (binding i)
-  h_load_addr_arith :
-    ((mainRowWithRomLd trace i).rom.b_offset_imm0 + (mainRowWithRomLd trace i).core.a_0).toNat =
-      c.ld_input.r1_val.toNat + (BitVec.signExtend 64 c.ld_input.imm).toNat
+  h_a0_value :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_0 i.val =
+      ZiskFv.Trusted.lane_lo c.ld_input.r1_val
   h_risc_v_assumptions :
     RISC_V_assumptions (binding i) regs.mstatus regs.pmaRegion regs.misa regs.mseccfg
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.ld_input.PC.toNat
-  h_pc_bound : c.ld_input.PC.toNat < GL_prime - 4
   h_memory_timeline :
     LoadMemoryTimelineCoherenceEvidence (binding i)
       (busLd trace i (Pilot.execRowOf trace i)).e1
@@ -2410,6 +2498,9 @@ structure Decode_lbu (trace : AcceptedZiskTrace numInstructions)
     (mainRowWithRomLd trace i).rom.b_src_ind = 1
   h_store_offset :
     (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lbu_input.rd)
+  h_b_offset_imm0 :
+    (mainRowWithRomLd trace i).rom.b_offset_imm0 =
+      ((BitVec.signExtend 64 c.lbu_input.imm).toNat : FGL)
 
 structure Inputs_lbu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lbu trace i) : Type where
@@ -2420,15 +2511,14 @@ structure Inputs_lbu (trace : AcceptedZiskTrace numInstructions) (binding : Sail
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
     i.val (busLd trace i (Pilot.execRowOf trace i)).e1
   h_opcode_assumptions : PureSpec.lbu_state_assumptions c.lbu_input (binding i)
-  h_load_addr_arith :
-    ((mainRowWithRomLd trace i).rom.b_offset_imm0 + (mainRowWithRomLd trace i).core.a_0).toNat =
-      c.lbu_input.r1_val.toNat + (BitVec.signExtend 64 c.lbu_input.imm).toNat
+  h_a0_value :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_0 i.val =
+      ZiskFv.Trusted.lane_lo c.lbu_input.r1_val
   h_risc_v_assumptions :
     RISC_V_assumptions (binding i) regs.mstatus regs.pmaRegion regs.misa regs.mseccfg
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.lbu_input.PC.toNat
-  h_pc_bound : c.lbu_input.PC.toNat < GL_prime - 4
   h_memory_timeline :
     LoadMemoryTimelineCoherenceEvidence (binding i)
       (busLd trace i (Pilot.execRowOf trace i)).e1
@@ -2493,6 +2583,9 @@ structure Decode_lhu (trace : AcceptedZiskTrace numInstructions)
     (mainRowWithRomLd trace i).rom.b_src_ind = 1
   h_store_offset :
     (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lhu_input.rd)
+  h_b_offset_imm0 :
+    (mainRowWithRomLd trace i).rom.b_offset_imm0 =
+      ((BitVec.signExtend 64 c.lhu_input.imm).toNat : FGL)
 
 structure Inputs_lhu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lhu trace i) : Type where
@@ -2503,15 +2596,14 @@ structure Inputs_lhu (trace : AcceptedZiskTrace numInstructions) (binding : Sail
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
     i.val (busLd trace i (Pilot.execRowOf trace i)).e1
   h_opcode_assumptions : PureSpec.lhu_state_assumptions c.lhu_input (binding i)
-  h_load_addr_arith :
-    ((mainRowWithRomLd trace i).rom.b_offset_imm0 + (mainRowWithRomLd trace i).core.a_0).toNat =
-      c.lhu_input.r1_val.toNat + (BitVec.signExtend 64 c.lhu_input.imm).toNat
+  h_a0_value :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_0 i.val =
+      ZiskFv.Trusted.lane_lo c.lhu_input.r1_val
   h_risc_v_assumptions :
     RISC_V_assumptions (binding i) regs.mstatus regs.pmaRegion regs.misa regs.mseccfg
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.lhu_input.PC.toNat
-  h_pc_bound : c.lhu_input.PC.toNat < GL_prime - 4
   h_memory_timeline :
     LoadMemoryTimelineCoherenceEvidence (binding i)
       (busLd trace i (Pilot.execRowOf trace i)).e1
@@ -2576,6 +2668,9 @@ structure Decode_lwu (trace : AcceptedZiskTrace numInstructions)
     (mainRowWithRomLd trace i).rom.b_src_ind = 1
   h_store_offset :
     (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lwu_input.rd)
+  h_b_offset_imm0 :
+    (mainRowWithRomLd trace i).rom.b_offset_imm0 =
+      ((BitVec.signExtend 64 c.lwu_input.imm).toNat : FGL)
 
 structure Inputs_lwu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lwu trace i) : Type where
@@ -2586,15 +2681,14 @@ structure Inputs_lwu (trace : AcceptedZiskTrace numInstructions) (binding : Sail
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
     i.val (busLd trace i (Pilot.execRowOf trace i)).e1
   h_opcode_assumptions : PureSpec.lwu_state_assumptions c.lwu_input (binding i)
-  h_load_addr_arith :
-    ((mainRowWithRomLd trace i).rom.b_offset_imm0 + (mainRowWithRomLd trace i).core.a_0).toNat =
-      c.lwu_input.r1_val.toNat + (BitVec.signExtend 64 c.lwu_input.imm).toNat
+  h_a0_value :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_0 i.val =
+      ZiskFv.Trusted.lane_lo c.lwu_input.r1_val
   h_risc_v_assumptions :
     RISC_V_assumptions (binding i) regs.mstatus regs.pmaRegion regs.misa regs.mseccfg
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.lwu_input.PC.toNat
-  h_pc_bound : c.lwu_input.PC.toNat < GL_prime - 4
   h_memory_timeline :
     LoadMemoryTimelineCoherenceEvidence (binding i)
       (busLd trace i (Pilot.execRowOf trace i)).e1
@@ -2670,6 +2764,9 @@ structure Decode_lb (trace : AcceptedZiskTrace numInstructions)
     (mainRowWithRomLd trace i).rom.b_src_ind = 1
   h_store_offset :
     (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lb_input.rd)
+  h_b_offset_imm0 :
+    (mainRowWithRomLd trace i).rom.b_offset_imm0 =
+      ((BitVec.signExtend 64 c.lb_input.imm).toNat : FGL)
 
 structure Inputs_lb (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lb trace i) : Type where
@@ -2677,15 +2774,14 @@ structure Inputs_lb (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   mem : Valid_Mem FGL FGL
   r_mem : ℕ
   h_opcode_assumptions : PureSpec.lb_state_assumptions c.lb_input (binding i)
-  h_load_addr_arith :
-    ((mainRowWithRomLd trace i).rom.b_offset_imm0 + (mainRowWithRomLd trace i).core.a_0).toNat =
-      c.lb_input.r1_val.toNat + (BitVec.signExtend 64 c.lb_input.imm).toNat
+  h_a0_value :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_0 i.val =
+      ZiskFv.Trusted.lane_lo c.lb_input.r1_val
   h_risc_v_assumptions :
     RISC_V_assumptions (binding i) regs.mstatus regs.pmaRegion regs.misa regs.mseccfg
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.lb_input.PC.toNat
-  h_pc_bound : c.lb_input.PC.toNat < GL_prime - 4
   h_memory_timeline :
     LoadMemoryTimelineCoherenceEvidence (binding i)
       (busLd trace i (Pilot.execRowOf trace i)).e1
@@ -2761,6 +2857,9 @@ structure Decode_lh (trace : AcceptedZiskTrace numInstructions)
     (mainRowWithRomLd trace i).rom.b_src_ind = 1
   h_store_offset :
     (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lh_input.rd)
+  h_b_offset_imm0 :
+    (mainRowWithRomLd trace i).rom.b_offset_imm0 =
+      ((BitVec.signExtend 64 c.lh_input.imm).toNat : FGL)
 
 structure Inputs_lh (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lh trace i) : Type where
@@ -2768,15 +2867,14 @@ structure Inputs_lh (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   mem : Valid_Mem FGL FGL
   r_mem : ℕ
   h_opcode_assumptions : PureSpec.lh_state_assumptions c.lh_input (binding i)
-  h_load_addr_arith :
-    ((mainRowWithRomLd trace i).rom.b_offset_imm0 + (mainRowWithRomLd trace i).core.a_0).toNat =
-      c.lh_input.r1_val.toNat + (BitVec.signExtend 64 c.lh_input.imm).toNat
+  h_a0_value :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_0 i.val =
+      ZiskFv.Trusted.lane_lo c.lh_input.r1_val
   h_risc_v_assumptions :
     RISC_V_assumptions (binding i) regs.mstatus regs.pmaRegion regs.misa regs.mseccfg
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.lh_input.PC.toNat
-  h_pc_bound : c.lh_input.PC.toNat < GL_prime - 4
   h_memory_timeline :
     LoadMemoryTimelineCoherenceEvidence (binding i)
       (busLd trace i (Pilot.execRowOf trace i)).e1
@@ -2852,6 +2950,9 @@ structure Decode_lw (trace : AcceptedZiskTrace numInstructions)
     (mainRowWithRomLd trace i).rom.b_src_ind = 1
   h_store_offset :
     (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lw_input.rd)
+  h_b_offset_imm0 :
+    (mainRowWithRomLd trace i).rom.b_offset_imm0 =
+      ((BitVec.signExtend 64 c.lw_input.imm).toNat : FGL)
 
 structure Inputs_lw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lw trace i) : Type where
@@ -2859,15 +2960,14 @@ structure Inputs_lw (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   mem : Valid_Mem FGL FGL
   r_mem : ℕ
   h_opcode_assumptions : PureSpec.lw_state_assumptions c.lw_input (binding i)
-  h_load_addr_arith :
-    ((mainRowWithRomLd trace i).rom.b_offset_imm0 + (mainRowWithRomLd trace i).core.a_0).toNat =
-      c.lw_input.r1_val.toNat + (BitVec.signExtend 64 c.lw_input.imm).toNat
+  h_a0_value :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_0 i.val =
+      ZiskFv.Trusted.lane_lo c.lw_input.r1_val
   h_risc_v_assumptions :
     RISC_V_assumptions (binding i) regs.mstatus regs.pmaRegion regs.misa regs.mseccfg
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.lw_input.PC.toNat
-  h_pc_bound : c.lw_input.PC.toNat < GL_prime - 4
   h_memory_timeline :
     LoadMemoryTimelineCoherenceEvidence (binding i)
       (busLd trace i (Pilot.execRowOf trace i)).e1

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
@@ -556,6 +556,11 @@ structure Decode_lui (trace : AcceptedZiskTrace numInstructions)
   h_store_pc :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).store_pc
       i.val = 0
+  h_store_ind :
+    (mainRowWithRomLui trace i).rom.store_ind = 0
+  h_store_offset :
+    (mainRowWithRomLui trace i).rom.store_offset =
+      Transpiler.ind (regidx_to_fin c.rd)
   h_imm_lo_nat :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).b_0 i.val).val
       = (c.imm ++ (0 : BitVec 12)).toNat
@@ -585,9 +590,6 @@ structure Inputs_lui (trace : AcceptedZiskTrace numInstructions) (binding : Sail
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = lui_input.PC.toNat
   h_pc_bound : lui_input.PC.toNat < GL_prime - 4
-  h_rd_idx :
-    lui_input.rd =
-      Transpiler.wrap_to_regidx (eRdLui trace i).ptr
 
 /-- Per-op residual bundle for the `lui` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_lui` bundles them. -/
@@ -626,6 +628,11 @@ structure Decode_auipc (trace : AcceptedZiskTrace numInstructions)
   h_store_pc :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).store_pc
       i.val = 1
+  h_store_ind :
+    (mainRowWithRomLui trace i).rom.store_ind = 0
+  h_store_offset :
+    (mainRowWithRomLui trace i).rom.store_offset =
+      Transpiler.ind (regidx_to_fin c.rd)
   -- #100 next-PC transition inputs (replace the exec artifacts; AUIPC already
   -- carries h_set_pc above): the next row exists, plus the AUIPC FLAG-row jmp
   -- pin `jmp_offset1 = 4` (Rust lowerer `zib.j(4, imm)`; cf.
@@ -656,9 +663,6 @@ structure Inputs_auipc (trace : AcceptedZiskTrace numInstructions) (binding : Sa
   -- ruling out FGL wrap on the next PC. Replaces the cross-world `h_nextPC_matches`,
   -- which is now derived via `Pilot.flag_path_nextPC_discharged`.
   h_pc_bound : auipc_input.PC.toNat < GL_prime - 4
-  h_rd_idx :
-    auipc_input.rd =
-      Transpiler.wrap_to_regidx (eRdLui trace i).ptr
   h_no_wrap : auipc_input.PC.toNat
     + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
       < GL_prime

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
@@ -649,6 +649,11 @@ structure Decode_jal (trace : AcceptedZiskTrace numInstructions)
   h_store_pc :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).store_pc
       i.val = 1
+  h_store_ind :
+    (mainRowWithRomLui trace i).rom.store_ind = 0
+  h_store_offset :
+    (mainRowWithRomLui trace i).rom.store_offset =
+      Transpiler.ind (regidx_to_fin c.rd)
   h_jmp2 :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
       i.val = 4
@@ -685,7 +690,6 @@ structure Inputs_jal (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1
   h_success : (PureSpec.execute_JAL_pure jal_input).success = true
   h_nextPC_option : (PureSpec.execute_JAL_pure jal_input).nextPC = .some nextPC_val
-  h_rd_idx : jal_input.rd = Transpiler.wrap_to_regidx (eRdLui trace i).ptr
   h_input_imm : jal_input.imm = c.imm
   h_not_throws : (PureSpec.execute_JAL_pure jal_input).throws = false
   h_pc_bound : jal_input.PC.toNat < GL_prime - 4
@@ -735,6 +739,11 @@ structure Decode_jalr (trace : AcceptedZiskTrace numInstructions)
   h_store_pc :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).store_pc
       i.val = 1
+  h_store_ind :
+    (mainRowWithRomLui trace i).rom.store_ind = 0
+  h_store_offset :
+    (mainRowWithRomLui trace i).rom.store_offset =
+      Transpiler.ind (regidx_to_fin c.rd)
   -- #100 next-PC transition inputs (replace the exec artifacts; the next-PC
   -- residual is now DERIVED via `jalr_setpc_nextPC_discharged`). All are
   -- same-world circuit / decode / ROM pins (no Sail-binding dependency).
@@ -794,7 +803,6 @@ structure Inputs_jalr (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1
   h_success : (PureSpec.execute_JALR_pure jalr_input).success = true
   h_nextPC_option : (PureSpec.execute_JALR_pure jalr_input).nextPC = .some nextPC_val
-  h_rd_idx : jalr_input.rd = Transpiler.wrap_to_regidx (eRdLui trace i).ptr
   h_input_imm : jalr_input.imm = c.imm
   h_input_rs1 : read_xreg (regidx_to_fin c.rs1) (binding i)
     = EStateM.Result.ok jalr_input.rs1_val (binding i)

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
@@ -41,6 +41,33 @@ seal mulwArow mulhuArow divuArow divuwArow remuArow remuwArow
 
 set_option maxHeartbeats 8000000
 
+/-- Branch theorem-domain range assumptions.
+
+This is not a decoded placement fact: it is the explicit soundness-domain condition needed by the
+branch next-PC cast. Keeping it separate from `Inputs_<branch>` leaves those input records focused
+on Sail/ZisK state and value agreement. -/
+def BranchRangeDomain (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin trace.numInstructions) (pc : BitVec 64) (takenOffset : FGL) : Prop :=
+  ((mainOfTable trace.program trace.mainTable).pc i.val).val + takenOffset.val < GL_prime
+    ∧ pc.toNat < GL_prime - 4
+
+/-- JAL theorem-domain range assumptions.
+
+These preserve the old JAL target no-wrap, PC-bound, and 32-bit next-PC obligations at the explicit
+soundness theorem boundary instead of mixing them into `Inputs_jal` state/value agreement. -/
+structure JalRangeDomain (jal_input : PureSpec.JalInput) : Prop where
+  h_no_fgl_wrap : jal_input.PC.toNat + (BitVec.signExtend 64 jal_input.imm).toNat < GL_prime
+  h_pc_bound : jal_input.PC.toNat < GL_prime - 4
+  h_pc_offset_lt_2_32 : (jal_input.PC + 4#64).toNat < 4294967296
+
+/-- JALR theorem-domain range assumptions.
+
+These preserve the old JALR link-PC range obligations at the explicit soundness theorem boundary
+instead of mixing them into `Inputs_jalr` state/value agreement. -/
+structure JalrRangeDomain (jalr_input : PureSpec.JalrInput) : Prop where
+  h_pc_bound : jalr_input.PC.toNat < GL_prime - 4
+  h_pc_offset_lt_2_32 : (jalr_input.PC + 4#64).toNat < 4294967296
+
 structure Claim_beq (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   imm : BitVec 13
   r1 : regidx
@@ -66,6 +93,10 @@ structure Decode_beq (trace : AcceptedZiskTrace numInstructions)
   h_jmp_offset2 :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
       i.val = 4
+  h_jmp_offset1_imm :
+    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
+        i.val).val
+      = (BitVec.signExtend 64 c.imm).toNat
   -- #100: taken on flag=1 (`r1 == r2`); `jmp_offset2 = 4` fall-through.
   h_idx : i.val + 1 < trace.mainTable.table.length
 
@@ -102,23 +133,11 @@ structure Inputs_beq (trace : AcceptedZiskTrace numInstructions) (binding : Sail
       ZiskFv.Trusted.lane_hi
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding i)).xreg
           (regidx_to_fin c.r2))
-  -- #100: taken-offset bridge (`jmp_offset1 = signExtend imm`) + PC bridge /
-  -- no-wrap / bound. Replace `h_nextPC_matches`, now DERIVED via
-  -- `Pilot.branch_nextPC_flag1_taken` + `branch_flag_eq_provided`.
-  h_off_bridge :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-        i.val).val
-      = (BitVec.signExtend 64 beq_input.imm).toNat
+  -- #100: PC bridge. The range/domain facts used by the branch next-PC cast live
+  -- in `RowOutsideDefectRegion` as `BranchRangeDomain`.
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = beq_input.PC.toNat
-  h_no_wrap :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
-      + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-          i.val).val
-      < GL_prime
-  h_pc_bound : beq_input.PC.toNat < 18446744069414584321 - 4
-  h_not_throws : (PureSpec.execute_BEQ_pure beq_input).throws = false
   h_success : (PureSpec.execute_BEQ_pure beq_input).success = true
 
 /-- Per-op residual bundle for the `beq` archetype: the 3-way `Claim`/`Decode`/`Inputs`
@@ -162,6 +181,10 @@ structure Decode_bne (trace : AcceptedZiskTrace numInstructions)
   h_jmp_offset1 :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
       i.val = 4
+  h_jmp_offset2_imm :
+    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
+        i.val).val
+      = (BitVec.signExtend 64 c.imm).toNat
   -- #100: `neg` polarity (taken on flag=0, `r1 ≠ r2`); the taken offset rides on
   -- `jmp_offset2`, `jmp_offset1 = 4` is the fall-through side.
   h_idx : i.val + 1 < trace.mainTable.table.length
@@ -199,23 +222,11 @@ structure Inputs_bne (trace : AcceptedZiskTrace numInstructions) (binding : Sail
       ZiskFv.Trusted.lane_hi
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding i)).xreg
           (regidx_to_fin c.r2))
-  -- #100: taken-offset bridge on `jmp_offset2` (the flag=0 side) + PC bridge /
-  -- no-wrap / bound. Replace `h_nextPC_matches`, now DERIVED via
-  -- `Pilot.branch_nextPC_flag0_taken` + `branch_flag_eq_provided`.
-  h_off_bridge :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
-        i.val).val
-      = (BitVec.signExtend 64 bne_input.imm).toNat
+  -- #100: PC bridge. The range/domain facts used by the branch next-PC cast live
+  -- in `RowOutsideDefectRegion` as `BranchRangeDomain`.
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = bne_input.PC.toNat
-  h_no_wrap :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
-      + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
-          i.val).val
-      < GL_prime
-  h_pc_bound : bne_input.PC.toNat < 18446744069414584321 - 4
-  h_not_throws : (PureSpec.execute_BNE_pure bne_input).throws = false
   h_success : (PureSpec.execute_BNE_pure bne_input).success = true
 
 /-- Per-op residual bundle for the `bne` archetype: the 3-way `Claim`/`Decode`/`Inputs`
@@ -259,6 +270,10 @@ structure Decode_blt (trace : AcceptedZiskTrace numInstructions)
   h_jmp_offset2 :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
       i.val = 4
+  h_jmp_offset1_imm :
+    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
+        i.val).val
+      = (BitVec.signExtend 64 c.imm).toNat
   -- #100: taken on flag=1 (signed `r1 <s r2`); `jmp_offset2 = 4` fall-through.
   h_idx : i.val + 1 < trace.mainTable.table.length
 
@@ -295,23 +310,11 @@ structure Inputs_blt (trace : AcceptedZiskTrace numInstructions) (binding : Sail
       ZiskFv.Trusted.lane_hi
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding i)).xreg
           (regidx_to_fin c.r2))
-  -- #100: taken-offset bridge (`jmp_offset1 = signExtend imm`) + PC bridge /
-  -- no-wrap / bound. Replace `h_nextPC_matches`, now DERIVED via
-  -- `Pilot.branch_nextPC_flag1_taken` + `branch_flag_lt_provided`.
-  h_off_bridge :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-        i.val).val
-      = (BitVec.signExtend 64 blt_input.imm).toNat
+  -- #100: PC bridge. The range/domain facts used by the branch next-PC cast live
+  -- in `RowOutsideDefectRegion` as `BranchRangeDomain`.
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = blt_input.PC.toNat
-  h_no_wrap :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
-      + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-          i.val).val
-      < GL_prime
-  h_pc_bound : blt_input.PC.toNat < 18446744069414584321 - 4
-  h_not_throws : (PureSpec.execute_BLT_pure blt_input).throws = false
   h_success : (PureSpec.execute_BLT_pure blt_input).success = true
 
 /-- Per-op residual bundle for the `blt` archetype: the 3-way `Claim`/`Decode`/`Inputs`
@@ -355,6 +358,10 @@ structure Decode_bge (trace : AcceptedZiskTrace numInstructions)
   h_jmp_offset1 :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
       i.val = 4
+  h_jmp_offset2_imm :
+    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
+        i.val).val
+      = (BitVec.signExtend 64 c.imm).toNat
   -- #100: `neg` polarity (taken on flag=0, signed `r1 ≥s r2`); the taken offset
   -- rides on `jmp_offset2`, `jmp_offset1 = 4` is the fall-through side.
   h_idx : i.val + 1 < trace.mainTable.table.length
@@ -392,23 +399,11 @@ structure Inputs_bge (trace : AcceptedZiskTrace numInstructions) (binding : Sail
       ZiskFv.Trusted.lane_hi
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding i)).xreg
           (regidx_to_fin c.r2))
-  -- #100: taken-offset bridge on `jmp_offset2` (the flag=0 side) + PC bridge /
-  -- no-wrap / bound. Replace `h_nextPC_matches`, now DERIVED via
-  -- `Pilot.branch_nextPC_flag0_taken` + `branch_flag_lt_provided`.
-  h_off_bridge :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
-        i.val).val
-      = (BitVec.signExtend 64 bge_input.imm).toNat
+  -- #100: PC bridge. The range/domain facts used by the branch next-PC cast live
+  -- in `RowOutsideDefectRegion` as `BranchRangeDomain`.
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = bge_input.PC.toNat
-  h_no_wrap :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
-      + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
-          i.val).val
-      < GL_prime
-  h_pc_bound : bge_input.PC.toNat < 18446744069414584321 - 4
-  h_not_throws : (PureSpec.execute_BGE_pure bge_input).throws = false
   h_success : (PureSpec.execute_BGE_pure bge_input).success = true
 
 /-- Per-op residual bundle for the `bge` archetype: the 3-way `Claim`/`Decode`/`Inputs`
@@ -452,10 +447,14 @@ structure Decode_bltu (trace : AcceptedZiskTrace numInstructions)
   h_jmp_offset2 :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
       i.val = 4
+  h_jmp_offset1_imm :
+    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
+        i.val).val
+      = (BitVec.signExtend 64 c.imm).toNat
   -- #100 next-PC transition input (replaces the exec artifacts): the next row
-  -- exists. The taken-offset pin (`jmp_offset1 = signExtend imm`) and the no-wrap
-  -- bound live in `Inputs` (they reference `bltu_input`). `flag = comparison` is
-  -- DERIVED in `stepStrong_bltu` from the LTU Binary provider.
+  -- exists. The taken-offset pin (`jmp_offset1 = signExtend imm`) is decoded from
+  -- the committed program; `flag = comparison` is DERIVED in `stepStrong_bltu`
+  -- from the LTU Binary provider.
   h_idx : i.val + 1 < trace.mainTable.table.length
 
 structure Inputs_bltu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
@@ -492,24 +491,11 @@ structure Inputs_bltu (trace : AcceptedZiskTrace numInstructions) (binding : Sai
       ZiskFv.Trusted.lane_hi
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding i)).xreg
           (regidx_to_fin c.r2))
-  -- #100: the taken-offset decode/ROM bridge (`jmp_offset1 = signExtend imm`),
-  -- the PC provenance bridge, the taken-target no-wrap bound, and the PC
-  -- trajectory bound. These replace the cross-world `h_nextPC_matches`, now
-  -- DERIVED via `Pilot.branch_nextPC_flag1_taken` + `branch_flag_ltu_provided`.
-  h_off_bridge :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-        i.val).val
-      = (BitVec.signExtend 64 bltu_input.imm).toNat
+  -- #100: PC bridge. The range/domain facts used by the branch next-PC cast live
+  -- in `RowOutsideDefectRegion` as `BranchRangeDomain`.
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = bltu_input.PC.toNat
-  h_no_wrap :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
-      + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-          i.val).val
-      < GL_prime
-  h_pc_bound : bltu_input.PC.toNat < 18446744069414584321 - 4
-  h_not_throws : (PureSpec.execute_BLTU_pure bltu_input).throws = false
   h_success : (PureSpec.execute_BLTU_pure bltu_input).success = true
 
 /-- Per-op residual bundle for the `bltu` archetype: the 3-way `Claim`/`Decode`/`Inputs`
@@ -553,10 +539,14 @@ structure Decode_bgeu (trace : AcceptedZiskTrace numInstructions)
   h_jmp_offset1 :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
       i.val = 4
+  h_jmp_offset2_imm :
+    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
+        i.val).val
+      = (BitVec.signExtend 64 c.imm).toNat
   -- #100 next-PC transition input (replaces the exec artifacts): the next row
   -- exists. BGEU is the `create_branch_op`-`neg` polarity (taken on `flag = 0`):
-  -- the taken offset rides on `jmp_offset2` (`Inputs`); `jmp_offset1 = 4` is the
-  -- fall-through side. `flag = comparison` is DERIVED in `stepStrong_bgeu`.
+  -- the taken offset rides on `jmp_offset2`; `jmp_offset1 = 4` is the fall-through
+  -- side. `flag = comparison` is DERIVED in `stepStrong_bgeu`.
   h_idx : i.val + 1 < trace.mainTable.table.length
 
 structure Inputs_bgeu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
@@ -592,24 +582,11 @@ structure Inputs_bgeu (trace : AcceptedZiskTrace numInstructions) (binding : Sai
       ZiskFv.Trusted.lane_hi
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding i)).xreg
           (regidx_to_fin c.r2))
-  -- #100: the taken-offset decode/ROM bridge — for BGEU the taken offset rides
-  -- on `jmp_offset2` (the `flag = 0` side) — plus PC bridge / no-wrap / bound.
-  -- These replace `h_nextPC_matches`, now DERIVED via
-  -- `Pilot.branch_nextPC_flag0_taken` + `branch_flag_ltu_provided`.
-  h_off_bridge :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
-        i.val).val
-      = (BitVec.signExtend 64 bgeu_input.imm).toNat
+  -- #100: PC bridge. The range/domain facts used by the branch next-PC cast live
+  -- in `RowOutsideDefectRegion` as `BranchRangeDomain`.
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = bgeu_input.PC.toNat
-  h_no_wrap :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
-      + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
-          i.val).val
-      < GL_prime
-  h_pc_bound : bgeu_input.PC.toNat < 18446744069414584321 - 4
-  h_not_throws : (PureSpec.execute_BGEU_pure bgeu_input).throws = false
   h_success : (PureSpec.execute_BGEU_pure bgeu_input).success = true
 
 /-- Per-op residual bundle for the `bgeu` archetype: the 3-way `Claim`/`Decode`/`Inputs`
@@ -654,13 +631,17 @@ structure Decode_jal (trace : AcceptedZiskTrace numInstructions)
   h_store_offset :
     (mainRowWithRomLui trace i).rom.store_offset =
       Transpiler.ind (regidx_to_fin c.rd)
+  h_jmp_offset1_imm :
+    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
+        i.val).val
+      = (BitVec.signExtend 64 c.imm).toNat
   h_jmp2 :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
       i.val = 4
   -- #100 next-PC transition input (replaces the exec artifacts; JAL already
-  -- carries h_set_pc above): the next row exists. The taken-offset pin
-  -- (`jmp_offset1 = signExtend imm`) and the target no-wrap bound live in
-  -- Inputs (they reference `jal_input.imm`). `flag = 1` is DERIVED in
+  -- carries h_set_pc above): the next row exists. The taken-offset pin is
+  -- committed-program decode (`h_jmp_offset1_imm`); the target no-wrap bound
+  -- still lives in Inputs because it references `jal_input.PC`. `flag = 1` is DERIVED in
   -- `stepStrong_jal` from the OP_FLAG decode pins + `internal_op0_sets_flag`.
   h_idx : i.val + 1 < trace.mainTable.table.length
 
@@ -668,32 +649,17 @@ structure Inputs_jal (trace : AcceptedZiskTrace numInstructions) (binding : Sail
     (i : Fin trace.numInstructions) (c : Claim_jal trace i) : Type where
   jal_input : PureSpec.JalInput
   misa_val : RegisterType Register.misa
-  nextPC_val : BitVec 64
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = jal_input.PC.toNat
-  -- #100: the taken-offset decode/ROM bridge (`jmp_offset1 = signExtend imm`,
-  -- Rust lowerer `zib.j(imm, 4)`; cf. `RowShape/Contract.lean` JAL arm, line 246)
-  -- — the same unsigned-equal offset contract AUIPC's `h_offset_bridge` uses —
-  -- plus the JAL-target no-wrap bound (target stays below the GL bound). These
-  -- replace the cross-world `h_nextPC_matches`, now DERIVED via
-  -- `Pilot.flag_path_nextPC_discharged` + `Pilot.ofNat_fgl_pc_plus_offset_eq`.
-  h_offset_bridge :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-        i.val).val
-      = (BitVec.signExtend 64 jal_input.imm).toNat
-  h_no_fgl_wrap :
-    jal_input.PC.toNat + (BitVec.signExtend 64 jal_input.imm).toNat < GL_prime
+  -- #100: PC bridge. The JAL range/domain facts live in `RowOutsideDefectRegion`
+  -- as `JalRangeDomain`.
   h_input_rd : jal_input.rd = regidx_to_fin c.rd
   h_input_pc : (binding i).regs.get? Register.PC = .some jal_input.PC
   h_input_misa : (binding i).regs.get? Register.misa = .some misa_val
   h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1
   h_success : (PureSpec.execute_JAL_pure jal_input).success = true
-  h_nextPC_option : (PureSpec.execute_JAL_pure jal_input).nextPC = .some nextPC_val
   h_input_imm : jal_input.imm = c.imm
-  h_not_throws : (PureSpec.execute_JAL_pure jal_input).throws = false
-  h_pc_bound : jal_input.PC.toNat < GL_prime - 4
-  h_pc_offset_lt_2_32 : (jal_input.PC + 4#64).toNat < 4294967296
 
 /-- Per-op residual bundle for the `jal` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_jal` bundles them. -/
@@ -764,6 +730,9 @@ structure Decode_jalr (trace : AcceptedZiskTrace numInstructions)
   h_c1_zero :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_1
       i.val = 0
+  h_jmp2 :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
+      i.val = 4
   --   * the `jmp_offset1` field ↔ `offset_bv` bridge (unsigned-equal offset
   --     contract, same shape AUIPC/JAL use) + the evenness ROM guard
   --     (aligned `imm % 4 == 0` ⇒ `offset_bv` even; trivial for unaligned
@@ -782,7 +751,6 @@ structure Inputs_jalr (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   jalr_input : PureSpec.JalrInput
   misa_val : RegisterType Register.misa
   mseccfg : RegisterType Register.mseccfg
-  nextPC_val : BitVec 64
   -- #100: the per-lowering operand identity replacing the cross-world
   -- `h_nextPC_matches`. The committed Main `b`-lane (`b_0 + b_1 · 2^32`) plus
   -- `offset_bv` equals Sail's pre-mask target `rs1_val + signExtend 64 imm`:
@@ -799,10 +767,12 @@ structure Inputs_jalr (trace : AcceptedZiskTrace numInstructions) (binding : Sai
       = jalr_input.rs1_val + BitVec.signExtend 64 jalr_input.imm
   h_input_rd : jalr_input.rd = regidx_to_fin c.rd
   h_input_pc : (binding i).regs.get? Register.PC = .some jalr_input.PC
+  h_pc_bridge :
+    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
+      = jalr_input.PC.toNat
   h_input_misa : (binding i).regs.get? Register.misa = .some misa_val
   h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1
   h_success : (PureSpec.execute_JALR_pure jalr_input).success = true
-  h_nextPC_option : (PureSpec.execute_JALR_pure jalr_input).nextPC = .some nextPC_val
   h_input_imm : jalr_input.imm = c.imm
   h_input_rs1 : read_xreg (regidx_to_fin c.rs1) (binding i)
     = EStateM.Result.ok jalr_input.rs1_val (binding i)
@@ -810,13 +780,8 @@ structure Inputs_jalr (trace : AcceptedZiskTrace numInstructions) (binding : Sai
     = EStateM.Result.ok Privilege.Machine (binding i)
   h_mseccfg : Sail.readReg Register.mseccfg (binding i)
     = EStateM.Result.ok mseccfg (binding i)
-  h_link_bridge :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val
-      + (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
-          i.val).val
-      = (jalr_input.PC + 4#64).toNat
-  h_pc_bound : jalr_input.PC.toNat < GL_prime - 4
-  h_pc_offset_lt_2_32 : (jalr_input.PC + 4#64).toNat < 4294967296
+  -- #100: JALR link-PC range/domain facts live in `RowOutsideDefectRegion`
+  -- as `JalrRangeDomain`.
 
 /-- Per-op residual bundle for the `jalr` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_jalr` bundles them. -/
@@ -878,7 +843,6 @@ structure Inputs_fence (trace : AcceptedZiskTrace numInstructions) (binding : Sa
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = fence_input.PC.toNat
-  h_pc_bound : fence_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `fence` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_fence` bundles them. -/

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongAluArith.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongAluArith.lean
@@ -22,6 +22,7 @@ import ZiskFv.Compliance
 import ZiskFv.Compliance.Defects
 import ZiskFv.Compliance.TraceLevelExport.Base
 import ZiskFv.Compliance.TraceLevelExport.RomDecodeBinding
+import ZiskFv.Compliance.TraceLevelExport.RomDecodeBindingOps
 import ZiskFv.Compliance.TraceLevelExport.RowDataAluShift
 import ZiskFv.Compliance.TraceLevelExport.RowDataArithMem
 import ZiskFv.Compliance.TraceLevelExport.RowDataControl
@@ -46,25 +47,6 @@ seal mulwArow mulhuArow divuArow divuwArow remuArow remuwArow
 
 set_option maxHeartbeats 8000000
 
-theorem busSub_rd_idx_of_decode
-    {numInstructions : Nat}
-    {trace : AcceptedZiskTrace numInstructions}
-    {i : Fin trace.numInstructions}
-    {execRow : List (Interaction.ExecutionBusEntry FGL)}
-    {rd : regidx}
-    (h_store_ind : (mainRowWithRomSub trace i).rom.store_ind = 0)
-    (h_store_offset :
-      (mainRowWithRomSub trace i).rom.store_offset =
-        Transpiler.ind (regidx_to_fin rd)) :
-    regidx_to_fin rd =
-      Transpiler.wrap_to_regidx (busSub trace i execRow).e2.ptr := by
-  have h_spec := RomDecodeBinding.mainAddressSpec_at trace ⟨i.val, trace.mainTable_index i⟩
-  have h_addr2 := h_spec.2.2.1
-  rw [busSub, ZiskFv.AirsClean.Main.cMemMessage,
-    ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry]
-  rw [h_addr2, h_store_offset, h_store_ind]
-  simp [Transpiler.wrap_to_regidx_ind]
-
 /-! ## Trace-level export: env-constructed channel-balance form
 
 The theorems below are the trace-level export over the accepted trace.  For each
@@ -86,6 +68,23 @@ trace's `mainOfTable` row; `execRow` remains a genuine ∀-binder inside the
 no `False.elim` or contradictory pair is used.
 -/
 
+private theorem itype_imm_subset_of_decode
+    {numInstructions : Nat}
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin trace.numInstructions)
+    (inputImm claimImm : BitVec 12)
+    (h_input_imm : inputImm = claimImm)
+    (h_b_src_imm : (mainRowWithRomSub trace i).rom.b_src_imm = 1)
+    (h_b_imm :
+      BitVec.signExtend 64 claimImm =
+        BitVec.ofNat 64
+          (((mainRowWithRomSub trace i).rom.b_offset_imm0).val
+            + ((mainRowWithRomSub trace i).rom.b_imm1).val * 4294967296)) :
+    itype_imm_subset_holds_main (mainOfTable trace.program trace.mainTable) i.val inputImm := by
+  refine RomDecodeBinding.itypeImmSubset_of_sourceSpec trace i inputImm
+    (RomDecodeBinding.mainRowWithRomSub_sourceSpec trace i) h_b_src_imm ?_
+  simpa [h_input_imm] using h_b_imm
+
 /-- Strengthened `sub` step: the channel-balance conclusion (the OLD global
     theorem's per-arm output) proven by CONSTRUCTING the `OpEnvelope.sub` arm
     from accepted-trace data (reusing `construction_sub_sound`'s internal
@@ -94,7 +93,7 @@ no `False.elim` or contradictory pair is used.
 theorem stepStrong_sub
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sub trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.sub_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -160,7 +159,7 @@ theorem stepStrong_sub
         Pilot.sub_nextPC_discharged trace binding i d.toInputs.sub_input
           d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -237,7 +236,7 @@ theorem stepStrong_sub
 theorem stepStrong_and
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_and trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.and_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -297,7 +296,7 @@ theorem stepStrong_and
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.and_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -374,7 +373,7 @@ theorem stepStrong_and
 theorem stepStrong_or
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_or trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.or_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -434,7 +433,7 @@ theorem stepStrong_or
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.or_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -511,7 +510,7 @@ theorem stepStrong_or
 theorem stepStrong_xor
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_xor trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.xor_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -571,7 +570,7 @@ theorem stepStrong_xor
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.xor_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -649,7 +648,7 @@ theorem stepStrong_xor
 theorem stepStrong_slt
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_slt trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.slt_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -709,7 +708,7 @@ theorem stepStrong_slt
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.slt_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -786,7 +785,7 @@ theorem stepStrong_slt
 theorem stepStrong_sltu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sltu trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.sltu_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -846,7 +845,7 @@ theorem stepStrong_sltu
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.sltu_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -922,7 +921,7 @@ theorem stepStrong_sltu
 theorem stepStrong_andi
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_andi trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.andi_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -982,7 +981,7 @@ theorem stepStrong_andi
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.andi_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -1033,17 +1032,20 @@ theorem stepStrong_andi
       ZiskFv.EquivCore.Bridge.Binary.input_r1_packed_a_row
         m providerInput i.val (regidx_to_fin d.toClaim.r1) d.toInputs.andi_input.r1_val
         h_matches h_m32_zero d.toInputs.h_a_lo_t d.toInputs.h_a_hi_t h_match d.toInputs.h_input_r1
+  have h_andi_subset :=
+    itype_imm_subset_of_decode trace i d.toInputs.andi_input.imm d.toClaim.imm
+      d.toInputs.h_input_imm d.toDecode.h_b_src_imm d.toDecode.h_b_imm
   have h_input_imm_row :
       BitVec.signExtend 64 d.toInputs.andi_input.imm
         = ZiskFv.EquivCore.Add.binaryRowB64 providerInput := by
     simpa [ZiskFv.EquivCore.Add.binaryRowB64] using
       ZiskFv.EquivCore.Bridge.Binary.itype_imm_subset_binary_row_of_main_row
         m providerInput i.val d.toInputs.andi_input.imm h_matches h_m32_zero h_match
-        d.toInputs.h_andi_subset
+        h_andi_subset
   let env : OpEnvelope state m i.val :=
     OpEnvelope.andi d.toInputs.andi_input d.toClaim.r1 d.toClaim.rd d.toClaim.imm zeroValidBinary bus pins
       providerTable providerRow h_component h_table_spec h_provider_row h_match
-      h_input_r1_row h_input_imm_row d.toInputs.h_andi_subset h_lane_rd promises
+      h_input_r1_row h_input_imm_row h_andi_subset h_lane_rd promises
   have h_bridge : env.aeneasBridgeTrust := by
     show _ ∧ _
     exact ⟨h_input_r1_row, h_input_imm_row⟩
@@ -1058,7 +1060,7 @@ theorem stepStrong_andi
 theorem stepStrong_ori
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_ori trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.ori_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -1118,7 +1120,7 @@ theorem stepStrong_ori
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.ori_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -1169,17 +1171,20 @@ theorem stepStrong_ori
       ZiskFv.EquivCore.Bridge.Binary.input_r1_packed_a_row
         m providerInput i.val (regidx_to_fin d.toClaim.r1) d.toInputs.ori_input.r1_val
         h_matches h_m32_zero d.toInputs.h_a_lo_t d.toInputs.h_a_hi_t h_match d.toInputs.h_input_r1
+  have h_ori_subset :=
+    itype_imm_subset_of_decode trace i d.toInputs.ori_input.imm d.toClaim.imm
+      d.toInputs.h_input_imm d.toDecode.h_b_src_imm d.toDecode.h_b_imm
   have h_input_imm_row :
       BitVec.signExtend 64 d.toInputs.ori_input.imm
         = ZiskFv.EquivCore.Add.binaryRowB64 providerInput := by
     simpa [ZiskFv.EquivCore.Add.binaryRowB64] using
       ZiskFv.EquivCore.Bridge.Binary.itype_imm_subset_binary_row_of_main_row
         m providerInput i.val d.toInputs.ori_input.imm h_matches h_m32_zero h_match
-        d.toInputs.h_ori_subset
+        h_ori_subset
   let env : OpEnvelope state m i.val :=
     OpEnvelope.ori d.toInputs.ori_input d.toClaim.r1 d.toClaim.rd d.toClaim.imm zeroValidBinary bus pins
       providerTable providerRow h_component h_table_spec h_provider_row h_match
-      h_input_r1_row h_input_imm_row d.toInputs.h_ori_subset h_lane_rd promises
+      h_input_r1_row h_input_imm_row h_ori_subset h_lane_rd promises
   have h_bridge : env.aeneasBridgeTrust := by
     show _ ∧ _
     exact ⟨h_input_r1_row, h_input_imm_row⟩
@@ -1194,7 +1199,7 @@ theorem stepStrong_ori
 theorem stepStrong_xori
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_xori trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.xori_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -1254,7 +1259,7 @@ theorem stepStrong_xori
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.xori_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -1303,17 +1308,20 @@ theorem stepStrong_xori
       ZiskFv.EquivCore.Bridge.Binary.input_r1_packed_a_row
         m providerInput i.val (regidx_to_fin d.toClaim.r1) d.toInputs.xori_input.r1_val
         h_matches h_m32_zero d.toInputs.h_a_lo_t d.toInputs.h_a_hi_t h_match d.toInputs.h_input_r1
+  have h_xori_subset :=
+    itype_imm_subset_of_decode trace i d.toInputs.xori_input.imm d.toClaim.imm
+      d.toInputs.h_input_imm d.toDecode.h_b_src_imm d.toDecode.h_b_imm
   have h_input_imm_row :
       BitVec.signExtend 64 d.toInputs.xori_input.imm
         = ZiskFv.EquivCore.Add.binaryRowB64 providerInput := by
     simpa [ZiskFv.EquivCore.Add.binaryRowB64] using
       ZiskFv.EquivCore.Bridge.Binary.itype_imm_subset_binary_row_of_main_row
         m providerInput i.val d.toInputs.xori_input.imm h_matches h_m32_zero h_match
-        d.toInputs.h_xori_subset
+        h_xori_subset
   let env : OpEnvelope state m i.val :=
     OpEnvelope.xori d.toInputs.xori_input d.toClaim.r1 d.toClaim.rd d.toClaim.imm zeroValidBinary bus pins
       providerTable providerRow h_component h_table_spec h_provider_row h_match
-      h_input_r1_row h_input_imm_row d.toInputs.h_xori_subset h_lane_rd promises
+      h_input_r1_row h_input_imm_row h_xori_subset h_lane_rd promises
   have h_bridge : env.aeneasBridgeTrust := by
     show _ ∧ _
     exact ⟨h_input_r1_row, h_input_imm_row⟩
@@ -1328,7 +1336,7 @@ theorem stepStrong_xori
 theorem stepStrong_slti
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_slti trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.slti_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -1388,7 +1396,7 @@ theorem stepStrong_slti
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.slti_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -1439,10 +1447,13 @@ theorem stepStrong_slti
       ZiskFv.EquivCore.Bridge.Binary.input_r1_packed_a_row
         m providerInput i.val (regidx_to_fin d.toClaim.r1) d.toInputs.slti_input.r1_val
         h_matches h_m32_zero d.toInputs.h_a_lo_t d.toInputs.h_a_hi_t h_match d.toInputs.h_input_r1
+  have h_slti_subset :=
+    itype_imm_subset_of_decode trace i d.toInputs.slti_input.imm d.toClaim.imm
+      d.toInputs.h_input_imm d.toDecode.h_b_src_imm d.toDecode.h_b_imm
   let env : OpEnvelope state m i.val :=
     OpEnvelope.slti d.toInputs.slti_input d.toClaim.r1 d.toClaim.rd d.toClaim.imm zeroValidBinary bus pins
       providerTable providerRow h_component h_table_spec h_provider_row h_match
-      h_m32_zero h_input_r1_row d.toInputs.h_slti_subset h_lane_rd promises
+      h_m32_zero h_input_r1_row h_slti_subset h_lane_rd promises
   have h_bridge : env.aeneasBridgeTrust := by
     show _ ∧ _
     exact ⟨h_m32_zero, h_input_r1_row⟩
@@ -1457,7 +1468,7 @@ theorem stepStrong_slti
 theorem stepStrong_sltiu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sltiu trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.sltiu_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -1517,7 +1528,7 @@ theorem stepStrong_sltiu
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.sltiu_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -1568,10 +1579,13 @@ theorem stepStrong_sltiu
       ZiskFv.EquivCore.Bridge.Binary.input_r1_packed_a_row
         m providerInput i.val (regidx_to_fin d.toClaim.r1) d.toInputs.sltiu_input.r1_val
         h_matches h_m32_zero d.toInputs.h_a_lo_t d.toInputs.h_a_hi_t h_match d.toInputs.h_input_r1
+  have h_sltiu_subset :=
+    itype_imm_subset_of_decode trace i d.toInputs.sltiu_input.imm d.toClaim.imm
+      d.toInputs.h_input_imm d.toDecode.h_b_src_imm d.toDecode.h_b_imm
   let env : OpEnvelope state m i.val :=
     OpEnvelope.sltiu d.toInputs.sltiu_input d.toClaim.r1 d.toClaim.rd d.toClaim.imm zeroValidBinary bus pins
       providerTable providerRow h_component h_table_spec h_provider_row h_match
-      h_m32_zero h_input_r1_row d.toInputs.h_sltiu_subset h_lane_rd promises
+      h_m32_zero h_input_r1_row h_sltiu_subset h_lane_rd promises
   have h_bridge : env.aeneasBridgeTrust := by
     show _ ∧ _
     exact ⟨h_m32_zero, h_input_r1_row⟩
@@ -1587,7 +1601,7 @@ theorem stepStrong_sltiu
 theorem stepStrong_sll
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sll trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.sll_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -1647,7 +1661,7 @@ theorem stepStrong_sll
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.sll_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -1687,7 +1701,7 @@ theorem stepStrong_sll
 theorem stepStrong_srl
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_srl trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.srl_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -1747,7 +1761,7 @@ theorem stepStrong_srl
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.srl_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -1787,7 +1801,7 @@ theorem stepStrong_srl
 theorem stepStrong_sra
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sra trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.sra_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -1847,7 +1861,7 @@ theorem stepStrong_sra
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.sra_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -1887,7 +1901,7 @@ theorem stepStrong_sra
 theorem stepStrong_slli
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_slli trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.slli_input.PC) :
     execute_instruction (instruction.SHIFTIOP (d.toClaim.shamt, d.toClaim.r1, d.toClaim.rd, sop.SLLI)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨(busSub trace i (Pilot.execRowOf trace i)).exec_row,
@@ -1943,7 +1957,7 @@ theorem stepStrong_slli
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.slli_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -1987,7 +2001,7 @@ theorem stepStrong_slli
 theorem stepStrong_srli
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_srli trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.srli_input.PC) :
     execute_instruction (instruction.SHIFTIOP (d.toClaim.shamt, d.toClaim.r1, d.toClaim.rd, sop.SRLI)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨(busSub trace i (Pilot.execRowOf trace i)).exec_row,
@@ -2043,7 +2057,7 @@ theorem stepStrong_srli
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.srli_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -2087,7 +2101,7 @@ theorem stepStrong_srli
 theorem stepStrong_srai
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_srai trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.srai_input.PC) :
     execute_instruction (instruction.SHIFTIOP (d.toClaim.shamt, d.toClaim.r1, d.toClaim.rd, sop.SRAI)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨(busSub trace i (Pilot.execRowOf trace i)).exec_row,
@@ -2143,7 +2157,7 @@ theorem stepStrong_srai
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.srai_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -2189,7 +2203,7 @@ theorem stepStrong_srai
 theorem stepStrong_subw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_subw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.subw_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -2294,7 +2308,7 @@ theorem stepStrong_subw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.subw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -2320,7 +2334,7 @@ theorem stepStrong_subw
 theorem stepStrong_addw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_addw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.addw_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -2425,7 +2439,7 @@ theorem stepStrong_addw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.addw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -2451,7 +2465,7 @@ theorem stepStrong_addw
 theorem stepStrong_addiw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_addiw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.addiw_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -2537,7 +2551,7 @@ theorem stepStrong_addiw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.addiw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -2546,9 +2560,12 @@ theorem stepStrong_addiw
       m2_as := by rfl,
       rd_idx := d.toInputs.h_input_rd.trans
         (busSub_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset) }
+  have h_addiw_subset :=
+    itype_imm_subset_of_decode trace i d.toInputs.addiw_input.imm d.toClaim.imm
+      d.toInputs.h_input_imm d.toDecode.h_b_src_imm d.toDecode.h_b_imm
   let env : OpEnvelope state m i.val :=
     OpEnvelope.addiw d.toInputs.addiw_input d.toClaim.r1 d.toClaim.rd d.toClaim.imm zeroValidBinary bus pins
-      d.toInputs.h_addiw_subset providerTable providerRow h_component h_table_spec h_provider_row
+      h_addiw_subset providerTable providerRow h_component h_table_spec h_provider_row
       h_match h_input_r1_extract h_lane_rd promises
   have h_bridge : env.aeneasBridgeTrust := h_input_r1_extract
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
@@ -2572,7 +2589,7 @@ real BinaryExtension Spec row from the committed trace. -/
 theorem stepStrong_sllw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sllw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.sllw_input.PC) :
     execute_instruction (instruction.RTYPEW (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, ropw.SLLW)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨(busSub trace i (Pilot.execRowOf trace i)).exec_row,
@@ -2628,7 +2645,7 @@ theorem stepStrong_sllw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.sllw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -2657,7 +2674,7 @@ theorem stepStrong_sllw
       d.toInputs.h_input_r1 d.toInputs.h_input_r2 d.toInputs.h_input_rd d.toInputs.h_input_pc (by rfl) (by rfl)
       (by rfl) (Pilot.sequential_nextPC_discharged trace i d.toInputs.sllw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound) (by rfl) (by rfl) (by rfl) (by rfl) (by rfl)
+          d.toInputs.h_pc_bridge h_domain) (by rfl) (by rfl) (by rfl) (by rfl) (by rfl)
       (by rfl) (d.toInputs.h_input_rd.trans
         (busSub_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset))
       pins h_component h_table_spec h_provider_row h_match
@@ -2675,7 +2692,7 @@ theorem stepStrong_sllw
 theorem stepStrong_srlw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_srlw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.srlw_input.PC) :
     execute_instruction (instruction.RTYPEW (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, ropw.SRLW)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨(busSub trace i (Pilot.execRowOf trace i)).exec_row,
@@ -2731,7 +2748,7 @@ theorem stepStrong_srlw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.srlw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -2760,7 +2777,7 @@ theorem stepStrong_srlw
       d.toInputs.h_input_r1 d.toInputs.h_input_r2 d.toInputs.h_input_rd d.toInputs.h_input_pc (by rfl) (by rfl)
       (by rfl) (Pilot.sequential_nextPC_discharged trace i d.toInputs.srlw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound) (by rfl) (by rfl) (by rfl) (by rfl) (by rfl)
+          d.toInputs.h_pc_bridge h_domain) (by rfl) (by rfl) (by rfl) (by rfl) (by rfl)
       (by rfl) (d.toInputs.h_input_rd.trans
         (busSub_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset))
       pins h_component h_table_spec h_provider_row h_match
@@ -2778,7 +2795,7 @@ theorem stepStrong_srlw
 theorem stepStrong_sraw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sraw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.sraw_input.PC) :
     execute_instruction (instruction.RTYPEW (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, ropw.SRAW)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨(busSub trace i (Pilot.execRowOf trace i)).exec_row,
@@ -2835,7 +2852,7 @@ theorem stepStrong_sraw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.sraw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -2864,7 +2881,7 @@ theorem stepStrong_sraw
       d.toInputs.h_input_r1 d.toInputs.h_input_r2 d.toInputs.h_input_rd d.toInputs.h_input_pc (by rfl) (by rfl)
       (by rfl) (Pilot.sequential_nextPC_discharged trace i d.toInputs.sraw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound) (by rfl) (by rfl) (by rfl) (by rfl) (by rfl)
+          d.toInputs.h_pc_bridge h_domain) (by rfl) (by rfl) (by rfl) (by rfl) (by rfl)
       (by rfl) (d.toInputs.h_input_rd.trans
         (busSub_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset))
       pins h_component h_table_spec h_provider_row h_match
@@ -2882,7 +2899,7 @@ theorem stepStrong_sraw
 theorem stepStrong_slliw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_slliw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.slliw_input.PC) :
     execute_instruction
       (instruction.SHIFTIWOP (d.toClaim.slliw_input.shamt, d.toClaim.r1, d.toClaim.rd, sopw.SLLIW)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
@@ -2938,7 +2955,7 @@ theorem stepStrong_slliw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toClaim.slliw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -2977,7 +2994,7 @@ theorem stepStrong_slliw
 theorem stepStrong_srliw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_srliw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.srliw_input.PC) :
     execute_instruction
       (instruction.SHIFTIWOP (d.toClaim.srliw_input.shamt, d.toClaim.r1, d.toClaim.rd, sopw.SRLIW)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
@@ -3033,7 +3050,7 @@ theorem stepStrong_srliw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toClaim.srliw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -3072,7 +3089,7 @@ theorem stepStrong_srliw
 theorem stepStrong_sraiw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sraiw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.sraiw_input.PC) :
     execute_instruction
       (instruction.SHIFTIWOP (d.toClaim.sraiw_input.shamt, d.toClaim.r1, d.toClaim.rd, sopw.SRAIW)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
@@ -3129,7 +3146,7 @@ theorem stepStrong_sraiw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toClaim.sraiw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -3172,7 +3189,7 @@ theorem stepStrong_sraiw
 theorem stepStrong_add
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_add trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.add_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -3231,7 +3248,7 @@ theorem stepStrong_add
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.add_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -3323,7 +3340,7 @@ theorem stepStrong_add
 theorem stepStrong_addi
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_addi trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.addi_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -3382,7 +3399,7 @@ theorem stepStrong_addi
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.addi_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -3437,17 +3454,20 @@ theorem stepStrong_addi
         ZiskFv.EquivCore.Bridge.Binary.input_r1_packed_a_row
           m providerInput i.val (regidx_to_fin d.toClaim.r1) d.toInputs.addi_input.r1_val
           h_matches h_m32_zero d.toInputs.h_a_lo_t d.toInputs.h_a_hi_t h_match d.toInputs.h_input_r1
+    have h_addi_subset :=
+      itype_imm_subset_of_decode trace i d.toInputs.addi_input.imm d.toClaim.imm
+        d.toInputs.h_input_imm d.toDecode.h_b_src_imm d.toDecode.h_b_imm
     have h_input_imm_row :
         BitVec.signExtend 64 d.toInputs.addi_input.imm
           = ZiskFv.EquivCore.Add.binaryRowB64 providerInput := by
       simpa [ZiskFv.EquivCore.Add.binaryRowB64] using
         ZiskFv.EquivCore.Bridge.Binary.itype_imm_subset_binary_row_of_main_row
           m providerInput i.val d.toInputs.addi_input.imm h_matches h_m32_zero h_match
-          d.toInputs.h_addi_subset
+          h_addi_subset
     let env : OpEnvelope state m i.val :=
       OpEnvelope.addi_via_binary d.toInputs.addi_input d.toClaim.r1 d.toClaim.rd d.toClaim.imm bus pins
         providerTable providerRow h_component h_table_spec h_provider_row h_match
-        d.toInputs.h_addi_subset h_input_r1_row h_input_imm_row h_lane_rd promises
+        h_addi_subset h_input_r1_row h_input_imm_row h_lane_rd promises
     have h_bridge : env.aeneasBridgeTrust := by
       show _ ∧ _
       exact ⟨h_input_r1_row, h_input_imm_row⟩
@@ -3457,10 +3477,13 @@ theorem stepStrong_addi
     exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.1
   · obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
         h_component, h_table_spec, h_match⟩ := h_binaryadd
+    have h_addi_subset :=
+      itype_imm_subset_of_decode trace i d.toInputs.addi_input.imm d.toClaim.imm
+        d.toInputs.h_input_imm d.toDecode.h_b_src_imm d.toDecode.h_b_imm
     let env : OpEnvelope state m i.val :=
       OpEnvelope.addi_via_binaryadd d.toInputs.addi_input d.toClaim.r1 d.toClaim.rd d.toClaim.imm bus pins
         providerTable providerRow h_component h_table_spec h_provider_row h_match
-        h_add_subset d.toInputs.h_addi_subset d.toInputs.h_a_lo_t d.toInputs.h_a_hi_t h_m32_zero h_set_pc_zero
+        h_add_subset h_addi_subset d.toInputs.h_a_lo_t d.toInputs.h_a_hi_t h_m32_zero h_set_pc_zero
         h_lane_rd promises
     have h_bridge : env.aeneasBridgeTrust := by
       show _ ∧ _ ∧ _ ∧ _

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
@@ -25,6 +25,7 @@ import ZiskFv.Compliance.TraceLevelExport.RowDataAluShift
 import ZiskFv.Compliance.TraceLevelExport.RowDataArithMem
 import ZiskFv.Compliance.TraceLevelExport.RowDataControl
 import ZiskFv.Compliance.TraceLevelExport.EnvOf
+import ZiskFv.Compliance.TraceLevelExport.RomDecodeBinding
 import ZiskFv.Compliance.Pilot.JalrNextPC
 import ZiskFv.Compliance.Pilot.BranchNextPC
 import ZiskFv.EquivCore.Bridge.BranchFlag
@@ -47,6 +48,25 @@ open Interaction
 seal mulwArow mulhuArow divuArow divuwArow remuArow remuwArow
 
 set_option maxHeartbeats 8000000
+
+/-- `eRdLui` destination register index derived from `AddressSpec` and decode. -/
+theorem eRdLui_rd_idx_of_decode
+    {numInstructions : Nat}
+    {trace : AcceptedZiskTrace numInstructions}
+    {i : Fin trace.numInstructions}
+    {rd : regidx}
+    (h_store_ind : (mainRowWithRomLui trace i).rom.store_ind = 0)
+    (h_store_offset :
+      (mainRowWithRomLui trace i).rom.store_offset =
+        Transpiler.ind (regidx_to_fin rd)) :
+    regidx_to_fin rd =
+      Transpiler.wrap_to_regidx (eRdLui trace i).ptr := by
+  have h_spec := RomDecodeBinding.mainAddressSpec_at trace ⟨i.val, trace.mainTable_index i⟩
+  have h_addr2 := h_spec.2.2.1
+  rw [eRdLui, ZiskFv.AirsClean.Main.cMemMessage,
+    ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry]
+  rw [h_addr2, h_store_offset, h_store_ind]
+  simp [Transpiler.wrap_to_regidx_ind]
 
 /-! ## Strengthened control-flow + U-type arms (branches, JAL/JALR, LUI/AUIPC)
 
@@ -814,7 +834,8 @@ theorem stepStrong_lui
       rd_mult := by rfl
       rd_as := by rfl
       nextPC_eq := rfl
-      rd_idx := d.toInputs.h_rd_idx }
+      rd_idx := d.toInputs.h_input_rd.trans
+        (eRdLui_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset) }
   let env : OpEnvelope state m i.val :=
     OpEnvelope.lui d.toInputs.lui_input d.toClaim.imm d.toClaim.rd next_pc (Pilot.execRowOf trace i) e_rd store_pc_mem
       provenance row_mode h_lui_subset d.toDecode.h_imm_lo_nat d.toDecode.h_imm_hi_nat promises
@@ -912,7 +933,8 @@ theorem stepStrong_auipc
       rd_mult := by rfl
       rd_as := by rfl
       nextPC_eq := rfl
-      rd_idx := d.toInputs.h_rd_idx }
+      rd_idx := d.toInputs.h_input_rd.trans
+        (eRdLui_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset) }
   let env : OpEnvelope state m i.val :=
     OpEnvelope.auipc d.toInputs.auipc_input d.toClaim.imm d.toClaim.rd (Pilot.execRowOf trace i) e_rd
       (PureSpec.execute_AUIPC_pure d.toInputs.auipc_input).nextPC next_pc store_pc_mem
@@ -1051,7 +1073,8 @@ theorem stepStrong_jal
       rd_as := by rfl
       success := d.toInputs.h_success
       nextPC_option := d.toInputs.h_nextPC_option
-      rd_idx := d.toInputs.h_rd_idx }
+      rd_idx := d.toInputs.h_input_rd.trans
+        (eRdLui_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset) }
   let env : OpEnvelope state m i.val :=
     OpEnvelope.jal d.toInputs.jal_input d.toClaim.imm d.toClaim.rd d.toInputs.misa_val next_pc (Pilot.execRowOf trace i) e_rd
       d.toInputs.nextPC_val store_pc_mem provenance row_mode h_jal_subset d.toDecode.h_jmp2 d.toInputs.h_pc_bridge
@@ -1235,7 +1258,8 @@ theorem stepStrong_jalr
       rd_as := by rfl
       success := d.toInputs.h_success
       nextPC_option := d.toInputs.h_nextPC_option
-      rd_idx := d.toInputs.h_rd_idx }
+      rd_idx := d.toInputs.h_input_rd.trans
+        (eRdLui_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset) }
   let env : OpEnvelope state m i.val :=
     OpEnvelope.jalr d.toInputs.jalr_input d.toClaim.imm d.toClaim.rs1 d.toClaim.rd d.toInputs.misa_val d.toInputs.mseccfg (Pilot.execRowOf trace i) e_rd
       d.toInputs.nextPC_val next_pc store_pc_mem pins d.toDecode.h_flag d.toDecode.h_m32 d.toDecode.h_set_pc d.toDecode.h_store_pc

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
@@ -29,6 +29,8 @@ import ZiskFv.Compliance.TraceLevelExport.RomDecodeBinding
 import ZiskFv.Compliance.Pilot.JalrNextPC
 import ZiskFv.Compliance.Pilot.BranchNextPC
 import ZiskFv.EquivCore.Bridge.BranchFlag
+import ZiskFv.Field.GoldilocksBridge
+import ZiskFv.Bits.PackedBitVec.Signed
 
 namespace ZiskFv.Compliance
 
@@ -68,24 +70,223 @@ theorem eRdLui_rd_idx_of_decode
   rw [h_addr2, h_store_offset, h_store_ind]
   simp [Transpiler.wrap_to_regidx_ind]
 
+private theorem lane_lo_eq_natCast_of_toNat_lt_2_32
+    {r1_val : BitVec 64}
+    (h_r1_lt32 : r1_val.toNat < 4294967296) :
+    lane_lo r1_val = (r1_val.toNat : FGL) := by
+  apply Fin.ext
+  rw [Goldilocks.lane_lo_val, Fin.val_natCast]
+  have h_r1_lt_gl : r1_val.toNat < GL_prime := by omega
+  rw [Nat.mod_eq_of_lt h_r1_lt32, Nat.mod_eq_of_lt h_r1_lt_gl]
+
+private theorem bitvec64_toNat_lt_2_32_of_lane_hi_eq_zero
+    {r1_val : BitVec 64}
+    (h_hi : lane_hi r1_val = 0) :
+    r1_val.toNat < 4294967296 := by
+  have h_val : (lane_hi r1_val).val = 0 := by
+    rw [h_hi]
+    rfl
+  rw [Goldilocks.lane_hi_val_eq_div] at h_val
+  by_contra hnot
+  have h_ge : 4294967296 ≤ r1_val.toNat := Nat.le_of_not_gt hnot
+  have h_pos : 0 < r1_val.toNat / 4294967296 := Nat.div_pos h_ge (by norm_num)
+  omega
+
+private theorem store_a1_zero_of_decode
+    {numInstructions : Nat}
+    {trace : AcceptedZiskTrace numInstructions}
+    {i : Fin trace.numInstructions}
+    (h_store_ind : (mainRowWithRomSt trace i).rom.store_ind = 1) :
+    (mainRowWithRomSt trace i).core.a_1 = 0 := by
+  let row := mainRowWithRomSt trace i
+  have h_guard : (row.rom.store_ind + row.rom.b_src_ind) * row.core.a_1 = 0 :=
+    (RomDecodeBinding.mainRowWithRomSt_addressSpec trace i).2.2.2
+  obtain ⟨_, _, _, _, _, _, _, _, _, _, _, h_b_src_ind_bool, _, _, _⟩ :=
+    RomDecodeBinding.mainRow_flags_boolean trace ⟨i.val, trace.mainTable_index i⟩
+  have h_b_bool : row.rom.b_src_ind * (1 - row.rom.b_src_ind) = 0 := by
+    simpa [row, mainRowWithRomSt] using h_b_src_ind_bool
+  rcases mul_eq_zero.mp h_b_bool with hb0 | hb1
+  · have h := h_guard
+    rw [h_store_ind, hb0] at h
+    simpa [row] using h
+  · have hb_eq_one : row.rom.b_src_ind = 1 := (sub_eq_zero.mp hb1).symm
+    have h := h_guard
+    rw [h_store_ind, hb_eq_one] at h
+    exact (mul_eq_zero.mp h).resolve_left (by decide)
+
+private theorem add_carry_out_eq_offset_msb_of_store_bounds
+    {imm : BitVec 12}
+    {r1_val : BitVec 64}
+    (h_r1_lt32 : r1_val.toNat < 4294967296)
+    (h_addr_bound :
+      (r1_val + BitVec.signExtend 64 imm).toNat < ZiskPhysicalAddressSpaceSize) :
+    Goldilocks.add_carry_out r1_val (BitVec.signExtend 64 imm) =
+      (((BitVec.signExtend 64 imm).msb.toNat : Nat) : FGL) := by
+  set off := BitVec.signExtend 64 imm
+  have h_bound32 : (r1_val + off).toNat < 4294967296 := by
+    have h := h_addr_bound
+    norm_num at h
+    simpa [off] using h
+  unfold Goldilocks.add_carry_out
+  by_cases hmsb : off.msb = true
+  · have hcarry : r1_val.toNat + off.toNat ≥ 18446744073709551616 := by
+      by_contra hnot
+      have hsum_lt : r1_val.toNat + off.toNat < 18446744073709551616 :=
+        Nat.lt_of_not_ge hnot
+      have h_bv_sum : (r1_val + off).toNat = r1_val.toNat + off.toNat := by
+        rw [BitVec.toNat_add]
+        exact Nat.mod_eq_of_lt hsum_lt
+      have h_off_ge : 2 ^ 63 ≤ off.toNat :=
+        ZiskFv.PackedBitVec.Signed.bv_toNat_ge_of_msb_true off hmsb
+      omega
+    rw [if_pos hcarry, hmsb]
+    norm_num
+  · have hmsb_false : off.msb = false := by
+      cases h : off.msb <;> simp_all
+    have hcarry : ¬ r1_val.toNat + off.toNat ≥ 18446744073709551616 := by
+      have h_off_lt : off.toNat < 2 ^ 63 :=
+        ZiskFv.PackedBitVec.Signed.bv_toNat_lt_of_msb_false off hmsb_false
+      omega
+    rw [if_neg hcarry, hmsb_false]
+    norm_num
+
+private theorem intCast_toInt_eq_natCast_sub_msb
+    (off : BitVec 64) :
+    ((off.toInt : FGL) =
+      (off.toNat : FGL) - (((off.msb.toNat : Nat) : FGL) * (4294967296 * 4294967296))) := by
+  by_cases hmsb : off.msb = true
+  · rw [ZiskFv.PackedBitVec.Signed.bv_toInt_eq_toNat_sub_pow_of_msb_true off hmsb, hmsb]
+    push_cast
+    norm_num
+  · have hmsb_false : off.msb = false := by
+      cases h : off.msb <;> simp_all
+    rw [ZiskFv.PackedBitVec.Signed.bv_toInt_eq_toNat_of_msb_false off hmsb_false, hmsb_false]
+    simp
+
+private theorem signed_offset_add_lane_lo_eq_bv_toNat_field
+    {imm : BitVec 12}
+    {r1_val : BitVec 64}
+    (h_r1_lt32 : r1_val.toNat < 4294967296)
+    (h_addr_bound :
+      (r1_val + BitVec.signExtend 64 imm).toNat < ZiskPhysicalAddressSpaceSize) :
+    ((((BitVec.signExtend 64 imm).toInt : FGL) + lane_lo r1_val : FGL) =
+      ((r1_val + BitVec.signExtend 64 imm).toNat : FGL)) := by
+  set off := BitVec.signExtend 64 imm
+  have h_lane_lo : lane_lo r1_val = (r1_val.toNat : FGL) :=
+    lane_lo_eq_natCast_of_toNat_lt_2_32 h_r1_lt32
+  have h_int := intCast_toInt_eq_natCast_sub_msb off
+  have h_carry :
+      Goldilocks.add_carry_out r1_val off =
+        (((off.msb.toNat : Nat) : FGL)) := by
+    simpa [off] using add_carry_out_eq_offset_msb_of_store_bounds
+      (imm := imm) (r1_val := r1_val) h_r1_lt32 h_addr_bound
+  have h_add := Goldilocks.add_bv_toNat_eq_field_sum_minus_carry r1_val off
+  calc
+    (((off.toInt : FGL) + lane_lo r1_val : FGL))
+        = ((off.toNat : FGL) - (((off.msb.toNat : Nat) : FGL)
+            * (4294967296 * 4294967296))) + (r1_val.toNat : FGL) := by
+          rw [h_int, h_lane_lo]
+    _ = (r1_val.toNat : FGL) + (off.toNat : FGL)
+          - Goldilocks.add_carry_out r1_val off * (4294967296 * 4294967296) := by
+          rw [h_carry]
+          ring
+    _ = ((r1_val + off).toNat : FGL) := by
+          rw [h_add]
+
+/-- The store address arithmetic bridge reconstructed from decoded signed ROM offset,
+    source-lane values, accepted-trace high-lane guard, and the Sail bitvector
+    effective-address bound. -/
+theorem store_addr_arith_of_decode
+    {numInstructions : Nat}
+    {trace : AcceptedZiskTrace numInstructions}
+    {i : Fin trace.numInstructions}
+    {imm : BitVec 12}
+    {r1_val : BitVec 64}
+    (h_store_offset_imm :
+      (mainRowWithRomSt trace i).rom.store_offset =
+        ((BitVec.signExtend 64 imm).toInt : FGL))
+    (h_a0_value : (mainRowWithRomSt trace i).core.a_0 = lane_lo r1_val)
+    (h_a1_value : (mainRowWithRomSt trace i).core.a_1 = lane_hi r1_val)
+    (h_a1_zero : (mainRowWithRomSt trace i).core.a_1 = 0)
+    (h_addr_bound :
+      (r1_val + BitVec.signExtend 64 imm).toNat < ZiskPhysicalAddressSpaceSize) :
+    ((mainRowWithRomSt trace i).rom.store_offset
+        + (mainRowWithRomSt trace i).core.a_0).toNat =
+      (r1_val + BitVec.signExtend 64 imm).toNat := by
+  have h_lane_hi_zero : lane_hi r1_val = 0 := by
+    rw [← h_a1_value]
+    exact h_a1_zero
+  have h_r1_lt32 : r1_val.toNat < 4294967296 :=
+    bitvec64_toNat_lt_2_32_of_lane_hi_eq_zero h_lane_hi_zero
+  have h_field :=
+    signed_offset_add_lane_lo_eq_bv_toNat_field
+      (imm := imm) (r1_val := r1_val) h_r1_lt32 h_addr_bound
+  rw [h_store_offset_imm, h_a0_value]
+  change ((((BitVec.signExtend 64 imm).toInt : FGL) + lane_lo r1_val : FGL).val) =
+    (r1_val + BitVec.signExtend 64 imm).toNat
+  rw [h_field, Fin.val_natCast]
+  exact Nat.mod_eq_of_lt (by
+    have h_bound32 : (r1_val + BitVec.signExtend 64 imm).toNat < 4294967296 := by
+      have h := h_addr_bound
+      norm_num at h
+      exact h
+    omega)
+
 /-- Store `addr2` placement derived from `AddressSpec` and the decoded store selector.
 
-The remaining arithmetic premise is deliberately over the `AddressSpec` right-hand
-side, not over `addr2`: it is the residual Sail/field address representation bridge,
-while this theorem discharges the Main-row address-placement part. -/
+The arithmetic equality is reconstructed locally from decode, source-lane
+agreement, the accepted-trace high-lane guard, and the Sail bitvector address bound. -/
 theorem store_addr2_of_decode
     {numInstructions : Nat}
     {trace : AcceptedZiskTrace numInstructions}
     {i : Fin trace.numInstructions}
-    {target : Nat}
+    {imm : BitVec 12}
+    {r1_val : BitVec 64}
     (h_store_ind : (mainRowWithRomSt trace i).rom.store_ind = 1)
-    (h_store_addr_arith :
-      ((mainRowWithRomSt trace i).rom.store_offset
-        + (mainRowWithRomSt trace i).core.a_0).toNat = target) :
-    (mainRowWithRomSt trace i).rom.addr2.toNat = target := by
+    (h_store_offset_imm :
+      (mainRowWithRomSt trace i).rom.store_offset =
+        ((BitVec.signExtend 64 imm).toInt : FGL))
+    (h_a0_value : (mainRowWithRomSt trace i).core.a_0 = lane_lo r1_val)
+    (h_a1_value : (mainRowWithRomSt trace i).core.a_1 = lane_hi r1_val)
+    (h_addr_bound :
+      (r1_val + BitVec.signExtend 64 imm).toNat < ZiskPhysicalAddressSpaceSize) :
+    (mainRowWithRomSt trace i).rom.addr2.toNat =
+      (r1_val + BitVec.signExtend 64 imm).toNat := by
+  have h_a1_zero := store_a1_zero_of_decode h_store_ind
+  have h_store_addr_arith :=
+    store_addr_arith_of_decode h_store_offset_imm h_a0_value h_a1_value h_a1_zero
+      h_addr_bound
   have h_addr2 := (RomDecodeBinding.mainRowWithRomSt_addressSpec trace i).2.2.1
   rw [h_addr2, h_store_ind]
   simpa using h_store_addr_arith
+
+/-- JALR link-value bridge reconstructed from the PC bridge and decoded fallthrough offset. -/
+theorem jalr_link_bridge_of_decode
+    {numInstructions : Nat}
+    {trace : AcceptedZiskTrace numInstructions}
+    {i : Fin trace.numInstructions}
+    {pc : BitVec 64}
+    (h_pc_bridge :
+      ((mainOfTable trace.program trace.mainTable).pc i.val).val = pc.toNat)
+    (h_jmp2 : (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4)
+    (h_pc_bound : pc.toNat < GL_prime - 4) :
+    ((mainOfTable trace.program trace.mainTable).pc i.val
+        + (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val).val
+      = (pc + 4#64).toNat := by
+  rw [h_jmp2]
+  have h_bv_eq :=
+    Pilot.ofNat_fgl_pc_plus_4_eq
+      ((mainOfTable trace.program trace.mainTable).pc i.val) pc h_pc_bridge h_pc_bound
+  have h_toNat := congrArg BitVec.toNat h_bv_eq
+  have h_gl_lt64 : GL_prime < 2 ^ 64 := by
+    have h_lit := ZiskFv.PackedBitVec.WidePCNoWrap.GL_prime_lt_pow_64
+    have h_two64 : 2 ^ 64 = 18446744073709551616 := by norm_num
+    omega
+  have h_val_lt64 : (((mainOfTable trace.program trace.mainTable).pc i.val + 4 : FGL).val)
+      < 2 ^ 64 :=
+    Nat.lt_trans (Fin.isLt _) h_gl_lt64
+  rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt h_val_lt64] at h_toNat
+  exact h_toNat
 
 /-! ## Strengthened control-flow + U-type arms (branches, JAL/JALR, LUI/AUIPC)
 
@@ -412,7 +613,9 @@ theorem branch_flag_eq_provided
 theorem stepStrong_beq
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_beq trace binding i)
-    (_h_known : True) :
+    (h_domain :
+      BranchRangeDomain trace i d.toInputs.beq_input.PC
+        ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val)) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BEQ)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨Pilot.execRowOf trace i, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -446,19 +649,24 @@ theorem stepStrong_beq
             d.toDecode.h_main_active d.toDecode.h_main_op d.toDecode.h_m32
             d.toInputs.h_a_lo_t d.toInputs.h_a_hi_t d.toInputs.h_b_lo_t d.toInputs.h_b_hi_t
             d.toInputs.h_input_r1 d.toInputs.h_input_r2
+        have h_off_bridge :
+            (m.jmp_offset1 i.val).val =
+              (BitVec.signExtend 64 d.toInputs.beq_input.imm).toNat := by
+          simpa [hm, d.toInputs.h_input_imm] using d.toDecode.h_jmp_offset1_imm
         have h_cast := Pilot.branch_nextPC_flag1_taken trace i
           (d.toInputs.beq_input.r1_val == d.toInputs.beq_input.r2_val)
           d.toInputs.beq_input.PC (BitVec.signExtend 64 d.toInputs.beq_input.imm)
           d.toDecode.h_idx d.toDecode.h_set_pc h_flag d.toDecode.h_jmp_offset2
-          d.toInputs.h_off_bridge d.toInputs.h_pc_bridge d.toInputs.h_no_wrap
-          d.toInputs.h_pc_bound
+          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2
         show (register_type_pc_equiv ▸
             (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
           = (PureSpec.execute_BEQ_pure d.toInputs.beq_input).nextPC
         rw [h_cast]
         exact (PureSpec.execute_BEQ_pure_nextPC_of_success
           d.toInputs.beq_input d.toInputs.h_success).symm
-      not_throws := d.toInputs.h_not_throws
+      not_throws :=
+        PureSpec.execute_BEQ_pure_succ_throws
+          d.toInputs.beq_input d.toInputs.h_success
       success := d.toInputs.h_success }
   let env : OpEnvelope state m i.val := OpEnvelope.beq d.toInputs.beq_input ops promises
   have h_bridge : env.aeneasBridgeTrust :=
@@ -472,7 +680,9 @@ theorem stepStrong_beq
 theorem stepStrong_bne
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_bne trace binding i)
-    (_h_known : True) :
+    (h_domain :
+      BranchRangeDomain trace i d.toInputs.bne_input.PC
+        ((mainOfTable trace.program trace.mainTable).jmp_offset2 i.val)) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BNE)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨Pilot.execRowOf trace i, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -506,19 +716,24 @@ theorem stepStrong_bne
             d.toDecode.h_main_active d.toDecode.h_main_op d.toDecode.h_m32
             d.toInputs.h_a_lo_t d.toInputs.h_a_hi_t d.toInputs.h_b_lo_t d.toInputs.h_b_hi_t
             d.toInputs.h_input_r1 d.toInputs.h_input_r2
+        have h_off_bridge :
+            (m.jmp_offset2 i.val).val =
+              (BitVec.signExtend 64 d.toInputs.bne_input.imm).toNat := by
+          simpa [hm, d.toInputs.h_input_imm] using d.toDecode.h_jmp_offset2_imm
         have h_cast := Pilot.branch_nextPC_flag0_taken trace i
           (d.toInputs.bne_input.r1_val == d.toInputs.bne_input.r2_val)
           d.toInputs.bne_input.PC (BitVec.signExtend 64 d.toInputs.bne_input.imm)
           d.toDecode.h_idx d.toDecode.h_set_pc h_flag d.toDecode.h_jmp_offset1
-          d.toInputs.h_off_bridge d.toInputs.h_pc_bridge d.toInputs.h_no_wrap
-          d.toInputs.h_pc_bound
+          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2
         show (register_type_pc_equiv ▸
             (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
           = (PureSpec.execute_BNE_pure d.toInputs.bne_input).nextPC
         rw [h_cast]
         exact (PureSpec.execute_BNE_pure_nextPC_of_success
           d.toInputs.bne_input d.toInputs.h_success).symm
-      not_throws := d.toInputs.h_not_throws
+      not_throws :=
+        PureSpec.execute_BNE_pure_succ_throws
+          d.toInputs.bne_input d.toInputs.h_success
       success := d.toInputs.h_success }
   let env : OpEnvelope state m i.val := OpEnvelope.bne d.toInputs.bne_input ops promises
   have h_bridge : env.aeneasBridgeTrust :=
@@ -532,7 +747,9 @@ theorem stepStrong_bne
 theorem stepStrong_blt
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_blt trace binding i)
-    (_h_known : True) :
+    (h_domain :
+      BranchRangeDomain trace i d.toInputs.blt_input.PC
+        ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val)) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BLT)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨Pilot.execRowOf trace i, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -566,19 +783,24 @@ theorem stepStrong_blt
             d.toDecode.h_main_active d.toDecode.h_main_op d.toDecode.h_m32
             d.toInputs.h_a_lo_t d.toInputs.h_a_hi_t d.toInputs.h_b_lo_t d.toInputs.h_b_hi_t
             d.toInputs.h_input_r1 d.toInputs.h_input_r2
+        have h_off_bridge :
+            (m.jmp_offset1 i.val).val =
+              (BitVec.signExtend 64 d.toInputs.blt_input.imm).toNat := by
+          simpa [hm, d.toInputs.h_input_imm] using d.toDecode.h_jmp_offset1_imm
         have h_cast := Pilot.branch_nextPC_flag1_taken trace i
           (BitVec.slt d.toInputs.blt_input.r1_val d.toInputs.blt_input.r2_val)
           d.toInputs.blt_input.PC (BitVec.signExtend 64 d.toInputs.blt_input.imm)
           d.toDecode.h_idx d.toDecode.h_set_pc h_flag d.toDecode.h_jmp_offset2
-          d.toInputs.h_off_bridge d.toInputs.h_pc_bridge d.toInputs.h_no_wrap
-          d.toInputs.h_pc_bound
+          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2
         show (register_type_pc_equiv ▸
             (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
           = (PureSpec.execute_BLT_pure d.toInputs.blt_input).nextPC
         rw [h_cast]
         exact (PureSpec.execute_BLT_pure_nextPC_of_success
           d.toInputs.blt_input d.toInputs.h_success).symm
-      not_throws := d.toInputs.h_not_throws
+      not_throws :=
+        PureSpec.execute_BLT_pure_succ_throws
+          d.toInputs.blt_input d.toInputs.h_success
       success := d.toInputs.h_success }
   let env : OpEnvelope state m i.val := OpEnvelope.blt d.toInputs.blt_input ops promises
   have h_bridge : env.aeneasBridgeTrust :=
@@ -592,7 +814,9 @@ theorem stepStrong_blt
 theorem stepStrong_bge
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_bge trace binding i)
-    (_h_known : True) :
+    (h_domain :
+      BranchRangeDomain trace i d.toInputs.bge_input.PC
+        ((mainOfTable trace.program trace.mainTable).jmp_offset2 i.val)) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BGE)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨Pilot.execRowOf trace i, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -626,19 +850,24 @@ theorem stepStrong_bge
             d.toDecode.h_main_active d.toDecode.h_main_op d.toDecode.h_m32
             d.toInputs.h_a_lo_t d.toInputs.h_a_hi_t d.toInputs.h_b_lo_t d.toInputs.h_b_hi_t
             d.toInputs.h_input_r1 d.toInputs.h_input_r2
+        have h_off_bridge :
+            (m.jmp_offset2 i.val).val =
+              (BitVec.signExtend 64 d.toInputs.bge_input.imm).toNat := by
+          simpa [hm, d.toInputs.h_input_imm] using d.toDecode.h_jmp_offset2_imm
         have h_cast := Pilot.branch_nextPC_flag0_taken trace i
           (BitVec.slt d.toInputs.bge_input.r1_val d.toInputs.bge_input.r2_val)
           d.toInputs.bge_input.PC (BitVec.signExtend 64 d.toInputs.bge_input.imm)
           d.toDecode.h_idx d.toDecode.h_set_pc h_flag d.toDecode.h_jmp_offset1
-          d.toInputs.h_off_bridge d.toInputs.h_pc_bridge d.toInputs.h_no_wrap
-          d.toInputs.h_pc_bound
+          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2
         show (register_type_pc_equiv ▸
             (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
           = (PureSpec.execute_BGE_pure d.toInputs.bge_input).nextPC
         rw [h_cast]
         exact (PureSpec.execute_BGE_pure_nextPC_of_success
           d.toInputs.bge_input d.toInputs.h_success).symm
-      not_throws := d.toInputs.h_not_throws
+      not_throws :=
+        PureSpec.execute_BGE_pure_succ_throws
+          d.toInputs.bge_input d.toInputs.h_success
       success := d.toInputs.h_success }
   let env : OpEnvelope state m i.val := OpEnvelope.bge d.toInputs.bge_input ops promises
   have h_bridge : env.aeneasBridgeTrust :=
@@ -652,7 +881,9 @@ theorem stepStrong_bge
 theorem stepStrong_bltu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_bltu trace binding i)
-    (_h_known : True) :
+    (h_domain :
+      BranchRangeDomain trace i d.toInputs.bltu_input.PC
+        ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val)) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BLTU)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨Pilot.execRowOf trace i, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -689,19 +920,24 @@ theorem stepStrong_bltu
             d.toDecode.h_main_active d.toDecode.h_main_op d.toDecode.h_m32
             d.toInputs.h_a_lo_t d.toInputs.h_a_hi_t d.toInputs.h_b_lo_t d.toInputs.h_b_hi_t
             d.toInputs.h_input_r1 d.toInputs.h_input_r2
+        have h_off_bridge :
+            (m.jmp_offset1 i.val).val =
+              (BitVec.signExtend 64 d.toInputs.bltu_input.imm).toNat := by
+          simpa [hm, d.toInputs.h_input_imm] using d.toDecode.h_jmp_offset1_imm
         have h_cast := Pilot.branch_nextPC_flag1_taken trace i
           (BitVec.ult d.toInputs.bltu_input.r1_val d.toInputs.bltu_input.r2_val)
           d.toInputs.bltu_input.PC (BitVec.signExtend 64 d.toInputs.bltu_input.imm)
           d.toDecode.h_idx d.toDecode.h_set_pc h_flag d.toDecode.h_jmp_offset2
-          d.toInputs.h_off_bridge d.toInputs.h_pc_bridge d.toInputs.h_no_wrap
-          d.toInputs.h_pc_bound
+          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2
         show (register_type_pc_equiv ▸
             (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
           = (PureSpec.execute_BLTU_pure d.toInputs.bltu_input).nextPC
         rw [h_cast]
         exact (PureSpec.execute_BLTU_pure_nextPC_of_success
           d.toInputs.bltu_input d.toInputs.h_success).symm
-      not_throws := d.toInputs.h_not_throws
+      not_throws :=
+        PureSpec.execute_BLTU_pure_succ_throws
+          d.toInputs.bltu_input d.toInputs.h_success
       success := d.toInputs.h_success }
   let env : OpEnvelope state m i.val := OpEnvelope.bltu d.toInputs.bltu_input ops promises
   have h_bridge : env.aeneasBridgeTrust :=
@@ -715,7 +951,9 @@ theorem stepStrong_bltu
 theorem stepStrong_bgeu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_bgeu trace binding i)
-    (_h_known : True) :
+    (h_domain :
+      BranchRangeDomain trace i d.toInputs.bgeu_input.PC
+        ((mainOfTable trace.program trace.mainTable).jmp_offset2 i.val)) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BGEU)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨Pilot.execRowOf trace i, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -752,19 +990,24 @@ theorem stepStrong_bgeu
             d.toDecode.h_main_active d.toDecode.h_main_op d.toDecode.h_m32
             d.toInputs.h_a_lo_t d.toInputs.h_a_hi_t d.toInputs.h_b_lo_t d.toInputs.h_b_hi_t
             d.toInputs.h_input_r1 d.toInputs.h_input_r2
+        have h_off_bridge :
+            (m.jmp_offset2 i.val).val =
+              (BitVec.signExtend 64 d.toInputs.bgeu_input.imm).toNat := by
+          simpa [hm, d.toInputs.h_input_imm] using d.toDecode.h_jmp_offset2_imm
         have h_cast := Pilot.branch_nextPC_flag0_taken trace i
           (BitVec.ult d.toInputs.bgeu_input.r1_val d.toInputs.bgeu_input.r2_val)
           d.toInputs.bgeu_input.PC (BitVec.signExtend 64 d.toInputs.bgeu_input.imm)
           d.toDecode.h_idx d.toDecode.h_set_pc h_flag d.toDecode.h_jmp_offset1
-          d.toInputs.h_off_bridge d.toInputs.h_pc_bridge d.toInputs.h_no_wrap
-          d.toInputs.h_pc_bound
+          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2
         show (register_type_pc_equiv ▸
             (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
           = (PureSpec.execute_BGEU_pure d.toInputs.bgeu_input).nextPC
         rw [h_cast]
         exact (PureSpec.execute_BGEU_pure_nextPC_of_success
           d.toInputs.bgeu_input d.toInputs.h_success).symm
-      not_throws := d.toInputs.h_not_throws
+      not_throws :=
+        PureSpec.execute_BGEU_pure_succ_throws
+          d.toInputs.bgeu_input d.toInputs.h_success
       success := d.toInputs.h_success }
   let env : OpEnvelope state m i.val := OpEnvelope.bgeu d.toInputs.bgeu_input ops promises
   have h_bridge : env.aeneasBridgeTrust :=
@@ -789,7 +1032,7 @@ theorem stepStrong_bgeu
 theorem stepStrong_lui
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lui trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.lui_input.PC) :
     execute_instruction (instruction.UTYPE (d.toClaim.imm, d.toClaim.rd, uop.LUI)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨Pilot.execRowOf trace i, [eRdLui trace i]⟩ (binding i) := by
@@ -849,7 +1092,7 @@ theorem stepStrong_lui
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       rd_mult := by rfl
       rd_as := by rfl
       nextPC_eq := rfl
@@ -878,7 +1121,7 @@ theorem stepStrong_lui
 theorem stepStrong_auipc
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_auipc trace binding i)
-    (_h_known : True) :
+    (h_domain : AuipcRangeDomain d.toInputs.auipc_input) :
     execute_instruction (instruction.UTYPE (d.toClaim.imm, d.toClaim.rd, uop.AUIPC)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨Pilot.execRowOf trace i, [eRdLui trace i]⟩ (binding i) := by
@@ -918,6 +1161,10 @@ theorem stepStrong_auipc
       (by simpa [ZiskFv.Compliance.boolF] using d.toDecode.h_store_pc)
   let row_mode : ZiskFv.Compliance.MainRowProvenance.AuipcRowMode provenance :=
     { op_eq := rfl, internal_eq := rfl, m32_eq := rfl, set_pc_eq := rfl, store_pc_eq := rfl }
+  have h_offset_bridge :
+      (m.jmp_offset2 i.val).val =
+        (BitVec.signExtend 64 (d.toInputs.auipc_input.imm ++ (0 : BitVec 12))).toNat := by
+    simpa [hm, d.toInputs.h_input_imm] using d.toDecode.h_jmp_offset2_imm
   have h_row_core :
       (mainRowWithRomLui trace i).core =
         ZiskFv.AirsClean.Main.rowAt m i.val := by
@@ -948,7 +1195,7 @@ theorem stepStrong_auipc
           d.toDecode.h_idx d.toDecode.h_set_pc h_flag
         rw [hstep, d.toDecode.h_jmp1]
         exact Pilot.ofNat_fgl_pc_plus_4_eq _ d.toInputs.auipc_input.PC
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain.h_pc_bound
       rd_mult := by rfl
       rd_as := by rfl
       nextPC_eq := rfl
@@ -957,10 +1204,10 @@ theorem stepStrong_auipc
   let env : OpEnvelope state m i.val :=
     OpEnvelope.auipc d.toInputs.auipc_input d.toClaim.imm d.toClaim.rd (Pilot.execRowOf trace i) e_rd
       (PureSpec.execute_AUIPC_pure d.toInputs.auipc_input).nextPC next_pc store_pc_mem
-      provenance row_mode h_auipc_subset d.toInputs.h_offset_bridge d.toInputs.h_pc_bridge promises
-      d.toInputs.h_no_wrap d.toInputs.h_pc_offset_lt_2_32
+      provenance row_mode h_auipc_subset h_offset_bridge d.toInputs.h_pc_bridge promises
+      h_domain.h_no_wrap h_domain.h_pc_offset_lt_2_32
   have h_bridge : env.aeneasBridgeTrust :=
-    ⟨⟨provenance⟩, row_mode, d.toInputs.h_offset_bridge, d.toInputs.h_pc_bridge⟩
+    ⟨⟨provenance⟩, row_mode, h_offset_bridge, d.toInputs.h_pc_bridge⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
     noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
@@ -979,7 +1226,7 @@ theorem stepStrong_auipc
 theorem stepStrong_jal
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_jal trace binding i)
-    (_h_known : True) :
+    (h_domain : JalRangeDomain d.toInputs.jal_input) :
     execute_instruction (instruction.JAL (d.toClaim.imm, d.toClaim.rd)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨Pilot.execRowOf trace i, [eRdLui trace i]⟩ (binding i) := by
@@ -997,41 +1244,25 @@ theorem stepStrong_jal
   have h_flag : m.flag i.val = 1 :=
     ZiskFv.Airs.Main.flag_eq_one_of_internal_op_zero m i.val d.toDecode.h_main_active
       (by simpa [ZiskFv.Trusted.OP_FLAG] using d.toDecode.h_main_op) h_set_flag
-  -- #100: the JAL jump target `nextPC_val = PC + signExtend 64 imm`, derived
-  -- from `success = true` (both alignment bits valid ⇒ the taken branch).
-  have h_target :
-      d.toInputs.jal_input.PC + BitVec.signExtend 64 d.toInputs.jal_input.imm
-        = d.toInputs.nextPC_val := by
-    have h_bit0_neg :
-        (!BitVec.ofBool
-            (d.toInputs.jal_input.PC + BitVec.signExtend 64 d.toInputs.jal_input.imm)[0]! == 0#1)
-          = false := by
-      have h_t : (PureSpec.execute_JAL_pure d.toInputs.jal_input).throws = false :=
-        d.toInputs.h_not_throws
-      simp only [PureSpec.execute_JAL_pure] at h_t
-      exact h_t
-    have h_bit1_neg :
-        (!BitVec.ofBool
-            (d.toInputs.jal_input.PC + BitVec.signExtend 64 d.toInputs.jal_input.imm)[1]! == 0#1)
-          = false := by
-      have h_s : (PureSpec.execute_JAL_pure d.toInputs.jal_input).success = true :=
-        d.toInputs.h_success
-      simp only [PureSpec.execute_JAL_pure] at h_s
-      simp_all
-    have ho := d.toInputs.h_nextPC_option
-    simp only [PureSpec.execute_JAL_pure, h_bit0_neg, h_bit1_neg, Bool.false_or] at ho
-    rw [if_neg (by decide)] at ho
-    exact Option.some.inj ho
+  let nextPC_val : BitVec 64 :=
+    d.toInputs.jal_input.PC + BitVec.signExtend 64 d.toInputs.jal_input.imm
+  have h_nextPC_option :
+      (PureSpec.execute_JAL_pure d.toInputs.jal_input).nextPC = .some nextPC_val :=
+    PureSpec.execute_JAL_pure_succ_nextPC d.toInputs.jal_input d.toInputs.h_success
   -- #100: the field-level no-wrap bound (`pc.val + jmp_offset1.val < GL_prime`),
   -- in column form for `ofNat_fgl_pc_plus_offset_eq`, from the input-facing
   -- target bound via the PC / offset row-shape bridges.
+  have h_offset_bridge :
+      (m.jmp_offset1 i.val).val =
+        (BitVec.signExtend 64 d.toInputs.jal_input.imm).toNat := by
+    simpa [hm, d.toInputs.h_input_imm] using d.toDecode.h_jmp_offset1_imm
   have h_no_wrap_fgl :
       ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
         + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
             i.val).val
         < GL_prime := by
-    rw [d.toInputs.h_pc_bridge, d.toInputs.h_offset_bridge]
-    exact d.toInputs.h_no_fgl_wrap
+    rw [d.toInputs.h_pc_bridge, h_offset_bridge]
+    exact h_domain.h_no_fgl_wrap
   let next_pc : FGL :=
     m.set_pc i.val * (m.c_0 i.val + m.jmp_offset1 i.val)
       + (1 - m.set_pc i.val) * (m.pc i.val + m.jmp_offset2 i.val)
@@ -1068,7 +1299,7 @@ theorem stepStrong_jal
       state d.toInputs.jal_input.PC d.toInputs.jal_input.rd d.toInputs.misa_val
       (PureSpec.execute_JAL_pure d.toInputs.jal_input).success
       (PureSpec.execute_JAL_pure d.toInputs.jal_input).nextPC
-      d.toClaim.rd (Pilot.execRowOf trace i) e_rd d.toInputs.nextPC_val :=
+      d.toClaim.rd (Pilot.execRowOf trace i) e_rd nextPC_val :=
     { input_rd_eq := d.toInputs.h_input_rd
       input_pc_eq := d.toInputs.h_input_pc
       input_misa_eq := d.toInputs.h_input_misa
@@ -1080,24 +1311,28 @@ theorem stepStrong_jal
       -- certificate via the FLAG-PATH lemma (set_pc=0, flag=1 ⇒ pc + jmp_offset1),
       -- then the signed-offset wide-PC cast (`jmp_offset1 = signExtend imm` +
       -- target no-wrap) gives JAL's taken target `PC + signExtend 64 imm`,
-      -- which `h_target` identifies with `nextPC_val`.
+      -- with `nextPC_val` chosen as that computed target.
       nextPC_matches := by
         have hstep := Pilot.flag_path_nextPC_discharged trace i
           d.toDecode.h_idx d.toDecode.h_set_pc h_flag
         rw [hstep]
-        exact (Pilot.ofNat_fgl_pc_plus_offset_eq _ _
+        simpa [nextPC_val] using (Pilot.ofNat_fgl_pc_plus_offset_eq _ _
           d.toInputs.jal_input.PC (BitVec.signExtend 64 d.toInputs.jal_input.imm)
-          d.toInputs.h_pc_bridge d.toInputs.h_offset_bridge h_no_wrap_fgl).trans h_target
+          d.toInputs.h_pc_bridge h_offset_bridge h_no_wrap_fgl)
       rd_mult := by rfl
       rd_as := by rfl
       success := d.toInputs.h_success
-      nextPC_option := d.toInputs.h_nextPC_option
+      nextPC_option := h_nextPC_option
       rd_idx := d.toInputs.h_input_rd.trans
         (eRdLui_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset) }
+  have h_not_throws : (PureSpec.execute_JAL_pure d.toInputs.jal_input).throws = false :=
+    PureSpec.execute_JAL_pure_succ_throws
+      d.toInputs.jal_input d.toInputs.h_success
   let env : OpEnvelope state m i.val :=
     OpEnvelope.jal d.toInputs.jal_input d.toClaim.imm d.toClaim.rd d.toInputs.misa_val next_pc (Pilot.execRowOf trace i) e_rd
-      d.toInputs.nextPC_val store_pc_mem provenance row_mode h_jal_subset d.toDecode.h_jmp2 d.toInputs.h_pc_bridge
-      promises d.toInputs.h_input_imm d.toInputs.h_not_throws d.toInputs.h_pc_bound d.toInputs.h_pc_offset_lt_2_32
+      nextPC_val store_pc_mem provenance row_mode h_jal_subset d.toDecode.h_jmp2 d.toInputs.h_pc_bridge
+      promises d.toInputs.h_input_imm h_not_throws h_domain.h_pc_bound
+      h_domain.h_pc_offset_lt_2_32
   have h_bridge : env.aeneasBridgeTrust :=
     ⟨⟨provenance⟩, row_mode, d.toDecode.h_jmp2, d.toInputs.h_pc_bridge⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
@@ -1117,7 +1352,7 @@ theorem stepStrong_jal
 theorem stepStrong_jalr
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_jalr trace binding i)
-    (_h_known : True) :
+    (h_domain : JalrRangeDomain d.toInputs.jalr_input) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.JALR (d.toClaim.imm, d.toClaim.rs1, d.toClaim.rd))) (binding i)
@@ -1224,20 +1459,12 @@ theorem stepStrong_jalr
   obtain ⟨hc0, hc1, hc2, hc3, hc4, hc5, hc6, hc7⟩ :=
     ZiskFv.EquivCore.Bridge.Binary.cByte_ranges_of_all_byte_matches_row
       providerInput h_matches
-  -- (d) JALR's pre-mask target value `nextPC_val = mask &&& (rs1 + signExtend imm)`,
-  --     identified from `success = true` (the aligned/taken branch), as JAL does.
-  have h_target : d.toInputs.nextPC_val
-      = 0xFFFFFFFFFFFFFFFE#64 &&&
-          (d.toInputs.jalr_input.rs1_val + BitVec.signExtend 64 d.toInputs.jalr_input.imm) := by
-    have h_s : (BitVec.ofBool
-          (d.toInputs.jalr_input.rs1_val
-            + BitVec.signExtend 64 d.toInputs.jalr_input.imm)[1]! == 0#1) = true := by
-      have := d.toInputs.h_success
-      simpa [PureSpec.execute_JALR_pure] using this
-    have ho := d.toInputs.h_nextPC_option
-    simp only [PureSpec.execute_JALR_pure, h_s, Bool.not_true, Bool.false_eq_true,
-      if_false] at ho
-    exact (Option.some.inj ho).symm
+  let nextPC_val : BitVec 64 :=
+    0xFFFFFFFFFFFFFFFE &&&
+      (d.toInputs.jalr_input.rs1_val + BitVec.signExtend 64 d.toInputs.jalr_input.imm)
+  have h_nextPC_option :
+      (PureSpec.execute_JALR_pure d.toInputs.jalr_input).nextPC = .some nextPC_val :=
+    PureSpec.execute_JALR_pure_succ_nextPC d.toInputs.jalr_input d.toInputs.h_success
   -- (e) #100: the cross-world next-PC residual is DISCHARGED from the accepted
   --     trace's in-circuit set-PC handshake composed with the masked-AND
   --     target-value derivation (`jalr_setpc_nextPC_discharged`), then bridged to
@@ -1246,7 +1473,7 @@ theorem stepStrong_jalr
   have h_nextPC_disch :
       (register_type_pc_equiv ▸
           (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
-        = d.toInputs.nextPC_val := by
+        = nextPC_val := by
     have hoo := d.toInputs.h_operand_offset
     rw [← hm] at hoo
     rw [ZiskFv.Compliance.Pilot.jalr_setpc_nextPC_discharged
@@ -1258,12 +1485,13 @@ theorem stepStrong_jalr
           hc0 hc1 hc2 hc3 hc4 hc5 hc6 hc7
           d.toDecode.h_c1_zero d.toDecode.h_offset_bridge
           d.toDecode.h_offset_even d.toDecode.h_no_fgl_wrap,
-        hoo, h_target]
+        hoo]
+    simp [nextPC_val]
   let promises : ZiskFv.EquivCore.Promises.JumpPromises
       state d.toInputs.jalr_input.PC d.toInputs.jalr_input.rd d.toInputs.misa_val
       (PureSpec.execute_JALR_pure d.toInputs.jalr_input).success
       (PureSpec.execute_JALR_pure d.toInputs.jalr_input).nextPC
-      d.toClaim.rd (Pilot.execRowOf trace i) e_rd d.toInputs.nextPC_val :=
+      d.toClaim.rd (Pilot.execRowOf trace i) e_rd nextPC_val :=
     { input_rd_eq := d.toInputs.h_input_rd
       input_pc_eq := d.toInputs.h_input_pc
       input_misa_eq := d.toInputs.h_input_misa
@@ -1276,16 +1504,18 @@ theorem stepStrong_jalr
       rd_mult := by rfl
       rd_as := by rfl
       success := d.toInputs.h_success
-      nextPC_option := d.toInputs.h_nextPC_option
+      nextPC_option := h_nextPC_option
       rd_idx := d.toInputs.h_input_rd.trans
         (eRdLui_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset) }
+  have h_link_bridge :=
+    jalr_link_bridge_of_decode d.toInputs.h_pc_bridge d.toDecode.h_jmp2 h_domain.h_pc_bound
   let env : OpEnvelope state m i.val :=
     OpEnvelope.jalr d.toInputs.jalr_input d.toClaim.imm d.toClaim.rs1 d.toClaim.rd d.toInputs.misa_val d.toInputs.mseccfg (Pilot.execRowOf trace i) e_rd
-      d.toInputs.nextPC_val next_pc store_pc_mem pins d.toDecode.h_flag d.toDecode.h_m32 d.toDecode.h_set_pc d.toDecode.h_store_pc
+      nextPC_val next_pc store_pc_mem pins d.toDecode.h_flag d.toDecode.h_m32 d.toDecode.h_set_pc d.toDecode.h_store_pc
       h_jalr_subset promises d.toInputs.h_input_imm d.toInputs.h_input_rs1 d.toInputs.h_cur_privilege d.toInputs.h_mseccfg
-      d.toInputs.h_link_bridge d.toInputs.h_pc_bound d.toInputs.h_pc_offset_lt_2_32
+      h_link_bridge h_domain.h_pc_bound h_domain.h_pc_offset_lt_2_32
   have h_bridge : env.aeneasBridgeTrust :=
-    ⟨d.toDecode.h_flag, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc, d.toInputs.h_link_bridge⟩
+    ⟨d.toDecode.h_flag, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc, h_link_bridge⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
     noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
@@ -1326,7 +1556,7 @@ private def emptyMainEnv : Environment FGL :=
 theorem stepStrong_sb
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sb trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.sb_input.PC) :
     execute_instruction (instruction.STORE
         (d.toClaim.sb_input.imm, regidx.Regidx d.toClaim.sb_input.r2, regidx.Regidx d.toClaim.sb_input.r1, 1))
         (binding i)
@@ -1367,7 +1597,7 @@ theorem stepStrong_sb
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -1382,8 +1612,21 @@ theorem stepStrong_sb
       (by simpa only [eval_mainConstVar] using h_core_store_pc)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
       (by
+        have h_a0_value :
+            (mainRowWithRomSt trace i).core.a_0 = lane_lo d.toClaim.sb_input.r1_val := by
+          rw [h_core]
+          simpa [ZiskFv.AirsClean.Main.rowAt] using d.toInputs.h_a0_value
+        have h_a1_value :
+            (mainRowWithRomSt trace i).core.a_1 = lane_hi d.toClaim.sb_input.r1_val := by
+          rw [h_core]
+          simpa [ZiskFv.AirsClean.Main.rowAt] using d.toInputs.h_a1_value
+        have h_addr_bound :
+            (d.toClaim.sb_input.r1_val + BitVec.signExtend 64 d.toClaim.sb_input.imm).toNat
+              < ZiskPhysicalAddressSpaceSize :=
+          d.toInputs.h_opcode_assumptions.2.2.2.1
         simpa only [eval_mainConstVar] using
-          store_addr2_of_decode d.toDecode.h_store_ind d.toInputs.h_store_addr_arith)
+          store_addr2_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset_imm
+            h_a0_value h_a1_value h_addr_bound)
       h_b0' h_b1' d.toInputs.h_m1 d.toInputs.h_m2 d.toInputs.h_m3 d.toInputs.h_m4 d.toInputs.h_m5 d.toInputs.h_m6 d.toInputs.h_m7
   have h_bridge : env.aeneasBridgeTrust := ⟨d.toDecode.h_main_ind_width, h_b0', h_b1'⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
@@ -1394,7 +1637,7 @@ theorem stepStrong_sb
 theorem stepStrong_sh
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sh trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.sh_input.PC) :
     execute_instruction (instruction.STORE
         (d.toClaim.sh_input.imm, regidx.Regidx d.toClaim.sh_input.r2, regidx.Regidx d.toClaim.sh_input.r1, 2))
         (binding i)
@@ -1435,7 +1678,7 @@ theorem stepStrong_sh
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -1450,8 +1693,21 @@ theorem stepStrong_sh
       (by simpa only [eval_mainConstVar] using h_core_store_pc)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
       (by
+        have h_a0_value :
+            (mainRowWithRomSt trace i).core.a_0 = lane_lo d.toClaim.sh_input.r1_val := by
+          rw [h_core]
+          simpa [ZiskFv.AirsClean.Main.rowAt] using d.toInputs.h_a0_value
+        have h_a1_value :
+            (mainRowWithRomSt trace i).core.a_1 = lane_hi d.toClaim.sh_input.r1_val := by
+          rw [h_core]
+          simpa [ZiskFv.AirsClean.Main.rowAt] using d.toInputs.h_a1_value
+        have h_addr_bound :
+            (d.toClaim.sh_input.r1_val + BitVec.signExtend 64 d.toClaim.sh_input.imm).toNat
+              < ZiskPhysicalAddressSpaceSize :=
+          d.toInputs.h_opcode_assumptions.2.2.2.1
         simpa only [eval_mainConstVar] using
-          store_addr2_of_decode d.toDecode.h_store_ind d.toInputs.h_store_addr_arith)
+          store_addr2_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset_imm
+            h_a0_value h_a1_value h_addr_bound)
       h_b0' h_b1' d.toInputs.h_m2 d.toInputs.h_m3 d.toInputs.h_m4 d.toInputs.h_m5 d.toInputs.h_m6 d.toInputs.h_m7
   have h_bridge : env.aeneasBridgeTrust := ⟨d.toDecode.h_main_ind_width, h_b0', h_b1'⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
@@ -1462,7 +1718,7 @@ theorem stepStrong_sh
 theorem stepStrong_sw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.sw_input.PC) :
     execute_instruction (instruction.STORE
         (d.toClaim.sw_input.imm, regidx.Regidx d.toClaim.sw_input.r2, regidx.Regidx d.toClaim.sw_input.r1, 4))
         (binding i)
@@ -1503,7 +1759,7 @@ theorem stepStrong_sw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -1518,8 +1774,21 @@ theorem stepStrong_sw
       (by simpa only [eval_mainConstVar] using h_core_store_pc)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
       (by
+        have h_a0_value :
+            (mainRowWithRomSt trace i).core.a_0 = lane_lo d.toClaim.sw_input.r1_val := by
+          rw [h_core]
+          simpa [ZiskFv.AirsClean.Main.rowAt] using d.toInputs.h_a0_value
+        have h_a1_value :
+            (mainRowWithRomSt trace i).core.a_1 = lane_hi d.toClaim.sw_input.r1_val := by
+          rw [h_core]
+          simpa [ZiskFv.AirsClean.Main.rowAt] using d.toInputs.h_a1_value
+        have h_addr_bound :
+            (d.toClaim.sw_input.r1_val + BitVec.signExtend 64 d.toClaim.sw_input.imm).toNat
+              < ZiskPhysicalAddressSpaceSize :=
+          d.toInputs.h_opcode_assumptions.2.2.2.1
         simpa only [eval_mainConstVar] using
-          store_addr2_of_decode d.toDecode.h_store_ind d.toInputs.h_store_addr_arith)
+          store_addr2_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset_imm
+            h_a0_value h_a1_value h_addr_bound)
       h_b0' h_b1' d.toInputs.h_m4 d.toInputs.h_m5 d.toInputs.h_m6 d.toInputs.h_m7
   have h_bridge : env.aeneasBridgeTrust := ⟨d.toDecode.h_main_ind_width, h_b0', h_b1'⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
@@ -1530,7 +1799,7 @@ theorem stepStrong_sw
 theorem stepStrong_sd
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sd trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.sd_input.PC) :
     execute_instruction (instruction.STORE
         (d.toClaim.sd_input.imm, regidx.Regidx d.toClaim.sd_input.r2, regidx.Regidx d.toClaim.sd_input.r1, 8))
         (binding i)
@@ -1571,7 +1840,7 @@ theorem stepStrong_sd
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -1586,8 +1855,21 @@ theorem stepStrong_sd
       (by simpa only [eval_mainConstVar] using h_core_store_pc)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
       (by
+        have h_a0_value :
+            (mainRowWithRomSt trace i).core.a_0 = lane_lo d.toClaim.sd_input.r1_val := by
+          rw [h_core]
+          simpa [ZiskFv.AirsClean.Main.rowAt] using d.toInputs.h_a0_value
+        have h_a1_value :
+            (mainRowWithRomSt trace i).core.a_1 = lane_hi d.toClaim.sd_input.r1_val := by
+          rw [h_core]
+          simpa [ZiskFv.AirsClean.Main.rowAt] using d.toInputs.h_a1_value
+        have h_addr_bound :
+            (d.toClaim.sd_input.r1_val + BitVec.signExtend 64 d.toClaim.sd_input.imm).toNat
+              < ZiskPhysicalAddressSpaceSize :=
+          d.toInputs.h_opcode_assumptions.2.2.2.1
         simpa only [eval_mainConstVar] using
-          store_addr2_of_decode d.toDecode.h_store_ind d.toInputs.h_store_addr_arith)
+          store_addr2_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset_imm
+            h_a0_value h_a1_value h_addr_bound)
       h_b0' h_b1'
   have h_bridge : env.aeneasBridgeTrust := ⟨h_b0', h_b1'⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
@@ -68,6 +68,25 @@ theorem eRdLui_rd_idx_of_decode
   rw [h_addr2, h_store_offset, h_store_ind]
   simp [Transpiler.wrap_to_regidx_ind]
 
+/-- Store `addr2` placement derived from `AddressSpec` and the decoded store selector.
+
+The remaining arithmetic premise is deliberately over the `AddressSpec` right-hand
+side, not over `addr2`: it is the residual Sail/field address representation bridge,
+while this theorem discharges the Main-row address-placement part. -/
+theorem store_addr2_of_decode
+    {numInstructions : Nat}
+    {trace : AcceptedZiskTrace numInstructions}
+    {i : Fin trace.numInstructions}
+    {target : Nat}
+    (h_store_ind : (mainRowWithRomSt trace i).rom.store_ind = 1)
+    (h_store_addr_arith :
+      ((mainRowWithRomSt trace i).rom.store_offset
+        + (mainRowWithRomSt trace i).core.a_0).toNat = target) :
+    (mainRowWithRomSt trace i).rom.addr2.toNat = target := by
+  have h_addr2 := (RomDecodeBinding.mainRowWithRomSt_addressSpec trace i).2.2.1
+  rw [h_addr2, h_store_ind]
+  simpa using h_store_addr_arith
+
 /-! ## Strengthened control-flow + U-type arms (branches, JAL/JALR, LUI/AUIPC)
 
 These arms reach the same channel-balance conclusion as the 22 above, but via a
@@ -1287,8 +1306,9 @@ mainRowVar` appears in five hypotheses (`h_main_row`/`h_main_spec`/`h_store_pc`/
 `eval` reduces to the concrete trace row `mainRowWithRomSt trace i`, so the
 five hypotheses become exactly the facts `construction_<store>_sound` already
 proves (Spec at the row, `store_pc = 0`, the self-referential `c`-emission match,
-the `addr2` bridge).  This `mainConstVar`-of-the-real-row pattern is the analogue
-of the M-ext/control "placeholder-env + real row" build and sidesteps the prior
+and the derived `addr2` placement bridge).  This `mainConstVar`-of-the-real-row
+pattern is the analogue of the M-ext/control "placeholder-env + real row" build
+and sidesteps the prior
 whnf BLOWUP (the `Eq.mpr` cast over a free `MainRowWithRom` motive) because the row
 is a `.const` literal of the committed trace row, not an opaque eval-binder.
 
@@ -1361,7 +1381,9 @@ theorem stepStrong_sb
       (by simpa only [eval_mainConstVar] using h_main_spec)
       (by simpa only [eval_mainConstVar] using h_core_store_pc)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
-      (by simpa only [eval_mainConstVar] using d.toInputs.h_addr2)
+      (by
+        simpa only [eval_mainConstVar] using
+          store_addr2_of_decode d.toDecode.h_store_ind d.toInputs.h_store_addr_arith)
       h_b0' h_b1' d.toInputs.h_m1 d.toInputs.h_m2 d.toInputs.h_m3 d.toInputs.h_m4 d.toInputs.h_m5 d.toInputs.h_m6 d.toInputs.h_m7
   have h_bridge : env.aeneasBridgeTrust := ⟨d.toDecode.h_main_ind_width, h_b0', h_b1'⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
@@ -1427,7 +1449,9 @@ theorem stepStrong_sh
       (by simpa only [eval_mainConstVar] using h_main_spec)
       (by simpa only [eval_mainConstVar] using h_core_store_pc)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
-      (by simpa only [eval_mainConstVar] using d.toInputs.h_addr2)
+      (by
+        simpa only [eval_mainConstVar] using
+          store_addr2_of_decode d.toDecode.h_store_ind d.toInputs.h_store_addr_arith)
       h_b0' h_b1' d.toInputs.h_m2 d.toInputs.h_m3 d.toInputs.h_m4 d.toInputs.h_m5 d.toInputs.h_m6 d.toInputs.h_m7
   have h_bridge : env.aeneasBridgeTrust := ⟨d.toDecode.h_main_ind_width, h_b0', h_b1'⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
@@ -1493,7 +1517,9 @@ theorem stepStrong_sw
       (by simpa only [eval_mainConstVar] using h_main_spec)
       (by simpa only [eval_mainConstVar] using h_core_store_pc)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
-      (by simpa only [eval_mainConstVar] using d.toInputs.h_addr2)
+      (by
+        simpa only [eval_mainConstVar] using
+          store_addr2_of_decode d.toDecode.h_store_ind d.toInputs.h_store_addr_arith)
       h_b0' h_b1' d.toInputs.h_m4 d.toInputs.h_m5 d.toInputs.h_m6 d.toInputs.h_m7
   have h_bridge : env.aeneasBridgeTrust := ⟨d.toDecode.h_main_ind_width, h_b0', h_b1'⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
@@ -1559,7 +1585,9 @@ theorem stepStrong_sd
       (by simpa only [eval_mainConstVar] using h_main_spec)
       (by simpa only [eval_mainConstVar] using h_core_store_pc)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
-      (by simpa only [eval_mainConstVar] using d.toInputs.h_addr2)
+      (by
+        simpa only [eval_mainConstVar] using
+          store_addr2_of_decode d.toDecode.h_store_ind d.toInputs.h_store_addr_arith)
       h_b0' h_b1'
   have h_bridge : env.aeneasBridgeTrust := ⟨h_b0', h_b1'⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongLoadMext.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongLoadMext.lean
@@ -93,21 +93,63 @@ theorem load_addr2_idx_of_decode
   rw [load_addr2_eq_ind_of_decode h_store_ind h_store_offset,
     Transpiler.wrap_to_regidx_ind_bitvec_idx]
 
+/-- The load address arithmetic bridge reconstructed from decoded ROM offset, the
+    source-lane value, and the existing load precondition bound. -/
+theorem load_addr_arith_of_decode
+    {numInstructions : Nat}
+    {trace : AcceptedZiskTrace numInstructions}
+    {i : Fin trace.numInstructions}
+    {imm : BitVec 12}
+    {r1_val : BitVec 64}
+    (h_b_offset_imm0 :
+      (mainRowWithRomLd trace i).rom.b_offset_imm0 =
+        ((BitVec.signExtend 64 imm).toNat : FGL))
+    (h_a0_value : (mainRowWithRomLd trace i).core.a_0 = lane_lo r1_val)
+    (h_addr_bound :
+      r1_val.toNat + (BitVec.signExtend 64 imm).toNat < ZiskPhysicalAddressSpaceSize) :
+    ((mainRowWithRomLd trace i).rom.b_offset_imm0
+        + (mainRowWithRomLd trace i).core.a_0).toNat =
+      r1_val.toNat + (BitVec.signExtend 64 imm).toNat := by
+  have h_bound32 : r1_val.toNat + (BitVec.signExtend 64 imm).toNat < 4294967296 := by
+    simpa using h_addr_bound
+  have h_r1_lt32 : r1_val.toNat < 4294967296 := by omega
+  have h_imm_lt32 : (BitVec.signExtend 64 imm).toNat < 4294967296 := by omega
+  have h_r1_lt_gl : r1_val.toNat < GL_prime := by omega
+  have h_imm_lt_gl : (BitVec.signExtend 64 imm).toNat < GL_prime := by omega
+  have h_sum_lt_gl : r1_val.toNat + (BitVec.signExtend 64 imm).toNat < GL_prime := by omega
+  rw [h_b_offset_imm0, h_a0_value]
+  change ((((BitVec.signExtend 64 imm).toNat : FGL) + lane_lo r1_val : FGL).val) =
+    r1_val.toNat + (BitVec.signExtend 64 imm).toNat
+  rw [Fin.val_add, Fin.val_natCast]
+  unfold lane_lo
+  rw [Fin.val_mk]
+  rw [Nat.mod_eq_of_lt h_imm_lt_gl]
+  rw [Nat.mod_eq_of_lt h_r1_lt32]
+  rw [Nat.mod_eq_of_lt]
+  · omega
+  · omega
+
 /-- Load `addr1` placement derived from `AddressSpec` and the decoded load selector.
 
-The remaining arithmetic premise is deliberately over the `AddressSpec` right-hand
-side, not over `addr1`: it is the residual Sail/field address representation bridge,
-while this theorem discharges the Main-row address-placement part. -/
+The arithmetic equality is now reconstructed locally from decode, source-lane
+agreement, and the load precondition bound. -/
 theorem load_addr1_of_decode
     {numInstructions : Nat}
     {trace : AcceptedZiskTrace numInstructions}
     {i : Fin trace.numInstructions}
-    {target : Nat}
+    {imm : BitVec 12}
+    {r1_val : BitVec 64}
     (h_b_src_ind : (mainRowWithRomLd trace i).rom.b_src_ind = 1)
-    (h_load_addr_arith :
-      ((mainRowWithRomLd trace i).rom.b_offset_imm0
-        + (mainRowWithRomLd trace i).core.a_0).toNat = target) :
-    (mainRowWithRomLd trace i).rom.addr1.toNat = target := by
+    (h_b_offset_imm0 :
+      (mainRowWithRomLd trace i).rom.b_offset_imm0 =
+        ((BitVec.signExtend 64 imm).toNat : FGL))
+    (h_a0_value : (mainRowWithRomLd trace i).core.a_0 = lane_lo r1_val)
+    (h_addr_bound :
+      r1_val.toNat + (BitVec.signExtend 64 imm).toNat < ZiskPhysicalAddressSpaceSize) :
+    (mainRowWithRomLd trace i).rom.addr1.toNat =
+      r1_val.toNat + (BitVec.signExtend 64 imm).toNat := by
+  have h_load_addr_arith :=
+    load_addr_arith_of_decode h_b_offset_imm0 h_a0_value h_addr_bound
   have h_addr1 := (RomDecodeBinding.mainRowWithRomLd_addressSpec trace i).2.1
   rw [h_addr1, h_b_src_ind]
   simpa using h_load_addr_arith
@@ -133,7 +175,7 @@ records are real `Valid_Mem`/`Valid_BinaryExtension` rows. -/
 theorem stepStrong_ld
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_ld trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.ld_input.PC) :
     execute_instruction (instruction.LOAD
         (d.toClaim.ld_input.imm, regidx.Regidx d.toClaim.ld_input.r1, regidx.Regidx d.toClaim.ld_input.rd, false, 8))
         (binding i)
@@ -177,7 +219,7 @@ theorem stepStrong_ld
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -199,8 +241,20 @@ theorem stepStrong_ld
       (by simpa only [eval_mainConstVar] using h_main_b_match)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
       (by
+        have h_a0_value :
+            (mainRowWithRomLd trace i).core.a_0 = lane_lo d.toClaim.ld_input.r1_val := by
+          rw [h_core]
+          simpa [ZiskFv.AirsClean.Main.rowAt] using d.toInputs.h_a0_value
+        have h_addr_bound :
+            d.toClaim.ld_input.r1_val.toNat
+              + (BitVec.signExtend 64 d.toClaim.ld_input.imm).toNat
+              < ZiskPhysicalAddressSpaceSize := by
+          rcases d.toInputs.h_opcode_assumptions with
+            ⟨_, _, _, _, _, _, _, _, _, _, h_bound, _, _⟩
+          exact h_bound
         simpa only [eval_mainConstVar] using
-          load_addr1_of_decode d.toDecode.h_b_src_ind d.toInputs.h_load_addr_arith)
+          load_addr1_of_decode d.toDecode.h_b_src_ind d.toDecode.h_b_offset_imm0
+            h_a0_value h_addr_bound)
       (by simpa only [eval_mainConstVar] using load_addr2_zero_iff_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       (by simpa only [eval_mainConstVar] using load_addr2_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
@@ -213,7 +267,7 @@ theorem stepStrong_ld
 theorem stepStrong_lbu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lbu trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.lbu_input.PC) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lbu_input.imm, regidx.Regidx d.toClaim.lbu_input.r1, regidx.Regidx d.toClaim.lbu_input.rd, true, 1))
         (binding i)
@@ -257,7 +311,7 @@ theorem stepStrong_lbu
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -279,8 +333,19 @@ theorem stepStrong_lbu
       (by simpa only [eval_mainConstVar] using h_main_b_match)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
       (by
+        have h_a0_value :
+            (mainRowWithRomLd trace i).core.a_0 = lane_lo d.toClaim.lbu_input.r1_val := by
+          rw [h_core]
+          simpa [ZiskFv.AirsClean.Main.rowAt] using d.toInputs.h_a0_value
+        have h_addr_bound :
+            d.toClaim.lbu_input.r1_val.toNat
+              + (BitVec.signExtend 64 d.toClaim.lbu_input.imm).toNat
+              < ZiskPhysicalAddressSpaceSize := by
+          rcases d.toInputs.h_opcode_assumptions with ⟨_, _, _, h_bound, _⟩
+          exact h_bound
         simpa only [eval_mainConstVar] using
-          load_addr1_of_decode d.toDecode.h_b_src_ind d.toInputs.h_load_addr_arith)
+          load_addr1_of_decode d.toDecode.h_b_src_ind d.toDecode.h_b_offset_imm0
+            h_a0_value h_addr_bound)
       (by simpa only [eval_mainConstVar] using load_addr2_zero_iff_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       (by simpa only [eval_mainConstVar] using load_addr2_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
@@ -293,7 +358,7 @@ theorem stepStrong_lbu
 theorem stepStrong_lhu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lhu trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.lhu_input.PC) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lhu_input.imm, regidx.Regidx d.toClaim.lhu_input.r1, regidx.Regidx d.toClaim.lhu_input.rd, true, 2))
         (binding i)
@@ -337,7 +402,7 @@ theorem stepStrong_lhu
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -359,8 +424,19 @@ theorem stepStrong_lhu
       (by simpa only [eval_mainConstVar] using h_main_b_match)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
       (by
+        have h_a0_value :
+            (mainRowWithRomLd trace i).core.a_0 = lane_lo d.toClaim.lhu_input.r1_val := by
+          rw [h_core]
+          simpa [ZiskFv.AirsClean.Main.rowAt] using d.toInputs.h_a0_value
+        have h_addr_bound :
+            d.toClaim.lhu_input.r1_val.toNat
+              + (BitVec.signExtend 64 d.toClaim.lhu_input.imm).toNat
+              < ZiskPhysicalAddressSpaceSize := by
+          rcases d.toInputs.h_opcode_assumptions with ⟨_, _, _, _, h_bound, _, _⟩
+          exact h_bound
         simpa only [eval_mainConstVar] using
-          load_addr1_of_decode d.toDecode.h_b_src_ind d.toInputs.h_load_addr_arith)
+          load_addr1_of_decode d.toDecode.h_b_src_ind d.toDecode.h_b_offset_imm0
+            h_a0_value h_addr_bound)
       (by simpa only [eval_mainConstVar] using load_addr2_zero_iff_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       (by simpa only [eval_mainConstVar] using load_addr2_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
@@ -373,7 +449,7 @@ theorem stepStrong_lhu
 theorem stepStrong_lwu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lwu trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.lwu_input.PC) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lwu_input.imm, regidx.Regidx d.toClaim.lwu_input.r1, regidx.Regidx d.toClaim.lwu_input.rd, true, 4))
         (binding i)
@@ -417,7 +493,7 @@ theorem stepStrong_lwu
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -439,8 +515,20 @@ theorem stepStrong_lwu
       (by simpa only [eval_mainConstVar] using h_main_b_match)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
       (by
+        have h_a0_value :
+            (mainRowWithRomLd trace i).core.a_0 = lane_lo d.toClaim.lwu_input.r1_val := by
+          rw [h_core]
+          simpa [ZiskFv.AirsClean.Main.rowAt] using d.toInputs.h_a0_value
+        have h_addr_bound :
+            d.toClaim.lwu_input.r1_val.toNat
+              + (BitVec.signExtend 64 d.toClaim.lwu_input.imm).toNat
+              < ZiskPhysicalAddressSpaceSize := by
+          rcases d.toInputs.h_opcode_assumptions with
+            ⟨_, _, _, _, _, _, h_bound, _, _⟩
+          exact h_bound
         simpa only [eval_mainConstVar] using
-          load_addr1_of_decode d.toDecode.h_b_src_ind d.toInputs.h_load_addr_arith)
+          load_addr1_of_decode d.toDecode.h_b_src_ind d.toDecode.h_b_offset_imm0
+            h_a0_value h_addr_bound)
       (by simpa only [eval_mainConstVar] using load_addr2_zero_iff_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       (by simpa only [eval_mainConstVar] using load_addr2_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
@@ -453,7 +541,7 @@ theorem stepStrong_lwu
 theorem stepStrong_lb
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lb trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.lb_input.PC) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lb_input.imm, regidx.Regidx d.toClaim.lb_input.r1, regidx.Regidx d.toClaim.lb_input.rd, false, 1))
         (binding i)
@@ -497,7 +585,7 @@ theorem stepStrong_lb
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -520,8 +608,19 @@ theorem stepStrong_lb
       (by simpa only [eval_mainConstVar] using h_main_b_match)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
       (by
+        have h_a0_value :
+            (mainRowWithRomLd trace i).core.a_0 = lane_lo d.toClaim.lb_input.r1_val := by
+          rw [h_core]
+          simpa [ZiskFv.AirsClean.Main.rowAt] using d.toInputs.h_a0_value
+        have h_addr_bound :
+            d.toClaim.lb_input.r1_val.toNat
+              + (BitVec.signExtend 64 d.toClaim.lb_input.imm).toNat
+              < ZiskPhysicalAddressSpaceSize := by
+          rcases d.toInputs.h_opcode_assumptions with ⟨_, _, _, h_bound, _⟩
+          exact h_bound
         simpa only [eval_mainConstVar] using
-          load_addr1_of_decode d.toDecode.h_b_src_ind d.toInputs.h_load_addr_arith)
+          load_addr1_of_decode d.toDecode.h_b_src_ind d.toDecode.h_b_offset_imm0
+            h_a0_value h_addr_bound)
       (by simpa only [eval_mainConstVar] using load_addr2_zero_iff_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       (by simpa only [eval_mainConstVar] using load_addr2_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
@@ -534,7 +633,7 @@ theorem stepStrong_lb
 theorem stepStrong_lh
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lh trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.lh_input.PC) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lh_input.imm, regidx.Regidx d.toClaim.lh_input.r1, regidx.Regidx d.toClaim.lh_input.rd, false, 2))
         (binding i)
@@ -578,7 +677,7 @@ theorem stepStrong_lh
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -601,8 +700,19 @@ theorem stepStrong_lh
       (by simpa only [eval_mainConstVar] using h_main_b_match)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
       (by
+        have h_a0_value :
+            (mainRowWithRomLd trace i).core.a_0 = lane_lo d.toClaim.lh_input.r1_val := by
+          rw [h_core]
+          simpa [ZiskFv.AirsClean.Main.rowAt] using d.toInputs.h_a0_value
+        have h_addr_bound :
+            d.toClaim.lh_input.r1_val.toNat
+              + (BitVec.signExtend 64 d.toClaim.lh_input.imm).toNat
+              < ZiskPhysicalAddressSpaceSize := by
+          rcases d.toInputs.h_opcode_assumptions with ⟨_, _, _, _, h_bound, _, _⟩
+          exact h_bound
         simpa only [eval_mainConstVar] using
-          load_addr1_of_decode d.toDecode.h_b_src_ind d.toInputs.h_load_addr_arith)
+          load_addr1_of_decode d.toDecode.h_b_src_ind d.toDecode.h_b_offset_imm0
+            h_a0_value h_addr_bound)
       (by simpa only [eval_mainConstVar] using load_addr2_zero_iff_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       (by simpa only [eval_mainConstVar] using load_addr2_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
@@ -615,7 +725,7 @@ theorem stepStrong_lh
 theorem stepStrong_lw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.lw_input.PC) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lw_input.imm, regidx.Regidx d.toClaim.lw_input.r1, regidx.Regidx d.toClaim.lw_input.rd, false, 4))
         (binding i)
@@ -659,7 +769,7 @@ theorem stepStrong_lw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -682,8 +792,20 @@ theorem stepStrong_lw
       (by simpa only [eval_mainConstVar] using h_main_b_match)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
       (by
+        have h_a0_value :
+            (mainRowWithRomLd trace i).core.a_0 = lane_lo d.toClaim.lw_input.r1_val := by
+          rw [h_core]
+          simpa [ZiskFv.AirsClean.Main.rowAt] using d.toInputs.h_a0_value
+        have h_addr_bound :
+            d.toClaim.lw_input.r1_val.toNat
+              + (BitVec.signExtend 64 d.toClaim.lw_input.imm).toNat
+              < ZiskPhysicalAddressSpaceSize := by
+          rcases d.toInputs.h_opcode_assumptions with
+            ⟨_, _, _, _, _, _, h_bound, _, _⟩
+          exact h_bound
         simpa only [eval_mainConstVar] using
-          load_addr1_of_decode d.toDecode.h_b_src_ind d.toInputs.h_load_addr_arith)
+          load_addr1_of_decode d.toDecode.h_b_src_ind d.toDecode.h_b_offset_imm0
+            h_a0_value h_addr_bound)
       (by simpa only [eval_mainConstVar] using load_addr2_zero_iff_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       (by simpa only [eval_mainConstVar] using load_addr2_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
@@ -723,7 +845,7 @@ the real `busSub` row.  These are strictly stronger than the corresponding
 theorem stepStrong_mulw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mulw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.mulw_input.PC) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.MULW (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd))) (binding i)
@@ -792,7 +914,7 @@ theorem stepStrong_mulw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.mulw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -831,7 +953,7 @@ theorem stepStrong_mulw
 theorem stepStrong_mulhu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mulhu trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.mulhu_input.PC) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute
@@ -910,7 +1032,7 @@ theorem stepStrong_mulhu
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.mulhu_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -945,7 +1067,7 @@ theorem stepStrong_mulhu
 theorem stepStrong_divu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_divu trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.divu_input.PC) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.DIV (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, true))) (binding i)
@@ -1025,7 +1147,7 @@ theorem stepStrong_divu
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.divu_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -1056,7 +1178,7 @@ theorem stepStrong_divu
 theorem stepStrong_divuw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_divuw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.divuw_input.PC) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.DIVW (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, true))) (binding i)
@@ -1132,7 +1254,7 @@ theorem stepStrong_divuw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.divuw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -1162,7 +1284,7 @@ theorem stepStrong_divuw
 theorem stepStrong_remu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_remu trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.remu_input.PC) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.REM (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, true))) (binding i)
@@ -1238,7 +1360,7 @@ theorem stepStrong_remu
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.remu_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -1267,7 +1389,7 @@ theorem stepStrong_remu
 theorem stepStrong_remuw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_remuw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.remuw_input.PC) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.REMW (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, true))) (binding i)
@@ -1343,7 +1465,7 @@ theorem stepStrong_remuw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.remuw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongLoadMext.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongLoadMext.lean
@@ -93,6 +93,25 @@ theorem load_addr2_idx_of_decode
   rw [load_addr2_eq_ind_of_decode h_store_ind h_store_offset,
     Transpiler.wrap_to_regidx_ind_bitvec_idx]
 
+/-- Load `addr1` placement derived from `AddressSpec` and the decoded load selector.
+
+The remaining arithmetic premise is deliberately over the `AddressSpec` right-hand
+side, not over `addr1`: it is the residual Sail/field address representation bridge,
+while this theorem discharges the Main-row address-placement part. -/
+theorem load_addr1_of_decode
+    {numInstructions : Nat}
+    {trace : AcceptedZiskTrace numInstructions}
+    {i : Fin trace.numInstructions}
+    {target : Nat}
+    (h_b_src_ind : (mainRowWithRomLd trace i).rom.b_src_ind = 1)
+    (h_load_addr_arith :
+      ((mainRowWithRomLd trace i).rom.b_offset_imm0
+        + (mainRowWithRomLd trace i).core.a_0).toNat = target) :
+    (mainRowWithRomLd trace i).rom.addr1.toNat = target := by
+  have h_addr1 := (RomDecodeBinding.mainRowWithRomLd_addressSpec trace i).2.1
+  rw [h_addr1, h_b_src_ind]
+  simpa using h_load_addr_arith
+
 /-! ## Strengthened load arms (LB/LH/LW/LD/LBU/LHU/LWU, channel-balance form)
 
 Same direct-lift route.  The hint's obstacle — the `OpEnvelope` load arm needing
@@ -179,7 +198,9 @@ theorem stepStrong_ld
       (by simpa only [eval_mainConstVar] using h_core_store_pc)
       (by simpa only [eval_mainConstVar] using h_main_b_match)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
-      (by simpa only [eval_mainConstVar] using d.toInputs.h_addr1)
+      (by
+        simpa only [eval_mainConstVar] using
+          load_addr1_of_decode d.toDecode.h_b_src_ind d.toInputs.h_load_addr_arith)
       (by simpa only [eval_mainConstVar] using load_addr2_zero_iff_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       (by simpa only [eval_mainConstVar] using load_addr2_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
@@ -257,7 +278,9 @@ theorem stepStrong_lbu
       (by simpa only [eval_mainConstVar] using h_core_store_pc)
       (by simpa only [eval_mainConstVar] using h_main_b_match)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
-      (by simpa only [eval_mainConstVar] using d.toInputs.h_addr1)
+      (by
+        simpa only [eval_mainConstVar] using
+          load_addr1_of_decode d.toDecode.h_b_src_ind d.toInputs.h_load_addr_arith)
       (by simpa only [eval_mainConstVar] using load_addr2_zero_iff_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       (by simpa only [eval_mainConstVar] using load_addr2_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
@@ -335,7 +358,9 @@ theorem stepStrong_lhu
       (by simpa only [eval_mainConstVar] using h_core_store_pc)
       (by simpa only [eval_mainConstVar] using h_main_b_match)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
-      (by simpa only [eval_mainConstVar] using d.toInputs.h_addr1)
+      (by
+        simpa only [eval_mainConstVar] using
+          load_addr1_of_decode d.toDecode.h_b_src_ind d.toInputs.h_load_addr_arith)
       (by simpa only [eval_mainConstVar] using load_addr2_zero_iff_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       (by simpa only [eval_mainConstVar] using load_addr2_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
@@ -413,7 +438,9 @@ theorem stepStrong_lwu
       (by simpa only [eval_mainConstVar] using h_core_store_pc)
       (by simpa only [eval_mainConstVar] using h_main_b_match)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
-      (by simpa only [eval_mainConstVar] using d.toInputs.h_addr1)
+      (by
+        simpa only [eval_mainConstVar] using
+          load_addr1_of_decode d.toDecode.h_b_src_ind d.toInputs.h_load_addr_arith)
       (by simpa only [eval_mainConstVar] using load_addr2_zero_iff_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       (by simpa only [eval_mainConstVar] using load_addr2_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
@@ -492,7 +519,9 @@ theorem stepStrong_lb
       (by simpa only [eval_mainConstVar] using h_core_store_pc)
       (by simpa only [eval_mainConstVar] using h_main_b_match)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
-      (by simpa only [eval_mainConstVar] using d.toInputs.h_addr1)
+      (by
+        simpa only [eval_mainConstVar] using
+          load_addr1_of_decode d.toDecode.h_b_src_ind d.toInputs.h_load_addr_arith)
       (by simpa only [eval_mainConstVar] using load_addr2_zero_iff_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       (by simpa only [eval_mainConstVar] using load_addr2_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
@@ -571,7 +600,9 @@ theorem stepStrong_lh
       (by simpa only [eval_mainConstVar] using h_core_store_pc)
       (by simpa only [eval_mainConstVar] using h_main_b_match)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
-      (by simpa only [eval_mainConstVar] using d.toInputs.h_addr1)
+      (by
+        simpa only [eval_mainConstVar] using
+          load_addr1_of_decode d.toDecode.h_b_src_ind d.toInputs.h_load_addr_arith)
       (by simpa only [eval_mainConstVar] using load_addr2_zero_iff_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       (by simpa only [eval_mainConstVar] using load_addr2_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
@@ -650,7 +681,9 @@ theorem stepStrong_lw
       (by simpa only [eval_mainConstVar] using h_core_store_pc)
       (by simpa only [eval_mainConstVar] using h_main_b_match)
       (by simpa only [eval_mainConstVar] using h_main_c_match)
-      (by simpa only [eval_mainConstVar] using d.toInputs.h_addr1)
+      (by
+        simpa only [eval_mainConstVar] using
+          load_addr1_of_decode d.toDecode.h_b_src_ind d.toInputs.h_load_addr_arith)
       (by simpa only [eval_mainConstVar] using load_addr2_zero_iff_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       (by simpa only [eval_mainConstVar] using load_addr2_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongSignedM.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongSignedM.lean
@@ -67,6 +67,7 @@ set_option maxHeartbeats 8000000
 theorem stepStrong_mul
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mul trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mul_input.PC)
     (h_known : ¬ Defects.SignedMulForge d.toInputs.v d.toInputs.r_a) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -77,10 +78,13 @@ theorem stepStrong_mul
              signed_rs1 := d.toClaim.srs1
              signed_rs2 := d.toClaim.srs2 }))) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
-          ⟨d.toClaim.bus.exec_row, [d.toClaim.bus.e0, d.toClaim.bus.e1, d.toClaim.bus.e2]⟩ (binding i) := by
+          ⟨(busSub trace i (Pilot.execRowOf trace i)).exec_row,
+           [ (busSub trace i (Pilot.execRowOf trace i)).e0
+           , (busSub trace i (Pilot.execRowOf trace i)).e1
+           , (busSub trace i (Pilot.execRowOf trace i)).e2 ]⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
   set state := binding i with hstate
-  let env : OpEnvelope state m i.val := mulEnvOf trace binding i d
+  let env : OpEnvelope state m i.val := mulEnvOf trace binding i d h_domain
   have h_bridge : env.aeneasBridgeTrust :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc,
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
@@ -105,6 +109,7 @@ theorem stepStrong_mul
 theorem stepStrong_mulh
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mulh trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mulh_input.PC)
     (h_known : ¬ Defects.SignedMulForge d.toInputs.v d.toInputs.r_a) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -115,10 +120,13 @@ theorem stepStrong_mulh
              signed_rs1 := .Signed
              signed_rs2 := .Signed }))) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
-          ⟨d.toClaim.bus.exec_row, [d.toClaim.bus.e0, d.toClaim.bus.e1, d.toClaim.bus.e2]⟩ (binding i) := by
+          ⟨(busSub trace i (Pilot.execRowOf trace i)).exec_row,
+           [ (busSub trace i (Pilot.execRowOf trace i)).e0
+           , (busSub trace i (Pilot.execRowOf trace i)).e1
+           , (busSub trace i (Pilot.execRowOf trace i)).e2 ]⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
   set state := binding i with hstate
-  let env : OpEnvelope state m i.val := mulhEnvOf trace binding i d
+  let env : OpEnvelope state m i.val := mulhEnvOf trace binding i d h_domain
   have h_bridge : env.aeneasBridgeTrust :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc,
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
@@ -133,6 +141,7 @@ theorem stepStrong_mulh
 theorem stepStrong_mulhsu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mulhsu trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mulhsu_input.PC)
     (h_known : ¬ Defects.SignedMulForge d.toInputs.v d.toInputs.r_a) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -143,10 +152,13 @@ theorem stepStrong_mulhsu
              signed_rs1 := .Signed
              signed_rs2 := .Unsigned }))) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
-          ⟨d.toClaim.bus.exec_row, [d.toClaim.bus.e0, d.toClaim.bus.e1, d.toClaim.bus.e2]⟩ (binding i) := by
+          ⟨(busSub trace i (Pilot.execRowOf trace i)).exec_row,
+           [ (busSub trace i (Pilot.execRowOf trace i)).e0
+           , (busSub trace i (Pilot.execRowOf trace i)).e1
+           , (busSub trace i (Pilot.execRowOf trace i)).e2 ]⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
   set state := binding i with hstate
-  let env : OpEnvelope state m i.val := mulhsuEnvOf trace binding i d
+  let env : OpEnvelope state m i.val := mulhsuEnvOf trace binding i d h_domain
   have h_bridge : env.aeneasBridgeTrust :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc,
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
@@ -178,15 +190,19 @@ theorem stepStrong_mulhsu
 theorem stepStrong_div
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_div trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.div_input.PC)
     (h_known : ¬ Defects.DivRemForge d.toInputs.div_input.r2_val d.toInputs.v d.toInputs.r_a) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.DIV (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, false))) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
-          ⟨d.toClaim.bus.exec_row, [d.toClaim.bus.e0, d.toClaim.bus.e1, d.toClaim.bus.e2]⟩ (binding i) := by
+          ⟨(busSub trace i (Pilot.execRowOf trace i)).exec_row,
+           [ (busSub trace i (Pilot.execRowOf trace i)).e0
+           , (busSub trace i (Pilot.execRowOf trace i)).e1
+           , (busSub trace i (Pilot.execRowOf trace i)).e2 ]⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
   set state := binding i with hstate
-  let env : OpEnvelope state m i.val := divEnvOf trace binding i d
+  let env : OpEnvelope state m i.val := divEnvOf trace binding i d h_domain
   have h_bridge : env.aeneasBridgeTrust :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc,
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
@@ -206,15 +222,19 @@ theorem stepStrong_div
 theorem stepStrong_rem
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_rem trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.rem_input.PC)
     (h_known : ¬ Defects.DivRemForge d.toInputs.rem_input.r2_val d.toInputs.v d.toInputs.r_a) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.REM (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, false))) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
-          ⟨d.toClaim.bus.exec_row, [d.toClaim.bus.e0, d.toClaim.bus.e1, d.toClaim.bus.e2]⟩ (binding i) := by
+          ⟨(busSub trace i (Pilot.execRowOf trace i)).exec_row,
+           [ (busSub trace i (Pilot.execRowOf trace i)).e0
+           , (busSub trace i (Pilot.execRowOf trace i)).e1
+           , (busSub trace i (Pilot.execRowOf trace i)).e2 ]⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
   set state := binding i with hstate
-  let env : OpEnvelope state m i.val := remEnvOf trace binding i d
+  let env : OpEnvelope state m i.val := remEnvOf trace binding i d h_domain
   have h_bridge : env.aeneasBridgeTrust :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc,
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
@@ -232,15 +252,19 @@ theorem stepStrong_rem
 theorem stepStrong_divw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_divw trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.divw_input.PC)
     (h_known : ¬ Defects.DivRemForgeW d.toInputs.divw_input.r2_val d.toInputs.v d.toInputs.r_a) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.DIVW (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, false))) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
-          ⟨d.toClaim.bus.exec_row, [d.toClaim.bus.e0, d.toClaim.bus.e1, d.toClaim.bus.e2]⟩ (binding i) := by
+          ⟨(busSub trace i (Pilot.execRowOf trace i)).exec_row,
+           [ (busSub trace i (Pilot.execRowOf trace i)).e0
+           , (busSub trace i (Pilot.execRowOf trace i)).e1
+           , (busSub trace i (Pilot.execRowOf trace i)).e2 ]⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
   set state := binding i with hstate
-  let env : OpEnvelope state m i.val := divwEnvOf trace binding i d
+  let env : OpEnvelope state m i.val := divwEnvOf trace binding i d h_domain
   have h_bridge : env.aeneasBridgeTrust :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc,
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
@@ -255,15 +279,19 @@ theorem stepStrong_divw
 theorem stepStrong_remw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_remw trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.remw_input.PC)
     (h_known : ¬ Defects.DivRemForgeW d.toInputs.remw_input.r2_val d.toInputs.v d.toInputs.r_a) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.REMW (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, false))) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
-          ⟨d.toClaim.bus.exec_row, [d.toClaim.bus.e0, d.toClaim.bus.e1, d.toClaim.bus.e2]⟩ (binding i) := by
+          ⟨(busSub trace i (Pilot.execRowOf trace i)).exec_row,
+           [ (busSub trace i (Pilot.execRowOf trace i)).e0
+           , (busSub trace i (Pilot.execRowOf trace i)).e1
+           , (busSub trace i (Pilot.execRowOf trace i)).e2 ]⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
   set state := binding i with hstate
-  let env : OpEnvelope state m i.val := remwEnvOf trace binding i d
+  let env : OpEnvelope state m i.val := remwEnvOf trace binding i d h_domain
   have h_bridge : env.aeneasBridgeTrust :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc,
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
@@ -291,12 +319,13 @@ theorem stepStrong_remw
 theorem stepStrong_fence
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_fence trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.fence_input.PC)
     (h_known : Defects.FenceKnownGood d.toClaim.fm d.toClaim.rs d.toClaim.rd) :
     execute_instruction (instruction.FENCE (d.toClaim.fm, d.toClaim.fenceP, d.toClaim.fenceS, d.toClaim.rs, d.toClaim.rd)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨Pilot.execRowOf trace i, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
   set state := binding i with hstate
-  let env : OpEnvelope state m i.val := fenceEnvOf trace binding i d
+  let env : OpEnvelope state m i.val := fenceEnvOf trace binding i d h_domain
   have h_bridge : env.aeneasBridgeTrust := ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   -- The threaded `FenceKnownGood` obligation is (defeq, via

--- a/ZiskFv/SailSpec/bge.lean
+++ b/ZiskFv/SailSpec/bge.lean
@@ -30,6 +30,15 @@ namespace PureSpec
       : BgeOutput
     }
 
+  lemma execute_BGE_pure_succ_throws
+    (input : BgeInput)
+  :
+    let output := execute_BGE_pure input
+    output.success = true → output.throws = false
+  := by
+    simp [execute_BGE_pure]
+    grind
+
   set_option maxHeartbeats 400000 in
   /-- BGE Sail-equivalence: BLT sibling with `≥b` instead of `<b`.
       Sail's `execute_BTYPE` BGE arm emits `zopz0zKzJ_s (rX rs1) (rX rs2)`
@@ -119,7 +128,7 @@ namespace PureSpec
           else bi.PC + BitVec.signExtend 64 bi.imm := by
     have hslt : BitVec.slt bi.r1_val bi.r2_val
         = !(bi.r1_val.toInt ≥b bi.r2_val.toInt) := by
-      simp [BitVec.slt, ge_iff_le, ← decide_not, Int.not_le]
+      simp [BitVec.slt, ge_iff_le, ← decide_not]
     rw [hslt]
     cases h : bi.r1_val.toInt ≥b bi.r2_val.toInt with
     | false => simp [execute_BGE_pure, h]

--- a/ZiskFv/SailSpec/bgeu.lean
+++ b/ZiskFv/SailSpec/bgeu.lean
@@ -30,6 +30,15 @@ namespace PureSpec
       : BgeuOutput
     }
 
+  lemma execute_BGEU_pure_succ_throws
+    (input : BgeuInput)
+  :
+    let output := execute_BGEU_pure input
+    output.success = true → output.throws = false
+  := by
+    simp [execute_BGEU_pure]
+    grind
+
   set_option maxHeartbeats 400000 in
   /-- BGEU Sail-equivalence: unsigned greater-equal sibling of BGE /
       BLTU. Closure shape identical to BLTU with `≥` swapped for `<`. -/
@@ -116,7 +125,7 @@ namespace PureSpec
           else bi.PC + BitVec.signExtend 64 bi.imm := by
     have hult : BitVec.ult bi.r1_val bi.r2_val
         = !(bi.r1_val.toNat ≥b bi.r2_val.toNat) := by
-      simp [BitVec.ult, ge_iff_le, ← decide_not, Nat.not_le]
+      simp [BitVec.ult, ge_iff_le, ← decide_not]
     rw [hult]
     cases h : bi.r1_val.toNat ≥b bi.r2_val.toNat with
     | false => simp [execute_BGEU_pure, h]

--- a/ZiskFv/SailSpec/blt.lean
+++ b/ZiskFv/SailSpec/blt.lean
@@ -30,6 +30,15 @@ namespace PureSpec
       : BltOutput
     }
 
+  lemma execute_BLT_pure_succ_throws
+    (input : BltInput)
+  :
+    let output := execute_BLT_pure input
+    output.success = true → output.throws = false
+  := by
+    simp [execute_BLT_pure]
+    grind
+
   set_option maxHeartbeats 400000 in
   /-- BLT Sail-equivalence: the `do` block consisting of a default
       `nextPC ← PC + 4` write followed by `execute (.BTYPE imm r2 r1 BLT)`

--- a/ZiskFv/SailSpec/bltu.lean
+++ b/ZiskFv/SailSpec/bltu.lean
@@ -30,6 +30,15 @@ namespace PureSpec
       : BltuOutput
     }
 
+  lemma execute_BLTU_pure_succ_throws
+    (input : BltuInput)
+  :
+    let output := execute_BLTU_pure input
+    output.success = true → output.throws = false
+  := by
+    simp [execute_BLTU_pure]
+    grind
+
   set_option maxHeartbeats 400000 in
   /-- BLTU Sail-equivalence: unsigned less-than sibling of BLT. Sail's
       `zopz0zI_u` unfolds to `.toNatInt <b .toNatInt`, and

--- a/ZiskFv/SailSpec/jal.lean
+++ b/ZiskFv/SailSpec/jal.lean
@@ -37,6 +37,25 @@ namespace PureSpec
       throws := !bit0_valid
     }
 
+  lemma execute_JAL_pure_succ_throws
+    (input : JalInput)
+  :
+    let output := execute_JAL_pure input
+    output.success = true → output.throws = false
+  := by
+    simp [execute_JAL_pure]
+    grind
+
+  lemma execute_JAL_pure_succ_nextPC
+    (input : JalInput)
+  :
+    let output := execute_JAL_pure input
+    output.success = true →
+      output.nextPC = .some (input.PC + BitVec.signExtend 64 input.imm)
+  := by
+    simp [execute_JAL_pure]
+    grind
+
   /-- Dispatcher-unfold: `execute (.JAL …)` reduces to `execute_JAL`.
       Mirrors `RV32D/jal.lean`'s `rv32d_execute_jal` lemma. -/
   lemma rv64d_execute_jal :

--- a/ZiskFv/SailSpec/jalr.lean
+++ b/ZiskFv/SailSpec/jalr.lean
@@ -36,6 +36,24 @@ namespace PureSpec
       success := (bit1_valid)
     }
 
+  lemma execute_JALR_pure_succ_nextPC
+    (input : JalrInput)
+  :
+    let output := execute_JALR_pure input
+    output.success = true →
+      output.nextPC =
+        .some (0xFFFFFFFFFFFFFFFE &&&
+          (input.rs1_val + BitVec.signExtend 64 input.imm))
+  := by
+    simp only [execute_JALR_pure]
+    intro h_valid
+    have h_eq :
+        BitVec.ofBool
+            (input.rs1_val + BitVec.signExtend 64 input.imm)[1]
+          = 0#1 := by
+      simpa only [beq_iff_eq] using h_valid
+    rw [if_neg (by simp [h_eq])]
+
   -- JALR Sail-equivalence. Direct port of the `execute_JAL_pure_equiv`
   -- proof shape, adapted for JALR's pre-masked target
   -- (`BitVec.update target 0 0#1` clears bit 0, so the

--- a/trust/consistency/completeness_witness_main.lean
+++ b/trust/consistency/completeness_witness_main.lean
@@ -148,8 +148,9 @@ private theorem romMemExternalWitness :
       (circuitWithRomAndMemBus 1 externalProgram).ProverAssumptions row data hint := by
   refine ⟨romExternalRow, ?_⟩
   intro data hint
-  refine ⟨finOne, externalBits, .external true 30 31, mainRomFree, rfl, ?_, ?_, rfl⟩
+  refine ⟨finOne, externalBits, .external true 30 31, mainRomFree, rfl, ?_, ?_, ?_, rfl⟩
   · simp [MainRomExecKind.Coherent, externalBits]
+  · simp [MainRomSourceGuard, externalBits, boolF]
   · simp [MainRomAddressGuard, externalBits, boolF]
 
 private theorem romMemInternalFlagWitness :
@@ -157,8 +158,9 @@ private theorem romMemInternalFlagWitness :
       (circuitWithRomAndMemBus 1 internalFlagProgram).ProverAssumptions row data hint := by
   refine ⟨romInternalFlagRow, ?_⟩
   intro data hint
-  refine ⟨finOne, internalFlagBits, .internalFlag, mainRomFree, rfl, ?_, ?_, rfl⟩
+  refine ⟨finOne, internalFlagBits, .internalFlag, mainRomFree, rfl, ?_, ?_, ?_, rfl⟩
   · simp [MainRomExecKind.Coherent, internalFlagBits, internalFlagProgram, romMsgOf]
+  · simp [MainRomSourceGuard, internalFlagBits, boolF]
   · simp [MainRomAddressGuard, internalFlagBits, boolF]
 
 private theorem romMemInternalCopyWitness :
@@ -166,8 +168,9 @@ private theorem romMemInternalCopyWitness :
       (circuitWithRomAndMemBus 1 internalCopyProgram).ProverAssumptions row data hint := by
   refine ⟨romInternalCopyRow, ?_⟩
   intro data hint
-  refine ⟨finOne, internalCopyBits, .internalCopyB, mainRomFree, rfl, ?_, ?_, rfl⟩
+  refine ⟨finOne, internalCopyBits, .internalCopyB, mainRomFree, rfl, ?_, ?_, ?_, rfl⟩
   · simp [MainRomExecKind.Coherent, internalCopyBits, internalCopyProgram, romMsgOf]
+  · simp [MainRomSourceGuard, internalCopyBits, boolF]
   · simp [MainRomAddressGuard, internalCopyBits, boolF]
 
 private theorem romMemOpExternalWitness :
@@ -175,8 +178,9 @@ private theorem romMemOpExternalWitness :
       (circuitWithRomMemAndOpBus 1 externalProgram).ProverAssumptions row data hint := by
   refine ⟨romExternalRow, ?_⟩
   intro data hint
-  refine ⟨finOne, externalBits, .external true 30 31, mainRomFree, rfl, ?_, ?_, rfl⟩
+  refine ⟨finOne, externalBits, .external true 30 31, mainRomFree, rfl, ?_, ?_, ?_, rfl⟩
   · simp [MainRomExecKind.Coherent, externalBits]
+  · simp [MainRomSourceGuard, externalBits, boolF]
   · simp [MainRomAddressGuard, externalBits, boolF]
 
 private theorem romMemOpInternalFlagWitness :
@@ -184,8 +188,9 @@ private theorem romMemOpInternalFlagWitness :
       (circuitWithRomMemAndOpBus 1 internalFlagProgram).ProverAssumptions row data hint := by
   refine ⟨romInternalFlagRow, ?_⟩
   intro data hint
-  refine ⟨finOne, internalFlagBits, .internalFlag, mainRomFree, rfl, ?_, ?_, rfl⟩
+  refine ⟨finOne, internalFlagBits, .internalFlag, mainRomFree, rfl, ?_, ?_, ?_, rfl⟩
   · simp [MainRomExecKind.Coherent, internalFlagBits, internalFlagProgram, romMsgOf]
+  · simp [MainRomSourceGuard, internalFlagBits, boolF]
   · simp [MainRomAddressGuard, internalFlagBits, boolF]
 
 private theorem romMemOpInternalCopyWitness :
@@ -193,8 +198,9 @@ private theorem romMemOpInternalCopyWitness :
       (circuitWithRomMemAndOpBus 1 internalCopyProgram).ProverAssumptions row data hint := by
   refine ⟨romInternalCopyRow, ?_⟩
   intro data hint
-  refine ⟨finOne, internalCopyBits, .internalCopyB, mainRomFree, rfl, ?_, ?_, rfl⟩
+  refine ⟨finOne, internalCopyBits, .internalCopyB, mainRomFree, rfl, ?_, ?_, ?_, rfl⟩
   · simp [MainRomExecKind.Coherent, internalCopyBits, internalCopyProgram, romMsgOf]
+  · simp [MainRomSourceGuard, internalCopyBits, boolF]
   · simp [MainRomAddressGuard, internalCopyBits, boolF]
 
 theorem completeness_witness_main :


### PR DESCRIPTION
Part 3 of the review-sized #141 stack. Base: #196.

This chunk consolidates placement removals for:

- LUI/AUIPC/JAL/JALR destination placement;
- store `addr2` placement;
- load `addr1` placement.

The PR keeps the Sail/value bridge facts where they are still real cross-world assumptions, but removes the Main-row placement pieces by deriving them from `AddressSpec`, committed-program selector facts, and the existing decode records.

Supersedes the old one-slice PRs #197 and #198.

Size: about +401/-66 lines.

Verification was run on the included heads before opening the original slices, including focused Lean gates, `lake build`, `trust/scripts/check-all.sh`, and `trust/scripts/check-all-semantic.sh`.
