### PR TITLE
#245: split executed steps from committed ROM length

### DIFF
--- a/ZiskFv/Compliance/AcceptedZiskTrace.lean
+++ b/ZiskFv/Compliance/AcceptedZiskTrace.lean
@@ -6,7 +6,8 @@ import ZiskFv.AirsClean.FullEnsemble.Balance.TableProjections
 # Accepted trace
 
 An `AcceptedZiskTrace` is one fully-populated, verifier-accepted run of the RV64IM
-circuit for a fixed `program` of `length` instructions.
+circuit for a fixed committed `program` and an executed trace. Execution can revisit
+committed instructions, so its step count need not equal the ROM length.
 
 The circuit is an **Air.Flat ensemble**: a collection of AIRs (the Main table
 plus the binary / arithmetic / memory / lookup tables) wired together by shared
@@ -56,11 +57,11 @@ def acceptedMemReplayFixedSegment
     discharge it by proving their mutable-Mem table is empty, while memory-carrying traces provide
     the same bridge package #115 already required. -/
 def MutableMemPresent
-    {numInstructions : Nat}
-    {program : ZiskFv.AirsClean.ZiskInstructionRom.Program numInstructions}
+    {programLength : Nat}
+    {program : ZiskFv.AirsClean.ZiskInstructionRom.Program programLength}
     (witness :
       Air.Flat.EnsembleWitness
-        (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble numInstructions program).ensemble) :
+        (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble programLength program).ensemble) :
     Prop :=
   ∃ table ∈ witness.allTables,
     table.component = ZiskFv.AirsClean.Mem.componentWithDualMemBus ∧
@@ -76,7 +77,8 @@ def MutableMemPresent
     `2 + 4*i` / `3 + 4*i` in their natural Goldilocks representatives. -/
 structure MainStepIndexFixedFacts
     (numInstructions : Nat)
-    (program : ZiskFv.AirsClean.ZiskInstructionRom.Program numInstructions)
+    (programLength : Nat)
+    (program : ZiskFv.AirsClean.ZiskInstructionRom.Program programLength)
     (table : Air.Flat.Table FGL) : Prop where
   main_step_eq_index : ∀ i : Fin numInstructions,
     (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero program table i.val).rom.main_step =
@@ -95,16 +97,19 @@ structure MainStepIndexFixedFacts
 
 /-- Accepted committed trace for the full RV64IM Clean ensemble.
 
-    `numInstructions` is a **structure parameter** (not a field) so that
-    `root_soundness` can share one instruction count across the ZisK and Sail
-    sides (issue #144). The `AcceptedZiskTrace.numInstructions` accessor below
-    recovers it, so the many `trace.numInstructions` uses keep working
-    unchanged. -/
+    `numInstructions` is a **structure parameter** (not a field): it counts
+    executed steps and therefore remains shared with the Sail trace and
+    `root_soundness`. `programLength` is a dependent field because the committed
+    ROM can be longer than the executed trace, while loops can execute more steps
+    than the committed ROM has entries.
+    The `AcceptedZiskTrace.numInstructions` accessor below preserves existing
+    execution-indexed uses. -/
 structure AcceptedZiskTrace (numInstructions : Nat) where
-  program : ZiskFv.AirsClean.ZiskInstructionRom.Program numInstructions
+  programLength : Nat
+  program : ZiskFv.AirsClean.ZiskInstructionRom.Program programLength
   witness :
     Air.Flat.EnsembleWitness
-      (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble numInstructions program).ensemble
+      (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble programLength program).ensemble
   constraints_hold : witness.Constraints
   channels_balanced : witness.BalancedChannels
   /-- Guarded concrete mutable-Mem table for traces whose witness has mutable-Mem rows.
@@ -182,7 +187,7 @@ structure AcceptedZiskTrace (numInstructions : Nat) where
       row count — specialized to the derived `mainTable` by `mainTable_index`. -/
   main_height : ∀ table ∈ witness.allTables,
       table.component =
-          ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus numInstructions program →
+          ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus programLength program →
         ∀ i : Fin numInstructions, i.val < table.table.length
   /-- The Main execution table's `SEGMENT_L1` fixed column is `[1,0,0,...]`
       (`main.pil:19`): the first row is a segment boundary, every later row is
@@ -198,7 +203,7 @@ structure AcceptedZiskTrace (numInstructions : Nat) where
       `AcceptedZiskTrace.mainTable_fixed` specializes it to that table. -/
   segment_l1_fixed : ∀ table ∈ witness.allTables,
       table.component =
-          ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus numInstructions program →
+          ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus programLength program →
         (0 < table.table.length →
             (ZiskFv.AirsClean.FullEnsemble.mainOfTable program table).segment_l1 0 = 1) ∧
         (∀ idx : Fin table.table.length, 0 < idx.val →
@@ -214,8 +219,8 @@ structure AcceptedZiskTrace (numInstructions : Nat) where
       `AcceptedZiskTrace.mainTable_main_step_index_fixed`. -/
   main_step_index_fixed : ∀ table ∈ witness.allTables,
       table.component =
-          ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus numInstructions program →
-        MainStepIndexFixedFacts numInstructions program table
+          ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus programLength program →
+        MainStepIndexFixedFacts numInstructions programLength program table
 
 /-- Recover the instruction count from a parameterized `AcceptedZiskTrace`.
     `numInstructions` is now a structure parameter rather than a field; this

--- a/ZiskFv/Compliance/AcceptedZiskTrace/MainTable.lean
+++ b/ZiskFv/Compliance/AcceptedZiskTrace/MainTable.lean
@@ -31,11 +31,11 @@ theorem AcceptedZiskTrace.mainTable_mem (trace : AcceptedZiskTrace n) :
 theorem AcceptedZiskTrace.mainTable_component (trace : AcceptedZiskTrace n) :
     trace.mainTable.component =
       ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-        trace.numInstructions trace.program :=
+        trace.programLength trace.program :=
   (ZiskFv.AirsClean.FullEnsemble.exists_main_table_of_fullRv64im_witness
     trace.witness).choose_spec.2
 
-/-- The derived Main table has a row for every instruction — `main_height`
+/-- The derived Main table has a row for every executed step — `main_height`
     specialized to `mainTable` via its membership and component facts. -/
 theorem AcceptedZiskTrace.mainTable_index (trace : AcceptedZiskTrace n) :
     ∀ i : Fin trace.numInstructions, i.val < trace.mainTable.table.length :=
@@ -44,7 +44,7 @@ theorem AcceptedZiskTrace.mainTable_index (trace : AcceptedZiskTrace n) :
 /-- The accepted-trace Main `main_step` row-index certificate specialized to
     the derived Main table. -/
 theorem AcceptedZiskTrace.mainTable_main_step_index_fixed (trace : AcceptedZiskTrace n) :
-    MainStepIndexFixedFacts trace.numInstructions trace.program trace.mainTable :=
+    MainStepIndexFixedFacts trace.numInstructions trace.programLength trace.program trace.mainTable :=
   trace.main_step_index_fixed trace.mainTable trace.mainTable_mem trace.mainTable_component
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/AddAddiSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/AddAddiSpinRootSoundness.lean
@@ -98,7 +98,10 @@ def addAddiSpinBootSeed :
     exact absurd (by simp [AcceptedZiskTrace.numInstructions]) h_nonempty
   placement := by
     intro i
-    fin_cases i <;> trivial
+    fin_cases i <;> simp [MemoryOpPlacement, addAddiSpinZiskStep]
+
+private theorem addAddiSpinAcceptedTrace_program :
+    addAddiSpinAcceptedTrace.program = addAddiSpinProgram := rfl
 
 private theorem addAddiSpinMainRowAt_zero :
     ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero addAddiSpinProgram
@@ -197,6 +200,7 @@ def addAddiSpinAddProgramDecode :
   h_bits_store_ind := by simp [addAddiSpinAddBits, addX1RomFlagBits]
   h_prog := by
     intro j hline
+    change Fin 3 at j
     fin_cases j
     · simp only [addAddiSpinAcceptedTrace, addAddiSpinProgram]
       constructor
@@ -212,10 +216,12 @@ def addAddiSpinAddProgramDecode :
           ZiskFv.AirsClean.Main.packFlags, addAddiSpinAddBits, addX1RomFlagBits,
           ZiskFv.AirsClean.boolF]
     · rw [addAddiSpinMainPc_add] at hline
+      rw [addAddiSpinAcceptedTrace_program] at hline
       norm_num [addAddiSpinAcceptedTrace, addAddiSpinProgram,
         addAddiSpinAddiProgramRow] at hline
       exact absurd (congrArg (fun value : FGL => value.val) hline) (by norm_num)
     · rw [addAddiSpinMainPc_add] at hline
+      rw [addAddiSpinAcceptedTrace_program] at hline
       norm_num [addAddiSpinAcceptedTrace, addAddiSpinProgram,
         addAddiSpinJalProgramRow] at hline
       exact absurd (congrArg (fun value : FGL => value.val) hline) (by norm_num)
@@ -235,8 +241,10 @@ def addAddiSpinAddiProgramDecode :
   h_bits_b_src_imm := by rfl
   h_prog := by
     intro j hline
+    change Fin 3 at j
     fin_cases j
     · rw [addAddiSpinMainPc_addi] at hline
+      rw [addAddiSpinAcceptedTrace_program] at hline
       norm_num [addAddiSpinAcceptedTrace, addAddiSpinProgram,
         addAddiSpinAddProgramRow, addX1ProgramRow] at hline
       exact absurd (congrArg (fun value : FGL => value.val) hline) (by norm_num)
@@ -255,6 +263,7 @@ def addAddiSpinAddiProgramDecode :
       · norm_num [addAddiSpinAddiProgramRow, ZiskFv.AirsClean.Main.packFlags,
           addAddiSpinAddiBits, ZiskFv.AirsClean.boolF]
     · rw [addAddiSpinMainPc_addi] at hline
+      rw [addAddiSpinAcceptedTrace_program] at hline
       norm_num [addAddiSpinAcceptedTrace, addAddiSpinProgram,
         addAddiSpinJalProgramRow] at hline
       exact absurd (congrArg (fun value : FGL => value.val) hline) (by norm_num)
@@ -273,12 +282,15 @@ def addAddiSpinJalProgramDecode :
   h_bits_store_ind := by rfl
   h_prog := by
     intro j hline
+    change Fin 3 at j
     fin_cases j
     · rw [addAddiSpinMainPc_jal] at hline
+      rw [addAddiSpinAcceptedTrace_program] at hline
       norm_num [addAddiSpinAcceptedTrace, addAddiSpinProgram,
         addAddiSpinAddProgramRow, addX1ProgramRow] at hline
       exact absurd (congrArg (fun value : FGL => value.val) hline) (by norm_num)
     · rw [addAddiSpinMainPc_jal] at hline
+      rw [addAddiSpinAcceptedTrace_program] at hline
       norm_num [addAddiSpinAcceptedTrace, addAddiSpinProgram,
         addAddiSpinAddiProgramRow] at hline
       exact absurd (congrArg (fun value : FGL => value.val) hline) (by norm_num)

--- a/ZiskFv/Compliance/AddAddiSpinWitness.lean
+++ b/ZiskFv/Compliance/AddAddiSpinWitness.lean
@@ -605,7 +605,7 @@ private theorem addAddiSpinMain_main_step_eq_index :
           (addAddiSpinJalRow 2))
 
 private theorem addAddiSpinMain_main_step_index_fixed :
-    MainStepIndexFixedFacts 3 addAddiSpinProgram addAddiSpinMainTable where
+    MainStepIndexFixedFacts 3 3 addAddiSpinProgram addAddiSpinMainTable where
   main_step_eq_index := addAddiSpinMain_main_step_eq_index
   timestamp_bound := by
     intro i
@@ -632,7 +632,7 @@ private theorem addAddiSpinMain_main_step_index_fixed :
 theorem addAddiSpinWitness_main_step_index_fixed :
     ∀ table ∈ addAddiSpinWitness.allTables,
       table.component = componentWithRomMemAndOpBus 3 addAddiSpinProgram →
-        MainStepIndexFixedFacts 3 addAddiSpinProgram table := by
+        MainStepIndexFixedFacts 3 3 addAddiSpinProgram table := by
   intro table h_table h_component
   have h_main := addAddiSpinWitness_main_component_cases h_table h_component
   subst table
@@ -1041,6 +1041,7 @@ theorem addAddiSpinWitness_balancedChannels : addAddiSpinWitness.BalancedChannel
   · exact addAddiSpinWitness_opBus_balanced
 
 def addAddiSpinAcceptedTrace : AcceptedZiskTrace 3 where
+  programLength := 3
   program := addAddiSpinProgram
   witness := addAddiSpinWitness
   constraints_hold := addAddiSpinWitness_constraints

--- a/ZiskFv/Compliance/AddSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/AddSpinRootSoundness.lean
@@ -88,7 +88,10 @@ def addSpinBootSeed :
     exact absurd (by simp [AcceptedZiskTrace.numInstructions]) h_nonempty
   placement := by
     intro i
-    fin_cases i <;> trivial
+    fin_cases i <;> simp [MemoryOpPlacement, addSpinZiskStep]
+
+private theorem addSpinAcceptedTrace_program :
+    addSpinAcceptedTrace.program = addSpinProgram := rfl
 
 private theorem addSpinMainRowAt_zero :
     ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero addSpinProgram
@@ -157,6 +160,7 @@ def addSpinAddProgramDecode :
   h_bits_store_ind := by simp [addSpinAddBits, addX1RomFlagBits]
   h_prog := by
     intro j hline
+    change Fin 2 at j
     fin_cases j
     · simp only [addSpinAcceptedTrace, addSpinProgram]
       constructor
@@ -171,6 +175,7 @@ def addSpinAddProgramDecode :
       · norm_num [addSpinAddProgramRow, addX1ProgramRow, ZiskFv.AirsClean.Main.packFlags,
           addSpinAddBits, addX1RomFlagBits, ZiskFv.AirsClean.boolF]
     · rw [addSpinMainPc_add] at hline
+      rw [addSpinAcceptedTrace_program] at hline
       norm_num [addSpinAcceptedTrace, addSpinProgram, addSpinJalProgramRow] at hline
       exfalso
       have hval := congrArg (fun x : FGL => x.val) hline
@@ -190,8 +195,10 @@ def addSpinJalProgramDecode :
   h_bits_store_ind := by rfl
   h_prog := by
     intro j hline
+    change Fin 2 at j
     fin_cases j
     · rw [addSpinMainPc_jal] at hline
+      rw [addSpinAcceptedTrace_program] at hline
       norm_num [addSpinAcceptedTrace, addSpinProgram, addSpinAddProgramRow, addX1ProgramRow]
         at hline
       exfalso
@@ -367,5 +374,228 @@ theorem addSpinAddStepSound :
     StepSound addSpinAcceptedTrace addSpinSailTrace addSpinAddIndex
       (addSpinZiskStep addSpinAddIndex) :=
   addSpinRootSoundness addSpinAddIndex
+
+def addPaddedAddIndex : Fin 1 := ⟨0, by decide⟩
+
+def addPaddedAddClaim : Claim_add addPaddedAcceptedTrace addPaddedAddIndex where
+  r1 := x1
+  r2 := x1
+  rd := x1
+
+def addPaddedZiskStep : ∀ i : Fin 1, ZiskStep addPaddedAcceptedTrace i
+  | ⟨0, _⟩ => .add addPaddedAddClaim
+
+def addPaddedSailTrace : SailTrace 1
+  | ⟨0, _⟩ => addSpinState (0#64)
+
+theorem addPaddedRowsOf_empty_readSound :
+    MemoryBusRowsPrefixReadSound
+      ({} : Std.ExtHashMap Nat (BitVec 8))
+      ((List.range addPaddedAcceptedTrace.numInstructions).flatMap (fun _ => [])) := by
+  change MemoryBusRowsPrefixReadSound ({} : Std.ExtHashMap Nat (BitVec 8)) []
+  intro priorRows entry laterRows h_split h_selected
+  simp at h_split
+
+def addPaddedBootSeed :
+    BootSegmentMemorySeed addPaddedAcceptedTrace addPaddedSailTrace addPaddedZiskStep where
+  memInit := {}
+  rowsOf := fun _ => []
+  boot := by
+    intro h
+    rfl
+  step := by
+    intro j h
+    change j + 1 < 1 at h
+    omega
+  readSoundInputs := fun h => absurd h addSpinWitness_not_mutableMemPresent
+  memPresent_of_executionRows_nonempty := by
+    intro h_nonempty
+    exact absurd (by simp [AcceptedZiskTrace.numInstructions]) h_nonempty
+  placement := by
+    intro i
+    fin_cases i
+    simp [MemoryOpPlacement, addPaddedZiskStep]
+
+private theorem addPaddedAcceptedTrace_program :
+    addPaddedAcceptedTrace.program = addSpinProgram := rfl
+
+private theorem addPaddedMainPc_add :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable addPaddedAcceptedTrace.program
+        addPaddedAcceptedTrace.mainTable).pc addPaddedAddIndex.val = 0 := by
+  rw [addPaddedAcceptedTrace_mainTable_eq]
+  change (ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
+      (mainRowsTable 2 addSpinProgram addSpinMainRows)).pc 0 = 0
+  simp [addSpinMainRowAt_zero, addSpinAddRow, addX1Row]
+
+private theorem addPaddedReadX1 :
+    read_xreg (regidx_to_fin x1) (addPaddedSailTrace addPaddedAddIndex) =
+      EStateM.Result.ok (0#64) (addPaddedSailTrace addPaddedAddIndex) := by
+  simp [addPaddedSailTrace, addPaddedAddIndex, addSpinState, addSpinRegs, x1,
+    regidx_to_fin, read_xreg, reg_of_fin]
+
+def addPaddedAddProgramDecode :
+    ProgramDecode_add addPaddedAcceptedTrace addPaddedAddIndex addPaddedAddClaim where
+  h_idx := by
+    rw [addPaddedAcceptedTrace_mainTable_eq]
+    change 0 + 1 < (mainRowsTable 2 addSpinProgram addSpinMainRows).table.length
+    norm_num [mainRowsTable, addSpinMainRows]
+  bits := addSpinAddBits
+  h_bits_ieo := by simp [addSpinAddBits, addX1RomFlagBits]
+  h_bits_m32 := by simp [addSpinAddBits, addX1RomFlagBits]
+  h_bits_set_pc := by simp [addSpinAddBits, addX1RomFlagBits]
+  h_bits_store_pc := by simp [addSpinAddBits, addX1RomFlagBits]
+  h_bits_store_ind := by simp [addSpinAddBits, addX1RomFlagBits]
+  h_prog := by
+    intro j hline
+    change Fin 2 at j
+    fin_cases j
+    · simp only [addPaddedAcceptedTrace, addSpinProgram]
+      constructor
+      · rfl
+      constructor
+      · rfl
+      constructor
+      · rfl
+      constructor
+      · simp [addSpinAddProgramRow, addX1ProgramRow, addPaddedAddClaim, x1,
+          Transpiler.ind, regidx_to_fin]
+      · norm_num [addSpinAddProgramRow, addX1ProgramRow, ZiskFv.AirsClean.Main.packFlags,
+          addSpinAddBits, addX1RomFlagBits, ZiskFv.AirsClean.boolF]
+    · rw [addPaddedMainPc_add] at hline
+      rw [addPaddedAcceptedTrace_program] at hline
+      norm_num [addPaddedAcceptedTrace, addSpinProgram, addSpinJalProgramRow] at hline
+      exfalso
+      have hval := congrArg (fun x : FGL => x.val) hline
+      norm_num at hval
+
+theorem addPaddedSuccessorRow_hasCommittedLookup :
+    ∃ j : Fin addPaddedAcceptedTrace.programLength,
+      ZiskFv.AirsClean.Main.romMessage
+        (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+          addPaddedAcceptedTrace.program addPaddedAcceptedTrace.mainTable 1) =
+        addPaddedAcceptedTrace.program j := by
+  exact mainRomMessage_at_eq_program addPaddedAcceptedTrace
+    ⟨1, by
+      rw [addPaddedAcceptedTrace_mainTable_eq]
+      norm_num [mainRowsTable, addSpinMainRows]⟩
+
+theorem addPaddedSuccessorRow_isCommittedJal :
+    ZiskFv.AirsClean.Main.romMessage
+      (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+        addPaddedAcceptedTrace.program addPaddedAcceptedTrace.mainTable 1) =
+      addPaddedAcceptedTrace.program ⟨1, by decide⟩ := by
+  rw [addPaddedAcceptedTrace_program, addPaddedAcceptedTrace_mainTable_eq]
+  rw [addSpinMainRowAt_one]
+  rfl
+
+private theorem addPaddedAddLaneLo
+    (field : ZiskFv.Airs.Main.Valid_Main FGL FGL → Nat → FGL)
+    (h_field :
+      (field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
+          (mainRowsTable 2 addSpinProgram addSpinMainRows)) 0) = 0) :
+    field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addPaddedAcceptedTrace.program
+        addPaddedAcceptedTrace.mainTable) addPaddedAddIndex.val =
+      lane_lo ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64
+        (addPaddedSailTrace addPaddedAddIndex)).xreg (regidx_to_fin x1)) := by
+  rw [ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64_xreg_eq_of_read_xreg
+    (addPaddedSailTrace addPaddedAddIndex) (regidx_to_fin x1) (0#64) addPaddedReadX1]
+  rw [addPaddedAcceptedTrace_mainTable_eq]
+  change field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
+      (mainRowsTable 2 addSpinProgram addSpinMainRows)) 0 = _
+  rw [h_field]
+  simp [lane_lo]
+
+private theorem addPaddedAddLaneHi
+    (field : ZiskFv.Airs.Main.Valid_Main FGL FGL → Nat → FGL)
+    (h_field :
+      (field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
+          (mainRowsTable 2 addSpinProgram addSpinMainRows)) 0) = 0) :
+    field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addPaddedAcceptedTrace.program
+        addPaddedAcceptedTrace.mainTable) addPaddedAddIndex.val =
+      lane_hi ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64
+        (addPaddedSailTrace addPaddedAddIndex)).xreg (regidx_to_fin x1)) := by
+  rw [ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64_xreg_eq_of_read_xreg
+    (addPaddedSailTrace addPaddedAddIndex) (regidx_to_fin x1) (0#64) addPaddedReadX1]
+  rw [addPaddedAcceptedTrace_mainTable_eq]
+  change field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
+      (mainRowsTable 2 addSpinProgram addSpinMainRows)) 0 = _
+  rw [h_field]
+  simp [lane_hi]
+
+def addPaddedAddInputs :
+    Inputs_add addPaddedAcceptedTrace addPaddedSailTrace addPaddedAddIndex addPaddedAddClaim where
+  add_input := addSpinAddInput
+  h_input_r1 := by
+    simpa [addSpinAddInput, addPaddedAddClaim] using addPaddedReadX1
+  h_input_r2 := by
+    simpa [addSpinAddInput, addPaddedAddClaim] using addPaddedReadX1
+  h_input_pc := by
+    simp [addSpinAddInput, addPaddedSailTrace, addPaddedAddIndex, addSpinState, addSpinRegs, x1,
+      regidx_to_fin, reg_of_fin, Std.ExtDHashMap.get?_insert]
+  h_input_rd := by
+    rfl
+  h_a_lo_t := by
+    change (ZiskFv.AirsClean.FullEnsemble.mainOfTable addPaddedAcceptedTrace.program
+          addPaddedAcceptedTrace.mainTable).a_0 addPaddedAddIndex.val =
+        lane_lo ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64
+          (addPaddedSailTrace addPaddedAddIndex)).xreg (regidx_to_fin x1))
+    exact addPaddedAddLaneLo (fun m i => m.a_0 i)
+      (by simp [addSpinMainRowAt_zero, addSpinAddRow, addX1Row])
+  h_a_hi_t := by
+    change (ZiskFv.AirsClean.FullEnsemble.mainOfTable addPaddedAcceptedTrace.program
+          addPaddedAcceptedTrace.mainTable).a_1 addPaddedAddIndex.val =
+        lane_hi ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64
+          (addPaddedSailTrace addPaddedAddIndex)).xreg (regidx_to_fin x1))
+    exact addPaddedAddLaneHi (fun m i => m.a_1 i)
+      (by simp [addSpinMainRowAt_zero, addSpinAddRow, addX1Row])
+  h_b_lo_t := by
+    change (ZiskFv.AirsClean.FullEnsemble.mainOfTable addPaddedAcceptedTrace.program
+          addPaddedAcceptedTrace.mainTable).b_0 addPaddedAddIndex.val =
+        lane_lo ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64
+          (addPaddedSailTrace addPaddedAddIndex)).xreg (regidx_to_fin x1))
+    exact addPaddedAddLaneLo (fun m i => m.b_0 i)
+      (by simp [addSpinMainRowAt_zero, addSpinAddRow, addX1Row])
+  h_b_hi_t := by
+    change (ZiskFv.AirsClean.FullEnsemble.mainOfTable addPaddedAcceptedTrace.program
+          addPaddedAcceptedTrace.mainTable).b_1 addPaddedAddIndex.val =
+        lane_hi ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64
+          (addPaddedSailTrace addPaddedAddIndex)).xreg (regidx_to_fin x1))
+    exact addPaddedAddLaneHi (fun m i => m.b_1 i)
+      (by simp [addSpinMainRowAt_zero, addSpinAddRow, addX1Row])
+  h_pc_bridge := by
+    rw [addPaddedAcceptedTrace_mainTable_eq]
+    change ((ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
+          (mainRowsTable 2 addSpinProgram addSpinMainRows)).pc 0).val = _
+    simp [addSpinMainRowAt_zero, addSpinAddRow, addX1Row, addSpinAddInput]
+
+def addPaddedProgramDecodes :
+    ∀ i : Fin 1, ProgramDecode addPaddedAcceptedTrace i (addPaddedZiskStep i)
+  | ⟨0, _⟩ => addPaddedAddProgramDecode
+
+def addPaddedInputsAgree :
+    ∀ i : Fin 1, InputsAgree addPaddedAcceptedTrace addPaddedSailTrace i (addPaddedZiskStep i)
+  | ⟨0, _⟩ => addPaddedAddInputs
+
+def addPaddedAddOutsideDefectRegion :
+    RowOutsideDefectRegion addPaddedAcceptedTrace addPaddedAddIndex
+      (addPaddedZiskStep addPaddedAddIndex) := by
+  unfold RowOutsideDefectRegion addPaddedZiskStep MainSequentialPcDomain mainPcVal
+  rw [addPaddedMainPc_add]
+  change 0 < GL_prime - 4
+  norm_num
+
+def addPaddedOutsideDefectRegion :
+    ∀ i : Fin 1, RowOutsideDefectRegion addPaddedAcceptedTrace i (addPaddedZiskStep i)
+  | ⟨0, _⟩ => addPaddedAddOutsideDefectRegion
+
+theorem addPaddedRootSoundness :
+    ∀ i : Fin 1, StepSound addPaddedAcceptedTrace addPaddedSailTrace i (addPaddedZiskStep i) :=
+  root_soundness 1 addPaddedAcceptedTrace addPaddedSailTrace addPaddedZiskStep
+    addPaddedProgramDecodes addPaddedInputsAgree addPaddedBootSeed addPaddedOutsideDefectRegion
+
+theorem addPaddedAddStepSound :
+    StepSound addPaddedAcceptedTrace addPaddedSailTrace addPaddedAddIndex
+      (addPaddedZiskStep addPaddedAddIndex) :=
+  addPaddedRootSoundness addPaddedAddIndex
 
 end ZiskFv.Compliance.AddSpinRootSoundness

--- a/ZiskFv/Compliance/AddSpinWitness.lean
+++ b/ZiskFv/Compliance/AddSpinWitness.lean
@@ -647,7 +647,7 @@ theorem addSpinMain_main_step_eq_index :
     rfl
 
 theorem addSpinMain_main_step_index_fixed :
-    MainStepIndexFixedFacts 2 addSpinProgram
+    MainStepIndexFixedFacts 2 2 addSpinProgram
       (mainRowsTable 2 addSpinProgram addSpinMainRows) where
   main_step_eq_index := addSpinMain_main_step_eq_index
   timestamp_bound := by
@@ -671,7 +671,7 @@ theorem addSpinMain_main_step_index_fixed :
 theorem addSpinWitness_main_step_index_fixed :
     ∀ table ∈ addSpinWitness.allTables,
       table.component = componentWithRomMemAndOpBus 2 addSpinProgram →
-        MainStepIndexFixedFacts 2 addSpinProgram table := by
+        MainStepIndexFixedFacts 2 2 addSpinProgram table := by
   intro table h_table h_component
   have h_main := addSpinWitness_main_component_cases h_table h_component
   subst table
@@ -1024,6 +1024,7 @@ theorem addSpinWitness_balancedChannels : addSpinWitness.BalancedChannels := by
   · exact addSpinWitness_opBus_balanced
 
 def addSpinAcceptedTrace : AcceptedZiskTrace 2 where
+  programLength := 2
   program := addSpinProgram
   witness := addSpinWitness
   constraints_hold := addSpinWitness_constraints
@@ -1048,5 +1049,70 @@ theorem addSpinAcceptedTrace_mainTable_eq :
   exact addSpinWitness_main_component_cases
     (by simpa [addSpinAcceptedTrace] using addSpinAcceptedTrace.mainTable_mem)
     (by simpa [addSpinAcceptedTrace] using addSpinAcceptedTrace.mainTable_component)
+
+theorem addSpinWitness_main_height_prefix_one :
+    ∀ table ∈ addSpinWitness.allTables,
+      table.component = componentWithRomMemAndOpBus 2 addSpinProgram →
+        ∀ i : Fin 1, i.val < table.table.length := by
+  intro table h_table h_component i
+  fin_cases i
+  exact addSpinWitness_main_height table h_table h_component ⟨0, by decide⟩
+
+theorem addSpinMain_main_step_index_fixed_prefix_one :
+    MainStepIndexFixedFacts 1 2 addSpinProgram
+      (mainRowsTable 2 addSpinProgram addSpinMainRows) where
+  main_step_eq_index := by
+    intro i
+    fin_cases i
+    exact addSpinMain_main_step_eq_index ⟨0, by decide⟩
+  timestamp_bound := by
+    intro i
+    fin_cases i
+    exact addSpinMain_main_step_index_fixed.timestamp_bound ⟨0, by decide⟩
+  load_timestamp_toNat := by
+    intro i
+    fin_cases i
+    exact addSpinMain_main_step_index_fixed.load_timestamp_toNat ⟨0, by decide⟩
+  store_timestamp_toNat := by
+    intro i
+    fin_cases i
+    exact addSpinMain_main_step_index_fixed.store_timestamp_toNat ⟨0, by decide⟩
+
+theorem addSpinWitness_main_step_index_fixed_prefix_one :
+    ∀ table ∈ addSpinWitness.allTables,
+      table.component = componentWithRomMemAndOpBus 2 addSpinProgram →
+        MainStepIndexFixedFacts 1 2 addSpinProgram table := by
+  intro table h_table h_component
+  have h_main := addSpinWitness_main_component_cases h_table h_component
+  subst table
+  exact addSpinMain_main_step_index_fixed_prefix_one
+
+/-- One executed ADD step with the full committed ADD/JAL ROM. -/
+def addPaddedAcceptedTrace : AcceptedZiskTrace 1 where
+  programLength := 2
+  program := addSpinProgram
+  witness := addSpinWitness
+  constraints_hold := addSpinWitness_constraints
+  channels_balanced := addSpinWitness_balancedChannels
+  mem_replay_table := fun h => absurd h addSpinWitness_not_mutableMemPresent
+  mem_replay_segment := fun h => absurd h addSpinWitness_not_mutableMemPresent
+  mem_replay_permutation := fun h => absurd h addSpinWitness_not_mutableMemPresent
+  mem_replay_gsum := fun h => absurd h addSpinWitness_not_mutableMemPresent
+  mem_replay_im0 := fun h => absurd h addSpinWitness_not_mutableMemPresent
+  mem_replay_im1 := fun h => absurd h addSpinWitness_not_mutableMemPresent
+  mem_replay_constraints := fun h => absurd h addSpinWitness_not_mutableMemPresent
+  mem_replay_row_ranges := fun h => absurd h addSpinWitness_not_mutableMemPresent
+  mem_replay_segment_ranges := fun h => absurd h addSpinWitness_not_mutableMemPresent
+  mem_replay_source_covers := fun h => absurd h addSpinWitness_not_mutableMemPresent
+  transitions_hold := addSpinWitness_transitions
+  main_height := addSpinWitness_main_height_prefix_one
+  segment_l1_fixed := addSpinWitness_segment_l1_fixed
+  main_step_index_fixed := addSpinWitness_main_step_index_fixed_prefix_one
+
+theorem addPaddedAcceptedTrace_mainTable_eq :
+    addPaddedAcceptedTrace.mainTable = mainRowsTable 2 addSpinProgram addSpinMainRows := by
+  exact addSpinWitness_main_component_cases
+    (by simpa [addPaddedAcceptedTrace] using addPaddedAcceptedTrace.mainTable_mem)
+    (by simpa [addPaddedAcceptedTrace] using addPaddedAcceptedTrace.mainTable_component)
 
 end ZiskFv.Compliance.AddSpinWitness

--- a/ZiskFv/Compliance/MainTransition.lean
+++ b/ZiskFv/Compliance/MainTransition.lean
@@ -63,11 +63,11 @@ theorem AcceptedZiskTrace.mainTransition_to_next_pc
       ((mainOfTable trace.program trace.mainTable).pc (i + 1)) := by
   have h_trans := trace.transitions_hold trace.mainTable trace.mainTable_mem i h_idx
   have hcomp : trace.mainTable.component
-      = ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus n trace.program :=
+      = ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.programLength trace.program :=
     trace.mainTable_component
   rw [hcomp] at h_trans
   have hproj :
-      (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus n trace.program).transition
+      (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.programLength trace.program).transition
         = ZiskFv.AirsClean.Main.pcHandshakeBetween := rfl
   rw [hproj,
       rowInput_eq_mainTableRowAtOrZero trace.program trace.mainTable i (by omega),

--- a/ZiskFv/Compliance/OpBusProviderMatch.lean
+++ b/ZiskFv/Compliance/OpBusProviderMatch.lean
@@ -56,17 +56,17 @@ theorem main_request_logic_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core.is_external_op)
+          trace.programLength trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          trace.programLength trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core =
+          trace.programLength trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -79,28 +79,28 @@ theorem main_request_logic_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core.is_external_op)
+              trace.programLength trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              trace.programLength trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.programLength trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     exists_staticBinary_provider_row_matches_legacy_main_of_logic_active_main_row_interaction
@@ -141,17 +141,17 @@ theorem main_request_sub_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core.is_external_op)
+          trace.programLength trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          trace.programLength trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core =
+          trace.programLength trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -164,28 +164,28 @@ theorem main_request_sub_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core.is_external_op)
+              trace.programLength trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              trace.programLength trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.programLength trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     exists_staticBinary_provider_row_matches_legacy_main_of_sub_active_main_row_interaction
@@ -243,17 +243,17 @@ theorem main_request_add_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core.is_external_op)
+          trace.programLength trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          trace.programLength trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core =
+          trace.programLength trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -266,28 +266,28 @@ theorem main_request_add_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core.is_external_op)
+              trace.programLength trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              trace.programLength trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.programLength trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   have h_main_component_spec :
       trace.mainTable.component.Spec
@@ -352,17 +352,17 @@ theorem main_request_compare_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core.is_external_op)
+          trace.programLength trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          trace.programLength trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core =
+          trace.programLength trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -375,28 +375,28 @@ theorem main_request_compare_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core.is_external_op)
+              trace.programLength trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              trace.programLength trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.programLength trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     exists_staticBinary_provider_row_matches_legacy_main_of_compare_active_main_row_interaction
@@ -437,17 +437,17 @@ theorem main_request_eq_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core.is_external_op)
+          trace.programLength trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          trace.programLength trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core =
+          trace.programLength trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -460,28 +460,28 @@ theorem main_request_eq_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core.is_external_op)
+              trace.programLength trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              trace.programLength trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.programLength trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     exists_staticBinary_provider_row_matches_legacy_main_of_eq_active_main_row_interaction
@@ -525,17 +525,17 @@ theorem main_request_w_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core.is_external_op)
+          trace.programLength trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          trace.programLength trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core =
+          trace.programLength trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -548,28 +548,28 @@ theorem main_request_w_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core.is_external_op)
+              trace.programLength trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              trace.programLength trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.programLength trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     exists_staticBinary_provider_row_matches_legacy_main_of_w_active_main_row_interaction
@@ -626,17 +626,17 @@ theorem main_request_shift_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core.is_external_op)
+          trace.programLength trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          trace.programLength trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core =
+          trace.programLength trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -649,28 +649,28 @@ theorem main_request_shift_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core.is_external_op)
+              trace.programLength trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              trace.programLength trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.programLength trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     exists_binaryExtension_provider_row_matches_legacy_main_of_shift_active_main_row_interaction
@@ -722,17 +722,17 @@ theorem main_request_mulw_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core.is_external_op)
+          trace.programLength trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          trace.programLength trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core =
+          trace.programLength trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -745,28 +745,28 @@ theorem main_request_mulw_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core.is_external_op)
+              trace.programLength trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              trace.programLength trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.programLength trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_primary_of_mulw_active_main_row_interaction
@@ -816,17 +816,17 @@ theorem main_request_mulhu_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core.is_external_op)
+          trace.programLength trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          trace.programLength trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core =
+          trace.programLength trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -839,28 +839,28 @@ theorem main_request_mulhu_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core.is_external_op)
+              trace.programLength trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              trace.programLength trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.programLength trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_secondary_of_mulhu_active_main_row_interaction
@@ -912,17 +912,17 @@ theorem main_request_divu_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core.is_external_op)
+          trace.programLength trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          trace.programLength trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core =
+          trace.programLength trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -935,28 +935,28 @@ theorem main_request_divu_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core.is_external_op)
+              trace.programLength trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              trace.programLength trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.programLength trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_primary_of_divu_active_main_row_interaction
@@ -1007,17 +1007,17 @@ theorem main_request_divuw_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core.is_external_op)
+          trace.programLength trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          trace.programLength trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core =
+          trace.programLength trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -1030,28 +1030,28 @@ theorem main_request_divuw_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core.is_external_op)
+              trace.programLength trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              trace.programLength trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.programLength trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_primary_of_divuw_active_main_row_interaction
@@ -1103,17 +1103,17 @@ theorem main_request_remu_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core.is_external_op)
+          trace.programLength trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          trace.programLength trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core =
+          trace.programLength trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -1126,28 +1126,28 @@ theorem main_request_remu_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core.is_external_op)
+              trace.programLength trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              trace.programLength trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.programLength trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_primary_of_remu_active_main_row_interaction
@@ -1200,17 +1200,17 @@ theorem main_request_remuw_provided
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
       (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core.is_external_op)
+          trace.programLength trace.program).rowInputVar.core.is_external_op)
       (ZiskFv.AirsClean.Main.opBusMessageExpr
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core)).toRaw).eval
+          trace.programLength trace.program).rowInputVar.core)).toRaw).eval
       (trace.mainTable.environment mainRow)
   have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
     simp [mainRow]
   have h_main_row :
       eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core =
+          trace.programLength trace.program).rowInputVar.core =
         ZiskFv.AirsClean.Main.rowAt
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
           i.val := by
@@ -1223,28 +1223,28 @@ theorem main_request_remuw_provided
           ZiskFv.Channels.OperationBus.OpBusChannel.toRaw := by
     simpa [mainInteraction, mainRow] using
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mem_interactionsWith
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         trace.mainTable_component h_mainRow_mem
   have h_mainInteraction_eval :
       mainInteraction =
         ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
           (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core.is_external_op)
+              trace.programLength trace.program).rowInputVar.core.is_external_op)
           (ZiskFv.AirsClean.Main.opBusMessageExpr
             (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              numInstructions trace.program).rowInputVar.core)).toRaw).eval
+              trace.programLength trace.program).rowInputVar.core)).toRaw).eval
           (trace.mainTable.environment mainRow) := rfl
   have h_active_row :
       (eval (trace.mainTable.environment mainRow)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions trace.program).rowInputVar.core).is_external_op = 1 := by
+          trace.programLength trace.program).rowInputVar.core).is_external_op = 1 := by
     rw [h_main_row]
     simpa [ZiskFv.AirsClean.Main.rowAt] using h_main_active
   have h_active : mainInteraction.mult = -1 := by
     rw [h_mainInteraction_eval]
     exact
       ZiskFv.AirsClean.FullEnsemble.main_op_row_eval_mult_neg_one_of_active
-        (length := numInstructions) (program := trace.program)
+        (length := trace.programLength) (program := trace.program)
         (trace.mainTable.environment mainRow) h_active_row
   exact
     ZiskFv.AirsClean.FullEnsemble.exists_arithMul_provider_row_matches_primary_of_remuw_active_main_row_interaction

--- a/ZiskFv/Compliance/SailTrace.lean
+++ b/ZiskFv/Compliance/SailTrace.lean
@@ -2,21 +2,21 @@ import ZiskFv.Compliance.AcceptedZiskTrace.MainTable
 import ZiskFv.SailSpec.Auxiliaries
 
 /-!
-A `SailTrace` is the Sail side of an `AcceptedZiskTrace`: the per-instruction
-sequence of Sail machine states the program steps through. It depends only on the
-instruction count (`AcceptedZiskTrace.numInstructions`), not the whole trace — so
+A `SailTrace` is the Sail side of an `AcceptedZiskTrace`: the per-executed-step
+sequence of Sail machine states. It depends only on the executed-step count
+(`AcceptedZiskTrace.numInstructions`), not the whole trace — so
 it is a plain function from an instruction index to the Sail machine state, and
 applying a `binding : SailTrace n` to an index `i : Fin n` is the state access.
 Everything about the Main execution table — which witness table it is, and that it
-has a row per instruction — is derived on `AcceptedZiskTrace`, not a `SailTrace`
+has a row per executed step — is derived on `AcceptedZiskTrace`, not a `SailTrace`
 field.
 -/
 
 namespace ZiskFv.Compliance
 
-/-- The Sail side of an `AcceptedZiskTrace`: the per-instruction Sail
-    machine-state sequence, indexed by instruction. Parameterized by the
-    instruction count (pass `trace.numInstructions`), not the trace itself. -/
+/-- The Sail side of an `AcceptedZiskTrace`: the per-executed-step Sail
+    machine-state sequence, indexed by executed step. Parameterized by the
+    executed-step count (pass `trace.numInstructions`), not the trace itself. -/
 abbrev SailTrace (numInstructions : Nat) :=
   Fin numInstructions →
     PreSail.SequentialState RegisterType Sail.trivialChoiceSource

--- a/ZiskFv/Compliance/SingleAddWitness.lean
+++ b/ZiskFv/Compliance/SingleAddWitness.lean
@@ -330,7 +330,7 @@ theorem addX1Main_main_step_eq_index :
   rfl
 
 theorem addX1Main_main_step_index_fixed :
-    MainStepIndexFixedFacts 1 addX1Program
+    MainStepIndexFixedFacts 1 1 addX1Program
       (mainSingleRowTable 1 addX1Program addX1Row) where
   main_step_eq_index := addX1Main_main_step_eq_index
   timestamp_bound := by
@@ -351,7 +351,7 @@ theorem addX1Main_main_step_index_fixed :
 theorem singleAddWitness_main_step_index_fixed :
     ∀ table ∈ singleAddWitness.allTables,
       table.component = componentWithRomMemAndOpBus 1 addX1Program →
-        MainStepIndexFixedFacts 1 addX1Program table := by
+        MainStepIndexFixedFacts 1 1 addX1Program table := by
   intro table h_table h_component
   have h_main := singleAddWitness_main_component_cases h_table h_component
   subst table
@@ -481,6 +481,7 @@ theorem singleAddWitness_balancedChannels : singleAddWitness.BalancedChannels :=
   · exact singleAddWitness_opBus_balanced
 
 def singleAddAcceptedTrace : AcceptedZiskTrace 1 where
+  programLength := 1
   program := addX1Program
   witness := singleAddWitness
   constraints_hold := singleAddWitness_constraints

--- a/ZiskFv/Compliance/TraceLevelExport/BootSegmentMemorySeed.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/BootSegmentMemorySeed.lean
@@ -497,32 +497,32 @@ theorem BootSegmentReadSoundInputs.mem_executionRows_of_activeMainMutableStoreMe
     ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL) :=
   ZiskFv.AirsClean.Main.bMemMessageExpr
     (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-      numInstructions ziskTrace.program).rowInputVar
+      ziskTrace.programLength ziskTrace.program).rowInputVar
 
 @[reducible] def storeCMemMainMessage
     (ziskTrace : AcceptedZiskTrace numInstructions) :
     ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL) :=
   ZiskFv.AirsClean.Main.cMemMessageExpr
     (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-      numInstructions ziskTrace.program).rowInputVar
+      ziskTrace.programLength ziskTrace.program).rowInputVar
 
 @[reducible] def loadBMemMainMultiplicity
     (ziskTrace : AcceptedZiskTrace numInstructions) : Expression FGL :=
   -((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-        numInstructions ziskTrace.program).rowInputVar.rom.b_src_mem
+        ziskTrace.programLength ziskTrace.program).rowInputVar.rom.b_src_mem
     + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-        numInstructions ziskTrace.program).rowInputVar.rom.b_src_ind
+        ziskTrace.programLength ziskTrace.program).rowInputVar.rom.b_src_ind
     + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-        numInstructions ziskTrace.program).rowInputVar.rom.b_src_reg)
+        ziskTrace.programLength ziskTrace.program).rowInputVar.rom.b_src_reg)
 
 @[reducible] def storeCMemMainMultiplicity
     (ziskTrace : AcceptedZiskTrace numInstructions) : Expression FGL :=
   -((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-        numInstructions ziskTrace.program).rowInputVar.rom.store_mem
+        ziskTrace.programLength ziskTrace.program).rowInputVar.rom.store_mem
     + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-        numInstructions ziskTrace.program).rowInputVar.rom.store_ind
+        ziskTrace.programLength ziskTrace.program).rowInputVar.rom.store_ind
     + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-        numInstructions ziskTrace.program).rowInputVar.rom.store_reg)
+        ziskTrace.programLength ziskTrace.program).rowInputVar.rom.store_reg)
 
 @[reducible] noncomputable def loadBMemMainInteraction
     (ziskTrace : AcceptedZiskTrace numInstructions)
@@ -598,7 +598,7 @@ theorem AcceptedZiskTrace.memReplayRows_of_loadBMemProviderEntry
   have h_row_eval :
       eval (ziskTrace.mainTable.environment (loadBMemMainRow ziskTrace i))
           (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            numInstructions ziskTrace.program).rowInputVar =
+            ziskTrace.programLength ziskTrace.program).rowInputVar =
         mainRowWithRomLd ziskTrace i := by
     simpa [loadBMemMainRow, mainRowWithRomLd] using
       (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get
@@ -611,35 +611,35 @@ theorem AcceptedZiskTrace.memReplayRows_of_loadBMemProviderEntry
       ZiskFv.AirsClean.Main.eval_bSourceSumExpr
         (ziskTrace.mainTable.environment (loadBMemMainRow ziskTrace i))
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions ziskTrace.program).rowInputVar
+          ziskTrace.programLength ziskTrace.program).rowInputVar
     have h_source_sum' :
         Expression.eval (ziskTrace.mainTable.environment (loadBMemMainRow ziskTrace i))
             ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar.rom.b_src_mem
+                ziskTrace.programLength ziskTrace.program).rowInputVar.rom.b_src_mem
               + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar.rom.b_src_ind
+                ziskTrace.programLength ziskTrace.program).rowInputVar.rom.b_src_ind
               + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar.rom.b_src_reg) =
+                ziskTrace.programLength ziskTrace.program).rowInputVar.rom.b_src_reg) =
           (eval (ziskTrace.mainTable.environment (loadBMemMainRow ziskTrace i))
               (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar).rom.b_src_mem
+                ziskTrace.programLength ziskTrace.program).rowInputVar).rom.b_src_mem
             + (eval (ziskTrace.mainTable.environment (loadBMemMainRow ziskTrace i))
               (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar).rom.b_src_ind
+                ziskTrace.programLength ziskTrace.program).rowInputVar).rom.b_src_ind
             + (eval (ziskTrace.mainTable.environment (loadBMemMainRow ziskTrace i))
               (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar).rom.b_src_reg := by
+                ziskTrace.programLength ziskTrace.program).rowInputVar).rom.b_src_reg := by
       simpa using h_source_sum
     rw [loadBMemMainMultiplicity]
     change
       (-1 : FGL) *
           Expression.eval (ziskTrace.mainTable.environment (loadBMemMainRow ziskTrace i))
             ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar.rom.b_src_mem
+                ziskTrace.programLength ziskTrace.program).rowInputVar.rom.b_src_mem
               + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar.rom.b_src_ind
+                ziskTrace.programLength ziskTrace.program).rowInputVar.rom.b_src_ind
               + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar.rom.b_src_reg) = -1
+                ziskTrace.programLength ziskTrace.program).rowInputVar.rom.b_src_reg) = -1
     rw [h_source_sum', h_row_eval]
     simpa using h_active
   have h_active_interaction :
@@ -708,7 +708,7 @@ theorem AcceptedZiskTrace.memReplayRows_of_storeCMemProviderEntry
   have h_row_eval :
       eval (ziskTrace.mainTable.environment (storeCMemMainRow ziskTrace i))
           (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            numInstructions ziskTrace.program).rowInputVar =
+            ziskTrace.programLength ziskTrace.program).rowInputVar =
         mainRowWithRomSt ziskTrace i := by
     simpa [storeCMemMainRow, mainRowWithRomSt] using
       (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get
@@ -721,35 +721,35 @@ theorem AcceptedZiskTrace.memReplayRows_of_storeCMemProviderEntry
       ZiskFv.AirsClean.Main.eval_cSourceSumExpr
         (ziskTrace.mainTable.environment (storeCMemMainRow ziskTrace i))
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions ziskTrace.program).rowInputVar
+          ziskTrace.programLength ziskTrace.program).rowInputVar
     have h_source_sum' :
         Expression.eval (ziskTrace.mainTable.environment (storeCMemMainRow ziskTrace i))
             ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar.rom.store_mem
+                ziskTrace.programLength ziskTrace.program).rowInputVar.rom.store_mem
               + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar.rom.store_ind
+                ziskTrace.programLength ziskTrace.program).rowInputVar.rom.store_ind
               + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar.rom.store_reg) =
+                ziskTrace.programLength ziskTrace.program).rowInputVar.rom.store_reg) =
           (eval (ziskTrace.mainTable.environment (storeCMemMainRow ziskTrace i))
               (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar).rom.store_mem
+                ziskTrace.programLength ziskTrace.program).rowInputVar).rom.store_mem
             + (eval (ziskTrace.mainTable.environment (storeCMemMainRow ziskTrace i))
               (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar).rom.store_ind
+                ziskTrace.programLength ziskTrace.program).rowInputVar).rom.store_ind
             + (eval (ziskTrace.mainTable.environment (storeCMemMainRow ziskTrace i))
               (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar).rom.store_reg := by
+                ziskTrace.programLength ziskTrace.program).rowInputVar).rom.store_reg := by
       simpa using h_source_sum
     rw [storeCMemMainMultiplicity]
     change
       (-1 : FGL) *
           Expression.eval (ziskTrace.mainTable.environment (storeCMemMainRow ziskTrace i))
             ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar.rom.store_mem
+                ziskTrace.programLength ziskTrace.program).rowInputVar.rom.store_mem
               + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar.rom.store_ind
+                ziskTrace.programLength ziskTrace.program).rowInputVar.rom.store_ind
               + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar.rom.store_reg) = -1
+                ziskTrace.programLength ziskTrace.program).rowInputVar.rom.store_reg) = -1
     rw [h_source_sum', h_row_eval]
     simpa using h_active
   have h_active_interaction :
@@ -844,7 +844,7 @@ theorem AcceptedZiskTrace.memReplayRows_of_loadBMemProviderEntry_of_no_nonmutabl
   have h_row_eval :
       eval (ziskTrace.mainTable.environment (loadBMemMainRow ziskTrace i))
           (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            numInstructions ziskTrace.program).rowInputVar =
+            ziskTrace.programLength ziskTrace.program).rowInputVar =
         mainRowWithRomLd ziskTrace i := by
     simpa [loadBMemMainRow, mainRowWithRomLd] using
       (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get
@@ -963,7 +963,7 @@ theorem AcceptedZiskTrace.memReplayRows_or_memAlignProvider_of_loadBMemProviderE
   have h_row_eval :
       eval (ziskTrace.mainTable.environment (loadBMemMainRow ziskTrace i))
           (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            numInstructions ziskTrace.program).rowInputVar =
+            ziskTrace.programLength ziskTrace.program).rowInputVar =
         mainRowWithRomLd ziskTrace i := by
     simpa [loadBMemMainRow, mainRowWithRomLd] using
       (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get
@@ -976,35 +976,35 @@ theorem AcceptedZiskTrace.memReplayRows_or_memAlignProvider_of_loadBMemProviderE
       ZiskFv.AirsClean.Main.eval_bSourceSumExpr
         (ziskTrace.mainTable.environment (loadBMemMainRow ziskTrace i))
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          numInstructions ziskTrace.program).rowInputVar
+          ziskTrace.programLength ziskTrace.program).rowInputVar
     have h_source_sum' :
         Expression.eval (ziskTrace.mainTable.environment (loadBMemMainRow ziskTrace i))
             ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar.rom.b_src_mem
+                ziskTrace.programLength ziskTrace.program).rowInputVar.rom.b_src_mem
               + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar.rom.b_src_ind
+                ziskTrace.programLength ziskTrace.program).rowInputVar.rom.b_src_ind
               + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar.rom.b_src_reg) =
+                ziskTrace.programLength ziskTrace.program).rowInputVar.rom.b_src_reg) =
           (eval (ziskTrace.mainTable.environment (loadBMemMainRow ziskTrace i))
               (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar).rom.b_src_mem
+                ziskTrace.programLength ziskTrace.program).rowInputVar).rom.b_src_mem
             + (eval (ziskTrace.mainTable.environment (loadBMemMainRow ziskTrace i))
               (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar).rom.b_src_ind
+                ziskTrace.programLength ziskTrace.program).rowInputVar).rom.b_src_ind
             + (eval (ziskTrace.mainTable.environment (loadBMemMainRow ziskTrace i))
               (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar).rom.b_src_reg := by
+                ziskTrace.programLength ziskTrace.program).rowInputVar).rom.b_src_reg := by
       simpa using h_source_sum
     rw [loadBMemMainMultiplicity]
     change
       (-1 : FGL) *
           Expression.eval (ziskTrace.mainTable.environment (loadBMemMainRow ziskTrace i))
             ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar.rom.b_src_mem
+                ziskTrace.programLength ziskTrace.program).rowInputVar.rom.b_src_mem
               + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar.rom.b_src_ind
+                ziskTrace.programLength ziskTrace.program).rowInputVar.rom.b_src_ind
               + (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                numInstructions ziskTrace.program).rowInputVar.rom.b_src_reg) = -1
+                ziskTrace.programLength ziskTrace.program).rowInputVar.rom.b_src_reg) = -1
     rw [h_source_sum', h_row_eval]
     simpa using h_active
   have h_active_interaction :

--- a/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
@@ -55,7 +55,7 @@ structure ProgramDecode_sub {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SUB
@@ -77,7 +77,7 @@ structure ProgramDecode_and {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_AND
@@ -99,7 +99,7 @@ structure ProgramDecode_or {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_OR
@@ -121,7 +121,7 @@ structure ProgramDecode_xor {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_XOR
@@ -143,7 +143,7 @@ structure ProgramDecode_slt {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LT
@@ -165,7 +165,7 @@ structure ProgramDecode_sltu {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LTU
@@ -188,7 +188,7 @@ structure ProgramDecode_andi {numInstructions : Nat}
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
   h_bits_b_src_imm : bits.b_src_imm = true
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_AND
@@ -215,7 +215,7 @@ structure ProgramDecode_ori {numInstructions : Nat}
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
   h_bits_b_src_imm : bits.b_src_imm = true
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_OR
@@ -242,7 +242,7 @@ structure ProgramDecode_xori {numInstructions : Nat}
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
   h_bits_b_src_imm : bits.b_src_imm = true
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_XOR
@@ -269,7 +269,7 @@ structure ProgramDecode_slti {numInstructions : Nat}
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
   h_bits_b_src_imm : bits.b_src_imm = true
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LT
@@ -296,7 +296,7 @@ structure ProgramDecode_sltiu {numInstructions : Nat}
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
   h_bits_b_src_imm : bits.b_src_imm = true
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LTU
@@ -322,7 +322,7 @@ structure ProgramDecode_sll {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SLL
@@ -344,7 +344,7 @@ structure ProgramDecode_srl {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SRL
@@ -366,7 +366,7 @@ structure ProgramDecode_sra {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SRA
@@ -391,7 +391,7 @@ structure ProgramDecode_slli {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SLL
@@ -416,7 +416,7 @@ structure ProgramDecode_srli {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SRL
@@ -441,7 +441,7 @@ structure ProgramDecode_srai {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SRA
@@ -463,7 +463,7 @@ structure ProgramDecode_add {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_ADD
@@ -486,7 +486,7 @@ structure ProgramDecode_addi {numInstructions : Nat}
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
   h_bits_b_src_imm : bits.b_src_imm = true
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_ADD
@@ -512,7 +512,7 @@ structure ProgramDecode_subw {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SUB_W
@@ -534,7 +534,7 @@ structure ProgramDecode_addw {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_ADD_W
@@ -557,7 +557,7 @@ structure ProgramDecode_addiw {numInstructions : Nat}
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
   h_bits_b_src_imm : bits.b_src_imm = true
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_ADD_W
@@ -583,7 +583,7 @@ structure ProgramDecode_sllw {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SLL_W
@@ -605,7 +605,7 @@ structure ProgramDecode_srlw {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SRL_W
@@ -627,7 +627,7 @@ structure ProgramDecode_sraw {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SRA_W
@@ -649,7 +649,7 @@ structure ProgramDecode_slliw {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SLL_W
@@ -671,7 +671,7 @@ structure ProgramDecode_srliw {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SRL_W
@@ -693,7 +693,7 @@ structure ProgramDecode_sraiw {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SRA_W
@@ -721,7 +721,7 @@ structure ProgramDecode_mul {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_MUL
@@ -749,7 +749,7 @@ structure ProgramDecode_mulh {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_MULH
@@ -777,7 +777,7 @@ structure ProgramDecode_mulhsu {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_MULSUH
@@ -799,7 +799,7 @@ structure ProgramDecode_mulw {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_MUL_W
@@ -823,7 +823,7 @@ structure ProgramDecode_mulhu {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_MULUH
@@ -851,7 +851,7 @@ structure ProgramDecode_div {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_DIV
@@ -879,7 +879,7 @@ structure ProgramDecode_rem {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_REM
@@ -907,7 +907,7 @@ structure ProgramDecode_divw {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_DIV_W
@@ -935,7 +935,7 @@ structure ProgramDecode_remw {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_REM_W
@@ -959,7 +959,7 @@ structure ProgramDecode_divu {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_DIVU
@@ -983,7 +983,7 @@ structure ProgramDecode_divuw {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_DIVU_W
@@ -1007,7 +1007,7 @@ structure ProgramDecode_remu {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_REMU
@@ -1031,7 +1031,7 @@ structure ProgramDecode_remuw {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_REMU_W
@@ -1052,7 +1052,7 @@ structure ProgramDecode_beq {numInstructions : Nat}
   h_bits_m32 : bits.m32 = false
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_EQ
@@ -1072,7 +1072,7 @@ structure ProgramDecode_bne {numInstructions : Nat}
   h_bits_m32 : bits.m32 = false
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_EQ
@@ -1092,7 +1092,7 @@ structure ProgramDecode_blt {numInstructions : Nat}
   h_bits_m32 : bits.m32 = false
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LT
@@ -1112,7 +1112,7 @@ structure ProgramDecode_bge {numInstructions : Nat}
   h_bits_m32 : bits.m32 = false
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LT
@@ -1132,7 +1132,7 @@ structure ProgramDecode_bltu {numInstructions : Nat}
   h_bits_m32 : bits.m32 = false
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LTU
@@ -1152,7 +1152,7 @@ structure ProgramDecode_bgeu {numInstructions : Nat}
   h_bits_m32 : bits.m32 = false
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LTU
@@ -1179,7 +1179,7 @@ structure ProgramDecode_lui {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_COPYB
@@ -1201,7 +1201,7 @@ structure ProgramDecode_auipc {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = true
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_FLAG
@@ -1224,7 +1224,7 @@ structure ProgramDecode_jal {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = true
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_FLAG
@@ -1267,7 +1267,7 @@ structure ProgramDecode_jalr {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = true
   h_bits_store_pc : bits.store_pc = true
   h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_AND
@@ -1287,7 +1287,7 @@ structure ProgramDecode_sb {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = true
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_COPYB
@@ -1310,7 +1310,7 @@ structure ProgramDecode_sh {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = true
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_COPYB
@@ -1333,7 +1333,7 @@ structure ProgramDecode_sw {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = true
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_COPYB
@@ -1356,7 +1356,7 @@ structure ProgramDecode_sd {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = true
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_COPYB
@@ -1380,7 +1380,7 @@ structure ProgramDecode_ld {numInstructions : Nat}
   h_bits_store_ind : bits.store_ind = false
   h_bits_store_reg : bits.store_reg = true
   h_bits_b_src_ind : bits.b_src_ind = true
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_COPYB
@@ -1406,7 +1406,7 @@ structure ProgramDecode_lbu {numInstructions : Nat}
   h_bits_store_ind : bits.store_ind = false
   h_bits_store_reg : bits.store_reg = true
   h_bits_b_src_ind : bits.b_src_ind = true
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_COPYB
@@ -1432,7 +1432,7 @@ structure ProgramDecode_lhu {numInstructions : Nat}
   h_bits_store_ind : bits.store_ind = false
   h_bits_store_reg : bits.store_reg = true
   h_bits_b_src_ind : bits.b_src_ind = true
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_COPYB
@@ -1458,7 +1458,7 @@ structure ProgramDecode_lwu {numInstructions : Nat}
   h_bits_store_ind : bits.store_ind = false
   h_bits_store_reg : bits.store_reg = true
   h_bits_b_src_ind : bits.b_src_ind = true
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_COPYB
@@ -1500,7 +1500,7 @@ structure ProgramDecode_lb {numInstructions : Nat}
   h_bits_store_ind : bits.store_ind = false
   h_bits_store_reg : bits.store_reg = true
   h_bits_b_src_ind : bits.b_src_ind = true
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SIGNEXTEND_B
@@ -1542,7 +1542,7 @@ structure ProgramDecode_lh {numInstructions : Nat}
   h_bits_store_ind : bits.store_ind = false
   h_bits_store_reg : bits.store_reg = true
   h_bits_b_src_ind : bits.b_src_ind = true
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SIGNEXTEND_H
@@ -1584,7 +1584,7 @@ structure ProgramDecode_lw {numInstructions : Nat}
   h_bits_store_ind : bits.store_ind = false
   h_bits_store_reg : bits.store_reg = true
   h_bits_b_src_ind : bits.b_src_ind = true
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SIGNEXTEND_W
@@ -1612,7 +1612,7 @@ structure ProgramDecode_fence {numInstructions : Nat}
   bits : RomFlagBits
   h_bits_ieo : bits.is_external_op = false
   h_bits_set_pc : bits.set_pc = false
-  h_prog : ∀ j : Fin numInstructions,
+  h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_FLAG

--- a/ZiskFv/Compliance/TraceLevelExport/RomDecodeBinding.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RomDecodeBinding.lean
@@ -70,7 +70,7 @@ feeds `romSpec_of_componentWithRomMemAndOpBus_constraints`. -/
 theorem mainOperationsConstraintsHold_at
     {numInstructions : Nat} (trace : AcceptedZiskTrace numInstructions)
     (idx : Fin trace.mainTable.table.length) :
-    (componentWithRomMemAndOpBus numInstructions trace.program).operations.ConstraintsHold
+    (componentWithRomMemAndOpBus trace.programLength trace.program).operations.ConstraintsHold
       (trace.mainTable.environment (trace.mainTable.table.get idx)) := by
   have h_tableConstraints : trace.mainTable.Constraints :=
     trace.constraints_hold trace.mainTable trace.mainTable_mem
@@ -90,7 +90,7 @@ theorem mainAddressSpec_at
   have h_holds := mainOperationsConstraintsHold_at trace idx
   have h_spec :=
     ZiskFv.AirsClean.Main.addressSpec_of_componentWithRomMemAndOpBus_constraints
-      numInstructions trace.program
+      trace.programLength trace.program
       (trace.mainTable.environment (trace.mainTable.table.get idx)) h_holds
   rw [ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get trace.program trace.mainTable idx]
   exact h_spec
@@ -105,7 +105,7 @@ theorem mainSourceSpec_at
   have h_holds := mainOperationsConstraintsHold_at trace idx
   have h_spec :=
     ZiskFv.AirsClean.Main.sourceSpec_of_componentWithRomMemAndOpBus_constraints
-      numInstructions trace.program
+      trace.programLength trace.program
       (trace.mainTable.environment (trace.mainTable.table.get idx)) h_holds
   rw [ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get trace.program trace.mainTable idx]
   exact h_spec
@@ -172,13 +172,13 @@ in-circuit ROM lookup. It is opcode-agnostic and reused by every per-op
 theorem mainRomMessage_at_eq_program
     {numInstructions : Nat} (trace : AcceptedZiskTrace numInstructions)
     (idx : Fin trace.mainTable.table.length) :
-    ∃ j : Fin trace.numInstructions,
+    ∃ j : Fin trace.programLength,
       romMessage (mainTableRowAtOrZero trace.program trace.mainTable idx.val)
         = trace.program j := by
   have h_holds := mainOperationsConstraintsHold_at trace idx
   have h_spec :=
     ZiskFv.AirsClean.Main.romSpec_of_componentWithRomMemAndOpBus_constraints
-      numInstructions trace.program
+      trace.programLength trace.program
       (trace.mainTable.environment (trace.mainTable.table.get idx)) h_holds
   simp only [ZiskFv.AirsClean.ZiskInstructionRom.romStaticTable] at h_spec
   obtain ⟨j, hj⟩ := h_spec
@@ -196,7 +196,7 @@ equal the entry's `flags` (the flag pins are unpacked separately). -/
 theorem mainDecodeColumns_at_eq_program
     {numInstructions : Nat} (trace : AcceptedZiskTrace numInstructions)
     (idx : Fin trace.mainTable.table.length) :
-    ∃ j : Fin trace.numInstructions,
+    ∃ j : Fin trace.programLength,
       (trace.program j).line = (mainOfTable trace.program trace.mainTable).pc idx.val
     ∧ (trace.program j).op = (mainOfTable trace.program trace.mainTable).op idx.val
     ∧ (trace.program j).jmp_offset1
@@ -320,18 +320,18 @@ theorem mainRow_flags_boolean
   intro r
   have h_holds := mainOperationsConstraintsHold_at trace idx
   have h_ieo := ZiskFv.AirsClean.Main.is_external_op_boolean_of_componentWithRomMemAndOpBus_constraints
-    numInstructions trace.program _ h_holds
+    trace.programLength trace.program _ h_holds
   obtain ⟨h_m32, h_set_pc, h_store_pc, h_a_src_imm, h_a_src_mem, h_is_precompiled,
     h_b_src_imm, h_b_src_mem, h_store_mem, h_store_ind, h_b_src_ind, h_a_src_reg,
     h_b_src_reg, h_store_reg⟩ :=
     ZiskFv.AirsClean.Main.romBoolSpec_of_componentWithRomMemAndOpBus_constraints
-      numInstructions trace.program _ h_holds
+      trace.programLength trace.program _ h_holds
   obtain ⟨b_ieo, b_m32, b_set_pc, b_store_pc, b_a_src_imm, b_a_src_mem,
     b_is_precompiled, b_b_src_imm, b_b_src_mem, b_store_mem, b_store_ind,
     b_b_src_ind, b_a_src_reg, b_b_src_reg, b_store_reg⟩ :=
     ZiskFv.AirsClean.Main.eval_flagBool_bridge
       (trace.mainTable.environment (trace.mainTable.table.get idx))
-      (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus numInstructions trace.program).rowInputVar
+      (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar
   show r.core.is_external_op * _ = 0 ∧ _
   rw [show r = _ from ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get
     trace.program trace.mainTable idx]
@@ -433,11 +433,11 @@ theorem mainRowWithRomLd_bMemInteraction_mem
     (trace : AcceptedZiskTrace numInstructions)
     (i : Fin trace.numInstructions) :
     (((MemBusChannel.emitted
-      (-((componentWithRomMemAndOpBus numInstructions trace.program).rowInputVar.rom.b_src_mem
-        + (componentWithRomMemAndOpBus numInstructions trace.program).rowInputVar.rom.b_src_ind
-        + (componentWithRomMemAndOpBus numInstructions trace.program).rowInputVar.rom.b_src_reg))
+      (-((componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar.rom.b_src_mem
+        + (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar.rom.b_src_ind
+        + (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar.rom.b_src_reg))
       (ZiskFv.AirsClean.Main.bMemMessageExpr
-        (componentWithRomMemAndOpBus numInstructions trace.program).rowInputVar)).toRaw).eval
+        (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)).toRaw).eval
       (trace.mainTable.environment
         (trace.mainTable.table.get ⟨i.val, trace.mainTable_index i⟩)))
       ∈ trace.mainTable.interactionsWith MemBusChannel.toRaw := by
@@ -458,11 +458,11 @@ theorem mainRowWithRomSt_cMemInteraction_mem
     (trace : AcceptedZiskTrace numInstructions)
     (i : Fin trace.numInstructions) :
     (((MemBusChannel.emitted
-      (-((componentWithRomMemAndOpBus numInstructions trace.program).rowInputVar.rom.store_mem
-        + (componentWithRomMemAndOpBus numInstructions trace.program).rowInputVar.rom.store_ind
-        + (componentWithRomMemAndOpBus numInstructions trace.program).rowInputVar.rom.store_reg))
+      (-((componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar.rom.store_mem
+        + (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar.rom.store_ind
+        + (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar.rom.store_reg))
       (ZiskFv.AirsClean.Main.cMemMessageExpr
-        (componentWithRomMemAndOpBus numInstructions trace.program).rowInputVar)).toRaw).eval
+        (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)).toRaw).eval
       (trace.mainTable.environment
         (trace.mainTable.table.get ⟨i.val, trace.mainTable_index i⟩)))
       ∈ trace.mainTable.interactionsWith MemBusChannel.toRaw := by
@@ -803,7 +803,7 @@ def Decode_add_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_ADD

--- a/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
@@ -41,7 +41,7 @@ set_option maxHeartbeats 1000000
 theorem mainRomColumns_at_eq_program
     {numInstructions : Nat} (trace : AcceptedZiskTrace numInstructions)
     (idx : Fin trace.mainTable.table.length) :
-    ∃ j : Fin trace.numInstructions,
+    ∃ j : Fin trace.programLength,
       (trace.program j).line = (mainOfTable trace.program trace.mainTable).pc idx.val
     ∧ (trace.program j).op = (mainOfTable trace.program trace.mainTable).op idx.val
     ∧ (trace.program j).ind_width
@@ -65,7 +65,7 @@ theorem mainRomColumns_at_eq_program
 theorem mainStoreOffset_at_eq_program
     {numInstructions : Nat} (trace : AcceptedZiskTrace numInstructions)
     (idx : Fin trace.mainTable.table.length) :
-    ∃ j : Fin trace.numInstructions,
+    ∃ j : Fin trace.programLength,
       (trace.program j).line = (mainOfTable trace.program trace.mainTable).pc idx.val
     ∧ (trace.program j).store_offset
         = (mainTableRowAtOrZero trace.program trace.mainTable idx.val).rom.store_offset := by
@@ -78,7 +78,7 @@ theorem mainStoreOffset_at_eq_program
 theorem mainBOffsetImm0_at_eq_program
     {numInstructions : Nat} (trace : AcceptedZiskTrace numInstructions)
     (idx : Fin trace.mainTable.table.length) :
-    ∃ j : Fin trace.numInstructions,
+    ∃ j : Fin trace.programLength,
       (trace.program j).line = (mainOfTable trace.program trace.mainTable).pc idx.val
     ∧ (trace.program j).b_offset_imm0
         = (mainTableRowAtOrZero trace.program trace.mainTable idx.val).rom.b_offset_imm0 := by
@@ -160,7 +160,7 @@ theorem mainBImmediateSourceFacts_of_program
     (bits : RomFlagBits)
     (imm : BitVec 12)
     (h_bits_b_src_imm : bits.b_src_imm = true)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           BitVec.signExtend 64 imm
@@ -249,7 +249,7 @@ theorem mainWritebackDestinationFacts_of_program
     (bits : RomFlagBits)
     (rd : regidx)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).store_offset = Transpiler.ind (regidx_to_fin rd)
@@ -283,7 +283,7 @@ theorem mainLuiDestinationFacts_of_program
     (bits : RomFlagBits)
     (rd : regidx)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).store_offset = Transpiler.ind (regidx_to_fin rd)
@@ -324,7 +324,7 @@ def Decode_sub_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SUB
@@ -389,7 +389,7 @@ def Decode_and_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_AND
@@ -445,7 +445,7 @@ def Decode_or_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_OR
@@ -501,7 +501,7 @@ def Decode_xor_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_XOR
@@ -557,7 +557,7 @@ def Decode_slt_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LT
@@ -613,7 +613,7 @@ def Decode_sltu_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LTU
@@ -670,7 +670,7 @@ def Decode_andi_of_program
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
     (h_bits_b_src_imm : bits.b_src_imm = true)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_AND
@@ -738,7 +738,7 @@ def Decode_ori_of_program
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
     (h_bits_b_src_imm : bits.b_src_imm = true)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_OR
@@ -806,7 +806,7 @@ def Decode_xori_of_program
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
     (h_bits_b_src_imm : bits.b_src_imm = true)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_XOR
@@ -874,7 +874,7 @@ def Decode_slti_of_program
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
     (h_bits_b_src_imm : bits.b_src_imm = true)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LT
@@ -942,7 +942,7 @@ def Decode_sltiu_of_program
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
     (h_bits_b_src_imm : bits.b_src_imm = true)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LTU
@@ -1010,7 +1010,7 @@ def Decode_addi_of_program
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
     (h_bits_b_src_imm : bits.b_src_imm = true)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_ADD
@@ -1089,7 +1089,7 @@ def Decode_sll_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SLL
@@ -1145,7 +1145,7 @@ def Decode_srl_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SRL
@@ -1201,7 +1201,7 @@ def Decode_sra_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SRA
@@ -1260,7 +1260,7 @@ def Decode_slli_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SLL
@@ -1320,7 +1320,7 @@ def Decode_srli_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SRL
@@ -1380,7 +1380,7 @@ def Decode_srai_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SRA
@@ -1440,7 +1440,7 @@ def Decode_subw_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SUB_W
@@ -1496,7 +1496,7 @@ def Decode_addw_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_ADD_W
@@ -1553,7 +1553,7 @@ def Decode_addiw_of_program
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
     (h_bits_b_src_imm : bits.b_src_imm = true)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_ADD_W
@@ -1620,7 +1620,7 @@ def Decode_sllw_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SLL_W
@@ -1676,7 +1676,7 @@ def Decode_srlw_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SRL_W
@@ -1732,7 +1732,7 @@ def Decode_sraw_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SRA_W
@@ -1788,7 +1788,7 @@ def Decode_slliw_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SLL_W
@@ -1844,7 +1844,7 @@ def Decode_srliw_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SRL_W
@@ -1900,7 +1900,7 @@ def Decode_sraiw_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SRA_W
@@ -1959,7 +1959,7 @@ def Decode_mulw_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_MUL_W
@@ -2021,7 +2021,7 @@ def Decode_mul_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_MUL
@@ -2085,7 +2085,7 @@ def Decode_mulh_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_MULH
@@ -2149,7 +2149,7 @@ def Decode_mulhsu_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_MULSUH
@@ -2213,7 +2213,7 @@ def Decode_div_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_DIV
@@ -2278,7 +2278,7 @@ def Decode_rem_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_REM
@@ -2343,7 +2343,7 @@ def Decode_divw_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_DIV_W
@@ -2408,7 +2408,7 @@ def Decode_remw_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_REM_W
@@ -2469,7 +2469,7 @@ def Decode_mulhu_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_MULUH
@@ -2528,7 +2528,7 @@ def Decode_divu_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_DIVU
@@ -2587,7 +2587,7 @@ def Decode_divuw_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_DIVU_W
@@ -2646,7 +2646,7 @@ def Decode_remu_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_REMU
@@ -2705,7 +2705,7 @@ def Decode_remuw_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_REMU_W
@@ -2762,7 +2762,7 @@ theorem mainLoadDestinationFacts_of_program
     (rd : BitVec 5)
     (h_bits_store_ind : bits.store_ind = false)
     (h_bits_store_reg : bits.store_reg = true)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 rd)
@@ -2798,7 +2798,7 @@ theorem mainLoadBsrcInd_of_program
     (h_lt : i.val < trace.mainTable.table.length)
     (bits : RomFlagBits)
     (h_bits_b_src_ind : bits.b_src_ind = true)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).flags = packFlags bits) :
@@ -2829,7 +2829,7 @@ def Decode_ld_of_program
     (h_bits_store_ind : bits.store_ind = false)
     (h_bits_store_reg : bits.store_reg = true)
     (h_bits_b_src_ind : bits.b_src_ind = true)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_COPYB
@@ -2917,7 +2917,7 @@ def Decode_lbu_of_program
     (h_bits_store_ind : bits.store_ind = false)
     (h_bits_store_reg : bits.store_reg = true)
     (h_bits_b_src_ind : bits.b_src_ind = true)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_COPYB
@@ -2990,7 +2990,7 @@ def Decode_lhu_of_program
     (h_bits_store_ind : bits.store_ind = false)
     (h_bits_store_reg : bits.store_reg = true)
     (h_bits_b_src_ind : bits.b_src_ind = true)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_COPYB
@@ -3063,7 +3063,7 @@ def Decode_lwu_of_program
     (h_bits_store_ind : bits.store_ind = false)
     (h_bits_store_reg : bits.store_reg = true)
     (h_bits_b_src_ind : bits.b_src_ind = true)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_COPYB
@@ -3152,7 +3152,7 @@ def Decode_lb_of_program
     (h_bits_store_ind : bits.store_ind = false)
     (h_bits_store_reg : bits.store_reg = true)
     (h_bits_b_src_ind : bits.b_src_ind = true)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SIGNEXTEND_B
@@ -3247,7 +3247,7 @@ def Decode_lh_of_program
     (h_bits_store_ind : bits.store_ind = false)
     (h_bits_store_reg : bits.store_reg = true)
     (h_bits_b_src_ind : bits.b_src_ind = true)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SIGNEXTEND_H
@@ -3342,7 +3342,7 @@ def Decode_lw_of_program
     (h_bits_store_ind : bits.store_ind = false)
     (h_bits_store_reg : bits.store_reg = true)
     (h_bits_b_src_ind : bits.b_src_ind = true)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_SIGNEXTEND_W
@@ -3422,7 +3422,7 @@ def Decode_sb_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = true)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_COPYB
@@ -3487,7 +3487,7 @@ def Decode_sh_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = true)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_COPYB
@@ -3552,7 +3552,7 @@ def Decode_sw_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = true)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_COPYB
@@ -3617,7 +3617,7 @@ def Decode_sd_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = true)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_COPYB
@@ -3689,7 +3689,7 @@ def Decode_lui_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_COPYB
@@ -3746,7 +3746,7 @@ def Decode_auipc_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = true)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_FLAG
@@ -3810,7 +3810,7 @@ def Decode_beq_of_program
     (h_bits_m32 : bits.m32 = false)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_EQ
@@ -3863,7 +3863,7 @@ def Decode_bne_of_program
     (h_bits_m32 : bits.m32 = false)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_EQ
@@ -3916,7 +3916,7 @@ def Decode_blt_of_program
     (h_bits_m32 : bits.m32 = false)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LT
@@ -3969,7 +3969,7 @@ def Decode_bge_of_program
     (h_bits_m32 : bits.m32 = false)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LT
@@ -4022,7 +4022,7 @@ def Decode_bltu_of_program
     (h_bits_m32 : bits.m32 = false)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LTU
@@ -4075,7 +4075,7 @@ def Decode_bgeu_of_program
     (h_bits_m32 : bits.m32 = false)
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LTU
@@ -4132,7 +4132,7 @@ def Decode_jal_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = true)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_FLAG
@@ -4214,7 +4214,7 @@ def Decode_jalr_of_program
     (h_bits_set_pc : bits.set_pc = true)
     (h_bits_store_pc : bits.store_pc = true)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_AND
@@ -4279,7 +4279,7 @@ def Decode_fence_of_program
     (bits : RomFlagBits)
     (h_bits_ieo : bits.is_external_op = false)
     (h_bits_set_pc : bits.set_pc = false)
-    (h_prog : ∀ j : Fin numInstructions,
+    (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_FLAG

--- a/ZiskFv/Soundness.lean
+++ b/ZiskFv/Soundness.lean
@@ -18,12 +18,11 @@ namespace ZiskFv.Compliance
     An AcceptedZiskTrace is a set of constraints, and a witness that satisfies those constraints and the
     channel balancing constraint enfoced in the proving system through a lookup argument.
 
-    A SailTrace is a choice of which table in the witness is the Main execution table, together
-    with the sequence of Sail machine states the program steps through and the facts that pin that
-    table into the witness : that it really occurs in it, that it really is the Main component, and
-    that it has one row per instruction.
+    A SailTrace is the sequence of Sail machine states for the executed steps. The Main execution
+    table is derived from the witness and has a row for every executed step; its physical row count
+    and the committed ROM length may both be larger than that executed-step count.
 
-    For each instruction i the per-step hypotheses split three ways:
+    For each executed step i the per-step hypotheses split three ways:
     `ziskStep` is what the ZisK machine did (its decoded op + operand/dest
     indices + committed bus row); `programDecodes` is the circuit-checkable fact
     that the row is a well-formed instance of that op, stated about the

--- a/trust/consistency/root_soundness_instantiation_add_spin.lean
+++ b/trust/consistency/root_soundness_instantiation_add_spin.lean
@@ -2,5 +2,10 @@ import ZiskFv.Compliance.AddSpinRootSoundness
 import ZiskFv.Compliance.SingleAddWitness
 
 #print axioms ZiskFv.Compliance.AddSpinRootSoundness.addSpinRootSoundness
+#print axioms ZiskFv.Compliance.AddSpinWitness.addPaddedAcceptedTrace
+#print axioms ZiskFv.Compliance.AddSpinRootSoundness.addPaddedRootSoundness
+#print axioms ZiskFv.Compliance.AddSpinRootSoundness.addPaddedAddStepSound
+#print axioms ZiskFv.Compliance.AddSpinRootSoundness.addPaddedSuccessorRow_hasCommittedLookup
+#print axioms ZiskFv.Compliance.AddSpinRootSoundness.addPaddedSuccessorRow_isCommittedJal
 #print axioms ZiskFv.Compliance.SingleAddWitness.singleAddAcceptedTrace
 #print axioms ZiskFv.Compliance.SingleAddWitness.singleAddWitness_balancedChannels

--- a/trust/consistency/root_soundness_instantiation_degenerate.lean
+++ b/trust/consistency/root_soundness_instantiation_degenerate.lean
@@ -153,7 +153,7 @@ private theorem wit_main_step_index_fixed :
     ∀ table ∈ wit.allTables,
       table.component =
           ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus 0 prog →
-        MainStepIndexFixedFacts 0 prog table := by
+        MainStepIndexFixedFacts 0 0 prog table := by
   intro table hmem hcomp
   exact
     { main_step_eq_index := fun i => i.elim0
@@ -164,6 +164,7 @@ private theorem wit_main_step_index_fixed :
 /-- The degenerate accepted trace: empty program, all-empty witness, trivial
     channel balance, vacuous transition / row-height / segment-fixed obligations. -/
 private def trace : AcceptedZiskTrace 0 where
+  programLength := 0
   program := prog
   witness := wit
   constraints_hold := wit_constraints

--- a/trust/generated/baseline-strong-export-closure.txt
+++ b/trust/generated/baseline-strong-export-closure.txt
@@ -23,7 +23,7 @@
 #     > trust/generated/baseline-strong-export-closure.txt  (body, below the header)
 #
 # Refresh via `trust/scripts/regenerate.sh` (requires `lake build`
-# artefacts under `.lake/build/`). Last regenerated: 2026-07-09.
+# artefacts under `.lake/build/`). Last regenerated: 2026-07-10.
 #
 # Total ZiskFv.* axiom entries: 0
 #

--- a/trust/generated/baseline-zisk-riscv-compliant.txt
+++ b/trust/generated/baseline-zisk-riscv-compliant.txt
@@ -25,7 +25,7 @@
 #     > trust/generated/baseline-zisk-riscv-compliant.txt
 #
 # Refresh via `trust/scripts/regenerate.sh` (requires `lake build`
-# artefacts under `.lake/build/`). Last regenerated: 2026-07-09.
+# artefacts under `.lake/build/`). Last regenerated: 2026-07-10.
 #
 # Total entries: 0
 #

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -687,7 +687,7 @@ trust surface even though they add no axiom.
 
 | Field (`Compliance/AcceptedZiskTrace.lean`) | PIL source | What it certifies |
 |---|---|---|
-| `main_height` (pre-existing) | — | the Main table has a row for every instruction (`i < length`) |
+| `main_height` (pre-existing) | — | the physical Main table has a row for every executed-step index; it may also carry padding rows |
 | `transitions_hold` (**#100**) | `main.pil:409-410` | the cross-row PC-handshake transition holds on every consecutive Main-row pair (a *polynomial* constraint the single-row per-row `Constraints` dropped) |
 | `segment_l1_fixed` (**#100**) | `main.pil:19` | the `SEGMENT_L1` fixed column is `[1,0,0,…]` (row 0 = boundary, all later rows within-segment) |
 | `main_step_index_fixed` (**#115**) | `main.pil:90` (`STEP = main_segment*N + SEGMENT_STEP`) | the Main `main_step` companion column is pinned to the Main row index, with no-wrap evidence for the `2+4*i` / `3+4*i` memory timestamp offsets; this single fixed-column-class certificate replaces the two anticipated step-counter residues (`MainStepDistinct`, `CrossOffsetSeparated`) and also supports target execution chronology |
@@ -737,12 +737,14 @@ class rather than `constraints_hold`'s.
 
 **Within-segment boundary (explicit).** `mainTransition_to_next_pc`
 (`Compliance/MainTransition.lean`) requires `i + 1 < mainTable.table.length` — a
-*successor* Main row must exist — surfaced as the per-opcode `h_idx`. `main_height`
-only gives `i < length`, so for the final instruction this needs
-`numInstructions < length` (a real ZisK segment is padded to its fixed power-of-two
-row count, so a successor row exists). When the segment is exactly full
-(`numInstructions = length`) the final instruction has no within-segment successor;
-its next-PC is the cross-segment continuation (`main.pil:501-529`), which is
+*physical Main-row successor* must exist — surfaced as the per-opcode `h_idx`.
+`main_height` only gives a row for each executed step, so the final executed step
+needs an additional physical Main row. This condition is separate from committed
+ROM length: Main's in-circuit lookup ranges over the full `programLength`, while
+the Sail trace and `root_soundness` range over executed steps. The #245 regression
+has one executed ADD step, a two-entry committed ADD/JAL ROM, and a faithful JAL
+lookup at the physical successor row. When no within-segment successor exists,
+the final next-PC is the cross-segment continuation (`main.pil:501-529`), which is
 **out of #100 scope = #103**. This is an applicability boundary, not an
 unsoundness: where `h_idx` holds the discharge is exact; where it does not, the
 final-row next-PC is a named #103 residual.


### PR DESCRIPTION
Closes #245.

## Summary
- Separate executed-step count from committed ROM length in `AcceptedZiskTrace`.
- Keep Main/ROM lookups and decode coverage committed-ROM indexed.
- Add an `exec = 1`, `ROM = 2` ADD/JAL root-soundness regression with a committed successor lookup.

## Verification
- `lake build`
- `trust/scripts/check-all.sh`
- `trust/scripts/check-all-semantic.sh`
- `nix run .#test`

Reviewer pass: no blockers.