### PR TITLE
Model Main register-prev MemBus pushes

### DIFF
--- a/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean
@@ -151,6 +151,129 @@ theorem mem_primary_read_replay_entry_match_of_main_b_match_and_msg_eq
   simpa [memPrimaryReadReplayEntryOfRow,
     ZiskFv.AirsClean.Mem.eval_memBusMessageExpr] using h_provider
 
+/-- A unified-Main provider-row interaction, paired with the payload match
+    induced by Clean message equality. This is the match-carrying counterpart
+    of `MainMemBusRowInteractionEval`. -/
+@[reducible]
+def MainMemBusRowInteractionMatchEval
+    {length : ℕ} (program : Program length)
+    (providerTable : Table FGL) (providerRow : Array FGL)
+    (providerInteraction : Interaction FGL)
+    (mainMsg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL))
+    (mainEnv : Environment FGL) (multiplicity as : FGL) : Prop :=
+  (providerInteraction =
+      ((MemBusChannel.emitted
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          length program).rowInputVar.rom.a_src_reg
+        (ZiskFv.AirsClean.Main.aRegPreMessageExpr
+          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar)).toRaw).eval
+        (providerTable.environment providerRow)
+    ∧ ZiskFv.Airs.MemoryBus.matches_memory_entry
+      (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+        (eval mainEnv mainMsg) multiplicity as)
+      (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+        (eval (providerTable.environment providerRow)
+          (ZiskFv.AirsClean.Main.aRegPreMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar))
+        multiplicity as))
+  ∨ (providerInteraction =
+      ((MemBusChannel.emitted
+        (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar.rom.a_src_mem
+          + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar.rom.a_src_reg))
+        (ZiskFv.AirsClean.Main.aMemMessageExpr
+          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar)).toRaw).eval
+        (providerTable.environment providerRow)
+    ∧ ZiskFv.Airs.MemoryBus.matches_memory_entry
+      (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+        (eval mainEnv mainMsg) multiplicity as)
+      (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+        (eval (providerTable.environment providerRow)
+          (ZiskFv.AirsClean.Main.aMemMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar))
+        multiplicity as))
+  ∨ (providerInteraction =
+      ((MemBusChannel.emitted
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          length program).rowInputVar.rom.b_src_reg
+        (ZiskFv.AirsClean.Main.bRegPreMessageExpr
+          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar)).toRaw).eval
+        (providerTable.environment providerRow)
+    ∧ ZiskFv.Airs.MemoryBus.matches_memory_entry
+      (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+        (eval mainEnv mainMsg) multiplicity as)
+      (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+        (eval (providerTable.environment providerRow)
+          (ZiskFv.AirsClean.Main.bRegPreMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar))
+        multiplicity as))
+  ∨ (providerInteraction =
+      ((MemBusChannel.emitted
+        (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar.rom.b_src_mem
+          + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar.rom.b_src_ind
+          + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar.rom.b_src_reg))
+        (ZiskFv.AirsClean.Main.bMemMessageExpr
+          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar)).toRaw).eval
+        (providerTable.environment providerRow)
+    ∧ ZiskFv.Airs.MemoryBus.matches_memory_entry
+      (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+        (eval mainEnv mainMsg) multiplicity as)
+      (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+        (eval (providerTable.environment providerRow)
+          (ZiskFv.AirsClean.Main.bMemMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar))
+        multiplicity as))
+  ∨ (providerInteraction =
+      ((MemBusChannel.emitted
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          length program).rowInputVar.rom.store_reg
+        (ZiskFv.AirsClean.Main.cRegPreMessageExpr
+          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar)).toRaw).eval
+        (providerTable.environment providerRow)
+    ∧ ZiskFv.Airs.MemoryBus.matches_memory_entry
+      (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+        (eval mainEnv mainMsg) multiplicity as)
+      (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+        (eval (providerTable.environment providerRow)
+          (ZiskFv.AirsClean.Main.cRegPreMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar))
+        multiplicity as))
+  ∨ (providerInteraction =
+      ((MemBusChannel.emitted
+        (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar.rom.store_mem
+          + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar.rom.store_ind
+          + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar.rom.store_reg))
+        (ZiskFv.AirsClean.Main.cMemMessageExpr
+          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar)).toRaw).eval
+        (providerTable.environment providerRow)
+    ∧ ZiskFv.Airs.MemoryBus.matches_memory_entry
+      (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+        (eval mainEnv mainMsg) multiplicity as)
+      (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+        (eval (providerTable.environment providerRow)
+          (ZiskFv.AirsClean.Main.cMemMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              length program).rowInputVar))
+        multiplicity as))
+
 /-- Row-native full-ensemble memory projection: an active unified-Main
     memory-bus interaction has a balanced same-message counterpart on a
     concrete full-ensemble table row.
@@ -173,40 +296,7 @@ theorem exists_mem_provider_row_msg_eq_of_active_main_table_interaction
       mainInteraction ∈ mainTable.interactionsWith MemBusChannel.toRaw)
     (h_active : mainInteraction.mult = -1) :
     ∃ mainRow ∈ mainTable.table,
-      (mainInteraction =
-          ((MemBusChannel.emitted
-            (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.a_src_mem
-              + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.a_src_reg))
-            (ZiskFv.AirsClean.Main.aMemMessageExpr
-              (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar)).toRaw).eval
-            (mainTable.environment mainRow)
-        ∨ mainInteraction =
-          ((MemBusChannel.emitted
-            (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.b_src_mem
-              + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.b_src_ind
-              + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.b_src_reg))
-            (ZiskFv.AirsClean.Main.bMemMessageExpr
-              (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar)).toRaw).eval
-            (mainTable.environment mainRow)
-        ∨ mainInteraction =
-          ((MemBusChannel.emitted
-            (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.store_mem
-              + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.store_ind
-              + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.store_reg))
-            (ZiskFv.AirsClean.Main.cMemMessageExpr
-              (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar)).toRaw).eval
-            (mainTable.environment mainRow))
+      MainMemBusRowInteractionEval program mainTable mainRow mainInteraction
       ∧ ∃ providerInteraction ∈ witness.interactionsWith MemBusChannel.toRaw,
         providerInteraction.msg = mainInteraction.msg
           ∧ providerInteraction.mult ≠ -1
@@ -257,41 +347,8 @@ theorem exists_mem_provider_row_msg_eq_of_active_main_table_interaction
                 ∨ (∃ providerRow ∈ providerTable.table,
                   providerTable.component =
                     ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program
-                    ∧
-                    (providerInteraction =
-                        ((MemBusChannel.emitted
-                          (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar.rom.a_src_mem
-                            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar.rom.a_src_reg))
-                          (ZiskFv.AirsClean.Main.aMemMessageExpr
-                            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar)).toRaw).eval
-                          (providerTable.environment providerRow)
-                      ∨ providerInteraction =
-                        ((MemBusChannel.emitted
-                          (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar.rom.b_src_mem
-                            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar.rom.b_src_ind
-                            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar.rom.b_src_reg))
-                          (ZiskFv.AirsClean.Main.bMemMessageExpr
-                            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar)).toRaw).eval
-                          (providerTable.environment providerRow)
-                      ∨ providerInteraction =
-                        ((MemBusChannel.emitted
-                          (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar.rom.store_mem
-                            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar.rom.store_ind
-                            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar.rom.store_reg))
-                          (ZiskFv.AirsClean.Main.cMemMessageExpr
-                            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar)).toRaw).eval
-                          (providerTable.environment providerRow)))) := by
+                    ∧ MainMemBusRowInteractionEval
+                      program providerTable providerRow providerInteraction)) := by
   have h_main_mem_witness :
       mainInteraction ∈ witness.interactionsWith MemBusChannel.toRaw := by
     rw [EnsembleWitness.mem_interactionsWith]
@@ -367,40 +424,7 @@ theorem exists_mem_provider_row_msg_eq_spec_of_active_main_table_interaction
     ∃ mainRow ∈ mainTable.table,
       mainTable.component.Spec (mainTable.environment mainRow)
         ∧
-        (mainInteraction =
-            ((MemBusChannel.emitted
-              (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                  length program).rowInputVar.rom.a_src_mem
-                + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                  length program).rowInputVar.rom.a_src_reg))
-              (ZiskFv.AirsClean.Main.aMemMessageExpr
-                (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                  length program).rowInputVar)).toRaw).eval
-              (mainTable.environment mainRow)
-          ∨ mainInteraction =
-            ((MemBusChannel.emitted
-              (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                  length program).rowInputVar.rom.b_src_mem
-                + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                  length program).rowInputVar.rom.b_src_ind
-                + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                  length program).rowInputVar.rom.b_src_reg))
-              (ZiskFv.AirsClean.Main.bMemMessageExpr
-                (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                  length program).rowInputVar)).toRaw).eval
-              (mainTable.environment mainRow)
-          ∨ mainInteraction =
-            ((MemBusChannel.emitted
-              (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                  length program).rowInputVar.rom.store_mem
-                + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                  length program).rowInputVar.rom.store_ind
-                + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                  length program).rowInputVar.rom.store_reg))
-              (ZiskFv.AirsClean.Main.cMemMessageExpr
-                (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                  length program).rowInputVar)).toRaw).eval
-              (mainTable.environment mainRow))
+        MainMemBusRowInteractionEval program mainTable mainRow mainInteraction
         ∧ ∃ providerInteraction ∈ witness.interactionsWith MemBusChannel.toRaw,
           providerInteraction.msg = mainInteraction.msg
             ∧ providerInteraction.mult ≠ -1
@@ -456,41 +480,8 @@ theorem exists_mem_provider_row_msg_eq_spec_of_active_main_table_interaction
                     providerTable.component.Spec (providerTable.environment providerRow)
                       ∧ providerTable.component =
                         ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program
-                      ∧
-                      (providerInteraction =
-                          ((MemBusChannel.emitted
-                            (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                                length program).rowInputVar.rom.a_src_mem
-                              + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                                length program).rowInputVar.rom.a_src_reg))
-                            (ZiskFv.AirsClean.Main.aMemMessageExpr
-                              (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                                length program).rowInputVar)).toRaw).eval
-                            (providerTable.environment providerRow)
-                        ∨ providerInteraction =
-                          ((MemBusChannel.emitted
-                            (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                                length program).rowInputVar.rom.b_src_mem
-                              + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                                length program).rowInputVar.rom.b_src_ind
-                              + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                                length program).rowInputVar.rom.b_src_reg))
-                            (ZiskFv.AirsClean.Main.bMemMessageExpr
-                              (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                                length program).rowInputVar)).toRaw).eval
-                            (providerTable.environment providerRow)
-                        ∨ providerInteraction =
-                          ((MemBusChannel.emitted
-                            (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                                length program).rowInputVar.rom.store_mem
-                              + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                                length program).rowInputVar.rom.store_ind
-                              + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                                length program).rowInputVar.rom.store_reg))
-                            (ZiskFv.AirsClean.Main.cMemMessageExpr
-                              (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                                length program).rowInputVar)).toRaw).eval
-                            (providerTable.environment providerRow)))) := by
+                      ∧ MainMemBusRowInteractionEval
+                        program providerTable providerRow providerInteraction)) := by
   obtain ⟨mainRow, h_mainRow, h_mainEval, providerInteraction,
       h_provider_witness, h_msg, h_nonpull, h_nonzero, providerTable, h_providerTable,
       h_providerInteraction, h_providerComponent⟩ :=
@@ -664,71 +655,9 @@ theorem exists_mem_provider_row_matches_entry_spec_of_active_main_eval
                   providerTable.component.Spec (providerTable.environment providerRow)
                     ∧ providerTable.component =
                       ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program
-                    ∧
-                    ((providerInteraction =
-                        ((MemBusChannel.emitted
-                          (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar.rom.a_src_mem
-                            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar.rom.a_src_reg))
-                          (ZiskFv.AirsClean.Main.aMemMessageExpr
-                            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar)).toRaw).eval
-                          (providerTable.environment providerRow)
-                      ∧ ZiskFv.Airs.MemoryBus.matches_memory_entry
-                        (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                          (eval (mainTable.environment mainRow) mainMsg)
-                          multiplicity as)
-                        (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                          (eval (providerTable.environment providerRow)
-                            (ZiskFv.AirsClean.Main.aMemMessageExpr
-                              (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                                length program).rowInputVar))
-                          multiplicity as))
-                    ∨ (providerInteraction =
-                        ((MemBusChannel.emitted
-                          (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar.rom.b_src_mem
-                            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar.rom.b_src_ind
-                            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar.rom.b_src_reg))
-                          (ZiskFv.AirsClean.Main.bMemMessageExpr
-                            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar)).toRaw).eval
-                          (providerTable.environment providerRow)
-                      ∧ ZiskFv.Airs.MemoryBus.matches_memory_entry
-                        (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                          (eval (mainTable.environment mainRow) mainMsg)
-                          multiplicity as)
-                        (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                          (eval (providerTable.environment providerRow)
-                            (ZiskFv.AirsClean.Main.bMemMessageExpr
-                              (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                                length program).rowInputVar))
-                          multiplicity as))
-                    ∨ (providerInteraction =
-                        ((MemBusChannel.emitted
-                          (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar.rom.store_mem
-                            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar.rom.store_ind
-                            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar.rom.store_reg))
-                          (ZiskFv.AirsClean.Main.cMemMessageExpr
-                            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar)).toRaw).eval
-                          (providerTable.environment providerRow)
-                      ∧ ZiskFv.Airs.MemoryBus.matches_memory_entry
-                        (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                          (eval (mainTable.environment mainRow) mainMsg)
-                          multiplicity as)
-                        (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                          (eval (providerTable.environment providerRow)
-                            (ZiskFv.AirsClean.Main.cMemMessageExpr
-                              (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                                length program).rowInputVar))
-                          multiplicity as))))) := by
+                    ∧ MainMemBusRowInteractionMatchEval
+                      program providerTable providerRow providerInteraction mainMsg
+                      (mainTable.environment mainRow) multiplicity as)) := by
   have h_main_mem_witness :
       mainInteraction ∈ witness.interactionsWith MemBusChannel.toRaw := by
     rw [EnsembleWitness.mem_interactionsWith]
@@ -808,19 +737,46 @@ theorem exists_mem_provider_row_matches_entry_spec_of_active_main_eval
     right
     refine ⟨providerRow, h_providerRow,
       h_providerSpecs providerRow h_providerRow, h_main, ?_⟩
-    rcases h_providerEval with h_a | h_b | h_c
+    rcases h_providerEval with h_a_prev | h_a | h_b_prev | h_b | h_c_prev | h_c
     · left
+      refine ⟨h_a_prev, ?_⟩
+      apply ZiskFv.Airs.MemoryBus.matches_memory_entry_of_eval_emitted_provider_msg_eq
+      rw [← h_a_prev, ← h_mainEval]
+      exact h_msg
+    · right
+      left
       refine ⟨h_a, ?_⟩
       apply ZiskFv.Airs.MemoryBus.matches_memory_entry_of_eval_emitted_provider_msg_eq
       rw [← h_a, ← h_mainEval]
       exact h_msg
     · right
+      right
+      left
+      refine ⟨h_b_prev, ?_⟩
+      apply ZiskFv.Airs.MemoryBus.matches_memory_entry_of_eval_emitted_provider_msg_eq
+      rw [← h_b_prev, ← h_mainEval]
+      exact h_msg
+    · right
+      right
+      right
       left
       refine ⟨h_b, ?_⟩
       apply ZiskFv.Airs.MemoryBus.matches_memory_entry_of_eval_emitted_provider_msg_eq
       rw [← h_b, ← h_mainEval]
       exact h_msg
     · right
+      right
+      right
+      right
+      left
+      refine ⟨h_c_prev, ?_⟩
+      apply ZiskFv.Airs.MemoryBus.matches_memory_entry_of_eval_emitted_provider_msg_eq
+      rw [← h_c_prev, ← h_mainEval]
+      exact h_msg
+    · right
+      right
+      right
+      right
       right
       refine ⟨h_c, ?_⟩
       apply ZiskFv.Airs.MemoryBus.matches_memory_entry_of_eval_emitted_provider_msg_eq
@@ -943,71 +899,9 @@ def ActiveMainMemProviderRowMatchSpec
               providerTable.component.Spec (providerTable.environment providerRow)
                 ∧ providerTable.component =
                   ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program
-                ∧
-                ((providerInteraction =
-                    ((MemBusChannel.emitted
-                      (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar.rom.a_src_mem
-                        + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar.rom.a_src_reg))
-                      (ZiskFv.AirsClean.Main.aMemMessageExpr
-                        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar)).toRaw).eval
-                      (providerTable.environment providerRow)
-                  ∧ ZiskFv.Airs.MemoryBus.matches_memory_entry
-                    (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                      (eval (mainTable.environment mainRow) mainMsg)
-                      multiplicity as)
-                    (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                      (eval (providerTable.environment providerRow)
-                        (ZiskFv.AirsClean.Main.aMemMessageExpr
-                          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                            length program).rowInputVar))
-                      multiplicity as))
-                ∨ (providerInteraction =
-                    ((MemBusChannel.emitted
-                      (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar.rom.b_src_mem
-                        + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar.rom.b_src_ind
-                        + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar.rom.b_src_reg))
-                      (ZiskFv.AirsClean.Main.bMemMessageExpr
-                        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar)).toRaw).eval
-                      (providerTable.environment providerRow)
-                  ∧ ZiskFv.Airs.MemoryBus.matches_memory_entry
-                    (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                      (eval (mainTable.environment mainRow) mainMsg)
-                      multiplicity as)
-                    (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                      (eval (providerTable.environment providerRow)
-                        (ZiskFv.AirsClean.Main.bMemMessageExpr
-                          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                            length program).rowInputVar))
-                      multiplicity as))
-                ∨ (providerInteraction =
-                    ((MemBusChannel.emitted
-                      (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar.rom.store_mem
-                        + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar.rom.store_ind
-                        + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar.rom.store_reg))
-                      (ZiskFv.AirsClean.Main.cMemMessageExpr
-                        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar)).toRaw).eval
-                      (providerTable.environment providerRow)
-                  ∧ ZiskFv.Airs.MemoryBus.matches_memory_entry
-                    (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                      (eval (mainTable.environment mainRow) mainMsg)
-                      multiplicity as)
-                    (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                        (eval (providerTable.environment providerRow)
-                          (ZiskFv.AirsClean.Main.cMemMessageExpr
-                            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                              length program).rowInputVar))
-                      multiplicity as)))))
+                ∧ MainMemBusRowInteractionMatchEval
+                  program providerTable providerRow providerInteraction mainMsg
+                  (mainTable.environment mainRow) multiplicity as))
 
 /-- Mutable-Mem branch of `ActiveMainMemProviderRowMatchSpec`.
 
@@ -1144,71 +1038,9 @@ def ActiveMainNonMutableMemProviderRowMatchSpec
               providerTable.component.Spec (providerTable.environment providerRow)
                 ∧ providerTable.component =
                   ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program
-                ∧
-                ((providerInteraction =
-                    ((MemBusChannel.emitted
-                      (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar.rom.a_src_mem
-                        + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar.rom.a_src_reg))
-                      (ZiskFv.AirsClean.Main.aMemMessageExpr
-                        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar)).toRaw).eval
-                      (providerTable.environment providerRow)
-                  ∧ ZiskFv.Airs.MemoryBus.matches_memory_entry
-                    (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                      (eval (mainTable.environment mainRow) mainMsg)
-                      multiplicity as)
-                    (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                      (eval (providerTable.environment providerRow)
-                        (ZiskFv.AirsClean.Main.aMemMessageExpr
-                          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                            length program).rowInputVar))
-                      multiplicity as))
-                ∨ (providerInteraction =
-                    ((MemBusChannel.emitted
-                      (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar.rom.b_src_mem
-                        + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar.rom.b_src_ind
-                        + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar.rom.b_src_reg))
-                      (ZiskFv.AirsClean.Main.bMemMessageExpr
-                        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar)).toRaw).eval
-                      (providerTable.environment providerRow)
-                  ∧ ZiskFv.Airs.MemoryBus.matches_memory_entry
-                    (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                      (eval (mainTable.environment mainRow) mainMsg)
-                      multiplicity as)
-                    (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                      (eval (providerTable.environment providerRow)
-                        (ZiskFv.AirsClean.Main.bMemMessageExpr
-                          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                            length program).rowInputVar))
-                      multiplicity as))
-                ∨ (providerInteraction =
-                    ((MemBusChannel.emitted
-                      (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar.rom.store_mem
-                        + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar.rom.store_ind
-                        + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar.rom.store_reg))
-                      (ZiskFv.AirsClean.Main.cMemMessageExpr
-                        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar)).toRaw).eval
-                      (providerTable.environment providerRow)
-                  ∧ ZiskFv.Airs.MemoryBus.matches_memory_entry
-                    (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                      (eval (mainTable.environment mainRow) mainMsg)
-                      multiplicity as)
-                    (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                    (eval (providerTable.environment providerRow)
-                        (ZiskFv.AirsClean.Main.cMemMessageExpr
-                          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                            length program).rowInputVar))
-                      multiplicity as)))))
+                ∧ MainMemBusRowInteractionMatchEval
+                  program providerTable providerRow providerInteraction mainMsg
+                  (mainTable.environment mainRow) multiplicity as))
 
 /-- MemAlignReadByte branch of
     `ActiveMainNonMutableMemProviderRowMatchSpec`. -/
@@ -1335,411 +1167,9 @@ def ActiveMainSelfMemProviderRowMatchSpec
             providerTable.component.Spec (providerTable.environment providerRow)
               ∧ providerTable.component =
                 ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program
-              ∧
-              ((providerInteraction =
-                  ((MemBusChannel.emitted
-                    (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                        length program).rowInputVar.rom.a_src_mem
-                      + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                        length program).rowInputVar.rom.a_src_reg))
-                    (ZiskFv.AirsClean.Main.aMemMessageExpr
-                      (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                        length program).rowInputVar)).toRaw).eval
-                    (providerTable.environment providerRow)
-                ∧ ZiskFv.Airs.MemoryBus.matches_memory_entry
-                  (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                    (eval (mainTable.environment mainRow) mainMsg)
-                    multiplicity as)
-                  (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                    (eval (providerTable.environment providerRow)
-                      (ZiskFv.AirsClean.Main.aMemMessageExpr
-                        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar))
-                    multiplicity as))
-              ∨ (providerInteraction =
-                  ((MemBusChannel.emitted
-                    (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                        length program).rowInputVar.rom.b_src_mem
-                      + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                        length program).rowInputVar.rom.b_src_ind
-                      + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                        length program).rowInputVar.rom.b_src_reg))
-                    (ZiskFv.AirsClean.Main.bMemMessageExpr
-                      (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                        length program).rowInputVar)).toRaw).eval
-                    (providerTable.environment providerRow)
-                ∧ ZiskFv.Airs.MemoryBus.matches_memory_entry
-                  (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                    (eval (mainTable.environment mainRow) mainMsg)
-                    multiplicity as)
-                  (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                    (eval (providerTable.environment providerRow)
-                      (ZiskFv.AirsClean.Main.bMemMessageExpr
-                        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar))
-                    multiplicity as))
-              ∨ (providerInteraction =
-                  ((MemBusChannel.emitted
-                    (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                        length program).rowInputVar.rom.store_mem
-                      + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                        length program).rowInputVar.rom.store_ind
-                      + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                        length program).rowInputVar.rom.store_reg))
-                    (ZiskFv.AirsClean.Main.cMemMessageExpr
-                      (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                        length program).rowInputVar)).toRaw).eval
-                    (providerTable.environment providerRow)
-                ∧ ZiskFv.Airs.MemoryBus.matches_memory_entry
-                  (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                    (eval (mainTable.environment mainRow) mainMsg)
-                    multiplicity as)
-                  (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
-                    (eval (providerTable.environment providerRow)
-                      (ZiskFv.AirsClean.Main.cMemMessageExpr
-                        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          length program).rowInputVar))
-                    multiplicity as)))
-
-/-- Main memory-bus interactions in the full ensemble are only active pulls
-    or inactive zero-multiplicity rows.
-
-    This is the missing source-legality invariant needed to rule out the
-    Main self-provider branch for direct loads. It is deliberately stated as
-    an explicit witness-level obligation: the current Main `Spec` only exposes
-    core Main constraints, while the needed fact depends on ROM/source flag
-    legality for every unified-Main row. -/
-def MainMemBusMultiplicitySound
-    {length : ℕ} (program : Program length)
-    (witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble) :
-    Prop :=
-  ∀ table ∈ witness.allTables,
-    table.component =
-        ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program →
-      ∀ interaction ∈ table.interactionsWith MemBusChannel.toRaw,
-        interaction.mult = -1 ∨ interaction.mult = 0
-
-/-- Row-local ROM/source selector legality needed to make unified-Main
-    memory-bus multiplicities pull-or-zero.
-
-    The sums are stated after table evaluation because this is the exact
-    proof surface consumed by `MainMemBusMultiplicitySound`: Main emits the
-    three memory-bus interactions with multiplicities `-aSum`, `-bSum`, and
-    `-storeSum`. -/
-def MainMemBusSourceMultiplicitySound
-    {length : ℕ} (program : Program length)
-    (witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble) :
-    Prop :=
-  ∀ table ∈ witness.allTables,
-    table.component =
-        ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program →
-      ∀ row ∈ table.table,
-        let env := table.environment row
-        (env ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              length program).rowInputVar.rom.a_src_mem
-            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              length program).rowInputVar.rom.a_src_reg) = 1
-          ∨ env ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              length program).rowInputVar.rom.a_src_mem
-            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              length program).rowInputVar.rom.a_src_reg) = 0)
-        ∧ (env ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              length program).rowInputVar.rom.b_src_mem
-            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              length program).rowInputVar.rom.b_src_ind
-            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              length program).rowInputVar.rom.b_src_reg) = 1
-          ∨ env ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              length program).rowInputVar.rom.b_src_mem
-            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              length program).rowInputVar.rom.b_src_ind
-            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              length program).rowInputVar.rom.b_src_reg) = 0)
-        ∧ (env ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              length program).rowInputVar.rom.store_mem
-            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              length program).rowInputVar.rom.store_ind
-            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              length program).rowInputVar.rom.store_reg) = 1
-          ∨ env ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              length program).rowInputVar.rom.store_mem
-            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              length program).rowInputVar.rom.store_ind
-            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              length program).rowInputVar.rom.store_reg) = 0)
-
-/-- Concrete source selector legality for one unified-Main row. -/
-def MainRomRowSourceMultiplicitySound
-    (row : ZiskFv.AirsClean.Main.MainRowWithRom FGL) : Prop :=
-  (row.rom.a_src_mem + row.rom.a_src_reg = 1
-    ∨ row.rom.a_src_mem + row.rom.a_src_reg = 0)
-  ∧ (row.rom.b_src_mem + row.rom.b_src_ind + row.rom.b_src_reg = 1
-    ∨ row.rom.b_src_mem + row.rom.b_src_ind + row.rom.b_src_reg = 0)
-  ∧ (row.rom.store_mem + row.rom.store_ind + row.rom.store_reg = 1
-    ∨ row.rom.store_mem + row.rom.store_ind + row.rom.store_reg = 0)
-
-/-- Row-indexed source selector legality for every concrete program ROM row.
-
-    This is closer to the production/provenance boundary than
-    `MainProgramRomSourceMultiplicitySound`: for each `program i`, any concrete
-    unified-Main row with that ROM message has source-selector sums `1` or `0`.
-    The remaining extraction work should prove this from row-shape provenance /
-    lowered instruction facts. -/
-def MainProgramRomRowsSourceMultiplicitySound
-    {length : ℕ} (program : Program length) : Prop :=
-  ∀ i : Fin length,
-    ∀ row : ZiskFv.AirsClean.Main.MainRowWithRom FGL,
-      ZiskFv.AirsClean.Main.romMessage row = program i →
-        MainRomRowSourceMultiplicitySound row
-
-/-- Program-ROM source selector legality for unified-Main rows.
-
-    This is the program-indexed source-legality burden exposed by the ROM
-    lookup split: accepted row constraints prove that a unified-Main row's ROM
-    message is in the program ROM, while this predicate says every such ROM row
-    has the source-selector sums needed by the memory-bus proof. -/
-def MainProgramRomSourceMultiplicitySound
-    {length : ℕ} (program : Program length) : Prop :=
-  ∀ env : Environment FGL,
-    (ZiskFv.AirsClean.ZiskInstructionRom.romStaticTable length program).Spec
-      (eval env
-        (ZiskFv.AirsClean.Main.romMessageExpr
-          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            length program).rowInputVar)) →
-      (env ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            length program).rowInputVar.rom.a_src_mem
-          + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            length program).rowInputVar.rom.a_src_reg) = 1
-        ∨ env ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            length program).rowInputVar.rom.a_src_mem
-          + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            length program).rowInputVar.rom.a_src_reg) = 0)
-      ∧ (env ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            length program).rowInputVar.rom.b_src_mem
-          + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            length program).rowInputVar.rom.b_src_ind
-          + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            length program).rowInputVar.rom.b_src_reg) = 1
-        ∨ env ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            length program).rowInputVar.rom.b_src_mem
-          + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            length program).rowInputVar.rom.b_src_ind
-          + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            length program).rowInputVar.rom.b_src_reg) = 0)
-      ∧ (env ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            length program).rowInputVar.rom.store_mem
-          + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            length program).rowInputVar.rom.store_ind
-          + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            length program).rowInputVar.rom.store_reg) = 1
-        ∨ env ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            length program).rowInputVar.rom.store_mem
-          + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            length program).rowInputVar.rom.store_ind
-          + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            length program).rowInputVar.rom.store_reg) = 0)
-
-/-- Row-indexed program ROM source legality implies the env-shaped program-ROM
-    source burden consumed by the full-ensemble split. -/
-theorem mainProgramRomSourceMultiplicitySound_of_programRowsSourceMultiplicitySound
-    {length : ℕ} {program : Program length}
-    (h_rows : MainProgramRomRowsSourceMultiplicitySound program) :
-    MainProgramRomSourceMultiplicitySound program := by
-  intro env h_rom
-  rcases h_rom with ⟨i, h_msg⟩
-  let component := ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program
-  let row : ZiskFv.AirsClean.Main.MainRowWithRom FGL := component.rowInput env
-  have h_eval_row : eval env component.rowInputVar = row := by
-    simpa only [row, component, Air.Flat.Component.rowInput,
-      Air.Flat.Component.rowInputVar] using
-        (eval_varFromOffset_valueFromOffset component.Input 0 env)
-  have h_row_msg : ZiskFv.AirsClean.Main.romMessage row = program i := by
-    have h_msg' :
-        ZiskFv.AirsClean.Main.romMessage (eval env component.rowInputVar) =
-          program i := by
-      simpa only [component, ZiskFv.AirsClean.Main.eval_romMessageExpr] using h_msg
-    simpa only [h_eval_row] using h_msg'
-  have h_row_source := h_rows i row h_row_msg
-  rcases h_row_source with ⟨h_a, h_b, h_c⟩
-  have h_a_sum :
-      env (component.rowInputVar.rom.a_src_mem
-          + component.rowInputVar.rom.a_src_reg) =
-        row.rom.a_src_mem + row.rom.a_src_reg := by
-    calc
-      env (component.rowInputVar.rom.a_src_mem
-          + component.rowInputVar.rom.a_src_reg)
-          = (eval env component.rowInputVar).rom.a_src_mem
-              + (eval env component.rowInputVar).rom.a_src_reg := by
-            exact ZiskFv.AirsClean.Main.eval_aSourceSumExpr env component.rowInputVar
-      _ = row.rom.a_src_mem + row.rom.a_src_reg := by
-            exact congrArg
-              (fun r : ZiskFv.AirsClean.Main.MainRowWithRom FGL =>
-                r.rom.a_src_mem + r.rom.a_src_reg) h_eval_row
-  have h_b_sum :
-      env (component.rowInputVar.rom.b_src_mem
-          + component.rowInputVar.rom.b_src_ind
-          + component.rowInputVar.rom.b_src_reg) =
-        row.rom.b_src_mem + row.rom.b_src_ind + row.rom.b_src_reg := by
-    calc
-      env (component.rowInputVar.rom.b_src_mem
-          + component.rowInputVar.rom.b_src_ind
-          + component.rowInputVar.rom.b_src_reg)
-          = (eval env component.rowInputVar).rom.b_src_mem
-              + (eval env component.rowInputVar).rom.b_src_ind
-              + (eval env component.rowInputVar).rom.b_src_reg := by
-            exact ZiskFv.AirsClean.Main.eval_bSourceSumExpr env component.rowInputVar
-      _ = row.rom.b_src_mem + row.rom.b_src_ind + row.rom.b_src_reg := by
-            exact congrArg
-              (fun r : ZiskFv.AirsClean.Main.MainRowWithRom FGL =>
-                r.rom.b_src_mem + r.rom.b_src_ind + r.rom.b_src_reg) h_eval_row
-  have h_c_sum :
-      env (component.rowInputVar.rom.store_mem
-          + component.rowInputVar.rom.store_ind
-          + component.rowInputVar.rom.store_reg) =
-        row.rom.store_mem + row.rom.store_ind + row.rom.store_reg := by
-    calc
-      env (component.rowInputVar.rom.store_mem
-          + component.rowInputVar.rom.store_ind
-          + component.rowInputVar.rom.store_reg)
-          = (eval env component.rowInputVar).rom.store_mem
-              + (eval env component.rowInputVar).rom.store_ind
-              + (eval env component.rowInputVar).rom.store_reg := by
-            exact ZiskFv.AirsClean.Main.eval_cSourceSumExpr env component.rowInputVar
-      _ = row.rom.store_mem + row.rom.store_ind + row.rom.store_reg := by
-            exact congrArg
-              (fun r : ZiskFv.AirsClean.Main.MainRowWithRom FGL =>
-                r.rom.store_mem + r.rom.store_ind + r.rom.store_reg) h_eval_row
-  exact ⟨ by simpa only [component, h_a_sum] using h_a
-        , by simpa only [component, h_b_sum] using h_b
-        , by simpa only [component, h_c_sum] using h_c ⟩
-
-/-- Accepted row constraints plus program-ROM source legality discharge the
-    row-local unified-Main source-multiplicity invariant. -/
-theorem mainMemBusSourceMultiplicitySound_of_constraints_and_programRomSourceMultiplicitySound
-    {length : ℕ} {program : Program length}
-    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
-    (h_constraints : witness.Constraints)
-    (h_program : MainProgramRomSourceMultiplicitySound program) :
-    MainMemBusSourceMultiplicitySound program witness := by
-  intro table h_table h_component row h_row
-  have h_row_constraints :
-      (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-        length program).operations.ConstraintsHold (table.environment row) := by
-    simpa [h_component] using h_constraints table h_table row h_row
-  exact h_program (table.environment row)
-    (ZiskFv.AirsClean.Main.romSpec_of_componentWithRomMemAndOpBus_constraints
-      length program (table.environment row) h_row_constraints)
-
-/-- Source selector legality discharges the coarser unified-Main memory-bus
-    multiplicity invariant used to rule out Main self-provider routes. -/
-theorem mainMemBusMultiplicitySound_of_sourceMultiplicitySound
-    {length : ℕ} {program : Program length}
-    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
-    (h_source : MainMemBusSourceMultiplicitySound program witness) :
-    MainMemBusMultiplicitySound program witness := by
-  intro table h_table h_component interaction h_interaction
-  obtain ⟨row, h_row, h_eval⟩ :=
-    exists_main_mem_row_eval_of_interaction_mem h_component h_interaction
-  have h_row_source := h_source table h_table h_component row h_row
-  dsimp only at h_row_source
-  rcases h_row_source with ⟨h_a, h_b, h_store⟩
-  rcases h_eval with h_eval | h_eval | h_eval
-  · rcases h_a with h_one | h_zero
-    · left
-      rw [h_eval]
-      change
-        (-1 : FGL) * Expression.eval (table.environment row)
-          ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.a_src_mem
-            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.a_src_reg) = -1
-      rw [h_one]
-      ring
-    · right
-      rw [h_eval]
-      change
-        (-1 : FGL) * Expression.eval (table.environment row)
-          ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.a_src_mem
-            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.a_src_reg) = 0
-      rw [h_zero]
-      ring
-  · rcases h_b with h_one | h_zero
-    · left
-      rw [h_eval]
-      change
-        (-1 : FGL) * Expression.eval (table.environment row)
-          ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.b_src_mem
-            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.b_src_ind
-            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.b_src_reg) = -1
-      rw [h_one]
-      ring
-    · right
-      rw [h_eval]
-      change
-        (-1 : FGL) * Expression.eval (table.environment row)
-          ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.b_src_mem
-            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.b_src_ind
-            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.b_src_reg) = 0
-      rw [h_zero]
-      ring
-  · rcases h_store with h_one | h_zero
-    · left
-      rw [h_eval]
-      change
-        (-1 : FGL) * Expression.eval (table.environment row)
-          ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.store_mem
-            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.store_ind
-            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.store_reg) = -1
-      rw [h_one]
-      ring
-    · right
-      rw [h_eval]
-      change
-        (-1 : FGL) * Expression.eval (table.environment row)
-          ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.store_mem
-            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.store_ind
-            + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.store_reg) = 0
-      rw [h_zero]
-      ring
-
-/-- Main self-provider memory routes are impossible once unified-Main
-    memory-bus multiplicities are known to be pull-or-zero only. -/
-theorem no_activeMainSelfMemProviderRowMatchSpec_of_mainMemBusMultiplicitySound
-    {length : ℕ} {program : Program length}
-    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
-    {mainTable : Table FGL}
-    {mainRow : Array FGL}
-    {mainInteraction : Interaction FGL}
-    {mainMsg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)}
-    {multiplicity as : FGL}
-    (h_mainMem : MainMemBusMultiplicitySound program witness) :
-    ¬ ActiveMainSelfMemProviderRowMatchSpec program witness mainTable mainRow
-      mainInteraction mainMsg multiplicity as := by
-  intro h_self
-  rcases h_self with
-    ⟨providerInteraction, _h_provider_witness, _h_msg, h_nonpull,
-      h_nonzero, providerTable, h_providerTable, h_providerInteraction,
-      providerRow, _h_providerRow, _h_providerSpec, h_component, _h_branch⟩
-  have h_mult :=
-    h_mainMem providerTable h_providerTable h_component providerInteraction
-      h_providerInteraction
-  rcases h_mult with h_pull | h_zero
-  · exact h_nonpull h_pull
-  · exact h_nonzero h_zero
+              ∧ MainMemBusRowInteractionMatchEval
+                program providerTable providerRow providerInteraction mainMsg
+                (mainTable.environment mainRow) multiplicity as
 
 /-- Branch split for the non-mutable active-Main provider family. -/
 theorem activeMainNonMutableMemProviderRowMatchSpec_branch_cases

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/RowExtraction.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/RowExtraction.lean
@@ -130,9 +130,74 @@ theorem main_op_row_eval_mem_interactionsWith
     h_singleton]
   exact ⟨row, h_row, rfl⟩
 
+/-- The six row-local Main memory-bus interactions exposed by the unified
+    component: previous-register pushes interleaved with current-access pulls. -/
+@[reducible]
+def MainMemBusRowInteractionEval
+    {length : ℕ} (program : Program length)
+    (table : Table FGL) (row : Array FGL) (interaction : Interaction FGL) : Prop :=
+  interaction =
+      ((MemBusChannel.emitted
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          length program).rowInputVar.rom.a_src_reg
+        (ZiskFv.AirsClean.Main.aRegPreMessageExpr
+          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar)).toRaw).eval
+        (table.environment row)
+    ∨ interaction =
+      ((MemBusChannel.emitted
+        (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar.rom.a_src_mem
+          + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar.rom.a_src_reg))
+        (ZiskFv.AirsClean.Main.aMemMessageExpr
+          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar)).toRaw).eval
+        (table.environment row)
+    ∨ interaction =
+      ((MemBusChannel.emitted
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          length program).rowInputVar.rom.b_src_reg
+        (ZiskFv.AirsClean.Main.bRegPreMessageExpr
+          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar)).toRaw).eval
+        (table.environment row)
+    ∨ interaction =
+      ((MemBusChannel.emitted
+        (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar.rom.b_src_mem
+          + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar.rom.b_src_ind
+          + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar.rom.b_src_reg))
+        (ZiskFv.AirsClean.Main.bMemMessageExpr
+          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar)).toRaw).eval
+        (table.environment row)
+    ∨ interaction =
+      ((MemBusChannel.emitted
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          length program).rowInputVar.rom.store_reg
+        (ZiskFv.AirsClean.Main.cRegPreMessageExpr
+          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar)).toRaw).eval
+        (table.environment row)
+    ∨ interaction =
+      ((MemBusChannel.emitted
+        (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar.rom.store_mem
+          + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar.rom.store_ind
+          + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar.rom.store_reg))
+        (ZiskFv.AirsClean.Main.cMemMessageExpr
+          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar)).toRaw).eval
+        (table.environment row)
+
 /-- Row extraction for the unified Main memory-bus interactions in the full
-    ensemble. Main exposes three memory interactions (`a`, `b`, and
-    `c/store`), so the result keeps that side disjunction explicit. -/
+    ensemble. Main exposes six row-local memory interactions, so the result
+    keeps the side disjunction behind `MainMemBusRowInteractionEval`. -/
 theorem exists_main_mem_row_eval_of_interaction_mem
     {length : ℕ} {program : Program length}
     {table : Table FGL}
@@ -142,49 +207,14 @@ theorem exists_main_mem_row_eval_of_interaction_mem
     {interaction : Interaction FGL}
     (h_mem : interaction ∈ table.interactionsWith MemBusChannel.toRaw) :
     ∃ row ∈ table.table,
-      interaction =
-          ((MemBusChannel.emitted
-            (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.a_src_mem
-              + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.a_src_reg))
-            (ZiskFv.AirsClean.Main.aMemMessageExpr
-              (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar)).toRaw).eval
-            (table.environment row)
-        ∨ interaction =
-          ((MemBusChannel.emitted
-            (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.b_src_mem
-              + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.b_src_ind
-              + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.b_src_reg))
-            (ZiskFv.AirsClean.Main.bMemMessageExpr
-              (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar)).toRaw).eval
-            (table.environment row)
-        ∨ interaction =
-          ((MemBusChannel.emitted
-            (-((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.store_mem
-              + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.store_ind
-              + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar.rom.store_reg))
-            (ZiskFv.AirsClean.Main.cMemMessageExpr
-              (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                length program).rowInputVar)).toRaw).eval
-            (table.environment row) := by
+      MainMemBusRowInteractionEval program table row interaction := by
   have h_interactions :=
     ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus_interactionsWith_memBus
       length program
   simp [Table.interactionsWith, Operations.interactionValuesWith_eq_map,
     h_component, h_interactions] at h_mem
-  rcases h_mem with ⟨row, h_row, h_eq | h_eq | h_eq⟩
-  · exact ⟨row, h_row, Or.inl h_eq⟩
-  · exact ⟨row, h_row, Or.inr (Or.inl h_eq)⟩
-  · exact ⟨row, h_row, Or.inr (Or.inr h_eq)⟩
+  rcases h_mem with ⟨row, h_row, h_eval⟩
+  exact ⟨row, h_row, h_eval⟩
 
 /-- Row extraction for a BinaryAdd operation-bus provider interaction in the
     full ensemble. -/

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/TableProjections.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/TableProjections.lean
@@ -61,7 +61,12 @@ def zeroMainRowWithRom : ZiskFv.AirsClean.Main.MainRowWithRom FGL where
     addr0 := 0
     addr1 := 0
     addr2 := 0
-    main_step := 0 }
+    main_step := 0
+    a_reg_prev_mem_step := 0
+    b_reg_prev_mem_step := 0
+    store_reg_prev_mem_step := 0
+    store_reg_prev_value_0 := 0
+    store_reg_prev_value_1 := 0 }
 
 /-- Project row `row` of a concrete Clean Main table to its unified Main+ROM
     row input. Out-of-range rows use `zeroMainRowWithRom` only to keep the

--- a/ZiskFv/AirsClean/Main/Bridge.lean
+++ b/ZiskFv/AirsClean/Main/Bridge.lean
@@ -191,6 +191,33 @@ def cMemMessage (row : MainRowWithRom FGL) : MemBusMessage FGL :=
         (row.core.pc + row.core.jmp_offset2 - row.core.c_0) + row.core.c_0
     value_1 := (1 - row.core.store_pc) * row.core.c_1 }
 
+@[reducible]
+def aRegPreMessage (row : MainRowWithRom FGL) : MemBusMessage FGL :=
+  { mem_op := 3
+    ptr := row.rom.a_offset_imm0
+    timestamp := row.rom.a_reg_prev_mem_step
+    width := 8
+    value_0 := row.core.a_0
+    value_1 := row.core.a_1 }
+
+@[reducible]
+def bRegPreMessage (row : MainRowWithRom FGL) : MemBusMessage FGL :=
+  { mem_op := 3
+    ptr := row.rom.b_offset_imm0
+    timestamp := row.rom.b_reg_prev_mem_step
+    width := 8
+    value_0 := row.core.b_0
+    value_1 := row.core.b_1 }
+
+@[reducible]
+def cRegPreMessage (row : MainRowWithRom FGL) : MemBusMessage FGL :=
+  { mem_op := 3
+    ptr := row.rom.store_offset
+    timestamp := row.rom.store_reg_prev_mem_step
+    width := 8
+    value_0 := row.rom.store_reg_prev_value_0
+    value_1 := row.rom.store_reg_prev_value_1 }
+
 theorem eval_aMemMessageExpr
     (env : Environment FGL) (row : Var MainRowWithRom FGL) :
     eval env (aMemMessageExpr row) = aMemMessage (eval env row) := by
@@ -224,6 +251,39 @@ theorem eval_cMemMessageExpr
     ProvableStruct.toComponents, ProvableStruct.eval.go,
     ProvableType.eval_field, Expression.eval]
   repeat constructor <;> simp <;> ring_nf
+
+theorem eval_aRegPreMessageExpr
+    (env : Environment FGL) (row : Var MainRowWithRom FGL) :
+    eval env (aRegPreMessageExpr row) = aRegPreMessage (eval env row) := by
+  rw [MemBusMessage.mk.injEq]
+  simp only [aRegPreMessageExpr,
+    ProvableStruct.eval_eq_eval, ProvableStruct.eval,
+    ProvableStruct.fromComponents, ProvableStruct.components,
+    ProvableStruct.toComponents, ProvableStruct.eval.go,
+    ProvableType.eval_field, Expression.eval]
+  repeat constructor <;> simp
+
+theorem eval_bRegPreMessageExpr
+    (env : Environment FGL) (row : Var MainRowWithRom FGL) :
+    eval env (bRegPreMessageExpr row) = bRegPreMessage (eval env row) := by
+  rw [MemBusMessage.mk.injEq]
+  simp only [bRegPreMessageExpr,
+    ProvableStruct.eval_eq_eval, ProvableStruct.eval,
+    ProvableStruct.fromComponents, ProvableStruct.components,
+    ProvableStruct.toComponents, ProvableStruct.eval.go,
+    ProvableType.eval_field, Expression.eval]
+  repeat constructor <;> simp
+
+theorem eval_cRegPreMessageExpr
+    (env : Environment FGL) (row : Var MainRowWithRom FGL) :
+    eval env (cRegPreMessageExpr row) = cRegPreMessage (eval env row) := by
+  rw [MemBusMessage.mk.injEq]
+  simp only [cRegPreMessageExpr,
+    ProvableStruct.eval_eq_eval, ProvableStruct.eval,
+    ProvableStruct.fromComponents, ProvableStruct.components,
+    ProvableStruct.toComponents, ProvableStruct.eval.go,
+    ProvableType.eval_field, Expression.eval]
+  repeat constructor <;> simp
 
 /-! ### Legacy lane facts from PIL-shaped Main memory messages -/
 

--- a/ZiskFv/AirsClean/Main/Circuit.lean
+++ b/ZiskFv/AirsClean/Main/Circuit.lean
@@ -227,6 +227,11 @@ structure MainRomFreeCols where
   im_high_degree_2 : FGL
   segment_l1 : FGL
   main_step : FGL
+  a_reg_prev_mem_step : FGL
+  b_reg_prev_mem_step : FGL
+  store_reg_prev_mem_step : FGL
+  store_reg_prev_value_0 : FGL
+  store_reg_prev_value_1 : FGL
 
 /-- Main execution shapes for rows whose instruction data comes from the ROM
     program row. The operation code itself is copied from the selected ROM
@@ -309,7 +314,12 @@ def mainRomRowOf (msg : ZiskFv.Channels.ZiskRomBus.ZiskRomMessage FGL)
         addr0 := msg.a_offset_imm0
         addr1 := msg.b_offset_imm0 + boolF bits.b_src_ind * free.a_0
         addr2 := msg.store_offset + boolF bits.store_ind * free.a_0
-        main_step := free.main_step } }
+        main_step := free.main_step
+        a_reg_prev_mem_step := free.a_reg_prev_mem_step
+        b_reg_prev_mem_step := free.b_reg_prev_mem_step
+        store_reg_prev_mem_step := free.store_reg_prev_mem_step
+        store_reg_prev_value_0 := free.store_reg_prev_value_0
+        store_reg_prev_value_1 := free.store_reg_prev_value_1 } }
 
 /-- The remaining address-placement constructibility condition from
 `main.pil:197`: indirect addressing must not overflow the low limb. -/
@@ -722,14 +732,23 @@ theorem componentWithRomMemAndOpBus_interactionsWith_memBus
     (componentWithRomMemAndOpBus length program).operations.interactionsWith
         MemBusChannel.toRaw =
       [ ((MemBusChannel.emitted
+            (componentWithRomMemAndOpBus length program).rowInputVar.rom.a_src_reg
+            (aRegPreMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw)
+      , ((MemBusChannel.emitted
             (-((componentWithRomMemAndOpBus length program).rowInputVar.rom.a_src_mem
               + (componentWithRomMemAndOpBus length program).rowInputVar.rom.a_src_reg))
             (aMemMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw)
+      , ((MemBusChannel.emitted
+            (componentWithRomMemAndOpBus length program).rowInputVar.rom.b_src_reg
+            (bRegPreMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw)
       , ((MemBusChannel.emitted
             (-((componentWithRomMemAndOpBus length program).rowInputVar.rom.b_src_mem
               + (componentWithRomMemAndOpBus length program).rowInputVar.rom.b_src_ind
               + (componentWithRomMemAndOpBus length program).rowInputVar.rom.b_src_reg))
             (bMemMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw)
+      , ((MemBusChannel.emitted
+            (componentWithRomMemAndOpBus length program).rowInputVar.rom.store_reg
+            (cRegPreMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw)
       , ((MemBusChannel.emitted
             (-((componentWithRomMemAndOpBus length program).rowInputVar.rom.store_mem
               + (componentWithRomMemAndOpBus length program).rowInputVar.rom.store_ind
@@ -738,14 +757,23 @@ theorem componentWithRomMemAndOpBus_interactionsWith_memBus
   apply Component.interactionsWith_of_exposedChannels
   change ⟨MemBusChannel.toRaw,
       [ ((MemBusChannel.emitted
+            (componentWithRomMemAndOpBus length program).rowInputVar.rom.a_src_reg
+            (aRegPreMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw)
+      , ((MemBusChannel.emitted
             (-((componentWithRomMemAndOpBus length program).rowInputVar.rom.a_src_mem
               + (componentWithRomMemAndOpBus length program).rowInputVar.rom.a_src_reg))
             (aMemMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw)
+      , ((MemBusChannel.emitted
+            (componentWithRomMemAndOpBus length program).rowInputVar.rom.b_src_reg
+            (bRegPreMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw)
       , ((MemBusChannel.emitted
             (-((componentWithRomMemAndOpBus length program).rowInputVar.rom.b_src_mem
               + (componentWithRomMemAndOpBus length program).rowInputVar.rom.b_src_ind
               + (componentWithRomMemAndOpBus length program).rowInputVar.rom.b_src_reg))
             (bMemMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw)
+      , ((MemBusChannel.emitted
+            (componentWithRomMemAndOpBus length program).rowInputVar.rom.store_reg
+            (cRegPreMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw)
       , ((MemBusChannel.emitted
             (-((componentWithRomMemAndOpBus length program).rowInputVar.rom.store_mem
               + (componentWithRomMemAndOpBus length program).rowInputVar.rom.store_ind
@@ -987,14 +1015,23 @@ theorem componentWithRomAndMemBus_interactionsWith_memBus
     (componentWithRomAndMemBus length program).operations.interactionsWith
         MemBusChannel.toRaw =
       [ ((MemBusChannel.emitted
+            (componentWithRomAndMemBus length program).rowInputVar.rom.a_src_reg
+            (aRegPreMessageExpr (componentWithRomAndMemBus length program).rowInputVar)).toRaw)
+      , ((MemBusChannel.emitted
             (-((componentWithRomAndMemBus length program).rowInputVar.rom.a_src_mem
               + (componentWithRomAndMemBus length program).rowInputVar.rom.a_src_reg))
             (aMemMessageExpr (componentWithRomAndMemBus length program).rowInputVar)).toRaw)
+      , ((MemBusChannel.emitted
+            (componentWithRomAndMemBus length program).rowInputVar.rom.b_src_reg
+            (bRegPreMessageExpr (componentWithRomAndMemBus length program).rowInputVar)).toRaw)
       , ((MemBusChannel.emitted
             (-((componentWithRomAndMemBus length program).rowInputVar.rom.b_src_mem
               + (componentWithRomAndMemBus length program).rowInputVar.rom.b_src_ind
               + (componentWithRomAndMemBus length program).rowInputVar.rom.b_src_reg))
             (bMemMessageExpr (componentWithRomAndMemBus length program).rowInputVar)).toRaw)
+      , ((MemBusChannel.emitted
+            (componentWithRomAndMemBus length program).rowInputVar.rom.store_reg
+            (cRegPreMessageExpr (componentWithRomAndMemBus length program).rowInputVar)).toRaw)
       , ((MemBusChannel.emitted
             (-((componentWithRomAndMemBus length program).rowInputVar.rom.store_mem
               + (componentWithRomAndMemBus length program).rowInputVar.rom.store_ind
@@ -1003,14 +1040,23 @@ theorem componentWithRomAndMemBus_interactionsWith_memBus
   apply Component.interactionsWith_of_exposedChannels
   change ⟨MemBusChannel.toRaw,
       [ ((MemBusChannel.emitted
+            (componentWithRomAndMemBus length program).rowInputVar.rom.a_src_reg
+            (aRegPreMessageExpr (componentWithRomAndMemBus length program).rowInputVar)).toRaw)
+      , ((MemBusChannel.emitted
             (-((componentWithRomAndMemBus length program).rowInputVar.rom.a_src_mem
               + (componentWithRomAndMemBus length program).rowInputVar.rom.a_src_reg))
             (aMemMessageExpr (componentWithRomAndMemBus length program).rowInputVar)).toRaw)
+      , ((MemBusChannel.emitted
+            (componentWithRomAndMemBus length program).rowInputVar.rom.b_src_reg
+            (bRegPreMessageExpr (componentWithRomAndMemBus length program).rowInputVar)).toRaw)
       , ((MemBusChannel.emitted
             (-((componentWithRomAndMemBus length program).rowInputVar.rom.b_src_mem
               + (componentWithRomAndMemBus length program).rowInputVar.rom.b_src_ind
               + (componentWithRomAndMemBus length program).rowInputVar.rom.b_src_reg))
             (bMemMessageExpr (componentWithRomAndMemBus length program).rowInputVar)).toRaw)
+      , ((MemBusChannel.emitted
+            (componentWithRomAndMemBus length program).rowInputVar.rom.store_reg
+            (cRegPreMessageExpr (componentWithRomAndMemBus length program).rowInputVar)).toRaw)
       , ((MemBusChannel.emitted
             (-((componentWithRomAndMemBus length program).rowInputVar.rom.store_mem
               + (componentWithRomAndMemBus length program).rowInputVar.rom.store_ind

--- a/ZiskFv/AirsClean/Main/Constraints.lean
+++ b/ZiskFv/AirsClean/Main/Constraints.lean
@@ -289,20 +289,24 @@ def mainWithRom (length : ℕ) (program : Program length)
 
 /-! ## T4.0.6 — memory-bus emission extension
 
-`mainWithMemBus` extends `mainWithRom` with the 3 per-row memory-bus
-consumer emissions matching `main.pil:284,300,323`:
+`mainWithMemBus` extends `mainWithRom` with the per-row memory-bus
+emissions matching `main.pil:277,284,293,300,316,323`:
 
-1. **a-side** (`main.pil:284-288`) — register read of rs1 (`a_src_reg`)
+1. **a-side prev** (`main.pil:277-280`) — register previous-access proof.
+2. **a-side current** (`main.pil:284-288`) — register read of rs1 (`a_src_reg`)
    or memory read at `addr0` (`a_src_mem`).
-2. **b-side** (`main.pil:300-305`) — register read of rs2 (`b_src_reg`)
+3. **b-side prev** (`main.pil:293-296`) — register previous-access proof.
+4. **b-side current** (`main.pil:300-305`) — register read of rs2 (`b_src_reg`)
    or memory access at `addr1` (`b_src_mem + b_src_ind`).
-3. **c-side / store** (`main.pil:323-328`) — register write to rd
+5. **c-side prev** (`main.pil:316-319`) — register previous-access proof.
+6. **c-side current / store** (`main.pil:323-328`) — register write to rd
    (`store_reg`) or memory write at `addr2` (`store_mem + store_ind`).
 
-Each `mem_op` PIL macro lowers to a `permutation_assumes(MEMORY_ID,
-[mem_op, addr, mem_step, bytes, value_0, value_1], sel: …)` push.
-Modelled here as a `MemBusChannel.emit` with multiplicity `-sel`
-(consumer side) using the unified 6-slot PIL `MemBusMessage`.
+Each `reg_pre_*` PIL macro lowers to `mem_proves` and is modelled as
+`MemBusChannel.emit sel` (producer side). Each `mem_op` PIL macro lowers to
+`permutation_assumes(MEMORY_ID, [mem_op, addr, mem_step, bytes, value_0,
+value_1], sel: …)` and is modelled as `MemBusChannel.emit (-sel)` (consumer
+side) using the unified 6-slot PIL `MemBusMessage`.
 
 Memory operation codes (`mem.pil:71-73`):
 * `MEMORY_LOAD_OP = 1`
@@ -388,25 +392,64 @@ def cMemMessageExpr (row : Var MainRowWithRom FGL) :
     value_0 := storeValueLoExpr row
     value_1 := storeValueHiExpr row }
 
-/-- Main constraints + ROM lookup + 3 memory-bus consumer emissions.
-    Composes `mainWithRom` with the 3 `MemBusChannel.emit` pushes
-    matching `main.pil:284,300,323`. -/
+/-- a-side register previous-access producer message (`main.pil:277-280`). -/
+@[reducible]
+def aRegPreMessageExpr (row : Var MainRowWithRom FGL) :
+    MemBusMessage (Expression FGL) :=
+  { mem_op := 3
+    ptr := row.rom.a_offset_imm0
+    timestamp := row.rom.a_reg_prev_mem_step
+    width := 8
+    value_0 := row.core.a_0
+    value_1 := row.core.a_1 }
+
+/-- b-side register previous-access producer message (`main.pil:293-296`). -/
+@[reducible]
+def bRegPreMessageExpr (row : Var MainRowWithRom FGL) :
+    MemBusMessage (Expression FGL) :=
+  { mem_op := 3
+    ptr := row.rom.b_offset_imm0
+    timestamp := row.rom.b_reg_prev_mem_step
+    width := 8
+    value_0 := row.core.b_0
+    value_1 := row.core.b_1 }
+
+/-- c-side register previous-access producer message (`main.pil:316-319`). -/
+@[reducible]
+def cRegPreMessageExpr (row : Var MainRowWithRom FGL) :
+    MemBusMessage (Expression FGL) :=
+  { mem_op := 3
+    ptr := row.rom.store_offset
+    timestamp := row.rom.store_reg_prev_mem_step
+    width := 8
+    value_0 := row.rom.store_reg_prev_value_0
+    value_1 := row.rom.store_reg_prev_value_1 }
+
+/-- Main constraints + ROM lookup + row-local memory-bus emissions.
+    Composes `mainWithRom` with the six `MemBusChannel.emit` interactions
+    matching `main.pil:277,284,293,300,316,323`. -/
 @[circuit_norm]
 def mainWithRomAndMemBus (length : ℕ) (program : Program length)
     (row : Var MainRowWithRom FGL) : Circuit FGL Unit := do
   mainWithRom length program row
-  -- a-side push (active when a_src_mem ∨ a_src_reg).
+  -- a-side register previous-access push (active when a_src_reg).
+  MemBusChannel.emit row.rom.a_src_reg (aRegPreMessageExpr row)
+  -- a-side current pull (active when a_src_mem ∨ a_src_reg).
   MemBusChannel.emit (-(row.rom.a_src_mem + row.rom.a_src_reg))
     (aMemMessageExpr row)
-  -- b-side push (active when b_src_mem ∨ b_src_ind ∨ b_src_reg).
+  -- b-side register previous-access push (active when b_src_reg).
+  MemBusChannel.emit row.rom.b_src_reg (bRegPreMessageExpr row)
+  -- b-side current pull (active when b_src_mem ∨ b_src_ind ∨ b_src_reg).
   MemBusChannel.emit (-(row.rom.b_src_mem + row.rom.b_src_ind + row.rom.b_src_reg))
     (bMemMessageExpr row)
-  -- c-side push (active when store_mem ∨ store_ind ∨ store_reg).
+  -- c-side register previous-access push (active when store_reg).
+  MemBusChannel.emit row.rom.store_reg (cRegPreMessageExpr row)
+  -- c-side current pull (active when store_mem ∨ store_ind ∨ store_reg).
   MemBusChannel.emit (-(row.rom.store_mem + row.rom.store_ind + row.rom.store_reg))
     (cMemMessageExpr row)
 
-/-- Elaborated `mainWithRomAndMemBus` circuit. Exposes the 3 mem-bus
-    consumer interactions as channel emissions; the ROM lookup is an
+/-- Elaborated `mainWithRomAndMemBus` circuit. Exposes the six row-local
+    mem-bus interactions as channel emissions; the ROM lookup is an
     internal `Table.fromStatic` consumer push and does not surface as
     a channel interaction. -/
 @[reducible] def mainWithRomAndMemBusElaborated
@@ -418,16 +461,23 @@ def mainWithRomAndMemBus (length : ℕ) (program : Program length)
   channelsWithRequirements := [MemBusChannel.toRaw]
   exposedChannels row _ :=
     expose MemBusChannel
-      [ MemBusChannel.emitted (-(row.rom.a_src_mem + row.rom.a_src_reg))
+      [ MemBusChannel.emitted row.rom.a_src_reg
+          (aRegPreMessageExpr row)
+      , MemBusChannel.emitted (-(row.rom.a_src_mem + row.rom.a_src_reg))
           (aMemMessageExpr row)
+      , MemBusChannel.emitted row.rom.b_src_reg
+          (bRegPreMessageExpr row)
       , MemBusChannel.emitted (-(row.rom.b_src_mem + row.rom.b_src_ind + row.rom.b_src_reg))
           (bMemMessageExpr row)
+      , MemBusChannel.emitted row.rom.store_reg
+          (cRegPreMessageExpr row)
       , MemBusChannel.emitted (-(row.rom.store_mem + row.rom.store_ind + row.rom.store_reg))
           (cMemMessageExpr row) ]
   channelsLawful := by
     simp only [circuit_norm, mainWithRomAndMemBus, mainWithRom, main,
       romMessageExpr, romFlagsExpr, romStaticTable,
       aMemMessageExpr, bMemMessageExpr, cMemMessageExpr,
+      aRegPreMessageExpr, bRegPreMessageExpr, cRegPreMessageExpr,
       aMemOpExpr, bMemOpExpr, cMemOpExpr,
       storeValueLoExpr, storeValueHiExpr, MemBusChannel]
 
@@ -463,10 +513,16 @@ def mainWithRomMemAndOpBus (length : ℕ) (program : Program length)
   channelsWithRequirements := [MemBusChannel.toRaw, OpBusChannel.toRaw]
   exposedChannels row _ :=
     expose MemBusChannel
-      [ MemBusChannel.emitted (-(row.rom.a_src_mem + row.rom.a_src_reg))
+      [ MemBusChannel.emitted row.rom.a_src_reg
+          (aRegPreMessageExpr row)
+      , MemBusChannel.emitted (-(row.rom.a_src_mem + row.rom.a_src_reg))
           (aMemMessageExpr row)
+      , MemBusChannel.emitted row.rom.b_src_reg
+          (bRegPreMessageExpr row)
       , MemBusChannel.emitted (-(row.rom.b_src_mem + row.rom.b_src_ind + row.rom.b_src_reg))
           (bMemMessageExpr row)
+      , MemBusChannel.emitted row.rom.store_reg
+          (cRegPreMessageExpr row)
       , MemBusChannel.emitted (-(row.rom.store_mem + row.rom.store_ind + row.rom.store_reg))
           (cMemMessageExpr row) ]
     ++ expose OpBusChannel
@@ -476,6 +532,7 @@ def mainWithRomMemAndOpBus (length : ℕ) (program : Program length)
     simp [circuit_norm, mainWithRomMemAndOpBus, mainWithRomAndMemBus,
       mainWithRom, main, romMessageExpr, romFlagsExpr, romStaticTable,
       aMemMessageExpr, bMemMessageExpr, cMemMessageExpr,
+      aRegPreMessageExpr, bRegPreMessageExpr, cRegPreMessageExpr,
       aMemOpExpr, bMemOpExpr, cMemOpExpr,
       storeValueLoExpr, storeValueHiExpr, opBusMessageExpr,
       MemBusChannel, OpBusChannel]

--- a/ZiskFv/AirsClean/Main/Row.lean
+++ b/ZiskFv/AirsClean/Main/Row.lean
@@ -111,6 +111,17 @@ structure MainRomRow (F : Type) where
       segment public + the SEGMENT_STEP fixed column is a cross-row
       concern outside the per-row Spec. -/
   main_step : F
+  -- #225 register-consistency additions: row-local previous-access columns.
+  /-- Previous a-register access memory step (`main.pil:261,277-279`). -/
+  a_reg_prev_mem_step : F
+  /-- Previous b-register access memory step (`main.pil:262,293-295`). -/
+  b_reg_prev_mem_step : F
+  /-- Previous store-register access memory step (`main.pil:263,316-318`). -/
+  store_reg_prev_mem_step : F
+  /-- Low lane of previous store-register value (`main.pil:264,316-319`). -/
+  store_reg_prev_value_0 : F
+  /-- High lane of previous store-register value (`main.pil:264,316-319`). -/
+  store_reg_prev_value_1 : F
 deriving ProvableStruct
 
 /-- The combined Main + ROM witness layout, used by `mainWithRom`. -/

--- a/ZiskFv/Compliance/TraceLevelExport/Base.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/Base.lean
@@ -138,7 +138,12 @@ noncomputable def mainRowProvenance_of_pins
       a_src_reg := ZiskFv.Compliance.selectorF er.aSrc ZiskFv.Compliance.ExtractedConst.srcReg
       b_src_reg := ZiskFv.Compliance.selectorF er.bSrc ZiskFv.Compliance.ExtractedConst.srcReg
       store_reg := ZiskFv.Compliance.selectorF er.store ZiskFv.Compliance.ExtractedConst.storeReg
-      addr0 := 0, addr1 := 0, addr2 := 0, main_step := 0 }
+      addr0 := 0, addr1 := 0, addr2 := 0, main_step := 0
+      a_reg_prev_mem_step := 0
+      b_reg_prev_mem_step := 0
+      store_reg_prev_mem_step := 0
+      store_reg_prev_value_0 := 0
+      store_reg_prev_value_1 := 0 }
   { mainRow := { core := ZiskFv.AirsClean.Main.rowAt m r, rom := rom }
     extractedRow := er
     row_eq := rfl
@@ -191,7 +196,12 @@ noncomputable def mainConstVar (row : ZiskFv.AirsClean.Main.MainRowWithRom FGL) 
         b_src_ind := .const row.rom.b_src_ind, a_src_reg := .const row.rom.a_src_reg
         b_src_reg := .const row.rom.b_src_reg, store_reg := .const row.rom.store_reg
         addr0 := .const row.rom.addr0, addr1 := .const row.rom.addr1
-        addr2 := .const row.rom.addr2, main_step := .const row.rom.main_step } }
+        addr2 := .const row.rom.addr2, main_step := .const row.rom.main_step
+        a_reg_prev_mem_step := .const row.rom.a_reg_prev_mem_step
+        b_reg_prev_mem_step := .const row.rom.b_reg_prev_mem_step
+        store_reg_prev_mem_step := .const row.rom.store_reg_prev_mem_step
+        store_reg_prev_value_0 := .const row.rom.store_reg_prev_value_0
+        store_reg_prev_value_1 := .const row.rom.store_reg_prev_value_1 } }
 
 /-- `eval env (mainConstVar row) = row` for any `env`: every leaf is a `.const`,
     so `eval` distributes to the carried concrete value. -/


### PR DESCRIPTION
Part 1 of #225.

This lands the row-local Main fidelity piece for register `mem_op = 3` traffic:

- add the three PIL-backed register-prev MemBus push emissions for `a`, `b`, and `store`
- surface the corresponding prev-step / prev-value fields through Main row/free/provenance data
- update Main MemBus row extraction and reverse bridge predicates from 3 to 6 cases
- retire the stale pull-or-zero Main self-provider path, since register-prev pushes make Main self-providers intentional

Not included here:

- boot global-pull representation
- per-segment reload boundary representation
- the final `add x1,x1,x1` constructible balance witness
- trust-ledger / V1/V2 integration cleanup

Verification run locally:

- `rtk lake build ZiskFv.AirsClean.Main.Circuit`
- `rtk lake build ZiskFv.AirsClean.FullEnsemble.Balance.RowExtraction`
- `rtk lake build ZiskFv.AirsClean.FullEnsemble.Balance.MemBusRowBridges`
- `rtk lake build ZiskFv.AirsClean.FullEnsemble.Balance`
- `rtk lake env lean ZiskFv/Scratch_RegBalanceSpike.lean` with axioms `[propext, Classical.choice, Quot.sound]`
- full `rtk lake build ZiskFv`

Refs #225.