### PR TITLE
Wire register MemBus witness into trust gates

### DIFF
--- a/trust/consistency/completeness_witness_main.lean
+++ b/trust/consistency/completeness_witness_main.lean
@@ -27,7 +27,12 @@ private def mainRomFree : MainRomFreeCols :=
     b_1 := 21
     im_high_degree_2 := 0
     segment_l1 := 0
-    main_step := 7 }
+    main_step := 7
+    a_reg_prev_mem_step := 0
+    b_reg_prev_mem_step := 0
+    store_reg_prev_mem_step := 0
+    store_reg_prev_value_0 := 0
+    store_reg_prev_value_1 := 0 }
 
 private def finOne : Fin 1 := ⟨0, by decide⟩
 

--- a/trust/consistency/global_theorem_instantiation_ld.lean
+++ b/trust/consistency/global_theorem_instantiation_ld.lean
@@ -156,7 +156,12 @@ private def ldMainFree : MainRomFreeCols :=
     b_1 := 0
     im_high_degree_2 := 0
     segment_l1 := 0
-    main_step := 0 }
+    main_step := 0
+    a_reg_prev_mem_step := 0
+    b_reg_prev_mem_step := 0
+    store_reg_prev_mem_step := 0
+    store_reg_prev_value_0 := 0
+    store_reg_prev_value_1 := 0 }
 
 private def ldMainRow : MainRowWithRom FGL :=
   mainRomRowOf ldRomMessage ldRomBits .internalCopyB ldMainFree
@@ -226,7 +231,12 @@ private def ldMainRowVar : Var ZiskFv.AirsClean.Main.MainRowWithRom FGL :=
         addr0 := .const ldMainRow.rom.addr0
         addr1 := .const ldMainRow.rom.addr1
         addr2 := .const ldMainRow.rom.addr2
-        main_step := .const ldMainRow.rom.main_step } }
+        main_step := .const ldMainRow.rom.main_step
+        a_reg_prev_mem_step := .const ldMainRow.rom.a_reg_prev_mem_step
+        b_reg_prev_mem_step := .const ldMainRow.rom.b_reg_prev_mem_step
+        store_reg_prev_mem_step := .const ldMainRow.rom.store_reg_prev_mem_step
+        store_reg_prev_value_0 := .const ldMainRow.rom.store_reg_prev_value_0
+        store_reg_prev_value_1 := .const ldMainRow.rom.store_reg_prev_value_1 } }
 
 private def ldMemRowVar : Var ZiskFv.AirsClean.Mem.MemRow FGL :=
   ZiskFv.AirsClean.Mem.constVar ldMemRow

--- a/trust/consistency/register_mem_bus_add_x1_x1_x1.lean
+++ b/trust/consistency/register_mem_bus_add_x1_x1_x1.lean
@@ -1,0 +1,22 @@
+import ZiskFv.Compliance.RegisterMemBusBalance
+
+/-!
+# Register MemBus balance witness for `add x1,x1,x1`
+
+Gate-discovered wrapper for issue #225's checked register-memory-bus balance
+artifact.  The theorem lives in main Lake under
+`ZiskFv.Compliance.RegisterMemBusBalance`; this file keeps its axiom closure
+visible to the semantic trust gate.
+-/
+
+namespace ZiskFv.TrustConsistency
+
+open ZiskFv.Compliance.RegisterMemBusBalance
+
+theorem register_mem_bus_add_x1_x1_x1_witness :
+    BalancedInteractions (pairedInteractions addX1X1X1RegisterMessages) :=
+  addX1X1X1_registerMemBus_balanced
+
+#print axioms register_mem_bus_add_x1_x1_x1_witness
+
+end ZiskFv.TrustConsistency

--- a/trust/consistency/root_soundness_instantiation_degenerate.lean
+++ b/trust/consistency/root_soundness_instantiation_degenerate.lean
@@ -138,13 +138,37 @@ private def sail : SailTrace 0 := nofun
 
 private def step : ∀ i : Fin 0, ZiskStep trace i := nofun
 
+private def emptySeedState : ZiskFv.ZiskCircuit.MemTrace.SailState :=
+  default
+
+private def emptySeedFacts :
+    ZiskFv.AirsClean.Mem.GeneratedMemReplayFacts emptySeedState [] :=
+  { initialMemory := emptySeedState.mem
+    prefixReadSound := by
+      intro priorRows _row _laterRows h_split _h_as _h_mult
+      cases priorRows <;> simp at h_split
+    initialAgreement := by
+      intro _addr
+      rfl }
+
+private def emptyBootSeed : BootSegmentMemorySeed trace sail step :=
+  { initialState := emptySeedState
+    rows := []
+    facts := emptySeedFacts
+    stateAt := fun _ => emptySeedState
+    h_seed := rfl
+    coherence := trivial
+    placement := by
+      intro i
+      exact i.elim0 }
+
 /-- `root_soundness` applied to a concrete (degenerate) accepted trace. The `Fin 0`
     conclusion is vacuous, but the term genuinely constructs an `AcceptedZiskTrace`
     and feeds it through the headline theorem — witnessing that the object
     `root_soundness` quantifies over is inhabited and accepted. -/
 theorem root_soundness_instantiation_degenerate :
     ∀ i : Fin 0, StepSound trace sail i (step i) :=
-  root_soundness 0 trace sail step nofun nofun nofun
+  root_soundness 0 trace sail step nofun nofun emptyBootSeed nofun
 
 #print axioms root_soundness_instantiation_degenerate
 

--- a/trust/scripts/check-all-semantic.sh
+++ b/trust/scripts/check-all-semantic.sh
@@ -63,26 +63,36 @@ run_root_soundness_instantiations() {
   return $ok
 }
 
-run "1/15 axiom-deps baseline (V2)"        "$dir/check-axiom-deps.sh"
-run "2/15 forbidden types (V2)"            "$dir/check-no-output-eq-v2.sh"
-run "3/15 closure vs baseline-axioms (V2)" "$dir/check-closure-vs-baseline.sh"
-run "4/15 global theorem binders (V2)"     "$dir/check-global-theorem-binders.sh"
-run "5/15 strong-export axiom closure (V2)" "$dir/check-strong-export-closure.sh"
-run "6/15 strong-export binders + forbidden types (V2)" "$dir/check-strong-export-binders.sh"
-run "7/15 consistency false probe rejected" reject_false_probe
-run "8/15 Sail memory timeline witness" \
+run_register_mem_bus_witnesses() {
+  local ok=0
+  for f in trust/consistency/register_mem_bus_*.lean; do
+    [ -e "$f" ] || continue
+    run_lean_no_sorry "$f" || ok=1
+  done
+  return $ok
+}
+
+run "1/16 axiom-deps baseline (V2)"        "$dir/check-axiom-deps.sh"
+run "2/16 forbidden types (V2)"            "$dir/check-no-output-eq-v2.sh"
+run "3/16 closure vs baseline-axioms (V2)" "$dir/check-closure-vs-baseline.sh"
+run "4/16 global theorem binders (V2)"     "$dir/check-global-theorem-binders.sh"
+run "5/16 strong-export axiom closure (V2)" "$dir/check-strong-export-closure.sh"
+run "6/16 strong-export binders + forbidden types (V2)" "$dir/check-strong-export-binders.sh"
+run "7/16 consistency false probe rejected" reject_false_probe
+run "8/16 Sail memory timeline witness" \
   run_lean_no_sorry trust/consistency/load_byte_agreement_witness.lean
-run "9/15 memory timeline construction witness" \
+run "9/16 memory timeline construction witness" \
   run_lean_no_sorry trust/consistency/memory_timeline_construction_witness.lean
-run "10/15 memory prefix alignment witness" \
+run "10/16 memory prefix alignment witness" \
   run_lean_no_sorry trust/consistency/memory_prefix_alignment_witness.lean
-run "11/15 global ADD theorem instantiation" \
+run "11/16 global ADD theorem instantiation" \
   run_lean_no_sorry trust/consistency/global_theorem_instantiation_add.lean
-run "12/15 global LD theorem instantiation" \
+run "12/16 global LD theorem instantiation" \
   run_lean_no_sorry trust/consistency/global_theorem_instantiation_ld.lean
-run "13/15 root_soundness instantiation witnesses" run_root_soundness_instantiations
-run "14/15 Clean completeness witnesses" run_witnesses
-run "15/15 Aeneas extraction-pin raw axiom closure (V2)" \
+run "13/16 root_soundness instantiation witnesses" run_root_soundness_instantiations
+run "14/16 Clean completeness witnesses" run_witnesses
+run "15/16 register MemBus balance witnesses" run_register_mem_bus_witnesses
+run "16/16 Aeneas extraction-pin raw axiom closure (V2)" \
   "$dir/check-extraction-closure.sh"
 
 if [ $overall -eq 0 ]; then

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -371,6 +371,35 @@ seed memory, with the post-store cursor state differing from the initial state i
 `regs` **and** `cycleCount` (`witnessStore_nondegenerate`), so it is not the
 frozen-state floor. Both depend on kernel axioms only.
 
+### Register MemBus balance (`MEMORY_REG_OP`) — #225 constructibility slice
+
+The Clean Main component now models the row-local register-consistency emissions
+that real ZisK sends on the shared MemBus: for `a`, `b`, and `store` register
+accesses, Main emits the previous register access as a `MEMORY_REG_OP`
+push-prev message in addition to the existing current-access pull. These are
+PIL-backed fidelity emissions, not a new trust premise and not a new AIR or Mem
+component behavior.
+
+The boot and reload ends of the register chain remain boundary-shaped terms:
+ZisK's boot `global_init_mem` contributes the step-0 zero register pulls, while
+the per-segment reload contributes the final register pushes. Those are not
+modeled as ordinary per-row Main-table emissions. Instead, the checked
+constructibility artifact
+`ZiskFv.Compliance.RegisterMemBusBalance.addX1X1X1_registerMemBus_balanced`
+lists the concrete register MemBus messages for the minimal no-prelude real
+register witness `add x1,x1,x1`: x1's boot/read/read/write/reload timeline plus
+the idle boot/reload zero pairs for tracked registers x2..x31. It proves that
+every listed message appears once as a pull and once as a push, so the register
+MemBus contribution balances. The semantic trust gate discovers the wrapper
+`trust/consistency/register_mem_bus_add_x1_x1_x1.lean`; its axiom closure is
+kernel-only (`propext`, `Classical.choice`, `Quot.sound`) and adds no project
+axioms.
+
+This slice does **not** claim register/memory access-ordering soundness. The
+monotone previous-step range checks are range/table obligations, not MemBus
+channel messages, and their full composition remains on the #169/#19
+range-fidelity axis.
+
 ## Platform Profile
 
 There are no project axioms for the current platform profile. PMP, PMA,


### PR DESCRIPTION
Part 3 of the #225 split after #228 and #229.

Changes:
- Add a trust/consistency wrapper for the checked add x1,x1,x1 register MemBus balance witness.
- Teach V2 to discover register_mem_bus_*.lean witnesses.
- Document the #225 constructibility slice and ordering residual in the trust ledger.
- Repair existing trust witnesses for the new Main ROM fields and root_soundness bootSeed argument.

Verification:
- lake env lean trust/consistency/register_mem_bus_add_x1_x1_x1.lean
- lake env lean trust/consistency/completeness_witness_main.lean
- lake env lean trust/consistency/global_theorem_instantiation_ld.lean
- lake env lean trust/consistency/root_soundness_instantiation_degenerate.lean
- trust/scripts/check-all.sh
- trust/scripts/check-all-semantic.sh
- nix run .#test