### PR TITLE
Derive JALR link bridge from decode

### DIFF
--- a/ZiskFv/Compliance/TraceLevelExport/Base.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/Base.lean
@@ -40,6 +40,15 @@ seal mulwArow mulhuArow divuArow divuwArow remuArow remuwArow
 
 set_option maxHeartbeats 8000000
 
+/-- Sequential next-PC theorem-domain range assumption.
+
+This is the explicit soundness-domain condition used by the sequential `PC + 4`
+cast. It is not Sail/ZisK state agreement and not a decoded placement fact, so
+`Inputs_<op>` records should not carry it once the opcode family has been
+factored to `RowOutsideDefectRegion`. -/
+def SequentialPcDomain (pc : BitVec 64) : Prop :=
+  pc.toNat < GL_prime - 4
+
 /-- All-zero `Valid_Binary` — pure data, never consumed by any dispatcher arm
     (the RTYPE/ITYPE/W binary `OpEnvelope` arms carry it as an unused field).
     Building it with `0` lanes is non-vacuous: it imposes no constraint and

--- a/ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean
@@ -259,30 +259,107 @@ def InputsAgree (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : Sai
 /-- Per-row known-defect exclusion obligation, stated DIRECTLY over the row data
     (no `OpEnvelope` detour).
 
-    The 8 defect-capable arms carry the genuine forge exclusion, read off the
+    The defect-capable arms carry the genuine forge exclusion, read off the
     arith witness / claim fields that live in `ia` (the `inputsAgree` half) or in
     the matched `ZiskStep` claim payload:
       * MUL / MULH / MULHSU → `¬ SignedMulForge` of the ArithMul sign witnesses;
       * DIV / REM → `¬ DivRemForge` of the 64-bit remainder/divisor magnitudes;
       * DIVW / REMW → `¬ DivRemForgeW` of the 32-bit remainder/divisor magnitudes;
       * FENCE → `FenceKnownGood` of the claim's `fm` / `rs` / `rd`.
-    Each is DEFINITIONALLY the same proposition as the corresponding `<op>EnvOf`
-    `OpEnvelope` defect shape (the `Iff.rfl` bridge lemmas in `EnvOf`), so the
-    re-expression off `OpEnvelope` carries no change of meaning.  Every other
-    (non-defect) arm carries no defect obligation (`True`). -/
+
+    The sequential, branch, and jump-like arms that have been factored carry
+    theorem-domain PC range assumptions separately from `InputsAgree`: these are
+    not state/value agreement facts, and they are not derived placement facts.
+    They preserve the old no-wrap / PC-bound obligations at the explicit
+    theorem-domain surface.
+    For defect-gated arms, the defect component is DEFINITIONALLY the same
+    proposition as the corresponding `<op>EnvOf` `OpEnvelope` defect shape (the
+    `Iff.rfl` bridge lemmas in `EnvOf`), so the re-expression off `OpEnvelope`
+    carries no change of meaning.  The separate sequential-domain component is
+    the old PC-bound obligation factored out of `InputsAgree`. -/
 def RowOutsideDefectRegion (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions)
     (i : Fin ziskTrace.numInstructions) (zs : ZiskStep ziskTrace i)
     (ia : InputsAgree ziskTrace sailTrace i zs) : Prop :=
   match zs, ia with
-  | .mul _, ia => ¬ Defects.SignedMulForge ia.v ia.r_a
-  | .mulh _, ia => ¬ Defects.SignedMulForge ia.v ia.r_a
-  | .mulhsu _, ia => ¬ Defects.SignedMulForge ia.v ia.r_a
-  | .div _, ia => ¬ Defects.DivRemForge ia.div_input.r2_val ia.v ia.r_a
-  | .rem _, ia => ¬ Defects.DivRemForge ia.rem_input.r2_val ia.v ia.r_a
-  | .divw _, ia => ¬ Defects.DivRemForgeW ia.divw_input.r2_val ia.v ia.r_a
-  | .remw _, ia => ¬ Defects.DivRemForgeW ia.remw_input.r2_val ia.v ia.r_a
-  | .fence c, _ => Defects.FenceKnownGood c.fm c.rs c.rd
-  | _, _ => True
+  | .mul _, ia => SequentialPcDomain ia.mul_input.PC ∧ ¬ Defects.SignedMulForge ia.v ia.r_a
+  | .mulh _, ia => SequentialPcDomain ia.mulh_input.PC ∧ ¬ Defects.SignedMulForge ia.v ia.r_a
+  | .mulhsu _, ia => SequentialPcDomain ia.mulhsu_input.PC ∧ ¬ Defects.SignedMulForge ia.v ia.r_a
+  | .div _, ia =>
+      SequentialPcDomain ia.div_input.PC ∧ ¬ Defects.DivRemForge ia.div_input.r2_val ia.v ia.r_a
+  | .rem _, ia =>
+      SequentialPcDomain ia.rem_input.PC ∧ ¬ Defects.DivRemForge ia.rem_input.r2_val ia.v ia.r_a
+  | .divw _, ia =>
+      SequentialPcDomain ia.divw_input.PC ∧ ¬ Defects.DivRemForgeW ia.divw_input.r2_val ia.v ia.r_a
+  | .remw _, ia =>
+      SequentialPcDomain ia.remw_input.PC ∧ ¬ Defects.DivRemForgeW ia.remw_input.r2_val ia.v ia.r_a
+  | .mulw _, ia => SequentialPcDomain ia.mulw_input.PC
+  | .mulhu _, ia => SequentialPcDomain ia.mulhu_input.PC
+  | .divu _, ia => SequentialPcDomain ia.divu_input.PC
+  | .divuw _, ia => SequentialPcDomain ia.divuw_input.PC
+  | .remu _, ia => SequentialPcDomain ia.remu_input.PC
+  | .remuw _, ia => SequentialPcDomain ia.remuw_input.PC
+  | .sub _, ia => SequentialPcDomain ia.sub_input.PC
+  | .and _, ia => SequentialPcDomain ia.and_input.PC
+  | .or _, ia => SequentialPcDomain ia.or_input.PC
+  | .xor _, ia => SequentialPcDomain ia.xor_input.PC
+  | .slt _, ia => SequentialPcDomain ia.slt_input.PC
+  | .sltu _, ia => SequentialPcDomain ia.sltu_input.PC
+  | .andi _, ia => SequentialPcDomain ia.andi_input.PC
+  | .ori _, ia => SequentialPcDomain ia.ori_input.PC
+  | .xori _, ia => SequentialPcDomain ia.xori_input.PC
+  | .slti _, ia => SequentialPcDomain ia.slti_input.PC
+  | .sltiu _, ia => SequentialPcDomain ia.sltiu_input.PC
+  | .sll _, ia => SequentialPcDomain ia.sll_input.PC
+  | .srl _, ia => SequentialPcDomain ia.srl_input.PC
+  | .sra _, ia => SequentialPcDomain ia.sra_input.PC
+  | .slli _, ia => SequentialPcDomain ia.slli_input.PC
+  | .srli _, ia => SequentialPcDomain ia.srli_input.PC
+  | .srai _, ia => SequentialPcDomain ia.srai_input.PC
+  | .add _, ia => SequentialPcDomain ia.add_input.PC
+  | .addi _, ia => SequentialPcDomain ia.addi_input.PC
+  | .subw _, ia => SequentialPcDomain ia.subw_input.PC
+  | .addw _, ia => SequentialPcDomain ia.addw_input.PC
+  | .addiw _, ia => SequentialPcDomain ia.addiw_input.PC
+  | .sllw _, ia => SequentialPcDomain ia.sllw_input.PC
+  | .srlw _, ia => SequentialPcDomain ia.srlw_input.PC
+  | .sraw _, ia => SequentialPcDomain ia.sraw_input.PC
+  | .slliw c, _ => SequentialPcDomain c.slliw_input.PC
+  | .srliw c, _ => SequentialPcDomain c.srliw_input.PC
+  | .sraiw c, _ => SequentialPcDomain c.sraiw_input.PC
+  | .beq _, ia =>
+      BranchRangeDomain ziskTrace i ia.beq_input.PC
+        ((mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset1 i.val)
+  | .bne _, ia =>
+      BranchRangeDomain ziskTrace i ia.bne_input.PC
+        ((mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset2 i.val)
+  | .blt _, ia =>
+      BranchRangeDomain ziskTrace i ia.blt_input.PC
+        ((mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset1 i.val)
+  | .bge _, ia =>
+      BranchRangeDomain ziskTrace i ia.bge_input.PC
+        ((mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset2 i.val)
+  | .bltu _, ia =>
+      BranchRangeDomain ziskTrace i ia.bltu_input.PC
+        ((mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset1 i.val)
+  | .bgeu _, ia =>
+      BranchRangeDomain ziskTrace i ia.bgeu_input.PC
+        ((mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset2 i.val)
+  | .auipc _, ia => AuipcRangeDomain ia.auipc_input
+  | .jal _, ia => JalRangeDomain ia.jal_input
+  | .jalr _, ia => JalrRangeDomain ia.jalr_input
+  | .lui _, ia => SequentialPcDomain ia.lui_input.PC
+  | .sb c, _ => SequentialPcDomain c.sb_input.PC
+  | .sh c, _ => SequentialPcDomain c.sh_input.PC
+  | .sw c, _ => SequentialPcDomain c.sw_input.PC
+  | .sd c, _ => SequentialPcDomain c.sd_input.PC
+  | .ld c, _ => SequentialPcDomain c.ld_input.PC
+  | .lbu c, _ => SequentialPcDomain c.lbu_input.PC
+  | .lhu c, _ => SequentialPcDomain c.lhu_input.PC
+  | .lwu c, _ => SequentialPcDomain c.lwu_input.PC
+  | .lb c, _ => SequentialPcDomain c.lb_input.PC
+  | .lh c, _ => SequentialPcDomain c.lh_input.PC
+  | .lw c, _ => SequentialPcDomain c.lw_input.PC
+  | .fence c, ia => SequentialPcDomain ia.fence_input.PC ∧ Defects.FenceKnownGood c.fm c.rs c.rd
 
 def StepSound
     (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions) (i : Fin ziskTrace.numInstructions) :
@@ -817,15 +894,15 @@ theorem stepSound_of_evidence (ziskTrace : AcceptedZiskTrace numInstructions) (s
   | slliw c => exact stepStrong_slliw ziskTrace sailTrace i (toRowData_slliw c rd ia) hAvoidKnownBugs
   | srliw c => exact stepStrong_srliw ziskTrace sailTrace i (toRowData_srliw c rd ia) hAvoidKnownBugs
   | sraiw c => exact stepStrong_sraiw ziskTrace sailTrace i (toRowData_sraiw c rd ia) hAvoidKnownBugs
-  | mul c => exact stepStrong_mul ziskTrace sailTrace i (toRowData_mul c rd ia) hAvoidKnownBugs
-  | mulh c => exact stepStrong_mulh ziskTrace sailTrace i (toRowData_mulh c rd ia) hAvoidKnownBugs
-  | mulhsu c => exact stepStrong_mulhsu ziskTrace sailTrace i (toRowData_mulhsu c rd ia) hAvoidKnownBugs
+  | mul c => exact stepStrong_mul ziskTrace sailTrace i (toRowData_mul c rd ia) hAvoidKnownBugs.1 hAvoidKnownBugs.2
+  | mulh c => exact stepStrong_mulh ziskTrace sailTrace i (toRowData_mulh c rd ia) hAvoidKnownBugs.1 hAvoidKnownBugs.2
+  | mulhsu c => exact stepStrong_mulhsu ziskTrace sailTrace i (toRowData_mulhsu c rd ia) hAvoidKnownBugs.1 hAvoidKnownBugs.2
   | mulw c => exact stepStrong_mulw ziskTrace sailTrace i (toRowData_mulw c rd ia) hAvoidKnownBugs
   | mulhu c => exact stepStrong_mulhu ziskTrace sailTrace i (toRowData_mulhu c rd ia) hAvoidKnownBugs
-  | div c => exact stepStrong_div ziskTrace sailTrace i (toRowData_div c rd ia) hAvoidKnownBugs
-  | rem c => exact stepStrong_rem ziskTrace sailTrace i (toRowData_rem c rd ia) hAvoidKnownBugs
-  | divw c => exact stepStrong_divw ziskTrace sailTrace i (toRowData_divw c rd ia) hAvoidKnownBugs
-  | remw c => exact stepStrong_remw ziskTrace sailTrace i (toRowData_remw c rd ia) hAvoidKnownBugs
+  | div c => exact stepStrong_div ziskTrace sailTrace i (toRowData_div c rd ia) hAvoidKnownBugs.1 hAvoidKnownBugs.2
+  | rem c => exact stepStrong_rem ziskTrace sailTrace i (toRowData_rem c rd ia) hAvoidKnownBugs.1 hAvoidKnownBugs.2
+  | divw c => exact stepStrong_divw ziskTrace sailTrace i (toRowData_divw c rd ia) hAvoidKnownBugs.1 hAvoidKnownBugs.2
+  | remw c => exact stepStrong_remw ziskTrace sailTrace i (toRowData_remw c rd ia) hAvoidKnownBugs.1 hAvoidKnownBugs.2
   | divu c => exact stepStrong_divu ziskTrace sailTrace i (toRowData_divu c rd ia) hAvoidKnownBugs
   | divuw c => exact stepStrong_divuw ziskTrace sailTrace i (toRowData_divuw c rd ia) hAvoidKnownBugs
   | remu c => exact stepStrong_remu ziskTrace sailTrace i (toRowData_remu c rd ia) hAvoidKnownBugs
@@ -851,6 +928,6 @@ theorem stepSound_of_evidence (ziskTrace : AcceptedZiskTrace numInstructions) (s
   | lb c => exact stepStrong_lb ziskTrace sailTrace i (toRowData_lb c rd ia) hAvoidKnownBugs
   | lh c => exact stepStrong_lh ziskTrace sailTrace i (toRowData_lh c rd ia) hAvoidKnownBugs
   | lw c => exact stepStrong_lw ziskTrace sailTrace i (toRowData_lw c rd ia) hAvoidKnownBugs
-  | fence c => exact stepStrong_fence ziskTrace sailTrace i (toRowData_fence c rd ia) hAvoidKnownBugs
+  | fence c => exact stepStrong_fence ziskTrace sailTrace i (toRowData_fence c rd ia) hAvoidKnownBugs.1 hAvoidKnownBugs.2
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/TraceLevelExport/EnvOf.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/EnvOf.lean
@@ -70,7 +70,8 @@ theorem busSub_rd_idx_of_decode
     exact env the proof feeds to `zisk_riscv_compliant_program_bus`. -/
 noncomputable def fenceEnvOf
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_fence trace binding i) :
+    (d : RowData_fence trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.fence_input.PC) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
   OpEnvelope.fence d.toInputs.fence_input d.toClaim.fm d.toClaim.fenceP d.toClaim.fenceS d.toClaim.rs d.toClaim.rd (Pilot.execRowOf trace i)
@@ -83,7 +84,7 @@ noncomputable def fenceEnvOf
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound }
+          d.toInputs.h_pc_bridge h_domain }
 
 /-- The `OpEnvelope.mul` env CONSTRUCTED from a `RowData_mul`.  Both the
     `RowOutsideDefectRegion` mul obligation AND `stepStrong_mul` reference THIS env, so
@@ -92,7 +93,8 @@ noncomputable def fenceEnvOf
     `fenceEnvOf`: a specific-env obligation, SATISFIABLE for an honest row.) -/
 noncomputable def mulEnvOf
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_mul trace binding i) :
+    (d : RowData_mul trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mul_input.PC) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
   let bus := busSub trace i (Pilot.execRowOf trace i)
@@ -106,7 +108,7 @@ noncomputable def mulEnvOf
       (by
         exact Pilot.sequential_nextPC_discharged trace i d.toInputs.mul_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound)
+          d.toInputs.h_pc_bridge h_domain)
       (d.toInputs.promises.input_rd_eq.trans
         (busSub_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)))
     d.toDecode.arith_mem d.toDecode.bounds d.toInputs.h_row_constraints
@@ -125,8 +127,9 @@ noncomputable def mulEnvOf
     the Lean-checked anti-vacuity guard for the strong-export MUL arm. -/
 theorem mul_noKnownDefect_of_rowData
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_mul trace binding i) :
-    Defects.NoKnownDefect (mulEnvOf trace binding i d) := by
+    (d : RowData_mul trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mul_input.PC) :
+    Defects.NoKnownDefect (mulEnvOf trace binding i d h_domain) := by
   intro id
   cases id with
   | arithMulSignedWitnessSoundness =>
@@ -142,7 +145,8 @@ theorem mul_noKnownDefect_of_rowData
     row.  Carries the SIGN-RANGE RESIDUAL `h_sign_a`/`h_sign_b`. -/
 noncomputable def mulhEnvOf
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_mulh trace binding i) :
+    (d : RowData_mulh trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mulh_input.PC) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
   let bus := busSub trace i (Pilot.execRowOf trace i)
@@ -154,7 +158,7 @@ noncomputable def mulhEnvOf
       (by
         exact Pilot.sequential_nextPC_discharged trace i d.toInputs.mulh_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound)
+          d.toInputs.h_pc_bridge h_domain)
       (d.toInputs.promises.input_rd_eq.trans
         (busSub_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)))
     d.toDecode.arith_mem d.toDecode.bounds d.toInputs.h_row_constraints
@@ -165,7 +169,8 @@ noncomputable def mulhEnvOf
     sign-range residual `h_sign_a` (op2 unsigned, table-pinned `nb = 0`). -/
 noncomputable def mulhsuEnvOf
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_mulhsu trace binding i) :
+    (d : RowData_mulhsu trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mulhsu_input.PC) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
   let bus := busSub trace i (Pilot.execRowOf trace i)
@@ -177,7 +182,7 @@ noncomputable def mulhsuEnvOf
       (by
         exact Pilot.sequential_nextPC_discharged trace i d.toInputs.mulhsu_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound)
+          d.toInputs.h_pc_bridge h_domain)
       (d.toInputs.promises.input_rd_eq.trans
         (busSub_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)))
     d.toDecode.arith_mem d.toDecode.bounds d.toInputs.h_row_constraints
@@ -190,8 +195,9 @@ noncomputable def mulhsuEnvOf
     `NoKnownDefect (mulhEnvOf …)` is TRUE — the `.mulh` strong arm is NON-VACUOUS. -/
 theorem mulh_noKnownDefect_of_rowData
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_mulh trace binding i) :
-    Defects.NoKnownDefect (mulhEnvOf trace binding i d) := by
+    (d : RowData_mulh trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mulh_input.PC) :
+    Defects.NoKnownDefect (mulhEnvOf trace binding i d h_domain) := by
   intro id
   cases id with
   | arithMulSignedWitnessSoundness =>
@@ -206,8 +212,9 @@ theorem mulh_noKnownDefect_of_rowData
     `mulh_noKnownDefect_of_rowData`). -/
 theorem mulhsu_noKnownDefect_of_rowData
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_mulhsu trace binding i) :
-    Defects.NoKnownDefect (mulhsuEnvOf trace binding i d) := by
+    (d : RowData_mulhsu trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mulhsu_input.PC) :
+    Defects.NoKnownDefect (mulhsuEnvOf trace binding i d h_domain) := by
   intro id
   cases id with
   | arithMulSignedWitnessSoundness =>
@@ -226,7 +233,8 @@ theorem mulhsu_noKnownDefect_of_rowData
     row whose `|r| ≠ |op2|`.) -/
 noncomputable def divEnvOf
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_div trace binding i) :
+    (d : RowData_div trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.div_input.PC) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
   let bus := busSub trace i (Pilot.execRowOf trace i)
@@ -238,7 +246,7 @@ noncomputable def divEnvOf
       (by
         exact Pilot.sequential_nextPC_discharged trace i d.toInputs.div_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound)
+          d.toInputs.h_pc_bridge h_domain)
       (d.toInputs.promises.input_rd_eq.trans
         (busSub_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)))
     d.toDecode.arith_mem d.toDecode.bounds d.toInputs.h_row_constraints d.toInputs.h_boundary
@@ -249,7 +257,8 @@ noncomputable def divEnvOf
 /-- The `OpEnvelope.rem` env CONSTRUCTED from a `RowData_rem` (secondary lane). -/
 noncomputable def remEnvOf
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_rem trace binding i) :
+    (d : RowData_rem trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.rem_input.PC) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
   let bus := busSub trace i (Pilot.execRowOf trace i)
@@ -260,7 +269,7 @@ noncomputable def remEnvOf
       (by
         exact Pilot.sequential_nextPC_discharged trace i d.toInputs.rem_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound)
+          d.toInputs.h_pc_bridge h_domain)
       (d.toInputs.promises.input_rd_eq.trans
         (busSub_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)))
     d.toDecode.arith_mem d.toDecode.bounds d.toInputs.h_row_constraints
@@ -271,7 +280,8 @@ noncomputable def remEnvOf
 /-- The `OpEnvelope.divw` env CONSTRUCTED from a `RowData_divw` (W-mode primary). -/
 noncomputable def divwEnvOf
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_divw trace binding i) :
+    (d : RowData_divw trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.divw_input.PC) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
   let bus := busSub trace i (Pilot.execRowOf trace i)
@@ -282,7 +292,7 @@ noncomputable def divwEnvOf
       (by
         exact Pilot.sequential_nextPC_discharged trace i d.toInputs.divw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound)
+          d.toInputs.h_pc_bridge h_domain)
       (d.toInputs.promises.input_rd_eq.trans
         (busSub_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)))
     d.toDecode.arith_mem d.toDecode.bounds
@@ -294,7 +304,8 @@ noncomputable def divwEnvOf
 /-- The `OpEnvelope.remw` env CONSTRUCTED from a `RowData_remw` (W-mode secondary). -/
 noncomputable def remwEnvOf
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_remw trace binding i) :
+    (d : RowData_remw trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.remw_input.PC) :
     OpEnvelope (binding i)
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val :=
   let bus := busSub trace i (Pilot.execRowOf trace i)
@@ -305,7 +316,7 @@ noncomputable def remwEnvOf
       (by
         exact Pilot.sequential_nextPC_discharged trace i d.toInputs.remw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound)
+          d.toInputs.h_pc_bridge h_domain)
       (d.toInputs.promises.input_rd_eq.trans
         (busSub_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)))
     d.toDecode.arith_mem d.toDecode.bounds
@@ -327,8 +338,9 @@ noncomputable def remwEnvOf
     Lean-checked anti-vacuity guard for the strong-export DIV arm. -/
 theorem div_noKnownDefect_of_rowData
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_div trace binding i) :
-    Defects.NoKnownDefect (divEnvOf trace binding i d) := by
+    (d : RowData_div trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.div_input.PC) :
+    Defects.NoKnownDefect (divEnvOf trace binding i d h_domain) := by
   intro id
   cases id with
   | arithMulSignedWitnessSoundness =>
@@ -343,8 +355,9 @@ theorem div_noKnownDefect_of_rowData
     `div_noKnownDefect_of_rowData`; secondary remainder lane). -/
 theorem rem_noKnownDefect_of_rowData
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_rem trace binding i) :
-    Defects.NoKnownDefect (remEnvOf trace binding i d) := by
+    (d : RowData_rem trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.rem_input.PC) :
+    Defects.NoKnownDefect (remEnvOf trace binding i d h_domain) := by
   intro id
   cases id with
   | arithMulSignedWitnessSoundness =>
@@ -361,8 +374,9 @@ theorem rem_noKnownDefect_of_rowData
     `div_noKnownDefect_of_rowData`; narrowed shape `|r₃₂| ≠ |op2₃₂|`). -/
 theorem divw_noKnownDefect_of_rowData
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_divw trace binding i) :
-    Defects.NoKnownDefect (divwEnvOf trace binding i d) := by
+    (d : RowData_divw trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.divw_input.PC) :
+    Defects.NoKnownDefect (divwEnvOf trace binding i d h_domain) := by
   intro id
   cases id with
   | arithMulSignedWitnessSoundness =>
@@ -377,8 +391,9 @@ theorem divw_noKnownDefect_of_rowData
     `divw_noKnownDefect_of_rowData`; W-mode secondary remainder lane). -/
 theorem remw_noKnownDefect_of_rowData
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_remw trace binding i) :
-    Defects.NoKnownDefect (remwEnvOf trace binding i d) := by
+    (d : RowData_remw trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.remw_input.PC) :
+    Defects.NoKnownDefect (remwEnvOf trace binding i d h_domain) := by
   intro id
   cases id with
   | arithMulSignedWitnessSoundness =>
@@ -402,51 +417,59 @@ re-expressed predicate were even slightly weaker or stronger than the original
 
 theorem signedMulForge_iff_mulShape
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_mul trace binding i) :
+    (d : RowData_mul trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mul_input.PC) :
     Defects.SignedMulForge d.toInputs.v d.toInputs.r_a
-      ↔ Defects.MaliciousSignedMulWitnessShape (mulEnvOf trace binding i d) := Iff.rfl
+      ↔ Defects.MaliciousSignedMulWitnessShape (mulEnvOf trace binding i d h_domain) := Iff.rfl
 
 theorem signedMulForge_iff_mulhShape
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_mulh trace binding i) :
+    (d : RowData_mulh trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mulh_input.PC) :
     Defects.SignedMulForge d.toInputs.v d.toInputs.r_a
-      ↔ Defects.MaliciousSignedMulWitnessShape (mulhEnvOf trace binding i d) := Iff.rfl
+      ↔ Defects.MaliciousSignedMulWitnessShape (mulhEnvOf trace binding i d h_domain) := Iff.rfl
 
 theorem signedMulForge_iff_mulhsuShape
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_mulhsu trace binding i) :
+    (d : RowData_mulhsu trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mulhsu_input.PC) :
     Defects.SignedMulForge d.toInputs.v d.toInputs.r_a
-      ↔ Defects.MaliciousSignedMulWitnessShape (mulhsuEnvOf trace binding i d) := Iff.rfl
+      ↔ Defects.MaliciousSignedMulWitnessShape (mulhsuEnvOf trace binding i d h_domain) := Iff.rfl
 
 theorem divRemForge_iff_divShape
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_div trace binding i) :
+    (d : RowData_div trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.div_input.PC) :
     Defects.DivRemForge d.toInputs.div_input.r2_val d.toInputs.v d.toInputs.r_a
-      ↔ Defects.ArithDivDynamicWitnessShape (divEnvOf trace binding i d) := Iff.rfl
+      ↔ Defects.ArithDivDynamicWitnessShape (divEnvOf trace binding i d h_domain) := Iff.rfl
 
 theorem divRemForge_iff_remShape
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_rem trace binding i) :
+    (d : RowData_rem trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.rem_input.PC) :
     Defects.DivRemForge d.toInputs.rem_input.r2_val d.toInputs.v d.toInputs.r_a
-      ↔ Defects.ArithDivDynamicWitnessShape (remEnvOf trace binding i d) := Iff.rfl
+      ↔ Defects.ArithDivDynamicWitnessShape (remEnvOf trace binding i d h_domain) := Iff.rfl
 
 theorem divRemForgeW_iff_divwShape
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_divw trace binding i) :
+    (d : RowData_divw trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.divw_input.PC) :
     Defects.DivRemForgeW d.toInputs.divw_input.r2_val d.toInputs.v d.toInputs.r_a
-      ↔ Defects.ArithDivDynamicWitnessShape (divwEnvOf trace binding i d) := Iff.rfl
+      ↔ Defects.ArithDivDynamicWitnessShape (divwEnvOf trace binding i d h_domain) := Iff.rfl
 
 theorem divRemForgeW_iff_remwShape
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_remw trace binding i) :
+    (d : RowData_remw trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.remw_input.PC) :
     Defects.DivRemForgeW d.toInputs.remw_input.r2_val d.toInputs.v d.toInputs.r_a
-      ↔ Defects.ArithDivDynamicWitnessShape (remwEnvOf trace binding i d) := Iff.rfl
+      ↔ Defects.ArithDivDynamicWitnessShape (remwEnvOf trace binding i d h_domain) := Iff.rfl
 
 theorem fenceKnownGood_iff_fenceShape
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_fence trace binding i) :
+    (d : RowData_fence trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.fence_input.PC) :
     Defects.FenceKnownGood d.toClaim.fm d.toClaim.rs d.toClaim.rd
-      ↔ Defects.FenceKnownGoodShape (fenceEnvOf trace binding i d) := Iff.rfl
+      ↔ Defects.FenceKnownGoodShape (fenceEnvOf trace binding i d h_domain) := Iff.rfl
 
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
@@ -1271,6 +1271,7 @@ structure ProgramDecode_jalr {numInstructions : Nat}
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_AND
+        ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits
 

--- a/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
@@ -4218,32 +4218,34 @@ def Decode_jalr_of_program
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_AND
+        ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_jalr trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
   have h_dest := mainLuiDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
     (fun j hline => by
-      obtain ⟨_hpo, hpso, hpf⟩ := h_prog j hline
+      obtain ⟨_hpo, _hpj2, hpso, hpf⟩ := h_prog j hline
       exact ⟨hpso, hpf⟩)
   have key :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_AND ∧
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1 ∧
       (mainOfTable trace.program trace.mainTable).m32 i.val = 0 ∧
       (mainOfTable trace.program trace.mainTable).set_pc i.val = 1 ∧
-      (mainOfTable trace.program trace.mainTable).store_pc i.val = 1 := by
-    obtain ⟨j, hline, hop, _, _, _, hflags⟩ :=
+      (mainOfTable trace.program trace.mainTable).store_pc i.val = 1 ∧
+      (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
+    obtain ⟨j, hline, hop, _, _, hjmp2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, _hpso, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj2, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
-    exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_true], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_true]⟩
+    exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_true], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_true], hjmp2.symm.trans hpj2⟩
   exact
     { h_main_op := key.1
       h_main_active := key.2.1
       h_m32 := key.2.2.1
       h_set_pc := key.2.2.2.1
-      h_store_pc := key.2.2.2.2
+      h_store_pc := key.2.2.2.2.1
       h_store_ind := h_dest.1
       h_store_offset := h_dest.2
       h_idx := h_idx
@@ -4251,6 +4253,7 @@ def Decode_jalr_of_program
       h_a_mask_lo := h_a_mask_lo
       h_a_mask_hi := h_a_mask_hi
       h_c1_zero := h_c1_zero
+      h_jmp2 := key.2.2.2.2.2
       h_offset_bridge := h_offset_bridge
       h_offset_even := h_offset_even
       h_no_fgl_wrap := h_no_fgl_wrap }

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataAluShift.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataAluShift.lean
@@ -135,7 +135,6 @@ structure Inputs_sub (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = sub_input.PC.toNat
-  h_pc_bound : sub_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `sub` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sub` bundles them. -/
@@ -222,7 +221,6 @@ structure Inputs_and (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = and_input.PC.toNat
-  h_pc_bound : and_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `and` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_and` bundles them. -/
@@ -309,7 +307,6 @@ structure Inputs_or (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = or_input.PC.toNat
-  h_pc_bound : or_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `or` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_or` bundles them. -/
@@ -396,7 +393,6 @@ structure Inputs_xor (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = xor_input.PC.toNat
-  h_pc_bound : xor_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `xor` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_xor` bundles them. -/
@@ -483,7 +479,6 @@ structure Inputs_slt (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = slt_input.PC.toNat
-  h_pc_bound : slt_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `slt` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_slt` bundles them. -/
@@ -570,7 +565,6 @@ structure Inputs_sltu (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = sltu_input.PC.toNat
-  h_pc_bound : sltu_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `sltu` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sltu` bundles them. -/
@@ -652,7 +646,6 @@ structure Inputs_andi (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = andi_input.PC.toNat
-  h_pc_bound : andi_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `andi` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_andi` bundles them. -/
@@ -734,7 +727,6 @@ structure Inputs_ori (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = ori_input.PC.toNat
-  h_pc_bound : ori_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `ori` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_ori` bundles them. -/
@@ -816,7 +808,6 @@ structure Inputs_xori (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = xori_input.PC.toNat
-  h_pc_bound : xori_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `xori` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_xori` bundles them. -/
@@ -898,7 +889,6 @@ structure Inputs_slti (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = slti_input.PC.toNat
-  h_pc_bound : slti_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `slti` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_slti` bundles them. -/
@@ -980,7 +970,6 @@ structure Inputs_sltiu (trace : AcceptedZiskTrace numInstructions) (binding : Sa
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = sltiu_input.PC.toNat
-  h_pc_bound : sltiu_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `sltiu` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sltiu` bundles them. -/
@@ -1067,7 +1056,6 @@ structure Inputs_sll (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = sll_input.PC.toNat
-  h_pc_bound : sll_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `sll` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sll` bundles them. -/
@@ -1154,7 +1142,6 @@ structure Inputs_srl (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = srl_input.PC.toNat
-  h_pc_bound : srl_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `srl` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_srl` bundles them. -/
@@ -1241,7 +1228,6 @@ structure Inputs_sra (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = sra_input.PC.toNat
-  h_pc_bound : sra_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `sra` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sra` bundles them. -/
@@ -1319,7 +1305,6 @@ structure Inputs_slli (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = slli_input.PC.toNat
-  h_pc_bound : slli_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `slli` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_slli` bundles them. -/
@@ -1397,7 +1382,6 @@ structure Inputs_srli (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = srli_input.PC.toNat
-  h_pc_bound : srli_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `srli` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_srli` bundles them. -/
@@ -1475,7 +1459,6 @@ structure Inputs_srai (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = srai_input.PC.toNat
-  h_pc_bound : srai_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `srai` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_srai` bundles them. -/
@@ -1562,7 +1545,6 @@ structure Inputs_sllw (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = sllw_input.PC.toNat
-  h_pc_bound : sllw_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `sllw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sllw` bundles them. -/
@@ -1649,7 +1631,6 @@ structure Inputs_srlw (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = srlw_input.PC.toNat
-  h_pc_bound : srlw_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `srlw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_srlw` bundles them. -/
@@ -1736,7 +1717,6 @@ structure Inputs_sraw (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = sraw_input.PC.toNat
-  h_pc_bound : sraw_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `sraw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sraw` bundles them. -/
@@ -1812,7 +1792,6 @@ structure Inputs_slliw (trace : AcceptedZiskTrace numInstructions) (binding : Sa
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.slliw_input.PC.toNat
-  h_pc_bound : c.slliw_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `slliw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_slliw` bundles them. -/
@@ -1888,7 +1867,6 @@ structure Inputs_srliw (trace : AcceptedZiskTrace numInstructions) (binding : Sa
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.srliw_input.PC.toNat
-  h_pc_bound : c.srliw_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `srliw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_srliw` bundles them. -/
@@ -1964,7 +1942,6 @@ structure Inputs_sraiw (trace : AcceptedZiskTrace numInstructions) (binding : Sa
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.sraiw_input.PC.toNat
-  h_pc_bound : c.sraiw_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `sraiw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sraiw` bundles them. -/

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
@@ -42,6 +42,20 @@ seal mulwArow mulhuArow divuArow divuwArow remuArow remuwArow
 
 set_option maxHeartbeats 8000000
 
+/-- AUIPC theorem-domain range assumptions.
+
+These are explicit soundness-domain conditions, not decoded placement facts or Sail/ZisK value
+agreement. Keeping them separate from `Inputs_auipc` leaves the input record focused on state and
+value agreement while preserving the same AUIPC range obligations at the theorem boundary. -/
+structure AuipcRangeDomain (auipc_input : PureSpec.AuipcInput) : Prop where
+  h_pc_bound : auipc_input.PC.toNat < GL_prime - 4
+  h_no_wrap : auipc_input.PC.toNat
+    + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
+      < GL_prime
+  h_pc_offset_lt_2_32 :
+    (auipc_input.PC + BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
+      < 4294967296
+
 /-- **`RTypePromises` minus derived next-PC and rd-placement fields (#100/#141).**
 
     Identical to `ZiskFv.EquivCore.Promises.RTypePromises` except that the
@@ -186,7 +200,6 @@ structure Inputs_add (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = add_input.PC.toNat
-  h_pc_bound : add_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `add` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_add` bundles them. -/
@@ -268,7 +281,6 @@ structure Inputs_addi (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = addi_input.PC.toNat
-  h_pc_bound : addi_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `addi` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_addi` bundles them. -/
@@ -355,7 +367,6 @@ structure Inputs_subw (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = subw_input.PC.toNat
-  h_pc_bound : subw_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `subw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_subw` bundles them. -/
@@ -442,7 +453,6 @@ structure Inputs_addw (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = addw_input.PC.toNat
-  h_pc_bound : addw_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `addw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_addw` bundles them. -/
@@ -524,7 +534,6 @@ structure Inputs_addiw (trace : AcceptedZiskTrace numInstructions) (binding : Sa
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = addiw_input.PC.toNat
-  h_pc_bound : addiw_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `addiw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_addiw` bundles them. -/
@@ -596,7 +605,6 @@ structure Inputs_lui (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = lui_input.PC.toNat
-  h_pc_bound : lui_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `lui` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_lui` bundles them. -/
@@ -665,17 +673,8 @@ structure Inputs_auipc (trace : AcceptedZiskTrace numInstructions) (binding : Sa
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = auipc_input.PC.toNat
-  -- #100: the JAL/AUIPC-style PC-trajectory no-wrap bound on the `pc + 4`
-  -- sequential successor (mirrors `Pilot.ofNat_fgl_pc_plus_4_eq`'s precondition),
-  -- ruling out FGL wrap on the next PC. Replaces the cross-world `h_nextPC_matches`,
-  -- which is now derived via `Pilot.flag_path_nextPC_discharged`.
-  h_pc_bound : auipc_input.PC.toNat < GL_prime - 4
-  h_no_wrap : auipc_input.PC.toNat
-    + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
-      < GL_prime
-  h_pc_offset_lt_2_32 :
-    (auipc_input.PC + BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
-      < 4294967296
+  -- #100: PC bridge. The AUIPC range/domain facts live in `RowOutsideDefectRegion`
+  -- as `AuipcRangeDomain`.
 
 /-- Per-op residual bundle for the `auipc` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_auipc` bundles them. -/
@@ -735,7 +734,6 @@ structure Inputs_mulw (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = mulw_input.PC.toNat
-  h_pc_bound : mulw_input.PC.toNat < GL_prime - 4
   h_a23 :
     ∀ (ha : (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
       (ho : (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_MUL_W),
@@ -872,7 +870,6 @@ structure Inputs_mul (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   -- derived from the transition certificate. The value-defect gate is untouched.
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val = mul_input.PC.toNat
-  h_pc_bound : mul_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `mul` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_mul` bundles them. -/
@@ -963,7 +960,6 @@ structure Inputs_mulh (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   -- #100 next-PC transition inputs (consumed by `mulhEnvOf`); see `Inputs_mul`.
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val = mulh_input.PC.toNat
-  h_pc_bound : mulh_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `mulh` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_mulh` bundles them. -/
@@ -1051,7 +1047,6 @@ structure Inputs_mulhsu (trace : AcceptedZiskTrace numInstructions) (binding : S
   -- #100 next-PC transition inputs (consumed by `mulhsuEnvOf`); see `Inputs_mul`.
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val = mulhsu_input.PC.toNat
-  h_pc_bound : mulhsu_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `mulhsu` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_mulhsu` bundles them. -/
@@ -1173,7 +1168,6 @@ structure Inputs_div (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   -- These are next-PC plumbing only and leave the DivRemForge value gate untouched.
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val = div_input.PC.toNat
-  h_pc_bound : div_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `div` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_div` bundles them. -/
@@ -1291,7 +1285,6 @@ structure Inputs_rem (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   -- #100 next-PC transition inputs (consumed by `remEnvOf`); see `Inputs_mul`.
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val = rem_input.PC.toNat
-  h_pc_bound : rem_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `rem` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_rem` bundles them. -/
@@ -1439,7 +1432,6 @@ structure Inputs_divw (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   -- #100 next-PC transition inputs (consumed by `divwEnvOf`); see `Inputs_mul`.
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val = divw_input.PC.toNat
-  h_pc_bound : divw_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `divw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_divw` bundles them. -/
@@ -1585,7 +1577,6 @@ structure Inputs_remw (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   -- #100 next-PC transition inputs (consumed by `remwEnvOf`); see `Inputs_mul`.
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val = remw_input.PC.toNat
-  h_pc_bound : remw_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `remw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_remw` bundles them. -/
@@ -1646,7 +1637,6 @@ structure Inputs_mulhu (trace : AcceptedZiskTrace numInstructions) (binding : Sa
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = mulhu_input.PC.toNat
-  h_pc_bound : mulhu_input.PC.toNat < GL_prime - 4
   h_rs1_value :
     ∀ (ha : (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
       (ho : (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_MULUH),
@@ -1725,7 +1715,6 @@ structure Inputs_divu (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = divu_input.PC.toNat
-  h_pc_bound : divu_input.PC.toNat < GL_prime - 4
   remainder_bound :
     ∀ (ha : (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
       (ho : (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU),
@@ -1809,7 +1798,6 @@ structure Inputs_divuw (trace : AcceptedZiskTrace numInstructions) (binding : Sa
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = divuw_input.PC.toNat
-  h_pc_bound : divuw_input.PC.toNat < GL_prime - 4
   remainder_bound :
     ∀ (ha : (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
       (ho : (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU_W),
@@ -1914,7 +1902,6 @@ structure Inputs_remu (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = remu_input.PC.toNat
-  h_pc_bound : remu_input.PC.toNat < GL_prime - 4
   remainder_bound :
     ∀ (ha : (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
       (ho : (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_REMU),
@@ -1998,7 +1985,6 @@ structure Inputs_remuw (trace : AcceptedZiskTrace numInstructions) (binding : Sa
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = remuw_input.PC.toNat
-  h_pc_bound : remuw_input.PC.toNat < GL_prime - 4
   remainder_bound :
     ∀ (ha : (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
       (ho : (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_REMU_W),
@@ -2118,7 +2104,6 @@ structure Inputs_sb (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.sb_input.PC.toNat
-  h_pc_bound : c.sb_input.PC.toNat < GL_prime - 4
   h_m1 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 1]?
     = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 1 : BitVec 8)
   h_m2 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 2]?
@@ -2208,7 +2193,6 @@ structure Inputs_sh (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.sh_input.PC.toNat
-  h_pc_bound : c.sh_input.PC.toNat < GL_prime - 4
   h_m2 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 2]?
     = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 2 : BitVec 8)
   h_m3 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 3]?
@@ -2296,7 +2280,6 @@ structure Inputs_sw (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.sw_input.PC.toNat
-  h_pc_bound : c.sw_input.PC.toNat < GL_prime - 4
   h_m4 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 4]?
     = some (ZiskFv.Channels.MemoryBusBytes.byteAt (busSt trace i (Pilot.execRowOf trace i)).e2 4 : BitVec 8)
   h_m5 : (binding i).mem[(busSt trace i (Pilot.execRowOf trace i)).e2.ptr.toNat + 5]?
@@ -2377,7 +2360,6 @@ structure Inputs_sd (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.sd_input.PC.toNat
-  h_pc_bound : c.sd_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `sd` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sd` bundles them. -/
@@ -2452,7 +2434,6 @@ structure Inputs_ld (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.ld_input.PC.toNat
-  h_pc_bound : c.ld_input.PC.toNat < GL_prime - 4
   h_memory_timeline :
     LoadMemoryTimelineCoherenceEvidence (binding i)
       (busLd trace i (Pilot.execRowOf trace i)).e1
@@ -2538,7 +2519,6 @@ structure Inputs_lbu (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.lbu_input.PC.toNat
-  h_pc_bound : c.lbu_input.PC.toNat < GL_prime - 4
   h_memory_timeline :
     LoadMemoryTimelineCoherenceEvidence (binding i)
       (busLd trace i (Pilot.execRowOf trace i)).e1
@@ -2624,7 +2604,6 @@ structure Inputs_lhu (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.lhu_input.PC.toNat
-  h_pc_bound : c.lhu_input.PC.toNat < GL_prime - 4
   h_memory_timeline :
     LoadMemoryTimelineCoherenceEvidence (binding i)
       (busLd trace i (Pilot.execRowOf trace i)).e1
@@ -2710,7 +2689,6 @@ structure Inputs_lwu (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.lwu_input.PC.toNat
-  h_pc_bound : c.lwu_input.PC.toNat < GL_prime - 4
   h_memory_timeline :
     LoadMemoryTimelineCoherenceEvidence (binding i)
       (busLd trace i (Pilot.execRowOf trace i)).e1
@@ -2804,7 +2782,6 @@ structure Inputs_lb (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.lb_input.PC.toNat
-  h_pc_bound : c.lb_input.PC.toNat < GL_prime - 4
   h_memory_timeline :
     LoadMemoryTimelineCoherenceEvidence (binding i)
       (busLd trace i (Pilot.execRowOf trace i)).e1
@@ -2898,7 +2875,6 @@ structure Inputs_lh (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.lh_input.PC.toNat
-  h_pc_bound : c.lh_input.PC.toNat < GL_prime - 4
   h_memory_timeline :
     LoadMemoryTimelineCoherenceEvidence (binding i)
       (busLd trace i (Pilot.execRowOf trace i)).e1
@@ -2992,7 +2968,6 @@ structure Inputs_lw (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.lw_input.PC.toNat
-  h_pc_bound : c.lw_input.PC.toNat < GL_prime - 4
   h_memory_timeline :
     LoadMemoryTimelineCoherenceEvidence (binding i)
       (busLd trace i (Pilot.execRowOf trace i)).e1

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
@@ -41,6 +41,33 @@ seal mulwArow mulhuArow divuArow divuwArow remuArow remuwArow
 
 set_option maxHeartbeats 8000000
 
+/-- Branch theorem-domain range assumptions.
+
+This is not a decoded placement fact: it is the explicit soundness-domain condition needed by the
+branch next-PC cast. Keeping it separate from `Inputs_<branch>` leaves those input records focused
+on Sail/ZisK state and value agreement. -/
+def BranchRangeDomain (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin trace.numInstructions) (pc : BitVec 64) (takenOffset : FGL) : Prop :=
+  ((mainOfTable trace.program trace.mainTable).pc i.val).val + takenOffset.val < GL_prime
+    ∧ pc.toNat < GL_prime - 4
+
+/-- JAL theorem-domain range assumptions.
+
+These preserve the old JAL target no-wrap, PC-bound, and 32-bit next-PC obligations at the explicit
+soundness theorem boundary instead of mixing them into `Inputs_jal` state/value agreement. -/
+structure JalRangeDomain (jal_input : PureSpec.JalInput) : Prop where
+  h_no_fgl_wrap : jal_input.PC.toNat + (BitVec.signExtend 64 jal_input.imm).toNat < GL_prime
+  h_pc_bound : jal_input.PC.toNat < GL_prime - 4
+  h_pc_offset_lt_2_32 : (jal_input.PC + 4#64).toNat < 4294967296
+
+/-- JALR theorem-domain range assumptions.
+
+These preserve the old JALR link-PC range obligations at the explicit soundness theorem boundary
+instead of mixing them into `Inputs_jalr` state/value agreement. -/
+structure JalrRangeDomain (jalr_input : PureSpec.JalrInput) : Prop where
+  h_pc_bound : jalr_input.PC.toNat < GL_prime - 4
+  h_pc_offset_lt_2_32 : (jalr_input.PC + 4#64).toNat < 4294967296
+
 structure Claim_beq (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   imm : BitVec 13
   r1 : regidx
@@ -106,17 +133,11 @@ structure Inputs_beq (trace : AcceptedZiskTrace numInstructions) (binding : Sail
       ZiskFv.Trusted.lane_hi
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding i)).xreg
           (regidx_to_fin c.r2))
-  -- #100: PC bridge / no-wrap / bound. Replace `h_nextPC_matches`, now DERIVED
-  -- via `Pilot.branch_nextPC_flag1_taken` + `branch_flag_eq_provided`.
+  -- #100: PC bridge. The range/domain facts used by the branch next-PC cast live
+  -- in `RowOutsideDefectRegion` as `BranchRangeDomain`.
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = beq_input.PC.toNat
-  h_no_wrap :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
-      + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-          i.val).val
-      < GL_prime
-  h_pc_bound : beq_input.PC.toNat < 18446744069414584321 - 4
   h_success : (PureSpec.execute_BEQ_pure beq_input).success = true
 
 /-- Per-op residual bundle for the `beq` archetype: the 3-way `Claim`/`Decode`/`Inputs`
@@ -201,17 +222,11 @@ structure Inputs_bne (trace : AcceptedZiskTrace numInstructions) (binding : Sail
       ZiskFv.Trusted.lane_hi
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding i)).xreg
           (regidx_to_fin c.r2))
-  -- #100: PC bridge / no-wrap / bound. Replace `h_nextPC_matches`, now DERIVED
-  -- via `Pilot.branch_nextPC_flag0_taken` + `branch_flag_eq_provided`.
+  -- #100: PC bridge. The range/domain facts used by the branch next-PC cast live
+  -- in `RowOutsideDefectRegion` as `BranchRangeDomain`.
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = bne_input.PC.toNat
-  h_no_wrap :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
-      + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
-          i.val).val
-      < GL_prime
-  h_pc_bound : bne_input.PC.toNat < 18446744069414584321 - 4
   h_success : (PureSpec.execute_BNE_pure bne_input).success = true
 
 /-- Per-op residual bundle for the `bne` archetype: the 3-way `Claim`/`Decode`/`Inputs`
@@ -295,17 +310,11 @@ structure Inputs_blt (trace : AcceptedZiskTrace numInstructions) (binding : Sail
       ZiskFv.Trusted.lane_hi
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding i)).xreg
           (regidx_to_fin c.r2))
-  -- #100: PC bridge / no-wrap / bound. Replace `h_nextPC_matches`, now DERIVED
-  -- via `Pilot.branch_nextPC_flag1_taken` + `branch_flag_lt_provided`.
+  -- #100: PC bridge. The range/domain facts used by the branch next-PC cast live
+  -- in `RowOutsideDefectRegion` as `BranchRangeDomain`.
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = blt_input.PC.toNat
-  h_no_wrap :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
-      + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-          i.val).val
-      < GL_prime
-  h_pc_bound : blt_input.PC.toNat < 18446744069414584321 - 4
   h_success : (PureSpec.execute_BLT_pure blt_input).success = true
 
 /-- Per-op residual bundle for the `blt` archetype: the 3-way `Claim`/`Decode`/`Inputs`
@@ -390,17 +399,11 @@ structure Inputs_bge (trace : AcceptedZiskTrace numInstructions) (binding : Sail
       ZiskFv.Trusted.lane_hi
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding i)).xreg
           (regidx_to_fin c.r2))
-  -- #100: PC bridge / no-wrap / bound. Replace `h_nextPC_matches`, now DERIVED
-  -- via `Pilot.branch_nextPC_flag0_taken` + `branch_flag_lt_provided`.
+  -- #100: PC bridge. The range/domain facts used by the branch next-PC cast live
+  -- in `RowOutsideDefectRegion` as `BranchRangeDomain`.
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = bge_input.PC.toNat
-  h_no_wrap :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
-      + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
-          i.val).val
-      < GL_prime
-  h_pc_bound : bge_input.PC.toNat < 18446744069414584321 - 4
   h_success : (PureSpec.execute_BGE_pure bge_input).success = true
 
 /-- Per-op residual bundle for the `bge` archetype: the 3-way `Claim`/`Decode`/`Inputs`
@@ -488,18 +491,11 @@ structure Inputs_bltu (trace : AcceptedZiskTrace numInstructions) (binding : Sai
       ZiskFv.Trusted.lane_hi
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding i)).xreg
           (regidx_to_fin c.r2))
-  -- #100: PC bridge, taken-target no-wrap bound, and PC trajectory bound. These
-  -- replace the cross-world `h_nextPC_matches`, now DERIVED via
-  -- `Pilot.branch_nextPC_flag1_taken` + `branch_flag_ltu_provided`.
+  -- #100: PC bridge. The range/domain facts used by the branch next-PC cast live
+  -- in `RowOutsideDefectRegion` as `BranchRangeDomain`.
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = bltu_input.PC.toNat
-  h_no_wrap :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
-      + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-          i.val).val
-      < GL_prime
-  h_pc_bound : bltu_input.PC.toNat < 18446744069414584321 - 4
   h_success : (PureSpec.execute_BLTU_pure bltu_input).success = true
 
 /-- Per-op residual bundle for the `bltu` archetype: the 3-way `Claim`/`Decode`/`Inputs`
@@ -586,17 +582,11 @@ structure Inputs_bgeu (trace : AcceptedZiskTrace numInstructions) (binding : Sai
       ZiskFv.Trusted.lane_hi
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 (binding i)).xreg
           (regidx_to_fin c.r2))
-  -- #100: PC bridge / no-wrap / bound. These replace `h_nextPC_matches`, now
-  -- DERIVED via `Pilot.branch_nextPC_flag0_taken` + `branch_flag_ltu_provided`.
+  -- #100: PC bridge. The range/domain facts used by the branch next-PC cast live
+  -- in `RowOutsideDefectRegion` as `BranchRangeDomain`.
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = bgeu_input.PC.toNat
-  h_no_wrap :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
-      + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
-          i.val).val
-      < GL_prime
-  h_pc_bound : bgeu_input.PC.toNat < 18446744069414584321 - 4
   h_success : (PureSpec.execute_BGEU_pure bgeu_input).success = true
 
 /-- Per-op residual bundle for the `bgeu` archetype: the 3-way `Claim`/`Decode`/`Inputs`
@@ -662,20 +652,14 @@ structure Inputs_jal (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = jal_input.PC.toNat
-  -- #100: JAL-target no-wrap bound (target stays below the GL bound). Together with
-  -- decode's committed-program offset fact, this replaces the cross-world `h_nextPC_matches`,
-  -- now DERIVED via
-  -- `Pilot.flag_path_nextPC_discharged` + `Pilot.ofNat_fgl_pc_plus_offset_eq`.
-  h_no_fgl_wrap :
-    jal_input.PC.toNat + (BitVec.signExtend 64 jal_input.imm).toNat < GL_prime
+  -- #100: PC bridge. The JAL range/domain facts live in `RowOutsideDefectRegion`
+  -- as `JalRangeDomain`.
   h_input_rd : jal_input.rd = regidx_to_fin c.rd
   h_input_pc : (binding i).regs.get? Register.PC = .some jal_input.PC
   h_input_misa : (binding i).regs.get? Register.misa = .some misa_val
   h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1
   h_success : (PureSpec.execute_JAL_pure jal_input).success = true
   h_input_imm : jal_input.imm = c.imm
-  h_pc_bound : jal_input.PC.toNat < GL_prime - 4
-  h_pc_offset_lt_2_32 : (jal_input.PC + 4#64).toNat < 4294967296
 
 /-- Per-op residual bundle for the `jal` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_jal` bundles them. -/
@@ -796,8 +780,8 @@ structure Inputs_jalr (trace : AcceptedZiskTrace numInstructions) (binding : Sai
     = EStateM.Result.ok Privilege.Machine (binding i)
   h_mseccfg : Sail.readReg Register.mseccfg (binding i)
     = EStateM.Result.ok mseccfg (binding i)
-  h_pc_bound : jalr_input.PC.toNat < GL_prime - 4
-  h_pc_offset_lt_2_32 : (jalr_input.PC + 4#64).toNat < 4294967296
+  -- #100: JALR link-PC range/domain facts live in `RowOutsideDefectRegion`
+  -- as `JalrRangeDomain`.
 
 /-- Per-op residual bundle for the `jalr` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_jalr` bundles them. -/
@@ -859,7 +843,6 @@ structure Inputs_fence (trace : AcceptedZiskTrace numInstructions) (binding : Sa
   h_pc_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
       = fence_input.PC.toNat
-  h_pc_bound : fence_input.PC.toNat < GL_prime - 4
 
 /-- Per-op residual bundle for the `fence` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_fence` bundles them. -/

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
@@ -746,6 +746,9 @@ structure Decode_jalr (trace : AcceptedZiskTrace numInstructions)
   h_c1_zero :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_1
       i.val = 0
+  h_jmp2 :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
+      i.val = 4
   --   * the `jmp_offset1` field ↔ `offset_bv` bridge (unsigned-equal offset
   --     contract, same shape AUIPC/JAL use) + the evenness ROM guard
   --     (aligned `imm % 4 == 0` ⇒ `offset_bv` even; trivial for unaligned
@@ -780,6 +783,9 @@ structure Inputs_jalr (trace : AcceptedZiskTrace numInstructions) (binding : Sai
       = jalr_input.rs1_val + BitVec.signExtend 64 jalr_input.imm
   h_input_rd : jalr_input.rd = regidx_to_fin c.rd
   h_input_pc : (binding i).regs.get? Register.PC = .some jalr_input.PC
+  h_pc_bridge :
+    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
+      = jalr_input.PC.toNat
   h_input_misa : (binding i).regs.get? Register.misa = .some misa_val
   h_misa_c : Sail.BitVec.extractLsb misa_val 2 2 = 0#1
   h_success : (PureSpec.execute_JALR_pure jalr_input).success = true
@@ -790,11 +796,6 @@ structure Inputs_jalr (trace : AcceptedZiskTrace numInstructions) (binding : Sai
     = EStateM.Result.ok Privilege.Machine (binding i)
   h_mseccfg : Sail.readReg Register.mseccfg (binding i)
     = EStateM.Result.ok mseccfg (binding i)
-  h_link_bridge :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val
-      + (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
-          i.val).val
-      = (jalr_input.PC + 4#64).toNat
   h_pc_bound : jalr_input.PC.toNat < GL_prime - 4
   h_pc_offset_lt_2_32 : (jalr_input.PC + 4#64).toNat < 4294967296
 

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongAluArith.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongAluArith.lean
@@ -93,7 +93,7 @@ private theorem itype_imm_subset_of_decode
 theorem stepStrong_sub
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sub trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.sub_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -159,7 +159,7 @@ theorem stepStrong_sub
         Pilot.sub_nextPC_discharged trace binding i d.toInputs.sub_input
           d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -236,7 +236,7 @@ theorem stepStrong_sub
 theorem stepStrong_and
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_and trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.and_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -296,7 +296,7 @@ theorem stepStrong_and
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.and_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -373,7 +373,7 @@ theorem stepStrong_and
 theorem stepStrong_or
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_or trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.or_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -433,7 +433,7 @@ theorem stepStrong_or
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.or_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -510,7 +510,7 @@ theorem stepStrong_or
 theorem stepStrong_xor
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_xor trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.xor_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -570,7 +570,7 @@ theorem stepStrong_xor
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.xor_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -648,7 +648,7 @@ theorem stepStrong_xor
 theorem stepStrong_slt
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_slt trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.slt_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -708,7 +708,7 @@ theorem stepStrong_slt
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.slt_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -785,7 +785,7 @@ theorem stepStrong_slt
 theorem stepStrong_sltu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sltu trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.sltu_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -845,7 +845,7 @@ theorem stepStrong_sltu
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.sltu_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -921,7 +921,7 @@ theorem stepStrong_sltu
 theorem stepStrong_andi
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_andi trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.andi_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -981,7 +981,7 @@ theorem stepStrong_andi
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.andi_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -1060,7 +1060,7 @@ theorem stepStrong_andi
 theorem stepStrong_ori
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_ori trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.ori_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -1120,7 +1120,7 @@ theorem stepStrong_ori
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.ori_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -1199,7 +1199,7 @@ theorem stepStrong_ori
 theorem stepStrong_xori
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_xori trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.xori_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -1259,7 +1259,7 @@ theorem stepStrong_xori
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.xori_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -1336,7 +1336,7 @@ theorem stepStrong_xori
 theorem stepStrong_slti
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_slti trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.slti_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -1396,7 +1396,7 @@ theorem stepStrong_slti
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.slti_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -1468,7 +1468,7 @@ theorem stepStrong_slti
 theorem stepStrong_sltiu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sltiu trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.sltiu_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -1528,7 +1528,7 @@ theorem stepStrong_sltiu
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.sltiu_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -1601,7 +1601,7 @@ theorem stepStrong_sltiu
 theorem stepStrong_sll
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sll trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.sll_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -1661,7 +1661,7 @@ theorem stepStrong_sll
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.sll_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -1701,7 +1701,7 @@ theorem stepStrong_sll
 theorem stepStrong_srl
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_srl trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.srl_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -1761,7 +1761,7 @@ theorem stepStrong_srl
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.srl_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -1801,7 +1801,7 @@ theorem stepStrong_srl
 theorem stepStrong_sra
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sra trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.sra_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -1861,7 +1861,7 @@ theorem stepStrong_sra
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.sra_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -1901,7 +1901,7 @@ theorem stepStrong_sra
 theorem stepStrong_slli
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_slli trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.slli_input.PC) :
     execute_instruction (instruction.SHIFTIOP (d.toClaim.shamt, d.toClaim.r1, d.toClaim.rd, sop.SLLI)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨(busSub trace i (Pilot.execRowOf trace i)).exec_row,
@@ -1957,7 +1957,7 @@ theorem stepStrong_slli
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.slli_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -2001,7 +2001,7 @@ theorem stepStrong_slli
 theorem stepStrong_srli
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_srli trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.srli_input.PC) :
     execute_instruction (instruction.SHIFTIOP (d.toClaim.shamt, d.toClaim.r1, d.toClaim.rd, sop.SRLI)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨(busSub trace i (Pilot.execRowOf trace i)).exec_row,
@@ -2057,7 +2057,7 @@ theorem stepStrong_srli
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.srli_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -2101,7 +2101,7 @@ theorem stepStrong_srli
 theorem stepStrong_srai
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_srai trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.srai_input.PC) :
     execute_instruction (instruction.SHIFTIOP (d.toClaim.shamt, d.toClaim.r1, d.toClaim.rd, sop.SRAI)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨(busSub trace i (Pilot.execRowOf trace i)).exec_row,
@@ -2157,7 +2157,7 @@ theorem stepStrong_srai
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.srai_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -2203,7 +2203,7 @@ theorem stepStrong_srai
 theorem stepStrong_subw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_subw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.subw_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -2308,7 +2308,7 @@ theorem stepStrong_subw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.subw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -2334,7 +2334,7 @@ theorem stepStrong_subw
 theorem stepStrong_addw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_addw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.addw_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -2439,7 +2439,7 @@ theorem stepStrong_addw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.addw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -2465,7 +2465,7 @@ theorem stepStrong_addw
 theorem stepStrong_addiw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_addiw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.addiw_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -2551,7 +2551,7 @@ theorem stepStrong_addiw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.addiw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -2589,7 +2589,7 @@ real BinaryExtension Spec row from the committed trace. -/
 theorem stepStrong_sllw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sllw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.sllw_input.PC) :
     execute_instruction (instruction.RTYPEW (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, ropw.SLLW)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨(busSub trace i (Pilot.execRowOf trace i)).exec_row,
@@ -2645,7 +2645,7 @@ theorem stepStrong_sllw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.sllw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -2674,7 +2674,7 @@ theorem stepStrong_sllw
       d.toInputs.h_input_r1 d.toInputs.h_input_r2 d.toInputs.h_input_rd d.toInputs.h_input_pc (by rfl) (by rfl)
       (by rfl) (Pilot.sequential_nextPC_discharged trace i d.toInputs.sllw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound) (by rfl) (by rfl) (by rfl) (by rfl) (by rfl)
+          d.toInputs.h_pc_bridge h_domain) (by rfl) (by rfl) (by rfl) (by rfl) (by rfl)
       (by rfl) (d.toInputs.h_input_rd.trans
         (busSub_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset))
       pins h_component h_table_spec h_provider_row h_match
@@ -2692,7 +2692,7 @@ theorem stepStrong_sllw
 theorem stepStrong_srlw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_srlw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.srlw_input.PC) :
     execute_instruction (instruction.RTYPEW (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, ropw.SRLW)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨(busSub trace i (Pilot.execRowOf trace i)).exec_row,
@@ -2748,7 +2748,7 @@ theorem stepStrong_srlw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.srlw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -2777,7 +2777,7 @@ theorem stepStrong_srlw
       d.toInputs.h_input_r1 d.toInputs.h_input_r2 d.toInputs.h_input_rd d.toInputs.h_input_pc (by rfl) (by rfl)
       (by rfl) (Pilot.sequential_nextPC_discharged trace i d.toInputs.srlw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound) (by rfl) (by rfl) (by rfl) (by rfl) (by rfl)
+          d.toInputs.h_pc_bridge h_domain) (by rfl) (by rfl) (by rfl) (by rfl) (by rfl)
       (by rfl) (d.toInputs.h_input_rd.trans
         (busSub_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset))
       pins h_component h_table_spec h_provider_row h_match
@@ -2795,7 +2795,7 @@ theorem stepStrong_srlw
 theorem stepStrong_sraw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sraw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.sraw_input.PC) :
     execute_instruction (instruction.RTYPEW (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, ropw.SRAW)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨(busSub trace i (Pilot.execRowOf trace i)).exec_row,
@@ -2852,7 +2852,7 @@ theorem stepStrong_sraw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.sraw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -2881,7 +2881,7 @@ theorem stepStrong_sraw
       d.toInputs.h_input_r1 d.toInputs.h_input_r2 d.toInputs.h_input_rd d.toInputs.h_input_pc (by rfl) (by rfl)
       (by rfl) (Pilot.sequential_nextPC_discharged trace i d.toInputs.sraw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound) (by rfl) (by rfl) (by rfl) (by rfl) (by rfl)
+          d.toInputs.h_pc_bridge h_domain) (by rfl) (by rfl) (by rfl) (by rfl) (by rfl)
       (by rfl) (d.toInputs.h_input_rd.trans
         (busSub_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset))
       pins h_component h_table_spec h_provider_row h_match
@@ -2899,7 +2899,7 @@ theorem stepStrong_sraw
 theorem stepStrong_slliw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_slliw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.slliw_input.PC) :
     execute_instruction
       (instruction.SHIFTIWOP (d.toClaim.slliw_input.shamt, d.toClaim.r1, d.toClaim.rd, sopw.SLLIW)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
@@ -2955,7 +2955,7 @@ theorem stepStrong_slliw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toClaim.slliw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -2994,7 +2994,7 @@ theorem stepStrong_slliw
 theorem stepStrong_srliw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_srliw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.srliw_input.PC) :
     execute_instruction
       (instruction.SHIFTIWOP (d.toClaim.srliw_input.shamt, d.toClaim.r1, d.toClaim.rd, sopw.SRLIW)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
@@ -3050,7 +3050,7 @@ theorem stepStrong_srliw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toClaim.srliw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -3089,7 +3089,7 @@ theorem stepStrong_srliw
 theorem stepStrong_sraiw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sraiw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.sraiw_input.PC) :
     execute_instruction
       (instruction.SHIFTIWOP (d.toClaim.sraiw_input.shamt, d.toClaim.r1, d.toClaim.rd, sopw.SRAIW)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
@@ -3146,7 +3146,7 @@ theorem stepStrong_sraiw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toClaim.sraiw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -3189,7 +3189,7 @@ theorem stepStrong_sraiw
 theorem stepStrong_add
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_add trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.add_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -3248,7 +3248,7 @@ theorem stepStrong_add
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.add_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,
@@ -3340,7 +3340,7 @@ theorem stepStrong_add
 theorem stepStrong_addi
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_addi trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.addi_input.PC) :
     (do
       Sail.writeReg Register.nextPC
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -3399,7 +3399,7 @@ theorem stepStrong_addi
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.addi_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound,
+          d.toInputs.h_pc_bridge h_domain,
       m0_mult := by rfl,
       m0_as := by rfl,
       m1_mult := by rfl,

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
@@ -136,6 +136,34 @@ theorem store_addr2_of_decode
   rw [h_addr2, h_store_ind]
   simpa using h_store_addr_arith
 
+/-- JALR link-value bridge reconstructed from the PC bridge and decoded fallthrough offset. -/
+theorem jalr_link_bridge_of_decode
+    {numInstructions : Nat}
+    {trace : AcceptedZiskTrace numInstructions}
+    {i : Fin trace.numInstructions}
+    {pc : BitVec 64}
+    (h_pc_bridge :
+      ((mainOfTable trace.program trace.mainTable).pc i.val).val = pc.toNat)
+    (h_jmp2 : (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4)
+    (h_pc_bound : pc.toNat < GL_prime - 4) :
+    ((mainOfTable trace.program trace.mainTable).pc i.val
+        + (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val).val
+      = (pc + 4#64).toNat := by
+  rw [h_jmp2]
+  have h_bv_eq :=
+    Pilot.ofNat_fgl_pc_plus_4_eq
+      ((mainOfTable trace.program trace.mainTable).pc i.val) pc h_pc_bridge h_pc_bound
+  have h_toNat := congrArg BitVec.toNat h_bv_eq
+  have h_gl_lt64 : GL_prime < 2 ^ 64 := by
+    have h_lit := ZiskFv.PackedBitVec.WidePCNoWrap.GL_prime_lt_pow_64
+    have h_two64 : 2 ^ 64 = 18446744073709551616 := by norm_num
+    omega
+  have h_val_lt64 : (((mainOfTable trace.program trace.mainTable).pc i.val + 4 : FGL).val)
+      < 2 ^ 64 :=
+    Nat.lt_trans (Fin.isLt _) h_gl_lt64
+  rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt h_val_lt64] at h_toNat
+  exact h_toNat
+
 /-! ## Strengthened control-flow + U-type arms (branches, JAL/JALR, LUI/AUIPC)
 
 These arms reach the same channel-balance conclusion as the 22 above, but via a
@@ -1348,13 +1376,15 @@ theorem stepStrong_jalr
       nextPC_option := h_nextPC_option
       rd_idx := d.toInputs.h_input_rd.trans
         (eRdLui_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset) }
+  have h_link_bridge :=
+    jalr_link_bridge_of_decode d.toInputs.h_pc_bridge d.toDecode.h_jmp2 d.toInputs.h_pc_bound
   let env : OpEnvelope state m i.val :=
     OpEnvelope.jalr d.toInputs.jalr_input d.toClaim.imm d.toClaim.rs1 d.toClaim.rd d.toInputs.misa_val d.toInputs.mseccfg (Pilot.execRowOf trace i) e_rd
       nextPC_val next_pc store_pc_mem pins d.toDecode.h_flag d.toDecode.h_m32 d.toDecode.h_set_pc d.toDecode.h_store_pc
       h_jalr_subset promises d.toInputs.h_input_imm d.toInputs.h_input_rs1 d.toInputs.h_cur_privilege d.toInputs.h_mseccfg
-      d.toInputs.h_link_bridge d.toInputs.h_pc_bound d.toInputs.h_pc_offset_lt_2_32
+      h_link_bridge d.toInputs.h_pc_bound d.toInputs.h_pc_offset_lt_2_32
   have h_bridge : env.aeneasBridgeTrust :=
-    ⟨d.toDecode.h_flag, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc, d.toInputs.h_link_bridge⟩
+    ⟨d.toDecode.h_flag, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc, h_link_bridge⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env :=
     noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
@@ -489,7 +489,9 @@ theorem branch_flag_eq_provided
 theorem stepStrong_beq
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_beq trace binding i)
-    (_h_known : True) :
+    (h_domain :
+      BranchRangeDomain trace i d.toInputs.beq_input.PC
+        ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val)) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BEQ)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨Pilot.execRowOf trace i, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -531,8 +533,7 @@ theorem stepStrong_beq
           (d.toInputs.beq_input.r1_val == d.toInputs.beq_input.r2_val)
           d.toInputs.beq_input.PC (BitVec.signExtend 64 d.toInputs.beq_input.imm)
           d.toDecode.h_idx d.toDecode.h_set_pc h_flag d.toDecode.h_jmp_offset2
-          h_off_bridge d.toInputs.h_pc_bridge d.toInputs.h_no_wrap
-          d.toInputs.h_pc_bound
+          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2
         show (register_type_pc_equiv ▸
             (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
           = (PureSpec.execute_BEQ_pure d.toInputs.beq_input).nextPC
@@ -555,7 +556,9 @@ theorem stepStrong_beq
 theorem stepStrong_bne
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_bne trace binding i)
-    (_h_known : True) :
+    (h_domain :
+      BranchRangeDomain trace i d.toInputs.bne_input.PC
+        ((mainOfTable trace.program trace.mainTable).jmp_offset2 i.val)) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BNE)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨Pilot.execRowOf trace i, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -597,8 +600,7 @@ theorem stepStrong_bne
           (d.toInputs.bne_input.r1_val == d.toInputs.bne_input.r2_val)
           d.toInputs.bne_input.PC (BitVec.signExtend 64 d.toInputs.bne_input.imm)
           d.toDecode.h_idx d.toDecode.h_set_pc h_flag d.toDecode.h_jmp_offset1
-          h_off_bridge d.toInputs.h_pc_bridge d.toInputs.h_no_wrap
-          d.toInputs.h_pc_bound
+          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2
         show (register_type_pc_equiv ▸
             (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
           = (PureSpec.execute_BNE_pure d.toInputs.bne_input).nextPC
@@ -621,7 +623,9 @@ theorem stepStrong_bne
 theorem stepStrong_blt
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_blt trace binding i)
-    (_h_known : True) :
+    (h_domain :
+      BranchRangeDomain trace i d.toInputs.blt_input.PC
+        ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val)) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BLT)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨Pilot.execRowOf trace i, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -663,8 +667,7 @@ theorem stepStrong_blt
           (BitVec.slt d.toInputs.blt_input.r1_val d.toInputs.blt_input.r2_val)
           d.toInputs.blt_input.PC (BitVec.signExtend 64 d.toInputs.blt_input.imm)
           d.toDecode.h_idx d.toDecode.h_set_pc h_flag d.toDecode.h_jmp_offset2
-          h_off_bridge d.toInputs.h_pc_bridge d.toInputs.h_no_wrap
-          d.toInputs.h_pc_bound
+          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2
         show (register_type_pc_equiv ▸
             (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
           = (PureSpec.execute_BLT_pure d.toInputs.blt_input).nextPC
@@ -687,7 +690,9 @@ theorem stepStrong_blt
 theorem stepStrong_bge
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_bge trace binding i)
-    (_h_known : True) :
+    (h_domain :
+      BranchRangeDomain trace i d.toInputs.bge_input.PC
+        ((mainOfTable trace.program trace.mainTable).jmp_offset2 i.val)) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BGE)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨Pilot.execRowOf trace i, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -729,8 +734,7 @@ theorem stepStrong_bge
           (BitVec.slt d.toInputs.bge_input.r1_val d.toInputs.bge_input.r2_val)
           d.toInputs.bge_input.PC (BitVec.signExtend 64 d.toInputs.bge_input.imm)
           d.toDecode.h_idx d.toDecode.h_set_pc h_flag d.toDecode.h_jmp_offset1
-          h_off_bridge d.toInputs.h_pc_bridge d.toInputs.h_no_wrap
-          d.toInputs.h_pc_bound
+          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2
         show (register_type_pc_equiv ▸
             (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
           = (PureSpec.execute_BGE_pure d.toInputs.bge_input).nextPC
@@ -753,7 +757,9 @@ theorem stepStrong_bge
 theorem stepStrong_bltu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_bltu trace binding i)
-    (_h_known : True) :
+    (h_domain :
+      BranchRangeDomain trace i d.toInputs.bltu_input.PC
+        ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val)) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BLTU)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨Pilot.execRowOf trace i, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -798,8 +804,7 @@ theorem stepStrong_bltu
           (BitVec.ult d.toInputs.bltu_input.r1_val d.toInputs.bltu_input.r2_val)
           d.toInputs.bltu_input.PC (BitVec.signExtend 64 d.toInputs.bltu_input.imm)
           d.toDecode.h_idx d.toDecode.h_set_pc h_flag d.toDecode.h_jmp_offset2
-          h_off_bridge d.toInputs.h_pc_bridge d.toInputs.h_no_wrap
-          d.toInputs.h_pc_bound
+          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2
         show (register_type_pc_equiv ▸
             (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
           = (PureSpec.execute_BLTU_pure d.toInputs.bltu_input).nextPC
@@ -822,7 +827,9 @@ theorem stepStrong_bltu
 theorem stepStrong_bgeu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_bgeu trace binding i)
-    (_h_known : True) :
+    (h_domain :
+      BranchRangeDomain trace i d.toInputs.bgeu_input.PC
+        ((mainOfTable trace.program trace.mainTable).jmp_offset2 i.val)) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BGEU)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨Pilot.execRowOf trace i, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -867,8 +874,7 @@ theorem stepStrong_bgeu
           (BitVec.ult d.toInputs.bgeu_input.r1_val d.toInputs.bgeu_input.r2_val)
           d.toInputs.bgeu_input.PC (BitVec.signExtend 64 d.toInputs.bgeu_input.imm)
           d.toDecode.h_idx d.toDecode.h_set_pc h_flag d.toDecode.h_jmp_offset1
-          h_off_bridge d.toInputs.h_pc_bridge d.toInputs.h_no_wrap
-          d.toInputs.h_pc_bound
+          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2
         show (register_type_pc_equiv ▸
             (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
           = (PureSpec.execute_BGEU_pure d.toInputs.bgeu_input).nextPC
@@ -902,7 +908,7 @@ theorem stepStrong_bgeu
 theorem stepStrong_lui
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lui trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.lui_input.PC) :
     execute_instruction (instruction.UTYPE (d.toClaim.imm, d.toClaim.rd, uop.LUI)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨Pilot.execRowOf trace i, [eRdLui trace i]⟩ (binding i) := by
@@ -962,7 +968,7 @@ theorem stepStrong_lui
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       rd_mult := by rfl
       rd_as := by rfl
       nextPC_eq := rfl
@@ -991,7 +997,7 @@ theorem stepStrong_lui
 theorem stepStrong_auipc
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_auipc trace binding i)
-    (_h_known : True) :
+    (h_domain : AuipcRangeDomain d.toInputs.auipc_input) :
     execute_instruction (instruction.UTYPE (d.toClaim.imm, d.toClaim.rd, uop.AUIPC)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨Pilot.execRowOf trace i, [eRdLui trace i]⟩ (binding i) := by
@@ -1065,7 +1071,7 @@ theorem stepStrong_auipc
           d.toDecode.h_idx d.toDecode.h_set_pc h_flag
         rw [hstep, d.toDecode.h_jmp1]
         exact Pilot.ofNat_fgl_pc_plus_4_eq _ d.toInputs.auipc_input.PC
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain.h_pc_bound
       rd_mult := by rfl
       rd_as := by rfl
       nextPC_eq := rfl
@@ -1075,7 +1081,7 @@ theorem stepStrong_auipc
     OpEnvelope.auipc d.toInputs.auipc_input d.toClaim.imm d.toClaim.rd (Pilot.execRowOf trace i) e_rd
       (PureSpec.execute_AUIPC_pure d.toInputs.auipc_input).nextPC next_pc store_pc_mem
       provenance row_mode h_auipc_subset h_offset_bridge d.toInputs.h_pc_bridge promises
-      d.toInputs.h_no_wrap d.toInputs.h_pc_offset_lt_2_32
+      h_domain.h_no_wrap h_domain.h_pc_offset_lt_2_32
   have h_bridge : env.aeneasBridgeTrust :=
     ⟨⟨provenance⟩, row_mode, h_offset_bridge, d.toInputs.h_pc_bridge⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
@@ -1096,7 +1102,7 @@ theorem stepStrong_auipc
 theorem stepStrong_jal
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_jal trace binding i)
-    (_h_known : True) :
+    (h_domain : JalRangeDomain d.toInputs.jal_input) :
     execute_instruction (instruction.JAL (d.toClaim.imm, d.toClaim.rd)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨Pilot.execRowOf trace i, [eRdLui trace i]⟩ (binding i) := by
@@ -1132,7 +1138,7 @@ theorem stepStrong_jal
             i.val).val
         < GL_prime := by
     rw [d.toInputs.h_pc_bridge, h_offset_bridge]
-    exact d.toInputs.h_no_fgl_wrap
+    exact h_domain.h_no_fgl_wrap
   let next_pc : FGL :=
     m.set_pc i.val * (m.c_0 i.val + m.jmp_offset1 i.val)
       + (1 - m.set_pc i.val) * (m.pc i.val + m.jmp_offset2 i.val)
@@ -1201,7 +1207,8 @@ theorem stepStrong_jal
   let env : OpEnvelope state m i.val :=
     OpEnvelope.jal d.toInputs.jal_input d.toClaim.imm d.toClaim.rd d.toInputs.misa_val next_pc (Pilot.execRowOf trace i) e_rd
       nextPC_val store_pc_mem provenance row_mode h_jal_subset d.toDecode.h_jmp2 d.toInputs.h_pc_bridge
-      promises d.toInputs.h_input_imm h_not_throws d.toInputs.h_pc_bound d.toInputs.h_pc_offset_lt_2_32
+      promises d.toInputs.h_input_imm h_not_throws h_domain.h_pc_bound
+      h_domain.h_pc_offset_lt_2_32
   have h_bridge : env.aeneasBridgeTrust :=
     ⟨⟨provenance⟩, row_mode, d.toDecode.h_jmp2, d.toInputs.h_pc_bridge⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
@@ -1221,7 +1228,7 @@ theorem stepStrong_jal
 theorem stepStrong_jalr
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_jalr trace binding i)
-    (_h_known : True) :
+    (h_domain : JalrRangeDomain d.toInputs.jalr_input) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.JALR (d.toClaim.imm, d.toClaim.rs1, d.toClaim.rd))) (binding i)
@@ -1377,12 +1384,12 @@ theorem stepStrong_jalr
       rd_idx := d.toInputs.h_input_rd.trans
         (eRdLui_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset) }
   have h_link_bridge :=
-    jalr_link_bridge_of_decode d.toInputs.h_pc_bridge d.toDecode.h_jmp2 d.toInputs.h_pc_bound
+    jalr_link_bridge_of_decode d.toInputs.h_pc_bridge d.toDecode.h_jmp2 h_domain.h_pc_bound
   let env : OpEnvelope state m i.val :=
     OpEnvelope.jalr d.toInputs.jalr_input d.toClaim.imm d.toClaim.rs1 d.toClaim.rd d.toInputs.misa_val d.toInputs.mseccfg (Pilot.execRowOf trace i) e_rd
       nextPC_val next_pc store_pc_mem pins d.toDecode.h_flag d.toDecode.h_m32 d.toDecode.h_set_pc d.toDecode.h_store_pc
       h_jalr_subset promises d.toInputs.h_input_imm d.toInputs.h_input_rs1 d.toInputs.h_cur_privilege d.toInputs.h_mseccfg
-      h_link_bridge d.toInputs.h_pc_bound d.toInputs.h_pc_offset_lt_2_32
+      h_link_bridge h_domain.h_pc_bound h_domain.h_pc_offset_lt_2_32
   have h_bridge : env.aeneasBridgeTrust :=
     ⟨d.toDecode.h_flag, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc, h_link_bridge⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
@@ -1425,7 +1432,7 @@ private def emptyMainEnv : Environment FGL :=
 theorem stepStrong_sb
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sb trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.sb_input.PC) :
     execute_instruction (instruction.STORE
         (d.toClaim.sb_input.imm, regidx.Regidx d.toClaim.sb_input.r2, regidx.Regidx d.toClaim.sb_input.r1, 1))
         (binding i)
@@ -1466,7 +1473,7 @@ theorem stepStrong_sb
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -1498,7 +1505,7 @@ theorem stepStrong_sb
 theorem stepStrong_sh
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sh trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.sh_input.PC) :
     execute_instruction (instruction.STORE
         (d.toClaim.sh_input.imm, regidx.Regidx d.toClaim.sh_input.r2, regidx.Regidx d.toClaim.sh_input.r1, 2))
         (binding i)
@@ -1539,7 +1546,7 @@ theorem stepStrong_sh
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -1571,7 +1578,7 @@ theorem stepStrong_sh
 theorem stepStrong_sw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.sw_input.PC) :
     execute_instruction (instruction.STORE
         (d.toClaim.sw_input.imm, regidx.Regidx d.toClaim.sw_input.r2, regidx.Regidx d.toClaim.sw_input.r1, 4))
         (binding i)
@@ -1612,7 +1619,7 @@ theorem stepStrong_sw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -1644,7 +1651,7 @@ theorem stepStrong_sw
 theorem stepStrong_sd
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sd trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.sd_input.PC) :
     execute_instruction (instruction.STORE
         (d.toClaim.sd_input.imm, regidx.Regidx d.toClaim.sd_input.r2, regidx.Regidx d.toClaim.sd_input.r1, 8))
         (binding i)
@@ -1685,7 +1692,7 @@ theorem stepStrong_sd
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongLoadMext.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongLoadMext.lean
@@ -175,7 +175,7 @@ records are real `Valid_Mem`/`Valid_BinaryExtension` rows. -/
 theorem stepStrong_ld
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_ld trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.ld_input.PC) :
     execute_instruction (instruction.LOAD
         (d.toClaim.ld_input.imm, regidx.Regidx d.toClaim.ld_input.r1, regidx.Regidx d.toClaim.ld_input.rd, false, 8))
         (binding i)
@@ -219,7 +219,7 @@ theorem stepStrong_ld
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -267,7 +267,7 @@ theorem stepStrong_ld
 theorem stepStrong_lbu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lbu trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.lbu_input.PC) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lbu_input.imm, regidx.Regidx d.toClaim.lbu_input.r1, regidx.Regidx d.toClaim.lbu_input.rd, true, 1))
         (binding i)
@@ -311,7 +311,7 @@ theorem stepStrong_lbu
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -358,7 +358,7 @@ theorem stepStrong_lbu
 theorem stepStrong_lhu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lhu trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.lhu_input.PC) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lhu_input.imm, regidx.Regidx d.toClaim.lhu_input.r1, regidx.Regidx d.toClaim.lhu_input.rd, true, 2))
         (binding i)
@@ -402,7 +402,7 @@ theorem stepStrong_lhu
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -449,7 +449,7 @@ theorem stepStrong_lhu
 theorem stepStrong_lwu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lwu trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.lwu_input.PC) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lwu_input.imm, regidx.Regidx d.toClaim.lwu_input.r1, regidx.Regidx d.toClaim.lwu_input.rd, true, 4))
         (binding i)
@@ -493,7 +493,7 @@ theorem stepStrong_lwu
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -541,7 +541,7 @@ theorem stepStrong_lwu
 theorem stepStrong_lb
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lb trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.lb_input.PC) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lb_input.imm, regidx.Regidx d.toClaim.lb_input.r1, regidx.Regidx d.toClaim.lb_input.rd, false, 1))
         (binding i)
@@ -585,7 +585,7 @@ theorem stepStrong_lb
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -633,7 +633,7 @@ theorem stepStrong_lb
 theorem stepStrong_lh
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lh trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.lh_input.PC) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lh_input.imm, regidx.Regidx d.toClaim.lh_input.r1, regidx.Regidx d.toClaim.lh_input.rd, false, 2))
         (binding i)
@@ -677,7 +677,7 @@ theorem stepStrong_lh
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -725,7 +725,7 @@ theorem stepStrong_lh
 theorem stepStrong_lw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toClaim.lw_input.PC) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lw_input.imm, regidx.Regidx d.toClaim.lw_input.r1, regidx.Regidx d.toClaim.lw_input.rd, false, 4))
         (binding i)
@@ -769,7 +769,7 @@ theorem stepStrong_lw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i _ d.toDecode.h_idx
           d.toDecode.h_set_pc d.toDecode.h_jmp1 d.toDecode.h_jmp2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -845,7 +845,7 @@ the real `busSub` row.  These are strictly stronger than the corresponding
 theorem stepStrong_mulw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mulw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.mulw_input.PC) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.MULW (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd))) (binding i)
@@ -914,7 +914,7 @@ theorem stepStrong_mulw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.mulw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -953,7 +953,7 @@ theorem stepStrong_mulw
 theorem stepStrong_mulhu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mulhu trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.mulhu_input.PC) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute
@@ -1032,7 +1032,7 @@ theorem stepStrong_mulhu
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.mulhu_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -1067,7 +1067,7 @@ theorem stepStrong_mulhu
 theorem stepStrong_divu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_divu trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.divu_input.PC) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.DIV (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, true))) (binding i)
@@ -1147,7 +1147,7 @@ theorem stepStrong_divu
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.divu_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -1178,7 +1178,7 @@ theorem stepStrong_divu
 theorem stepStrong_divuw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_divuw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.divuw_input.PC) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.DIVW (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, true))) (binding i)
@@ -1254,7 +1254,7 @@ theorem stepStrong_divuw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.divuw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -1284,7 +1284,7 @@ theorem stepStrong_divuw
 theorem stepStrong_remu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_remu trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.remu_input.PC) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.REM (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, true))) (binding i)
@@ -1360,7 +1360,7 @@ theorem stepStrong_remu
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.remu_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl
@@ -1389,7 +1389,7 @@ theorem stepStrong_remu
 theorem stepStrong_remuw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_remuw trace binding i)
-    (_h_known : True) :
+    (h_domain : SequentialPcDomain d.toInputs.remuw_input.PC) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.REMW (d.toClaim.r2, d.toClaim.r1, d.toClaim.rd, true))) (binding i)
@@ -1465,7 +1465,7 @@ theorem stepStrong_remuw
       nextPC_matches :=
         Pilot.sequential_nextPC_discharged trace i d.toInputs.remuw_input.PC
           d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_jmp_offset1 d.toDecode.h_jmp_offset2
-          d.toInputs.h_pc_bridge d.toInputs.h_pc_bound
+          d.toInputs.h_pc_bridge h_domain
       m0_mult := by rfl
       m0_as := by rfl
       m1_mult := by rfl

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongSignedM.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongSignedM.lean
@@ -67,6 +67,7 @@ set_option maxHeartbeats 8000000
 theorem stepStrong_mul
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mul trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mul_input.PC)
     (h_known : ¬ Defects.SignedMulForge d.toInputs.v d.toInputs.r_a) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -83,7 +84,7 @@ theorem stepStrong_mul
            , (busSub trace i (Pilot.execRowOf trace i)).e2 ]⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
   set state := binding i with hstate
-  let env : OpEnvelope state m i.val := mulEnvOf trace binding i d
+  let env : OpEnvelope state m i.val := mulEnvOf trace binding i d h_domain
   have h_bridge : env.aeneasBridgeTrust :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc,
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
@@ -108,6 +109,7 @@ theorem stepStrong_mul
 theorem stepStrong_mulh
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mulh trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mulh_input.PC)
     (h_known : ¬ Defects.SignedMulForge d.toInputs.v d.toInputs.r_a) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -124,7 +126,7 @@ theorem stepStrong_mulh
            , (busSub trace i (Pilot.execRowOf trace i)).e2 ]⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
   set state := binding i with hstate
-  let env : OpEnvelope state m i.val := mulhEnvOf trace binding i d
+  let env : OpEnvelope state m i.val := mulhEnvOf trace binding i d h_domain
   have h_bridge : env.aeneasBridgeTrust :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc,
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
@@ -139,6 +141,7 @@ theorem stepStrong_mulh
 theorem stepStrong_mulhsu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_mulhsu trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.mulhsu_input.PC)
     (h_known : ¬ Defects.SignedMulForge d.toInputs.v d.toInputs.r_a) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -155,7 +158,7 @@ theorem stepStrong_mulhsu
            , (busSub trace i (Pilot.execRowOf trace i)).e2 ]⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
   set state := binding i with hstate
-  let env : OpEnvelope state m i.val := mulhsuEnvOf trace binding i d
+  let env : OpEnvelope state m i.val := mulhsuEnvOf trace binding i d h_domain
   have h_bridge : env.aeneasBridgeTrust :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc,
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
@@ -187,6 +190,7 @@ theorem stepStrong_mulhsu
 theorem stepStrong_div
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_div trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.div_input.PC)
     (h_known : ¬ Defects.DivRemForge d.toInputs.div_input.r2_val d.toInputs.v d.toInputs.r_a) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -198,7 +202,7 @@ theorem stepStrong_div
            , (busSub trace i (Pilot.execRowOf trace i)).e2 ]⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
   set state := binding i with hstate
-  let env : OpEnvelope state m i.val := divEnvOf trace binding i d
+  let env : OpEnvelope state m i.val := divEnvOf trace binding i d h_domain
   have h_bridge : env.aeneasBridgeTrust :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc,
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
@@ -218,6 +222,7 @@ theorem stepStrong_div
 theorem stepStrong_rem
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_rem trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.rem_input.PC)
     (h_known : ¬ Defects.DivRemForge d.toInputs.rem_input.r2_val d.toInputs.v d.toInputs.r_a) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -229,7 +234,7 @@ theorem stepStrong_rem
            , (busSub trace i (Pilot.execRowOf trace i)).e2 ]⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
   set state := binding i with hstate
-  let env : OpEnvelope state m i.val := remEnvOf trace binding i d
+  let env : OpEnvelope state m i.val := remEnvOf trace binding i d h_domain
   have h_bridge : env.aeneasBridgeTrust :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc,
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
@@ -247,6 +252,7 @@ theorem stepStrong_rem
 theorem stepStrong_divw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_divw trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.divw_input.PC)
     (h_known : ¬ Defects.DivRemForgeW d.toInputs.divw_input.r2_val d.toInputs.v d.toInputs.r_a) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -258,7 +264,7 @@ theorem stepStrong_divw
            , (busSub trace i (Pilot.execRowOf trace i)).e2 ]⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
   set state := binding i with hstate
-  let env : OpEnvelope state m i.val := divwEnvOf trace binding i d
+  let env : OpEnvelope state m i.val := divwEnvOf trace binding i d h_domain
   have h_bridge : env.aeneasBridgeTrust :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc,
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
@@ -273,6 +279,7 @@ theorem stepStrong_divw
 theorem stepStrong_remw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_remw trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.remw_input.PC)
     (h_known : ¬ Defects.DivRemForgeW d.toInputs.remw_input.r2_val d.toInputs.v d.toInputs.r_a) :
     (do
       Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
@@ -284,7 +291,7 @@ theorem stepStrong_remw
            , (busSub trace i (Pilot.execRowOf trace i)).e2 ]⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
   set state := binding i with hstate
-  let env : OpEnvelope state m i.val := remwEnvOf trace binding i d
+  let env : OpEnvelope state m i.val := remwEnvOf trace binding i d h_domain
   have h_bridge : env.aeneasBridgeTrust :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc,
       d.toDecode.h_jmp_offset1, d.toDecode.h_jmp_offset2⟩
@@ -312,12 +319,13 @@ theorem stepStrong_remw
 theorem stepStrong_fence
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_fence trace binding i)
+    (h_domain : SequentialPcDomain d.toInputs.fence_input.PC)
     (h_known : Defects.FenceKnownGood d.toClaim.fm d.toClaim.rs d.toClaim.rd) :
     execute_instruction (instruction.FENCE (d.toClaim.fm, d.toClaim.fenceP, d.toClaim.fenceS, d.toClaim.rs, d.toClaim.rd)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨Pilot.execRowOf trace i, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
   set state := binding i with hstate
-  let env : OpEnvelope state m i.val := fenceEnvOf trace binding i d
+  let env : OpEnvelope state m i.val := fenceEnvOf trace binding i d h_domain
   have h_bridge : env.aeneasBridgeTrust := ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   -- The threaded `FenceKnownGood` obligation is (defeq, via


### PR DESCRIPTION
Part of #141.

This proof slice removes the public `Inputs_jalr.h_link_bridge` premise. Instead, `Decode_jalr` now exposes the committed-program `jmp_offset2 = 4` fact, `Inputs_jalr` carries the narrower PC state bridge, and `StepStrongControlStore` reconstructs the old link-value bridge locally.

Verification:
- `lake build ZiskFv.Compliance.TraceLevelExport.RomDecodeBindingOps ZiskFv.Compliance.TraceLevelExport.ProgramDecode ZiskFv.Compliance.TraceLevelExport.StepStrongControlStore ZiskFv.Compliance.TraceLevelExport.Dispatcher`
- `lake build`
- `trust/scripts/check-all.sh`
- `trust/scripts/check-all-semantic.sh`
