### PR TITLE
#217: EnsembleWitness builder + balance combinator + degenerate root_soundness instantiation

### DIFF
--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -158,7 +158,8 @@ import ZiskFv.Compliance.ConstructionBranch
 import ZiskFv.Compliance.ConstructionJump
 import ZiskFv.Compliance.TraceLevelExport
 import ZiskFv.Compliance
-import ZiskFv.Compliance.EnsembleWitnessBuilder.TraceLevelExport.RomDecodeBinding
+import ZiskFv.Compliance.EnsembleWitnessBuilder
+import ZiskFv.Compliance.TraceLevelExport.RomDecodeBinding
 import ZiskFv.Compliance.TraceLevelExport.RomDecodeBindingOps
 import ZiskFv.Compliance.TraceLevelExport.ProgramDecode
 import ZiskFv.Compliance

--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -157,7 +157,8 @@ import ZiskFv.Compliance.ConstructionLoad
 import ZiskFv.Compliance.ConstructionBranch
 import ZiskFv.Compliance.ConstructionJump
 import ZiskFv.Compliance.TraceLevelExport
-import ZiskFv.Compliance.TraceLevelExport.RomDecodeBinding
+import ZiskFv.Compliance
+import ZiskFv.Compliance.EnsembleWitnessBuilder.TraceLevelExport.RomDecodeBinding
 import ZiskFv.Compliance.TraceLevelExport.RomDecodeBindingOps
 import ZiskFv.Compliance.TraceLevelExport.ProgramDecode
 import ZiskFv.Compliance

--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -157,12 +157,11 @@ import ZiskFv.Compliance.ConstructionLoad
 import ZiskFv.Compliance.ConstructionBranch
 import ZiskFv.Compliance.ConstructionJump
 import ZiskFv.Compliance.TraceLevelExport
-import ZiskFv.Compliance
-import ZiskFv.Compliance.EnsembleWitnessBuilder
 import ZiskFv.Compliance.TraceLevelExport.RomDecodeBinding
 import ZiskFv.Compliance.TraceLevelExport.RomDecodeBindingOps
 import ZiskFv.Compliance.TraceLevelExport.ProgramDecode
 import ZiskFv.Compliance
+import ZiskFv.Compliance.EnsembleWitnessBuilder
 -- In-build per-opcode static decode/row-mode pin discharge from the real
 -- Aeneas-extracted ZisK lowerer (eth-act/zisk-fv#111). Standalone; not yet
 -- wired into root_soundness. Per-theorem collectAxioms keeps the aeneas runtime

--- a/ZiskFv/Compliance/EnsembleWitnessBuilder.lean
+++ b/ZiskFv/Compliance/EnsembleWitnessBuilder.lean
@@ -1,0 +1,135 @@
+import Clean.Air.FlatEnsemble
+
+/-!
+# Forward `EnsembleWitness` builder + channel-balance combinator
+
+Reusable, ZisK-agnostic machinery for constructing an `Air.Flat.EnsembleWitness`
+from a position-indexed row assignment, together with a lemma-driven
+`BalancedInteractions` combinator and the generic verifier-empty reductions of
+`Constraints` / `BalancedChannels` to per-`tables` obligations.
+
+This is the foundation for instantiating `ZiskFv.Compliance.root_soundness` on a
+concrete accepted trace (eth-act/zisk-fv#217, feeding #218/#219). Nothing here is
+ZisK-specific: everything is stated over an abstract `Air.Flat.Ensemble`.
+
+The tree previously had no forward `EnsembleWitness` construction and no forward
+`BalancedChannels` proof — every balance lemma ran the reverse direction
+(projecting the hypothesis out). These are the first forward pieces.
+-/
+
+namespace Air.Flat
+
+variable {F : Type} [Field F]
+
+/-- **Channel-balance combinator.** To show an interaction list `L` is balanced it
+    suffices to (a) bound its length below the field characteristic and (b) verify
+    balance only for the messages that actually occur (`present`). A message absent
+    from `L` balances automatically because its filter is empty.
+
+    `Air.Flat.Interaction` has no `DecidableEq` (its `RawChannel` carries
+    `Prop`-valued fields), so `BalancedInteractions` cannot be discharged by
+    `decide`; this lemma is the finite-check replacement. The degenerate n=0 witness
+    uses `present := []`; #219 will use the singleton shared message of a ±1
+    push/pull pair (via `balanceOf_append`). -/
+theorem balancedInteractions_of_present [DecidableEq F] {L : List (Interaction F)}
+    (hlen : L.length < ringChar F ∨ ringChar F = 0)
+    (present : List (Array F))
+    (hmsg : ∀ i ∈ L, i.msg ∈ present)
+    (hbal : ∀ msg ∈ present, balanceOf L msg = 0) :
+    BalancedInteractions L := by
+  refine ⟨hlen, fun msg => ?_⟩
+  by_cases hp : msg ∈ present
+  · exact hbal msg hp
+  · have hfilter : L.filter (·.msg = msg) = [] := by
+      rw [List.filter_eq_nil_iff]
+      intro i hi hpi
+      simp only [decide_eq_true_eq] at hpi
+      exact hp (hpi ▸ hmsg i hi)
+    simp only [balanceOf, hfilter, List.map_nil, List.sum_nil]
+
+namespace EnsembleWitness
+
+variable {PublicIO : TypeMap} [ProvableType PublicIO]
+
+/-- The `i`-th table of the builder: `ens.tables[i]` as its component, carrying the
+    caller's `rows i`. Keeping this named (rather than an inline structure literal)
+    keeps the projection/membership lemmas below clean `rfl`s. -/
+def tableAt (ens : Ensemble F PublicIO) (data : ProverData F)
+    (rows : Fin ens.tables.length → List (Array F))
+    (huniform : ∀ i : Fin ens.tables.length,
+        ∀ row ∈ rows i, row.size = (ens.tables[i.val]'i.isLt).width)
+    (i : Fin ens.tables.length) : Table F where
+  component := ens.tables[i.val]'i.isLt
+  width := (ens.tables[i.val]'i.isLt).width
+  table := rows i
+  data := data
+  uniform_width := huniform i
+
+@[simp] lemma tableAt_component (ens : Ensemble F PublicIO) (data : ProverData F)
+    (rows : Fin ens.tables.length → List (Array F)) (huniform) (i) :
+    (tableAt ens data rows huniform i).component = ens.tables[i.val]'i.isLt := rfl
+
+@[simp] lemma tableAt_table (ens : Ensemble F PublicIO) (data : ProverData F)
+    (rows : Fin ens.tables.length → List (Array F)) (huniform) (i) :
+    (tableAt ens data rows huniform i).table = rows i := rfl
+
+@[simp] lemma tableAt_data (ens : Ensemble F PublicIO) (data : ProverData F)
+    (rows : Fin ens.tables.length → List (Array F)) (huniform) (i) :
+    (tableAt ens data rows huniform i).data = data := rfl
+
+/-- Build an `EnsembleWitness ens` from a position-indexed row assignment. The
+    `tables` list is `List.ofFn` over `Fin ens.tables.length`, so every built
+    table's component is definitionally `ens.tables[i]` — making the three `same_*`
+    obligations one-liners. Callers supply `rows` (per-table row lists) and a
+    per-table `uniform_width` proof; #218/#219 supply non-empty `rows`, the
+    degenerate #217 witness supplies `fun _ => []`. -/
+def ofRows (ens : Ensemble F PublicIO) (data : ProverData F) (publicInput : PublicIO F)
+    (rows : Fin ens.tables.length → List (Array F))
+    (huniform : ∀ i : Fin ens.tables.length,
+        ∀ row ∈ rows i, row.size = (ens.tables[i.val]'i.isLt).width) :
+    EnsembleWitness ens where
+  tables := List.ofFn (tableAt ens data rows huniform)
+  data := data
+  publicInput := publicInput
+  same_length := by rw [List.length_ofFn]
+  same_circuits := by intro i hi; simp only [List.getElem_ofFn, tableAt_component]
+  same_data := by
+    intro t h; rw [List.mem_ofFn] at h; obtain ⟨i, rfl⟩ := h; rfl
+
+@[simp] lemma ofRows_tables (ens : Ensemble F PublicIO) (data : ProverData F)
+    (publicInput : PublicIO F) (rows : Fin ens.tables.length → List (Array F)) (huniform) :
+    (ofRows ens data publicInput rows huniform).tables =
+      List.ofFn (tableAt ens data rows huniform) := rfl
+
+@[simp] lemma ofRows_data (ens : Ensemble F PublicIO) (data : ProverData F)
+    (publicInput : PublicIO F) (rows : Fin ens.tables.length → List (Array F)) (huniform) :
+    (ofRows ens data publicInput rows huniform).data = data := rfl
+
+@[simp] lemma ofRows_publicInput (ens : Ensemble F PublicIO) (data : ProverData F)
+    (publicInput : PublicIO F) (rows : Fin ens.tables.length → List (Array F)) (huniform) :
+    (ofRows ens data publicInput rows huniform).publicInput = publicInput := rfl
+
+/-- With an empty verifier, `witness.Constraints` reduces to the per-`tables`
+    obligation (the verifier table's own constraints are discharged by
+    `verifierTable_constraints_of_verifier_empty`). -/
+theorem constraints_of_tables {ens : Ensemble F PublicIO} (witness : EnsembleWitness ens)
+    (h_verifier : ens.verifier = .empty F PublicIO)
+    (h : ∀ table ∈ witness.tables, table.Constraints) : witness.Constraints := by
+  simp only [EnsembleWitness.Constraints, forall_mem_allTables_iff]
+  exact ⟨verifierTable_constraints_of_verifier_empty h_verifier, h⟩
+
+/-- With an empty verifier, `witness.BalancedChannels` reduces to per-channel balance
+    of the `tables`-only interaction list (the verifier contributes none). -/
+theorem balancedChannels_of_tables [DecidableEq F] {ens : Ensemble F PublicIO}
+    (witness : EnsembleWitness ens) (h_verifier : ens.verifier = .empty F PublicIO)
+    (h : ∀ channel ∈ ens.channels,
+        BalancedInteractions (witness.tables.flatMap (·.interactionsWith channel))) :
+    witness.BalancedChannels := by
+  simp only [EnsembleWitness.BalancedChannels, EnsembleWitness.BalancedChannel]
+  intro channel h_mem
+  rw [EnsembleWitness.interactionsWith_allTablesWitness,
+      EnsembleWitness.interactionsWith_of_verifier_empty h_verifier]
+  exact h channel h_mem
+
+end EnsembleWitness
+end Air.Flat

--- a/trust/consistency/root_soundness_instantiation_degenerate.lean
+++ b/trust/consistency/root_soundness_instantiation_degenerate.lean
@@ -1,0 +1,151 @@
+import ZiskFv.Soundness
+import ZiskFv.Compliance.EnsembleWitnessBuilder
+import ZiskFv.AirsClean.FullEnsemble.Balance.Classification
+
+/-!
+# Degenerate `root_soundness` instantiation (end-to-end integration witness, base case)
+
+The first concrete inhabitant of `ZiskFv.Compliance.AcceptedZiskTrace` fed through
+`ZiskFv.Compliance.root_soundness` (eth-act/zisk-fv#217, foundation of #74).
+
+This is the DEGENERATE base case: `numInstructions = 0`, every provider table empty.
+It exercises the whole witness-construction pipeline — the 10-table
+`EnsembleWitness` (`same_length`/`same_circuits`/`same_data`), `constraints_hold`,
+`transitions_hold`, `segment_l1_fixed`, and the first forward `BalancedChannels`
+proof — and applies `root_soundness` to the result. The `∀ i : Fin 0` conclusion
+is vacuous, so this establishes only that the quantified-over trace object is
+INHABITED and accepted; the non-vacuous single-ADD instance is #219/#220. No new
+axioms, no `sorry`.
+
+## Regeneration
+
+The trace is hand-authored (not dumped from an execution): the empty program
+`nofun : Program 0` has no rows, so there are no literals to regenerate. #220 will
+add the first witness with real row literals.
+-/
+
+namespace ZiskFv.TrustConsistency
+
+open Goldilocks
+open Air.Flat
+open ZiskFv.Compliance
+open ZiskFv.AirsClean.FullEnsemble (fullRv64imEnsemble fullRv64imSoundEnsemble)
+open ZiskFv.AirsClean.ZiskInstructionRom (Program)
+
+/-- The empty 0-instruction program. -/
+private def prog : Program 0 := nofun
+
+private def emptyData : ProverData FGL := fun _ _ => #[]
+
+/-- The degenerate witness: every one of the ensemble's tables carries no rows. -/
+private def wit : EnsembleWitness (fullRv64imEnsemble 0 prog).ensemble :=
+  EnsembleWitness.ofRows (fullRv64imEnsemble 0 prog).ensemble emptyData ()
+    (fun _ => []) (by intro i row hrow; simp at hrow)
+
+/-- The full ensemble's verifier is empty (it is `SoundEnsemble.empty`'s verifier,
+    preserved by `addTable`/`addFinishedChannel`; `fullRv64imEnsemble` is
+    definitionally its `SoundEnsemble`'s ensemble). -/
+private theorem wit_verifier :
+    (fullRv64imEnsemble 0 prog).ensemble.verifier = .empty FGL unit :=
+  (fullRv64imSoundEnsemble 0 prog).verifier_empty
+
+/-- Every table of the degenerate witness has at most one row: the provider
+    tables are empty (0 rows) and the verifier table carries the single public
+    input row. This is what makes `transitions_hold` vacuous (no consecutive row
+    pair exists). -/
+private theorem wit_tables_len_le_one (table : Table FGL)
+    (hmem : table ∈ wit.allTables) : table.table.length ≤ 1 := by
+  rw [EnsembleWitness.allTables, List.mem_cons] at hmem
+  rcases hmem with hv | ht
+  · rw [hv]; simp [EnsembleWitness.verifierTable]
+  · simp only [wit, EnsembleWitness.ofRows_tables, List.mem_ofFn] at ht
+    obtain ⟨i, rfl⟩ := ht
+    simp [EnsembleWitness.tableAt_table]
+
+/-- The only table of the degenerate witness carrying the Main component has no
+    rows. The provider tables are empty by construction; the single non-empty
+    table is the verifier, whose component exposes NO operation-bus interactions
+    (`verifierTable_interactionsWith_opBus_nil`) while Main's are a non-empty
+    singleton (`componentWithRomMemAndOpBus_interactionsWith_opBus`), so the
+    verifier's component cannot equal Main's. This makes `segment_l1_fixed`
+    vacuous. -/
+private theorem main_component_tables_empty (table : Table FGL)
+    (hmem : table ∈ wit.allTables)
+    (hcomp : table.component =
+      ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus 0 prog) :
+    table.table = [] := by
+  rw [EnsembleWitness.allTables, List.mem_cons] at hmem
+  rcases hmem with hv | ht
+  · exfalso
+    rw [hv, EnsembleWitness.verifierTable_component] at hcomp
+    have hv_nil :=
+      ZiskFv.AirsClean.FullEnsemble.verifierTable_interactionsWith_opBus_nil 0 prog
+    rw [hcomp,
+      ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus_interactionsWith_opBus 0 prog] at hv_nil
+    exact absurd hv_nil (by simp)
+  · simp only [wit, EnsembleWitness.ofRows_tables, List.mem_ofFn] at ht
+    obtain ⟨i, rfl⟩ := ht
+    simp [EnsembleWitness.tableAt_table]
+
+private theorem wit_constraints : wit.Constraints := by
+  refine wit.constraints_of_tables wit_verifier ?_
+  intro t ht
+  simp only [wit, EnsembleWitness.ofRows_tables, List.mem_ofFn] at ht
+  obtain ⟨i, rfl⟩ := ht
+  simp [Air.Flat.Table.Constraints, EnsembleWitness.tableAt_table]
+
+private theorem wit_balanced : wit.BalancedChannels := by
+  refine wit.balancedChannels_of_tables wit_verifier ?_
+  intro channel _
+  have hnil : wit.tables.flatMap (·.interactionsWith channel) = [] := by
+    rw [List.flatMap_eq_nil_iff]
+    intro t ht
+    simp only [wit, EnsembleWitness.ofRows_tables, List.mem_ofFn] at ht
+    obtain ⟨i, rfl⟩ := ht
+    simp [Air.Flat.Table.interactionsWith, EnsembleWitness.tableAt_table]
+  rw [hnil]
+  exact balancedInteractions_of_present (Or.symm (Nat.eq_zero_or_pos _)) []
+    (by simp) (by simp)
+
+private theorem wit_transitions : wit.TransitionConstraints := by
+  intro table hmem i h
+  exact absurd h (by have := wit_tables_len_le_one table hmem; omega)
+
+private theorem wit_segment_l1 :
+    ∀ table ∈ wit.allTables,
+      table.component =
+          ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus 0 prog →
+        (0 < table.table.length →
+            (ZiskFv.AirsClean.FullEnsemble.mainOfTable prog table).segment_l1 0 = 1) ∧
+        (∀ idx : Fin table.table.length, 0 < idx.val →
+            (ZiskFv.AirsClean.FullEnsemble.mainOfTable prog table).segment_l1 idx.val = 0) := by
+  intro table hmem hcomp
+  have htab : table.table = [] := main_component_tables_empty table hmem hcomp
+  exact ⟨fun h => absurd h (by simp [htab]), fun idx _ => absurd idx.isLt (by simp [htab])⟩
+
+/-- The degenerate accepted trace: empty program, all-empty witness, trivial
+    channel balance, vacuous transition / row-height / segment-fixed obligations. -/
+private def trace : AcceptedZiskTrace 0 where
+  program := prog
+  witness := wit
+  constraints_hold := wit_constraints
+  channels_balanced := wit_balanced
+  transitions_hold := wit_transitions
+  main_height := by intro table _ _ i; exact i.elim0
+  segment_l1_fixed := wit_segment_l1
+
+private def sail : SailTrace 0 := nofun
+
+private def step : ∀ i : Fin 0, ZiskStep trace i := nofun
+
+/-- `root_soundness` applied to a concrete (degenerate) accepted trace. The `Fin 0`
+    conclusion is vacuous, but the term genuinely constructs an `AcceptedZiskTrace`
+    and feeds it through the headline theorem — witnessing that the object
+    `root_soundness` quantifies over is inhabited and accepted. -/
+theorem root_soundness_instantiation_degenerate :
+    ∀ i : Fin 0, StepSound trace sail i (step i) :=
+  root_soundness 0 trace sail step nofun nofun nofun
+
+#print axioms root_soundness_instantiation_degenerate
+
+end ZiskFv.TrustConsistency

--- a/trust/scripts/check-all-semantic.sh
+++ b/trust/scripts/check-all-semantic.sh
@@ -54,25 +54,35 @@ run_witnesses() {
   return $ok
 }
 
-run "1/14 axiom-deps baseline (V2)"        "$dir/check-axiom-deps.sh"
-run "2/14 forbidden types (V2)"            "$dir/check-no-output-eq-v2.sh"
-run "3/14 closure vs baseline-axioms (V2)" "$dir/check-closure-vs-baseline.sh"
-run "4/14 global theorem binders (V2)"     "$dir/check-global-theorem-binders.sh"
-run "5/14 strong-export axiom closure (V2)" "$dir/check-strong-export-closure.sh"
-run "6/14 strong-export binders + forbidden types (V2)" "$dir/check-strong-export-binders.sh"
-run "7/14 consistency false probe rejected" reject_false_probe
-run "8/14 Sail memory timeline witness" \
+run_root_soundness_instantiations() {
+  local ok=0
+  for f in trust/consistency/root_soundness_instantiation_*.lean; do
+    [ -e "$f" ] || continue
+    run_lean_no_sorry "$f" || ok=1
+  done
+  return $ok
+}
+
+run "1/15 axiom-deps baseline (V2)"        "$dir/check-axiom-deps.sh"
+run "2/15 forbidden types (V2)"            "$dir/check-no-output-eq-v2.sh"
+run "3/15 closure vs baseline-axioms (V2)" "$dir/check-closure-vs-baseline.sh"
+run "4/15 global theorem binders (V2)"     "$dir/check-global-theorem-binders.sh"
+run "5/15 strong-export axiom closure (V2)" "$dir/check-strong-export-closure.sh"
+run "6/15 strong-export binders + forbidden types (V2)" "$dir/check-strong-export-binders.sh"
+run "7/15 consistency false probe rejected" reject_false_probe
+run "8/15 Sail memory timeline witness" \
   run_lean_no_sorry trust/consistency/load_byte_agreement_witness.lean
-run "9/14 memory timeline construction witness" \
+run "9/15 memory timeline construction witness" \
   run_lean_no_sorry trust/consistency/memory_timeline_construction_witness.lean
-run "10/14 memory prefix alignment witness" \
+run "10/15 memory prefix alignment witness" \
   run_lean_no_sorry trust/consistency/memory_prefix_alignment_witness.lean
-run "11/14 global ADD theorem instantiation" \
+run "11/15 global ADD theorem instantiation" \
   run_lean_no_sorry trust/consistency/global_theorem_instantiation_add.lean
-run "12/14 global LD theorem instantiation" \
+run "12/15 global LD theorem instantiation" \
   run_lean_no_sorry trust/consistency/global_theorem_instantiation_ld.lean
-run "13/14 Clean completeness witnesses" run_witnesses
-run "14/14 Aeneas extraction-pin raw axiom closure (V2)" \
+run "13/15 root_soundness instantiation witnesses" run_root_soundness_instantiations
+run "14/15 Clean completeness witnesses" run_witnesses
+run "15/15 Aeneas extraction-pin raw axiom closure (V2)" \
   "$dir/check-extraction-closure.sh"
 
 if [ $overall -eq 0 ]; then


### PR DESCRIPTION
## What

Foundation for instantiating the headline `ZiskFv.Compliance.root_soundness`
(`ZiskFv/Soundness.lean`) on a concrete accepted trace — the base of the
#217 → #218 → #219 → #220 ladder toward #74's end-to-end non-vacuity witness.

Adds the **first forward construction of an `Air.Flat.EnsembleWitness`** and the
**first forward `BalancedChannels` proof** in the tree (every prior balance lemma
runs the reverse direction, projecting the hypothesis out).

### `ZiskFv/Compliance/EnsembleWitnessBuilder.lean` (new, generic over `F`/`PublicIO`)
- `EnsembleWitness.ofRows` — build a witness from a position-indexed row
  assignment via `List.ofFn` over `Fin ens.tables.length`, discharging
  `same_length` / `same_circuits` / `same_data` once. (Position-keyed rows are
  exactly the interface #218/#219 need to place distinct rows on Main vs the
  providers.)
- `balancedInteractions_of_present` — reduce the infinite `∀ msg` balance
  obligation to a finite check over the messages actually present (a message
  absent from the list balances via its empty filter). `Interaction` has no
  `DecidableEq`, so this is the lemma-driven replacement for `decide`.
- `constraints_of_tables` / `balancedChannels_of_tables` — with an empty verifier,
  reduce whole-witness `Constraints` / `BalancedChannels` to the per-`tables`
  obligation.

### `trust/consistency/root_soundness_instantiation_degenerate.lean` (new)
The degenerate `numInstructions = 0` / all-empty-provider `AcceptedZiskTrace`, fed
through `root_soundness`. Discharges all seven trace fields — including the
XCAP-added `transitions_hold` (vacuous: every table has ≤ 1 row) and
`segment_l1_fixed` (vacuous: the Main-component table is empty, the 1-row verifier
excluded via the op-bus interaction discriminator).

**Anti-laundering:** the witness `#print axioms` closure is **identical** to
`root_soundness` — it adds no axioms, no `sorry`, no new trust. The `∀ i : Fin 0`
conclusion is vacuous, so this establishes only inhabitedness/acceptance of the
trace object; the non-vacuous single-ADD instance is #219/#220.

### `trust/scripts/check-all-semantic.sh`
Discovers the new `root_soundness_instantiation_*.lean` witnesses via a glob loop
(renumbered 14 → 15), mirroring the existing `completeness_witness_*` loop.

## Verification
- `lake build ZiskFv` green.
- V1 trust gate: 16/16 pass. V2 trust gate: 15/15 pass (new check 13/15 = the witness).
- Witness axiom closure == `root_soundness` closure.

Closes #217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
