### PR TITLE
Derive jump nextPC witnesses from success

### DIFF
--- a/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
@@ -662,7 +662,6 @@ structure Inputs_jal (trace : AcceptedZiskTrace numInstructions) (binding : Sail
     (i : Fin trace.numInstructions) (c : Claim_jal trace i) : Type where
   jal_input : PureSpec.JalInput
   misa_val : RegisterType Register.misa
-  nextPC_val : BitVec 64
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = jal_input.PC.toNat
@@ -683,7 +682,6 @@ structure Inputs_jal (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_input_misa : (binding i).regs.get? Register.misa = .some misa_val
   h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1
   h_success : (PureSpec.execute_JAL_pure jal_input).success = true
-  h_nextPC_option : (PureSpec.execute_JAL_pure jal_input).nextPC = .some nextPC_val
   h_input_imm : jal_input.imm = c.imm
   h_pc_bound : jal_input.PC.toNat < GL_prime - 4
   h_pc_offset_lt_2_32 : (jal_input.PC + 4#64).toNat < 4294967296
@@ -775,7 +773,6 @@ structure Inputs_jalr (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   jalr_input : PureSpec.JalrInput
   misa_val : RegisterType Register.misa
   mseccfg : RegisterType Register.mseccfg
-  nextPC_val : BitVec 64
   -- #100: the per-lowering operand identity replacing the cross-world
   -- `h_nextPC_matches`. The committed Main `b`-lane (`b_0 + b_1 · 2^32`) plus
   -- `offset_bv` equals Sail's pre-mask target `rs1_val + signExtend 64 imm`:
@@ -795,7 +792,6 @@ structure Inputs_jalr (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_input_misa : (binding i).regs.get? Register.misa = .some misa_val
   h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1
   h_success : (PureSpec.execute_JALR_pure jalr_input).success = true
-  h_nextPC_option : (PureSpec.execute_JALR_pure jalr_input).nextPC = .some nextPC_val
   h_input_imm : jalr_input.imm = c.imm
   h_input_rs1 : read_xreg (regidx_to_fin c.rs1) (binding i)
     = EStateM.Result.ok jalr_input.rs1_val (binding i)

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
@@ -1009,32 +1009,11 @@ theorem stepStrong_jal
   have h_flag : m.flag i.val = 1 :=
     ZiskFv.Airs.Main.flag_eq_one_of_internal_op_zero m i.val d.toDecode.h_main_active
       (by simpa [ZiskFv.Trusted.OP_FLAG] using d.toDecode.h_main_op) h_set_flag
-  -- #100: the JAL jump target `nextPC_val = PC + signExtend 64 imm`, derived
-  -- from `success = true` (both alignment bits valid ⇒ the taken branch).
-  have h_target :
-      d.toInputs.jal_input.PC + BitVec.signExtend 64 d.toInputs.jal_input.imm
-        = d.toInputs.nextPC_val := by
-    have h_bit0_neg :
-        (!BitVec.ofBool
-            (d.toInputs.jal_input.PC + BitVec.signExtend 64 d.toInputs.jal_input.imm)[0]! == 0#1)
-          = false := by
-      have h_t : (PureSpec.execute_JAL_pure d.toInputs.jal_input).throws = false :=
-        PureSpec.execute_JAL_pure_succ_throws
-          d.toInputs.jal_input d.toInputs.h_success
-      simp only [PureSpec.execute_JAL_pure] at h_t
-      exact h_t
-    have h_bit1_neg :
-        (!BitVec.ofBool
-            (d.toInputs.jal_input.PC + BitVec.signExtend 64 d.toInputs.jal_input.imm)[1]! == 0#1)
-          = false := by
-      have h_s : (PureSpec.execute_JAL_pure d.toInputs.jal_input).success = true :=
-        d.toInputs.h_success
-      simp only [PureSpec.execute_JAL_pure] at h_s
-      simp_all
-    have ho := d.toInputs.h_nextPC_option
-    simp only [PureSpec.execute_JAL_pure, h_bit0_neg, h_bit1_neg, Bool.false_or] at ho
-    rw [if_neg (by decide)] at ho
-    exact Option.some.inj ho
+  let nextPC_val : BitVec 64 :=
+    d.toInputs.jal_input.PC + BitVec.signExtend 64 d.toInputs.jal_input.imm
+  have h_nextPC_option :
+      (PureSpec.execute_JAL_pure d.toInputs.jal_input).nextPC = .some nextPC_val :=
+    PureSpec.execute_JAL_pure_succ_nextPC d.toInputs.jal_input d.toInputs.h_success
   -- #100: the field-level no-wrap bound (`pc.val + jmp_offset1.val < GL_prime`),
   -- in column form for `ofNat_fgl_pc_plus_offset_eq`, from the input-facing
   -- target bound via the PC / offset row-shape bridges.
@@ -1081,7 +1060,7 @@ theorem stepStrong_jal
       state d.toInputs.jal_input.PC d.toInputs.jal_input.rd d.toInputs.misa_val
       (PureSpec.execute_JAL_pure d.toInputs.jal_input).success
       (PureSpec.execute_JAL_pure d.toInputs.jal_input).nextPC
-      d.toClaim.rd (Pilot.execRowOf trace i) e_rd d.toInputs.nextPC_val :=
+      d.toClaim.rd (Pilot.execRowOf trace i) e_rd nextPC_val :=
     { input_rd_eq := d.toInputs.h_input_rd
       input_pc_eq := d.toInputs.h_input_pc
       input_misa_eq := d.toInputs.h_input_misa
@@ -1093,18 +1072,18 @@ theorem stepStrong_jal
       -- certificate via the FLAG-PATH lemma (set_pc=0, flag=1 ⇒ pc + jmp_offset1),
       -- then the signed-offset wide-PC cast (`jmp_offset1 = signExtend imm` +
       -- target no-wrap) gives JAL's taken target `PC + signExtend 64 imm`,
-      -- which `h_target` identifies with `nextPC_val`.
+      -- with `nextPC_val` chosen as that computed target.
       nextPC_matches := by
         have hstep := Pilot.flag_path_nextPC_discharged trace i
           d.toDecode.h_idx d.toDecode.h_set_pc h_flag
         rw [hstep]
-        exact (Pilot.ofNat_fgl_pc_plus_offset_eq _ _
+        simpa [nextPC_val] using (Pilot.ofNat_fgl_pc_plus_offset_eq _ _
           d.toInputs.jal_input.PC (BitVec.signExtend 64 d.toInputs.jal_input.imm)
-          d.toInputs.h_pc_bridge d.toInputs.h_offset_bridge h_no_wrap_fgl).trans h_target
+          d.toInputs.h_pc_bridge d.toInputs.h_offset_bridge h_no_wrap_fgl)
       rd_mult := by rfl
       rd_as := by rfl
       success := d.toInputs.h_success
-      nextPC_option := d.toInputs.h_nextPC_option
+      nextPC_option := h_nextPC_option
       rd_idx := d.toInputs.h_input_rd.trans
         (eRdLui_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset) }
   have h_not_throws : (PureSpec.execute_JAL_pure d.toInputs.jal_input).throws = false :=
@@ -1112,7 +1091,7 @@ theorem stepStrong_jal
       d.toInputs.jal_input d.toInputs.h_success
   let env : OpEnvelope state m i.val :=
     OpEnvelope.jal d.toInputs.jal_input d.toClaim.imm d.toClaim.rd d.toInputs.misa_val next_pc (Pilot.execRowOf trace i) e_rd
-      d.toInputs.nextPC_val store_pc_mem provenance row_mode h_jal_subset d.toDecode.h_jmp2 d.toInputs.h_pc_bridge
+      nextPC_val store_pc_mem provenance row_mode h_jal_subset d.toDecode.h_jmp2 d.toInputs.h_pc_bridge
       promises d.toInputs.h_input_imm h_not_throws d.toInputs.h_pc_bound d.toInputs.h_pc_offset_lt_2_32
   have h_bridge : env.aeneasBridgeTrust :=
     ⟨⟨provenance⟩, row_mode, d.toDecode.h_jmp2, d.toInputs.h_pc_bridge⟩
@@ -1240,20 +1219,12 @@ theorem stepStrong_jalr
   obtain ⟨hc0, hc1, hc2, hc3, hc4, hc5, hc6, hc7⟩ :=
     ZiskFv.EquivCore.Bridge.Binary.cByte_ranges_of_all_byte_matches_row
       providerInput h_matches
-  -- (d) JALR's pre-mask target value `nextPC_val = mask &&& (rs1 + signExtend imm)`,
-  --     identified from `success = true` (the aligned/taken branch), as JAL does.
-  have h_target : d.toInputs.nextPC_val
-      = 0xFFFFFFFFFFFFFFFE#64 &&&
-          (d.toInputs.jalr_input.rs1_val + BitVec.signExtend 64 d.toInputs.jalr_input.imm) := by
-    have h_s : (BitVec.ofBool
-          (d.toInputs.jalr_input.rs1_val
-            + BitVec.signExtend 64 d.toInputs.jalr_input.imm)[1]! == 0#1) = true := by
-      have := d.toInputs.h_success
-      simpa [PureSpec.execute_JALR_pure] using this
-    have ho := d.toInputs.h_nextPC_option
-    simp only [PureSpec.execute_JALR_pure, h_s, Bool.not_true, Bool.false_eq_true,
-      if_false] at ho
-    exact (Option.some.inj ho).symm
+  let nextPC_val : BitVec 64 :=
+    0xFFFFFFFFFFFFFFFE &&&
+      (d.toInputs.jalr_input.rs1_val + BitVec.signExtend 64 d.toInputs.jalr_input.imm)
+  have h_nextPC_option :
+      (PureSpec.execute_JALR_pure d.toInputs.jalr_input).nextPC = .some nextPC_val :=
+    PureSpec.execute_JALR_pure_succ_nextPC d.toInputs.jalr_input d.toInputs.h_success
   -- (e) #100: the cross-world next-PC residual is DISCHARGED from the accepted
   --     trace's in-circuit set-PC handshake composed with the masked-AND
   --     target-value derivation (`jalr_setpc_nextPC_discharged`), then bridged to
@@ -1262,7 +1233,7 @@ theorem stepStrong_jalr
   have h_nextPC_disch :
       (register_type_pc_equiv ▸
           (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
-        = d.toInputs.nextPC_val := by
+        = nextPC_val := by
     have hoo := d.toInputs.h_operand_offset
     rw [← hm] at hoo
     rw [ZiskFv.Compliance.Pilot.jalr_setpc_nextPC_discharged
@@ -1274,12 +1245,13 @@ theorem stepStrong_jalr
           hc0 hc1 hc2 hc3 hc4 hc5 hc6 hc7
           d.toDecode.h_c1_zero d.toDecode.h_offset_bridge
           d.toDecode.h_offset_even d.toDecode.h_no_fgl_wrap,
-        hoo, h_target]
+        hoo]
+    simp [nextPC_val]
   let promises : ZiskFv.EquivCore.Promises.JumpPromises
       state d.toInputs.jalr_input.PC d.toInputs.jalr_input.rd d.toInputs.misa_val
       (PureSpec.execute_JALR_pure d.toInputs.jalr_input).success
       (PureSpec.execute_JALR_pure d.toInputs.jalr_input).nextPC
-      d.toClaim.rd (Pilot.execRowOf trace i) e_rd d.toInputs.nextPC_val :=
+      d.toClaim.rd (Pilot.execRowOf trace i) e_rd nextPC_val :=
     { input_rd_eq := d.toInputs.h_input_rd
       input_pc_eq := d.toInputs.h_input_pc
       input_misa_eq := d.toInputs.h_input_misa
@@ -1292,12 +1264,12 @@ theorem stepStrong_jalr
       rd_mult := by rfl
       rd_as := by rfl
       success := d.toInputs.h_success
-      nextPC_option := d.toInputs.h_nextPC_option
+      nextPC_option := h_nextPC_option
       rd_idx := d.toInputs.h_input_rd.trans
         (eRdLui_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset) }
   let env : OpEnvelope state m i.val :=
     OpEnvelope.jalr d.toInputs.jalr_input d.toClaim.imm d.toClaim.rs1 d.toClaim.rd d.toInputs.misa_val d.toInputs.mseccfg (Pilot.execRowOf trace i) e_rd
-      d.toInputs.nextPC_val next_pc store_pc_mem pins d.toDecode.h_flag d.toDecode.h_m32 d.toDecode.h_set_pc d.toDecode.h_store_pc
+      nextPC_val next_pc store_pc_mem pins d.toDecode.h_flag d.toDecode.h_m32 d.toDecode.h_set_pc d.toDecode.h_store_pc
       h_jalr_subset promises d.toInputs.h_input_imm d.toInputs.h_input_rs1 d.toInputs.h_cur_privilege d.toInputs.h_mseccfg
       d.toInputs.h_link_bridge d.toInputs.h_pc_bound d.toInputs.h_pc_offset_lt_2_32
   have h_bridge : env.aeneasBridgeTrust :=

--- a/ZiskFv/SailSpec/jal.lean
+++ b/ZiskFv/SailSpec/jal.lean
@@ -46,6 +46,16 @@ namespace PureSpec
     simp [execute_JAL_pure]
     grind
 
+  lemma execute_JAL_pure_succ_nextPC
+    (input : JalInput)
+  :
+    let output := execute_JAL_pure input
+    output.success = true →
+      output.nextPC = .some (input.PC + BitVec.signExtend 64 input.imm)
+  := by
+    simp [execute_JAL_pure]
+    grind
+
   /-- Dispatcher-unfold: `execute (.JAL …)` reduces to `execute_JAL`.
       Mirrors `RV32D/jal.lean`'s `rv32d_execute_jal` lemma. -/
   lemma rv64d_execute_jal :

--- a/ZiskFv/SailSpec/jalr.lean
+++ b/ZiskFv/SailSpec/jalr.lean
@@ -36,6 +36,24 @@ namespace PureSpec
       success := (bit1_valid)
     }
 
+  lemma execute_JALR_pure_succ_nextPC
+    (input : JalrInput)
+  :
+    let output := execute_JALR_pure input
+    output.success = true →
+      output.nextPC =
+        .some (0xFFFFFFFFFFFFFFFE &&&
+          (input.rs1_val + BitVec.signExtend 64 input.imm))
+  := by
+    simp only [execute_JALR_pure]
+    intro h_valid
+    have h_eq :
+        BitVec.ofBool
+            (input.rs1_val + BitVec.signExtend 64 input.imm)[1]
+          = 0#1 := by
+      simpa only [beq_iff_eq] using h_valid
+    rw [if_neg (by simp [h_eq])]
+
   -- JALR Sail-equivalence. Direct port of the `execute_JAL_pure_equiv`
   -- proof shape, adapted for JALR's pre-masked target
   -- (`BitVec.update target 0 0#1` clears bit 0, so the


### PR DESCRIPTION
Part of #141. Stacked on #202.

This removes the JAL/JALR input-carried `nextPC_val` and `h_nextPC_option` witnesses. The step-strong proof now chooses the computed JAL/JALR target locally and derives `JumpPromises.nextPC_option` from the existing pure-spec `success` fact.

Verification:
- `lake env lean --tstack=400000 ZiskFv/SailSpec/jal.lean`
- `lake env lean --tstack=400000 ZiskFv/SailSpec/jalr.lean`
- `lake build ZiskFv.SailSpec.jal ZiskFv.SailSpec.jalr`
- `lake env lean --tstack=400000 ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean`
- `lake env lean --tstack=400000 ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean`
- `lake build ZiskFv.Compliance.TraceLevelExport.RowDataControl ZiskFv.Compliance.TraceLevelExport.StepStrongControlStore`
- `lake env lean --tstack=400000 ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean`
- `lake build ZiskFv.Compliance.TraceLevelExport.Dispatcher`
- `lake build`
- `trust/scripts/check-all.sh`
- `trust/scripts/check-all-semantic.sh`