### PR TITLE
Split Aeneas lean-check dependency cache

### DIFF
--- a/.github/workflows/proofs.yml
+++ b/.github/workflows/proofs.yml
@@ -367,16 +367,33 @@ jobs:
           name: zisk-fv
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-      - name: Cache Aeneas lean-check .lake
+      - name: Cache Aeneas lean-check dependencies
         uses: actions/cache@v4
         with:
-          path: build/aeneas-production-extraction/lean-check/.lake
-          key: aeneas-lean-check-${{ runner.os }}-${{ hashFiles('flake.lock', 'lean-toolchain', 'scripts/aeneas-production-extract.sh', 'zisk/core/src/aeneas_extract.rs', 'ZiskFv/Compliance/RowProvenance.lean', 'trust/aeneas/ProductionM2.lean') }}
-          # Use only exact cache hits. The temporary Lake workspace stores
-          # package build products such as ProofWidgets' widgetJsAll target;
-          # prefix restores can mix those artifacts across harness/toolchain
-          # changes and make `lake exe cache get` appear successful while the
-          # following build still fails as stale.
+          path: |
+            build/aeneas-production-extraction/lean-check/.lake/packages
+            build/aeneas-production-extraction/lean-check/aeneas-lean/.lake
+          key: aeneas-lean-check-deps-${{ runner.os }}-${{ hashFiles('lean-toolchain', 'lakefile.toml', 'lake-manifest.json', 'flake.lock', 'nix/aeneas-lean.nix') }}
+          # Safe to reuse across generated-check changes: these paths contain
+          # dependency/package artifacts (Mathlib/ProofWidgets/Aeneas runtime),
+          # not root generated `RvDecode*` build products. The key tracks the
+          # Lean toolchain, resolved Lake package identities, and pinned Aeneas
+          # runtime patch surface.
+
+      - name: Cache Aeneas generated lean-check artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/aeneas-production-extraction/lean-check/.lake/build
+            build/aeneas-production-extraction/lean-check/.lake/lakefile.olean
+            build/aeneas-production-extraction/lean-check/.lake/lakefile.ilean
+            build/aeneas-production-extraction/lean-check/.lake/lakefile.trace
+            build/aeneas-production-extraction/lean-check/.lake/lakefile.hash
+          key: aeneas-lean-check-generated-${{ runner.os }}-${{ hashFiles('flake.lock', 'lean-toolchain', 'scripts/aeneas-production-extract.sh', 'zisk/core/src/aeneas_extract.rs', 'ZiskFv/Compliance/RowProvenance.lean', 'trust/aeneas/ProductionM2.lean') }}
+          # Use only exact cache hits for root generated artifacts. Prefix
+          # restores for the full lean-check `.lake` can mix stale generated
+          # oleans across harness/toolchain/source changes, which is the
+          # failure mode fixed by #161.
 
       - name: Run full Aeneas production extraction completeness check
         env:


### PR DESCRIPTION
## Summary

Closes #165.

The Aeneas production extraction job previously cached the whole temporary `build/aeneas-production-extraction/lean-check/.lake` workspace under one exact key. That preserved #161's correctness fix, but any generated-check/harness key change cold-built dependency/package oleans too.

This splits the cache into:

- `aeneas-lean-check-deps-*`: dependency/package artifacts only:
  - `build/aeneas-production-extraction/lean-check/.lake/packages`
  - `build/aeneas-production-extraction/lean-check/aeneas-lean/.lake`
  - keyed by Lean toolchain, root Lake manifest files, `flake.lock`, and `nix/aeneas-lean.nix`
- `aeneas-lean-check-generated-*`: root generated lean-check artifacts only:
  - root `.lake/build` plus root lakefile artifacts
  - still exact-keyed to `scripts/aeneas-production-extract.sh`, `zisk/core/src/aeneas_extract.rs`, `ZiskFv/Compliance/RowProvenance.lean`, `trust/aeneas/ProductionM2.lean`, `flake.lock`, and `lean-toolchain`

There are still no broad prefix restores for the generated root lean-check cache, preserving the #161 stale-artifact guardrail.

## Range

- Base: `main`
- Head branch: `issue-165-aeneas-cache-split`
- Head SHA: `bd16d5da3fb77bcd9defe177efe583c02db7cdf3`
- GitHub-listed range: 1 commit

## Verification At Head SHA

Run at `bd16d5da3fb77bcd9defe583c02db7cdf3`:

- `lake build` — passed, 9042 jobs after `nix run .#populate` refreshed generated sources in the fresh worktree
- `trust/scripts/check-all.sh` — passed 16/16
- `trust/scripts/check-all-semantic.sh` — passed 16/16
- `nix run .#test` — passed all 8 stages, including extraction, embedded `lake build`, V1, V2, and flake repro

Earlier focused verification also passed for PyYAML parsing of `.github/workflows/proofs.yml` and `git diff --check`.

## Known Incompleteness

This is CI cache topology only. It does not change extraction semantics, and the generated-root cache remains exact-keyed by design.
