### PR TITLE
#249: derive Mem row ranges and predecessor chains

### DIFF
--- a/ZiskFv/AirsClean/FullEnsemble/Balance/TableProjections.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/TableProjections.lean
@@ -916,6 +916,48 @@ structure MemTableGeneratedRangeFacts
       mem.sel_dual idx.val = 1 →
         ZiskFv.Airs.Mem.dual_step_delta_in_range mem idx.val
 
+/-- Derive the concrete Mem row range facts from the live dual-Mem component
+    constraints. The seven static lookups composed in `memWithDualMemBus`
+    mirror `mem.pil:384-385,397`; this consumes the table's actual row
+    constraints rather than a detached lookup witness. -/
+theorem memTableGeneratedRangeFacts_of_component_constraints
+    (table : Table FGL)
+    (gsum im0 im1 : ℕ → FGL)
+    (h_component :
+      table.component = ZiskFv.AirsClean.Mem.componentWithDualMemBus)
+    (h_constraints : table.Constraints) :
+    MemTableGeneratedRangeFacts table (memOfTable table gsum im0 im1) := by
+  have rangeAt : ∀ idx : Fin table.table.length,
+      ZiskFv.AirsClean.Mem.dualMemRowRangeFacts
+        (eval (table.environment (table.table.get idx))
+          ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar) := by
+    intro idx
+    have h_mem : table.table.get idx ∈ table.table :=
+      List.mem_iff_get.mpr ⟨idx, rfl⟩
+    have h_holds : table.component.operations.ConstraintsHold
+        (table.environment (table.table.get idx)) :=
+      h_constraints (table.table.get idx) h_mem
+    rw [h_component] at h_holds
+    exact ZiskFv.AirsClean.Mem.dualMemRowRangeFacts_of_componentWithDualMemBus_constraints
+      _ h_holds
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · intro idx
+    have h := rangeAt idx
+    rw [← rowAt_memOfTable table gsum im0 im1 idx] at h
+    exact ⟨h.1, h.2.1⟩
+  · intro idx
+    have h := rangeAt idx
+    rw [← rowAt_memOfTable table gsum im0 im1 idx] at h
+    exact h.2.2.1
+  · intro idx
+    have h := rangeAt idx
+    rw [← rowAt_memOfTable table gsum im0 im1 idx] at h
+    exact ⟨h.2.2.2.1, h.2.2.2.2.1, h.2.2.2.2.2.1⟩
+  · intro idx h_sel_dual
+    have h := rangeAt idx
+    rw [← rowAt_memOfTable table gsum im0 im1 idx] at h
+    exact h.2.2.2.2.2.2 h_sel_dual
+
 /-- Segment-level range facts for one generated Mem table segment.
 
     These facts name the segment-global range-check surface used by

--- a/ZiskFv/AirsClean/Mem/Circuit.lean
+++ b/ZiskFv/AirsClean/Mem/Circuit.lean
@@ -173,19 +173,23 @@ def circuitWithDualMemBus : GeneralFormalCircuit FGL MemRow unit :=
   { memWithDualMemBusElaborated with
     Assumptions := fun _ _ => True
     Spec := fun row _ _ => Spec row
-    -- Completeness covers the same honest rows as `circuit`; the two memory-bus
-    -- emissions add only trivially-true channel guarantees.
+    -- Completeness covers honest Mem rows with the PIL's own range inputs;
+    -- the static lookups make those checks live rather than caller-supplied
+    -- accepted-trace facts.
     ProverAssumptions := fun row _ _ =>
       ∃ sel selDual wr addrChanges addr step stepDual previousStep
         increment_0 increment_1 value_0 value_1,
         (selDual = true → sel = true) ∧ (wr = true → sel = true) ∧
+          dualMemRowRangeFacts row ∧
           row = memRowOf sel selDual wr addrChanges
             addr step stepDual previousStep increment_0 increment_1 value_0 value_1
     ProverSpec := fun _ _ _ => True
     soundness := by
       circuit_proof_start
       refine ⟨?_, ?_⟩
-      · obtain ⟨h0, h1, h2, h3, h4, h5, h6, h7, h8⟩ := h_holds
+      · obtain ⟨h0, h1, h2, h3, h4, h5, h6, h7, h8,
+          _h_increment_0, _h_increment_1, _h_addr, _h_step, _h_step_dual,
+          _h_previous_step, _h_delta⟩ := h_holds
         exact ⟨ by simpa only [sub_eq_add_neg] using h0
               , by simpa only [sub_eq_add_neg] using h1
               , by simpa only [sub_eq_add_neg] using h2
@@ -197,22 +201,65 @@ def circuitWithDualMemBus : GeneralFormalCircuit FGL MemRow unit :=
               , by simpa only [sub_eq_add_neg] using h8 ⟩
       · exact ⟨by intro _; trivial, by intro _; trivial⟩
     completeness := by
-      circuit_proof_start [MemBusChannel]
+      circuit_proof_start [MemBusChannel, Lookup.completeness_def]
       obtain ⟨sel, selDual, wr, addrChanges, addr, step, stepDual, previousStep,
-        increment_0, increment_1, value_0, value_1, h_selDual, h_wr, hrow⟩ :=
+        increment_0, increment_1, value_0, value_1, h_selDual, h_wr, h_ranges, hrow⟩ :=
         h_assumptions
       injection hrow with h_addr h_step h_sel h_addr_changes h_step_dual h_sel_dual
         h_value_0 h_value_1 h_wr_col h_previous_step h_increment_0 h_increment_1
         h_read_same_addr
       subst_vars
-      simpa only [Spec, memRowOf, memReadSameAddrOf, memValueOf, sub_eq_add_neg] using
-        memRowOf_constraintsHold sel selDual wr addrChanges
-          addr step stepDual previousStep increment_0 increment_1 value_0 value_1
-          h_selDual h_wr }
+      rcases h_ranges with
+        ⟨h_increment_0, h_increment_1, h_addr, h_step, h_step_dual, h_previous_step, h_delta⟩
+      have h_main := memRowOf_constraintsHold sel selDual wr addrChanges
+        addr step stepDual previousStep increment_0 increment_1 value_0 value_1 h_selDual h_wr
+      simp only [memRowOf, memReadSameAddrOf, memValueOf] at *
+      rcases h_main with ⟨h0, h1, h2, h3, h4, h5, h6, h7, h8⟩
+      refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+      · simp
+      · simpa [sub_eq_add_neg] using h1
+      · simp
+      · simp
+      · simp
+      · simpa [sub_eq_add_neg] using h5
+      · simp [sub_eq_add_neg]
+      · simpa [sub_eq_add_neg] using h7
+      · simpa [sub_eq_add_neg] using h8
+      · simpa [ZiskFv.AirsClean.RangeTables.rangeTable22,
+          ZiskFv.AirsClean.RangeTables.rangeStaticTable] using h_increment_0
+      · simpa [ZiskFv.AirsClean.RangeTables.rangeTable16,
+          ZiskFv.AirsClean.RangeTables.rangeStaticTable] using h_increment_1
+      · simpa [ZiskFv.AirsClean.RangeTables.rangeTable29,
+          ZiskFv.AirsClean.RangeTables.rangeStaticTable] using h_addr
+      · simpa [ZiskFv.AirsClean.RangeTables.rangeTable40,
+          ZiskFv.AirsClean.RangeTables.rangeStaticTable] using h_step
+      · simpa [ZiskFv.AirsClean.RangeTables.rangeTable40,
+          ZiskFv.AirsClean.RangeTables.rangeStaticTable] using h_step_dual
+      · simpa [ZiskFv.AirsClean.RangeTables.rangeTable40,
+          ZiskFv.AirsClean.RangeTables.rangeStaticTable] using h_previous_step
+      · cases selDual with
+        | false => simp [boolF, ZiskFv.AirsClean.RangeTables.rangeTable24,
+            ZiskFv.AirsClean.RangeTables.rangeStaticTable]
+        | true =>
+          simpa [boolF, sub_eq_add_neg, ZiskFv.AirsClean.RangeTables.rangeTable24,
+            ZiskFv.AirsClean.RangeTables.rangeStaticTable] using h_delta (by simp [boolF]) }
 
 /-- Mem as a Clean `Air.Flat.Component` exposing both primary and dual
     memory-bus provider emissions. -/
 def componentWithDualMemBus : Air.Flat.Component FGL := { circuit := circuitWithDualMemBus }
+
+/-- Project the live dual-Mem static lookups to the row-level range facts they
+    mirror in `mem.pil:384-385,397`. -/
+theorem dualMemRowRangeFacts_of_componentWithDualMemBus_constraints
+    (env : Environment FGL)
+    (h_holds : componentWithDualMemBus.operations.ConstraintsHold env) :
+    dualMemRowRangeFacts (eval env componentWithDualMemBus.rowInputVar) := by
+  have h_row : componentWithDualMemBus.rowOperations.ConstraintsHold env :=
+    (Component.constraintsHold_iff (component := componentWithDualMemBus) env).mp h_holds
+  exact dualMemRowRangeFacts_of_memWithDualMemBus_constraints
+    componentWithDualMemBus.rowInputVar componentWithDualMemBus.rowOffset env (by
+      simpa only [componentWithDualMemBus, circuitWithDualMemBus,
+        Component.rowOperations] using h_row)
 
 theorem eval_memRow_sel
     (env : Environment FGL) (row : Var MemRow FGL) :

--- a/ZiskFv/AirsClean/Mem/Constraints.lean
+++ b/ZiskFv/AirsClean/Mem/Constraints.lean
@@ -50,16 +50,34 @@ def main (row : Var MemRow FGL) : Circuit FGL Unit := do
   -- address change without write zeros high value chunk
   assertZero ((row.addr_changes * (1 - row.wr)) * row.value_1)
 
-/-- Lookup-aware source for the ungated mutable-Mem row range facts:
-    `l_increment : bits(22)`, `h_increment : bits(16)`, `addr : bits(29)`,
-    and the three `MEM_STEP_BITS = 40` step columns. -/
+/-- Row-level facts for the range checks that `mem.pil:384-385,397` places on
+    the live dual-Mem component. The completeness witness supplies these
+    constructibly; accepted traces derive them from component constraints. -/
+@[reducible]
+def dualMemRowRangeFacts (row : MemRow FGL) : Prop :=
+  row.increment_0.val < 2 ^ 22
+    ∧ row.increment_1.val < 2 ^ 16
+    ∧ row.addr.val < 2 ^ 29
+    ∧ row.step.val < 2 ^ 40
+    ∧ row.step_dual.val < 2 ^ 40
+    ∧ row.previous_step.val < 2 ^ 40
+    ∧ (row.sel_dual = 1 → (row.step_dual - row.step - row.wr).val < 2 ^ 24)
+
+/-- Lookup-aware source for the ungated mutable-Mem row range facts: increment
+    chunks mirror `mem.pil:384-385`; `addr : bits(29)` mirrors `mem.pil:109`;
+    and the three `MEM_STEP_BITS = 40` step columns mirror `mem.pil:110,122`. -/
 @[circuit_norm]
 def rowRangeLookups (row : Var MemRow FGL) : Circuit FGL Unit := do
+  -- `l_increment : bits(22)` / `h_increment : bits(16)`, `mem.pil:384-385`.
   lookup (Table.fromStatic rangeTable22) row.increment_0
   lookup (Table.fromStatic rangeTable16) row.increment_1
+  -- `addr : bits(29)`, `mem.pil:109`.
   lookup (Table.fromStatic rangeTable29) row.addr
+  -- `step : bits(MEM_STEP_BITS)`, `mem.pil:110`.
   lookup (Table.fromStatic rangeTable40) row.step
+  -- `step_dual : bits(MEM_STEP_BITS)`, `mem.pil:122`.
   lookup (Table.fromStatic rangeTable40) row.step_dual
+  -- `previous_step : bits(40)`, `mem.pil:365`.
   lookup (Table.fromStatic rangeTable40) row.previous_step
 
 /-- Lookup-aware source for the selector-gated dual-step delta range check.
@@ -68,6 +86,14 @@ def rowRangeLookups (row : Var MemRow FGL) : Circuit FGL Unit := do
 @[circuit_norm]
 def dualStepDeltaRangeLookup (row : Var MemRow FGL) : Circuit FGL Unit := do
   lookup (Table.fromStatic rangeTable24) (row.step_dual - row.step - row.wr)
+
+/-- Live selector-gated form of `mem.pil:397`'s dual-step delta range check.
+    Multiplying by `sel_dual` makes inactive rows check the in-range zero while
+    retaining the original expression on active rows. -/
+@[circuit_norm]
+def gatedDualStepDeltaRangeLookup (row : Var MemRow FGL) : Circuit FGL Unit := do
+  lookup (Table.fromStatic rangeTable24)
+    (row.sel_dual * (row.step_dual - row.step - row.wr))
 
 /-- Lookup-aware source for the segment-level `distance_base` range checks
     used by mutable-Mem continuation segments. -/
@@ -234,8 +260,122 @@ def memWithMemBus (row : Var MemRow FGL) : Circuit FGL Unit := do
 @[circuit_norm]
 def memWithDualMemBus (row : Var MemRow FGL) : Circuit FGL Unit := do
   main row
+  rowRangeLookups row
+  gatedDualStepDeltaRangeLookup row
   MemBusChannel.emit row.sel (memBusMessageExpr row)
   MemBusChannel.emit row.sel_dual (memBusDualMessageExpr row)
+
+/-- Project the live dual-Mem static lookups to the row-level range facts they
+    mirror in `mem.pil:384-385,397`. -/
+theorem dualMemRowRangeFacts_of_memWithDualMemBus_constraints
+    (row : Var MemRow FGL) (offset : ℕ) (env : Environment FGL)
+    (h_holds :
+      Operations.ConstraintsHold env ((memWithDualMemBus row).operations offset)) :
+    dualMemRowRangeFacts (eval env row) := by
+  simp only [memWithDualMemBus, main, rowRangeLookups,
+    gatedDualStepDeltaRangeLookup, MemBusChannel, circuit_norm] at h_holds
+  have staticRange := fun (table : Table FGL field) (entry : Expression FGL)
+      (h_sound :
+        let lookup : Lookup FGL := { table := table.toRaw, entry := #v[entry] }
+        lookup.Soundness env) =>
+    (Lookup.soundess_def_field table env entry).mp h_sound
+  let increment0Table := Table.fromStatic rangeTable22
+  let increment0Lookup : Lookup FGL :=
+    { table := increment0Table.toRaw, entry := #v[row.increment_0] }
+  let increment1Table := Table.fromStatic rangeTable16
+  let increment1Lookup : Lookup FGL :=
+    { table := increment1Table.toRaw, entry := #v[row.increment_1] }
+  let addrTable := Table.fromStatic rangeTable29
+  let addrLookup : Lookup FGL := { table := addrTable.toRaw, entry := #v[row.addr] }
+  let stepTable := Table.fromStatic rangeTable40
+  let stepLookup : Lookup FGL := { table := stepTable.toRaw, entry := #v[row.step] }
+  let stepDualTable := Table.fromStatic rangeTable40
+  let stepDualLookup : Lookup FGL :=
+    { table := stepDualTable.toRaw, entry := #v[row.step_dual] }
+  let previousStepTable := Table.fromStatic rangeTable40
+  let previousStepLookup : Lookup FGL :=
+    { table := previousStepTable.toRaw, entry := #v[row.previous_step] }
+  let deltaTable := Table.fromStatic rangeTable24
+  let deltaLookup : Lookup FGL :=
+    { table := deltaTable.toRaw,
+      entry := #v[row.sel_dual * (row.step_dual - row.step - row.wr)] }
+  have h_increment_0_contains : increment0Lookup.Contains env := by
+    apply h_holds.2 increment0Lookup
+    dsimp [increment0Lookup, increment0Table, Table.fromStatic, StaticTable.toTable]
+    left
+    rfl
+  have h_increment_1_contains : increment1Lookup.Contains env := by
+    apply h_holds.2 increment1Lookup
+    dsimp [increment1Lookup, increment1Table, Table.fromStatic, StaticTable.toTable]
+    right; left
+    rfl
+  have h_addr_contains : addrLookup.Contains env := by
+    apply h_holds.2 addrLookup
+    dsimp [addrLookup, addrTable, Table.fromStatic, StaticTable.toTable]
+    right; right; left
+    rfl
+  have h_step_contains : stepLookup.Contains env := by
+    apply h_holds.2 stepLookup
+    dsimp [stepLookup, stepTable, Table.fromStatic, StaticTable.toTable]
+    right; right; right; left
+    rfl
+  have h_step_dual_contains : stepDualLookup.Contains env := by
+    apply h_holds.2 stepDualLookup
+    dsimp [stepDualLookup, stepDualTable, Table.fromStatic, StaticTable.toTable]
+    right; right; right; right; left
+    rfl
+  have h_previous_step_contains : previousStepLookup.Contains env := by
+    apply h_holds.2 previousStepLookup
+    dsimp [previousStepLookup, previousStepTable, Table.fromStatic, StaticTable.toTable]
+    right; right; right; right; right; left
+    rfl
+  have h_delta_contains : deltaLookup.Contains env := by
+    apply h_holds.2 deltaLookup
+    dsimp [deltaLookup, deltaTable, Table.fromStatic, StaticTable.toTable]
+    right; right; right; right; right; right
+    rfl
+  have h_increment_0 := staticRange increment0Table row.increment_0
+    (increment0Lookup.table.imply_soundness _ _ h_increment_0_contains)
+  have h_increment_1 := staticRange increment1Table row.increment_1
+    (increment1Lookup.table.imply_soundness _ _ h_increment_1_contains)
+  have h_addr := staticRange addrTable row.addr
+    (addrLookup.table.imply_soundness _ _ h_addr_contains)
+  have h_step := staticRange stepTable row.step
+    (stepLookup.table.imply_soundness _ _ h_step_contains)
+  have h_step_dual := staticRange stepDualTable row.step_dual
+    (stepDualLookup.table.imply_soundness _ _ h_step_dual_contains)
+  have h_previous_step := staticRange previousStepTable row.previous_step
+    (previousStepLookup.table.imply_soundness _ _ h_previous_step_contains)
+  have h_delta := staticRange deltaTable
+    (row.sel_dual * (row.step_dual - row.step - row.wr))
+    (deltaLookup.table.imply_soundness _ _ h_delta_contains)
+  cases row with
+  | mk addr step sel addr_changes step_dual sel_dual value_0 value_1 wr previous_step
+      increment_0 increment_1 read_same_addr =>
+    simp only [ProvableStruct.eval_eq_eval, ProvableStruct.eval, ProvableStruct.fromComponents,
+      ProvableStruct.components, ProvableStruct.toComponents, ProvableStruct.eval.go,
+      ProvableType.eval_field] at *
+    refine ⟨by simpa [CircuitType.eval_expr, increment0Table, Table.fromStatic,
+        StaticTable.toTable, rangeTable22, rangeStaticTable] using h_increment_0,
+      by simpa [CircuitType.eval_expr, increment1Table, Table.fromStatic,
+        StaticTable.toTable, rangeTable16, rangeStaticTable] using h_increment_1,
+      by simpa [CircuitType.eval_expr, addrTable, Table.fromStatic,
+        StaticTable.toTable, rangeTable29, rangeStaticTable] using h_addr,
+      by simpa [CircuitType.eval_expr, stepTable, Table.fromStatic,
+        StaticTable.toTable, rangeTable40, rangeStaticTable] using h_step,
+      by simpa [CircuitType.eval_expr, stepDualTable, Table.fromStatic,
+        StaticTable.toTable, rangeTable40, rangeStaticTable] using h_step_dual,
+      by simpa [CircuitType.eval_expr, previousStepTable, Table.fromStatic,
+        StaticTable.toTable, rangeTable40, rangeStaticTable] using h_previous_step, ?_⟩
+    have h_delta_range :
+        rangeTable24.Spec
+          (Expression.eval env sel_dual *
+            (Expression.eval env step_dual + -Expression.eval env step + -Expression.eval env wr)) := by
+      simpa [Expression.eval, deltaTable, Table.fromStatic, StaticTable.toTable] using h_delta
+    intro h_sel_dual
+    change Expression.eval env sel_dual = 1 at h_sel_dual
+    rw [h_sel_dual] at h_delta_range
+    simpa [sub_eq_add_neg, rangeTable24, rangeStaticTable] using h_delta_range
 
 /-- Elaborated `memWithMemBus` circuit, ready for use in Clean
     memory-bus component assembly. -/
@@ -266,7 +406,7 @@ def memWithDualMemBus (row : Var MemRow FGL) : Circuit FGL Unit := do
       [ MemBusChannel.emitted row.sel (memBusMessageExpr row)
         , MemBusChannel.emitted row.sel_dual (memBusDualMessageExpr row) ]
   channelsLawful := by
-    simp only [circuit_norm, memWithDualMemBus, main, memBusMessageExpr,
-      memBusDualMessageExpr, MemBusChannel]
+    simp only [circuit_norm, memWithDualMemBus, main, rowRangeLookups,
+      gatedDualStepDeltaRangeLookup, memBusMessageExpr, memBusDualMessageExpr, MemBusChannel]
 
 end ZiskFv.AirsClean.Mem

--- a/ZiskFv/Compliance/AcceptedZiskTrace.lean
+++ b/ZiskFv/Compliance/AcceptedZiskTrace.lean
@@ -151,16 +151,12 @@ structure AcceptedZiskTrace (numInstructions : Nat) where
         (mem_replay_im1 h))
       (acceptedMemReplayFixedSegment (mem_replay_segment h))
       (mem_replay_permutation h)
-  /-- Guarded row range facts for the selected mutable-Mem table projection. -/
-  mem_replay_row_ranges : ∀ (h : MutableMemPresent witness),
-    ZiskFv.AirsClean.FullEnsemble.MemTableGeneratedRangeFacts
-      (mem_replay_table h).1
-      (acceptedMemReplayMem
-        (mem_replay_table h).1
-        (mem_replay_gsum h)
-        (mem_replay_im0 h)
-        (mem_replay_im1 h))
-  /-- Guarded segment range facts for the selected mutable-Mem sidecar segment. -/
+  /-- Guarded segment range facts for the selected mutable-Mem sidecar segment.
+
+      HELD for Project Closeout S3's lookup-wiring extraction. The sidecar
+      `distance_base_*` values are not component-row inputs, so S1a's live Mem
+      lookups do not derive this field. S3 must derive and delete this
+      caller-supplied promise hypothesis; it is not a permanent survivor. -/
   mem_replay_segment_ranges : ∀ (h : MutableMemPresent witness),
     ZiskFv.AirsClean.FullEnsemble.MemSegmentGeneratedRangeFacts
       (acceptedMemReplayFixedSegment (mem_replay_segment h))
@@ -236,6 +232,24 @@ def AcceptedZiskTrace.memReplayTable {n : Nat} (trace : AcceptedZiskTrace n)
     (h_present : MutableMemPresent trace.witness) : Air.Flat.Table FGL :=
   (trace.mem_replay_table h_present).1
 
+/-- The selected mutable-Mem table's row range facts are derived from the
+    accepted live component constraints. The static lookups mirror
+    `mem.pil:384-385,397`; no accepted-trace range certificate remains. -/
+theorem AcceptedZiskTrace.memReplayRowRanges {n : Nat}
+    (trace : AcceptedZiskTrace n)
+    (h_present : MutableMemPresent trace.witness) :
+    ZiskFv.AirsClean.FullEnsemble.MemTableGeneratedRangeFacts
+      (trace.memReplayTable h_present)
+      (acceptedMemReplayMem
+        (trace.memReplayTable h_present)
+        (trace.mem_replay_gsum h_present)
+        (trace.mem_replay_im0 h_present)
+        (trace.mem_replay_im1 h_present)) := by
+  apply ZiskFv.AirsClean.FullEnsemble.memTableGeneratedRangeFacts_of_component_constraints
+  · exact (trace.mem_replay_table h_present).2.2.1
+  · exact trace.constraints_hold (trace.memReplayTable h_present)
+      (trace.mem_replay_table h_present).2.1
+
 /-- The guarded raw Mem source sidecar rebuilt from accepted-trace factor fields. -/
 def AcceptedZiskTrace.memReplayRawSourceSidecar {n : Nat} (trace : AcceptedZiskTrace n)
     (h_present : MutableMemPresent trace.witness) :
@@ -248,7 +262,7 @@ def AcceptedZiskTrace.memReplayRawSourceSidecar {n : Nat} (trace : AcceptedZiskT
   im1 := trace.mem_replay_im1 h_present
   facts :=
     { constraints := trace.mem_replay_constraints h_present
-      rowRanges := trace.mem_replay_row_ranges h_present
+      rowRanges := trace.memReplayRowRanges h_present
       segmentRanges := trace.mem_replay_segment_ranges h_present }
 
 /-- The guarded Mem AIR source selected when the accepted witness has mutable-Mem rows, rebuilt

--- a/ZiskFv/Compliance/AddAddiSpinWitness.lean
+++ b/ZiskFv/Compliance/AddAddiSpinWitness.lean
@@ -55,23 +55,41 @@ def addAddiSpinAddiProgramRow : ZiskRomMessage FGL :=
     ind_width := 8, op := ZiskFv.Trusted.OP_ADD, store_offset := 1, jmp_offset1 := 4,
     jmp_offset2 := 4, flags := packFlags addAddiSpinAddiBits }
 
-def addAddiSpinAddiFreeCols : MainRomFreeCols where
-  a_0 := 0
-  a_1 := 0
-  b_0 := 0
-  b_1 := 0
-  im_high_degree_2 := 0
-  segment_l1 := 0
-  main_step := 1
-  a_reg_prev_mem_step := 3
-  b_reg_prev_mem_step := 0
-  store_reg_prev_mem_step := 5
-  store_reg_prev_value_0 := 0
-  store_reg_prev_value_1 := 0
+/-! The inactive predecessor fields begin at boot; the active ADDI predecessors below are then
+materialized from the preceding ADD/access history. -/
+@[reducible]
+def addAddiSpinAddiFreeColsTemplate : MainRomFreeCols :=
+  mainRomFreeColsWithRegisterPrevious
+    { addX1MainFreeCols with
+      a_0 := 0
+      a_1 := 0
+      b_0 := 0
+      b_1 := 0
+      im_high_degree_2 := 0
+      segment_l1 := 0
+      main_step := 1 }
+    addX1RegisterInitial
 
-def addAddiSpinAddiRow : MainRowWithRom FGL :=
+@[reducible]
+def addAddiSpinAddiRowTemplate : MainRowWithRom FGL :=
   mainRomRowOf addAddiSpinAddiProgramRow addAddiSpinAddiBits
-    (MainRomExecKind.external false 0 0) addAddiSpinAddiFreeCols
+    (MainRomExecKind.external false 0 0) addAddiSpinAddiFreeColsTemplate
+
+/-- The ADDI row and final x1 state after the ADD/ADDI access history. -/
+@[reducible]
+def addAddiSpinAddiRowWithLast : MemBusMessage FGL × MainRowWithRom FGL :=
+  materializeMainRegisterRow addX1RowWithLast.1 addAddiSpinAddiRowTemplate
+    [MainRegisterAccess.a, MainRegisterAccess.store]
+
+def addAddiSpinAddiRow : MainRowWithRom FGL := addAddiSpinAddiRowWithLast.2
+
+@[reducible]
+def addAddiSpinAddiFreeCols : MainRomFreeCols :=
+  mainRomFreeColsOfRow addAddiSpinAddiRow
+
+private theorem addAddiSpinAddiRow_b_0 : addAddiSpinAddiRow.core.b_0 = 0 := rfl
+
+private theorem addAddiSpinAddiRow_b_1 : addAddiSpinAddiRow.core.b_1 = 0 := rfl
 
 def addAddiSpinJalBits : RomFlagBits := addSpinJalBits
 
@@ -100,7 +118,12 @@ def addAddiSpinBinaryAddRows : List (ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL
 
 def addAddiSpinBoundaryRowX1 :
     ZiskFv.AirsClean.RegisterBoundary.RegisterBoundaryRow FGL :=
-  { boundaryRowX1 with reloadTimestamp := 7 }
+  registerBoundaryRowFromLast 1 addAddiSpinAddiRowWithLast.1
+
+private theorem addAddiSpinReloadMessage_eq :
+    ZiskFv.AirsClean.RegisterBoundary.reloadMessage addAddiSpinBoundaryRowX1 =
+      cMemMessage addAddiSpinAddiRow := by
+  rfl
 
 def addAddiSpinBoundaryRows :
     List (ZiskFv.AirsClean.RegisterBoundary.RegisterBoundaryRow FGL) :=
@@ -124,8 +147,8 @@ theorem addAddiSpinAddMain_proverAssumptions :
   · decide
   · simp [MainRomExecKind.Coherent, addAddiSpinAddBits, addX1RomFlagBits]
   · simp [MainRomSourceGuard, addAddiSpinProgram, addAddiSpinAddProgramRow,
-      addAddiSpinAddBits, addX1RomFlagBits, addX1MainFreeCols]
-  · simp [MainRomAddressGuard, addAddiSpinAddBits, addX1RomFlagBits, addX1MainFreeCols]
+      addAddiSpinAddBits, addX1RomFlagBits]
+  · simp [MainRomAddressGuard, addAddiSpinAddBits, addX1RomFlagBits]
   · rfl
 
 theorem addAddiSpinAddiMain_proverAssumptions :
@@ -136,8 +159,8 @@ theorem addAddiSpinAddiMain_proverAssumptions :
   · decide
   · simp [MainRomExecKind.Coherent, addAddiSpinAddiBits]
   · simp [MainRomSourceGuard, addAddiSpinProgram, addAddiSpinAddiProgramRow,
-      addAddiSpinAddiBits, addAddiSpinAddiFreeCols]
-  · simp [MainRomAddressGuard, addAddiSpinAddiBits, addAddiSpinAddiFreeCols]
+      addAddiSpinAddiBits, addAddiSpinAddiRow_b_0, addAddiSpinAddiRow_b_1]
+  · simp [MainRomAddressGuard, addAddiSpinAddiBits]
   · rfl
 
 theorem addAddiSpinJalMain_proverAssumptions (step : FGL) :
@@ -149,9 +172,9 @@ theorem addAddiSpinJalMain_proverAssumptions (step : FGL) :
   · norm_num [MainRomExecKind.Coherent, addAddiSpinProgram, addAddiSpinJalProgramRow,
       addAddiSpinJalBits, addSpinJalBits, ZiskFv.Trusted.OP_FLAG]
   · simp [MainRomSourceGuard, addAddiSpinProgram, addAddiSpinJalProgramRow,
-      addAddiSpinJalBits, addSpinJalBits, addAddiSpinJalFreeCols, addSpinJalFreeCols]
+      addAddiSpinJalBits, addSpinJalBits, addAddiSpinJalFreeCols]
   · simp [MainRomAddressGuard, addAddiSpinJalBits, addSpinJalBits,
-      addAddiSpinJalFreeCols, addSpinJalFreeCols]
+      addAddiSpinJalFreeCols]
   · rfl
 
 private theorem addAddiSpinMainRow_constraints
@@ -312,19 +335,19 @@ theorem addAddiSpinWitness_constraints : addAddiSpinWitness.Constraints :=
 private theorem addAddiSpinMain_pcHandshake_add_addi :
     pcHandshakeBetween addAddiSpinAddRow addAddiSpinAddiRow := by
   simp [pcHandshakeBetween, addAddiSpinAddRow, addAddiSpinAddiRow,
-    addAddiSpinAddiProgramRow, addAddiSpinAddiBits, addAddiSpinAddiFreeCols, addX1Row,
+    addAddiSpinAddiProgramRow, addAddiSpinAddiBits, addX1Row,
     mainRomRowOf]
 
 private theorem addAddiSpinMain_pcHandshake_addi_jal :
     pcHandshakeBetween addAddiSpinAddiRow (addAddiSpinJalRow 2) := by
   simp [pcHandshakeBetween, addAddiSpinAddiRow, addAddiSpinAddiProgramRow,
-    addAddiSpinAddiBits, addAddiSpinAddiFreeCols, addAddiSpinJalRow,
-    addSpinJalRow, addSpinJalProgramRow, addSpinJalBits, addSpinJalFreeCols, mainRomRowOf]
+    addAddiSpinAddiBits, addAddiSpinJalRow,
+    addSpinJalRow, addSpinJalProgramRow, addSpinJalBits, mainRomRowOf]
 
 private theorem addAddiSpinMain_pcHandshake_jal_jal :
     pcHandshakeBetween (addAddiSpinJalRow 2) (addAddiSpinJalRow 3) := by
   simp [pcHandshakeBetween, addAddiSpinJalRow, addSpinJalRow, addSpinJalProgramRow,
-    addSpinJalBits, addSpinJalFreeCols, mainRomRowOf]
+    addSpinJalBits, mainRomRowOf]
   ring
 
 private theorem addAddiSpinMainTable_transition (prev curr : MainRowWithRom FGL) :
@@ -747,11 +770,7 @@ private theorem addAddiSpinBoundaryInteractions_eq :
       [ emittedPulledValue
           (ZiskFv.AirsClean.RegisterBoundary.bootMessage addAddiSpinBoundaryRowX1)
       , MemBusChannel.pushedValue (cMemMessage addAddiSpinAddiRow) ] := by
-  simp [boundaryInteractions, registerBoundaryMemBusInteractions,
-    registerBoundaryBootInteraction, registerBoundaryReloadInteraction,
-    addAddiSpinBoundaryRowX1, boundaryRowX1, addAddiSpinAddiRow,
-    addAddiSpinAddiProgramRow, addAddiSpinAddiBits, addAddiSpinAddiFreeCols, mainRomRowOf,
-    emittedPulledValue, Channel.pushedValue, cMemMessage]
+  rw [boundaryInteractions_eq_messages, addAddiSpinReloadMessage_eq]
 
 private theorem addAddiSpinAddInteractions_eq :
     addAddiSpinMainValueMemBusInteractions addAddiSpinAddRow =
@@ -766,7 +785,7 @@ private theorem addAddiSpinAddInteractions_eq :
     mainARegPreInteraction,
     mainAMemInteraction, mainBRegPreInteraction, mainBMemInteraction,
     mainCRegPreInteraction, mainCMemInteraction, addAddiSpinAddRow, addX1Row,
-    addAddiSpinBoundaryRowX1, boundaryRowX1, emittedPulledValue, Channel.pushedValue,
+    addAddiSpinBoundaryRowX1, emittedPulledValue, Channel.pushedValue,
     aRegPreMessage, aMemMessage, bRegPreMessage, bMemMessage, cRegPreMessage, cMemMessage]
 
 private theorem addAddiSpinAddiInteractions_eq :
@@ -781,7 +800,7 @@ private theorem addAddiSpinAddiInteractions_eq :
     mainARegPreInteraction,
     mainAMemInteraction, mainCRegPreInteraction, mainCMemInteraction,
     addAddiSpinAddRow, addX1Row, addAddiSpinAddiRow, addAddiSpinAddiProgramRow,
-    addAddiSpinAddiBits, addAddiSpinAddiFreeCols, mainRomRowOf,
+    addAddiSpinAddiBits, mainRomRowOf,
     emittedPulledValue, Channel.pushedValue, aRegPreMessage, aMemMessage,
     cRegPreMessage, cMemMessage]
 
@@ -867,7 +886,7 @@ private theorem addAddiSpinJalMemBusInactive (step : FGL) :
     MainMemBusInactive (addAddiSpinJalRow step) := by
   constructor <;>
     simp [addAddiSpinJalRow, addSpinJalRow, addSpinJalProgramRow, addSpinJalBits,
-      addSpinJalFreeCols, mainRomRowOf]
+      mainRomRowOf]
 
 private theorem addAddiSpinJalMemBusInteractions_balanced (step : FGL) :
     BalancedInteractions

--- a/ZiskFv/Compliance/AddAddiSpinWitness.lean
+++ b/ZiskFv/Compliance/AddAddiSpinWitness.lean
@@ -1072,7 +1072,6 @@ def addAddiSpinAcceptedTrace : AcceptedZiskTrace 3 where
   mem_replay_im0 := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
   mem_replay_im1 := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
   mem_replay_constraints := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
-  mem_replay_row_ranges := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
   mem_replay_segment_ranges := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
   mem_replay_source_covers := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
   transitions_hold := addAddiSpinWitness_transitions

--- a/ZiskFv/Compliance/AddSpinWitness.lean
+++ b/ZiskFv/Compliance/AddSpinWitness.lean
@@ -1034,7 +1034,6 @@ def addSpinAcceptedTrace : AcceptedZiskTrace 2 where
   mem_replay_im0 := fun h => absurd h addSpinWitness_not_mutableMemPresent
   mem_replay_im1 := fun h => absurd h addSpinWitness_not_mutableMemPresent
   mem_replay_constraints := fun h => absurd h addSpinWitness_not_mutableMemPresent
-  mem_replay_row_ranges := fun h => absurd h addSpinWitness_not_mutableMemPresent
   mem_replay_segment_ranges := fun h => absurd h addSpinWitness_not_mutableMemPresent
   mem_replay_source_covers := fun h => absurd h addSpinWitness_not_mutableMemPresent
   transitions_hold := addSpinWitness_transitions
@@ -1099,7 +1098,6 @@ def addPaddedAcceptedTrace : AcceptedZiskTrace 1 where
   mem_replay_im0 := fun h => absurd h addSpinWitness_not_mutableMemPresent
   mem_replay_im1 := fun h => absurd h addSpinWitness_not_mutableMemPresent
   mem_replay_constraints := fun h => absurd h addSpinWitness_not_mutableMemPresent
-  mem_replay_row_ranges := fun h => absurd h addSpinWitness_not_mutableMemPresent
   mem_replay_segment_ranges := fun h => absurd h addSpinWitness_not_mutableMemPresent
   mem_replay_source_covers := fun h => absurd h addSpinWitness_not_mutableMemPresent
   transitions_hold := addSpinWitness_transitions

--- a/ZiskFv/Compliance/AddSpinWitness.lean
+++ b/ZiskFv/Compliance/AddSpinWitness.lean
@@ -54,19 +54,19 @@ def addSpinJalProgramRow : ZiskRomMessage FGL :=
     ind_width := 8, op := ZiskFv.Trusted.OP_FLAG, store_offset := 0, jmp_offset1 := 0,
     jmp_offset2 := 4, flags := packFlags addSpinJalBits }
 
-def addSpinJalFreeCols (step : FGL) : MainRomFreeCols where
-  a_0 := 0
-  a_1 := 0
-  b_0 := 0
-  b_1 := 0
-  im_high_degree_2 := 0
-  segment_l1 := 0
-  main_step := step
-  a_reg_prev_mem_step := 0
-  b_reg_prev_mem_step := 0
-  store_reg_prev_mem_step := 0
-  store_reg_prev_value_0 := 0
-  store_reg_prev_value_1 := 0
+/-- JAL has no active register access; its inactive predecessor columns come from boot. -/
+@[reducible]
+def addSpinJalFreeCols (step : FGL) : MainRomFreeCols :=
+  mainRomFreeColsWithRegisterPrevious
+    { addX1MainFreeCols with
+      a_0 := 0
+      a_1 := 0
+      b_0 := 0
+      b_1 := 0
+      im_high_degree_2 := 0
+      segment_l1 := 0
+      main_step := step }
+    addX1RegisterInitial
 
 def addSpinJalRow (step : FGL) : MainRowWithRom FGL :=
   mainRomRowOf addSpinJalProgramRow addSpinJalBits MainRomExecKind.internalFlag
@@ -250,8 +250,8 @@ theorem addSpinAddMain_proverAssumptions :
   · decide
   · simp [MainRomExecKind.Coherent, addSpinAddBits, addX1RomFlagBits]
   · simp [MainRomSourceGuard, addSpinProgram, addSpinAddProgramRow, addSpinAddBits,
-      addX1RomFlagBits, addX1MainFreeCols]
-  · simp [MainRomAddressGuard, addSpinAddBits, addX1RomFlagBits, addX1MainFreeCols]
+      addX1RomFlagBits]
+  · simp [MainRomAddressGuard, addSpinAddBits, addX1RomFlagBits]
   · rfl
 
 theorem addSpinJalMain_proverAssumptions (step : FGL) :
@@ -262,9 +262,8 @@ theorem addSpinJalMain_proverAssumptions (step : FGL) :
   · decide
   · norm_num [MainRomExecKind.Coherent, addSpinProgram, addSpinJalProgramRow,
       addSpinJalBits, ZiskFv.Trusted.OP_FLAG]
-  · simp [MainRomSourceGuard, addSpinProgram, addSpinJalProgramRow, addSpinJalBits,
-      addSpinJalFreeCols]
-  · simp [MainRomAddressGuard, addSpinJalBits, addSpinJalFreeCols]
+  · simp [MainRomSourceGuard, addSpinProgram, addSpinJalProgramRow, addSpinJalBits]
+  · simp [MainRomAddressGuard, addSpinJalBits]
   · rfl
 
 private theorem addSpinMainRow_constraints
@@ -307,12 +306,11 @@ theorem addSpinMainTable_constraints :
 theorem addSpinMain_pcHandshake_add_jal :
     pcHandshakeBetween addSpinAddRow (addSpinJalRow 1) := by
   simp [pcHandshakeBetween, addSpinAddRow, addSpinJalRow, addSpinJalProgramRow, addSpinJalBits,
-    addSpinJalFreeCols, addX1Row, mainRomRowOf]
+    addX1Row, mainRomRowOf]
 
 theorem addSpinMain_pcHandshake_jal_jal :
     pcHandshakeBetween (addSpinJalRow 1) (addSpinJalRow 2) := by
-  simp [pcHandshakeBetween, addSpinJalRow, addSpinJalProgramRow, addSpinJalBits,
-    addSpinJalFreeCols, mainRomRowOf]
+  simp [pcHandshakeBetween, addSpinJalRow, addSpinJalProgramRow, addSpinJalBits, mainRomRowOf]
   ring
 
 theorem addSpinMainTable_rowInput_zero
@@ -989,7 +987,7 @@ theorem addSpinJalMemBusInteractions_balanced (step : FGL) :
     rcases h_interaction with rfl | rfl | rfl | rfl | rfl | rfl <;>
       simp [mainARegPreInteraction, mainAMemInteraction, mainBRegPreInteraction,
         mainBMemInteraction, mainCRegPreInteraction, mainCMemInteraction, addSpinJalRow,
-        addSpinJalProgramRow, addSpinJalBits, addSpinJalFreeCols, mainRomRowOf]
+        addSpinJalProgramRow, addSpinJalBits, mainRomRowOf]
   · left
     change 6 < ringChar FGL
     rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]

--- a/ZiskFv/Compliance/RegisterMemBusBalance.lean
+++ b/ZiskFv/Compliance/RegisterMemBusBalance.lean
@@ -28,11 +28,10 @@ selectors `a_src_reg`/`b_src_reg`/`store_reg` are `1` and the pull selectors
 **Scope.** This is the register-partition balance (`BalancedInteractions` over the `mem_op = 3`
 messages), the object #219 consumes.  It does **not** build the whole-channel
 `witness.BalancedChannels` or the constraint-satisfying accepted trace — those stay #219.  The
-balance is conditional on the previous-step timestamp chain (`a_reg_prev_mem_step = 0`,
-`b_reg_prev_mem_step = 1`, `store_reg_prev_mem_step = 2`, reload at `3`), which ZisK's ordering/range
-checks enforce (the #169/#19 axis, `main.pil:447`), pinned here in the concrete row.  `x0` is not
-used: ZisK decodes `x0` operands as immediate/no-op register accesses emitting no `mem_op = 3`
-traffic, so `x1,x1,x1` is the minimal real-register witness.
+concrete witness materializes the predecessor chain from the boot/access history; the resulting
+timestamps are `0/1/2` with reload at `3`.  `x0` is not used: ZisK decodes `x0` operands as
+immediate/no-op register accesses emitting no `mem_op = 3` traffic, so `x1,x1,x1` is the minimal
+real-register witness.
 
 This file also exposes the actual table interaction reductions for the concrete Main row and
 RegisterBoundary rows.  The remaining #219 bridge is the projection from Main's evaluated
@@ -50,7 +49,7 @@ open ZiskFv.Channels.ZiskRomBus (ZiskRomMessage)
 open ZiskFv.AirsClean.ZiskInstructionRom (Program)
 open ZiskFv.AirsClean.Main (MainRowWithRom aRegPreMessage aMemMessage bRegPreMessage bMemMessage
   cRegPreMessage cMemMessage aRegPreMessageExpr aMemMessageExpr bRegPreMessageExpr
-  bMemMessageExpr cRegPreMessageExpr cMemMessageExpr)
+  bMemMessageExpr cRegPreMessageExpr cMemMessageExpr MainRomFreeCols)
 open ZiskFv.AirsClean.RegisterBoundary (RegisterBoundaryRow bootMessage reloadMessage)
 open ZiskFv.Compliance.Instantiation
 
@@ -201,13 +200,112 @@ theorem registerTelescopingInteractions_balanced
   exact balancedInteractions_of_perm
     (pairedInteractions_balanced (first :: rest) h_paired_len) h_perm.symm
 
+/-! ## Register-access row materialization -/
+
+/-- The Main register-access slots in the same predecessor/current order used by
+    `registerAccessChain`. -/
+inductive MainRegisterAccess
+  | a
+  | b
+  | store
+
+/-- The current message emitted by one Main register-access slot. -/
+@[reducible]
+def mainRegisterCurrentMessage (access : MainRegisterAccess)
+    (row : MainRowWithRom FGL) : MemBusMessage FGL :=
+  match access with
+  | .a => aMemMessage row
+  | .b => bMemMessage row
+  | .store => cMemMessage row
+
+/-- Fill one Main register-access predecessor from the preceding access message. -/
+@[reducible]
+def withMainRegisterPrevious (access : MainRegisterAccess)
+    (previous : MemBusMessage FGL) (row : MainRowWithRom FGL) : MainRowWithRom FGL :=
+  match access with
+  | .a =>
+      { row with rom := { row.rom with a_reg_prev_mem_step := previous.timestamp } }
+  | .b =>
+      { row with rom := { row.rom with b_reg_prev_mem_step := previous.timestamp } }
+  | .store =>
+      { row with rom :=
+          { row.rom with
+            store_reg_prev_mem_step := previous.timestamp
+            store_reg_prev_value_0 := previous.value_0
+            store_reg_prev_value_1 := previous.value_1 } }
+
+/-- Materialize a row's active register predecessors by the same history walk as
+    `registerAccessChain`. This is only a data construction: it introduces no trace assertion. -/
+@[reducible]
+def materializeMainRegisterAccesses
+    (previous : MemBusMessage FGL) (row : MainRowWithRom FGL) :
+    List MainRegisterAccess → MemBusMessage FGL × MainRowWithRom FGL
+  | [] => (previous, row)
+  | access :: rest =>
+      let row := withMainRegisterPrevious access previous row
+      materializeMainRegisterAccesses (mainRegisterCurrentMessage access row) row rest
+
+/-- Build a concrete Main row and its final register state from an access history. -/
+@[reducible]
+def materializeMainRegisterRow (previous : MemBusMessage FGL) (row : MainRowWithRom FGL)
+    (accesses : List MainRegisterAccess) : MemBusMessage FGL × MainRowWithRom FGL :=
+  materializeMainRegisterAccesses previous row accesses
+
+/-- Set the register-predecessor free columns from an already materialized history state. -/
+@[reducible]
+def mainRomFreeColsWithRegisterPrevious (free : MainRomFreeCols)
+    (previous : MemBusMessage FGL) : MainRomFreeCols :=
+  { free with
+    a_reg_prev_mem_step := previous.timestamp
+    b_reg_prev_mem_step := previous.timestamp
+    store_reg_prev_mem_step := previous.timestamp
+    store_reg_prev_value_0 := previous.value_0
+    store_reg_prev_value_1 := previous.value_1 }
+
+/-- Recover the free Main columns from a materialized ROM-backed row. -/
+@[reducible]
+def mainRomFreeColsOfRow (row : MainRowWithRom FGL) : MainRomFreeCols :=
+  { a_0 := row.core.a_0
+    a_1 := row.core.a_1
+    b_0 := row.core.b_0
+    b_1 := row.core.b_1
+    im_high_degree_2 := row.core.im_high_degree_2
+    segment_l1 := row.core.segment_l1
+    main_step := row.rom.main_step
+    a_reg_prev_mem_step := row.rom.a_reg_prev_mem_step
+    b_reg_prev_mem_step := row.rom.b_reg_prev_mem_step
+    store_reg_prev_mem_step := row.rom.store_reg_prev_mem_step
+    store_reg_prev_value_0 := row.rom.store_reg_prev_value_0
+    store_reg_prev_value_1 := row.rom.store_reg_prev_value_1 }
+
+/-- Reload data derived from the last access in a concrete register history. -/
+@[reducible]
+def registerBoundaryRowFromLast (reg : FGL) (last : MemBusMessage FGL) :
+    RegisterBoundaryRow FGL :=
+  { reg := reg
+    reloadTimestamp := last.timestamp
+    reloadValue_0 := last.value_0
+    reloadValue_1 := last.value_1 }
+
 /-! ## The concrete `add x1,x1,x1` row and boundary rows -/
 
-/-- The concrete register-register `add x1,x1,x1` Main row.  Register operands x1: the six MemBus
-    pointers (`a_offset_imm0`/`b_offset_imm0`/`store_offset` and `addr0`/`addr1`/`addr2`) are `1`;
+/-! Register operands x1 use the six MemBus pointers
+    (`a_offset_imm0`/`b_offset_imm0`/`store_offset` and `addr0`/`addr1`/`addr2`) at `1`;
     the three register selectors are `1` and the memory selectors `0`; the previous-step chain is
-    `0/1/2`; all values `0`; `store_pc = 0` collapses the c-value to `c_0 = 0`. -/
-def addX1Row : MainRowWithRom FGL :=
+    materialized from the boot/access history; all values `0`; `store_pc = 0` collapses the c-value
+    to `c_0 = 0`. -/
+/-- Boundary row for an idle tracked register `r`: boot and reload both at ts 0, value 0. -/
+def boundaryRowIdle (r : FGL) : RegisterBoundaryRow FGL :=
+  { reg := r, reloadTimestamp := 0, reloadValue_0 := 0, reloadValue_1 := 0 }
+
+/-- Initial x1 state for the concrete ADD access history. -/
+@[reducible]
+def addX1RegisterInitial : MemBusMessage FGL :=
+  bootMessage (boundaryRowIdle 1)
+
+/-- The ADD row before its active register predecessors are materialized. -/
+@[reducible]
+def addX1RowTemplate : MainRowWithRom FGL :=
   { core :=
       { a_0 := 0, a_1 := 0, b_0 := 0, b_1 := 0, c_0 := 0, c_1 := 0,
         flag := 0, pc := 0, is_external_op := 1, op := ZiskFv.Trusted.OP_ADD, m32 := 0,
@@ -219,9 +317,20 @@ def addX1Row : MainRowWithRom FGL :=
         b_src_imm := 0, b_src_mem := 0, store_mem := 0, store_ind := 0,
         b_src_ind := 0, a_src_reg := 1, b_src_reg := 1, store_reg := 1,
         addr0 := 1, addr1 := 1, addr2 := 1, main_step := 0,
-        a_reg_prev_mem_step := 0, b_reg_prev_mem_step := 1,
-        store_reg_prev_mem_step := 2, store_reg_prev_value_0 := 0,
-        store_reg_prev_value_1 := 0 } }
+        a_reg_prev_mem_step := addX1RegisterInitial.timestamp,
+        b_reg_prev_mem_step := addX1RegisterInitial.timestamp,
+        store_reg_prev_mem_step := addX1RegisterInitial.timestamp,
+        store_reg_prev_value_0 := addX1RegisterInitial.value_0,
+        store_reg_prev_value_1 := addX1RegisterInitial.value_1 } }
+
+/-- The final x1 state and ADD row produced by the concrete access history. -/
+@[reducible]
+def addX1RowWithLast : MemBusMessage FGL × MainRowWithRom FGL :=
+  materializeMainRegisterRow addX1RegisterInitial addX1RowTemplate
+    [MainRegisterAccess.a, MainRegisterAccess.b, MainRegisterAccess.store]
+
+/-- The concrete register-register `add x1,x1,x1` Main row. -/
+def addX1Row : MainRowWithRom FGL := addX1RowWithLast.2
 
 /-- The ROM row matching `addX1Row`'s decoded selector pins. -/
 def addX1ProgramRow : ZiskRomMessage FGL :=
@@ -232,13 +341,9 @@ def addX1ProgramRow : ZiskRomMessage FGL :=
 /-- A one-instruction concrete program for the `add x1,x1,x1` witness. -/
 def addX1Program : Program 1 := fun _ => addX1ProgramRow
 
-/-- Boundary row for register x1: reload closes the chain at the last access (ts 3), value 0. -/
+/-- Boundary row for register x1, whose reload closes the materialized access history. -/
 def boundaryRowX1 : RegisterBoundaryRow FGL :=
-  { reg := 1, reloadTimestamp := 3, reloadValue_0 := 0, reloadValue_1 := 0 }
-
-/-- Boundary row for an idle tracked register `r`: boot and reload both at ts 0, value 0. -/
-def boundaryRowIdle (r : FGL) : RegisterBoundaryRow FGL :=
-  { reg := r, reloadTimestamp := 0, reloadValue_0 := 0, reloadValue_1 := 0 }
+  registerBoundaryRowFromLast 1 addX1RowWithLast.1
 
 /-! ## The real-emission register interaction list for `add x1,x1,x1` -/
 
@@ -261,6 +366,12 @@ def mainRegisterInteractions : List (Interaction FGL) :=
     interaction reduction. -/
 def boundaryInteractions (row : RegisterBoundaryRow FGL) : List (Interaction FGL) :=
   registerBoundaryMemBusInteractions row
+
+/-- The concrete RegisterBoundary emissions in value-level interaction form. -/
+theorem boundaryInteractions_eq_messages (row : RegisterBoundaryRow FGL) :
+    boundaryInteractions row =
+      [emittedPulledValue (bootMessage row), MemBusChannel.pushedValue (reloadMessage row)] := by
+  rfl
 
 /-- Idle tracked registers x2..x31, each contributing a self-balancing boot/reload zero pair. -/
 def idleBoundaryInteractions : List (Interaction FGL) :=

--- a/ZiskFv/Compliance/SingleAddWitness.lean
+++ b/ZiskFv/Compliance/SingleAddWitness.lean
@@ -64,19 +64,10 @@ def addX1RomFlagBits : RomFlagBits where
   b_src_reg := true
   store_reg := true
 
-def addX1MainFreeCols : MainRomFreeCols where
-  a_0 := 0
-  a_1 := 0
-  b_0 := 0
-  b_1 := 0
-  im_high_degree_2 := 0
-  segment_l1 := 1
-  main_step := 0
-  a_reg_prev_mem_step := 0
-  b_reg_prev_mem_step := 1
-  store_reg_prev_mem_step := 2
-  store_reg_prev_value_0 := 0
-  store_reg_prev_value_1 := 0
+/-- The free columns recovered from the materialized ADD access history. -/
+@[reducible]
+def addX1MainFreeCols : MainRomFreeCols :=
+  mainRomFreeColsOfRow addX1Row
 
 theorem addX1Main_proverAssumptions :
     (componentWithRomMemAndOpBus 1 addX1Program).circuit.ProverAssumptions
@@ -85,8 +76,8 @@ theorem addX1Main_proverAssumptions :
     addX1MainFreeCols, ?_, ?_, ?_, ?_, ?_⟩
   · decide
   · simp [MainRomExecKind.Coherent, addX1RomFlagBits]
-  · simp [MainRomSourceGuard, addX1Program, addX1RomFlagBits, addX1MainFreeCols, boolF]
-  · simp [MainRomAddressGuard, addX1RomFlagBits, addX1MainFreeCols, boolF]
+  · simp [MainRomSourceGuard, addX1Program, addX1RomFlagBits, boolF]
+  · simp [MainRomAddressGuard, addX1RomFlagBits, boolF]
   · rfl
 
 theorem addX1MainTable_constraints :

--- a/ZiskFv/Compliance/SingleAddWitness.lean
+++ b/ZiskFv/Compliance/SingleAddWitness.lean
@@ -484,7 +484,6 @@ def singleAddAcceptedTrace : AcceptedZiskTrace 1 where
   mem_replay_im0 := fun h => absurd h singleAddWitness_not_mutableMemPresent
   mem_replay_im1 := fun h => absurd h singleAddWitness_not_mutableMemPresent
   mem_replay_constraints := fun h => absurd h singleAddWitness_not_mutableMemPresent
-  mem_replay_row_ranges := fun h => absurd h singleAddWitness_not_mutableMemPresent
   mem_replay_segment_ranges := fun h => absurd h singleAddWitness_not_mutableMemPresent
   mem_replay_source_covers := fun h => absurd h singleAddWitness_not_mutableMemPresent
   transitions_hold := singleAddWitness_transitions

--- a/trust/consistency/completeness_witness_mem.lean
+++ b/trust/consistency/completeness_witness_mem.lean
@@ -8,6 +8,12 @@ open ZiskFv.AirsClean.Mem
 private def memWitnessRow : MemRow FGL :=
   memRowOf true true true false 16 9 10 8 1 2 42 43
 
+/-- Concrete static-table memberships required to construct the live dual-Mem
+    range lookups for this completeness witness. -/
+private theorem memWitnessDualMemRowRangeFacts :
+    dualMemRowRangeFacts memWitnessRow := by
+  norm_num [dualMemRowRangeFacts, memWitnessRow, memRowOf, memReadSameAddrOf, memValueOf]
+
 private theorem memWitnessCircuitProverAssumptions
     (data : ProverData FGL) (hint : ProverHint FGL) :
     circuit.ProverAssumptions memWitnessRow data hint := by
@@ -26,7 +32,7 @@ private theorem memWitnessWithDualMemBusProverAssumptions
     (data : ProverData FGL) (hint : ProverHint FGL) :
     circuitWithDualMemBus.ProverAssumptions memWitnessRow data hint := by
   refine ⟨true, true, true, false, 16, 9, 10, 8, 1, 2, 42, 43,
-    (by intro _; rfl), (by intro _; rfl), ?_⟩
+    (by intro _; rfl), (by intro _; rfl), memWitnessDualMemRowRangeFacts, ?_⟩
   rfl
 
 theorem completeness_witness_mem :

--- a/trust/consistency/root_soundness_instantiation_degenerate.lean
+++ b/trust/consistency/root_soundness_instantiation_degenerate.lean
@@ -176,7 +176,6 @@ private def trace : AcceptedZiskTrace 0 where
   mem_replay_im0 := fun h => absurd h wit_not_mutableMemPresent
   mem_replay_im1 := fun h => absurd h wit_not_mutableMemPresent
   mem_replay_constraints := fun h => absurd h wit_not_mutableMemPresent
-  mem_replay_row_ranges := fun h => absurd h wit_not_mutableMemPresent
   mem_replay_segment_ranges := fun h => absurd h wit_not_mutableMemPresent
   mem_replay_source_covers := fun h => absurd h wit_not_mutableMemPresent
   transitions_hold := wit_transitions

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -259,8 +259,9 @@ fabricate an empty replay bridge. The generated Mem source residue is now split 
 accepted-trace fields: stage-2 sidecar columns (`mem_replay_segment`,
 `mem_replay_permutation`, `mem_replay_gsum`, `mem_replay_im0`,
 `mem_replay_im1`), split generated constraint facts
-(`mem_replay_constraints`), row range facts (`mem_replay_row_ranges`), and
-segment range facts (`mem_replay_segment_ranges`). The
+(`mem_replay_constraints`), and HELD segment range facts
+(`mem_replay_segment_ranges`). Row range facts are derived from live Mem
+`Table.fromStatic` lookups rather than carried as an accepted-trace field. The
 `memReplayRawSourceSidecar`/`memReplaySource`/`memReplayBridge` accessors
 rebuild the raw sidecar, `FullWitnessMemAirSource`, and `FullWitnessMemReplayBridge`
 downstream. This is narrower than carrying the replay bridge, a full
@@ -268,7 +269,9 @@ downstream. This is narrower than carrying the replay bridge, a full
 sidecar field directly, and fixed-column shape is no longer accepted-trace
 residue, but it still strengthens memory-present `AcceptedZiskTrace` construction
 until the remaining Mem generated-source/cross-row facts are derived or
-explicitly approved. `mem_replay_source_covers` is the matching structural
+explicitly approved. `mem_replay_segment_ranges` is HELD for Project Closeout S3
+lookup-wiring extraction, which must derive and delete it; it is not a permanent
+caller-supplied promise hypothesis. `mem_replay_source_covers` is the matching structural
 source-correlation certificate: every mutable-Mem table in the witness is the
 selected source table.
 
@@ -440,8 +443,9 @@ chronology, and named row-count/order certificates. This reduces the seed-side
 read-value assumption, but it also adds a nonempty accepted-trace constructor
 burden: `mem_replay_table` must select the concrete mutable Mem AIR table and
 nonempty proof; the source-column fields, `mem_replay_constraints`,
-`mem_replay_row_ranges`, and `mem_replay_segment_ranges` must provide the raw
-generated Mem source factors for that selected table; and `mem_replay_source_covers`
+and HELD `mem_replay_segment_ranges` must provide the remaining raw generated
+Mem source factors for that selected table. Row range facts are derived from the
+live Mem component rather than supplied by the accepted trace; and `mem_replay_source_covers`
 must certify structural coverage of mutable-Mem tables by that selected table.
 The direct-Mem row-count equality is visible as `ScopedDirectMemReplayLengthCertificate`
 and belongs to the #219 whole-channel balance route for future derivation.
@@ -694,8 +698,7 @@ trust surface even though they add no axiom.
 | `mem_replay_table` (**#115**, guarded by `MutableMemPresent witness`) | Full-ensemble table selection for the mutable Mem component | selects the concrete mutable-Mem table, proves witness membership and component identity, and proves the table is nonempty |
 | `mem_replay_segment` / `mem_replay_permutation` / `mem_replay_gsum` / `mem_replay_im0` / `mem_replay_im1` (**#115**, guarded by `MutableMemPresent witness`) | Raw generated Mem sidecar columns for the selected mutable Mem table; deterministic Mem `SEGMENT_L1` shape is derived via `segmentWithFixedL1` | supplies the source columns used to rebuild the raw sidecar and typed Mem AIR source for `mem_replay_table` |
 | `mem_replay_constraints` (**#115**, guarded by `MutableMemPresent witness`) | split generated Mem constraints for the selected mutable Mem table | supplies the `segment_every_row` / `permutation_every_row` generated constraint facts used to derive replay rows |
-| `mem_replay_row_ranges` (**#115**, guarded by `MutableMemPresent witness`) | row range facts for the selected mutable Mem table projection | supplies range facts over the projected Mem rows used by the replay bridge |
-| `mem_replay_segment_ranges` (**#115**, guarded by `MutableMemPresent witness`) | segment range facts for the selected mutable Mem sidecar segment | supplies range facts over the fixed-`SEGMENT_L1` sidecar segment used by the replay bridge |
+| `mem_replay_segment_ranges` (**#115**, guarded by `MutableMemPresent witness`) | segment range facts for the selected mutable Mem sidecar segment | **HELD** caller-supplied promise hypothesis for Project Closeout S3 lookup-wiring extraction; S3 must derive and delete it from extracted lookup wiring. Until then it supplies range facts over the fixed-`SEGMENT_L1` sidecar segment used by the replay bridge. |
 | `mem_replay_source_covers` (**#115**, guarded by `MutableMemPresent witness`) | Full-ensemble table/source correlation for the mutable Mem component | certifies that every mutable-Mem table in the accepted witness is the selected `mem_replay_table`; this is table identity only, not read-value agreement |
 
 **#115 constructor-burden note.** Removing the raw seed
@@ -705,9 +708,9 @@ memory-present traces. Constructors whose mutable-Mem table is empty, such as
 the degenerate base case and #219/#220's ADD witnesses, prove
 `MutableMemPresent` impossible instead of supplying replay fields. A constructor
 with mutable-Mem rows must build the guarded `mem_replay_table`, source-column,
-generated-constraint, and range fields in addition to
+generated-constraint, and HELD segment-range fields in addition to
 `constraints_hold`/`channels_balanced`/`transitions_hold`/`main_height`/fixed
-columns. These fields are not read-value agreement predicates, and they no
+columns. Row range facts are derived from live Mem constraints. These fields are not read-value agreement predicates, and they no
 longer carry deterministic Mem fixed columns. The paired
 `mem_replay_source_covers` field is a structural table-coverage certificate that
 removes this residue from seed-layer wrappers. For the #115 direct-Mem closeout,


### PR DESCRIPTION
## Summary
- Compose the seven static Mem range lookups into the live dual-Mem component and derive row range facts from accepted `constraints_hold`.
- Delete the `mem_replay_row_ranges` caller-supplied promise hypothesis; the selected table and live component constraints now derive it.
- Compute concrete register predecessor chains from access history, removing handwritten predecessor literals from the requested witness constructors.
- Keep `mem_replay_segment_ranges` HELD for Project Closeout S3 lookup-wiring extraction.

## Trust Surface
- No new project axioms, `sorry`, `native_decide`, or allowlist edits.
- The accepted-trace trust surface shrinks by one caller-supplied promise hypothesis.
- The live lookup completeness fixture constructs bounded inputs explicitly; it is not an accepted-trace promise.

## Verification
- `lake build`
- `trust/scripts/check-all.sh`
- `trust/scripts/check-all-semantic.sh`
- `nix run .#test`
- Independent review: no blocking findings.

Refs #249