### PR TITLE
#185: name the boot/cross-segment memory seed as one premise of root_soundness

### DIFF
--- a/ZiskFv/Compliance/TraceLevelExport.lean
+++ b/ZiskFv/Compliance/TraceLevelExport.lean
@@ -8,6 +8,7 @@ import ZiskFv.Compliance.TraceLevelExport.StepStrongControlStore
 import ZiskFv.Compliance.TraceLevelExport.StepStrongLoadMext
 import ZiskFv.Compliance.TraceLevelExport.StepStrongSignedM
 import ZiskFv.Compliance.TraceLevelExport.Dispatcher
+import ZiskFv.Compliance.TraceLevelExport.BootSegmentMemorySeed
 
 /-!
 # TraceLevelExport.lean — P5 trace-level export (channel-balance form)

--- a/ZiskFv/Compliance/TraceLevelExport.lean
+++ b/ZiskFv/Compliance/TraceLevelExport.lean
@@ -9,6 +9,7 @@ import ZiskFv.Compliance.TraceLevelExport.StepStrongLoadMext
 import ZiskFv.Compliance.TraceLevelExport.StepStrongSignedM
 import ZiskFv.Compliance.TraceLevelExport.Dispatcher
 import ZiskFv.Compliance.TraceLevelExport.BootSegmentMemorySeed
+import ZiskFv.Compliance.TraceLevelExport.BootSegmentMemorySeedWitness
 
 /-!
 # TraceLevelExport.lean — P5 trace-level export (channel-balance form)

--- a/ZiskFv/Compliance/TraceLevelExport/BootSegmentMemorySeed.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/BootSegmentMemorySeed.lean
@@ -1,0 +1,193 @@
+import ZiskFv.Compliance.TraceLevelExport.Dispatcher
+
+/-!
+# The boot / cross-segment memory seed (`BootSegmentMemorySeed`)
+
+`root_soundness`'s loads and stores each consume a memory-coherence fact — "the
+value in memory at this address is what the circuit claims" — that no single
+instruction can supply, because it depends on the whole history of earlier
+writes.  Historically the ten memory ops (seven loads + `sb`/`sh`/`sw`) each
+carried their *own* existential copy of that story as an `Inputs_<op>` field
+(`h_memory_timeline` / `h_store_rmw`), so nothing forced the ten copies to agree.
+
+This module replaces those ten scattered residuals with ONE named premise, the
+`BootSegmentMemorySeed`: the segment's initial memory state plus the single
+consistent per-row memory-evolution chain (`RowTraceCoherence` over the *whole*
+consumed memory-bus row sequence).  `memEvidence_of_bootSeed` then *derives* each
+op's residual from that shared seed, restricting the whole-sequence coherence to
+the op's prefix via `rowTraceCoherence_of_append`.
+
+This is the MVP legibility step of issue #185: the seed is legitimately *assumed*
+(a segment does not contain its own starting state — it is carried in from the
+previous segment / boot).  Driving the seed to zero is the follow-on work in #115
+/ #119.  Only the memory field of each cursor state is constrained; PC /
+registers are pinned only incidentally through the initial-state snapshot
+(per-step next-PC is discharged separately, #163), which is why this is a
+*memory* seed rather than a "memory+PC" one. -/
+
+namespace ZiskFv.Compliance
+
+open Interaction
+
+variable {numInstructions : Nat}
+
+/-! ## Restricting the shared whole-sequence coherence to one op's prefix -/
+
+/-- Derive one load's `LoadMemoryTimelineCoherenceEvidence` from the shared seed
+    data (replay facts, cursor-indexed state assignment, whole-sequence
+    coherence) plus this op's prefix split and cursor tie.  The whole-sequence
+    coherence `RowTraceCoherence stateAt [] rows` is restricted to the op's prefix
+    by `rowTraceCoherence_of_append`. -/
+theorem loadCoherence_of_shared
+    {initialState : ZiskFv.ZiskCircuit.MemTrace.SailState}
+    {rows : List (MemoryBusEntry FGL)}
+    (facts : ZiskFv.AirsClean.Mem.GeneratedMemReplayFacts initialState rows)
+    (stateAt : List (MemoryBusEntry FGL) → ZiskFv.ZiskCircuit.MemTrace.SailState)
+    (h_seed : stateAt [] = initialState)
+    (coherence : ZiskFv.ZiskCircuit.MemTimeline.Spike.RowTraceCoherence stateAt [] rows)
+    {state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource}
+    {entry : MemoryBusEntry FGL}
+    {priorRows laterRows : List (MemoryBusEntry FGL)}
+    (h_split : rows = priorRows ++ entry :: laterRows)
+    (h_tie : stateAt priorRows = state) :
+    LoadMemoryTimelineCoherenceEvidence state entry := by
+  refine ⟨initialState, rows, facts, stateAt, priorRows, laterRows, h_split, h_seed, h_tie, ?_⟩
+  rw [h_split] at coherence
+  exact ZiskFv.ZiskCircuit.MemTimeline.Spike.rowTraceCoherence_of_append
+    stateAt [] priorRows (entry :: laterRows) coherence
+
+/-- The store analogue of `loadCoherence_of_shared`, additionally carrying the
+    narrow-store preserved-byte prefix fact into the RMW evidence. -/
+theorem storeCoherence_of_shared
+    {initialState : ZiskFv.ZiskCircuit.MemTrace.SailState}
+    {rows : List (MemoryBusEntry FGL)}
+    (facts : ZiskFv.AirsClean.Mem.GeneratedMemReplayFacts initialState rows)
+    (stateAt : List (MemoryBusEntry FGL) → ZiskFv.ZiskCircuit.MemTrace.SailState)
+    (h_seed : stateAt [] = initialState)
+    (coherence : ZiskFv.ZiskCircuit.MemTimeline.Spike.RowTraceCoherence stateAt [] rows)
+    {state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource}
+    {entry : MemoryBusEntry FGL} {firstPreserved : Nat}
+    {priorRows laterRows : List (MemoryBusEntry FGL)}
+    (h_split : rows = priorRows ++ entry :: laterRows)
+    (h_tie : stateAt priorRows = state)
+    (h_bytes : StoreRmwPreservedBytesAtPrefix
+      (ZiskFv.ZiskCircuit.MemTrace.replayMemoryAfterBusRows facts.initialMemory priorRows)
+      entry firstPreserved) :
+    StoreRmwMemoryCoherenceEvidence state entry firstPreserved := by
+  refine ⟨initialState, rows, facts, stateAt, priorRows, laterRows, h_split, h_seed, h_tie, ?_, h_bytes⟩
+  rw [h_split] at coherence
+  exact ZiskFv.ZiskCircuit.MemTimeline.Spike.rowTraceCoherence_of_append
+    stateAt [] priorRows (entry :: laterRows) coherence
+
+/-! ## The seed and its per-op derivation -/
+
+/-- Per-memory-op placement relative to a shared segment memory seed: for each
+    load / narrow store row, where its memory-bus entry sits in the shared row
+    sequence `rows`, that the op's Sail state `binding i` is the seed's cursor
+    state `stateAt priorRows` there, and (for narrow RMW stores) that the
+    preserved high bytes are already present in the replay memory at that prefix.
+    Non-memory ops and `sd` (a full-doubleword store) impose nothing. -/
+def MemoryOpPlacement
+    (ziskTrace : AcceptedZiskTrace numInstructions)
+    (binding : SailTrace ziskTrace.numInstructions)
+    (rows : List (MemoryBusEntry FGL))
+    (stateAt : List (MemoryBusEntry FGL) → ZiskFv.ZiskCircuit.MemTrace.SailState)
+    (initialMemory : Std.ExtHashMap Nat (BitVec 8))
+    (i : Fin ziskTrace.numInstructions) : ZiskStep ziskTrace i → Prop
+  | .ld _ | .lbu _ | .lhu _ | .lwu _ | .lb _ | .lh _ | .lw _ =>
+      ∃ priorRows laterRows,
+        rows = priorRows ++ (busLd ziskTrace i (Pilot.execRowOf ziskTrace i)).e1 :: laterRows
+          ∧ stateAt priorRows = binding i
+  | .sb _ =>
+      ∃ priorRows laterRows,
+        rows = priorRows ++ (busSt ziskTrace i (Pilot.execRowOf ziskTrace i)).e2 :: laterRows
+          ∧ stateAt priorRows = binding i
+          ∧ StoreRmwPreservedBytesAtPrefix
+              (ZiskFv.ZiskCircuit.MemTrace.replayMemoryAfterBusRows initialMemory priorRows)
+              (busSt ziskTrace i (Pilot.execRowOf ziskTrace i)).e2 1
+  | .sh _ =>
+      ∃ priorRows laterRows,
+        rows = priorRows ++ (busSt ziskTrace i (Pilot.execRowOf ziskTrace i)).e2 :: laterRows
+          ∧ stateAt priorRows = binding i
+          ∧ StoreRmwPreservedBytesAtPrefix
+              (ZiskFv.ZiskCircuit.MemTrace.replayMemoryAfterBusRows initialMemory priorRows)
+              (busSt ziskTrace i (Pilot.execRowOf ziskTrace i)).e2 2
+  | .sw _ =>
+      ∃ priorRows laterRows,
+        rows = priorRows ++ (busSt ziskTrace i (Pilot.execRowOf ziskTrace i)).e2 :: laterRows
+          ∧ stateAt priorRows = binding i
+          ∧ StoreRmwPreservedBytesAtPrefix
+              (ZiskFv.ZiskCircuit.MemTrace.replayMemoryAfterBusRows initialMemory priorRows)
+              (busSt ziskTrace i (Pilot.execRowOf ziskTrace i)).e2 4
+  | _ => True
+
+/-- **The single named boot / cross-segment memory seed premise of `root_soundness`.**
+
+    One shared assumption for the whole segment, replacing the ten former per-op
+    memory residuals.  It supplies:
+    * `initialState` — the segment-entry Sail state (its memory is the boot /
+      cross-segment seed carried in from the previous segment / boot);
+    * `rows` / `facts` — the consumed memory-bus row sequence and its replay facts
+      (seed memory agreement + prefix read-soundness);
+    * `stateAt` / `coherence` — a cursor-indexed Sail-state assignment whose
+      empty-prefix value is `initialState`, coherent (memory only) across the
+      *whole* row sequence;
+    * `placement` — for each memory op, where its bus entry sits in `rows` and
+      that its Sail state is the cursor state there (plus preserved bytes for
+      narrow stores).
+
+    `memEvidence_of_bootSeed` derives every op's `MemoryOpEvidenceFor` residual
+    from this one seed.  This is a named external-trust premise (the same class as
+    channel-balance), NOT an axiom and NOT a defect; driving it to zero is #115 /
+    #119. -/
+structure BootSegmentMemorySeed
+    (ziskTrace : AcceptedZiskTrace numInstructions)
+    (binding : SailTrace ziskTrace.numInstructions)
+    (ziskStep : ∀ i : Fin ziskTrace.numInstructions, ZiskStep ziskTrace i) where
+  initialState : ZiskFv.ZiskCircuit.MemTrace.SailState
+  rows : List (MemoryBusEntry FGL)
+  facts : ZiskFv.AirsClean.Mem.GeneratedMemReplayFacts initialState rows
+  stateAt : List (MemoryBusEntry FGL) → ZiskFv.ZiskCircuit.MemTrace.SailState
+  h_seed : stateAt [] = initialState
+  coherence : ZiskFv.ZiskCircuit.MemTimeline.Spike.RowTraceCoherence stateAt [] rows
+  placement : ∀ i : Fin ziskTrace.numInstructions,
+    MemoryOpPlacement ziskTrace binding rows stateAt facts.initialMemory i (ziskStep i)
+
+/-- Derive each memory op's residual (`MemoryOpEvidenceFor`) from the one shared
+    seed, restricting its whole-sequence coherence to the op's prefix.  Non-memory
+    ops and `sd` get the trivial residual. -/
+def memEvidence_of_bootSeed
+    {ziskTrace : AcceptedZiskTrace numInstructions}
+    {binding : SailTrace ziskTrace.numInstructions}
+    {ziskStep : ∀ i : Fin ziskTrace.numInstructions, ZiskStep ziskTrace i}
+    (seed : BootSegmentMemorySeed ziskTrace binding ziskStep)
+    (i : Fin ziskTrace.numInstructions) :
+    MemoryOpEvidenceFor ziskTrace binding i (ziskStep i) :=
+  match ziskStep i, seed.placement i with
+  | .ld _, ⟨_, _, h_split, h_tie⟩
+  | .lbu _, ⟨_, _, h_split, h_tie⟩
+  | .lhu _, ⟨_, _, h_split, h_tie⟩
+  | .lwu _, ⟨_, _, h_split, h_tie⟩
+  | .lb _, ⟨_, _, h_split, h_tie⟩
+  | .lh _, ⟨_, _, h_split, h_tie⟩
+  | .lw _, ⟨_, _, h_split, h_tie⟩ =>
+      loadCoherence_of_shared seed.facts seed.stateAt seed.h_seed seed.coherence h_split h_tie
+  | .sb _, ⟨_, _, h_split, h_tie, h_bytes⟩ =>
+      storeCoherence_of_shared seed.facts seed.stateAt seed.h_seed seed.coherence h_split h_tie h_bytes
+  | .sh _, ⟨_, _, h_split, h_tie, h_bytes⟩ =>
+      storeCoherence_of_shared seed.facts seed.stateAt seed.h_seed seed.coherence h_split h_tie h_bytes
+  | .sw _, ⟨_, _, h_split, h_tie, h_bytes⟩ =>
+      storeCoherence_of_shared seed.facts seed.stateAt seed.h_seed seed.coherence h_split h_tie h_bytes
+  | .sub _, _ | .and _, _ | .or _, _ | .xor _, _ | .slt _, _ | .sltu _, _
+  | .andi _, _ | .ori _, _ | .xori _, _ | .slti _, _ | .sltiu _, _
+  | .sll _, _ | .srl _, _ | .sra _, _ | .slli _, _ | .srli _, _ | .srai _, _
+  | .add _, _ | .addi _, _ | .subw _, _ | .addw _, _ | .addiw _, _
+  | .sllw _, _ | .srlw _, _ | .sraw _, _ | .slliw _, _ | .srliw _, _ | .sraiw _, _
+  | .mul _, _ | .mulh _, _ | .mulhsu _, _ | .mulw _, _ | .mulhu _, _
+  | .div _, _ | .rem _, _ | .divw _, _ | .remw _, _ | .divu _, _ | .divuw _, _
+  | .remu _, _ | .remuw _, _
+  | .beq _, _ | .bne _, _ | .blt _, _ | .bge _, _ | .bltu _, _ | .bgeu _, _
+  | .lui _, _ | .auipc _, _ | .jal _, _ | .jalr _, _ | .sd _, _ | .fence _, _ =>
+      trivial
+
+end ZiskFv.Compliance

--- a/ZiskFv/Compliance/TraceLevelExport/BootSegmentMemorySeedWitness.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/BootSegmentMemorySeedWitness.lean
@@ -1,0 +1,154 @@
+import ZiskFv.Compliance.TraceLevelExport.BootSegmentMemorySeed
+
+/-!
+# Non-vacuity witness for `BootSegmentMemorySeed` (issue #185)
+
+The load-only Spike witness (`ZiskFv/ZiskCircuit/MemTimeline/Spike.lean`) exhibits
+the shared-seed data (`GeneratedMemReplayFacts`, `RowTraceCoherence`) and the load
+residual over **empty** initial memory.  But a narrow store's
+`StoreRmwPreservedBytesAtPrefix` floor is **false** over empty memory — its
+preserved high bytes must already be present.  This module supplies the missing
+store half: the preserved-byte floor is satisfiable off a NON-empty seed memory
+(the bytes carried in from the previous segment / boot), and hence a concrete
+`StoreRmwMemoryCoherenceEvidence` is non-vacuously inhabited — with the store's
+Sail state genuinely differing from the initial state in `regs` and `cycleCount`,
+so this is not the frozen-state laundering floor.  Together with the Spike load
+witness this shows both per-op residuals of `memEvidence_of_bootSeed` are
+inhabitable from shared-seed-shaped data. -/
+
+namespace ZiskFv.Compliance
+
+open Interaction
+open ZiskFv.ZiskCircuit.MemTrace
+
+/-- **The store-side non-vacuity crux.** After a full eight-lane write of `entry`,
+    the replay memory contains exactly `entry`'s committed bytes, so *every*
+    preserved high byte is present — `StoreRmwPreservedBytesAtPrefix` holds for any
+    `firstPreserved`.  Over empty memory this is false, which is why the load-only
+    Spike witness does not cover the store side. -/
+theorem storeRmwPreservedBytes_nonvacuous
+    (entry : MemoryBusEntry FGL) (firstPreserved : Nat) :
+    StoreRmwPreservedBytesAtPrefix
+      (writeMemoryOfEntry ({} : Std.ExtHashMap Nat (BitVec 8)) entry) entry firstPreserved := by
+  have h := readEventReplayAgreement_of_writeMemoryOfEntry_same
+    (mem := ({} : Std.ExtHashMap Nat (BitVec 8)))
+    (writeEntry := entry) (readEntry := entry) rfl rfl rfl
+  simp only [ReadEventReplayAgreement, eventOfEntry_byteAt] at h
+  obtain ⟨h0, h1, h2, h3, h4, h5, h6, h7⟩ := h
+  intro i _hfp hi8
+  interval_cases i
+  · simpa using h0
+  · exact h1
+  · exact h2
+  · exact h3
+  · exact h4
+  · exact h5
+  · exact h6
+  · exact h7
+
+/-! ## A concrete `StoreRmwMemoryCoherenceEvidence` inhabitant
+
+The store is the first op; its preserved high bytes are supplied by the seed
+memory `writeMemoryOfEntry {} witnessStoreRow` (the boot / cross-segment carry-in).
+The cursor state after the store differs from the initial state in `regs` and
+`cycleCount`, so this is not the frozen-state floor. -/
+
+open ZiskFv.ZiskCircuit.MemTimeline.Spike (witnessStoreRow)
+
+/-- Seed memory carrying the store's committed bytes. -/
+noncomputable def witnessSeedMem : Std.ExtHashMap Nat (BitVec 8) :=
+  writeMemoryOfEntry ({} : Std.ExtHashMap Nat (BitVec 8)) witnessStoreRow
+
+/-- Segment-entry Sail state: memory already carries the store's preserved bytes. -/
+noncomputable def witnessStoreInitState
+    (regs0 : Std.ExtDHashMap Register RegisterType)
+    (cs0 : Sail.trivialChoiceSource.α) : SailState :=
+  { regs := regs0, choiceState := cs0, mem := witnessSeedMem, tags := (),
+    cycleCount := 0, sailOutput := #[] }
+
+/-- Cursor-indexed state: after the store, `regs` and `cycleCount` are mutated. -/
+noncomputable def witnessStoreStateAt
+    (regs0 regs1 : Std.ExtDHashMap Register RegisterType)
+    (cs0 : Sail.trivialChoiceSource.α) :
+    List (MemoryBusEntry FGL) → SailState
+  | [] => witnessStoreInitState regs0 cs0
+  | _ =>
+      { regs := regs1, choiceState := cs0,
+        mem := writeMemoryOfEntry witnessSeedMem witnessStoreRow,
+        tags := (), cycleCount := 99, sailOutput := #[] }
+
+/-- `prefixReadSound` for `[witnessStoreRow]` is vacuous: the only row is a write
+    (`multiplicity = 1 ≠ -1`), so there is no read to constrain. -/
+theorem witnessStore_prefixReadSound :
+    MemoryBusRowsPrefixReadSound witnessSeedMem [witnessStoreRow] := by
+  intro priorRows row laterRows h_split _h_as h_mult
+  rcases priorRows with _ | ⟨a, rest⟩
+  · simp only [List.nil_append, List.cons.injEq] at h_split
+    rw [← h_split.1] at h_mult
+    simp only [witnessStoreRow] at h_mult
+    exact absurd h_mult (by decide)
+  · simp only [List.cons_append, List.cons.injEq] at h_split
+    exact absurd h_split.2 (by simp)
+
+/-- Replay facts for the single-store witness segment. -/
+noncomputable def witnessStoreFacts
+    (regs0 : Std.ExtDHashMap Register RegisterType)
+    (cs0 : Sail.trivialChoiceSource.α) :
+    ZiskFv.AirsClean.Mem.GeneratedMemReplayFacts
+      (witnessStoreInitState regs0 cs0) [witnessStoreRow] :=
+  { initialMemory := witnessSeedMem
+    prefixReadSound := witnessStore_prefixReadSound
+    initialAgreement := fun _ => rfl }
+
+/-- Whole-sequence coherence over `[witnessStoreRow]`: the single write step is
+    discharged from the canonical write-entry transition. -/
+theorem witnessStore_rowTraceCoherence
+    (regs0 regs1 : Std.ExtDHashMap Register RegisterType)
+    (cs0 : Sail.trivialChoiceSource.α) :
+    ZiskFv.ZiskCircuit.MemTimeline.Spike.RowTraceCoherence
+      (witnessStoreStateAt regs0 regs1 cs0) [] [witnessStoreRow] := by
+  refine ⟨?_, trivial⟩
+  intro mem h_agree
+  exact ZiskFv.ZiskCircuit.MemTimeline.Spike.rowStep_store_entry
+    (witnessStoreStateAt regs0 regs1 cs0 [])
+    (witnessStoreStateAt regs0 regs1 cs0 ([] ++ [witnessStoreRow]))
+    witnessStoreRow (by simp [witnessStoreRow]) (by simp [witnessStoreRow])
+    rfl mem h_agree
+
+/-- **The store residual is non-vacuously inhabited.** A concrete
+    `StoreRmwMemoryCoherenceEvidence` for the store, with the preserved bytes
+    supplied by the (non-empty) seed memory — the store half the empty-memory
+    Spike witness cannot provide.  The load half is
+    `ZiskFv.ZiskCircuit.MemTimeline.Spike.witness_memoryTraceAgreement`; together
+    both `MemoryOpEvidenceFor` residuals are inhabitable from seed-shaped data. -/
+theorem witnessStore_evidence
+    (regs0 regs1 : Std.ExtDHashMap Register RegisterType)
+    (cs0 : Sail.trivialChoiceSource.α) (firstPreserved : Nat) :
+    StoreRmwMemoryCoherenceEvidence
+      (witnessStoreInitState regs0 cs0) witnessStoreRow firstPreserved :=
+  storeCoherence_of_shared (priorRows := []) (laterRows := [])
+    (witnessStoreFacts regs0 cs0)
+    (witnessStoreStateAt regs0 regs1 cs0)
+    rfl
+    (witnessStore_rowTraceCoherence regs0 regs1 cs0)
+    rfl
+    rfl
+    (by
+      simpa [witnessStoreFacts, witnessSeedMem, replayMemoryAfterBusRows] using
+        storeRmwPreservedBytes_nonvacuous witnessStoreRow firstPreserved)
+
+/-- **Non-degeneracy.** With `regs1 ≠ regs0`, the post-store cursor state's `regs`
+    and `cycleCount` both differ from the segment initial state's — the non-frozen
+    case the whole-state alignment cannot express. -/
+theorem witnessStore_nondegenerate
+    (regs0 regs1 : Std.ExtDHashMap Register RegisterType)
+    (cs0 : Sail.trivialChoiceSource.α) (h_regs : regs1 ≠ regs0) :
+    (witnessStoreStateAt regs0 regs1 cs0 [witnessStoreRow]).regs
+        ≠ (witnessStoreStateAt regs0 regs1 cs0 []).regs
+    ∧ (witnessStoreStateAt regs0 regs1 cs0 [witnessStoreRow]).cycleCount
+        ≠ (witnessStoreStateAt regs0 regs1 cs0 []).cycleCount := by
+  refine ⟨?_, ?_⟩
+  · simpa [witnessStoreStateAt, witnessStoreInitState] using h_regs
+  · simp [witnessStoreStateAt, witnessStoreInitState]
+
+end ZiskFv.Compliance

--- a/ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean
@@ -254,6 +254,31 @@ def InputsAgree (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : Sai
   | .lw c => Inputs_lw ziskTrace sailTrace i c
   | .fence c => Inputs_fence ziskTrace sailTrace i c
 
+/-- The per-op memory-coherence residual each memory `stepStrong_<op>` core
+    consumes, dispatched by op-kind: the load memory-timeline evidence for the
+    seven loads, the sub-doubleword RMW evidence for `sb`/`sh`/`sw`, and `True`
+    for every non-memory op (and `sd`, a full-doubleword store that overwrites the
+    whole lane).  A single seed-derived value of this type is threaded through
+    `stepSound_of_evidence` in place of the ten former per-op `Inputs_<op>` memory
+    fields — see `BootSegmentMemorySeed` / `memEvidence_of_bootSeed`. -/
+def MemoryOpEvidenceFor
+    (ziskTrace : AcceptedZiskTrace numInstructions)
+    (sailTrace : SailTrace ziskTrace.numInstructions)
+    (i : Fin ziskTrace.numInstructions) : ZiskStep ziskTrace i → Prop
+  | .ld _ | .lbu _ | .lhu _ | .lwu _ | .lb _ | .lh _ | .lw _ =>
+      LoadMemoryTimelineCoherenceEvidence (sailTrace i)
+        (busLd ziskTrace i (Pilot.execRowOf ziskTrace i)).e1
+  | .sb _ =>
+      StoreRmwMemoryCoherenceEvidence (sailTrace i)
+        (busSt ziskTrace i (Pilot.execRowOf ziskTrace i)).e2 1
+  | .sh _ =>
+      StoreRmwMemoryCoherenceEvidence (sailTrace i)
+        (busSt ziskTrace i (Pilot.execRowOf ziskTrace i)).e2 2
+  | .sw _ =>
+      StoreRmwMemoryCoherenceEvidence (sailTrace i)
+        (busSt ziskTrace i (Pilot.execRowOf ziskTrace i)).e2 4
+  | _ => True
+
 
 
 /-- Per-row known-defect exclusion obligation, stated over the accepted ZisK row

--- a/ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean
@@ -1040,6 +1040,7 @@ def StepSound
 theorem stepSound_of_evidence (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions)
     (i : Fin ziskTrace.numInstructions) (zs : ZiskStep ziskTrace i)
     (rd : RowDecode ziskTrace i zs) (ia : InputsAgree ziskTrace sailTrace i zs)
+    (memEv : MemoryOpEvidenceFor ziskTrace sailTrace i zs)
     (hAvoidKnownBugs : RowOutsideDefectRegion ziskTrace i zs) :
     StepSound ziskTrace sailTrace i zs := by
   cases zs with
@@ -1201,17 +1202,17 @@ theorem stepSound_of_evidence (ziskTrace : AcceptedZiskTrace numInstructions) (s
   | jalr c =>
       exact stepStrong_jalr ziskTrace sailTrace i (toRowData_jalr c rd ia)
         (jalrRangeDomain_of_main ia.h_pc_bridge hAvoidKnownBugs)
-  | sb c => exact stepStrong_sb ziskTrace sailTrace i (toRowData_sb c rd ia) hAvoidKnownBugs
-  | sh c => exact stepStrong_sh ziskTrace sailTrace i (toRowData_sh c rd ia) hAvoidKnownBugs
-  | sw c => exact stepStrong_sw ziskTrace sailTrace i (toRowData_sw c rd ia) hAvoidKnownBugs
+  | sb c => exact stepStrong_sb ziskTrace sailTrace i (toRowData_sb c rd ia) memEv hAvoidKnownBugs
+  | sh c => exact stepStrong_sh ziskTrace sailTrace i (toRowData_sh c rd ia) memEv hAvoidKnownBugs
+  | sw c => exact stepStrong_sw ziskTrace sailTrace i (toRowData_sw c rd ia) memEv hAvoidKnownBugs
   | sd c => exact stepStrong_sd ziskTrace sailTrace i (toRowData_sd c rd ia) hAvoidKnownBugs
-  | ld c => exact stepStrong_ld ziskTrace sailTrace i (toRowData_ld c rd ia) hAvoidKnownBugs
-  | lbu c => exact stepStrong_lbu ziskTrace sailTrace i (toRowData_lbu c rd ia) hAvoidKnownBugs
-  | lhu c => exact stepStrong_lhu ziskTrace sailTrace i (toRowData_lhu c rd ia) hAvoidKnownBugs
-  | lwu c => exact stepStrong_lwu ziskTrace sailTrace i (toRowData_lwu c rd ia) hAvoidKnownBugs
-  | lb c => exact stepStrong_lb ziskTrace sailTrace i (toRowData_lb c rd ia) hAvoidKnownBugs
-  | lh c => exact stepStrong_lh ziskTrace sailTrace i (toRowData_lh c rd ia) hAvoidKnownBugs
-  | lw c => exact stepStrong_lw ziskTrace sailTrace i (toRowData_lw c rd ia) hAvoidKnownBugs
+  | ld c => exact stepStrong_ld ziskTrace sailTrace i (toRowData_ld c rd ia) memEv hAvoidKnownBugs
+  | lbu c => exact stepStrong_lbu ziskTrace sailTrace i (toRowData_lbu c rd ia) memEv hAvoidKnownBugs
+  | lhu c => exact stepStrong_lhu ziskTrace sailTrace i (toRowData_lhu c rd ia) memEv hAvoidKnownBugs
+  | lwu c => exact stepStrong_lwu ziskTrace sailTrace i (toRowData_lwu c rd ia) memEv hAvoidKnownBugs
+  | lb c => exact stepStrong_lb ziskTrace sailTrace i (toRowData_lb c rd ia) memEv hAvoidKnownBugs
+  | lh c => exact stepStrong_lh ziskTrace sailTrace i (toRowData_lh c rd ia) memEv hAvoidKnownBugs
+  | lw c => exact stepStrong_lw ziskTrace sailTrace i (toRowData_lw c rd ia) memEv hAvoidKnownBugs
   | fence c =>
       exact stepStrong_fence ziskTrace sailTrace i (toRowData_fence c rd ia)
         (sequentialPcDomain_of_main ia.h_pc_bridge hAvoidKnownBugs.1)

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
@@ -2095,9 +2095,6 @@ structure Inputs_sb (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.sb_input.PC.toNat
-  h_store_rmw :
-    StoreRmwMemoryCoherenceEvidence (binding i)
-      (busSt trace i (Pilot.execRowOf trace i)).e2 1
 
 /-- Per-op residual bundle for the `sb` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sb` bundles them. -/
@@ -2173,9 +2170,6 @@ structure Inputs_sh (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.sh_input.PC.toNat
-  h_store_rmw :
-    StoreRmwMemoryCoherenceEvidence (binding i)
-      (busSt trace i (Pilot.execRowOf trace i)).e2 2
 
 /-- Per-op residual bundle for the `sh` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sh` bundles them. -/
@@ -2251,9 +2245,6 @@ structure Inputs_sw (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.sw_input.PC.toNat
-  h_store_rmw :
-    StoreRmwMemoryCoherenceEvidence (binding i)
-      (busSt trace i (Pilot.execRowOf trace i)).e2 4
 
 /-- Per-op residual bundle for the `sw` archetype: the 3-way `Claim`/`Decode`/`Inputs`
     split is the single declaration site for every field; `RowData_sw` bundles them. -/
@@ -2400,9 +2391,6 @@ structure Inputs_ld (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.ld_input.PC.toNat
-  h_memory_timeline :
-    LoadMemoryTimelineCoherenceEvidence (binding i)
-      (busLd trace i (Pilot.execRowOf trace i)).e1
   h_msg :
     loadMemMsg (ZiskFv.AirsClean.Mem.rowAt mem r_mem) =
       loadMainMsg (mainRowWithRomLd trace i)
@@ -2485,9 +2473,6 @@ structure Inputs_lbu (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.lbu_input.PC.toNat
-  h_memory_timeline :
-    LoadMemoryTimelineCoherenceEvidence (binding i)
-      (busLd trace i (Pilot.execRowOf trace i)).e1
   h_msg :
     loadMemMsg (ZiskFv.AirsClean.Mem.rowAt mem r_mem) =
       loadMainMsg (mainRowWithRomLd trace i)
@@ -2570,9 +2555,6 @@ structure Inputs_lhu (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.lhu_input.PC.toNat
-  h_memory_timeline :
-    LoadMemoryTimelineCoherenceEvidence (binding i)
-      (busLd trace i (Pilot.execRowOf trace i)).e1
   h_msg :
     loadMemMsg (ZiskFv.AirsClean.Mem.rowAt mem r_mem) =
       loadMainMsg (mainRowWithRomLd trace i)
@@ -2655,9 +2637,6 @@ structure Inputs_lwu (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.lwu_input.PC.toNat
-  h_memory_timeline :
-    LoadMemoryTimelineCoherenceEvidence (binding i)
-      (busLd trace i (Pilot.execRowOf trace i)).e1
   h_msg :
     loadMemMsg (ZiskFv.AirsClean.Mem.rowAt mem r_mem) =
       loadMainMsg (mainRowWithRomLd trace i)
@@ -2748,9 +2727,6 @@ structure Inputs_lb (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.lb_input.PC.toNat
-  h_memory_timeline :
-    LoadMemoryTimelineCoherenceEvidence (binding i)
-      (busLd trace i (Pilot.execRowOf trace i)).e1
   h_msg :
     loadMemMsg (ZiskFv.AirsClean.Mem.rowAt mem r_mem) =
       loadMainMsg (mainRowWithRomLd trace i)
@@ -2841,9 +2817,6 @@ structure Inputs_lh (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.lh_input.PC.toNat
-  h_memory_timeline :
-    LoadMemoryTimelineCoherenceEvidence (binding i)
-      (busLd trace i (Pilot.execRowOf trace i)).e1
   h_msg :
     loadMemMsg (ZiskFv.AirsClean.Mem.rowAt mem r_mem) =
       loadMainMsg (mainRowWithRomLd trace i)
@@ -2934,9 +2907,6 @@ structure Inputs_lw (trace : AcceptedZiskTrace numInstructions) (binding : SailT
   h_pc_bridge :
     ((mainOfTable trace.program trace.mainTable).pc i.val).val
       = c.lw_input.PC.toNat
-  h_memory_timeline :
-    LoadMemoryTimelineCoherenceEvidence (binding i)
-      (busLd trace i (Pilot.execRowOf trace i)).e1
   h_msg :
     loadMemMsg (ZiskFv.AirsClean.Mem.rowAt mem r_mem) =
       loadMainMsg (mainRowWithRomLd trace i)

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
@@ -1555,6 +1555,8 @@ private def emptyMainEnv : Environment FGL :=
 theorem stepStrong_sb
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sb trace binding i)
+    (h_store_rmw_ev : StoreRmwMemoryCoherenceEvidence (binding i)
+      (busSt trace i (Pilot.execRowOf trace i)).e2 1)
     (h_domain : SequentialPcDomain d.toClaim.sb_input.PC) :
     execute_instruction (instruction.STORE
         (d.toClaim.sb_input.imm, regidx.Regidx d.toClaim.sb_input.r2, regidx.Regidx d.toClaim.sb_input.r1, 1))
@@ -1626,7 +1628,7 @@ theorem stepStrong_sb
         simpa only [eval_mainConstVar] using
           store_addr2_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset_imm
             h_a0_value h_a1_value h_addr_bound)
-      h_b0' h_b1' d.toInputs.h_store_rmw
+      h_b0' h_b1' h_store_rmw_ev
   have h_bridge : env.aeneasBridgeTrust := ⟨d.toDecode.h_main_ind_width, h_b0', h_b1'⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
@@ -1636,6 +1638,8 @@ theorem stepStrong_sb
 theorem stepStrong_sh
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sh trace binding i)
+    (h_store_rmw_ev : StoreRmwMemoryCoherenceEvidence (binding i)
+      (busSt trace i (Pilot.execRowOf trace i)).e2 2)
     (h_domain : SequentialPcDomain d.toClaim.sh_input.PC) :
     execute_instruction (instruction.STORE
         (d.toClaim.sh_input.imm, regidx.Regidx d.toClaim.sh_input.r2, regidx.Regidx d.toClaim.sh_input.r1, 2))
@@ -1707,7 +1711,7 @@ theorem stepStrong_sh
         simpa only [eval_mainConstVar] using
           store_addr2_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset_imm
             h_a0_value h_a1_value h_addr_bound)
-      h_b0' h_b1' d.toInputs.h_store_rmw
+      h_b0' h_b1' h_store_rmw_ev
   have h_bridge : env.aeneasBridgeTrust := ⟨d.toDecode.h_main_ind_width, h_b0', h_b1'⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
@@ -1717,6 +1721,8 @@ theorem stepStrong_sh
 theorem stepStrong_sw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_sw trace binding i)
+    (h_store_rmw_ev : StoreRmwMemoryCoherenceEvidence (binding i)
+      (busSt trace i (Pilot.execRowOf trace i)).e2 4)
     (h_domain : SequentialPcDomain d.toClaim.sw_input.PC) :
     execute_instruction (instruction.STORE
         (d.toClaim.sw_input.imm, regidx.Regidx d.toClaim.sw_input.r2, regidx.Regidx d.toClaim.sw_input.r1, 4))
@@ -1788,7 +1794,7 @@ theorem stepStrong_sw
         simpa only [eval_mainConstVar] using
           store_addr2_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset_imm
             h_a0_value h_a1_value h_addr_bound)
-      h_b0' h_b1' d.toInputs.h_store_rmw
+      h_b0' h_b1' h_store_rmw_ev
   have h_bridge : env.aeneasBridgeTrust := ⟨d.toDecode.h_main_ind_width, h_b0', h_b1'⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial
   have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongLoadMext.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongLoadMext.lean
@@ -175,6 +175,8 @@ records are real `Valid_Mem`/`Valid_BinaryExtension` rows. -/
 theorem stepStrong_ld
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_ld trace binding i)
+    (h_mem_ev : LoadMemoryTimelineCoherenceEvidence (binding i)
+      (busLd trace i (Pilot.execRowOf trace i)).e1)
     (h_domain : SequentialPcDomain d.toClaim.ld_input.PC) :
     execute_instruction (instruction.LOAD
         (d.toClaim.ld_input.imm, regidx.Regidx d.toClaim.ld_input.r1, regidx.Regidx d.toClaim.ld_input.rd, false, 8))
@@ -259,7 +261,7 @@ theorem stepStrong_ld
       (by simpa only [eval_mainConstVar] using load_addr2_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
   have h_bridge : env.aeneasBridgeTrust := d.toDecode.h_width
-  have h_mem : env.memoryTimelineConstructionEvidence := d.toInputs.h_memory_timeline
+  have h_mem : env.memoryTimelineConstructionEvidence := h_mem_ev
   have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.1
 
@@ -267,6 +269,8 @@ theorem stepStrong_ld
 theorem stepStrong_lbu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lbu trace binding i)
+    (h_mem_ev : LoadMemoryTimelineCoherenceEvidence (binding i)
+      (busLd trace i (Pilot.execRowOf trace i)).e1)
     (h_domain : SequentialPcDomain d.toClaim.lbu_input.PC) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lbu_input.imm, regidx.Regidx d.toClaim.lbu_input.r1, regidx.Regidx d.toClaim.lbu_input.rd, true, 1))
@@ -350,7 +354,7 @@ theorem stepStrong_lbu
       (by simpa only [eval_mainConstVar] using load_addr2_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
   have h_bridge : env.aeneasBridgeTrust := d.toDecode.h_width
-  have h_mem : env.memoryTimelineConstructionEvidence := d.toInputs.h_memory_timeline
+  have h_mem : env.memoryTimelineConstructionEvidence := h_mem_ev
   have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
@@ -358,6 +362,8 @@ theorem stepStrong_lbu
 theorem stepStrong_lhu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lhu trace binding i)
+    (h_mem_ev : LoadMemoryTimelineCoherenceEvidence (binding i)
+      (busLd trace i (Pilot.execRowOf trace i)).e1)
     (h_domain : SequentialPcDomain d.toClaim.lhu_input.PC) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lhu_input.imm, regidx.Regidx d.toClaim.lhu_input.r1, regidx.Regidx d.toClaim.lhu_input.rd, true, 2))
@@ -441,7 +447,7 @@ theorem stepStrong_lhu
       (by simpa only [eval_mainConstVar] using load_addr2_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
   have h_bridge : env.aeneasBridgeTrust := d.toDecode.h_width
-  have h_mem : env.memoryTimelineConstructionEvidence := d.toInputs.h_memory_timeline
+  have h_mem : env.memoryTimelineConstructionEvidence := h_mem_ev
   have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
@@ -449,6 +455,8 @@ theorem stepStrong_lhu
 theorem stepStrong_lwu
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lwu trace binding i)
+    (h_mem_ev : LoadMemoryTimelineCoherenceEvidence (binding i)
+      (busLd trace i (Pilot.execRowOf trace i)).e1)
     (h_domain : SequentialPcDomain d.toClaim.lwu_input.PC) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lwu_input.imm, regidx.Regidx d.toClaim.lwu_input.r1, regidx.Regidx d.toClaim.lwu_input.rd, true, 4))
@@ -533,7 +541,7 @@ theorem stepStrong_lwu
       (by simpa only [eval_mainConstVar] using load_addr2_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
   have h_bridge : env.aeneasBridgeTrust := d.toDecode.h_width
-  have h_mem : env.memoryTimelineConstructionEvidence := d.toInputs.h_memory_timeline
+  have h_mem : env.memoryTimelineConstructionEvidence := h_mem_ev
   have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
@@ -541,6 +549,8 @@ theorem stepStrong_lwu
 theorem stepStrong_lb
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lb trace binding i)
+    (h_mem_ev : LoadMemoryTimelineCoherenceEvidence (binding i)
+      (busLd trace i (Pilot.execRowOf trace i)).e1)
     (h_domain : SequentialPcDomain d.toClaim.lb_input.PC) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lb_input.imm, regidx.Regidx d.toClaim.lb_input.r1, regidx.Regidx d.toClaim.lb_input.rd, false, 1))
@@ -625,7 +635,7 @@ theorem stepStrong_lb
       (by simpa only [eval_mainConstVar] using load_addr2_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
   have h_bridge : env.aeneasBridgeTrust := d.toDecode.h_width
-  have h_mem : env.memoryTimelineConstructionEvidence := d.toInputs.h_memory_timeline
+  have h_mem : env.memoryTimelineConstructionEvidence := h_mem_ev
   have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.1
 
@@ -633,6 +643,8 @@ theorem stepStrong_lb
 theorem stepStrong_lh
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lh trace binding i)
+    (h_mem_ev : LoadMemoryTimelineCoherenceEvidence (binding i)
+      (busLd trace i (Pilot.execRowOf trace i)).e1)
     (h_domain : SequentialPcDomain d.toClaim.lh_input.PC) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lh_input.imm, regidx.Regidx d.toClaim.lh_input.r1, regidx.Regidx d.toClaim.lh_input.rd, false, 2))
@@ -717,7 +729,7 @@ theorem stepStrong_lh
       (by simpa only [eval_mainConstVar] using load_addr2_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
   have h_bridge : env.aeneasBridgeTrust := d.toDecode.h_width
-  have h_mem : env.memoryTimelineConstructionEvidence := d.toInputs.h_memory_timeline
+  have h_mem : env.memoryTimelineConstructionEvidence := h_mem_ev
   have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.1
 
@@ -725,6 +737,8 @@ theorem stepStrong_lh
 theorem stepStrong_lw
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (d : RowData_lw trace binding i)
+    (h_mem_ev : LoadMemoryTimelineCoherenceEvidence (binding i)
+      (busLd trace i (Pilot.execRowOf trace i)).e1)
     (h_domain : SequentialPcDomain d.toClaim.lw_input.PC) :
     execute_instruction (instruction.LOAD
         (d.toClaim.lw_input.imm, regidx.Regidx d.toClaim.lw_input.r1, regidx.Regidx d.toClaim.lw_input.rd, false, 4))
@@ -810,7 +824,7 @@ theorem stepStrong_lw
       (by simpa only [eval_mainConstVar] using load_addr2_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset)
       d.toInputs.h_mem_sel d.toInputs.h_mem_wr
   have h_bridge : env.aeneasBridgeTrust := d.toDecode.h_width
-  have h_mem : env.memoryTimelineConstructionEvidence := d.toInputs.h_memory_timeline
+  have h_mem : env.memoryTimelineConstructionEvidence := h_mem_ev
   have h_known : Defects.NoKnownDefect env := noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.1
 

--- a/ZiskFv/Soundness.lean
+++ b/ZiskFv/Soundness.lean
@@ -34,6 +34,20 @@ namespace ZiskFv.Compliance
     fact that ZisK's inputs equal the Sail model's register / PC / memory state.
     `hAvoidKnownBugs` excludes the enumerated forge defects.
 
+    `bootSeed` is the single named **cross-row memory seed** premise: the segment's
+    initial memory state at segment entry, together with the one consistent
+    per-row memory-evolution chain (`RowTraceCoherence` over the whole consumed
+    memory-bus row sequence).  Every load's and store's memory-coherence fact is
+    *derived* from this one seed (`memEvidence_of_bootSeed`), rather than each of
+    the ten memory ops carrying its own copy.  It is a named external-trust premise
+    (the same class as channel-balance), documented in
+    `trust/trusted-base.md` — it is genuinely irreducible at the single-segment
+    level (a segment does not contain its own starting state; it is carried in from
+    the previous segment / boot), and driving it to zero is #115 / #119.  It is a
+    *memory* seed: the coherence chain constrains only memory; PC / registers are
+    pinned only incidentally through the initial-state snapshot (per-step next-PC is
+    discharged separately by the `AcceptedZiskTrace` PC-handshake certificate).
+
     Every row then satisfies the canonical channel-balance conclusion
     (`= state_effect_via_channels …`). The per-row `OpEnvelope` is constructed
     from the trace inside each `stepStrong_<op>` — nothing is caller-supplied

--- a/ZiskFv/Soundness.lean
+++ b/ZiskFv/Soundness.lean
@@ -45,11 +45,13 @@ theorem root_soundness
     (ziskStep : ∀ i : Fin numInstructions, ZiskStep ziskTrace i)
     (programDecodes : ∀ i : Fin numInstructions, ProgramDecode ziskTrace i (ziskStep i))
     (inputsAgree : ∀ i : Fin numInstructions, InputsAgree ziskTrace sailTrace i (ziskStep i))
+    (bootSeed : BootSegmentMemorySeed ziskTrace sailTrace ziskStep)
     (hAvoidKnownBugs : ∀ i : Fin numInstructions,
       RowOutsideDefectRegion ziskTrace i (ziskStep i)) :
     ∀ i : Fin numInstructions, StepSound ziskTrace sailTrace i (ziskStep i) :=
   fun i =>
     stepSound_of_evidence ziskTrace sailTrace i (ziskStep i)
-      (rowDecode_of_programDecode ziskTrace i (programDecodes i)) (inputsAgree i) (hAvoidKnownBugs i)
+      (rowDecode_of_programDecode ziskTrace i (programDecodes i)) (inputsAgree i)
+      (memEvidence_of_bootSeed bootSeed i) (hAvoidKnownBugs i)
 
 end ZiskFv.Compliance

--- a/trust/generated/baseline-strong-export-binders.txt
+++ b/trust/generated/baseline-strong-export-binders.txt
@@ -4,5 +4,6 @@
 3 :: ziskStep :: (i : Fin numInstructions) → ZiskFv.Compliance.ZiskStep ziskTrace i
 4 :: programDecodes :: (i : Fin numInstructions) → ZiskFv.Compliance.ProgramDecode ziskTrace i (ziskStep i)
 5 :: inputsAgree :: (i : Fin numInstructions) → ZiskFv.Compliance.InputsAgree ziskTrace sailTrace i (ziskStep i)
-6 :: hAvoidKnownBugs :: ∀ (i : Fin numInstructions), ZiskFv.Compliance.RowOutsideDefectRegion ziskTrace i (ziskStep i)
-7 :: i :: Fin numInstructions
+6 :: bootSeed :: ZiskFv.Compliance.BootSegmentMemorySeed ziskTrace sailTrace ziskStep
+7 :: hAvoidKnownBugs :: ∀ (i : Fin numInstructions), ZiskFv.Compliance.RowOutsideDefectRegion ziskTrace i (ziskStep i)
+8 :: i :: Fin numInstructions

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -40,7 +40,7 @@ Lean axiom ledger:
 | Class                         | Declarations | In global closure | Removability                                                                                             |
 | ---                           | ---:         | ---:              | ---                                                                                                      |
 | Aeneas row-lowering condition | 0            | 0                 | Discharge `env.aeneasBridgeTrust` by importing generated Aeneas Lean into main Lake.                      |
-| Sail memory timeline          | 0            | 0                 | Load arm reduced to the memory-only `RowTraceCoherence` trace-coherence floor (#76 Fold-B; see below). Discharge by the #100 whole-execution memory replay/timeline induction. |
+| Sail memory timeline          | 0            | 0                 | Reduced to the memory-only `RowTraceCoherence` trace-coherence floor (#76 Fold-B; see below), and on `root_soundness` unified into one named `BootSegmentMemorySeed` premise (#185; per-op residuals derived from it). Discharge by the #115/#119 whole-execution memory replay/timeline induction. |
 | Clean completeness            | 0            | 0                 | Retired from source trust; false/circular fields are visible non-claims.                                  |
 
 
@@ -320,6 +320,56 @@ only inside dispatchers, as the load residual is). Reducing them requires an
 store cores, which touches the caller-burden / hypothesis-count baselines for
 the store opcodes. They are therefore **deferred** to a follow-up; only the load
 residual is reduced here.
+
+### One named seed premise (`BootSegmentMemorySeed`) — #185 legibility MVP
+
+The headline theorem `ZiskFv.Compliance.root_soundness` no longer carries the
+memory-coherence residual as **ten scattered per-op fields**. Previously each of
+the ten memory ops (seven loads carrying
+`LoadMemoryTimelineCoherenceEvidence`, and `sb`/`sh`/`sw` carrying
+`StoreRmwMemoryCoherenceEvidence`, after #119) was an `Inputs_<op>` field, each an
+independent existential re-positing its *own* `initialState` / `rows` / `stateAt`
+/ `RowTraceCoherence` chain — nothing forced the ten copies to describe the same
+execution.
+
+* **After (live):** `root_soundness` takes **one** binder
+  `bootSeed : BootSegmentMemorySeed ziskTrace sailTrace ziskStep`
+  (`ZiskFv/Compliance/TraceLevelExport/BootSegmentMemorySeed.lean`). It bundles a
+  single `initialState` / `rows` / `GeneratedMemReplayFacts` / cursor-indexed
+  `stateAt`, the whole-sequence chain `RowTraceCoherence stateAt [] rows`, and a
+  per-memory-op `placement` (where each op's bus entry sits in `rows`, that its
+  Sail state is the cursor state there, and — for narrow stores — the preserved
+  high bytes). `memEvidence_of_bootSeed` **derives** every op's per-op residual
+  from this one seed, restricting the whole-sequence coherence to the op's prefix
+  via `rowTraceCoherence_of_append`. The ten `Inputs_<op>` memory fields are
+  **removed**; the dispatcher threads the seed-derived `MemoryOpEvidenceFor` into
+  each `stepStrong_<op>`.
+
+**Trust class.** Identical to the `RowTraceCoherence` trace-coherence floor
+above — a named external-trust premise (the class of channel-balance), **not** an
+axiom and **not** a defect. `root_soundness`'s `ZiskFv.*` axiom closure is
+unchanged (empty — see `baseline-strong-export-closure.txt`); only its binder
+list gains `bootSeed` (`baseline-strong-export-binders.txt`). The seed is
+genuinely irreducible at the single-segment level (a segment does not contain its
+own initial state — it is carried in from the previous segment / boot); driving
+it to zero by replaying the trace's writes is the follow-on **#115** (loads) /
+**#119** (store byte facts, already reduced to the coherence shape).
+
+**Memory, not memory+PC.** The coherence chain constrains only `.mem`; the seed's
+`initialState` snapshot pins PC / registers only incidentally, and per-step
+next-PC is discharged separately (the `AcceptedZiskTrace` PC-handshake
+certificate, #100/#163). Naming it a *memory* seed keeps the premise from
+promising more than the proof delivers.
+
+**Non-vacuity (both halves).** The premise is inhabitable non-degenerately. The
+load half is `ZiskFv.ZiskCircuit.MemTimeline.Spike.witness_memoryTraceAgreement`
+(over empty seed memory). The store half — which the empty-memory Spike witness
+cannot supply, since a narrow store's `StoreRmwPreservedBytesAtPrefix` floor is
+false over empty memory — is `witnessStore_evidence`: a concrete
+`StoreRmwMemoryCoherenceEvidence` whose preserved bytes come from a **non-empty**
+seed memory, with the post-store cursor state differing from the initial state in
+`regs` **and** `cycleCount` (`witnessStore_nondegenerate`), so it is not the
+frozen-state floor. Both depend on kernel axioms only.
 
 ## Platform Profile
 


### PR DESCRIPTION
Closes #185.

## What

Replaces the **ten scattered per-op memory-coherence residuals** on `root_soundness`
with **one named premise**, `BootSegmentMemorySeed` — the MVP legibility deliverable of #185.

Before, each of the 10 memory ops carried its own independent `∃`-packed copy of the
"how memory evolved" story as an `Inputs_<op>` field (7 loads:
`LoadMemoryTimelineCoherenceEvidence`; `sb`/`sh`/`sw`: `StoreRmwMemoryCoherenceEvidence`,
after #119) — nothing forced the ten copies to describe the same execution. Now
`root_soundness` takes **one** binder `bootSeed : BootSegmentMemorySeed ziskTrace
sailTrace ziskStep`, and each per-op residual is *derived* from it.

## How

- **`BootSegmentMemorySeed`** (`TraceLevelExport/BootSegmentMemorySeed.lean`) bundles a
  single `initialState` / `rows` / `GeneratedMemReplayFacts` / cursor-indexed `stateAt`,
  the whole-sequence `RowTraceCoherence stateAt [] rows`, and a per-memory-op `placement`
  (where each op's bus entry sits, that its Sail state is the cursor state there, and — for
  narrow stores — the preserved high bytes).
- **`memEvidence_of_bootSeed`** derives each op's `MemoryOpEvidenceFor` residual from the
  one seed, restricting the whole-sequence coherence to the op's prefix via
  `rowTraceCoherence_of_append`.
- **Threading:** `stepSound_of_evidence` gains a `memEv : MemoryOpEvidenceFor` param passed
  to the 10 memory `stepStrong_<op>` (which now take the per-op residual explicitly);
  the 10 `Inputs_<op>` memory fields are removed; `root_soundness` supplies
  `memEvidence_of_bootSeed bootSeed i`.

## Naming: *memory* seed, not "memory+PC"

Per discussion on the issue, the only cross-row trust this premise adds is about memory —
`RowTraceCoherence` constrains only `.mem`. The seed carries a full starting-state snapshot
(so initial PC/registers are pinned incidentally) but does no PC-tracking; per-step next-PC
is already discharged (#100/#163). The issue title was renamed to drop "+PC".

## Anti-laundering / non-vacuity

Genuine trust reduction: 10 independent `∃`-packs → 1 shared, consistent seed. The premise
is inhabitable non-degenerately:
- **Load half:** `Spike.witness_memoryTraceAgreement` (existing).
- **Store half (the trap):** a narrow store's `StoreRmwPreservedBytesAtPrefix` floor is
  *false* over empty memory, which the load-only Spike witness never exercises. This PR adds
  `storeRmwPreservedBytes_nonvacuous` + `witnessStore_evidence`: a concrete
  `StoreRmwMemoryCoherenceEvidence` whose preserved bytes come from a **non-empty** seed
  memory, with the post-store cursor state differing from the initial state in `regs` **and**
  `cycleCount` (`witnessStore_nondegenerate`) — not the frozen-state floor.

## Trust

- **0 new `ZiskFv.*` project axioms.** `root_soundness`'s axiom closure is unchanged
  (Sail-translation + kernel axioms only; `baseline-strong-export-closure.txt` stays empty).
- Only `baseline-strong-export-binders.txt` changes (adds the `bootSeed` binder);
  `baseline-axioms.txt` / `baseline-equiv-axiom-deps.txt` / `baseline-global-theorem-binders.txt`
  byte-identical.
- Documented in `root_soundness`'s docstring + `trust/trusted-base.md`.

## Verification

- `lake build` green (full); V1 syntactic gate 16/16; V2 semantic gate 14/14; `nix run .#test` green.

## Coordination note

PR #223 (open) adds a concrete `root_soundness` instantiation. When both land, whichever
merges second must supply a `bootSeed` to that witness (trivially inhabitable — e.g. empty
`rows`, whose `RowTraceCoherence`/placement are `True`). No conflict beyond that one-line add.

The seed is legitimately *assumed* for now (a segment does not contain its own starting
state); driving it to zero by replaying the trace's writes is the follow-on #115 / #119.
Blocks #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
