### PR TITLE
Derive JAL no-throw fact from success

### DIFF
--- a/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
@@ -685,7 +685,6 @@ structure Inputs_jal (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_success : (PureSpec.execute_JAL_pure jal_input).success = true
   h_nextPC_option : (PureSpec.execute_JAL_pure jal_input).nextPC = .some nextPC_val
   h_input_imm : jal_input.imm = c.imm
-  h_not_throws : (PureSpec.execute_JAL_pure jal_input).throws = false
   h_pc_bound : jal_input.PC.toNat < GL_prime - 4
   h_pc_offset_lt_2_32 : (jal_input.PC + 4#64).toNat < 4294967296
 

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
@@ -1019,7 +1019,8 @@ theorem stepStrong_jal
             (d.toInputs.jal_input.PC + BitVec.signExtend 64 d.toInputs.jal_input.imm)[0]! == 0#1)
           = false := by
       have h_t : (PureSpec.execute_JAL_pure d.toInputs.jal_input).throws = false :=
-        d.toInputs.h_not_throws
+        PureSpec.execute_JAL_pure_succ_throws
+          d.toInputs.jal_input d.toInputs.h_success
       simp only [PureSpec.execute_JAL_pure] at h_t
       exact h_t
     have h_bit1_neg :
@@ -1106,10 +1107,13 @@ theorem stepStrong_jal
       nextPC_option := d.toInputs.h_nextPC_option
       rd_idx := d.toInputs.h_input_rd.trans
         (eRdLui_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset) }
+  have h_not_throws : (PureSpec.execute_JAL_pure d.toInputs.jal_input).throws = false :=
+    PureSpec.execute_JAL_pure_succ_throws
+      d.toInputs.jal_input d.toInputs.h_success
   let env : OpEnvelope state m i.val :=
     OpEnvelope.jal d.toInputs.jal_input d.toClaim.imm d.toClaim.rd d.toInputs.misa_val next_pc (Pilot.execRowOf trace i) e_rd
       d.toInputs.nextPC_val store_pc_mem provenance row_mode h_jal_subset d.toDecode.h_jmp2 d.toInputs.h_pc_bridge
-      promises d.toInputs.h_input_imm d.toInputs.h_not_throws d.toInputs.h_pc_bound d.toInputs.h_pc_offset_lt_2_32
+      promises d.toInputs.h_input_imm h_not_throws d.toInputs.h_pc_bound d.toInputs.h_pc_offset_lt_2_32
   have h_bridge : env.aeneasBridgeTrust :=
     ⟨⟨provenance⟩, row_mode, d.toDecode.h_jmp2, d.toInputs.h_pc_bridge⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial

--- a/ZiskFv/SailSpec/jal.lean
+++ b/ZiskFv/SailSpec/jal.lean
@@ -37,6 +37,15 @@ namespace PureSpec
       throws := !bit0_valid
     }
 
+  lemma execute_JAL_pure_succ_throws
+    (input : JalInput)
+  :
+    let output := execute_JAL_pure input
+    output.success = true → output.throws = false
+  := by
+    simp [execute_JAL_pure]
+    grind
+
   /-- Dispatcher-unfold: `execute (.JAL …)` reduces to `execute_JAL`.
       Mirrors `RV32D/jal.lean`'s `rv32d_execute_jal` lemma. -/
   lemma rv64d_execute_jal :


### PR DESCRIPTION
Part of #141.

This is the thirteenth stacked #141 review slice, based on #201. It removes the remaining JAL no-throw premise from the trace-level export inputs and derives it in the step-strong construction instead of carrying it as a public assumption.

Changes:
- remove `h_not_throws` from `Inputs_jal`
- add `PureSpec.execute_JAL_pure_succ_throws`
- derive the local JAL no-throw fact from `h_success` in `StepStrongControlStore`
- use that derived fact both in the JAL target proof and when constructing `OpEnvelope.jal`

Verification:
- `lake env lean --tstack=400000 ZiskFv/SailSpec/jal.lean`
- `lake env lean --tstack=400000 ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean`
- `lake build ZiskFv.SailSpec.jal`
- `lake env lean --tstack=400000 ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean`
- `lake build ZiskFv.Compliance.TraceLevelExport.StepStrongControlStore`
- `lake env lean --tstack=400000 ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean`
- `lake build ZiskFv.Compliance.TraceLevelExport.Dispatcher`
- `lake build`
- `trust/scripts/check-all.sh`
- `trust/scripts/check-all-semantic.sh`
