### PR TITLE
#220: instantiate heterogeneous multi-row root soundness

### DIFF
--- a/ZiskFv/Compliance/AddAddiSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/AddAddiSpinRootSoundness.lean
@@ -1,0 +1,509 @@
+import ZiskFv.Compliance.AddAddiSpinWitness
+import ZiskFv.Soundness
+
+set_option maxRecDepth 10000
+
+/-!
+# Concrete `root_soundness` instantiation for the ADD/ADDI/spin trace (#220)
+
+This file binds the heterogeneous accepted Zisk trace to a three-state Sail trace and applies the
+public `root_soundness` theorem at all three executed rows.
+-/
+
+open Goldilocks
+open ZiskFv.Compliance
+open ZiskFv.Compliance.AddAddiSpinWitness
+open ZiskFv.Compliance.AddSpinWitness
+open ZiskFv.Compliance.Instantiation
+open ZiskFv.Compliance.RegisterMemBusBalance
+open ZiskFv.Compliance.RomDecodeBinding
+open ZiskFv.Compliance.SingleAddWitness
+open ZiskFv.ZiskCircuit.MemTrace
+open ZiskFv.Trusted
+
+namespace ZiskFv.Compliance.AddAddiSpinRootSoundness
+
+def x0 : regidx := regidx.Regidx (0#5)
+
+def x1 : regidx := regidx.Regidx (1#5)
+
+def addAddiSpinAddIndex : Fin 3 := ⟨0, by decide⟩
+
+def addAddiSpinAddiIndex : Fin 3 := ⟨1, by decide⟩
+
+def addAddiSpinJalIndex : Fin 3 := ⟨2, by decide⟩
+
+def addAddiSpinAddClaim : Claim_add addAddiSpinAcceptedTrace addAddiSpinAddIndex where
+  r1 := x1
+  r2 := x1
+  rd := x1
+
+def addAddiSpinAddiClaim : Claim_addi addAddiSpinAcceptedTrace addAddiSpinAddiIndex where
+  r1 := x1
+  rd := x1
+  imm := 0#12
+
+def addAddiSpinJalClaim : Claim_jal addAddiSpinAcceptedTrace addAddiSpinJalIndex where
+  imm := 0#21
+  rd := x0
+
+def addAddiSpinZiskStep : ∀ i : Fin 3, ZiskStep addAddiSpinAcceptedTrace i
+  | ⟨0, _⟩ => .add addAddiSpinAddClaim
+  | ⟨1, _⟩ => .addi addAddiSpinAddiClaim
+  | ⟨2, _⟩ => .jal addAddiSpinJalClaim
+
+def addAddiSpinMisa : RegisterType Register.misa := 0#64
+
+def addAddiSpinRegs (pc : BitVec 64) : Std.ExtDHashMap Register RegisterType :=
+  let regs0 := (default : PreSail.SequentialState RegisterType Sail.trivialChoiceSource).regs
+  let regs1 := regs0.insert Register.PC pc
+  let regs2 := regs1.insert Register.misa addAddiSpinMisa
+  regs2.insert (reg_of_fin (regidx_to_fin x1)) (0#64)
+
+def addAddiSpinState (pc : BitVec 64) :
+    PreSail.SequentialState RegisterType Sail.trivialChoiceSource :=
+  { (default : PreSail.SequentialState RegisterType Sail.trivialChoiceSource) with
+    regs := addAddiSpinRegs pc
+    mem := {} }
+
+def addAddiSpinSailTrace : SailTrace 3
+  | ⟨0, _⟩ => addAddiSpinState (0#64)
+  | ⟨1, _⟩ => addAddiSpinState (4#64)
+  | ⟨2, _⟩ => addAddiSpinState (8#64)
+
+theorem addAddiSpinRowsOf_empty_readSound :
+    MemoryBusRowsPrefixReadSound
+      ({} : Std.ExtHashMap Nat (BitVec 8))
+      ((List.range addAddiSpinAcceptedTrace.numInstructions).flatMap (fun _ => [])) := by
+  change MemoryBusRowsPrefixReadSound ({} : Std.ExtHashMap Nat (BitVec 8)) []
+  intro priorRows entry laterRows h_split h_selected
+  simp at h_split
+
+def addAddiSpinBootSeed :
+    BootSegmentMemorySeed addAddiSpinAcceptedTrace addAddiSpinSailTrace addAddiSpinZiskStep where
+  memInit := {}
+  rowsOf := fun _ => []
+  boot := by
+    intro h
+    rfl
+  step := by
+    intro j h
+    change j + 1 < 3 at h
+    have hj : j = 0 ∨ j = 1 := by omega
+    rcases hj with rfl | rfl <;>
+      simp [addAddiSpinSailTrace, addAddiSpinState, replayMemoryAfterBusRows]
+  readSoundInputs := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
+  memPresent_of_executionRows_nonempty := by
+    intro h_nonempty
+    exact absurd (by simp [AcceptedZiskTrace.numInstructions]) h_nonempty
+  placement := by
+    intro i
+    fin_cases i <;> trivial
+
+private theorem addAddiSpinMainRowAt_zero :
+    ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero addAddiSpinProgram
+      addAddiSpinMainTable 0 = addAddiSpinAddRow := by
+  simp [ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero, addAddiSpinMainTable,
+    mainRowsTable, addAddiSpinMainRows]
+  change eval (addAddiSpinMainTable.environment (mainRowArray addAddiSpinAddRow))
+      (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus 3
+        addAddiSpinProgram).rowInputVar = addAddiSpinAddRow
+  simpa [addAddiSpinMainTable] using
+    mainRowsTable_eval_rowInputVar 3 addAddiSpinProgram addAddiSpinMainRows addAddiSpinAddRow
+
+private theorem addAddiSpinMainRowAt_one :
+    ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero addAddiSpinProgram
+      addAddiSpinMainTable 1 = addAddiSpinAddiRow := by
+  simp [ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero, addAddiSpinMainTable,
+    mainRowsTable, addAddiSpinMainRows]
+  change eval (addAddiSpinMainTable.environment (mainRowArray addAddiSpinAddiRow))
+      (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus 3
+        addAddiSpinProgram).rowInputVar = addAddiSpinAddiRow
+  simpa [addAddiSpinMainTable] using
+    mainRowsTable_eval_rowInputVar 3 addAddiSpinProgram addAddiSpinMainRows addAddiSpinAddiRow
+
+private theorem addAddiSpinMainRowAt_two :
+    ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero addAddiSpinProgram
+      addAddiSpinMainTable 2 = addAddiSpinJalRow 2 := by
+  simp [ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero, addAddiSpinMainTable,
+    mainRowsTable, addAddiSpinMainRows]
+  change eval (addAddiSpinMainTable.environment (mainRowArray (addAddiSpinJalRow 2)))
+      (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus 3
+        addAddiSpinProgram).rowInputVar = addAddiSpinJalRow 2
+  simpa [addAddiSpinMainTable] using
+    mainRowsTable_eval_rowInputVar 3 addAddiSpinProgram addAddiSpinMainRows
+      (addAddiSpinJalRow 2)
+
+private theorem addAddiSpinMainPc_add :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinAcceptedTrace.program
+        addAddiSpinAcceptedTrace.mainTable).pc addAddiSpinAddIndex.val = 0 := by
+  rw [addAddiSpinAcceptedTrace_mainTable_eq]
+  change (ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinProgram
+      addAddiSpinMainTable).pc 0 = 0
+  simp [addAddiSpinMainRowAt_zero, addAddiSpinAddRow, addX1Row]
+
+private theorem addAddiSpinMainPc_addi :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinAcceptedTrace.program
+        addAddiSpinAcceptedTrace.mainTable).pc addAddiSpinAddiIndex.val = 4 := by
+  rw [addAddiSpinAcceptedTrace_mainTable_eq]
+  change (ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinProgram
+      addAddiSpinMainTable).pc 1 = 4
+  simp [addAddiSpinMainRowAt_one, addAddiSpinAddiRow, addAddiSpinAddiProgramRow,
+    addAddiSpinAddiBits, addAddiSpinAddiFreeCols, ZiskFv.AirsClean.Main.mainRomRowOf]
+
+private theorem addAddiSpinMainPc_jal :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinAcceptedTrace.program
+        addAddiSpinAcceptedTrace.mainTable).pc addAddiSpinJalIndex.val = 8 := by
+  rw [addAddiSpinAcceptedTrace_mainTable_eq]
+  change (ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinProgram
+      addAddiSpinMainTable).pc 2 = 8
+  simp [addAddiSpinMainRowAt_two, addAddiSpinJalRow]
+
+private theorem addAddiSpinReadX1 (i : Fin 3) :
+    read_xreg (regidx_to_fin x1) (addAddiSpinSailTrace i) =
+      EStateM.Result.ok (0#64) (addAddiSpinSailTrace i) := by
+  fin_cases i <;>
+    simp [addAddiSpinSailTrace, addAddiSpinState, addAddiSpinRegs, x1,
+      regidx_to_fin, read_xreg, reg_of_fin]
+
+def addAddiSpinAddInput : PureSpec.AddInput where
+  r1_val := 0#64
+  r2_val := 0#64
+  rd := regidx_to_fin x1
+  PC := 0#64
+
+def addAddiSpinAddiInput : PureSpec.AddiInput where
+  r1_val := 0#64
+  imm := 0#12
+  rd := regidx_to_fin x1
+  PC := 4#64
+
+def addAddiSpinJalInput : PureSpec.JalInput where
+  imm := 0#21
+  rd := regidx_to_fin x0
+  PC := 8#64
+
+def addAddiSpinAddProgramDecode :
+    ProgramDecode_add addAddiSpinAcceptedTrace addAddiSpinAddIndex addAddiSpinAddClaim where
+  h_idx := by
+    rw [addAddiSpinAcceptedTrace_mainTable_eq]
+    change 0 + 1 < addAddiSpinMainTable.table.length
+    norm_num [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows]
+  bits := addAddiSpinAddBits
+  h_bits_ieo := by simp [addAddiSpinAddBits, addX1RomFlagBits]
+  h_bits_m32 := by simp [addAddiSpinAddBits, addX1RomFlagBits]
+  h_bits_set_pc := by simp [addAddiSpinAddBits, addX1RomFlagBits]
+  h_bits_store_pc := by simp [addAddiSpinAddBits, addX1RomFlagBits]
+  h_bits_store_ind := by simp [addAddiSpinAddBits, addX1RomFlagBits]
+  h_prog := by
+    intro j hline
+    fin_cases j
+    · simp only [addAddiSpinAcceptedTrace, addAddiSpinProgram]
+      constructor
+      · rfl
+      constructor
+      · rfl
+      constructor
+      · rfl
+      constructor
+      · simp [addAddiSpinAddProgramRow, addX1ProgramRow, addAddiSpinAddClaim, x1,
+          Transpiler.ind, regidx_to_fin]
+      · norm_num [addAddiSpinAddProgramRow, addX1ProgramRow,
+          ZiskFv.AirsClean.Main.packFlags, addAddiSpinAddBits, addX1RomFlagBits,
+          ZiskFv.AirsClean.boolF]
+    · rw [addAddiSpinMainPc_add] at hline
+      norm_num [addAddiSpinAcceptedTrace, addAddiSpinProgram,
+        addAddiSpinAddiProgramRow] at hline
+      exact absurd (congrArg (fun value : FGL => value.val) hline) (by norm_num)
+    · rw [addAddiSpinMainPc_add] at hline
+      norm_num [addAddiSpinAcceptedTrace, addAddiSpinProgram,
+        addAddiSpinJalProgramRow] at hline
+      exact absurd (congrArg (fun value : FGL => value.val) hline) (by norm_num)
+
+def addAddiSpinAddiProgramDecode :
+    ProgramDecode_addi addAddiSpinAcceptedTrace addAddiSpinAddiIndex addAddiSpinAddiClaim where
+  h_idx := by
+    rw [addAddiSpinAcceptedTrace_mainTable_eq]
+    change 1 + 1 < addAddiSpinMainTable.table.length
+    norm_num [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows]
+  bits := addAddiSpinAddiBits
+  h_bits_ieo := by rfl
+  h_bits_m32 := by rfl
+  h_bits_set_pc := by rfl
+  h_bits_store_pc := by rfl
+  h_bits_store_ind := by rfl
+  h_bits_b_src_imm := by rfl
+  h_prog := by
+    intro j hline
+    fin_cases j
+    · rw [addAddiSpinMainPc_addi] at hline
+      norm_num [addAddiSpinAcceptedTrace, addAddiSpinProgram,
+        addAddiSpinAddProgramRow, addX1ProgramRow] at hline
+      exact absurd (congrArg (fun value : FGL => value.val) hline) (by norm_num)
+    · simp only [addAddiSpinAcceptedTrace, addAddiSpinProgram]
+      constructor
+      · rfl
+      constructor
+      · rfl
+      constructor
+      · rfl
+      constructor
+      · simp [addAddiSpinAddiProgramRow, addAddiSpinAddiClaim, x1,
+          Transpiler.ind, regidx_to_fin]
+      constructor
+      · simp [addAddiSpinAddiProgramRow, addAddiSpinAddiClaim]
+      · norm_num [addAddiSpinAddiProgramRow, ZiskFv.AirsClean.Main.packFlags,
+          addAddiSpinAddiBits, ZiskFv.AirsClean.boolF]
+    · rw [addAddiSpinMainPc_addi] at hline
+      norm_num [addAddiSpinAcceptedTrace, addAddiSpinProgram,
+        addAddiSpinJalProgramRow] at hline
+      exact absurd (congrArg (fun value : FGL => value.val) hline) (by norm_num)
+
+def addAddiSpinJalProgramDecode :
+    ProgramDecode_jal addAddiSpinAcceptedTrace addAddiSpinJalIndex addAddiSpinJalClaim where
+  h_idx := by
+    rw [addAddiSpinAcceptedTrace_mainTable_eq]
+    change 2 + 1 < addAddiSpinMainTable.table.length
+    norm_num [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows]
+  bits := addAddiSpinJalBits
+  h_bits_ieo := by rfl
+  h_bits_m32 := by rfl
+  h_bits_set_pc := by rfl
+  h_bits_store_pc := by rfl
+  h_bits_store_ind := by rfl
+  h_prog := by
+    intro j hline
+    fin_cases j
+    · rw [addAddiSpinMainPc_jal] at hline
+      norm_num [addAddiSpinAcceptedTrace, addAddiSpinProgram,
+        addAddiSpinAddProgramRow, addX1ProgramRow] at hline
+      exact absurd (congrArg (fun value : FGL => value.val) hline) (by norm_num)
+    · rw [addAddiSpinMainPc_jal] at hline
+      norm_num [addAddiSpinAcceptedTrace, addAddiSpinProgram,
+        addAddiSpinAddiProgramRow] at hline
+      exact absurd (congrArg (fun value : FGL => value.val) hline) (by norm_num)
+    · simp only [addAddiSpinAcceptedTrace, addAddiSpinProgram]
+      constructor
+      · rfl
+      constructor
+      · rfl
+      constructor
+      · rfl
+      constructor
+      · simp [addAddiSpinJalProgramRow, addAddiSpinJalClaim, x0,
+          Transpiler.ind, regidx_to_fin]
+      · norm_num [addAddiSpinJalProgramRow, ZiskFv.AirsClean.Main.packFlags,
+          addAddiSpinJalBits, addSpinJalBits, ZiskFv.AirsClean.boolF]
+
+private theorem addAddiSpinLaneLo
+    (i : Fin 3) (field : ZiskFv.Airs.Main.Valid_Main FGL FGL → Nat → FGL)
+    (h_field :
+      field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinProgram
+        addAddiSpinMainTable) i.val = 0) :
+    field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinAcceptedTrace.program
+        addAddiSpinAcceptedTrace.mainTable) i.val =
+      lane_lo ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64
+        (addAddiSpinSailTrace i)).xreg (regidx_to_fin x1)) := by
+  rw [ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64_xreg_eq_of_read_xreg
+    (addAddiSpinSailTrace i) (regidx_to_fin x1) (0#64) (addAddiSpinReadX1 i)]
+  rw [addAddiSpinAcceptedTrace_mainTable_eq]
+  change field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinProgram
+      addAddiSpinMainTable) i.val = _
+  rw [h_field]
+  simp [lane_lo]
+
+private theorem addAddiSpinLaneHi
+    (i : Fin 3) (field : ZiskFv.Airs.Main.Valid_Main FGL FGL → Nat → FGL)
+    (h_field :
+      field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinProgram
+        addAddiSpinMainTable) i.val = 0) :
+    field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinAcceptedTrace.program
+        addAddiSpinAcceptedTrace.mainTable) i.val =
+      lane_hi ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64
+        (addAddiSpinSailTrace i)).xreg (regidx_to_fin x1)) := by
+  rw [ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64_xreg_eq_of_read_xreg
+    (addAddiSpinSailTrace i) (regidx_to_fin x1) (0#64) (addAddiSpinReadX1 i)]
+  rw [addAddiSpinAcceptedTrace_mainTable_eq]
+  change field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinProgram
+      addAddiSpinMainTable) i.val = _
+  rw [h_field]
+  simp [lane_hi]
+
+def addAddiSpinAddInputs :
+    Inputs_add addAddiSpinAcceptedTrace addAddiSpinSailTrace addAddiSpinAddIndex
+      addAddiSpinAddClaim where
+  add_input := addAddiSpinAddInput
+  h_input_r1 := by
+    simpa [addAddiSpinAddInput, addAddiSpinAddClaim] using
+      addAddiSpinReadX1 addAddiSpinAddIndex
+  h_input_r2 := by
+    simpa [addAddiSpinAddInput, addAddiSpinAddClaim] using
+      addAddiSpinReadX1 addAddiSpinAddIndex
+  h_input_pc := by
+    simp [addAddiSpinAddInput, addAddiSpinSailTrace, addAddiSpinAddIndex,
+      addAddiSpinState, addAddiSpinRegs, x1, regidx_to_fin, reg_of_fin,
+      Std.ExtDHashMap.get?_insert]
+  h_input_rd := by
+    rfl
+  h_a_lo_t := by
+    exact addAddiSpinLaneLo addAddiSpinAddIndex (fun m i => m.a_0 i)
+      (by simp [addAddiSpinAddIndex, addAddiSpinMainRowAt_zero,
+        addAddiSpinAddRow, addX1Row])
+  h_a_hi_t := by
+    exact addAddiSpinLaneHi addAddiSpinAddIndex (fun m i => m.a_1 i)
+      (by simp [addAddiSpinAddIndex, addAddiSpinMainRowAt_zero,
+        addAddiSpinAddRow, addX1Row])
+  h_b_lo_t := by
+    exact addAddiSpinLaneLo addAddiSpinAddIndex (fun m i => m.b_0 i)
+      (by simp [addAddiSpinAddIndex, addAddiSpinMainRowAt_zero,
+        addAddiSpinAddRow, addX1Row])
+  h_b_hi_t := by
+    exact addAddiSpinLaneHi addAddiSpinAddIndex (fun m i => m.b_1 i)
+      (by simp [addAddiSpinAddIndex, addAddiSpinMainRowAt_zero,
+        addAddiSpinAddRow, addX1Row])
+  h_pc_bridge := by
+    rw [addAddiSpinAcceptedTrace_mainTable_eq]
+    change ((ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinProgram
+      addAddiSpinMainTable).pc 0).val = _
+    simp [addAddiSpinMainRowAt_zero, addAddiSpinAddRow, addX1Row,
+      addAddiSpinAddInput]
+
+def addAddiSpinAddiInputs :
+    Inputs_addi addAddiSpinAcceptedTrace addAddiSpinSailTrace addAddiSpinAddiIndex
+      addAddiSpinAddiClaim where
+  addi_input := addAddiSpinAddiInput
+  h_input_r1 := by
+    simpa [addAddiSpinAddiInput, addAddiSpinAddiClaim] using
+      addAddiSpinReadX1 addAddiSpinAddiIndex
+  h_input_imm := by
+    rfl
+  h_input_pc := by
+    simp [addAddiSpinAddiInput, addAddiSpinSailTrace, addAddiSpinAddiIndex,
+      addAddiSpinState, addAddiSpinRegs, x1, regidx_to_fin, reg_of_fin,
+      Std.ExtDHashMap.get?_insert]
+  h_input_rd := by
+    rfl
+  h_a_lo_t := by
+    exact addAddiSpinLaneLo addAddiSpinAddiIndex (fun m i => m.a_0 i)
+      (by simp [addAddiSpinAddiIndex, addAddiSpinMainRowAt_one,
+        addAddiSpinAddiRow, addAddiSpinAddiProgramRow, addAddiSpinAddiBits,
+        addAddiSpinAddiFreeCols, ZiskFv.AirsClean.Main.mainRomRowOf])
+  h_a_hi_t := by
+    exact addAddiSpinLaneHi addAddiSpinAddiIndex (fun m i => m.a_1 i)
+      (by simp [addAddiSpinAddiIndex, addAddiSpinMainRowAt_one,
+        addAddiSpinAddiRow, addAddiSpinAddiProgramRow, addAddiSpinAddiBits,
+        addAddiSpinAddiFreeCols, ZiskFv.AirsClean.Main.mainRomRowOf])
+  h_pc_bridge := by
+    rw [addAddiSpinAcceptedTrace_mainTable_eq]
+    change ((ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinProgram
+      addAddiSpinMainTable).pc 1).val = _
+    simp [addAddiSpinMainRowAt_one, addAddiSpinAddiRow, addAddiSpinAddiProgramRow,
+      addAddiSpinAddiBits, addAddiSpinAddiFreeCols,
+      ZiskFv.AirsClean.Main.mainRomRowOf, addAddiSpinAddiInput]
+
+def addAddiSpinJalInputs :
+    Inputs_jal addAddiSpinAcceptedTrace addAddiSpinSailTrace addAddiSpinJalIndex
+      addAddiSpinJalClaim where
+  jal_input := addAddiSpinJalInput
+  misa_val := addAddiSpinMisa
+  h_pc_bridge := by
+    rw [addAddiSpinAcceptedTrace_mainTable_eq]
+    change ((ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinProgram
+      addAddiSpinMainTable).pc 2).val = _
+    simp [addAddiSpinMainRowAt_two, addAddiSpinJalRow, addAddiSpinJalInput]
+  h_input_rd := by
+    rfl
+  h_input_pc := by
+    simp [addAddiSpinJalInput, addAddiSpinSailTrace, addAddiSpinJalIndex,
+      addAddiSpinState, addAddiSpinRegs, x1, regidx_to_fin, reg_of_fin,
+      Std.ExtDHashMap.get?_insert]
+  h_input_misa := by
+    simp [addAddiSpinSailTrace, addAddiSpinJalIndex, addAddiSpinState,
+      addAddiSpinRegs, x1, regidx_to_fin, reg_of_fin, Std.ExtDHashMap.get?_insert]
+  h_misa_c := by
+    simp [addAddiSpinMisa]
+  h_success := by
+    simp [addAddiSpinJalInput, PureSpec.execute_JAL_pure]
+  h_input_imm := by
+    rfl
+
+def addAddiSpinProgramDecodes :
+    ∀ i : Fin 3, ProgramDecode addAddiSpinAcceptedTrace i (addAddiSpinZiskStep i)
+  | ⟨0, _⟩ => addAddiSpinAddProgramDecode
+  | ⟨1, _⟩ => addAddiSpinAddiProgramDecode
+  | ⟨2, _⟩ => addAddiSpinJalProgramDecode
+
+def addAddiSpinInputsAgree :
+    ∀ i : Fin 3, InputsAgree addAddiSpinAcceptedTrace addAddiSpinSailTrace i
+      (addAddiSpinZiskStep i)
+  | ⟨0, _⟩ => addAddiSpinAddInputs
+  | ⟨1, _⟩ => addAddiSpinAddiInputs
+  | ⟨2, _⟩ => addAddiSpinJalInputs
+
+def addAddiSpinAddOutsideDefectRegion :
+    RowOutsideDefectRegion addAddiSpinAcceptedTrace addAddiSpinAddIndex
+      (addAddiSpinZiskStep addAddiSpinAddIndex) := by
+  unfold RowOutsideDefectRegion addAddiSpinZiskStep MainSequentialPcDomain mainPcVal
+  rw [addAddiSpinMainPc_add]
+  change 0 < GL_prime - 4
+  norm_num
+
+def addAddiSpinAddiOutsideDefectRegion :
+    RowOutsideDefectRegion addAddiSpinAcceptedTrace addAddiSpinAddiIndex
+      (addAddiSpinZiskStep addAddiSpinAddiIndex) := by
+  unfold RowOutsideDefectRegion addAddiSpinZiskStep MainSequentialPcDomain mainPcVal
+  rw [addAddiSpinMainPc_addi]
+  change 4 < GL_prime - 4
+  norm_num
+
+def addAddiSpinJalOutsideDefectRegion :
+    RowOutsideDefectRegion addAddiSpinAcceptedTrace addAddiSpinJalIndex
+      (addAddiSpinZiskStep addAddiSpinJalIndex) where
+  h_no_fgl_wrap := by
+    unfold mainPcVal
+    rw [addAddiSpinMainPc_jal]
+    change 8 + (BitVec.signExtend 64 (0#21)).toNat < GL_prime
+    simp
+  h_pc_bound := by
+    unfold MainSequentialPcDomain mainPcVal
+    rw [addAddiSpinMainPc_jal]
+    change 8 < GL_prime - 4
+    norm_num
+  h_pc_offset_lt_2_32 := by
+    intro pc hpc
+    unfold mainPcVal at hpc
+    rw [addAddiSpinMainPc_jal] at hpc
+    rw [BitVec.toNat_add]
+    rw [← hpc]
+    norm_num
+
+def addAddiSpinOutsideDefectRegion :
+    ∀ i : Fin 3, RowOutsideDefectRegion addAddiSpinAcceptedTrace i
+      (addAddiSpinZiskStep i)
+  | ⟨0, _⟩ => addAddiSpinAddOutsideDefectRegion
+  | ⟨1, _⟩ => addAddiSpinAddiOutsideDefectRegion
+  | ⟨2, _⟩ => addAddiSpinJalOutsideDefectRegion
+
+theorem addAddiSpinRootSoundness :
+    ∀ i : Fin 3,
+      StepSound addAddiSpinAcceptedTrace addAddiSpinSailTrace i (addAddiSpinZiskStep i) :=
+  root_soundness 3 addAddiSpinAcceptedTrace addAddiSpinSailTrace addAddiSpinZiskStep
+    addAddiSpinProgramDecodes addAddiSpinInputsAgree addAddiSpinBootSeed
+    addAddiSpinOutsideDefectRegion
+
+theorem addAddiSpinAddStepSound :
+    StepSound addAddiSpinAcceptedTrace addAddiSpinSailTrace addAddiSpinAddIndex
+      (addAddiSpinZiskStep addAddiSpinAddIndex) :=
+  addAddiSpinRootSoundness addAddiSpinAddIndex
+
+theorem addAddiSpinAddiStepSound :
+    StepSound addAddiSpinAcceptedTrace addAddiSpinSailTrace addAddiSpinAddiIndex
+      (addAddiSpinZiskStep addAddiSpinAddiIndex) :=
+  addAddiSpinRootSoundness addAddiSpinAddiIndex
+
+theorem addAddiSpinJalStepSound :
+    StepSound addAddiSpinAcceptedTrace addAddiSpinSailTrace addAddiSpinJalIndex
+      (addAddiSpinZiskStep addAddiSpinJalIndex) :=
+  addAddiSpinRootSoundness addAddiSpinJalIndex
+
+end ZiskFv.Compliance.AddAddiSpinRootSoundness

--- a/ZiskFv/Compliance/AddAddiSpinWitness.lean
+++ b/ZiskFv/Compliance/AddAddiSpinWitness.lean
@@ -1,0 +1,1069 @@
+import ZiskFv.Compliance.AddSpinWitness
+
+/-!
+# Heterogeneous ADD/ADDI plus self-looping JAL accepted trace (#220)
+
+This trace executes `ADD x1,x1,x1; ADDI x1,x1,0; JAL x0,0`. The extra successor Main row
+repeats the JAL entry, satisfying the committed-ROM next-row requirement. ADD and ADDI share a
+two-row BinaryAdd provider, while their x1 register accesses form one timestamp telescope.
+-/
+
+set_option maxRecDepth 10000
+set_option maxHeartbeats 800000
+set_option Elab.async false
+
+open Goldilocks
+open Air.Flat
+open ZiskFv.AirsClean.FullEnsemble (fullRv64imEnsemble fullRv64imSoundEnsemble)
+open ZiskFv.AirsClean.Main
+open ZiskFv.AirsClean.ZiskInstructionRom (Program)
+open ZiskFv.Channels.MemoryBus (MemBusChannel MemBusMessage)
+open ZiskFv.Channels.OperationBus (OpBusChannel)
+open ZiskFv.Channels.ZiskRomBus (ZiskRomMessage)
+open ZiskFv.Compliance.AddSpinWitness
+open ZiskFv.Compliance.Instantiation
+open ZiskFv.Compliance.RegisterMemBusBalance
+open ZiskFv.Compliance.SingleAddWitness
+
+namespace ZiskFv.Compliance.AddAddiSpinWitness
+
+def addAddiSpinAddBits : RomFlagBits := addX1RomFlagBits
+
+def addAddiSpinAddProgramRow : ZiskRomMessage FGL := addX1ProgramRow
+
+def addAddiSpinAddRow : MainRowWithRom FGL := addX1Row
+
+def addAddiSpinAddiBits : RomFlagBits where
+  a_src_imm := false
+  a_src_mem := false
+  is_precompiled := false
+  b_src_imm := true
+  b_src_mem := false
+  is_external_op := true
+  store_pc := false
+  store_mem := false
+  store_ind := false
+  set_pc := false
+  m32 := false
+  b_src_ind := false
+  a_src_reg := true
+  b_src_reg := false
+  store_reg := true
+
+def addAddiSpinAddiProgramRow : ZiskRomMessage FGL :=
+  { line := 4, a_offset_imm0 := 1, a_imm1 := 0, b_offset_imm0 := 0, b_imm1 := 0,
+    ind_width := 8, op := ZiskFv.Trusted.OP_ADD, store_offset := 1, jmp_offset1 := 4,
+    jmp_offset2 := 4, flags := packFlags addAddiSpinAddiBits }
+
+def addAddiSpinAddiFreeCols : MainRomFreeCols where
+  a_0 := 0
+  a_1 := 0
+  b_0 := 0
+  b_1 := 0
+  im_high_degree_2 := 0
+  segment_l1 := 0
+  main_step := 1
+  a_reg_prev_mem_step := 3
+  b_reg_prev_mem_step := 0
+  store_reg_prev_mem_step := 5
+  store_reg_prev_value_0 := 0
+  store_reg_prev_value_1 := 0
+
+def addAddiSpinAddiRow : MainRowWithRom FGL :=
+  mainRomRowOf addAddiSpinAddiProgramRow addAddiSpinAddiBits
+    (MainRomExecKind.external false 0 0) addAddiSpinAddiFreeCols
+
+def addAddiSpinJalBits : RomFlagBits := addSpinJalBits
+
+def addAddiSpinJalProgramRow : ZiskRomMessage FGL :=
+  { line := 8, a_offset_imm0 := 0, a_imm1 := 0, b_offset_imm0 := 0, b_imm1 := 0,
+    ind_width := 8, op := ZiskFv.Trusted.OP_FLAG, store_offset := 0, jmp_offset1 := 0,
+    jmp_offset2 := 4, flags := packFlags addAddiSpinJalBits }
+
+def addAddiSpinJalFreeCols (step : FGL) : MainRomFreeCols :=
+  { addSpinJalFreeCols step with main_step := step }
+
+def addAddiSpinJalRow (step : FGL) : MainRowWithRom FGL :=
+  { addSpinJalRow step with
+    core := { (addSpinJalRow step).core with pc := 8 } }
+
+def addAddiSpinProgram : Program 3
+  | ⟨0, _⟩ => addAddiSpinAddProgramRow
+  | ⟨1, _⟩ => addAddiSpinAddiProgramRow
+  | ⟨2, _⟩ => addAddiSpinJalProgramRow
+
+def addAddiSpinMainRows : List (MainRowWithRom FGL) :=
+  [addAddiSpinAddRow, addAddiSpinAddiRow, addAddiSpinJalRow 2, addAddiSpinJalRow 3]
+
+def addAddiSpinBinaryAddRows : List (ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL) :=
+  [addX1BinaryAddRow, addX1BinaryAddRow]
+
+def addAddiSpinBoundaryRowX1 :
+    ZiskFv.AirsClean.RegisterBoundary.RegisterBoundaryRow FGL :=
+  { boundaryRowX1 with reloadTimestamp := 7 }
+
+def addAddiSpinBoundaryRows :
+    List (ZiskFv.AirsClean.RegisterBoundary.RegisterBoundaryRow FGL) :=
+  addAddiSpinBoundaryRowX1 ::
+    (List.range 30).map (fun i => boundaryRowIdle ((i + 2 : Nat) : FGL))
+
+def addAddiSpinBoundaryTable : Table FGL :=
+  registerBoundaryRowsTableOf addAddiSpinBoundaryRows
+
+def addAddiSpinBinaryAddTable : Table FGL :=
+  binaryAddRowsTable addAddiSpinBinaryAddRows
+
+def addAddiSpinMainTable : Table FGL :=
+  mainRowsTable 3 addAddiSpinProgram addAddiSpinMainRows
+
+theorem addAddiSpinAddMain_proverAssumptions :
+    (componentWithRomMemAndOpBus 3 addAddiSpinProgram).circuit.ProverAssumptions
+      addAddiSpinAddRow emptyData (ProverHint.empty FGL) := by
+  refine ⟨⟨0, by decide⟩, addAddiSpinAddBits, MainRomExecKind.external false 0 0,
+    addX1MainFreeCols, ?_, ?_, ?_, ?_, ?_⟩
+  · decide
+  · simp [MainRomExecKind.Coherent, addAddiSpinAddBits, addX1RomFlagBits]
+  · simp [MainRomSourceGuard, addAddiSpinProgram, addAddiSpinAddProgramRow,
+      addAddiSpinAddBits, addX1RomFlagBits, addX1MainFreeCols]
+  · simp [MainRomAddressGuard, addAddiSpinAddBits, addX1RomFlagBits, addX1MainFreeCols]
+  · rfl
+
+theorem addAddiSpinAddiMain_proverAssumptions :
+    (componentWithRomMemAndOpBus 3 addAddiSpinProgram).circuit.ProverAssumptions
+      addAddiSpinAddiRow emptyData (ProverHint.empty FGL) := by
+  refine ⟨⟨1, by decide⟩, addAddiSpinAddiBits, MainRomExecKind.external false 0 0,
+    addAddiSpinAddiFreeCols, ?_, ?_, ?_, ?_, ?_⟩
+  · decide
+  · simp [MainRomExecKind.Coherent, addAddiSpinAddiBits]
+  · simp [MainRomSourceGuard, addAddiSpinProgram, addAddiSpinAddiProgramRow,
+      addAddiSpinAddiBits, addAddiSpinAddiFreeCols]
+  · simp [MainRomAddressGuard, addAddiSpinAddiBits, addAddiSpinAddiFreeCols]
+  · rfl
+
+theorem addAddiSpinJalMain_proverAssumptions (step : FGL) :
+    (componentWithRomMemAndOpBus 3 addAddiSpinProgram).circuit.ProverAssumptions
+      (addAddiSpinJalRow step) emptyData (ProverHint.empty FGL) := by
+  refine ⟨⟨2, by decide⟩, addAddiSpinJalBits, MainRomExecKind.internalFlag,
+    addAddiSpinJalFreeCols step, ?_, ?_, ?_, ?_, ?_⟩
+  · decide
+  · norm_num [MainRomExecKind.Coherent, addAddiSpinProgram, addAddiSpinJalProgramRow,
+      addAddiSpinJalBits, addSpinJalBits, ZiskFv.Trusted.OP_FLAG]
+  · simp [MainRomSourceGuard, addAddiSpinProgram, addAddiSpinJalProgramRow,
+      addAddiSpinJalBits, addSpinJalBits, addAddiSpinJalFreeCols, addSpinJalFreeCols]
+  · simp [MainRomAddressGuard, addAddiSpinJalBits, addSpinJalBits,
+      addAddiSpinJalFreeCols, addSpinJalFreeCols]
+  · rfl
+
+private theorem addAddiSpinMainRow_constraints
+    {row : MainRowWithRom FGL}
+    (h_row : row = addAddiSpinAddRow ∨ row = addAddiSpinAddiRow ∨
+      row = addAddiSpinJalRow 2 ∨ row = addAddiSpinJalRow 3) :
+    (componentWithRomMemAndOpBus 3 addAddiSpinProgram).operations.ConstraintsHold
+      (Environment.fromInput row emptyData) := by
+  rcases h_row with rfl | rfl | rfl | rfl
+  · exact
+      (show (mainSingleRowTable 3 addAddiSpinProgram addAddiSpinAddRow).Constraints from
+        mainSingleRowTable_constraints_of_proverAssumptions 3 addAddiSpinProgram
+          addAddiSpinAddRow addAddiSpinAddMain_proverAssumptions)
+        (mainRowArray addAddiSpinAddRow) (by simp [mainSingleRowTable])
+  · exact
+      (show (mainSingleRowTable 3 addAddiSpinProgram addAddiSpinAddiRow).Constraints from
+        mainSingleRowTable_constraints_of_proverAssumptions 3 addAddiSpinProgram
+          addAddiSpinAddiRow addAddiSpinAddiMain_proverAssumptions)
+        (mainRowArray addAddiSpinAddiRow) (by simp [mainSingleRowTable])
+  · exact
+      (show (mainSingleRowTable 3 addAddiSpinProgram (addAddiSpinJalRow 2)).Constraints from
+        mainSingleRowTable_constraints_of_proverAssumptions 3 addAddiSpinProgram
+          (addAddiSpinJalRow 2) (addAddiSpinJalMain_proverAssumptions 2))
+        (mainRowArray (addAddiSpinJalRow 2)) (by simp [mainSingleRowTable])
+  · exact
+      (show (mainSingleRowTable 3 addAddiSpinProgram (addAddiSpinJalRow 3)).Constraints from
+        mainSingleRowTable_constraints_of_proverAssumptions 3 addAddiSpinProgram
+          (addAddiSpinJalRow 3) (addAddiSpinJalMain_proverAssumptions 3))
+        (mainRowArray (addAddiSpinJalRow 3)) (by simp [mainSingleRowTable])
+
+theorem addAddiSpinMainTable_constraints : addAddiSpinMainTable.Constraints := by
+  rw [Table.Constraints]
+  intro arr h_arr
+  simp [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows] at h_arr
+  rcases h_arr with h_arr | h_arr | h_arr | h_arr
+  · subst arr
+    simpa [addAddiSpinMainTable, mainRowsTable, mainRowArray] using
+      addAddiSpinMainRow_constraints (Or.inl rfl)
+  · subst arr
+    simpa [addAddiSpinMainTable, mainRowsTable, mainRowArray] using
+      addAddiSpinMainRow_constraints (Or.inr (Or.inl rfl))
+  · subst arr
+    simpa [addAddiSpinMainTable, mainRowsTable, mainRowArray] using
+      addAddiSpinMainRow_constraints (Or.inr (Or.inr (Or.inl rfl)))
+  · subst arr
+    simpa [addAddiSpinMainTable, mainRowsTable, mainRowArray] using
+      addAddiSpinMainRow_constraints (Or.inr (Or.inr (Or.inr rfl)))
+
+theorem addAddiSpinBinaryAddTable_constraints : addAddiSpinBinaryAddTable.Constraints := by
+  apply binaryAddRowsTable_constraints_of_proverAssumptions
+  intro row h_row
+  simp [addAddiSpinBinaryAddRows] at h_row
+  subst row
+  exact ⟨0, 0, by decide, by decide, rfl⟩
+
+theorem addAddiSpinBoundaryTable_constraints : addAddiSpinBoundaryTable.Constraints :=
+  registerBoundaryRowsTableOf_constraints addAddiSpinBoundaryRows
+
+def addAddiSpinEnsemble : Ensemble FGL unit :=
+  (fullRv64imEnsemble 3 addAddiSpinProgram).ensemble
+
+theorem addAddiSpinEnsemble_verifier :
+    addAddiSpinEnsemble.verifier = .empty FGL unit :=
+  (fullRv64imSoundEnsemble 3 addAddiSpinProgram).verifier_empty
+
+theorem addAddiSpinEnsemble_tables :
+    addAddiSpinEnsemble.tables =
+      [ ZiskFv.AirsClean.RegisterBoundary.component
+      , ZiskFv.AirsClean.MemAlignReadByte.component
+      , ZiskFv.AirsClean.MemAlignByte.component
+      , ZiskFv.AirsClean.MemAlign.component
+      , ZiskFv.AirsClean.Mem.componentWithDualMemBus
+      , ZiskFv.AirsClean.ArithDiv.component
+      , ZiskFv.AirsClean.ArithMul.componentWithArithTable
+      , ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+      , ZiskFv.AirsClean.Binary.staticLookupComponent
+      , ZiskFv.AirsClean.BinaryAdd.component
+      , componentWithRomMemAndOpBus 3 addAddiSpinProgram ] := by
+  rfl
+
+def addAddiSpinRows : Fin 11 → List (Array FGL) :=
+  fun i =>
+    if i.val = 0 then addAddiSpinBoundaryTable.table
+    else if i.val = 9 then addAddiSpinBinaryAddTable.table
+    else if i.val = 10 then addAddiSpinMainTable.table
+    else []
+
+theorem addAddiSpinRows_uniform :
+    ∀ i : Fin 11,
+      ∀ row ∈ addAddiSpinRows i,
+        row.size = (addAddiSpinEnsemble.tables[i.val]'i.isLt).width := by
+  intro i row h_row
+  fin_cases i
+  · have h_width := addAddiSpinBoundaryTable.uniform_width row (by
+      simpa [addAddiSpinRows] using h_row)
+    simpa only [addAddiSpinBoundaryTable, registerBoundaryRowsTableOf,
+      addAddiSpinEnsemble_tables] using h_width
+  · simp [addAddiSpinRows] at h_row
+  · simp [addAddiSpinRows] at h_row
+  · simp [addAddiSpinRows] at h_row
+  · simp [addAddiSpinRows] at h_row
+  · simp [addAddiSpinRows] at h_row
+  · simp [addAddiSpinRows] at h_row
+  · simp [addAddiSpinRows] at h_row
+  · simp [addAddiSpinRows] at h_row
+  · have h_width := addAddiSpinBinaryAddTable.uniform_width row (by
+      simpa [addAddiSpinRows] using h_row)
+    simpa only [addAddiSpinBinaryAddTable, binaryAddRowsTable,
+      addAddiSpinEnsemble_tables] using h_width
+  · have h_width := addAddiSpinMainTable.uniform_width row (by
+      simpa [addAddiSpinRows] using h_row)
+    simpa only [addAddiSpinMainTable, mainRowsTable, addAddiSpinEnsemble_tables] using h_width
+
+def addAddiSpinWitness : EnsembleWitness addAddiSpinEnsemble :=
+  EnsembleWitness.ofRows addAddiSpinEnsemble emptyData () addAddiSpinRows
+    addAddiSpinRows_uniform
+
+def addAddiSpinTables : List (Table FGL) :=
+  [ addAddiSpinBoundaryTable
+  , emptyComponentTable ZiskFv.AirsClean.MemAlignReadByte.component
+  , emptyComponentTable ZiskFv.AirsClean.MemAlignByte.component
+  , emptyComponentTable ZiskFv.AirsClean.MemAlign.component
+  , emptyComponentTable ZiskFv.AirsClean.Mem.componentWithDualMemBus
+  , emptyComponentTable ZiskFv.AirsClean.ArithDiv.component
+  , emptyComponentTable ZiskFv.AirsClean.ArithMul.componentWithArithTable
+  , emptyComponentTable ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+  , emptyComponentTable ZiskFv.AirsClean.Binary.staticLookupComponent
+  , addAddiSpinBinaryAddTable
+  , addAddiSpinMainTable ]
+
+theorem addAddiSpinWitness_tables :
+    addAddiSpinWitness.tables = addAddiSpinTables := by
+  rfl
+
+theorem addAddiSpinWitness_table_constraints :
+    ∀ table ∈ addAddiSpinWitness.tables, table.Constraints := by
+  intro table h_table
+  rw [addAddiSpinWitness_tables] at h_table
+  simp [addAddiSpinTables] at h_table
+  rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+  · exact addAddiSpinBoundaryTable_constraints
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlignReadByte.component
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlignByte.component
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlign.component
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.Mem.componentWithDualMemBus
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.ArithDiv.component
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.ArithMul.componentWithArithTable
+  · exact emptyComponentTable_constraints
+      ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.Binary.staticLookupComponent
+  · exact addAddiSpinBinaryAddTable_constraints
+  · exact addAddiSpinMainTable_constraints
+
+theorem addAddiSpinWitness_constraints : addAddiSpinWitness.Constraints :=
+  addAddiSpinWitness.constraints_of_tables addAddiSpinEnsemble_verifier
+    addAddiSpinWitness_table_constraints
+
+private theorem addAddiSpinMain_pcHandshake_add_addi :
+    pcHandshakeBetween addAddiSpinAddRow addAddiSpinAddiRow := by
+  simp [pcHandshakeBetween, addAddiSpinAddRow, addAddiSpinAddiRow,
+    addAddiSpinAddiProgramRow, addAddiSpinAddiBits, addAddiSpinAddiFreeCols, addX1Row,
+    mainRomRowOf]
+
+private theorem addAddiSpinMain_pcHandshake_addi_jal :
+    pcHandshakeBetween addAddiSpinAddiRow (addAddiSpinJalRow 2) := by
+  simp [pcHandshakeBetween, addAddiSpinAddiRow, addAddiSpinAddiProgramRow,
+    addAddiSpinAddiBits, addAddiSpinAddiFreeCols, addAddiSpinJalRow,
+    addSpinJalRow, addSpinJalProgramRow, addSpinJalBits, addSpinJalFreeCols, mainRomRowOf]
+
+private theorem addAddiSpinMain_pcHandshake_jal_jal :
+    pcHandshakeBetween (addAddiSpinJalRow 2) (addAddiSpinJalRow 3) := by
+  simp [pcHandshakeBetween, addAddiSpinJalRow, addSpinJalRow, addSpinJalProgramRow,
+    addSpinJalBits, addSpinJalFreeCols, mainRomRowOf]
+  ring
+
+private theorem addAddiSpinMainTable_transition (prev curr : MainRowWithRom FGL) :
+    addAddiSpinMainTable.component.transition prev curr = pcHandshakeBetween prev curr := by
+  rfl
+
+private theorem addAddiSpinMainTable_rowInput_zero
+    (h : 0 < addAddiSpinMainTable.table.length) :
+    addAddiSpinMainTable.component.rowInput
+        (addAddiSpinMainTable.environment (addAddiSpinMainTable.table[0]'h)) =
+      addAddiSpinAddRow := by
+  simpa [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows] using
+    mainRowsTable_rowInput 3 addAddiSpinProgram addAddiSpinMainRows addAddiSpinAddRow
+
+private theorem addAddiSpinMainTable_rowInput_one
+    (h : 1 < addAddiSpinMainTable.table.length) :
+    addAddiSpinMainTable.component.rowInput
+        (addAddiSpinMainTable.environment (addAddiSpinMainTable.table[1]'h)) =
+      addAddiSpinAddiRow := by
+  simpa [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows] using
+    mainRowsTable_rowInput 3 addAddiSpinProgram addAddiSpinMainRows addAddiSpinAddiRow
+
+private theorem addAddiSpinMainTable_rowInput_two
+    (h : 2 < addAddiSpinMainTable.table.length) :
+    addAddiSpinMainTable.component.rowInput
+        (addAddiSpinMainTable.environment (addAddiSpinMainTable.table[2]'h)) =
+      addAddiSpinJalRow 2 := by
+  simpa [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows] using
+    mainRowsTable_rowInput 3 addAddiSpinProgram addAddiSpinMainRows (addAddiSpinJalRow 2)
+
+private theorem addAddiSpinMainTable_rowInput_three
+    (h : 3 < addAddiSpinMainTable.table.length) :
+    addAddiSpinMainTable.component.rowInput
+        (addAddiSpinMainTable.environment (addAddiSpinMainTable.table[3]'h)) =
+      addAddiSpinJalRow 3 := by
+  simpa [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows] using
+    mainRowsTable_rowInput 3 addAddiSpinProgram addAddiSpinMainRows (addAddiSpinJalRow 3)
+
+theorem addAddiSpinMainTable_transitions : addAddiSpinMainTable.TransitionConstraints := by
+  rw [Table.TransitionConstraints]
+  intro i h_i
+  have h_len : addAddiSpinMainTable.table.length = 4 := by
+    simp [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows]
+  have h_i_lt : i < 3 := by omega
+  interval_cases i
+  · rw [addAddiSpinMainTable_transition, addAddiSpinMainTable_rowInput_zero,
+      addAddiSpinMainTable_rowInput_one]
+    exact addAddiSpinMain_pcHandshake_add_addi
+  · rw [addAddiSpinMainTable_transition, addAddiSpinMainTable_rowInput_one,
+      addAddiSpinMainTable_rowInput_two]
+    exact addAddiSpinMain_pcHandshake_addi_jal
+  · rw [addAddiSpinMainTable_transition, addAddiSpinMainTable_rowInput_two,
+      addAddiSpinMainTable_rowInput_three]
+    exact addAddiSpinMain_pcHandshake_jal_jal
+
+theorem addAddiSpinWitness_transitions : addAddiSpinWitness.TransitionConstraints := by
+  intro table h_table
+  rw [EnsembleWitness.allTables, List.mem_cons] at h_table
+  rcases h_table with h_verifier | h_table
+  · subst table
+    rw [Table.TransitionConstraints]
+    intro i h_i
+    simp [EnsembleWitness.verifierTable] at h_i
+  · rw [addAddiSpinWitness_tables] at h_table
+    simp [addAddiSpinTables] at h_table
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    · rw [Table.TransitionConstraints]
+      intro i h_i
+      simp [addAddiSpinBoundaryTable, registerBoundaryRowsTableOf,
+        ZiskFv.AirsClean.RegisterBoundary.component] at h_i ⊢
+    · rw [Table.TransitionConstraints]
+      intro i h_i
+      simp [emptyComponentTable] at h_i
+    · rw [Table.TransitionConstraints]
+      intro i h_i
+      simp [emptyComponentTable] at h_i
+    · rw [Table.TransitionConstraints]
+      intro i h_i
+      simp [emptyComponentTable] at h_i
+    · rw [Table.TransitionConstraints]
+      intro i h_i
+      simp [emptyComponentTable] at h_i
+    · rw [Table.TransitionConstraints]
+      intro i h_i
+      simp [emptyComponentTable] at h_i
+    · rw [Table.TransitionConstraints]
+      intro i h_i
+      simp [emptyComponentTable] at h_i
+    · rw [Table.TransitionConstraints]
+      intro i h_i
+      simp [emptyComponentTable] at h_i
+    · rw [Table.TransitionConstraints]
+      intro i h_i
+      simp [emptyComponentTable] at h_i
+    · rw [Table.TransitionConstraints]
+      intro i h_i
+      simp [addAddiSpinBinaryAddTable, binaryAddRowsTable,
+        ZiskFv.AirsClean.BinaryAdd.component] at h_i ⊢
+    · exact addAddiSpinMainTable_transitions
+
+private theorem not_addAddiSpin_main_component_of_name_ne
+    {component : Component FGL}
+    (h_name : component.circuit.name ≠
+      (componentWithRomMemAndOpBus 3 addAddiSpinProgram).circuit.name)
+    (h_component : component = componentWithRomMemAndOpBus 3 addAddiSpinProgram) : False :=
+  h_name (congrArg (fun c : Component FGL => c.circuit.name) h_component)
+
+private theorem not_addAddiSpin_main_component_of_width_ne
+    {component : Component FGL}
+    (h_width : component.width ≠ (componentWithRomMemAndOpBus 3 addAddiSpinProgram).width)
+    (h_component : component = componentWithRomMemAndOpBus 3 addAddiSpinProgram) : False :=
+  h_width (congrArg Component.width h_component)
+
+private theorem not_addAddiSpin_mutable_mem_component_of_name_ne
+    {component : Component FGL}
+    (h_name : component.circuit.name ≠
+      ZiskFv.AirsClean.Mem.componentWithDualMemBus.circuit.name)
+    (h_component : component = ZiskFv.AirsClean.Mem.componentWithDualMemBus) : False :=
+  h_name (congrArg (fun c : Component FGL => c.circuit.name) h_component)
+
+private theorem addAddiSpinWitness_main_component_cases
+    {table : Table FGL}
+    (h_table : table ∈ addAddiSpinWitness.allTables)
+    (h_component : table.component = componentWithRomMemAndOpBus 3 addAddiSpinProgram) :
+    table = addAddiSpinMainTable := by
+  rw [EnsembleWitness.allTables, List.mem_cons] at h_table
+  rcases h_table with h_verifier | h_table
+  · subst table
+    exfalso
+    exact not_addAddiSpin_main_component_of_width_ne (by decide) h_component
+  · rw [addAddiSpinWitness_tables] at h_table
+    simp [addAddiSpinTables] at h_table
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    · exfalso
+      exact not_addAddiSpin_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addAddiSpin_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addAddiSpin_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addAddiSpin_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addAddiSpin_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addAddiSpin_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addAddiSpin_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addAddiSpin_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addAddiSpin_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addAddiSpin_main_component_of_name_ne (by decide) h_component
+    · rfl
+
+private theorem addAddiSpinWitness_mutable_mem_component_tables_empty
+    (table : Table FGL) (h_table : table ∈ addAddiSpinWitness.allTables)
+    (h_component : table.component = ZiskFv.AirsClean.Mem.componentWithDualMemBus) :
+    table.table = [] := by
+  rw [EnsembleWitness.allTables, List.mem_cons] at h_table
+  rcases h_table with h_verifier | h_table
+  · exfalso
+    rw [h_verifier, EnsembleWitness.verifierTable_component] at h_component
+    have h_verifier_nil :=
+      ZiskFv.AirsClean.FullEnsemble.verifierTable_interactionsWith_memBus_nil
+        3 addAddiSpinProgram
+    change Operations.interactionsWith MemBusChannel.toRaw
+      addAddiSpinEnsemble.verifierTable.operations = [] at h_verifier_nil
+    rw [h_component,
+      ZiskFv.AirsClean.Mem.componentWithDualMemBus_interactionsWith_memBus] at h_verifier_nil
+    exact absurd h_verifier_nil (by simp)
+  · rw [addAddiSpinWitness_tables] at h_table
+    simp [addAddiSpinTables] at h_table
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    · exfalso
+      exact not_addAddiSpin_mutable_mem_component_of_name_ne (by decide) h_component
+    · simp [emptyComponentTable]
+    · simp [emptyComponentTable]
+    · simp [emptyComponentTable]
+    · simp [emptyComponentTable]
+    · simp [emptyComponentTable]
+    · simp [emptyComponentTable]
+    · simp [emptyComponentTable]
+    · simp [emptyComponentTable]
+    · exfalso
+      exact not_addAddiSpin_mutable_mem_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addAddiSpin_mutable_mem_component_of_name_ne (by decide) h_component
+
+theorem addAddiSpinWitness_not_mutableMemPresent :
+    ¬ MutableMemPresent addAddiSpinWitness := by
+  intro h_present
+  obtain ⟨table, h_table, h_component, h_length⟩ := h_present
+  have h_empty :=
+    addAddiSpinWitness_mutable_mem_component_tables_empty table h_table h_component
+  exact absurd h_length (by simp [h_empty])
+
+theorem addAddiSpinWitness_main_height :
+    ∀ table ∈ addAddiSpinWitness.allTables,
+      table.component = componentWithRomMemAndOpBus 3 addAddiSpinProgram →
+        ∀ i : Fin 3, i.val < table.table.length := by
+  intro table h_table h_component i
+  have h_main := addAddiSpinWitness_main_component_cases h_table h_component
+  subst table
+  fin_cases i <;> norm_num [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows]
+
+private theorem addAddiSpinMain_segment_l1_first :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinProgram
+        addAddiSpinMainTable).segment_l1 0 = 1 := by
+  simp [ZiskFv.AirsClean.FullEnsemble.mainOfTable_segment_l1]
+  unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+  change (Eval.eval (addAddiSpinMainTable.environment (mainRowArray addAddiSpinAddRow))
+      (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar).core.segment_l1 = 1
+  simpa [addAddiSpinMainTable] using congrArg (fun row : MainRowWithRom FGL => row.core.segment_l1)
+    (mainRowsTable_eval_rowInputVar 3 addAddiSpinProgram addAddiSpinMainRows addAddiSpinAddRow)
+
+private theorem addAddiSpinMain_segment_l1_later
+    (idx : Fin addAddiSpinMainTable.table.length) (h_idx : 0 < idx.val) :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinProgram
+        addAddiSpinMainTable).segment_l1 idx.val = 0 := by
+  have h_idx_lt : idx.val < 4 := by
+    have h_table_len : addAddiSpinMainTable.table.length = 4 := by
+      simp [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows]
+    rw [← h_table_len]
+    exact idx.isLt
+  interval_cases idx.val
+  · simp [ZiskFv.AirsClean.FullEnsemble.mainOfTable_segment_l1]
+    unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+    change (Eval.eval (addAddiSpinMainTable.environment (mainRowArray addAddiSpinAddiRow))
+        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar).core.segment_l1 = 0
+    simpa [addAddiSpinMainTable] using
+      congrArg (fun row : MainRowWithRom FGL => row.core.segment_l1)
+        (mainRowsTable_eval_rowInputVar 3 addAddiSpinProgram addAddiSpinMainRows
+          addAddiSpinAddiRow)
+  · simp [ZiskFv.AirsClean.FullEnsemble.mainOfTable_segment_l1]
+    unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+    change (Eval.eval (addAddiSpinMainTable.environment (mainRowArray (addAddiSpinJalRow 2)))
+        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar).core.segment_l1 = 0
+    simpa [addAddiSpinMainTable] using
+      congrArg (fun row : MainRowWithRom FGL => row.core.segment_l1)
+        (mainRowsTable_eval_rowInputVar 3 addAddiSpinProgram addAddiSpinMainRows
+          (addAddiSpinJalRow 2))
+  · simp [ZiskFv.AirsClean.FullEnsemble.mainOfTable_segment_l1]
+    unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+    change (Eval.eval (addAddiSpinMainTable.environment (mainRowArray (addAddiSpinJalRow 3)))
+        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar).core.segment_l1 = 0
+    simpa [addAddiSpinMainTable] using
+      congrArg (fun row : MainRowWithRom FGL => row.core.segment_l1)
+        (mainRowsTable_eval_rowInputVar 3 addAddiSpinProgram addAddiSpinMainRows
+          (addAddiSpinJalRow 3))
+
+private theorem addAddiSpinMain_main_step_eq_index :
+    ∀ i : Fin 3,
+      (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero addAddiSpinProgram
+          addAddiSpinMainTable i.val).rom.main_step = (i.val : FGL) := by
+  intro i
+  fin_cases i
+  · unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+    change (Eval.eval (addAddiSpinMainTable.environment (mainRowArray addAddiSpinAddRow))
+        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar).rom.main_step = 0
+    simpa [addAddiSpinMainTable] using
+      congrArg (fun row : MainRowWithRom FGL => row.rom.main_step)
+        (mainRowsTable_eval_rowInputVar 3 addAddiSpinProgram addAddiSpinMainRows
+          addAddiSpinAddRow)
+  · unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+    change (Eval.eval (addAddiSpinMainTable.environment (mainRowArray addAddiSpinAddiRow))
+        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar).rom.main_step = 1
+    simpa [addAddiSpinMainTable] using
+      congrArg (fun row : MainRowWithRom FGL => row.rom.main_step)
+        (mainRowsTable_eval_rowInputVar 3 addAddiSpinProgram addAddiSpinMainRows
+          addAddiSpinAddiRow)
+  · unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+    change (Eval.eval (addAddiSpinMainTable.environment (mainRowArray (addAddiSpinJalRow 2)))
+        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar).rom.main_step = 2
+    simpa [addAddiSpinMainTable] using
+      congrArg (fun row : MainRowWithRom FGL => row.rom.main_step)
+        (mainRowsTable_eval_rowInputVar 3 addAddiSpinProgram addAddiSpinMainRows
+          (addAddiSpinJalRow 2))
+
+private theorem addAddiSpinMain_main_step_index_fixed :
+    MainStepIndexFixedFacts 3 addAddiSpinProgram addAddiSpinMainTable where
+  main_step_eq_index := addAddiSpinMain_main_step_eq_index
+  timestamp_bound := by
+    intro i
+    fin_cases i <;> decide
+  load_timestamp_toNat := by
+    intro i
+    fin_cases i
+    · rw [addAddiSpinMain_main_step_eq_index ⟨0, by decide⟩]
+      decide
+    · rw [addAddiSpinMain_main_step_eq_index ⟨1, by decide⟩]
+      decide
+    · rw [addAddiSpinMain_main_step_eq_index ⟨2, by decide⟩]
+      decide
+  store_timestamp_toNat := by
+    intro i
+    fin_cases i
+    · rw [addAddiSpinMain_main_step_eq_index ⟨0, by decide⟩]
+      decide
+    · rw [addAddiSpinMain_main_step_eq_index ⟨1, by decide⟩]
+      decide
+    · rw [addAddiSpinMain_main_step_eq_index ⟨2, by decide⟩]
+      decide
+
+theorem addAddiSpinWitness_main_step_index_fixed :
+    ∀ table ∈ addAddiSpinWitness.allTables,
+      table.component = componentWithRomMemAndOpBus 3 addAddiSpinProgram →
+        MainStepIndexFixedFacts 3 addAddiSpinProgram table := by
+  intro table h_table h_component
+  have h_main := addAddiSpinWitness_main_component_cases h_table h_component
+  subst table
+  exact addAddiSpinMain_main_step_index_fixed
+
+set_option linter.unnecessarySimpa false in
+theorem addAddiSpinWitness_segment_l1_fixed :
+    ∀ table ∈ addAddiSpinWitness.allTables,
+      table.component = componentWithRomMemAndOpBus 3 addAddiSpinProgram →
+        (0 < table.table.length →
+            (ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinProgram table).segment_l1 0 = 1) ∧
+        (∀ idx : Fin table.table.length, 0 < idx.val →
+            (ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinProgram table).segment_l1
+              idx.val = 0) := by
+  intro table h_table h_component
+  have h_main := addAddiSpinWitness_main_component_cases h_table h_component
+  subst table
+  exact ⟨fun _ => addAddiSpinMain_segment_l1_first, addAddiSpinMain_segment_l1_later⟩
+
+theorem addAddiSpinOpBus_interactions :
+    addAddiSpinWitness.tables.flatMap (·.interactionsWith OpBusChannel.toRaw) =
+      [ binaryAddOpBusInteraction addX1BinaryAddRow
+      , binaryAddOpBusInteraction addX1BinaryAddRow
+      , mainOpBusInteraction addAddiSpinAddRow
+      , mainOpBusInteraction addAddiSpinAddiRow
+      , mainOpBusInteraction (addAddiSpinJalRow 2)
+      , mainOpBusInteraction (addAddiSpinJalRow 3) ] := by
+  have h_registerBoundary :
+      addAddiSpinBoundaryTable.interactionsWith OpBusChannel.toRaw = [] := by
+    exact ZiskFv.AirsClean.FullEnsemble.registerBoundary_table_interactionsWith_opBus_nil
+      (table := addAddiSpinBoundaryTable) rfl
+  rw [addAddiSpinWitness_tables]
+  simp [addAddiSpinTables, h_registerBoundary, emptyComponentTable_interactionsWith,
+    addAddiSpinBinaryAddTable, binaryAddRowsTable_interactionsWith_opBus,
+    addAddiSpinBinaryAddRows, addAddiSpinMainTable, mainRowsTable_interactionsWith_opBus,
+    addAddiSpinMainRows]
+
+theorem addAddiSpinWitness_opBus_balanced :
+    BalancedInteractions
+      (addAddiSpinWitness.tables.flatMap (·.interactionsWith OpBusChannel.toRaw)) := by
+  rw [addAddiSpinOpBus_interactions]
+  refine Air.Flat.balancedInteractions_of_present ?_
+    ([ binaryAddOpBusInteraction addX1BinaryAddRow
+      , binaryAddOpBusInteraction addX1BinaryAddRow
+      , mainOpBusInteraction addAddiSpinAddRow
+      , mainOpBusInteraction addAddiSpinAddiRow
+      , mainOpBusInteraction (addAddiSpinJalRow 2)
+      , mainOpBusInteraction (addAddiSpinJalRow 3) ].map (·.msg)) ?_ ?_
+  · left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+  · intro interaction h_interaction
+    exact List.mem_map_of_mem h_interaction
+  · intro msg h_msg
+    simp only [List.mem_map] at h_msg
+    rcases h_msg with ⟨interaction, h_interaction, rfl⟩
+    simp at h_interaction
+    rcases h_interaction with rfl | rfl | rfl | rfl | rfl | rfl <;>
+      decide
+
+def addAddiSpinMainValueMemBusInteractions
+    (row : MainRowWithRom FGL) : List (Interaction FGL) :=
+  mainValueMemBusInteractions row
+
+theorem addAddiSpinBoundaryRows_interactions :
+    addAddiSpinBoundaryRows.flatMap registerBoundaryMemBusInteractions =
+      boundaryInteractions addAddiSpinBoundaryRowX1 ++ idleBoundaryInteractions := by
+  simp [addAddiSpinBoundaryRows, boundaryInteractions, idleBoundaryInteractions]
+  generalize List.range 30 = indices
+  induction indices with
+  | nil => rfl
+  | cons _ _ ih => simp [ih]
+
+def addAddiSpinX1Interactions : List (Interaction FGL) :=
+  boundaryInteractions addAddiSpinBoundaryRowX1 ++
+    addAddiSpinMainValueMemBusInteractions addAddiSpinAddRow ++
+    addAddiSpinMainValueMemBusInteractions addAddiSpinAddiRow
+
+def addAddiSpinX1Telescope : List (Interaction FGL) :=
+  registerTelescopingInteractions
+    (ZiskFv.AirsClean.RegisterBoundary.bootMessage addAddiSpinBoundaryRowX1)
+    [ aMemMessage addAddiSpinAddRow
+    , bMemMessage addAddiSpinAddRow
+    , cMemMessage addAddiSpinAddRow
+    , aMemMessage addAddiSpinAddiRow
+    , cMemMessage addAddiSpinAddiRow ]
+
+def addAddiSpinAddiZeroInteractions : List (Interaction FGL) :=
+  [ mainBRegPreInteraction addAddiSpinAddiRow
+  , mainBMemInteraction addAddiSpinAddiRow ]
+
+private def addAddiSpinX1Prefix : List (Interaction FGL) :=
+  [ emittedPulledValue
+      (ZiskFv.AirsClean.RegisterBoundary.bootMessage addAddiSpinBoundaryRowX1)
+  , MemBusChannel.pushedValue (cMemMessage addAddiSpinAddiRow)
+  , MemBusChannel.pushedValue
+      (ZiskFv.AirsClean.RegisterBoundary.bootMessage addAddiSpinBoundaryRowX1)
+  , emittedPulledValue (aMemMessage addAddiSpinAddRow)
+  , MemBusChannel.pushedValue (aMemMessage addAddiSpinAddRow)
+  , emittedPulledValue (bMemMessage addAddiSpinAddRow)
+  , MemBusChannel.pushedValue (bMemMessage addAddiSpinAddRow)
+  , emittedPulledValue (cMemMessage addAddiSpinAddRow)
+  , MemBusChannel.pushedValue (cMemMessage addAddiSpinAddRow)
+  , emittedPulledValue (aMemMessage addAddiSpinAddiRow) ]
+
+private def addAddiSpinX1FinalPair : List (Interaction FGL) :=
+  [ MemBusChannel.pushedValue (aMemMessage addAddiSpinAddiRow)
+  , emittedPulledValue (cMemMessage addAddiSpinAddiRow) ]
+
+private theorem addAddiSpinBoundaryInteractions_eq :
+    boundaryInteractions addAddiSpinBoundaryRowX1 =
+      [ emittedPulledValue
+          (ZiskFv.AirsClean.RegisterBoundary.bootMessage addAddiSpinBoundaryRowX1)
+      , MemBusChannel.pushedValue (cMemMessage addAddiSpinAddiRow) ] := by
+  simp [boundaryInteractions, registerBoundaryMemBusInteractions,
+    registerBoundaryBootInteraction, registerBoundaryReloadInteraction,
+    addAddiSpinBoundaryRowX1, boundaryRowX1, addAddiSpinAddiRow,
+    addAddiSpinAddiProgramRow, addAddiSpinAddiBits, addAddiSpinAddiFreeCols, mainRomRowOf,
+    emittedPulledValue, Channel.pushedValue, cMemMessage]
+
+private theorem addAddiSpinAddInteractions_eq :
+    addAddiSpinMainValueMemBusInteractions addAddiSpinAddRow =
+      [ MemBusChannel.pushedValue
+          (ZiskFv.AirsClean.RegisterBoundary.bootMessage addAddiSpinBoundaryRowX1)
+      , emittedPulledValue (aMemMessage addAddiSpinAddRow)
+      , MemBusChannel.pushedValue (aMemMessage addAddiSpinAddRow)
+      , emittedPulledValue (bMemMessage addAddiSpinAddRow)
+      , MemBusChannel.pushedValue (bMemMessage addAddiSpinAddRow)
+      , emittedPulledValue (cMemMessage addAddiSpinAddRow) ] := by
+  simp [addAddiSpinMainValueMemBusInteractions, mainValueMemBusInteractions,
+    mainARegPreInteraction,
+    mainAMemInteraction, mainBRegPreInteraction, mainBMemInteraction,
+    mainCRegPreInteraction, mainCMemInteraction, addAddiSpinAddRow, addX1Row,
+    addAddiSpinBoundaryRowX1, boundaryRowX1, emittedPulledValue, Channel.pushedValue,
+    aRegPreMessage, aMemMessage, bRegPreMessage, bMemMessage, cRegPreMessage, cMemMessage]
+
+private theorem addAddiSpinAddiInteractions_eq :
+    addAddiSpinMainValueMemBusInteractions addAddiSpinAddiRow =
+      [ MemBusChannel.pushedValue (cMemMessage addAddiSpinAddRow)
+      , emittedPulledValue (aMemMessage addAddiSpinAddiRow)
+      , mainBRegPreInteraction addAddiSpinAddiRow
+      , mainBMemInteraction addAddiSpinAddiRow
+      , MemBusChannel.pushedValue (aMemMessage addAddiSpinAddiRow)
+      , emittedPulledValue (cMemMessage addAddiSpinAddiRow) ] := by
+  simp [addAddiSpinMainValueMemBusInteractions, mainValueMemBusInteractions,
+    mainARegPreInteraction,
+    mainAMemInteraction, mainCRegPreInteraction, mainCMemInteraction,
+    addAddiSpinAddRow, addX1Row, addAddiSpinAddiRow, addAddiSpinAddiProgramRow,
+    addAddiSpinAddiBits, addAddiSpinAddiFreeCols, mainRomRowOf,
+    emittedPulledValue, Channel.pushedValue, aRegPreMessage, aMemMessage,
+    cRegPreMessage, cMemMessage]
+
+private theorem addAddiSpinX1Interactions_eq :
+    addAddiSpinX1Interactions =
+      addAddiSpinX1Prefix ++ addAddiSpinAddiZeroInteractions ++ addAddiSpinX1FinalPair := by
+  rw [addAddiSpinX1Interactions, addAddiSpinBoundaryInteractions_eq,
+    addAddiSpinAddInteractions_eq, addAddiSpinAddiInteractions_eq]
+  rfl
+
+private theorem addAddiSpinX1Telescope_eq :
+    addAddiSpinX1Telescope = addAddiSpinX1Prefix ++ addAddiSpinX1FinalPair := by
+  rfl
+
+private theorem addAddiSpinX1Interactions_perm :
+    List.Perm addAddiSpinX1Interactions
+      (addAddiSpinX1Telescope ++ addAddiSpinAddiZeroInteractions) := by
+  rw [addAddiSpinX1Interactions_eq, addAddiSpinX1Telescope_eq]
+  have h_tail : List.Perm
+      (addAddiSpinAddiZeroInteractions ++ addAddiSpinX1FinalPair)
+      (addAddiSpinX1FinalPair ++ addAddiSpinAddiZeroInteractions) :=
+    List.perm_append_comm
+  simpa [List.append_assoc] using
+    List.Perm.append (List.Perm.refl addAddiSpinX1Prefix) h_tail
+
+theorem addAddiSpinX1Interactions_balanced :
+    BalancedInteractions addAddiSpinX1Interactions := by
+  have h_telescope : BalancedInteractions addAddiSpinX1Telescope := by
+    apply registerTelescopingInteractions_balanced
+    left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+  have h_zero : BalancedInteractions addAddiSpinAddiZeroInteractions := by
+    apply ZiskFv.Compliance.RegisterMemBusBalance.zeroInteractions_balanced
+    · intro interaction h_interaction
+      simp [addAddiSpinAddiZeroInteractions] at h_interaction
+      rcases h_interaction with rfl | rfl <;>
+        decide
+    · left
+      rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+      decide
+  have h_combined :
+      BalancedInteractions (addAddiSpinX1Telescope ++ addAddiSpinAddiZeroInteractions) :=
+    balancedInteractions_append_of_balanced h_telescope h_zero (by
+      left
+      rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+      decide)
+  exact balancedInteractions_of_perm h_combined addAddiSpinX1Interactions_perm.symm
+
+private def addAddiSpinIdleBoundaryMessages : List (MemBusMessage FGL) :=
+  (List.range 30).map fun i =>
+    ZiskFv.AirsClean.RegisterBoundary.bootMessage
+      (boundaryRowIdle ((i + 2 : Nat) : FGL))
+
+private theorem addAddiSpinIdleBoundaryInteractions_eq_paired :
+    idleBoundaryInteractions = pairedInteractions addAddiSpinIdleBoundaryMessages := by
+  unfold idleBoundaryInteractions addAddiSpinIdleBoundaryMessages
+  generalize List.range 30 = indices
+  induction indices with
+  | nil => rfl
+  | cons i rest ih =>
+      simp only [List.map_cons, List.flatMap_cons, pairedInteractions]
+      have h_head : boundaryInteractions (boundaryRowIdle ((i + 2 : Nat) : FGL)) =
+          pairedInteraction
+            (ZiskFv.AirsClean.RegisterBoundary.bootMessage
+              (boundaryRowIdle ((i + 2 : Nat) : FGL))) := by
+        simp [boundaryInteractions, registerBoundaryMemBusInteractions,
+          registerBoundaryBootInteraction, registerBoundaryReloadInteraction,
+          pairedInteraction, boundaryRowIdle, emittedPulledValue, Channel.pushedValue]
+      rw [h_head]
+      rw [ih]
+      rfl
+
+private theorem addAddiSpinIdleBoundaryInteractions_balanced :
+    BalancedInteractions idleBoundaryInteractions := by
+  rw [addAddiSpinIdleBoundaryInteractions_eq_paired]
+  apply pairedInteractions_balanced
+  left
+  rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+  decide
+
+private theorem addAddiSpinJalMemBusInactive (step : FGL) :
+    MainMemBusInactive (addAddiSpinJalRow step) := by
+  constructor <;>
+    simp [addAddiSpinJalRow, addSpinJalRow, addSpinJalProgramRow, addSpinJalBits,
+      addSpinJalFreeCols, mainRomRowOf]
+
+private theorem addAddiSpinJalMemBusInteractions_balanced (step : FGL) :
+    BalancedInteractions
+      (mainMemBusInteractionsFor 3 addAddiSpinProgram (addAddiSpinJalRow step)) := by
+  exact mainMemBusInteractionsFor_balanced_of_inactive 3 addAddiSpinProgram
+    (addAddiSpinJalRow step) (addAddiSpinJalMemBusInactive step)
+
+noncomputable def addAddiSpinMemBusInteractions : List (Interaction FGL) :=
+  addAddiSpinWitness.tables.flatMap (·.interactionsWith MemBusChannel.toRaw)
+
+private noncomputable def addAddiSpinReducedMemBusInteractions : List (Interaction FGL) :=
+  (boundaryInteractions addAddiSpinBoundaryRowX1 ++ idleBoundaryInteractions) ++
+    addAddiSpinMainValueMemBusInteractions addAddiSpinAddRow ++
+    addAddiSpinMainValueMemBusInteractions addAddiSpinAddiRow ++
+    mainMemBusInteractionsFor 3 addAddiSpinProgram (addAddiSpinJalRow 2) ++
+    mainMemBusInteractionsFor 3 addAddiSpinProgram (addAddiSpinJalRow 3)
+
+private theorem addAddiSpinMemBusInteractions_eq_tables :
+    addAddiSpinMemBusInteractions =
+      addAddiSpinTables.flatMap (·.interactionsWith MemBusChannel.toRaw) := by
+  exact congrArg (fun tables => tables.flatMap (·.interactionsWith MemBusChannel.toRaw))
+    addAddiSpinWitness_tables
+
+private theorem flatMap_eleven_of_middle_nil
+    {α : Type u} {β : Type v} (f : α → List β)
+    (first e₀ e₁ e₂ e₃ e₄ e₅ e₆ e₇ last₀ last₁ : α)
+    (h₀ : f e₀ = []) (h₁ : f e₁ = []) (h₂ : f e₂ = []) (h₃ : f e₃ = [])
+    (h₄ : f e₄ = []) (h₅ : f e₅ = []) (h₆ : f e₆ = []) (h₇ : f e₇ = []) :
+    [first, e₀, e₁, e₂, e₃, e₄, e₅, e₆, e₇, last₀, last₁].flatMap f =
+      f first ++ f last₀ ++ f last₁ := by
+  simp [h₀, h₁, h₂, h₃, h₄, h₅, h₆, h₇]
+
+private theorem addAddiSpinTablesMemBusInteractions_eq_active :
+    addAddiSpinTables.flatMap (·.interactionsWith MemBusChannel.toRaw) =
+      addAddiSpinBoundaryTable.interactionsWith MemBusChannel.toRaw ++
+        addAddiSpinBinaryAddTable.interactionsWith MemBusChannel.toRaw ++
+        addAddiSpinMainTable.interactionsWith MemBusChannel.toRaw := by
+  unfold addAddiSpinTables
+  exact flatMap_eleven_of_middle_nil
+    (α := Table FGL) (β := Interaction FGL)
+    (f := fun table => table.interactionsWith MemBusChannel.toRaw)
+    (first := addAddiSpinBoundaryTable)
+    (e₀ := emptyComponentTable ZiskFv.AirsClean.MemAlignReadByte.component)
+    (e₁ := emptyComponentTable ZiskFv.AirsClean.MemAlignByte.component)
+    (e₂ := emptyComponentTable ZiskFv.AirsClean.MemAlign.component)
+    (e₃ := emptyComponentTable ZiskFv.AirsClean.Mem.componentWithDualMemBus)
+    (e₄ := emptyComponentTable ZiskFv.AirsClean.ArithDiv.component)
+    (e₅ := emptyComponentTable ZiskFv.AirsClean.ArithMul.componentWithArithTable)
+    (e₆ := emptyComponentTable ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
+    (e₇ := emptyComponentTable ZiskFv.AirsClean.Binary.staticLookupComponent)
+    (last₀ := addAddiSpinBinaryAddTable) (last₁ := addAddiSpinMainTable)
+    (h₀ := emptyComponentTable_interactionsWith
+      ZiskFv.AirsClean.MemAlignReadByte.component MemBusChannel.toRaw)
+    (h₁ := emptyComponentTable_interactionsWith
+      ZiskFv.AirsClean.MemAlignByte.component MemBusChannel.toRaw)
+    (h₂ := emptyComponentTable_interactionsWith
+      ZiskFv.AirsClean.MemAlign.component MemBusChannel.toRaw)
+    (h₃ := emptyComponentTable_interactionsWith
+      ZiskFv.AirsClean.Mem.componentWithDualMemBus MemBusChannel.toRaw)
+    (h₄ := emptyComponentTable_interactionsWith
+      ZiskFv.AirsClean.ArithDiv.component MemBusChannel.toRaw)
+    (h₅ := emptyComponentTable_interactionsWith
+      ZiskFv.AirsClean.ArithMul.componentWithArithTable MemBusChannel.toRaw)
+    (h₆ := emptyComponentTable_interactionsWith
+      ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent MemBusChannel.toRaw)
+    (h₇ := emptyComponentTable_interactionsWith
+      ZiskFv.AirsClean.Binary.staticLookupComponent MemBusChannel.toRaw)
+
+private theorem addAddiSpinBoundaryTableMemBusInteractions_eq_rows :
+    addAddiSpinBoundaryTable.interactionsWith MemBusChannel.toRaw =
+      addAddiSpinBoundaryRows.flatMap registerBoundaryMemBusInteractions := by
+  unfold addAddiSpinBoundaryTable
+  exact registerBoundaryRowsTableOf_interactionsWith_memBus addAddiSpinBoundaryRows
+
+private theorem addAddiSpinBinaryAddTableMemBusInteractions_eq_nil :
+    addAddiSpinBinaryAddTable.interactionsWith MemBusChannel.toRaw = [] := by
+  exact ZiskFv.AirsClean.FullEnsemble.binaryAdd_table_interactionsWith_memBus_nil
+    (table := addAddiSpinBinaryAddTable) rfl
+
+private theorem addAddiSpinMainTableMemBusInteractions_eq_rows :
+    addAddiSpinMainTable.interactionsWith MemBusChannel.toRaw =
+      mainMemBusInteractionsForRows 3 addAddiSpinProgram addAddiSpinMainRows := by
+  unfold addAddiSpinMainTable
+  exact mainRowsTable_interactionsWith_memBus 3 addAddiSpinProgram addAddiSpinMainRows
+
+private theorem addAddiSpinMainRowsMemBusInteractions_eq_expanded :
+    mainMemBusInteractionsForRows 3 addAddiSpinProgram addAddiSpinMainRows =
+      mainMemBusInteractionsFor 3 addAddiSpinProgram addAddiSpinAddRow ++
+        mainMemBusInteractionsFor 3 addAddiSpinProgram addAddiSpinAddiRow ++
+        mainMemBusInteractionsFor 3 addAddiSpinProgram (addAddiSpinJalRow 2) ++
+        mainMemBusInteractionsFor 3 addAddiSpinProgram (addAddiSpinJalRow 3) := by
+  unfold addAddiSpinMainRows
+  exact mainMemBusInteractionsForRows_four 3 addAddiSpinProgram addAddiSpinAddRow
+    addAddiSpinAddiRow (addAddiSpinJalRow 2) (addAddiSpinJalRow 3)
+
+private theorem addAddiSpinExpandedMemBusInteractions_eq_reduced :
+    (boundaryInteractions addAddiSpinBoundaryRowX1 ++ idleBoundaryInteractions) ++
+      (mainMemBusInteractionsFor 3 addAddiSpinProgram addAddiSpinAddRow ++
+        mainMemBusInteractionsFor 3 addAddiSpinProgram addAddiSpinAddiRow ++
+        mainMemBusInteractionsFor 3 addAddiSpinProgram (addAddiSpinJalRow 2) ++
+        mainMemBusInteractionsFor 3 addAddiSpinProgram (addAddiSpinJalRow 3)) =
+      addAddiSpinReducedMemBusInteractions := by
+  unfold addAddiSpinReducedMemBusInteractions
+  rw [mainMemBusInteractionsFor_eq_valueLevel 3 addAddiSpinProgram addAddiSpinAddRow,
+    mainMemBusInteractionsFor_eq_valueLevel 3 addAddiSpinProgram addAddiSpinAddiRow]
+  rfl
+
+private theorem addAddiSpinReducedMemBusInteractions_balanced :
+    BalancedInteractions addAddiSpinReducedMemBusInteractions := by
+  unfold addAddiSpinReducedMemBusInteractions
+  let addRows := addAddiSpinMainValueMemBusInteractions addAddiSpinAddRow ++
+    addAddiSpinMainValueMemBusInteractions addAddiSpinAddiRow
+  let jalRows := mainMemBusInteractionsFor 3 addAddiSpinProgram (addAddiSpinJalRow 2) ++
+    mainMemBusInteractionsFor 3 addAddiSpinProgram (addAddiSpinJalRow 3)
+  have h_perm : List.Perm
+      ((boundaryInteractions addAddiSpinBoundaryRowX1 ++ idleBoundaryInteractions) ++
+        addRows ++ jalRows)
+      (addAddiSpinX1Interactions ++ idleBoundaryInteractions ++ jalRows) := by
+    have h_swap : List.Perm (idleBoundaryInteractions ++ addRows)
+        (addRows ++ idleBoundaryInteractions) := List.perm_append_comm
+    have h_with_boundary := List.Perm.append
+      (List.Perm.append (List.Perm.refl (boundaryInteractions addAddiSpinBoundaryRowX1))
+        h_swap)
+      (List.Perm.refl jalRows)
+    simpa [addRows, jalRows, addAddiSpinX1Interactions, List.append_assoc] using
+      h_with_boundary
+  have h_jal : BalancedInteractions jalRows :=
+    balancedInteractions_append_of_balanced
+      (addAddiSpinJalMemBusInteractions_balanced 2)
+      (addAddiSpinJalMemBusInteractions_balanced 3) (by
+        left
+        rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+        decide)
+  have h_reordered :
+      BalancedInteractions (addAddiSpinX1Interactions ++ idleBoundaryInteractions ++ jalRows) :=
+    balancedInteractions_append_of_balanced
+      (balancedInteractions_append_of_balanced
+        addAddiSpinX1Interactions_balanced addAddiSpinIdleBoundaryInteractions_balanced (by
+          left
+          rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+          decide))
+      h_jal (by
+        left
+        rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+        decide)
+  apply balancedInteractions_of_perm h_reordered
+  simpa [addRows, jalRows, List.append_assoc] using h_perm.symm
+
+theorem addAddiSpinWitness_memBus_balanced :
+    BalancedInteractions addAddiSpinMemBusInteractions := by
+  rw [addAddiSpinMemBusInteractions_eq_tables,
+    addAddiSpinTablesMemBusInteractions_eq_active,
+    addAddiSpinBoundaryTableMemBusInteractions_eq_rows,
+    addAddiSpinBinaryAddTableMemBusInteractions_eq_nil,
+    addAddiSpinMainTableMemBusInteractions_eq_rows]
+  simp only [List.append_nil]
+  rw [addAddiSpinBoundaryRows_interactions,
+    addAddiSpinMainRowsMemBusInteractions_eq_expanded,
+    addAddiSpinExpandedMemBusInteractions_eq_reduced]
+  exact addAddiSpinReducedMemBusInteractions_balanced
+
+theorem addAddiSpinWitness_balancedChannels : addAddiSpinWitness.BalancedChannels := by
+  refine addAddiSpinWitness.balancedChannels_of_tables addAddiSpinEnsemble_verifier ?_
+  intro channel h_channel
+  simp [addAddiSpinEnsemble, fullRv64imEnsemble, fullRv64imSoundEnsemble,
+    SoundEnsemble.toFormal, SoundEnsemble.addFinishedChannel_channels,
+    SoundEnsemble.addTable_channels, SoundEnsemble.empty_channels] at h_channel
+  rcases h_channel with rfl | rfl
+  · change BalancedInteractions addAddiSpinMemBusInteractions
+    exact addAddiSpinWitness_memBus_balanced
+  · exact addAddiSpinWitness_opBus_balanced
+
+def addAddiSpinAcceptedTrace : AcceptedZiskTrace 3 where
+  program := addAddiSpinProgram
+  witness := addAddiSpinWitness
+  constraints_hold := addAddiSpinWitness_constraints
+  channels_balanced := addAddiSpinWitness_balancedChannels
+  mem_replay_table := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
+  mem_replay_segment := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
+  mem_replay_permutation := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
+  mem_replay_gsum := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
+  mem_replay_im0 := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
+  mem_replay_im1 := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
+  mem_replay_constraints := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
+  mem_replay_row_ranges := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
+  mem_replay_segment_ranges := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
+  mem_replay_source_covers := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
+  transitions_hold := addAddiSpinWitness_transitions
+  main_height := addAddiSpinWitness_main_height
+  segment_l1_fixed := addAddiSpinWitness_segment_l1_fixed
+  main_step_index_fixed := addAddiSpinWitness_main_step_index_fixed
+
+theorem addAddiSpinAcceptedTrace_mainTable_eq :
+    addAddiSpinAcceptedTrace.mainTable = addAddiSpinMainTable := by
+  exact addAddiSpinWitness_main_component_cases
+    (by simpa [addAddiSpinAcceptedTrace] using addAddiSpinAcceptedTrace.mainTable_mem)
+    (by simpa [addAddiSpinAcceptedTrace] using addAddiSpinAcceptedTrace.mainTable_component)
+
+end ZiskFv.Compliance.AddAddiSpinWitness

--- a/ZiskFv/Compliance/AddSpinWitness.lean
+++ b/ZiskFv/Compliance/AddSpinWitness.lean
@@ -149,13 +149,74 @@ theorem mainRowsTable_interactionsWith_opBus
       rows.flatMap fun row => [mainOpBusInteraction row]
   exact mainRowsTable_interactionsWith_opBus_go length program rows rows
 
+def mainMemBusInteractionsFor
+    (length : ℕ) (program : Program length) (row : MainRowWithRom FGL) :
+    List (Interaction FGL) :=
+  mainMemBusInteractions length program row
+
+def mainValueMemBusInteractions (row : MainRowWithRom FGL) : List (Interaction FGL) :=
+  [ mainARegPreInteraction row
+  , mainAMemInteraction row
+  , mainBRegPreInteraction row
+  , mainBMemInteraction row
+  , mainCRegPreInteraction row
+  , mainCMemInteraction row ]
+
+theorem mainValueMemBusInteractions_balanced_of_zero
+    (row : MainRowWithRom FGL)
+    (h_aReg : (mainARegPreInteraction row).mult = 0)
+    (h_aMem : (mainAMemInteraction row).mult = 0)
+    (h_bReg : (mainBRegPreInteraction row).mult = 0)
+    (h_bMem : (mainBMemInteraction row).mult = 0)
+    (h_cReg : (mainCRegPreInteraction row).mult = 0)
+    (h_cMem : (mainCMemInteraction row).mult = 0) :
+    BalancedInteractions (mainValueMemBusInteractions row) := by
+  apply zeroInteractions_balanced
+  · intro interaction h_interaction
+    simp [mainValueMemBusInteractions] at h_interaction
+    rcases h_interaction with rfl | rfl | rfl | rfl | rfl | rfl
+    · exact h_aReg
+    · exact h_aMem
+    · exact h_bReg
+    · exact h_bMem
+    · exact h_cReg
+    · exact h_cMem
+  · left
+    change 6 < ringChar FGL
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+
+def mainMemBusInteractionsForRows
+    (length : ℕ) (program : Program length) :
+    List (MainRowWithRom FGL) → List (Interaction FGL)
+  | [] => []
+  | row :: rest =>
+      mainMemBusInteractionsFor length program row ++
+        mainMemBusInteractionsForRows length program rest
+
+theorem mainMemBusInteractionsForRows_four
+    (length : ℕ) (program : Program length)
+    (row₀ row₁ row₂ row₃ : MainRowWithRom FGL) :
+    mainMemBusInteractionsForRows length program [row₀, row₁, row₂, row₃] =
+      mainMemBusInteractionsFor length program row₀ ++
+        mainMemBusInteractionsFor length program row₁ ++
+        mainMemBusInteractionsFor length program row₂ ++
+        mainMemBusInteractionsFor length program row₃ := by
+  rfl
+
+def mainValueMemBusInteractionsForRows :
+    List (MainRowWithRom FGL) → List (Interaction FGL)
+  | [] => []
+  | row :: rest =>
+      mainValueMemBusInteractions row ++ mainValueMemBusInteractionsForRows rest
+
 theorem mainRowsTable_memBus_row
     (length : ℕ) (program : Program length) (rows : List (MainRowWithRom FGL))
     (row : MainRowWithRom FGL) :
     (componentWithRomMemAndOpBus length program).operations.interactionValuesWith
         MemBusChannel.toRaw
         ((mainRowsTable length program rows).environment (mainRowArray row)) =
-      mainMemBusInteractions length program row := by
+      mainMemBusInteractionsFor length program row := by
   simpa [Table.interactionsWith, mainSingleRowTable, mainRowsTable] using
     mainSingleRowTable_interactionsWith_memBus length program row
 
@@ -165,20 +226,20 @@ private theorem mainRowsTable_interactionsWith_memBus_go
     (rows.map mainRowArray).flatMap (fun arr =>
         (componentWithRomMemAndOpBus length program).operations.interactionValuesWith
           MemBusChannel.toRaw ((mainRowsTable length program allRows).environment arr)) =
-      rows.flatMap (mainMemBusInteractions length program) := by
+      mainMemBusInteractionsForRows length program rows := by
   induction rows with
   | nil => rfl
   | cons row rest ih =>
-      simp [mainRowsTable_memBus_row, ih]
+      simp [mainRowsTable_memBus_row, mainMemBusInteractionsForRows, ih]
 
 theorem mainRowsTable_interactionsWith_memBus
     (length : ℕ) (program : Program length) (rows : List (MainRowWithRom FGL)) :
     (mainRowsTable length program rows).interactionsWith MemBusChannel.toRaw =
-      rows.flatMap (mainMemBusInteractions length program) := by
+      mainMemBusInteractionsForRows length program rows := by
   change (rows.map mainRowArray).flatMap (fun arr =>
         (componentWithRomMemAndOpBus length program).operations.interactionValuesWith
           MemBusChannel.toRaw ((mainRowsTable length program rows).environment arr)) =
-      rows.flatMap (mainMemBusInteractions length program)
+      mainMemBusInteractionsForRows length program rows
   exact mainRowsTable_interactionsWith_memBus_go length program rows rows
 
 theorem addSpinAddMain_proverAssumptions :
@@ -634,16 +695,6 @@ theorem addSpinWitness_segment_l1_fixed :
   · intro idx h_idx
     exact addSpinMain_segment_l1_later idx h_idx
 
-private theorem zeroInteractions_balanced
-    (interactions : List (Interaction FGL))
-    (h_zero : ∀ interaction ∈ interactions, interaction.mult = 0)
-    (h_len : interactions.length < ringChar FGL ∨ ringChar FGL = 0) :
-    BalancedInteractions interactions := by
-  refine ⟨h_len, ?_⟩
-  intro msg
-  rw [balanceOf_eq_of_const_mult' h_zero]
-  simp
-
 theorem addSpinOpBus_interactions :
     addSpinWitness.tables.flatMap (·.interactionsWith OpBusChannel.toRaw) =
       [binaryAddOpBusInteraction addX1BinaryAddRow, mainOpBusInteraction addSpinAddRow,
@@ -690,7 +741,7 @@ theorem addSpinWitness_opBus_balanced :
       rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
       decide)
 
-private theorem mainMemBusInteractions_eq_valueLevel
+theorem mainMemBusInteractions_eq_valueLevel
     (length : ℕ) (program : Program length) (row : MainRowWithRom FGL) :
     mainMemBusInteractions length program row =
       [mainARegPreInteraction row, mainAMemInteraction row, mainBRegPreInteraction row,
@@ -827,6 +878,67 @@ private theorem mainMemBusInteractions_eq_valueLevel
         mainBMemInteraction row, mainCRegPreInteraction row, mainCMemInteraction row]
   simp [h_aReg, h_aMem, h_bReg, h_bMem, h_cReg, h_cMem]
 
+theorem mainMemBusInteractionsFor_eq_valueLevel
+    (length : ℕ) (program : Program length) (row : MainRowWithRom FGL) :
+    mainMemBusInteractionsFor length program row = mainValueMemBusInteractions row := by
+  unfold mainMemBusInteractionsFor mainValueMemBusInteractions
+  exact mainMemBusInteractions_eq_valueLevel length program row
+
+theorem mainMemBusInteractionsFor_balanced_of_zero
+    (length : ℕ) (program : Program length) (row : MainRowWithRom FGL)
+    (h_aReg : (mainARegPreInteraction row).mult = 0)
+    (h_aMem : (mainAMemInteraction row).mult = 0)
+    (h_bReg : (mainBRegPreInteraction row).mult = 0)
+    (h_bMem : (mainBMemInteraction row).mult = 0)
+    (h_cReg : (mainCRegPreInteraction row).mult = 0)
+    (h_cMem : (mainCMemInteraction row).mult = 0) :
+    BalancedInteractions (mainMemBusInteractionsFor length program row) := by
+  rw [mainMemBusInteractionsFor_eq_valueLevel]
+  exact mainValueMemBusInteractions_balanced_of_zero row
+    h_aReg h_aMem h_bReg h_bMem h_cReg h_cMem
+
+structure MainMemBusInactive (row : MainRowWithRom FGL) : Prop where
+  aSrcReg : row.rom.a_src_reg = 0
+  aSrcMem : row.rom.a_src_mem = 0
+  bSrcReg : row.rom.b_src_reg = 0
+  bSrcMem : row.rom.b_src_mem = 0
+  bSrcInd : row.rom.b_src_ind = 0
+  storeReg : row.rom.store_reg = 0
+  storeMem : row.rom.store_mem = 0
+  storeInd : row.rom.store_ind = 0
+
+theorem mainMemBusInteractionsFor_balanced_of_inactive
+    (length : ℕ) (program : Program length) (row : MainRowWithRom FGL)
+    (h : MainMemBusInactive row) :
+    BalancedInteractions (mainMemBusInteractionsFor length program row) := by
+  apply mainMemBusInteractionsFor_balanced_of_zero
+  · simpa [mainARegPreInteraction] using h.aSrcReg
+  · simp [mainAMemInteraction, h.aSrcReg, h.aSrcMem]
+  · simpa [mainBRegPreInteraction] using h.bSrcReg
+  · simp [mainBMemInteraction, h.bSrcReg, h.bSrcMem, h.bSrcInd]
+  · simpa [mainCRegPreInteraction] using h.storeReg
+  · simp [mainCMemInteraction, h.storeReg, h.storeMem, h.storeInd]
+
+theorem mainMemBusInteractionsForRows_eq_valueLevel
+    (length : ℕ) (program : Program length) (rows : List (MainRowWithRom FGL)) :
+    mainMemBusInteractionsForRows length program rows =
+      mainValueMemBusInteractionsForRows rows := by
+  induction rows with
+  | nil => rfl
+  | cons row rest ih =>
+      exact (congrArg
+        (fun interactions => interactions ++
+          mainMemBusInteractionsForRows length program rest)
+        (mainMemBusInteractionsFor_eq_valueLevel length program row)).trans
+        (congrArg (fun interactions => mainValueMemBusInteractions row ++ interactions) ih)
+
+theorem mainRowsTable_interactionsWith_memBus_eq_valueLevel
+    (length : ℕ) (program : Program length) (rows : List (MainRowWithRom FGL)) :
+    (mainRowsTable length program rows).interactionsWith MemBusChannel.toRaw =
+      mainValueMemBusInteractionsForRows rows :=
+  (mainRowsTable_interactionsWith_memBus length program rows).trans
+    (mainMemBusInteractionsForRows_eq_valueLevel length program rows)
+
 theorem addSpinAddMainMemBusInteractions_eq :
     mainMemBusInteractions 2 addSpinProgram addSpinAddRow =
       mainRegisterInteractionsFromTable := by
@@ -858,7 +970,8 @@ theorem addSpinMemBus_interactions :
         mainMemBusInteractions 2 addSpinProgram addSpinAddRow ++
         mainMemBusInteractions 2 addSpinProgram (addSpinJalRow 1) ++
         mainMemBusInteractions 2 addSpinProgram (addSpinJalRow 2) := by
-    simp [mainRowsTable_interactionsWith_memBus, addSpinMainRows]
+    simp [mainRowsTable_interactionsWith_memBus, mainMemBusInteractionsForRows,
+      mainMemBusInteractionsFor, addSpinMainRows]
   rw [show addSpinWitness.tables = addSpinTables from rfl]
   rw [show addSpinTables =
       addSpinNonMainTables ++ [mainRowsTable 2 addSpinProgram addSpinMainRows] from rfl]

--- a/ZiskFv/Compliance/AddSpinWitness.lean
+++ b/ZiskFv/Compliance/AddSpinWitness.lean
@@ -307,7 +307,7 @@ def addSpinTables : List (Table FGL) :=
   , emptyComponentTable ZiskFv.AirsClean.ArithMul.componentWithArithTable
   , emptyComponentTable ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
   , emptyComponentTable ZiskFv.AirsClean.Binary.staticLookupComponent
-  , binaryAddSingleRowTable addX1BinaryAddRow
+  , binaryAddRowsTable [addX1BinaryAddRow]
   , mainRowsTable 2 addSpinProgram addSpinMainRows ]
 
 def addSpinNonMainTables : List (Table FGL) :=
@@ -320,7 +320,7 @@ def addSpinNonMainTables : List (Table FGL) :=
   , emptyComponentTable ZiskFv.AirsClean.ArithMul.componentWithArithTable
   , emptyComponentTable ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
   , emptyComponentTable ZiskFv.AirsClean.Binary.staticLookupComponent
-  , binaryAddSingleRowTable addX1BinaryAddRow ]
+  , binaryAddRowsTable [addX1BinaryAddRow] ]
 
 def addSpinEnsemble : Ensemble FGL unit :=
   (fullRv64imEnsemble 2 addSpinProgram).ensemble
@@ -345,12 +345,12 @@ def addSpinWitness : EnsembleWitness addSpinEnsemble where
       simp [addSpinEnsemble, fullRv64imEnsemble, fullRv64imSoundEnsemble, addSpinTables,
         SoundEnsemble.toFormal, SoundEnsemble.addFinishedChannel_tables, SoundEnsemble.addTable,
         SoundEnsemble.empty_tables, Ensemble.addTable, registerBoundaryRowsTable,
-        registerBoundaryRowsTableOf, emptyComponentTable, binaryAddSingleRowTable,
+        registerBoundaryRowsTableOf, emptyComponentTable, binaryAddRowsTable,
         mainRowsTable]
   same_data := by
     intro table h_table
     simp [addSpinTables, registerBoundaryRowsTable, registerBoundaryRowsTableOf,
-      emptyComponentTable, binaryAddSingleRowTable, mainRowsTable] at h_table
+      emptyComponentTable, binaryAddRowsTable, mainRowsTable] at h_table
     rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
       rfl
 
@@ -416,7 +416,7 @@ theorem addSpinWitness_transitions : addSpinWitness.TransitionConstraints := by
       simp [emptyComponentTable] at h_i
     · rw [Table.TransitionConstraints]
       intro i h_i
-      simp [binaryAddSingleRowTable, ZiskFv.AirsClean.BinaryAdd.component] at h_i ⊢
+      simp [binaryAddRowsTable, ZiskFv.AirsClean.BinaryAdd.component] at h_i ⊢
     · exact addSpinMainTable_transitions
 
 private theorem not_addSpin_main_component_of_name_ne
@@ -654,7 +654,7 @@ theorem addSpinOpBus_interactions :
       (table := registerBoundaryRowsTable) rfl
   rw [show addSpinWitness.tables = addSpinTables from rfl]
   simp [addSpinTables, h_registerBoundary, emptyComponentTable_interactionsWith,
-    binaryAddSingleRowTable_interactionsWith_opBus, mainRowsTable_interactionsWith_opBus,
+    binaryAddRowsTable_interactionsWith_opBus, mainRowsTable_interactionsWith_opBus,
     addSpinMainRows]
 
 theorem addSpinJalOpBusInteraction_zero (step : FGL) :
@@ -848,9 +848,9 @@ theorem addSpinMemBus_interactions :
       simpa [registerBoundaryRowsTable] using
         registerBoundaryRowsTableOf_interactionsWith_memBus singleAddBoundaryRows
     have h_binaryAdd :
-        (binaryAddSingleRowTable addX1BinaryAddRow).interactionsWith MemBusChannel.toRaw = [] := by
+        (binaryAddRowsTable [addX1BinaryAddRow]).interactionsWith MemBusChannel.toRaw = [] := by
       exact ZiskFv.AirsClean.FullEnsemble.binaryAdd_table_interactionsWith_memBus_nil
-        (table := binaryAddSingleRowTable addX1BinaryAddRow) rfl
+        (table := binaryAddRowsTable [addX1BinaryAddRow]) rfl
     simp [addSpinNonMainTables, h_registerBoundary, h_binaryAdd,
       emptyComponentTable_interactionsWith]
   have h_main :

--- a/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
+++ b/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
@@ -572,22 +572,22 @@ example :
 def binaryAddRowArray (row : ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL) : Array FGL :=
   (toElements row).toArray
 
-def binaryAddSingleRowTable (row : ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL) :
-    Table FGL where
+def binaryAddRowsTable
+    (rows : List (ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL)) : Table FGL where
   component := ZiskFv.AirsClean.BinaryAdd.component
   width := size ZiskFv.AirsClean.BinaryAdd.BinaryAddRow
-  table := [binaryAddRowArray row]
+  table := rows.map binaryAddRowArray
   data := emptyData
   uniform_width := by
     intro arr h_arr
-    simp [binaryAddRowArray] at h_arr
-    subst arr
-    simp
+    rcases List.mem_map.mp h_arr with ⟨row, _, rfl⟩
+    simp [binaryAddRowArray]
 
-theorem binaryAddSingleRowTable_rowInput
+theorem binaryAddRowsTable_rowInput
+    (rows : List (ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL))
     (row : ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL) :
     ZiskFv.AirsClean.BinaryAdd.component.rowInput
-        ((binaryAddSingleRowTable row).environment (binaryAddRowArray row)) =
+        ((binaryAddRowsTable rows).environment (binaryAddRowArray row)) =
       row := by
   change ZiskFv.AirsClean.BinaryAdd.component.rowInput
       (Environment.fromInput row emptyData) = row
@@ -602,13 +602,14 @@ def binaryAddOpBusInteraction (row : ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL
   assumeGuarantees := false
 
 theorem binaryAddComponentOpBusInteraction_eval
+    (rows : List (ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL))
     (row : ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL) :
     (((OpBusChannel.pushed
         (ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr
           ZiskFv.AirsClean.BinaryAdd.component.rowInputVar)).toRaw).eval
-      ((binaryAddSingleRowTable row).environment (binaryAddRowArray row))) =
+      ((binaryAddRowsTable rows).environment (binaryAddRowArray row))) =
       binaryAddOpBusInteraction row := by
-  let env := (binaryAddSingleRowTable row).environment (binaryAddRowArray row)
+  let env := (binaryAddRowsTable rows).environment (binaryAddRowArray row)
   let rowVar := ZiskFv.AirsClean.BinaryAdd.component.rowInputVar
   have h_input : eval env rowVar = row := by
     change eval (Environment.fromInput row emptyData)
@@ -630,37 +631,61 @@ theorem binaryAddComponentOpBusInteraction_eval
     rw [h_msg_eval]
   · rfl
 
-theorem binaryAddSingleRowTable_interactionsWith_opBus
+theorem binaryAddRowsTable_opBus_row
+    (rows : List (ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL))
     (row : ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL) :
-    (binaryAddSingleRowTable row).interactionsWith OpBusChannel.toRaw =
+    ZiskFv.AirsClean.BinaryAdd.component.operations.interactionValuesWith
+        OpBusChannel.toRaw
+        ((binaryAddRowsTable rows).environment (binaryAddRowArray row)) =
       [binaryAddOpBusInteraction row] := by
-  simp [Table.interactionsWith, binaryAddSingleRowTable, binaryAddRowArray,
+  simp [binaryAddRowsTable,
     Operations.interactionValuesWith_eq_map,
     ZiskFv.AirsClean.BinaryAdd.component_interactionsWith_opBus]
-  exact binaryAddComponentOpBusInteraction_eval row
+  exact binaryAddComponentOpBusInteraction_eval rows row
 
-theorem binaryAddSingleRowTable_constraints_of_proverAssumptions
-    (row : ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL)
+private theorem binaryAddRowsTable_interactionsWith_opBus_go
+    (allRows rows : List (ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL)) :
+    (rows.map binaryAddRowArray).flatMap (fun arr =>
+        ZiskFv.AirsClean.BinaryAdd.component.operations.interactionValuesWith
+          OpBusChannel.toRaw ((binaryAddRowsTable allRows).environment arr)) =
+      rows.flatMap fun row => [binaryAddOpBusInteraction row] := by
+  induction rows with
+  | nil => rfl
+  | cons row rest ih =>
+      simp [binaryAddRowsTable_opBus_row, ih]
+
+theorem binaryAddRowsTable_interactionsWith_opBus
+    (rows : List (ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL)) :
+    (binaryAddRowsTable rows).interactionsWith OpBusChannel.toRaw =
+      rows.flatMap fun row => [binaryAddOpBusInteraction row] := by
+  change (rows.map binaryAddRowArray).flatMap (fun arr =>
+        ZiskFv.AirsClean.BinaryAdd.component.operations.interactionValuesWith
+          OpBusChannel.toRaw ((binaryAddRowsTable rows).environment arr)) =
+      rows.flatMap fun row => [binaryAddOpBusInteraction row]
+  exact binaryAddRowsTable_interactionsWith_opBus_go rows rows
+
+theorem binaryAddRowsTable_constraints_of_proverAssumptions
+    (rows : List (ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL))
     (h_assumptions :
-      ZiskFv.AirsClean.BinaryAdd.component.circuit.ProverAssumptions
-        row emptyData (ProverHint.empty FGL)) :
-    (binaryAddSingleRowTable row).Constraints := by
+      ∀ row ∈ rows,
+        ZiskFv.AirsClean.BinaryAdd.component.circuit.ProverAssumptions
+          row emptyData (ProverHint.empty FGL)) :
+    (binaryAddRowsTable rows).Constraints := by
   have h_localLength :
       ZiskFv.AirsClean.BinaryAdd.component.circuit.localLength
         ZiskFv.AirsClean.BinaryAdd.component.rowInputVar = 0 := by
     change ZiskFv.AirsClean.BinaryAdd.binaryAddElaborated.localLength
         ZiskFv.AirsClean.BinaryAdd.component.rowInputVar = 0
     rfl
+  rw [Table.Constraints]
+  intro arr h_arr
+  rcases List.mem_map.mp h_arr with ⟨row, h_row, rfl⟩
   have h_component :
       ZiskFv.AirsClean.BinaryAdd.component.operations.ConstraintsHold
         (Environment.fromInput row emptyData) :=
     component_constraintsHold_of_proverAssumptions
-      ZiskFv.AirsClean.BinaryAdd.component row h_localLength h_assumptions
-  rw [Table.Constraints]
-  intro arr h_arr
-  simp [binaryAddSingleRowTable, binaryAddRowArray] at h_arr
-  subst arr
-  simpa [binaryAddSingleRowTable, binaryAddRowArray, Environment.fromInput] using h_component
+      ZiskFv.AirsClean.BinaryAdd.component row h_localLength (h_assumptions row h_row)
+  simpa [binaryAddRowsTable, binaryAddRowArray, Environment.fromInput] using h_component
 
 def binaryRowArray (row : ZiskFv.AirsClean.Binary.BinaryRow FGL) : Array FGL :=
   (toElements row).toArray

--- a/ZiskFv/Compliance/RegisterMemBusBalance.lean
+++ b/ZiskFv/Compliance/RegisterMemBusBalance.lean
@@ -116,6 +116,70 @@ theorem pairedInteractions_balanced
       exact balancedInteractions_append_of_balanced
         (pairedInteraction_balanced msg) (ih h_rest_len) (by simpa [pairedInteractions] using h_len)
 
+/-! ## Register-access telescoping -/
+
+/-- The real-emission order for successive accesses to one register. The boundary component emits
+    the initial pull and final push first; every Main access then pushes its previous state and
+    pulls its current state. -/
+def registerAccessChain (previous : MemBusMessage FGL) :
+    List (MemBusMessage FGL) → List (Interaction FGL)
+  | [] => []
+  | current :: rest =>
+      [MemBusChannel.pushedValue previous, MemBusChannel.pulledValue current] ++
+        registerAccessChain current rest
+
+/-- The last state in a nonempty register history represented by its first state and tail. -/
+def registerLastMessage (first : MemBusMessage FGL) :
+    List (MemBusMessage FGL) → MemBusMessage FGL
+  | [] => first
+  | current :: rest => registerLastMessage current rest
+
+/-- Boundary emissions followed by the Main access chain for one register. -/
+def registerTelescopingInteractions
+    (first : MemBusMessage FGL) (rest : List (MemBusMessage FGL)) :
+    List (Interaction FGL) :=
+  [MemBusChannel.pulledValue first,
+    MemBusChannel.pushedValue (registerLastMessage first rest)] ++
+      registerAccessChain first rest
+
+/-- A register history contains one pull and one push of every state, independently of the
+    boundary-first real-emission order. -/
+theorem registerTelescopingInteractions_perm
+    (first : MemBusMessage FGL) (rest : List (MemBusMessage FGL)) :
+    List.Perm (registerTelescopingInteractions first rest)
+      (pairedInteractions (first :: rest)) := by
+  induction rest generalizing first with
+  | nil =>
+      rfl
+  | cons current rest ih =>
+      have h_rotate :
+          List.Perm (registerTelescopingInteractions first (current :: rest))
+            (pairedInteraction first ++ registerTelescopingInteractions current rest) := by
+        simp only [registerTelescopingInteractions, registerLastMessage, registerAccessChain,
+          pairedInteraction]
+        exact List.Perm.cons _ <|
+          (List.Perm.swap _ _ _).trans (List.Perm.cons _ (List.Perm.swap _ _ _))
+      have h_tail :
+          List.Perm (pairedInteraction first ++ registerTelescopingInteractions current rest)
+            (pairedInteraction first ++ pairedInteractions (current :: rest)) :=
+        List.Perm.append (List.Perm.refl _) (ih current)
+      exact h_rotate.trans h_tail
+
+/-- The N-access register telescope balances once its finite interaction count fits in the field. -/
+theorem registerTelescopingInteractions_balanced
+    (first : MemBusMessage FGL) (rest : List (MemBusMessage FGL))
+    (h_len :
+      (registerTelescopingInteractions first rest).length < ringChar FGL ∨
+        ringChar FGL = 0) :
+    BalancedInteractions (registerTelescopingInteractions first rest) := by
+  have h_perm := registerTelescopingInteractions_perm first rest
+  have h_paired_len :
+      (pairedInteractions (first :: rest)).length < ringChar FGL ∨ ringChar FGL = 0 := by
+    rw [← h_perm.length_eq]
+    exact h_len
+  exact balancedInteractions_of_perm
+    (pairedInteractions_balanced (first :: rest) h_paired_len) h_perm.symm
+
 /-! ## The concrete `add x1,x1,x1` row and boundary rows -/
 
 /-- The concrete register-register `add x1,x1,x1` Main row.  Register operands x1: the six MemBus

--- a/ZiskFv/Compliance/RegisterMemBusBalance.lean
+++ b/ZiskFv/Compliance/RegisterMemBusBalance.lean
@@ -40,7 +40,8 @@ RegisterBoundary rows.  The remaining #219 bridge is the projection from Main's 
 
 ## Trust note
 
-No axioms.  `pulledValue` / `pushedValue` are Clean's `-1` / `+1` value-level channel interactions.
+No axioms. The local `emittedPulledValue` and Clean's `pushedValue` reproduce actual emitted
+`-1` / `+1` value-level channel interactions, including their guarantee metadata.
 -/
 
 open Goldilocks
@@ -57,9 +58,18 @@ namespace ZiskFv.Compliance.RegisterMemBusBalance
 
 /-! ## Paired-interaction balance infrastructure (message-agnostic) -/
 
+/-- A concrete negative MemBus emission. Unlike `Channel.pulledValue`, actual component emissions
+    do not assume the channel guarantees, so this constructor keeps `assumeGuarantees := false`. -/
+def emittedPulledValue (msg : MemBusMessage FGL) : Interaction FGL where
+  channel := MemBusChannel.toRaw
+  mult := -1
+  msg := (toElements msg).toArray
+  same_size := by simp [Channel.toRaw]
+  assumeGuarantees := false
+
 /-- One pull/push pair for the same MemBus message balances. -/
 def pairedInteraction (msg : MemBusMessage FGL) : List (Interaction FGL) :=
-  [MemBusChannel.pulledValue msg, MemBusChannel.pushedValue msg]
+  [emittedPulledValue msg, MemBusChannel.pushedValue msg]
 
 /-- A list of messages, each emitted once as a pull and once as a push. -/
 def pairedInteractions (msgs : List (MemBusMessage FGL)) : List (Interaction FGL) :=
@@ -81,7 +91,7 @@ theorem pairedInteraction_balanced (msg : MemBusMessage FGL) :
   · intro presentMsg h_present
     simp only [List.mem_singleton] at h_present
     subst presentMsg
-    simp [pairedInteraction, balanceOf, Channel.pulledValue, Channel.pushedValue]
+    simp [pairedInteraction, emittedPulledValue, balanceOf, Channel.pushedValue]
 
 theorem balancedInteractions_append_of_balanced
     {left right : List (Interaction FGL)}
@@ -92,6 +102,17 @@ theorem balancedInteractions_append_of_balanced
   refine ⟨h_len, ?_⟩
   intro msg
   rw [balanceOf_append, h_left.2 msg, h_right.2 msg, add_zero]
+
+/-- A finite interaction list whose selectors are all zero is balanced. -/
+theorem zeroInteractions_balanced
+    (interactions : List (Interaction FGL))
+    (h_zero : ∀ interaction ∈ interactions, interaction.mult = 0)
+    (h_len : interactions.length < ringChar FGL ∨ ringChar FGL = 0) :
+    BalancedInteractions interactions := by
+  refine ⟨h_len, ?_⟩
+  intro msg
+  rw [balanceOf_eq_of_const_mult' h_zero]
+  simp
 
 theorem pairedInteractions_balanced
     (msgs : List (MemBusMessage FGL))
@@ -125,7 +146,7 @@ def registerAccessChain (previous : MemBusMessage FGL) :
     List (MemBusMessage FGL) → List (Interaction FGL)
   | [] => []
   | current :: rest =>
-      [MemBusChannel.pushedValue previous, MemBusChannel.pulledValue current] ++
+      [MemBusChannel.pushedValue previous, emittedPulledValue current] ++
         registerAccessChain current rest
 
 /-- The last state in a nonempty register history represented by its first state and tail. -/
@@ -137,8 +158,8 @@ def registerLastMessage (first : MemBusMessage FGL) :
 /-- Boundary emissions followed by the Main access chain for one register. -/
 def registerTelescopingInteractions
     (first : MemBusMessage FGL) (rest : List (MemBusMessage FGL)) :
-    List (Interaction FGL) :=
-  [MemBusChannel.pulledValue first,
+  List (Interaction FGL) :=
+  [emittedPulledValue first,
     MemBusChannel.pushedValue (registerLastMessage first rest)] ++
       registerAccessChain first rest
 

--- a/ZiskFv/Compliance/SingleAddWitness.lean
+++ b/ZiskFv/Compliance/SingleAddWitness.lean
@@ -95,8 +95,11 @@ theorem addX1MainTable_constraints :
     addX1Main_proverAssumptions
 
 theorem addX1BinaryAddTable_constraints :
-    (binaryAddSingleRowTable addX1BinaryAddRow).Constraints := by
-  apply binaryAddSingleRowTable_constraints_of_proverAssumptions
+    (binaryAddRowsTable [addX1BinaryAddRow]).Constraints := by
+  apply binaryAddRowsTable_constraints_of_proverAssumptions
+  intro row h_row
+  simp only [List.mem_singleton] at h_row
+  subst row
   exact ⟨0, 0, by decide, by decide, rfl⟩
 
 def singleAddBoundaryRows : List (ZiskFv.AirsClean.RegisterBoundary.RegisterBoundaryRow FGL) :=
@@ -119,7 +122,7 @@ def singleAddTables : List (Table FGL) :=
   , emptyComponentTable ZiskFv.AirsClean.ArithMul.componentWithArithTable
   , emptyComponentTable ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
   , emptyComponentTable ZiskFv.AirsClean.Binary.staticLookupComponent
-  , binaryAddSingleRowTable addX1BinaryAddRow
+  , binaryAddRowsTable [addX1BinaryAddRow]
   , mainSingleRowTable 1 addX1Program addX1Row ]
 
 def singleAddEnsemble : Ensemble FGL unit :=
@@ -145,12 +148,12 @@ def singleAddWitness : EnsembleWitness singleAddEnsemble where
       simp [singleAddEnsemble, fullRv64imEnsemble, fullRv64imSoundEnsemble, singleAddTables,
         SoundEnsemble.toFormal, SoundEnsemble.addFinishedChannel_tables, SoundEnsemble.addTable,
         SoundEnsemble.empty_tables, Ensemble.addTable, registerBoundaryRowsTable,
-        registerBoundaryRowsTableOf, emptyComponentTable, binaryAddSingleRowTable,
+        registerBoundaryRowsTableOf, emptyComponentTable, binaryAddRowsTable,
         mainSingleRowTable]
   same_data := by
     intro table h_table
     simp [singleAddTables, registerBoundaryRowsTable, registerBoundaryRowsTableOf,
-      emptyComponentTable, binaryAddSingleRowTable, mainSingleRowTable] at h_table
+      emptyComponentTable, binaryAddRowsTable, mainSingleRowTable] at h_table
     rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
       rfl
 
@@ -189,7 +192,7 @@ theorem singleAddWitness_transitions : singleAddWitness.TransitionConstraints :=
       rw [Table.TransitionConstraints] <;>
       intro i h_i <;>
       simp [registerBoundaryRowsTable, registerBoundaryRowsTableOf, emptyComponentTable,
-        binaryAddSingleRowTable, mainSingleRowTable, ZiskFv.AirsClean.RegisterBoundary.component,
+        binaryAddRowsTable, mainSingleRowTable, ZiskFv.AirsClean.RegisterBoundary.component,
         ZiskFv.AirsClean.BinaryAdd.component] at h_i ⊢
 
 private theorem not_main_component_of_name_ne
@@ -397,7 +400,7 @@ theorem singleAddWitness_opBus_interactions :
       (table := registerBoundaryRowsTable) rfl
   rw [show singleAddWitness.tables = singleAddTables from rfl]
   simp [singleAddTables, h_registerBoundary, emptyComponentTable_interactionsWith,
-    binaryAddSingleRowTable_interactionsWith_opBus, mainSingleRowTable_interactionsWith_opBus]
+    binaryAddRowsTable_interactionsWith_opBus, mainSingleRowTable_interactionsWith_opBus]
 
 theorem singleAddWitness_opBus_balanced :
     BalancedInteractions
@@ -440,9 +443,9 @@ theorem singleAddWitness_memBus_interactions :
     simpa [registerBoundaryRowsTable] using
       registerBoundaryRowsTableOf_interactionsWith_memBus singleAddBoundaryRows
   have h_binaryAdd :
-      (binaryAddSingleRowTable addX1BinaryAddRow).interactionsWith MemBusChannel.toRaw = [] := by
+      (binaryAddRowsTable [addX1BinaryAddRow]).interactionsWith MemBusChannel.toRaw = [] := by
     exact ZiskFv.AirsClean.FullEnsemble.binaryAdd_table_interactionsWith_memBus_nil
-      (table := binaryAddSingleRowTable addX1BinaryAddRow) rfl
+      (table := binaryAddRowsTable [addX1BinaryAddRow]) rfl
   rw [show singleAddWitness.tables = singleAddTables from rfl]
   simp [singleAddTables, h_registerBoundary, h_binaryAdd, emptyComponentTable_interactionsWith,
     addX1Row_main_interactionsWith_memBus_eq_mainRegisterInteractionsFromTable,

--- a/trust/consistency/root_soundness_instantiation_add_addi_spin.lean
+++ b/trust/consistency/root_soundness_instantiation_add_addi_spin.lean
@@ -1,0 +1,5 @@
+import ZiskFv.Compliance.AddAddiSpinRootSoundness
+
+#print axioms ZiskFv.Compliance.AddAddiSpinRootSoundness.addAddiSpinRootSoundness
+#print axioms ZiskFv.Compliance.AddAddiSpinWitness.addAddiSpinAcceptedTrace
+#print axioms ZiskFv.Compliance.AddAddiSpinWitness.addAddiSpinWitness_balancedChannels


### PR DESCRIPTION
## Summary
- generalize Main MemBus reductions and preserve real emission metadata for multi-row register telescopes
- construct an accepted `ADD x1,x1,x1; ADDI x1,x1,0; JAL x0,0` trace with four Main rows and two BinaryAdd rows
- bind all three executed rows to Sail, instantiate `root_soundness`, and add a trust consistency witness

Closes #220

## Verification
- `lake build ZiskFv.Compliance.AddAddiSpinWitness`
- `lake build ZiskFv.Compliance.AddAddiSpinRootSoundness`
- `trust/scripts/check-all.sh`
- `trust/scripts/check-all-semantic.sh`
- `lake build`
- `nix run .#test`