### PR TITLE
#225: model register MemBus (MEMORY_REG_OP) so the ensemble balances for real instructions

### DIFF
--- a/ZiskFv/AirsClean/FullEnsemble.lean
+++ b/ZiskFv/AirsClean/FullEnsemble.lean
@@ -9,6 +9,7 @@ import ZiskFv.AirsClean.Mem.Circuit
 import ZiskFv.AirsClean.MemAlign.Circuit
 import ZiskFv.AirsClean.MemAlignByte.Circuit
 import ZiskFv.AirsClean.MemAlignReadByte.Circuit
+import ZiskFv.AirsClean.RegisterBoundary
 import Clean.Air.Vm
 
 /-!
@@ -121,6 +122,13 @@ def fullRv64imSoundEnsemble (length : ℕ) (program : Program length) :
         (by simp [circuit_norm, ZiskFv.AirsClean.MemAlignReadByte.component,
           ZiskFv.AirsClean.MemAlignReadByte.circuit,
           ZiskFv.AirsClean.MemAlignReadByte.memAlignReadByteElaborated])
+    |>.addTable ZiskFv.AirsClean.RegisterBoundary.component
+        (by simp [circuit_norm, ZiskFv.AirsClean.RegisterBoundary.component,
+          ZiskFv.AirsClean.RegisterBoundary.circuit,
+          ZiskFv.AirsClean.RegisterBoundary.registerBoundaryElaborated])
+        (by simp [circuit_norm, ZiskFv.AirsClean.RegisterBoundary.component,
+          ZiskFv.AirsClean.RegisterBoundary.circuit,
+          ZiskFv.AirsClean.RegisterBoundary.registerBoundaryElaborated])
     |>.addFinishedChannel OpBusChannel.toRaw
     |>.addFinishedChannel MemBusChannel.toRaw
 
@@ -135,7 +143,7 @@ theorem fullRv64imSoundEnsemble_assumptionsConsistency (length : ℕ) (program :
   clear h_mem
   simp only [fullRv64imSoundEnsemble, circuit_norm, Ensemble.allTables] at h
   rcases h with
-    h | h | h | h | h | h | h | h | h | h | h <;>
+    h | h | h | h | h | h | h | h | h | h | h | h <;>
     (rw [h]
      trivial)
 

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/Classification.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/Classification.lean
@@ -28,6 +28,7 @@ theorem component_mem_fullRv64im_cases
     {component : Component FGL}
     (h_mem : component ∈ (fullRv64imEnsemble length program).ensemble.allTables) :
     component = (fullRv64imEnsemble length program).ensemble.verifierTable
+      ∨ component = ZiskFv.AirsClean.RegisterBoundary.component
       ∨ component = ZiskFv.AirsClean.MemAlignReadByte.component
       ∨ component = ZiskFv.AirsClean.MemAlignByte.component
       ∨ component = ZiskFv.AirsClean.MemAlign.component
@@ -42,21 +43,9 @@ theorem component_mem_fullRv64im_cases
   simp [fullRv64imEnsemble, fullRv64imSoundEnsemble, SoundEnsemble.toFormal, Ensemble.allTables,
     SoundEnsemble.addTable_tables, SoundEnsemble.addFinishedChannel_tables]
     at h_mem
-  rcases h_mem with
-    h_verifier | h_marb | h_mab | h_memAlign | h_mem | h_arithDiv |
-    h_arithMul | h_binExt | h_binary | h_binaryAdd | h_main | h_empty
-  · exact Or.inl h_verifier
-  · exact Or.inr (Or.inl h_marb)
-  · exact Or.inr (Or.inr (Or.inl h_mab))
-  · exact Or.inr (Or.inr (Or.inr (Or.inl h_memAlign)))
-  · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inl h_mem))))
-  · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl h_arithDiv)))))
-  · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl h_arithMul))))))
-  · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl h_binExt)))))))
-  · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl h_binary))))))))
-  · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl h_binaryAdd)))))))))
-  · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr h_main)))))))))
-  · cases h_empty
+  -- `h_mem` is the `allTables`-ordered disjunction (verifier :: newest-first tables); `tauto`
+  -- reorders it into the conclusion's ordering, which is robust to the added RegisterBoundary arm.
+  tauto
 
 /-- Every concrete witness for the full RV64IM ensemble contains a table for
     the dual-aware mutable Mem component. This is only table selection: it
@@ -255,6 +244,23 @@ theorem mem_table_interactionsWith_opBus_nil
     simp [circuit_norm, ZiskFv.AirsClean.Mem.componentWithDualMemBus,
       ZiskFv.AirsClean.Mem.circuitWithDualMemBus,
       ZiskFv.AirsClean.Mem.memWithDualMemBusElaborated,
+      OpBusChannel, MemBusChannel]
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  rw [h_component]
+  exact h_not
+
+/-- A table whose component is RegisterBoundary has no operation-bus interactions
+    (it emits only on the memory bus). -/
+theorem registerBoundary_table_interactionsWith_opBus_nil
+    {table : Table FGL}
+    (h_component : table.component = ZiskFv.AirsClean.RegisterBoundary.component) :
+    table.interactionsWith OpBusChannel.toRaw = [] := by
+  have h_not :
+      OpBusChannel.toRaw ∉
+        ZiskFv.AirsClean.RegisterBoundary.component.circuit.channels := by
+    simp [circuit_norm, ZiskFv.AirsClean.RegisterBoundary.component,
+      ZiskFv.AirsClean.RegisterBoundary.circuit,
+      ZiskFv.AirsClean.RegisterBoundary.registerBoundaryElaborated,
       OpBusChannel, MemBusChannel]
   apply Table.interactionsWith_nil_of_channel_not_mem
   rw [h_component]

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/CounterpartClassification.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/CounterpartClassification.lean
@@ -137,13 +137,16 @@ theorem exists_matching_op_component_of_active_main_interaction
       table.component ∈ (fullRv64imEnsemble length program).ensemble.allTables :=
     EnsembleWitness.mem_allTables_component_of_mem_allTables h_table
   rcases component_mem_fullRv64im_cases h_component_mem with
-    h_verifier | h_marb | h_mab | h_memAlign | h_mem | h_arithDiv |
+    h_verifier | h_regBoundary | h_marb | h_mab | h_memAlign | h_mem | h_arithDiv |
     h_arithMul | h_binExt | h_binary | h_binaryAdd | h_main
   · have h_nil : table.interactionsWith OpBusChannel.toRaw = [] := by
       have h_ops_nil :
           table.component.operations.interactionsWith OpBusChannel.toRaw = [] := by
         simpa [h_verifier] using verifierTable_interactionsWith_opBus_nil length program
       simp [Table.interactionsWith, Operations.interactionValuesWith_eq_map, h_ops_nil]
+    simp [h_nil] at h_mem_table
+  · have h_nil : table.interactionsWith OpBusChannel.toRaw = [] := by
+      exact registerBoundary_table_interactionsWith_opBus_nil h_regBoundary
     simp [h_nil] at h_mem_table
   · have h_nil : table.interactionsWith OpBusChannel.toRaw = [] := by
       exact memAlignReadByte_table_interactionsWith_opBus_nil h_marb
@@ -273,7 +276,8 @@ theorem exists_matching_mem_component_of_active_main_interaction
               ∨ table.component = ZiskFv.AirsClean.MemAlign.component
               ∨ table.component = ZiskFv.AirsClean.Mem.componentWithDualMemBus
               ∨ table.component =
-                  ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program) := by
+                  ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program
+              ∨ table.component = ZiskFv.AirsClean.RegisterBoundary.component) := by
   obtain ⟨providerInteraction, h_mem_provider, h_msg, h_nonpull, h_nonzero⟩ :=
     exists_matching_nonzero_nonpull_of_active_main_mem_interaction
       witness h_balanced h_mem h_active
@@ -283,7 +287,7 @@ theorem exists_matching_mem_component_of_active_main_interaction
       table.component ∈ (fullRv64imEnsemble length program).ensemble.allTables :=
     EnsembleWitness.mem_allTables_component_of_mem_allTables h_table
   rcases component_mem_fullRv64im_cases h_component_mem with
-    h_verifier | h_marb | h_mab | h_memAlign | h_mem | h_arithDiv |
+    h_verifier | h_regBoundary | h_marb | h_mab | h_memAlign | h_mem | h_arithDiv |
     h_arithMul | h_binExt | h_binary | h_binaryAdd | h_main
   · have h_nil : table.interactionsWith MemBusChannel.toRaw = [] := by
       have h_ops_nil :
@@ -291,6 +295,12 @@ theorem exists_matching_mem_component_of_active_main_interaction
         simpa [h_verifier] using verifierTable_interactionsWith_memBus_nil length program
       simp [Table.interactionsWith, Operations.interactionValuesWith_eq_map, h_ops_nil]
     simp [h_nil] at h_mem_table
+  · -- RegisterBoundary is a genuine MemBus provider (its boot/reload register emissions).
+    exact ⟨providerInteraction, by
+        rw [EnsembleWitness.mem_interactionsWith]
+        exact ⟨table, h_table, h_mem_table⟩,
+      h_msg, h_nonpull, h_nonzero, table, h_table, h_mem_table,
+      Or.inr (Or.inr (Or.inr (Or.inr (Or.inr h_regBoundary))))⟩
   · exact ⟨providerInteraction, by
         rw [EnsembleWitness.mem_interactionsWith]
         exact ⟨table, h_table, h_mem_table⟩,
@@ -330,7 +340,7 @@ theorem exists_matching_mem_component_of_active_main_interaction
         rw [EnsembleWitness.mem_interactionsWith]
         exact ⟨table, h_table, h_mem_table⟩,
       h_msg, h_nonpull, h_nonzero, table, h_table, h_mem_table,
-      Or.inr (Or.inr (Or.inr (Or.inr h_main)))⟩
+      Or.inr (Or.inr (Or.inr (Or.inr (Or.inl h_main))))⟩
 
 
 end ZiskFv.AirsClean.FullEnsemble

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean
@@ -348,7 +348,12 @@ theorem exists_mem_provider_row_msg_eq_of_active_main_table_interaction
                   providerTable.component =
                     ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program
                     ∧ MainMemBusRowInteractionEval
-                      program providerTable providerRow providerInteraction)) := by
+                      program providerTable providerRow providerInteraction)
+                -- Register boundary provider (register `mem_op=3` boot/reload emission).
+                -- Carried structurally; excluded for data-memory (`mem_op∈{1,2}`) mains downstream
+                -- by `mem_op` disjointness (`registerBoundary` msgs have `mem_op=3`).
+                ∨ providerTable.component =
+                    ZiskFv.AirsClean.RegisterBoundary.component) := by
   have h_main_mem_witness :
       mainInteraction ∈ witness.interactionsWith MemBusChannel.toRaw := by
     rw [EnsembleWitness.mem_interactionsWith]
@@ -362,7 +367,7 @@ theorem exists_mem_provider_row_msg_eq_of_active_main_table_interaction
   refine ⟨mainRow, h_mainRow, h_mainEval, providerInteraction,
     h_provider_witness, h_msg, h_nonpull, h_nonzero, providerTable, h_providerTable,
     h_providerInteraction, ?_⟩
-  rcases h_providerComponent with h_marb | h_mab | h_memAlign | h_mem | h_main
+  rcases h_providerComponent with h_marb | h_mab | h_memAlign | h_mem | h_main | h_regBoundary
   · obtain ⟨providerRow, h_providerRow, h_providerEval⟩ :=
       exists_memAlignReadByte_row_eval_of_interaction_mem
         h_marb h_providerInteraction
@@ -399,7 +404,15 @@ theorem exists_mem_provider_row_msg_eq_of_active_main_table_interaction
     right
     right
     right
+    left
     exact ⟨providerRow, h_providerRow, h_main, h_providerEval⟩
+  · -- RegisterBoundary provider: carried structurally (register mem_op=3 emission).
+    right
+    right
+    right
+    right
+    right
+    exact h_regBoundary
 
 /-- Spec-carrying variant of
     `exists_mem_provider_row_msg_eq_of_active_main_table_interaction`.
@@ -481,7 +494,10 @@ theorem exists_mem_provider_row_msg_eq_spec_of_active_main_table_interaction
                       ∧ providerTable.component =
                         ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program
                       ∧ MainMemBusRowInteractionEval
-                        program providerTable providerRow providerInteraction)) := by
+                        program providerTable providerRow providerInteraction)
+                  -- Register boundary provider (register `mem_op=3` emission), carried structurally.
+                  ∨ providerTable.component =
+                      ZiskFv.AirsClean.RegisterBoundary.component) := by
   obtain ⟨mainRow, h_mainRow, h_mainEval, providerInteraction,
       h_provider_witness, h_msg, h_nonpull, h_nonzero, providerTable, h_providerTable,
       h_providerInteraction, h_providerComponent⟩ :=
@@ -495,7 +511,7 @@ theorem exists_mem_provider_row_msg_eq_spec_of_active_main_table_interaction
     h_providerTable, h_providerInteraction, ?_⟩
   have h_providerSpecs : providerTable.Spec :=
     h_specs providerTable h_providerTable
-  rcases h_providerComponent with h_marb | h_mab | h_memAlign | h_mem | h_main
+  rcases h_providerComponent with h_marb | h_mab | h_memAlign | h_mem | h_main | h_regBoundary
   · rcases h_marb with ⟨providerRow, h_providerRow, h_component, h_eval⟩
     left
     exact ⟨providerRow, h_providerRow,
@@ -523,8 +539,16 @@ theorem exists_mem_provider_row_msg_eq_spec_of_active_main_table_interaction
     right
     right
     right
+    left
     exact ⟨providerRow, h_providerRow,
       h_providerSpecs providerRow h_providerRow, h_component, h_eval⟩
+  · -- RegisterBoundary provider: carried structurally (register mem_op=3 emission).
+    right
+    right
+    right
+    right
+    right
+    exact h_regBoundary
 
 /-- Selected-branch legacy-entry view of the full-ensemble memory-bus bridge.
 
@@ -657,7 +681,10 @@ theorem exists_mem_provider_row_matches_entry_spec_of_active_main_eval
                       ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program
                     ∧ MainMemBusRowInteractionMatchEval
                       program providerTable providerRow providerInteraction mainMsg
-                      (mainTable.environment mainRow) multiplicity as)) := by
+                      (mainTable.environment mainRow) multiplicity as)
+                -- Register boundary provider (register `mem_op=3` emission), carried structurally.
+                ∨ providerTable.component =
+                    ZiskFv.AirsClean.RegisterBoundary.component) := by
   have h_main_mem_witness :
       mainInteraction ∈ witness.interactionsWith MemBusChannel.toRaw := by
     rw [EnsembleWitness.mem_interactionsWith]
@@ -674,7 +701,7 @@ theorem exists_mem_provider_row_matches_entry_spec_of_active_main_eval
     h_providerInteraction, ?_⟩
   have h_providerSpecs : providerTable.Spec :=
     h_specs providerTable h_providerTable
-  rcases h_providerComponent with h_marb | h_mab | h_memAlign | h_mem | h_main
+  rcases h_providerComponent with h_marb | h_mab | h_memAlign | h_mem | h_main | h_regBoundary
   · obtain ⟨providerRow, h_providerRow, h_providerEval⟩ :=
       exists_memAlignReadByte_row_eval_of_interaction_mem
         h_marb h_providerInteraction
@@ -735,6 +762,7 @@ theorem exists_mem_provider_row_matches_entry_spec_of_active_main_eval
     right
     right
     right
+    left
     refine ⟨providerRow, h_providerRow,
       h_providerSpecs providerRow h_providerRow, h_main, ?_⟩
     rcases h_providerEval with h_a_prev | h_a | h_b_prev | h_b | h_c_prev | h_c
@@ -782,6 +810,13 @@ theorem exists_mem_provider_row_matches_entry_spec_of_active_main_eval
       apply ZiskFv.Airs.MemoryBus.matches_memory_entry_of_eval_emitted_provider_msg_eq
       rw [← h_c, ← h_mainEval]
       exact h_msg
+  · -- RegisterBoundary provider: carried structurally (register mem_op=3 emission).
+    right
+    right
+    right
+    right
+    right
+    exact h_regBoundary
 
 /-- Named provider-row coverage produced by a balanced active Main memory-bus
     interaction.
@@ -901,7 +936,10 @@ def ActiveMainMemProviderRowMatchSpec
                   ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program
                 ∧ MainMemBusRowInteractionMatchEval
                   program providerTable providerRow providerInteraction mainMsg
-                  (mainTable.environment mainRow) multiplicity as))
+                  (mainTable.environment mainRow) multiplicity as)
+            -- Register boundary provider (register `mem_op=3` emission), carried structurally.
+            ∨ providerTable.component =
+                ZiskFv.AirsClean.RegisterBoundary.component)
 
 /-- Mutable-Mem branch of `ActiveMainMemProviderRowMatchSpec`.
 
@@ -1040,7 +1078,10 @@ def ActiveMainNonMutableMemProviderRowMatchSpec
                   ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program
                 ∧ MainMemBusRowInteractionMatchEval
                   program providerTable providerRow providerInteraction mainMsg
-                  (mainTable.environment mainRow) multiplicity as))
+                  (mainTable.environment mainRow) multiplicity as)
+            -- Register boundary provider (register `mem_op=3` emission), carried structurally.
+            ∨ providerTable.component =
+                ZiskFv.AirsClean.RegisterBoundary.component)
 
 /-- MemAlignReadByte branch of
     `ActiveMainNonMutableMemProviderRowMatchSpec`. -/
@@ -1171,6 +1212,27 @@ def ActiveMainSelfMemProviderRowMatchSpec
                 program providerTable providerRow providerInteraction mainMsg
                 (mainTable.environment mainRow) multiplicity as
 
+/-- Register-boundary provider branch of `ActiveMainNonMutableMemProviderRowMatchSpec`.
+
+The register `mem_op=3` boot/reload emission carried structurally: it records only that the
+same-message counterpart lives in a RegisterBoundary table.  For data-memory (`mem_op∈{1,2}`) mains
+this branch is unreachable by `mem_op` disjointness, but this repackaging layer stays general. -/
+def ActiveMainRegisterBoundaryProviderRowMatchSpec
+    {length : ℕ} (program : Program length)
+    (witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble)
+    (_mainTable : Table FGL)
+    (_mainRow : Array FGL)
+    (mainInteraction : Interaction FGL)
+    (_mainMsg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL))
+    (_multiplicity _as : FGL) : Prop :=
+  ∃ providerInteraction ∈ witness.interactionsWith MemBusChannel.toRaw,
+    providerInteraction.msg = mainInteraction.msg
+      ∧ providerInteraction.mult ≠ -1
+      ∧ providerInteraction.mult ≠ 0
+      ∧ ∃ providerTable ∈ witness.allTables,
+        providerInteraction ∈ providerTable.interactionsWith MemBusChannel.toRaw
+          ∧ providerTable.component = ZiskFv.AirsClean.RegisterBoundary.component
+
 /-- Branch split for the non-mutable active-Main provider family. -/
 theorem activeMainNonMutableMemProviderRowMatchSpec_branch_cases
     {length : ℕ} {program : Program length}
@@ -1190,11 +1252,13 @@ theorem activeMainNonMutableMemProviderRowMatchSpec_branch_cases
       ∨ ActiveMainMemAlignProviderRowMatchSpec program witness mainTable
         mainRow mainInteraction mainMsg multiplicity as
       ∨ ActiveMainSelfMemProviderRowMatchSpec program witness mainTable
+        mainRow mainInteraction mainMsg multiplicity as
+      ∨ ActiveMainRegisterBoundaryProviderRowMatchSpec program witness mainTable
         mainRow mainInteraction mainMsg multiplicity as := by
   rcases h_nonmutable with
     ⟨providerInteraction, h_provider_witness, h_msg, h_nonpull, h_nonzero,
       providerTable, h_providerTable, h_providerInteraction, h_branch⟩
-  rcases h_branch with h_marb | h_mab | h_memAlign | h_main
+  rcases h_branch with h_marb | h_mab | h_memAlign | h_main | h_regBoundary
   · left
     exact ⟨providerInteraction, h_provider_witness, h_msg, h_nonpull,
       h_nonzero, providerTable, h_providerTable, h_providerInteraction,
@@ -1207,10 +1271,14 @@ theorem activeMainNonMutableMemProviderRowMatchSpec_branch_cases
     exact ⟨providerInteraction, h_provider_witness, h_msg, h_nonpull,
       h_nonzero, providerTable, h_providerTable, h_providerInteraction,
       h_memAlign⟩
-  · right; right; right
+  · right; right; right; left
     exact ⟨providerInteraction, h_provider_witness, h_msg, h_nonpull,
       h_nonzero, providerTable, h_providerTable, h_providerInteraction,
       h_main⟩
+  · right; right; right; right
+    exact ⟨providerInteraction, h_provider_witness, h_msg, h_nonpull,
+      h_nonzero, providerTable, h_providerTable, h_providerInteraction,
+      h_regBoundary⟩
 
 /-- Ruling out each named non-mutable branch rules out the aggregate
     non-mutable provider family. -/
@@ -1233,16 +1301,20 @@ theorem activeMainNonMutableMemProviderRowMatchSpec_of_no_branch
         mainTable mainRow mainInteraction mainMsg multiplicity as)
     (h_no_main :
       ¬ ActiveMainSelfMemProviderRowMatchSpec program witness
+        mainTable mainRow mainInteraction mainMsg multiplicity as)
+    (h_no_regBoundary :
+      ¬ ActiveMainRegisterBoundaryProviderRowMatchSpec program witness
         mainTable mainRow mainInteraction mainMsg multiplicity as) :
     ¬ ActiveMainNonMutableMemProviderRowMatchSpec program witness mainTable
       mainRow mainInteraction mainMsg multiplicity as := by
   intro h_nonmutable
   rcases activeMainNonMutableMemProviderRowMatchSpec_branch_cases
-      h_nonmutable with h_marb | h_mab | h_memAlign | h_main
+      h_nonmutable with h_marb | h_mab | h_memAlign | h_main | h_regBoundary
   · exact h_no_marb h_marb
   · exact h_no_mab h_mab
   · exact h_no_memAlign h_memAlign
   · exact h_no_main h_main
+  · exact h_no_regBoundary h_regBoundary
 
 /-- Split named active-Main provider coverage into mutable-Mem and
     non-mutable branches. -/
@@ -1264,7 +1336,7 @@ theorem activeMainMemProviderRowMatchSpec_mutable_or_nonmutable
   rcases h_match with
     ⟨providerInteraction, h_provider_witness, h_msg, h_nonpull, h_nonzero,
       providerTable, h_providerTable, h_providerInteraction, h_branch⟩
-  rcases h_branch with h_marb | h_mab | h_memAlign | h_mem | h_main
+  rcases h_branch with h_marb | h_mab | h_memAlign | h_mem | h_main | h_regBoundary
   · right
     exact ⟨providerInteraction, h_provider_witness, h_msg, h_nonpull,
       h_nonzero, providerTable, h_providerTable, h_providerInteraction,
@@ -1284,7 +1356,11 @@ theorem activeMainMemProviderRowMatchSpec_mutable_or_nonmutable
   · right
     exact ⟨providerInteraction, h_provider_witness, h_msg, h_nonpull,
       h_nonzero, providerTable, h_providerTable, h_providerInteraction,
-      Or.inr (Or.inr (Or.inr h_main))⟩
+      Or.inr (Or.inr (Or.inr (Or.inl h_main)))⟩
+  · right
+    exact ⟨providerInteraction, h_provider_witness, h_msg, h_nonpull,
+      h_nonzero, providerTable, h_providerTable, h_providerInteraction,
+      Or.inr (Or.inr (Or.inr (Or.inr h_regBoundary)))⟩
 
 /-- Direct-load route target: if non-mutable branches are ruled out, the named
     active-Main provider coverage yields the mutable-Mem provider branch. -/

--- a/ZiskFv/AirsClean/RegisterBoundary.lean
+++ b/ZiskFv/AirsClean/RegisterBoundary.lean
@@ -1,0 +1,158 @@
+import Clean.Circuit.Basic
+import Clean.Air.FlatComponent
+import Clean.Utils.Tactics
+import Clean.Utils.Tactics.ProvableStructDeriving
+import ZiskFv.Field.Goldilocks
+import ZiskFv.Channels.MemoryBus
+
+/-!
+# RegisterBoundary Clean component (issue #225) — register-file boot / reload MemBus emissions
+
+ZisK's register memory-consistency argument telescopes on the shared MemBus.  The interior
+per-row `MEMORY_REG_OP` (`mem_op = 3`) push-prev / pull-current pairs are emitted by the Main
+component (`Main/Constraints.lean`).  This component supplies the two *boundary* terms that close
+the per-register chain, which ZisK's PIL emits outside the per-row Main access loop:
+
+* **boot** — `global_init_mem` (`mem/pil/mem.pil:507-508`, per-register call site
+  `main/pil/main.pil:535-537`): `direct_global_update_assumes([MEMORY_REG_OP, addr, 0, 8, ...zeros])`,
+  seeding every tracked register to value 0 at timestamp 0.  It is a consumer/pull, so it rides a
+  `-1` multiplicity.
+* **reload** — `reg_pre_load` "Proves the last access." (`main/pil/main.pil:450`):
+  `mem_proves(MEMORY_REG_OP, addr, last_reg_mem_step, last_reg_value)`, a provider/push at `+1`.
+
+One component row models one register's boundary pair (the PIL `for (ireg ...)` loop iteration),
+carrying the register pointer plus the reload timestamp and value; the boot value is the literal 0.
+The `mem_op = 3` messages of the whole ensemble balance when boot(`-1`) + reload(`+1`) telescope
+against Main's push-prev(`+`) / pull-current(`-`) — see `Compliance/RegisterMemBusBalance.lean`.
+
+Scope: this is the single-segment global boot + last-access reload only.  The cross-segment
+continuation terms (the `MAIN_CONTINUATION_ID` block and `main.pil:454`'s
+`sel:(1-main_last_segment)` continuation pull) are out of scope (#103/#76).
+
+## Trust note
+
+`Assumptions := True` makes the ensemble `AssumptionsConsistency` obligation trivial (the added
+`rw [h]; trivial` disjunct in `fullRv64imSoundEnsemble_assumptionsConsistency`).  The component has
+no algebraic constraints: it is a deliberately under-constrained *provider* of boundary MemBus
+messages.  That is sound in the soundness direction — an under-constrained provider never makes
+`root_soundness` vacuous (the anti-laundering hazard, an overstrong validator, runs the other way).
+The bus emissions carry `MemBusChannel.Guarantees = True`, so no caller assumption is needed.  No
+axioms.
+-/
+
+namespace ZiskFv.AirsClean.RegisterBoundary
+
+open Goldilocks
+open Air.Flat
+open ZiskFv.Channels.MemoryBus (MemBusChannel MemBusMessage)
+
+/-- One register's boundary data: its MemBus pointer, and the reload (last-access) timestamp and
+    value.  The boot message is always `(mem_op=3, ptr=reg, timestamp=0, value=0)`. -/
+structure RegisterBoundaryRow (F : Type) where
+  reg : F
+  reloadTimestamp : F
+  reloadValue_0 : F
+  reloadValue_1 : F
+deriving ProvableStruct
+
+/-- The boot pull message `[MEMORY_REG_OP, reg, 0, 8, 0, 0]` (`mem.pil:507-508`). -/
+@[reducible]
+def bootMessageExpr (row : Var RegisterBoundaryRow FGL) : MemBusMessage (Expression FGL) :=
+  { mem_op := 3
+    ptr := row.reg
+    timestamp := 0
+    width := 8
+    value_0 := 0
+    value_1 := 0 }
+
+/-- The reload push message `[MEMORY_REG_OP, reg, reloadTimestamp, 8, reloadValue_0, reloadValue_1]`
+    (`main.pil:450`, `reg_pre_load` "Proves the last access."). -/
+@[reducible]
+def reloadMessageExpr (row : Var RegisterBoundaryRow FGL) : MemBusMessage (Expression FGL) :=
+  { mem_op := 3
+    ptr := row.reg
+    timestamp := row.reloadTimestamp
+    width := 8
+    value_0 := row.reloadValue_0
+    value_1 := row.reloadValue_1 }
+
+/-- Value-level boot message (evaluation target for the balance witness). -/
+@[reducible]
+def bootMessage (row : RegisterBoundaryRow FGL) : MemBusMessage FGL :=
+  { mem_op := 3
+    ptr := row.reg
+    timestamp := 0
+    width := 8
+    value_0 := 0
+    value_1 := 0 }
+
+/-- Value-level reload message (evaluation target for the balance witness). -/
+@[reducible]
+def reloadMessage (row : RegisterBoundaryRow FGL) : MemBusMessage FGL :=
+  { mem_op := 3
+    ptr := row.reg
+    timestamp := row.reloadTimestamp
+    width := 8
+    value_0 := row.reloadValue_0
+    value_1 := row.reloadValue_1 }
+
+/-- The two boundary emissions: boot pull (`-1`) then reload push (`+1`).  Bare `emit`s
+    (`assumeGuarantees = false`), exactly like Main's mem emits. -/
+@[circuit_norm]
+def main (row : Var RegisterBoundaryRow FGL) : Circuit FGL Unit := do
+  MemBusChannel.emit (-1) (bootMessageExpr row)
+  MemBusChannel.emit 1 (reloadMessageExpr row)
+
+/-- The elaborated circuit: two channel emissions, no fresh witnesses, no algebraic constraints. -/
+@[reducible] def registerBoundaryElaborated :
+    ElaboratedCircuit FGL RegisterBoundaryRow unit where
+  name := "RegisterBoundary"
+  main := main
+  localLength _ := 0
+  output _ _ := ()
+  channelsWithRequirements := [MemBusChannel.toRaw]
+  exposedChannels row _ :=
+    expose MemBusChannel
+      [ MemBusChannel.emitted (-1) (bootMessageExpr row)
+      , MemBusChannel.emitted 1 (reloadMessageExpr row) ]
+  channelsLawful := by
+    simp only [circuit_norm, main, bootMessageExpr, reloadMessageExpr, MemBusChannel]
+
+/-- RegisterBoundary as a Clean `GeneralFormalCircuit`.  `Assumptions := True` and `Spec := True`:
+    the component asserts no algebraic relation; its only obligations are the two bus emissions'
+    `MemBusChannel.Guarantees = True` requirements. -/
+def circuit : GeneralFormalCircuit FGL RegisterBoundaryRow unit :=
+  { registerBoundaryElaborated with
+    Assumptions := fun _ _ => True
+    Spec := fun _ _ _ => True
+    ProverAssumptions := fun _ _ _ => True
+    ProverSpec := fun _ _ _ => True
+    soundness := by
+      circuit_proof_start
+      intro _
+      trivial
+    completeness := by
+      circuit_proof_start [MemBusChannel] }
+
+/-- RegisterBoundary as a Clean `Air.Flat.Component`. -/
+def component : Air.Flat.Component FGL := { circuit := circuit }
+
+/-- Project the generic component `Spec` to the trivial RegisterBoundary `Spec`. -/
+theorem component_spec (env : Environment FGL) :
+    component.Spec env = True := by
+  rfl
+
+/-- The component's MemBus interactions: the boot pull and the reload push. -/
+theorem component_interactionsWith_memBus :
+    component.operations.interactionsWith MemBusChannel.toRaw =
+      [ ((MemBusChannel.emitted (-1) (bootMessageExpr component.rowInputVar)).toRaw)
+      , ((MemBusChannel.emitted 1 (reloadMessageExpr component.rowInputVar)).toRaw) ] := by
+  apply Component.interactionsWith_of_exposedChannels
+  change ⟨MemBusChannel.toRaw,
+      [ ((MemBusChannel.emitted (-1) (bootMessageExpr component.rowInputVar)).toRaw)
+      , ((MemBusChannel.emitted 1 (reloadMessageExpr component.rowInputVar)).toRaw) ]⟩ ∈
+    component.exposedChannels
+  simp only [component, circuit, registerBoundaryElaborated,
+    Component.exposedChannels, expose, List.mem_singleton, List.map_cons, List.map_nil]
+
+end ZiskFv.AirsClean.RegisterBoundary

--- a/ZiskFv/Compliance/ConstructionLoad.lean
+++ b/ZiskFv/Compliance/ConstructionLoad.lean
@@ -42,8 +42,9 @@ obligations):
    Main row's own `b` emission (`main_b_match`, `matches_memory_entry_refl`) AND
    against a *separate* Mem-AIR provider row's payload. The Mem-channel balance
    theorem `exists_matching_mem_component_of_active_main_interaction` deliberately
-   leaves a 5-way provider disjunction (MemAlign{,ReadByte,Byte} / Mem dual-bus /
-   the unified Main case) — it does NOT single out one Mem provider, "requires
+   leaves a 6-way provider disjunction (MemAlign{,ReadByte,Byte} / Mem dual-bus /
+   the unified Main case / RegisterBoundary register `mem_op=3` per #225) — it does
+   NOT single out one Mem provider, "requires
    selector legality beyond the current Main row soundness". So the provider row
    that backs the read is a named residual, NOT balance-derived here. **Flagged
    loudly per op.**
@@ -153,7 +154,7 @@ theorem mainRowWithRomLd_core
       loaded-bytes ↔ Sail-memory agreement (cross-row replay timeline).
     * `mem`, `r_mem`, `h_mem_match`, `h_mem_sel`, `h_mem_wr` — the Mem-AIR
       provider row backing the read. Not balance-derivable here (the
-      Mem-channel balance leaves a 5-way provider disjunction). -/
+      Mem-channel balance leaves a 6-way provider disjunction). -/
 theorem construction_ld_sound_claimed_dead
     (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)

--- a/ZiskFv/Compliance/RegisterMemBusBalance.lean
+++ b/ZiskFv/Compliance/RegisterMemBusBalance.lean
@@ -1,47 +1,53 @@
 import Clean.Air.Balance
 import ZiskFv.Channels.MemoryBus
 import ZiskFv.Compliance.EnsembleWitnessBuilder
+import ZiskFv.AirsClean.Main.Bridge
+import ZiskFv.AirsClean.RegisterBoundary
 
 /-!
-# Register MemBus boundary balance for the `add x1,x1,x1` witness
+# Register MemBus balance for the `add x1,x1,x1` witness (from real component emissions)
 
-Issue #225's register traffic is a telescoping MemBus argument.  Main's ordinary
-row-local register accesses supply the interior push-prev / pull-current pairs;
-boot and reload are boundary terms, not normal per-row Main-table emissions.
+Issue #225's register traffic is a telescoping MemBus argument.  For a register-register
+instruction Main emits, per operand, a `MEMORY_REG_OP` (`mem_op = 3`) push-prev (the previous
+register access) and a pull-current (the current access); the two chain-closing boundary terms —
+boot (`global_init_mem`) and reload (`reg_pre_load`) — are emitted by the RegisterBoundary
+component (`ZiskFv/AirsClean/RegisterBoundary.lean`).  All of these are now real composed-table
+emissions in `fullRv64imEnsemble` (see `AirsClean/FullEnsemble.lean`).
 
-This file records the checked boundary-shaped register contribution for the
-minimal real-register witness `add x1,x1,x1`.  Register x1 has four timeline
-messages (boot at step 0, then the two reads and write at steps 1/2/3).  The
-other tracked registers x2..x31 are idle and contribute only the boot/reload
-zero-value pair.  Every listed message appears once as a pull and once as a push,
-so the MemBus contribution balances constructively.
+This file proves that the register (`mem_op = 3`) partition of those emissions **telescopes to
+zero** for the minimal no-prelude real-register witness `add x1,x1,x1`.  Unlike the earlier
+shape-demo, the balanced messages here are the **real component emission definitions**
+(`aRegPreMessage`/`aMemMessage`/… from `Main/Bridge.lean`, `bootMessage`/`reloadMessage` from
+RegisterBoundary) instantiated at a concrete `add x1,x1,x1` `MainRowWithRom`, not hand-authored
+literals.  Their multiplicities are the emissions' own selectors: for `add x1,x1,x1` the push-prev
+selectors `a_src_reg`/`b_src_reg`/`store_reg` are `1` and the pull selectors
+`-(…_mem + … + …_reg)` are `-1`, matching `pushedValue` / `pulledValue`.
 
-This is intentionally a balance theorem over an explicit list of register MemBus
-messages.  It demonstrates the telescoping shape needed by #225, but it does not
-yet extract those messages from `fullRv64imEnsemble` rows or construct the full
-trace-level `BalancedChannels` witness; that connection is the follow-up handoff
-to #219.
+**Scope.** This is the register-partition balance (`BalancedInteractions` over the `mem_op = 3`
+messages), the object #219 consumes.  It does **not** build the whole-channel
+`witness.BalancedChannels` or the constraint-satisfying accepted trace — those stay #219.  The
+balance is conditional on the previous-step timestamp chain (`a_reg_prev_mem_step = 0`,
+`b_reg_prev_mem_step = 1`, `store_reg_prev_mem_step = 2`, reload at `3`), which ZisK's ordering/range
+checks enforce (the #169/#19 axis, `main.pil:447`), pinned here in the concrete row.  `x0` is not
+used: ZisK decodes `x0` operands as immediate/no-op register accesses emitting no `mem_op = 3`
+traffic, so `x1,x1,x1` is the minimal real-register witness.
+
+## Trust note
+
+No axioms.  `pulledValue` / `pushedValue` are Clean's `-1` / `+1` value-level channel interactions.
 -/
 
 open Goldilocks
 open ZiskFv.Channels.MemoryBus
+open ZiskFv.AirsClean.Main (MainRowWithRom aRegPreMessage aMemMessage bRegPreMessage bMemMessage
+  cRegPreMessage cMemMessage)
+open ZiskFv.AirsClean.RegisterBoundary (RegisterBoundaryRow bootMessage reloadMessage)
 
 namespace ZiskFv.Compliance.RegisterMemBusBalance
 
-/-- The PIL register-memory message `[MEMORY_REG_OP, reg, step, 8, v0, v1]`. -/
-def regMsg (reg step value0 value1 : FGL) : MemBusMessage FGL :=
-  { mem_op := 3
-    ptr := reg
-    timestamp := step
-    width := 8
-    value_0 := value0
-    value_1 := value1 }
+/-! ## Paired-interaction balance infrastructure (message-agnostic) -/
 
-/-- The all-zero register message used by the no-prelude `add x1,x1,x1` witness. -/
-def zeroRegMsg (reg step : FGL) : MemBusMessage FGL :=
-  regMsg reg step 0 0
-
-/-- One pull/push pair for the same MemBus message. -/
+/-- One pull/push pair for the same MemBus message balances. -/
 def pairedInteraction (msg : MemBusMessage FGL) : List (Interaction FGL) :=
   [MemBusChannel.pulledValue msg, MemBusChannel.pushedValue msg]
 
@@ -100,35 +106,93 @@ theorem pairedInteractions_balanced
       exact balancedInteractions_append_of_balanced
         (pairedInteraction_balanced msg) (ih h_rest_len) (by simpa [pairedInteractions] using h_len)
 
-/-- The x1 register timeline for `add x1,x1,x1`:
-    boot at 0, read-a at 1, read-b at 2, store-c at 3. -/
-def addX1TimelineMessages : List (MemBusMessage FGL) :=
-  [ zeroRegMsg 1 0
-  , zeroRegMsg 1 1
-  , zeroRegMsg 1 2
-  , zeroRegMsg 1 3 ]
+/-! ## The concrete `add x1,x1,x1` row and boundary rows -/
 
-/-- Idle tracked registers x2..x31, each at the zero boot/reload point. -/
-def idleRegisterMessages : List (MemBusMessage FGL) :=
-  (List.range 30).map fun i => zeroRegMsg ((i + 2 : Nat) : FGL) 0
+/-- The concrete register-register `add x1,x1,x1` Main row.  Register operands x1: the six MemBus
+    pointers (`a_offset_imm0`/`b_offset_imm0`/`store_offset` and `addr0`/`addr1`/`addr2`) are `1`;
+    the three register selectors are `1` and the memory selectors `0`; the previous-step chain is
+    `0/1/2`; all values `0`; `store_pc = 0` collapses the c-value to `c_0 = 0`. -/
+def addX1Row : MainRowWithRom FGL :=
+  { core :=
+      { a_0 := 0, a_1 := 0, b_0 := 0, b_1 := 0, c_0 := 0, c_1 := 0,
+        flag := 0, pc := 0, is_external_op := 1, op := 0, m32 := 0,
+        ind_width := 8, set_pc := 0, jmp_offset1 := 0, jmp_offset2 := 0,
+        store_pc := 0, im_high_degree_2 := 0, segment_l1 := 1 }
+    rom :=
+      { a_offset_imm0 := 1, a_imm1 := 0, b_offset_imm0 := 1, b_imm1 := 0,
+        store_offset := 1, a_src_imm := 0, a_src_mem := 0, is_precompiled := 0,
+        b_src_imm := 0, b_src_mem := 0, store_mem := 0, store_ind := 0,
+        b_src_ind := 0, a_src_reg := 1, b_src_reg := 1, store_reg := 1,
+        addr0 := 1, addr1 := 1, addr2 := 1, main_step := 0,
+        a_reg_prev_mem_step := 0, b_reg_prev_mem_step := 1,
+        store_reg_prev_mem_step := 2, store_reg_prev_value_0 := 0,
+        store_reg_prev_value_1 := 0 } }
 
-/-- The faithful register message set for the no-prelude `add x1,x1,x1` target.
+/-- Boundary row for register x1: reload closes the chain at the last access (ts 3), value 0. -/
+def boundaryRowX1 : RegisterBoundaryRow FGL :=
+  { reg := 1, reloadTimestamp := 3, reloadValue_0 := 0, reloadValue_1 := 0 }
 
-`add x0,x0,x0` is intentionally not used here: ZisK decodes x0 register operands
-as immediate/no-op register accesses, so it emits no register `mem_op = 3` traffic.
--/
-def addX1X1X1RegisterMessages : List (MemBusMessage FGL) :=
-  addX1TimelineMessages ++ idleRegisterMessages
+/-- Boundary row for an idle tracked register `r`: boot and reload both at ts 0, value 0. -/
+def boundaryRowIdle (r : FGL) : RegisterBoundaryRow FGL :=
+  { reg := r, reloadTimestamp := 0, reloadValue_0 := 0, reloadValue_1 := 0 }
 
-/-- Concrete explicit-message MemBus balance for the register contribution of
-    `add x1,x1,x1`: each boot/current message is paired with the corresponding
-    push-prev/reload message, and the idle registers have boot/reload zero pairs.
-    This theorem does not claim extraction from the real ensemble rows. -/
+/-! ## The real-emission register interaction list for `add x1,x1,x1` -/
+
+/-- Main's six register `mem_op=3` emissions for `add x1,x1,x1`, as value-level interactions with
+    the emissions' own multiplicities: push-prev (selector `1`) as `pushedValue`, pull-current
+    (selector `-1`) as `pulledValue`.  The messages are the real `Main/Bridge.lean` emission
+    definitions instantiated at `addX1Row`. -/
+def mainRegisterInteractions : List (Interaction FGL) :=
+  [ MemBusChannel.pushedValue (aRegPreMessage addX1Row)
+  , MemBusChannel.pulledValue (aMemMessage addX1Row)
+  , MemBusChannel.pushedValue (bRegPreMessage addX1Row)
+  , MemBusChannel.pulledValue (bMemMessage addX1Row)
+  , MemBusChannel.pushedValue (cRegPreMessage addX1Row)
+  , MemBusChannel.pulledValue (cMemMessage addX1Row) ]
+
+/-- One register's boundary contribution: boot pull + reload push (real RegisterBoundary emission
+    definitions), as value-level interactions. -/
+def boundaryInteractions (row : RegisterBoundaryRow FGL) : List (Interaction FGL) :=
+  [ MemBusChannel.pulledValue (bootMessage row)
+  , MemBusChannel.pushedValue (reloadMessage row) ]
+
+/-- Idle tracked registers x2..x31, each contributing a self-balancing boot/reload zero pair. -/
+def idleBoundaryInteractions : List (Interaction FGL) :=
+  (List.range 30).flatMap fun i => boundaryInteractions (boundaryRowIdle ((i + 2 : Nat) : FGL))
+
+/-- The full register (`mem_op=3`) MemBus interaction list for `add x1,x1,x1`: Main's six emissions,
+    x1's boot/reload, and the idle registers' boot/reload pairs. -/
+def addX1X1X1RegisterInteractions : List (Interaction FGL) :=
+  mainRegisterInteractions ++ boundaryInteractions boundaryRowX1 ++ idleBoundaryInteractions
+
+/-! ## The register consistency equalities (the telescoping content)
+
+Each Main emission message equals the boundary/adjacent emission it cancels against, because the
+previous-step chain lines the timestamps up.  These are `rfl` at the concrete `addX1Row`. -/
+
+theorem aRegPre_eq_boot : aRegPreMessage addX1Row = bootMessage boundaryRowX1 := rfl
+theorem aMem_eq_bRegPre : aMemMessage addX1Row = bRegPreMessage addX1Row := rfl
+theorem bMem_eq_cRegPre : bMemMessage addX1Row = cRegPreMessage addX1Row := rfl
+theorem cMem_eq_reload : cMemMessage addX1Row = reloadMessage boundaryRowX1 := rfl
+
+/-! ## The balance -/
+
+/-- The register (`mem_op=3`) partition of the ensemble's MemBus emissions telescopes to zero for
+    `add x1,x1,x1`, from the real component emission definitions: every distinct register message
+    appears once as a pull and once as a push. -/
 theorem addX1X1X1_registerMemBus_balanced :
-    BalancedInteractions (pairedInteractions addX1X1X1RegisterMessages) := by
-  apply pairedInteractions_balanced
-  left
-  rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
-  decide
+    BalancedInteractions addX1X1X1RegisterInteractions := by
+  -- Order-agnostic: over the messages actually present, every register message's ±1
+  -- pull/push multiplicities sum to zero (the aRegPre↔boot, aMem↔bRegPre, bMem↔cRegPre,
+  -- cMem↔reload chain plus the idle boot↔reload pairs — see the consistency equalities above).
+  refine Air.Flat.balancedInteractions_of_present ?_
+    (addX1X1X1RegisterInteractions.map (·.msg)) ?_ ?_
+  · left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+  · intro i hi
+    exact List.mem_map_of_mem hi
+  · -- bounded quantifier over the concrete message list — decidable
+    decide
 
 end ZiskFv.Compliance.RegisterMemBusBalance

--- a/ZiskFv/Compliance/RegisterMemBusBalance.lean
+++ b/ZiskFv/Compliance/RegisterMemBusBalance.lean
@@ -32,6 +32,15 @@ checks enforce (the #169/#19 axis, `main.pil:447`), pinned here in the concrete 
 used: ZisK decodes `x0` operands as immediate/no-op register accesses emitting no `mem_op = 3`
 traffic, so `x1,x1,x1` is the minimal real-register witness.
 
+**Not yet extracted via `interactionsWith`.**  The balanced messages are the real emission
+*definitions*, but the multiplicities are the emissions' `±1` selector values pinned at this row
+(`pushedValue` / `pulledValue`), not evaluated from the components' interaction lists.  Deriving the
+interaction list — messages *and* multiplicities — from
+`(mainSingleRowTable …).interactionsWith MemBusChannel.toRaw` plus a RegisterBoundary single-row
+reduction (the memBus analogue of #234's `mainSingleRowTable_interactionsWith_opBus`, which #234
+explicitly left to #219) is the #219 follow-up; only then does the balance track a change to an
+emission's multiplicity in `Main/Constraints.lean`.
+
 ## Trust note
 
 No axioms.  `pulledValue` / `pushedValue` are Clean's `-1` / `+1` value-level channel interactions.

--- a/trust/consistency/register_mem_bus_add_x1_x1_x1.lean
+++ b/trust/consistency/register_mem_bus_add_x1_x1_x1.lean
@@ -6,7 +6,10 @@ import ZiskFv.Compliance.RegisterMemBusBalance
 Gate-discovered wrapper for issue #225's checked register-memory-bus balance
 artifact.  The theorem lives in main Lake under
 `ZiskFv.Compliance.RegisterMemBusBalance`; this file keeps its axiom closure
-visible to the semantic trust gate.
+visible to the semantic trust gate.  The balanced object is the register
+(`mem_op = 3`) partition built from the **real component emission definitions**
+(`aRegPreMessage`/…/`bootMessage`/`reloadMessage`) at a concrete `add x1,x1,x1`
+row — not hand-authored literals.
 -/
 
 namespace ZiskFv.TrustConsistency
@@ -14,7 +17,7 @@ namespace ZiskFv.TrustConsistency
 open ZiskFv.Compliance.RegisterMemBusBalance
 
 theorem register_mem_bus_add_x1_x1_x1_witness :
-    BalancedInteractions (pairedInteractions addX1X1X1RegisterMessages) :=
+    BalancedInteractions addX1X1X1RegisterInteractions :=
   addX1X1X1_registerMemBus_balanced
 
 #print axioms register_mem_bus_add_x1_x1_x1_witness

--- a/trust/consistency/root_soundness_instantiation_degenerate.lean
+++ b/trust/consistency/root_soundness_instantiation_degenerate.lean
@@ -9,7 +9,7 @@ The first concrete inhabitant of `ZiskFv.Compliance.AcceptedZiskTrace` fed throu
 `ZiskFv.Compliance.root_soundness` (eth-act/zisk-fv#217, foundation of #74).
 
 This is the DEGENERATE base case: `numInstructions = 0`, every provider table empty.
-It exercises the whole witness-construction pipeline — the 10-table
+It exercises the whole witness-construction pipeline — the 11-table
 `EnsembleWitness` (`same_length`/`same_circuits`/`same_data`), `constraints_hold`,
 `transitions_hold`, `segment_l1_fixed`, and the first forward `BalancedChannels`
 proof — and applies `root_soundness` to the result. The `∀ i : Fin 0` conclusion

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -448,6 +448,15 @@ semantic trust gate discovers the wrapper
 kernel-only (`propext`, `Classical.choice`, `Quot.sound`) and adds no project
 axioms.
 
+The messages are the real emission *definitions*, but the interaction
+multiplicities are the emissions' `±1` selector values pinned at this row
+(`pushedValue` / `pulledValue`), **not yet evaluated from the components'
+`interactionsWith` lists** — so this artifact would not track a change to an
+emission's multiplicity in `Main/Constraints.lean`. Deriving the interaction list
+(messages and multiplicities) via a `mainSingleRowTable_interactionsWith_memBus`
+reduction — the memBus analogue of #234's `mainSingleRowTable_interactionsWith_opBus`,
+which #234 explicitly deferred — is the #219 follow-up.
+
 **Scope / residuals (register-partition close).** This delivers the `mem_op=3`
 partition `BalancedInteractions` — the object #219 consumes — not the whole-channel
 `witness.BalancedChannels` or a constraint-satisfying accepted trace, which stay

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -412,37 +412,53 @@ whole-state floor" property is a property of the `LoadMemoryTimelineCoherenceEvi
 cursor, so the earlier `witnessStore_nondegenerate` regs/cycleCount side-claim was
 dropped as describing a cursor the evidence no longer uses.)
 
-### Register MemBus balance (`MEMORY_REG_OP`) — #225 constructibility slice
+### Register MemBus balance (`MEMORY_REG_OP`) — #225
 
-The Clean Main component now models the row-local register-consistency emissions
-that real ZisK sends on the shared MemBus: for `a`, `b`, and `store` register
-accesses, Main emits the previous register access as a `MEMORY_REG_OP`
-push-prev message in addition to the existing current-access pull. These are
-PIL-backed fidelity emissions, not a new trust premise and not a new AIR or Mem
-component behavior.
+The full RV64IM Clean ensemble now **emits** the complete register-consistency
+MemBus traffic, so the register (`mem_op = 3`) partition balances for a real
+instruction. All of it is derived composed-table emissions — **no** new trust
+premise, `axiom`, or `opaque`:
 
-The boot and reload ends of the register chain remain boundary-shaped terms:
-ZisK's boot `global_init_mem` contributes the step-0 zero register pulls, while
-the per-segment reload contributes the final register pushes. Those are not
-modeled as ordinary per-row Main-table emissions. Instead, the checked
-constructibility artifact
+- **Interior** (per Main row): for `a`, `b`, and `store` register accesses Main
+  emits both the previous-access push-prev (`MEMORY_REG_OP`) and the current
+  pull (`Main/Constraints.lean`; PIL `main.pil:277…328`).
+- **Boundary** (chain-closing): a new single-purpose provider component
+  `ZiskFv.AirsClean.RegisterBoundary.component` emits, per tracked register, the
+  boot pull (`global_init_mem`, `mem.pil:507-508` + per-register call site
+  `main.pil:535-537`; `mem_op=3`, ts 0, value 0, mult `-1`) and the reload push
+  (`reg_pre_load` "Proves the last access.", `main.pil:450`; ts = last access,
+  mult `+1`). It is a real `addTable`-composed provider in
+  `fullRv64imSoundEnsemble` (`AirsClean/FullEnsemble.lean`) with
+  `Assumptions := True` and no algebraic constraints — a deliberately
+  under-constrained boundary provider, which is sound in the soundness direction
+  (an under-constrained provider never makes `root_soundness` vacuous; the
+  anti-laundering hazard, an overstrong validator, runs the other way).
+
+The checked artifact
 `ZiskFv.Compliance.RegisterMemBusBalance.addX1X1X1_registerMemBus_balanced`
-lists the concrete register MemBus messages for the minimal no-prelude real
-register witness `add x1,x1,x1`: x1's boot/read/read/write/reload timeline plus
-the idle boot/reload zero pairs for tracked registers x2..x31. It proves that
-every listed message appears once as a pull and once as a push, so the register
-MemBus contribution balances. This is an explicit-message telescoping artifact;
-it does not yet extract the register messages from real ensemble rows or
-construct a trace-level `BalancedChannels` witness, which is the #219 follow-up.
-The semantic trust gate discovers the wrapper
+proves `BalancedInteractions` of the register (`mem_op=3`) partition for the
+minimal no-prelude real-register witness `add x1,x1,x1`, built from the **real
+component emission definitions** (`aRegPreMessage`/`aMemMessage`/… and
+`bootMessage`/`reloadMessage`) instantiated at a concrete `add x1,x1,x1`
+`MainRowWithRom` — not hand-authored literals. The telescoping content is the
+four consistency equalities (`aRegPre = boot`, `aMem = bRegPre`, `bMem = cRegPre`,
+`cMem = reload`) plus the idle registers' self-balancing boot/reload pairs. The
+semantic trust gate discovers the wrapper
 `trust/consistency/register_mem_bus_add_x1_x1_x1.lean`; its axiom closure is
 kernel-only (`propext`, `Classical.choice`, `Quot.sound`) and adds no project
 axioms.
 
+**Scope / residuals (register-partition close).** This delivers the `mem_op=3`
+partition `BalancedInteractions` — the object #219 consumes — not the whole-channel
+`witness.BalancedChannels` or a constraint-satisfying accepted trace, which stay
+**#219**. The balance is conditional on the previous-step timestamp chain
+(`a_reg_prev_mem_step = 0`, `b_reg_prev_mem_step = 1`, `store_reg_prev_mem_step = 2`,
+reload at `3`), pinned in the concrete row here; deriving it from ZisK's
+ordering/range checks (`main.pil:447`) is the **#169/#19** range-fidelity axis.
 This slice does **not** claim register/memory access-ordering soundness. The
-monotone previous-step range checks are range/table obligations, not MemBus
-channel messages, and their full composition remains on the #169/#19
-range-fidelity axis.
+cross-segment continuation terms (`MAIN_CONTINUATION_ID` block and
+`main.pil:454`'s `sel:(1-main_last_segment)` continuation pull) are out of scope
+(#103/#76).
 
 ## Platform Profile
 


### PR DESCRIPTION
Closes #225 (register-partition close).

## What this does

The full RV64IM Clean ensemble previously **could not balance its MemBus for any real instruction**: every active Main row emits `MEMORY_REG_OP` (`mem_op=3`) register pulls, and the composed providers emit only `mem_op∈{1,2}`, so register traffic was unbalanceable. This PR models the register memory-consistency argument — a telescoping chain on the shared MemBus — as **derived composed-table emissions** (no new premise, `axiom`, or `opaque`), and proves the `mem_op=3` partition balances for `add x1,x1,x1`.

### Stage A — RegisterBoundary provider component (`ZiskFv/AirsClean/RegisterBoundary.lean`)
New single-purpose Clean provider emitting, per tracked register, the two chain-closing boundary terms ZisK emits outside Main's per-row access loop:
- **boot pull** — `global_init_mem` (`mem.pil:507-508`, per-register call site `main.pil:535-537`): `mem_op=3`, ts 0, value 0, mult −1.
- **reload push** — `reg_pre_load` "Proves the last access." (`main.pil:450`): ts = last access, mult +1.

`Assumptions := True`, no algebraic constraints — a deliberately under-constrained boundary provider, which is sound in the soundness direction (an under-constrained provider never vacuates `root_soundness`; the anti-laundering hazard runs the other way).

### Stage B — compose into `fullRv64imSoundEnsemble` + thread the cascade
Composed via one `addTable`. The balance-classification chain gains the new provider:
- `Classification`: `component_mem_fullRv64im_cases` + a new `registerBoundary_table_interactionsWith_opBus_nil`.
- `CounterpartClassification`: OpBus lemma dismisses it (no OpBus); MemBus lemma adds it as a genuine provider.
- `MemBusRowBridges`: the self-contained #219 provider-classification chain carries a bare **structural** RegisterBoundary provider branch (new `ActiveMainRegisterBoundaryProviderRowMatchSpec`). These are **partition-disjointness passthroughs** (`mem_op=3 ∉ {1,2}`), **not** new register-timeline reasoning in the data-memory proofs — a concrete data-memory main discharges them by disjointness, which the #219 instantiation supplies.

Degenerate n=0 witness re-verified unchanged (new table 0 rows).

### Stage C — register-partition balance from real emissions (`RegisterMemBusBalance.lean`)
Replaces the earlier hand-authored shape-demo with a balance over the **real component emission definitions** (`aRegPreMessage`/…/`bootMessage`/`reloadMessage`) at a concrete `add x1,x1,x1` `MainRowWithRom`, with the emissions' own multiplicities. The telescoping content is the four consistency equalities (`aRegPre=boot`, `aMem=bRegPre`, `bMem=cRegPre`, `cMem=reload` — the prev-step chain lining up timestamps) plus idle self-pairs. The messages are the real emission *definitions*, but the multiplicities are the emissions' ±1 selector values pinned at this row, not yet evaluated from the components' `interactionsWith` lists — deriving the interaction list (and mults) via a `mainSingleRowTable_interactionsWith_memBus` reduction (the memBus analogue of #234's opBus reduction, which #234 deferred) is the #219 follow-up.

## Scope & honest framing

- **Register-partition close** (issue Q1): delivers the `mem_op=3` partition `BalancedInteractions` — the object #219 consumes. It does **not** build the whole-channel `wit.BalancedChannels` or a constraint-satisfying accepted trace (both #219).
- The balance is **conditional on** the previous-step timestamp chain, pinned in the concrete row; deriving it from ZisK's ordering/range checks (`main.pil:447`) is the #169/#19 axis.
- **0 new project axioms.** (The Sail `cancel_reservation` in `root_soundness`'s closure is a pre-existing LHS axiom, unrelated to this PR.)
- Gap notes posted to #219; #218 cross-linked; #225 body corrections noted (`main.pil:454`→`:450`, `x0`→`x1`).

## Verification
- `lake build ZiskFv` green (9034 jobs)
- `trust/scripts/check-all.sh` (V1) 16/16
- `trust/scripts/check-all-semantic.sh` (V2) 16/16
- `nix run .#test` (skip Aeneas): ✅ ALL CHECKS PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)