### PR TITLE
Derive branch no-throw facts from success

### DIFF
--- a/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
@@ -118,7 +118,6 @@ structure Inputs_beq (trace : AcceptedZiskTrace numInstructions) (binding : Sail
           i.val).val
       < GL_prime
   h_pc_bound : beq_input.PC.toNat < 18446744069414584321 - 4
-  h_not_throws : (PureSpec.execute_BEQ_pure beq_input).throws = false
   h_success : (PureSpec.execute_BEQ_pure beq_input).success = true
 
 /-- Per-op residual bundle for the `beq` archetype: the 3-way `Claim`/`Decode`/`Inputs`
@@ -215,7 +214,6 @@ structure Inputs_bne (trace : AcceptedZiskTrace numInstructions) (binding : Sail
           i.val).val
       < GL_prime
   h_pc_bound : bne_input.PC.toNat < 18446744069414584321 - 4
-  h_not_throws : (PureSpec.execute_BNE_pure bne_input).throws = false
   h_success : (PureSpec.execute_BNE_pure bne_input).success = true
 
 /-- Per-op residual bundle for the `bne` archetype: the 3-way `Claim`/`Decode`/`Inputs`
@@ -311,7 +309,6 @@ structure Inputs_blt (trace : AcceptedZiskTrace numInstructions) (binding : Sail
           i.val).val
       < GL_prime
   h_pc_bound : blt_input.PC.toNat < 18446744069414584321 - 4
-  h_not_throws : (PureSpec.execute_BLT_pure blt_input).throws = false
   h_success : (PureSpec.execute_BLT_pure blt_input).success = true
 
 /-- Per-op residual bundle for the `blt` archetype: the 3-way `Claim`/`Decode`/`Inputs`
@@ -408,7 +405,6 @@ structure Inputs_bge (trace : AcceptedZiskTrace numInstructions) (binding : Sail
           i.val).val
       < GL_prime
   h_pc_bound : bge_input.PC.toNat < 18446744069414584321 - 4
-  h_not_throws : (PureSpec.execute_BGE_pure bge_input).throws = false
   h_success : (PureSpec.execute_BGE_pure bge_input).success = true
 
 /-- Per-op residual bundle for the `bge` archetype: the 3-way `Claim`/`Decode`/`Inputs`
@@ -509,7 +505,6 @@ structure Inputs_bltu (trace : AcceptedZiskTrace numInstructions) (binding : Sai
           i.val).val
       < GL_prime
   h_pc_bound : bltu_input.PC.toNat < 18446744069414584321 - 4
-  h_not_throws : (PureSpec.execute_BLTU_pure bltu_input).throws = false
   h_success : (PureSpec.execute_BLTU_pure bltu_input).success = true
 
 /-- Per-op residual bundle for the `bltu` archetype: the 3-way `Claim`/`Decode`/`Inputs`
@@ -609,7 +604,6 @@ structure Inputs_bgeu (trace : AcceptedZiskTrace numInstructions) (binding : Sai
           i.val).val
       < GL_prime
   h_pc_bound : bgeu_input.PC.toNat < 18446744069414584321 - 4
-  h_not_throws : (PureSpec.execute_BGEU_pure bgeu_input).throws = false
   h_success : (PureSpec.execute_BGEU_pure bgeu_input).success = true
 
 /-- Per-op residual bundle for the `bgeu` archetype: the 3-way `Claim`/`Decode`/`Inputs`

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
@@ -458,7 +458,9 @@ theorem stepStrong_beq
         rw [h_cast]
         exact (PureSpec.execute_BEQ_pure_nextPC_of_success
           d.toInputs.beq_input d.toInputs.h_success).symm
-      not_throws := d.toInputs.h_not_throws
+      not_throws :=
+        PureSpec.execute_BEQ_pure_succ_throws
+          d.toInputs.beq_input d.toInputs.h_success
       success := d.toInputs.h_success }
   let env : OpEnvelope state m i.val := OpEnvelope.beq d.toInputs.beq_input ops promises
   have h_bridge : env.aeneasBridgeTrust :=
@@ -518,7 +520,9 @@ theorem stepStrong_bne
         rw [h_cast]
         exact (PureSpec.execute_BNE_pure_nextPC_of_success
           d.toInputs.bne_input d.toInputs.h_success).symm
-      not_throws := d.toInputs.h_not_throws
+      not_throws :=
+        PureSpec.execute_BNE_pure_succ_throws
+          d.toInputs.bne_input d.toInputs.h_success
       success := d.toInputs.h_success }
   let env : OpEnvelope state m i.val := OpEnvelope.bne d.toInputs.bne_input ops promises
   have h_bridge : env.aeneasBridgeTrust :=
@@ -578,7 +582,9 @@ theorem stepStrong_blt
         rw [h_cast]
         exact (PureSpec.execute_BLT_pure_nextPC_of_success
           d.toInputs.blt_input d.toInputs.h_success).symm
-      not_throws := d.toInputs.h_not_throws
+      not_throws :=
+        PureSpec.execute_BLT_pure_succ_throws
+          d.toInputs.blt_input d.toInputs.h_success
       success := d.toInputs.h_success }
   let env : OpEnvelope state m i.val := OpEnvelope.blt d.toInputs.blt_input ops promises
   have h_bridge : env.aeneasBridgeTrust :=
@@ -638,7 +644,9 @@ theorem stepStrong_bge
         rw [h_cast]
         exact (PureSpec.execute_BGE_pure_nextPC_of_success
           d.toInputs.bge_input d.toInputs.h_success).symm
-      not_throws := d.toInputs.h_not_throws
+      not_throws :=
+        PureSpec.execute_BGE_pure_succ_throws
+          d.toInputs.bge_input d.toInputs.h_success
       success := d.toInputs.h_success }
   let env : OpEnvelope state m i.val := OpEnvelope.bge d.toInputs.bge_input ops promises
   have h_bridge : env.aeneasBridgeTrust :=
@@ -701,7 +709,9 @@ theorem stepStrong_bltu
         rw [h_cast]
         exact (PureSpec.execute_BLTU_pure_nextPC_of_success
           d.toInputs.bltu_input d.toInputs.h_success).symm
-      not_throws := d.toInputs.h_not_throws
+      not_throws :=
+        PureSpec.execute_BLTU_pure_succ_throws
+          d.toInputs.bltu_input d.toInputs.h_success
       success := d.toInputs.h_success }
   let env : OpEnvelope state m i.val := OpEnvelope.bltu d.toInputs.bltu_input ops promises
   have h_bridge : env.aeneasBridgeTrust :=
@@ -764,7 +774,9 @@ theorem stepStrong_bgeu
         rw [h_cast]
         exact (PureSpec.execute_BGEU_pure_nextPC_of_success
           d.toInputs.bgeu_input d.toInputs.h_success).symm
-      not_throws := d.toInputs.h_not_throws
+      not_throws :=
+        PureSpec.execute_BGEU_pure_succ_throws
+          d.toInputs.bgeu_input d.toInputs.h_success
       success := d.toInputs.h_success }
   let env : OpEnvelope state m i.val := OpEnvelope.bgeu d.toInputs.bgeu_input ops promises
   have h_bridge : env.aeneasBridgeTrust :=

--- a/ZiskFv/SailSpec/bge.lean
+++ b/ZiskFv/SailSpec/bge.lean
@@ -30,6 +30,15 @@ namespace PureSpec
       : BgeOutput
     }
 
+  lemma execute_BGE_pure_succ_throws
+    (input : BgeInput)
+  :
+    let output := execute_BGE_pure input
+    output.success = true → output.throws = false
+  := by
+    simp [execute_BGE_pure]
+    grind
+
   set_option maxHeartbeats 400000 in
   /-- BGE Sail-equivalence: BLT sibling with `≥b` instead of `<b`.
       Sail's `execute_BTYPE` BGE arm emits `zopz0zKzJ_s (rX rs1) (rX rs2)`
@@ -119,7 +128,7 @@ namespace PureSpec
           else bi.PC + BitVec.signExtend 64 bi.imm := by
     have hslt : BitVec.slt bi.r1_val bi.r2_val
         = !(bi.r1_val.toInt ≥b bi.r2_val.toInt) := by
-      simp [BitVec.slt, ge_iff_le, ← decide_not, Int.not_le]
+      simp [BitVec.slt, ge_iff_le, ← decide_not]
     rw [hslt]
     cases h : bi.r1_val.toInt ≥b bi.r2_val.toInt with
     | false => simp [execute_BGE_pure, h]

--- a/ZiskFv/SailSpec/bgeu.lean
+++ b/ZiskFv/SailSpec/bgeu.lean
@@ -30,6 +30,15 @@ namespace PureSpec
       : BgeuOutput
     }
 
+  lemma execute_BGEU_pure_succ_throws
+    (input : BgeuInput)
+  :
+    let output := execute_BGEU_pure input
+    output.success = true → output.throws = false
+  := by
+    simp [execute_BGEU_pure]
+    grind
+
   set_option maxHeartbeats 400000 in
   /-- BGEU Sail-equivalence: unsigned greater-equal sibling of BGE /
       BLTU. Closure shape identical to BLTU with `≥` swapped for `<`. -/
@@ -116,7 +125,7 @@ namespace PureSpec
           else bi.PC + BitVec.signExtend 64 bi.imm := by
     have hult : BitVec.ult bi.r1_val bi.r2_val
         = !(bi.r1_val.toNat ≥b bi.r2_val.toNat) := by
-      simp [BitVec.ult, ge_iff_le, ← decide_not, Nat.not_le]
+      simp [BitVec.ult, ge_iff_le, ← decide_not]
     rw [hult]
     cases h : bi.r1_val.toNat ≥b bi.r2_val.toNat with
     | false => simp [execute_BGEU_pure, h]

--- a/ZiskFv/SailSpec/blt.lean
+++ b/ZiskFv/SailSpec/blt.lean
@@ -30,6 +30,15 @@ namespace PureSpec
       : BltOutput
     }
 
+  lemma execute_BLT_pure_succ_throws
+    (input : BltInput)
+  :
+    let output := execute_BLT_pure input
+    output.success = true → output.throws = false
+  := by
+    simp [execute_BLT_pure]
+    grind
+
   set_option maxHeartbeats 400000 in
   /-- BLT Sail-equivalence: the `do` block consisting of a default
       `nextPC ← PC + 4` write followed by `execute (.BTYPE imm r2 r1 BLT)`

--- a/ZiskFv/SailSpec/bltu.lean
+++ b/ZiskFv/SailSpec/bltu.lean
@@ -30,6 +30,15 @@ namespace PureSpec
       : BltuOutput
     }
 
+  lemma execute_BLTU_pure_succ_throws
+    (input : BltuInput)
+  :
+    let output := execute_BLTU_pure input
+    output.success = true → output.throws = false
+  := by
+    simp [execute_BLTU_pure]
+    grind
+
   set_option maxHeartbeats 400000 in
   /-- BLTU Sail-equivalence: unsigned less-than sibling of BLT. Sail's
       `zopz0zI_u` unfolds to `.toNatInt <b .toNatInt`, and


### PR DESCRIPTION
Part of #141.

This is the twelfth stacked #141 review slice, based on #200. It removes redundant branch no-throw premises from the trace-level export inputs and derives them in the step-strong construction instead of carrying them as public assumptions.

Changes:
- remove `h_not_throws` from `Inputs_beq`, `Inputs_bne`, `Inputs_blt`, `Inputs_bge`, `Inputs_bltu`, and `Inputs_bgeu`
- add pure-spec success-implies-no-throw lemmas for BLT/BGE/BLTU/BGEU, matching the existing BEQ/BNE lemmas
- derive each `BranchPromises.not_throws` field in `StepStrongControlStore` from the existing `h_success` proof

Verification:
- `lake env lean --tstack=400000 ZiskFv/SailSpec/blt.lean`
- `lake env lean --tstack=400000 ZiskFv/SailSpec/bge.lean`
- `lake env lean --tstack=400000 ZiskFv/SailSpec/bltu.lean`
- `lake env lean --tstack=400000 ZiskFv/SailSpec/bgeu.lean`
- `lake env lean --tstack=400000 ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean`
- `lake build ZiskFv.SailSpec.blt ZiskFv.SailSpec.bge ZiskFv.SailSpec.bltu ZiskFv.SailSpec.bgeu`
- `lake env lean --tstack=400000 ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean`
- `lake build ZiskFv.Compliance.TraceLevelExport.StepStrongControlStore`
- `lake env lean --tstack=400000 ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean`
- `lake build ZiskFv.Compliance.TraceLevelExport.Dispatcher`
- `lake build`
- `trust/scripts/check-all.sh`
- `trust/scripts/check-all-semantic.sh`
