### PR TITLE
#243/#226: materialize canonical indexed fixed columns

### DIFF
--- a/ZiskFv/Airs/Mem.lean
+++ b/ZiskFv/Airs/Mem.lean
@@ -290,6 +290,67 @@ def segment_every_row
       (v.value_1 row - segment_previous_value_1 cols v row) = 0
   ∧ (v.addr_changes row * (1 - v.wr row)) * v.value_1 row = 0
 
+/-- The generated segment constraints not already enforced by the nine local
+    Mem component equations. -/
+@[simp]
+def segmentResidualEveryRow
+    (cols : SegmentColumns F) (v : Valid_Mem F F) (row : ℕ) : Prop :=
+  cols.is_first_segment * (1 - cols.is_first_segment) = 0
+  ∧ cols.is_last_segment * (1 - cols.is_last_segment) = 0
+  ∧ cols.is_first_segment * cols.segment_id = 0
+  ∧ cols.segment_l1 (row + 1) *
+      (v.value_0 row - cols.segment_last_value_0) = 0
+  ∧ cols.segment_l1 (row + 1) *
+      (v.value_1 row - cols.segment_last_value_1) = 0
+  ∧ cols.segment_l1 (row + 1) *
+      (v.addr row - cols.segment_last_addr) = 0
+  ∧ cols.segment_l1 (row + 1) *
+      (v.sel_dual row * (v.step_dual row - v.step row) + v.step row
+        - cols.segment_last_step) = 0
+  ∧ (cols.previous_segment_addr - 335544320)
+      - (cols.distance_base_0 + 65536 * cols.distance_base_1) = 0
+  ∧ (402653183 - cols.segment_last_addr)
+      - (cols.distance_end_0 + 65536 * cols.distance_end_1) = 0
+  ∧ v.previous_step row
+      - (cols.segment_l1 row *
+          (cols.previous_segment_step - previous_row_step v row)
+        + previous_row_step v row) = 0
+  ∧ (v.increment_0 row + 4194304 * v.increment_1 row + 1)
+      - (v.addr_changes row * (delta_addr cols v row - delta_step v row)
+        + delta_step v row) = 0
+  ∧ (cols.is_first_segment * cols.segment_l1 row) *
+      (1 - v.addr_changes row) = 0
+  ∧ (1 - v.addr_changes row) *
+      (v.addr row - segment_previous_addr cols v row) = 0
+  ∧ v.read_same_addr row *
+      (v.value_0 row - segment_previous_value_0 cols v row) = 0
+  ∧ v.read_same_addr row *
+      (v.value_1 row - segment_previous_value_1 cols v row) = 0
+
+/-- Project the non-local generated segment constraints from the full
+    `0..=23` generated surface. -/
+theorem segmentResidualEveryRow_of_segment_every_row
+    {cols : SegmentColumns F} {v : Valid_Mem F F} {row : ℕ}
+    (h : segment_every_row cols v row) :
+    segmentResidualEveryRow cols v row := by
+  rcases h with
+    ⟨h0, h1, h2, _, _, _, _, _, _, h9, h10, h11, h12, h13, h14, h15, h16,
+      h17, _, h19, h20, _, h22, _⟩
+  exact ⟨h0, h1, h2, h9, h10, h11, h12, h13, h14, h15, h16, h17, h19, h20, h22⟩
+
+/-- Reconstruct the complete generated segment surface from the local Mem
+    component equations and the non-local residual. -/
+theorem segment_every_row_of_core_and_residual
+    {cols : SegmentColumns F} {v : Valid_Mem F F} {row : ℕ}
+    (h_core : core_every_row v row)
+    (h_residual : segmentResidualEveryRow cols v row) :
+    segment_every_row cols v row := by
+  rcases h_core with ⟨h3, h4, h5, h6, h7, h8, h18, h21, h23⟩
+  rcases h_residual with
+    ⟨h0, h1, h2, h9, h10, h11, h12, h13, h14, h15, h16, h17, h19, h20, h22⟩
+  exact ⟨h0, h1, h2, h3, h4, h5, h6, h7, h8, h9, h10, h11, h12, h13, h14, h15,
+    h16, h17, h18, h19, h20, h21, h22, h23⟩
+
 /-- The active local Mem bridge is a projection of the generated 0-23
 segment/continuity surface. -/
 theorem core_every_row_of_segment_every_row

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/RowsBridgeFacts.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/RowsBridgeFacts.lean
@@ -237,8 +237,9 @@ def FullWitnessMemTableGeneratedRowsBridge
     `acceptedMemoryReplayEvidence_of_memTableGeneratedRowsBridge_segmentRangeFacts`:
     the table selected from the full witness, the active replay row projection,
     generated Mem row constraints, row/segment range checks, and nonempty
-    segment evidence. The deterministic `SEGMENT_L1` fixed-column shape is
-    derived by `segmentWithFixedL1` rather than carried as bridge residue. -/
+    segment evidence. The fixed-column shape is a derived bridge fact: legacy
+    constructors obtain it from `segmentWithFixedL1`, while live-component
+    constructors obtain it from the component-owned fixed schema. -/
 structure FullWitnessMemReplayBridge
     {length : ℕ} {program : Program length}
     (witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble)
@@ -251,13 +252,53 @@ structure FullWitnessMemReplayBridge
   rowCount : ℕ
   rows_eq : rows = activeMemReplayRowsOfTable table
   generatedRows :
-    MemTableGeneratedRowsBridge table mem (segmentWithFixedL1 segment) permutation rowCount
+    MemTableGeneratedRowsBridge table mem segment permutation rowCount
   rowRanges : MemTableGeneratedRangeFacts table mem
-  segmentRanges : MemSegmentGeneratedRangeFacts (segmentWithFixedL1 segment)
+  segmentRanges : MemSegmentGeneratedRangeFacts segment
+  fixedColumns : MemTableGeneratedFixedColumnFacts table segment
   nonempty : 0 < table.table.length
 
+/-- Construct the full-witness replay bridge from a concrete Mem table
+    projection and a derived fixed-column fact for its actual segment.
+
+    This is the canonical constructor for live component data. The fixed fact
+    is derived from the component schema by its caller, never carried by an
+    accepted trace as a replacement certificate. -/
+def fullWitnessMemReplayBridge_of_memTable_with_fixedColumns
+    {length : ℕ} {program : Program length}
+    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
+    {table : Table FGL}
+    {segment : ZiskFv.Airs.Mem.SegmentColumns FGL}
+    {permutation : ZiskFv.Airs.Mem.PermutationColumns FGL}
+    {gsum im0 im1 : ℕ → FGL}
+    (h_table : table ∈ witness.allTables)
+    (h_component :
+      table.component = ZiskFv.AirsClean.Mem.componentWithDualMemBus)
+    (h_generatedAt :
+      ∀ idx : Fin table.table.length,
+        ZiskFv.Airs.Mem.generated_every_row
+          segment permutation (memOfTable table gsum im0 im1) idx.val)
+    (h_rowRanges : MemTableGeneratedRangeFacts table (memOfTable table gsum im0 im1))
+    (h_segmentRanges : MemSegmentGeneratedRangeFacts segment)
+    (h_fixedColumns : MemTableGeneratedFixedColumnFacts table segment)
+    (h_nonempty : 0 < table.table.length) :
+    FullWitnessMemReplayBridge witness (activeMemReplayRowsOfTable table) :=
+  { table := table
+    table_mem := h_table
+    mem := memOfTable table gsum im0 im1
+    segment := segment
+    permutation := permutation
+    rowCount := table.table.length
+    rows_eq := rfl
+    generatedRows :=
+      memTableGeneratedRowsBridge_of_memOfTable h_component h_generatedAt
+    rowRanges := h_rowRanges
+    segmentRanges := h_segmentRanges
+    fixedColumns := h_fixedColumns
+    nonempty := h_nonempty }
+
 /-- Construct the full-witness replay bridge from the concrete Mem table
-    projection using the deterministic `SEGMENT_L1` fixed-column shape.
+    projection using the deterministic `SEGMENT_L1` compatibility shape.
 
     This is the intended extractor-facing constructor: table membership,
     component identity, row projection, row count, and accepted-row projection
@@ -283,18 +324,16 @@ def fullWitnessMemReplayBridge_of_memTable
     (h_segmentRanges : MemSegmentGeneratedRangeFacts (segmentWithFixedL1 segment))
     (h_nonempty : 0 < table.table.length) :
     FullWitnessMemReplayBridge witness (activeMemReplayRowsOfTable table) :=
-  { table := table
-    table_mem := h_table
-    mem := memOfTable table gsum im0 im1
-    segment := segment
-    permutation := permutation
-    rowCount := table.table.length
-    rows_eq := rfl
-    generatedRows :=
-      memTableGeneratedRowsBridge_of_memOfTable h_component h_generatedAt
-    rowRanges := h_rowRanges
-    segmentRanges := h_segmentRanges
-    nonempty := h_nonempty }
+  fullWitnessMemReplayBridge_of_memTable_with_fixedColumns
+    (segment := segmentWithFixedL1 segment)
+    (gsum := gsum) (im0 := im0) (im1 := im1)
+    h_table
+    h_component
+    h_generatedAt
+    h_rowRanges
+    h_segmentRanges
+    (memTableGeneratedFixedColumnFacts_of_segmentWithFixedL1 table segment)
+    h_nonempty
 
 /-- Construct the full-witness replay bridge using the deterministic
     `SEGMENT_L1` fixed-column shape. The remaining caller-facing inputs are the
@@ -882,15 +921,15 @@ theorem fullWitnessMemAirSourceOfRawSidecars_eq_rawFacts
         (fullWitnessMemAirSourceRawFacts_of_sidecars h_sidecars) := by
   rfl
 
-/-- The compact full-witness replay bridge includes the generated-row bridge
-    obligation for the deterministic fixed-L1 segment shape. -/
+/-- The compact full-witness replay bridge includes its actual generated-row
+    bridge. Its fixed-column fact is stored separately as a derived field. -/
 theorem fullWitnessMemTableGeneratedRowsBridge_of_fullWitnessMemReplayBridge
     {length : ℕ} {program : Program length}
     {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
     {rows : List (Interaction.MemoryBusEntry FGL)}
     (h_bridge : FullWitnessMemReplayBridge witness rows) :
     FullWitnessMemTableGeneratedRowsBridge witness
-      h_bridge.mem (segmentWithFixedL1 h_bridge.segment) h_bridge.permutation h_bridge.rowCount :=
+      h_bridge.mem h_bridge.segment h_bridge.permutation h_bridge.rowCount :=
   ⟨h_bridge.table, h_bridge.table_mem, h_bridge.generatedRows⟩
 
 /-- Full-witness replay bridge wrapper for the address-separation

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/SidecarColumns.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/SidecarColumns.lean
@@ -4,6 +4,7 @@ import ZiskFv.AirsClean.Binary.Bridge
 import ZiskFv.AirsClean.BinaryAdd.Bridge
 import ZiskFv.AirsClean.BinaryExtension.Bridge
 import ZiskFv.AirsClean.Mem.Bridge
+import ZiskFv.AirsClean.Mem.SidecarColumns
 import ZiskFv.AirsClean.Mem.TraceSpec
 import ZiskFv.AirsClean.FullEnsemble.Balance.Classification
 import ZiskFv.AirsClean.FullEnsemble.Balance.CounterpartClassification
@@ -23,125 +24,25 @@ open ZiskFv.AirsClean.BinaryExtension (shiftStaticLookupComponent)
 
 /-! ### Prover-data-backed Mem sidecar columns -/
 
-/- `ProverData` keys for the generated Mem sidecar columns.
+/-- Compatibility re-exports for balance-layer callers. The implementations
+live with the Mem component so canonical fixed-column source constructors can
+be used without importing the full-ensemble layer. -/
+abbrev memSidecarGsumOfProverData (data : ProverData FGL) : Nat -> FGL :=
+  ZiskFv.AirsClean.Mem.memSidecarGsumOfProverData data
 
-   These names are the Lean-side contract for generated/full-ensemble code:
-   each key stores a one-column array (`n = 1`) whose row `0` is used for
-   scalars and whose row index is used for table columns. The source map in
-   `MemAirFacts.md` ties these keys to pilout witness columns, fixed columns,
-   AIR_VALUE entries, and challenges. -/
-namespace MemRawSidecarDataKey
+abbrev memSidecarIm0OfProverData (data : ProverData FGL) : Nat -> FGL :=
+  ZiskFv.AirsClean.Mem.memSidecarIm0OfProverData data
 
-abbrev gsum : String := "Mem.sidecar.gsum"
-abbrev im0 : String := "Mem.sidecar.im0"
-abbrev im1 : String := "Mem.sidecar.im1"
+abbrev memSidecarIm1OfProverData (data : ProverData FGL) : Nat -> FGL :=
+  ZiskFv.AirsClean.Mem.memSidecarIm1OfProverData data
 
-namespace Segment
+abbrev memSegmentColumnsOfProverData (data : ProverData FGL) :
+    ZiskFv.Airs.Mem.SegmentColumns FGL :=
+  ZiskFv.AirsClean.Mem.memSegmentColumnsOfProverData data
 
-abbrev segmentId : String := "Mem.sidecar.segment.segment_id"
-abbrev isFirstSegment : String := "Mem.sidecar.segment.is_first_segment"
-abbrev isLastSegment : String := "Mem.sidecar.segment.is_last_segment"
-abbrev previousSegmentValue0 : String := "Mem.sidecar.segment.previous_segment_value_0"
-abbrev previousSegmentValue1 : String := "Mem.sidecar.segment.previous_segment_value_1"
-abbrev previousSegmentStep : String := "Mem.sidecar.segment.previous_segment_step"
-abbrev previousSegmentAddr : String := "Mem.sidecar.segment.previous_segment_addr"
-abbrev segmentLastValue0 : String := "Mem.sidecar.segment.segment_last_value_0"
-abbrev segmentLastValue1 : String := "Mem.sidecar.segment.segment_last_value_1"
-abbrev segmentLastStep : String := "Mem.sidecar.segment.segment_last_step"
-abbrev segmentLastAddr : String := "Mem.sidecar.segment.segment_last_addr"
-abbrev distanceBase0 : String := "Mem.sidecar.segment.distance_base_0"
-abbrev distanceBase1 : String := "Mem.sidecar.segment.distance_base_1"
-abbrev distanceEnd0 : String := "Mem.sidecar.segment.distance_end_0"
-abbrev distanceEnd1 : String := "Mem.sidecar.segment.distance_end_1"
-abbrev segmentL1 : String := "Mem.sidecar.segment.segment_l1"
-
-end Segment
-
-namespace Permutation
-
-abbrev stdAlpha : String := "Mem.sidecar.permutation.std_alpha"
-abbrev stdGamma : String := "Mem.sidecar.permutation.std_gamma"
-abbrev l1 : String := "Mem.sidecar.permutation.l1"
-abbrev imDirect0 : String := "Mem.sidecar.permutation.im_direct_0"
-abbrev imDirect1 : String := "Mem.sidecar.permutation.im_direct_1"
-abbrev imDirect2 : String := "Mem.sidecar.permutation.im_direct_2"
-abbrev imDirect3 : String := "Mem.sidecar.permutation.im_direct_3"
-abbrev imDirect4 : String := "Mem.sidecar.permutation.im_direct_4"
-abbrev imDirect5 : String := "Mem.sidecar.permutation.im_direct_5"
-
-end Permutation
-
-end MemRawSidecarDataKey
-
-/-- Read one field element from a one-column `ProverData` array.
-
-    Missing keys or out-of-range rows default to zero, matching Clean's
-    `Environment.fromArray` convention for absent witness cells. Correctness
-    is not hidden here: generated code must still prove
-    `MemTableGeneratedRawSourceFacts` for the columns read by this function. -/
-@[reducible]
-def proverDataColumn (data : ProverData FGL) (key : String) (row : ℕ) : FGL :=
-  match (data key 1)[row]? with
-  | some values => values[0]
-  | none => 0
-
-/-- Read a scalar sidecar value from row `0` of a one-column `ProverData`
-    array. -/
-@[reducible]
-def proverDataScalar (data : ProverData FGL) (key : String) : FGL :=
-  proverDataColumn data key 0
-
-@[reducible]
-def memSidecarGsumOfProverData (data : ProverData FGL) : ℕ → FGL :=
-  proverDataColumn data MemRawSidecarDataKey.gsum
-
-@[reducible]
-def memSidecarIm0OfProverData (data : ProverData FGL) : ℕ → FGL :=
-  proverDataColumn data MemRawSidecarDataKey.im0
-
-@[reducible]
-def memSidecarIm1OfProverData (data : ProverData FGL) : ℕ → FGL :=
-  proverDataColumn data MemRawSidecarDataKey.im1
-
-/-- Segment sidecar columns read from the shared Clean `ProverData` map. -/
-@[reducible]
-def memSegmentColumnsOfProverData
-    (data : ProverData FGL) :
-    ZiskFv.Airs.Mem.SegmentColumns FGL where
-  segment_id := proverDataScalar data MemRawSidecarDataKey.Segment.segmentId
-  is_first_segment := proverDataScalar data MemRawSidecarDataKey.Segment.isFirstSegment
-  is_last_segment := proverDataScalar data MemRawSidecarDataKey.Segment.isLastSegment
-  previous_segment_value_0 :=
-    proverDataScalar data MemRawSidecarDataKey.Segment.previousSegmentValue0
-  previous_segment_value_1 :=
-    proverDataScalar data MemRawSidecarDataKey.Segment.previousSegmentValue1
-  previous_segment_step := proverDataScalar data MemRawSidecarDataKey.Segment.previousSegmentStep
-  previous_segment_addr := proverDataScalar data MemRawSidecarDataKey.Segment.previousSegmentAddr
-  segment_last_value_0 := proverDataScalar data MemRawSidecarDataKey.Segment.segmentLastValue0
-  segment_last_value_1 := proverDataScalar data MemRawSidecarDataKey.Segment.segmentLastValue1
-  segment_last_step := proverDataScalar data MemRawSidecarDataKey.Segment.segmentLastStep
-  segment_last_addr := proverDataScalar data MemRawSidecarDataKey.Segment.segmentLastAddr
-  distance_base_0 := proverDataScalar data MemRawSidecarDataKey.Segment.distanceBase0
-  distance_base_1 := proverDataScalar data MemRawSidecarDataKey.Segment.distanceBase1
-  distance_end_0 := proverDataScalar data MemRawSidecarDataKey.Segment.distanceEnd0
-  distance_end_1 := proverDataScalar data MemRawSidecarDataKey.Segment.distanceEnd1
-  segment_l1 := proverDataColumn data MemRawSidecarDataKey.Segment.segmentL1
-
-/-- Permutation/direct-update sidecar columns read from the shared Clean
-    `ProverData` map. -/
-@[reducible]
-def memPermutationColumnsOfProverData
-    (data : ProverData FGL) :
-    ZiskFv.Airs.Mem.PermutationColumns FGL where
-  std_alpha := proverDataScalar data MemRawSidecarDataKey.Permutation.stdAlpha
-  std_gamma := proverDataScalar data MemRawSidecarDataKey.Permutation.stdGamma
-  l1 := proverDataColumn data MemRawSidecarDataKey.Permutation.l1
-  im_direct_0 := proverDataScalar data MemRawSidecarDataKey.Permutation.imDirect0
-  im_direct_1 := proverDataScalar data MemRawSidecarDataKey.Permutation.imDirect1
-  im_direct_2 := proverDataScalar data MemRawSidecarDataKey.Permutation.imDirect2
-  im_direct_3 := proverDataScalar data MemRawSidecarDataKey.Permutation.imDirect3
-  im_direct_4 := proverDataScalar data MemRawSidecarDataKey.Permutation.imDirect4
-  im_direct_5 := proverDataScalar data MemRawSidecarDataKey.Permutation.imDirect5
+abbrev memPermutationColumnsOfProverData (data : ProverData FGL) :
+    ZiskFv.Airs.Mem.PermutationColumns FGL :=
+  ZiskFv.AirsClean.Mem.memPermutationColumnsOfProverData data
 
 /-- Table-level sidecar for generated raw Mem AIR source data.
 

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/TableProjections.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/TableProjections.lean
@@ -4,6 +4,7 @@ import ZiskFv.AirsClean.Binary.Bridge
 import ZiskFv.AirsClean.BinaryAdd.Bridge
 import ZiskFv.AirsClean.BinaryExtension.Bridge
 import ZiskFv.AirsClean.Mem.Bridge
+import ZiskFv.AirsClean.Mem.GeneratedTransition
 import ZiskFv.AirsClean.Mem.TraceSpec
 import ZiskFv.AirsClean.FullEnsemble.Balance.Classification
 import ZiskFv.AirsClean.FullEnsemble.Balance.CounterpartClassification
@@ -722,6 +723,30 @@ def memOfTable
   im_0 := im0
   im_1 := im1
 
+/-- Canonical named-column Mem view for a live table. The primary columns come
+from the table's materialized rows, while the selected stage-2 columns come
+from that same table's shared `ProverData`. -/
+@[reducible]
+def memOfTableData (table : Table FGL) : ZiskFv.Airs.Mem.Valid_Mem FGL FGL :=
+  memOfTable table
+    (ZiskFv.AirsClean.Mem.memSidecarGsumOfProverData table.data)
+    (ZiskFv.AirsClean.Mem.memSidecarIm0OfProverData table.data)
+    (ZiskFv.AirsClean.Mem.memSidecarIm1OfProverData table.data)
+
+/-- Canonical generated-segment columns for a live Mem table. `SEGMENT_L1`
+comes only from the component-owned fixed schema, not from prover data. -/
+@[reducible]
+def memSegmentOfTableData (table : Table FGL) : ZiskFv.Airs.Mem.SegmentColumns FGL :=
+  ZiskFv.AirsClean.Mem.memSegmentColumnsOfProverDataAndFixed table.data
+    (fun row => table.fixedAt ZiskFv.AirsClean.Mem.MemFixedColumn.segmentL1 row)
+
+/-- Canonical generated-permutation columns for a live Mem table. `__L1__`
+comes only from the component-owned fixed schema, not from prover data. -/
+@[reducible]
+def memPermutationOfTableData (table : Table FGL) : ZiskFv.Airs.Mem.PermutationColumns FGL :=
+  ZiskFv.AirsClean.Mem.memPermutationColumnsOfProverDataAndFixed table.data
+    (fun row => table.fixedAt ZiskFv.AirsClean.Mem.MemFixedColumn.l1 row)
+
 /-- In-range concrete table projection agrees with `List.get`. -/
 theorem memTableRowAtOrZero_get
     (table : Table FGL)
@@ -761,6 +786,103 @@ theorem rowAt_memOfTable
       read_same_addr := row.read_same_addr } = row
   cases row
   rfl
+
+/-- The canonical table-data projection has the same in-range named-row view
+as the live dual-Mem component input. -/
+theorem rowAt_memOfTableData
+    (table : Table FGL)
+    (idx : Fin table.table.length) :
+    ZiskFv.AirsClean.Mem.rowAt (memOfTableData table) idx.val =
+      eval (table.environment (table.table.get idx))
+        ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar :=
+  rowAt_memOfTable table
+    (ZiskFv.AirsClean.Mem.memSidecarGsumOfProverData table.data)
+    (ZiskFv.AirsClean.Mem.memSidecarIm0OfProverData table.data)
+    (ZiskFv.AirsClean.Mem.memSidecarIm1OfProverData table.data)
+    idx
+
+/-- Decoding the current effective table environment agrees with the total
+named-row table projection at an in-range row. -/
+theorem memRowFromEnvironmentAt_eq_memTableRowAtOrZero
+    (table : Table FGL)
+    (idx : Fin table.length) :
+    ZiskFv.AirsClean.Mem.memRowFromEnvironment (table.environmentAt idx) =
+      memTableRowAtOrZero table idx.val := by
+  have h_idx : idx.val < table.table.length := by
+    simpa only [Table.table_length] using idx.isLt
+  unfold ZiskFv.AirsClean.Mem.memRowFromEnvironment Table.environmentAt
+  unfold memTableRowAtOrZero
+  rw [dif_pos h_idx]
+  rfl
+
+/-- Decoding a transition's saturated predecessor environment agrees with the
+total named-row table projection at the preceding index. -/
+theorem memRowFromPreviousEnvironment_eq_memTableRowAtOrZero
+    (table : Table FGL)
+    (idx : Fin table.length) :
+    ZiskFv.AirsClean.Mem.memRowFromEnvironment (table.previousEnvironment idx) =
+      memTableRowAtOrZero table (idx.val - 1) := by
+  let previous : Fin table.length := ⟨idx.val - 1, by omega⟩
+  simpa [Table.previousEnvironment, previous] using
+    memRowFromEnvironmentAt_eq_memTableRowAtOrZero table previous
+
+/-- The live Mem transition is exactly the non-local generated surface over
+the canonical table-data projections. The predecessor is the table's
+saturated predecessor row, and both fixed selectors are read from the same
+component-owned schema that materializes the table. -/
+theorem generatedTransition_iff_canonicalTableData
+    (table : Table FGL)
+    (h_component :
+      table.component = ZiskFv.AirsClean.Mem.componentWithDualMemBus)
+    (idx : Fin table.length) :
+    ZiskFv.AirsClean.Mem.generatedTransition ZiskFv.AirsClean.Mem.memFixedColumns idx.val
+        (table.previousEnvironment idx) (table.environmentAt idx) ↔
+      (ZiskFv.Airs.Mem.segmentResidualEveryRow
+          (memSegmentOfTableData table) (memOfTableData table) idx.val
+        ∧ ZiskFv.Airs.Mem.permutation_every_row
+          (memSegmentOfTableData table) (memPermutationOfTableData table)
+          (memOfTableData table) idx.val) := by
+  rcases table with ⟨component, rawRows, data, raw_uniform_width, fixed_domain⟩
+  change component = ZiskFv.AirsClean.Mem.componentWithDualMemBus at h_component
+  subst component
+  let table : Table FGL :=
+    { component := ZiskFv.AirsClean.Mem.componentWithDualMemBus
+      rawRows := rawRows
+      data := data
+      raw_uniform_width := raw_uniform_width
+      fixed_domain := fixed_domain }
+  change ZiskFv.AirsClean.Mem.generatedTransition
+      ZiskFv.AirsClean.Mem.memFixedColumns idx.val
+      (table.previousEnvironment idx) (table.environmentAt idx) ↔
+    (ZiskFv.Airs.Mem.segmentResidualEveryRow
+        (memSegmentOfTableData table) (memOfTableData table) idx.val
+      ∧ ZiskFv.Airs.Mem.permutation_every_row
+        (memSegmentOfTableData table) (memPermutationOfTableData table)
+        (memOfTableData table) idx.val)
+  have h_fixed_at : ∀ slot row : Nat,
+      table.fixedAt slot row =
+        ZiskFv.AirsClean.Mem.memFixedColumns.fixedAt slot row := by
+    intro slot row
+    rfl
+  have h_current :
+      ZiskFv.AirsClean.Mem.memRowFromEnvironment (table.environmentAt idx) =
+        ZiskFv.AirsClean.Mem.rowAt (memOfTableData table) idx.val := by
+    rw [memRowFromEnvironmentAt_eq_memTableRowAtOrZero]
+  have h_previous :
+      ZiskFv.AirsClean.Mem.memRowFromEnvironment (table.previousEnvironment idx) =
+        ZiskFv.AirsClean.Mem.rowAt (memOfTableData table) (idx.val - 1) := by
+    rw [memRowFromPreviousEnvironment_eq_memTableRowAtOrZero]
+  have h_data : (table.environmentAt idx).data = table.data := rfl
+  by_cases h_zero : idx.val = 0
+  · simp only [ZiskFv.AirsClean.Mem.generatedTransition,
+      ZiskFv.AirsClean.Mem.memWindow]
+    rw [h_current, h_previous, h_data]
+    simp [memOfTableData, memOfTable, h_fixed_at, h_zero]
+  · have h_previous_ne : idx.val - 1 ≠ idx.val := by omega
+    simp only [ZiskFv.AirsClean.Mem.generatedTransition,
+      ZiskFv.AirsClean.Mem.memWindow]
+    rw [h_current, h_previous, h_data]
+    simp [memOfTableData, memOfTable, h_fixed_at, h_previous_ne]
 
 /-- The component `Spec` for a concrete dual-Mem table row projects to the
     named-column `Spec` for the corresponding `memOfTable` row.
@@ -958,6 +1080,23 @@ theorem memTableGeneratedRangeFacts_of_component_constraints
     rw [← rowAt_memOfTable table gsum im0 im1 idx] at h
     exact h.2.2.2.2.2.2 h_sel_dual
 
+/-- Derive the concrete Mem row-range facts from the canonical live-table
+    projection. The selected `ProverData` columns and materialized witness rows
+    are the same data consumed by the live dual-Mem constraints, so this needs
+    no legacy sidecar correlation or caller-supplied certificate. -/
+theorem memTableGeneratedRangeFacts_of_component_constraints_canonical
+    (table : Table FGL)
+    (h_component :
+      table.component = ZiskFv.AirsClean.Mem.componentWithDualMemBus)
+    (h_constraints : table.Constraints) :
+    MemTableGeneratedRangeFacts table (memOfTableData table) := by
+  simpa only [memOfTableData] using
+    memTableGeneratedRangeFacts_of_component_constraints table
+      (ZiskFv.AirsClean.Mem.memSidecarGsumOfProverData table.data)
+      (ZiskFv.AirsClean.Mem.memSidecarIm0OfProverData table.data)
+      (ZiskFv.AirsClean.Mem.memSidecarIm1OfProverData table.data)
+      h_component h_constraints
+
 /-- Segment-level range facts for one generated Mem table segment.
 
     These facts name the segment-global range-check surface used by
@@ -1099,6 +1238,58 @@ structure MemTableGeneratedConstraintFacts
   permutationAt :
     ∀ idx : Fin table.table.length,
       ZiskFv.Airs.Mem.permutation_every_row segment permutation mem idx.val
+
+/-- Derive the full generated Mem constraint surface from one live table.
+
+The component's ordinary constraints supply the nine row-local equations; its
+right-indexed transition supplies the remaining segment residual and all
+permutation equations. Both paths read the same materialized rows, selected
+`ProverData`, and component-owned fixed schema. -/
+theorem memTableGeneratedConstraintFacts_of_component_constraints_transitions
+    (table : Table FGL)
+    (h_component :
+      table.component = ZiskFv.AirsClean.Mem.componentWithDualMemBus)
+    (h_constraints : table.Constraints)
+    (h_transitions : table.TransitionConstraints) :
+    MemTableGeneratedConstraintFacts
+      table (memOfTableData table) (memSegmentOfTableData table)
+      (memPermutationOfTableData table) := by
+  have transitionFacts : ∀ idx : Fin table.length,
+      ZiskFv.Airs.Mem.segmentResidualEveryRow
+          (memSegmentOfTableData table) (memOfTableData table) idx.val
+        ∧ ZiskFv.Airs.Mem.permutation_every_row
+          (memSegmentOfTableData table) (memPermutationOfTableData table)
+          (memOfTableData table) idx.val := by
+    intro idx
+    apply (generatedTransition_iff_canonicalTableData table h_component idx).mp
+    simpa only [h_component, ZiskFv.AirsClean.Mem.componentWithDualMemBus] using
+      h_transitions idx
+  refine ⟨?_, ?_⟩
+  · intro idx
+    have h_mem : table.table.get idx ∈ table.table :=
+      List.mem_iff_get.mpr ⟨idx, rfl⟩
+    have h_holds : table.component.operations.ConstraintsHold
+        (table.environment (table.table.get idx)) :=
+      h_constraints (table.table.get idx) h_mem
+    rw [h_component] at h_holds
+    have h_spec :=
+      ZiskFv.AirsClean.Mem.spec_of_componentWithDualMemBus_constraints
+        (table.environment (table.table.get idx)) h_holds
+    have h_row_spec : ZiskFv.AirsClean.Mem.Spec
+        (ZiskFv.AirsClean.Mem.rowAt (memOfTableData table) idx.val) := by
+      rw [rowAt_memOfTableData table idx]
+      exact h_spec
+    have h_core : ZiskFv.Airs.Mem.core_every_row (memOfTableData table) idx.val := by
+      simpa [ZiskFv.Airs.Mem.core_every_row, ZiskFv.AirsClean.Mem.Spec,
+        ZiskFv.AirsClean.Mem.rowAt] using h_row_spec
+    let transitionIdx : Fin table.length := ⟨idx.val, by
+      simpa only [Table.table_length] using idx.isLt⟩
+    exact ZiskFv.Airs.Mem.segment_every_row_of_core_and_residual
+      h_core (transitionFacts transitionIdx).1
+  · intro idx
+    let transitionIdx : Fin table.length := ⟨idx.val, by
+      simpa only [Table.table_length] using idx.isLt⟩
+    exact (transitionFacts transitionIdx).2
 
 /-- Type-level package for raw generated Mem facts.
 
@@ -1270,6 +1461,55 @@ theorem memTableGeneratedFixedColumnFacts_of_segmentWithFixedL1
     intro idx h_pos
     have h_ne : idx.val ≠ 0 := Nat.ne_of_gt h_pos
     simp [h_ne]
+
+/-- Derive the Mem `SEGMENT_L1` shape from the component-owned fixed schema.
+
+    `Table.index_lt_fixed_capacity` consumes the table carrier's intrinsic
+    `fixed_domain` invariant, so a concrete materialized row cannot observe a
+    periodic wraparound. The fact is therefore derived data, not a
+    caller-supplied replay certificate. -/
+theorem memTableGeneratedFixedColumnFacts_of_component_fixedColumns
+    (table : Table FGL)
+    (h_component :
+      table.component = ZiskFv.AirsClean.Mem.componentWithDualMemBus) :
+    MemTableGeneratedFixedColumnFacts table (memSegmentOfTableData table) := by
+  cases table with
+  | mk component rawRows data raw_uniform_width fixed_domain =>
+    change component = ZiskFv.AirsClean.Mem.componentWithDualMemBus at h_component
+    subst component
+    let table : Table FGL :=
+      { component := ZiskFv.AirsClean.Mem.componentWithDualMemBus
+        rawRows := rawRows
+        data := data
+        raw_uniform_width := raw_uniform_width
+        fixed_domain := fixed_domain }
+    change MemTableGeneratedFixedColumnFacts table (memSegmentOfTableData table)
+    have h_columns :
+        table.component.fixedColumns = some ZiskFv.AirsClean.Mem.memFixedColumns := by
+      rfl
+    have h_fixed_at : ∀ slot row : Nat,
+        table.fixedAt slot row = ZiskFv.AirsClean.Mem.memFixedColumns.fixedAt slot row := by
+      intro slot row
+      exact Table.fixedAt_of_fixedColumns table ZiskFv.AirsClean.Mem.memFixedColumns
+        h_columns slot row
+    refine ⟨?_, ?_⟩
+    · intro _h_nonempty
+      change table.fixedAt ZiskFv.AirsClean.Mem.MemFixedColumn.segmentL1 0 = 1
+      rw [h_fixed_at]
+      rfl
+    · intro idx h_pos
+      change table.fixedAt ZiskFv.AirsClean.Mem.MemFixedColumn.segmentL1 idx.val = 0
+      rw [h_fixed_at]
+      have h_idx : idx.val < ZiskFv.AirsClean.Mem.memFixedColumns.capacity :=
+        Table.index_lt_fixed_capacity table ZiskFv.AirsClean.Mem.memFixedColumns h_columns
+          ⟨idx.val, by simpa only [Table.table_length] using idx.isLt⟩
+      change (if idx.val % ZiskFv.AirsClean.Mem.memFixedCapacity = 0 then 1 else 0) = 0
+      have h_idx_capacity : idx.val < ZiskFv.AirsClean.Mem.memFixedCapacity := by
+        simpa [ZiskFv.AirsClean.Mem.memFixedColumns] using h_idx
+      have h_mod_ne : idx.val % ZiskFv.AirsClean.Mem.memFixedCapacity ≠ 0 := by
+        rw [Nat.mod_eq_of_lt h_idx_capacity]
+        exact Nat.ne_of_gt h_pos
+      simp [h_mod_ne]
 
 /-- Typed Lean target for the Mem AIR facts source reported by
     `pil-extract mem-air-facts`.

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/TimelineEvidence.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/TimelineEvidence.lean
@@ -385,12 +385,10 @@ theorem previous_activeMemReplayEntry_timestamp_le_current_primary_of_fullWitnes
     entry.timestamp.toNat ≤
       (memPrimaryReplayEntryOfRow
         (ZiskFv.AirsClean.Mem.rowAt h_bridge.mem idx.val)).timestamp.toNat := by
-  have h_fixed :=
-    memTableGeneratedFixedColumnFacts_of_segmentWithFixedL1 h_bridge.table h_bridge.segment
   exact
     previous_activeMemReplayEntry_timestamp_le_current_primary_of_same_addr_memTableGeneratedRowsBridge
       h_bridge.generatedRows h_bridge.rowRanges idx h_same_addr
-      (h_fixed.segmentL1_nonfirst idx h_idx_pos) h_entry
+      (h_bridge.fixedColumns.segmentL1_nonfirst idx h_idx_pos) h_entry
 
 /-- The previous generated Mem row's primary timestamp is chronologically no
 later than the current primary timestamp at a non-boundary same-address row.
@@ -706,7 +704,7 @@ theorem prior_activeMemReplayEntry_timestamp_le_current_primary_of_fullWitnessMe
   exact
     prior_activeMemReplayEntry_timestamp_le_current_primary_of_same_addr_memTableGeneratedRowsBridge
       h_bridge.generatedRows h_bridge.rowRanges
-      (memTableGeneratedFixedColumnFacts_of_segmentWithFixedL1 h_bridge.table h_bridge.segment)
+      h_bridge.fixedColumns
       priorIdx selectedIdx h_prior_lt h_addr_eq h_entry
 
 /-- Active replay entries from a strictly earlier generated Mem row at the same
@@ -759,7 +757,7 @@ theorem prior_activeMemReplayEntry_timestamp_le_activeMemReplayEntry_of_fullWitn
   exact
     prior_activeMemReplayEntry_timestamp_le_activeMemReplayEntry_of_same_addr_memTableGeneratedRowsBridge
       h_bridge.generatedRows h_bridge.rowRanges
-      (memTableGeneratedFixedColumnFacts_of_segmentWithFixedL1 h_bridge.table h_bridge.segment)
+      h_bridge.fixedColumns
       priorIdx selectedIdx h_prior_lt h_addr_eq h_prior_entry h_selected_entry
 
 /-- The active replay projection of a generated Mem table is chronologically
@@ -847,7 +845,7 @@ theorem activeMemReplayRows_pairwise_timestamp_toNat_le_of_same_ptr_of_fullWitne
   rw [h_bridge.rows_eq]
   exact activeMemReplayRowsOfTable_pairwise_timestamp_toNat_le_of_same_ptr
     h_bridge.generatedRows h_bridge.rowRanges
-    (memTableGeneratedFixedColumnFacts_of_segmentWithFixedL1 h_bridge.table h_bridge.segment)
+    h_bridge.fixedColumns
 
 /-- At a selected address-change row, every prior table row has a different
     Mem address.
@@ -2289,14 +2287,14 @@ def acceptedMemoryReplayEvidence_of_fullWitnessMemReplayBridge
   acceptedMemoryReplayEvidence_of_memTableGeneratedRowsBridge_segmentRangeFacts
     (table := h_bridge.table)
     (mem := h_bridge.mem)
-    (segment := segmentWithFixedL1 h_bridge.segment)
+    (segment := h_bridge.segment)
     (permutation := h_bridge.permutation)
     (rowCount := h_bridge.rowCount)
     h_bridge.rows_eq
     h_bridge.generatedRows
     h_bridge.rowRanges
     h_bridge.segmentRanges
-    (memTableGeneratedFixedColumnFacts_of_segmentWithFixedL1 h_bridge.table h_bridge.segment)
+    h_bridge.fixedColumns
     h_bridge.nonempty
 
 @[simp]

--- a/ZiskFv/AirsClean/Main/Circuit.lean
+++ b/ZiskFv/AirsClean/Main/Circuit.lean
@@ -712,12 +712,170 @@ def pcHandshakeBetween (prev curr : MainRowWithRom FGL) : Prop :=
         + (1 - prev.core.set_pc) * (prev.core.pc + prev.core.jmp_offset2)
         + prev.core.flag * (prev.core.jmp_offset1 - prev.core.jmp_offset2))) = 0
 
+/-- ZisK instantiates both the Main witness and fixed traces over this physical
+    domain (`zisk/pil/src/pil_helpers/traces.rs:273-282`). -/
+def mainFixedCapacity : Nat := 4194304
+
+/-- Map the 43 effective `MainRowWithRom` slots to 41 raw witness slots plus
+    the two physical fixed columns. The flattened `ProvableStruct` order is
+    `core.segment_l1` at slot 17 and `rom.main_step` at slot 37. -/
+private def mainFixedLayout (slot : Fin 43) : Sum (Fin 41) (Fin 2) :=
+  if h_segment_l1 : slot.val = 17 then
+    .inr ⟨0, by omega⟩
+  else if h_main_step : slot.val = 37 then
+    .inr ⟨1, by omega⟩
+  else
+    .inl
+      ⟨slot.val - (if 17 < slot.val then 1 else 0) -
+          (if 37 < slot.val then 1 else 0), by
+        split <;> split <;> omega⟩
+
+/-- Main's two fixed columns for the currently modeled segment: `SEGMENT_L1`
+    is `[1, 0, ...]`, and the modeled `main_step` is `SEGMENT_STEP = [0..N-1]`.
+    The latter is the segment-zero specialization of `STEP` from `main.pil:90`,
+    matching the existing single-segment accepted-trace model. -/
+private def mainFixedValues (slot : Fin 2) (row : Fin mainFixedCapacity) : FGL :=
+  if slot.val = 0 then
+    if row.val = 0 then 1 else 0
+  else
+    (row.val : FGL)
+
+/-- Component-owned Main fixed schema. `IndexedFixedColumns.fixedAt` supplies
+    physical-domain periodic access, while `Table.fixed_domain` bounds every
+    materialized Main prefix by this capacity. -/
+def mainFixedColumns : IndexedFixedColumns FGL 41 where
+  capacity := mainFixedCapacity
+  capacity_pos := by decide
+  effectiveWidth := 43
+  fixedWidth := 2
+  layout := mainFixedLayout
+  values := mainFixedValues
+
+/-- The 41 raw witness cells of a Main row, omitting the component-owned
+    `SEGMENT_L1` and `main_step` fixed cells at effective slots 17 and 37. -/
+def mainRawRow (row : MainRowWithRom FGL) : Array FGL :=
+  #[row.core.a_0, row.core.a_1, row.core.b_0, row.core.b_1, row.core.c_0,
+    row.core.c_1, row.core.flag, row.core.pc, row.core.is_external_op,
+    row.core.op, row.core.m32, row.core.ind_width, row.core.set_pc,
+    row.core.jmp_offset1, row.core.jmp_offset2, row.core.store_pc,
+    row.core.im_high_degree_2,
+    row.rom.a_offset_imm0, row.rom.a_imm1, row.rom.b_offset_imm0,
+    row.rom.b_imm1, row.rom.store_offset, row.rom.a_src_imm,
+    row.rom.a_src_mem, row.rom.is_precompiled, row.rom.b_src_imm,
+    row.rom.b_src_mem, row.rom.store_mem, row.rom.store_ind,
+    row.rom.b_src_ind, row.rom.a_src_reg, row.rom.b_src_reg,
+    row.rom.store_reg, row.rom.addr0, row.rom.addr1, row.rom.addr2,
+    row.rom.a_reg_prev_mem_step, row.rom.b_reg_prev_mem_step,
+    row.rom.store_reg_prev_mem_step, row.rom.store_reg_prev_value_0,
+    row.rom.store_reg_prev_value_1]
+
+@[simp] theorem mainRawRow_size (row : MainRowWithRom FGL) : (mainRawRow row).size = 41 := by
+  simp [mainRawRow]
+
+/-- The materialized raw Main prefix reconstructs its core component, with
+    `SEGMENT_L1` supplied solely by the component-owned fixed schema. -/
+private theorem eval_mainRawRow_core_materialize
+    (index : Nat) (data : ProverData FGL) (row : MainRowWithRom FGL)
+    (h_segment_l1 : row.core.segment_l1 = mainFixedColumns.fixedAt 0 index) :
+    Eval.eval
+      (Environment.fromArray (mainFixedColumns.materialize index (mainRawRow row)) data)
+      (varFromOffset (F := FGL) MainRow 0) = row.core := by
+  rw [ProvableStruct.eval_eq_eval, ProvableStruct.varFromOffset_eq_varFromOffset]
+  unfold ProvableStruct.eval ProvableStruct.varFromOffset
+  simp only [instProvableStructMainRow, ProvableStruct.eval.go,
+    ProvableStruct.varFromOffset.go, ProvableType.eval_field,
+    ProvableType.varFromOffset_field, Expression.eval, Nat.zero_add]
+  cases row with
+  | mk core rom =>
+    cases core with
+    | mk a_0 a_1 b_0 b_1 c_0 c_1 flag pc is_external_op op m32 ind_width set_pc
+        jmp_offset1 jmp_offset2 store_pc im_high_degree_2 segment_l1 =>
+      change segment_l1 = mainFixedColumns.fixedAt 0 index at h_segment_l1
+      simp [IndexedFixedColumns.materialize, IndexedFixedColumns.fixedAt,
+        mainFixedColumns, mainFixedLayout, mainFixedValues, mainRawRow,
+        ProvableType.size]
+      simpa [IndexedFixedColumns.fixedAt, mainFixedColumns, mainFixedValues] using
+        h_segment_l1.symm
+
+/-- The materialized raw Main prefix reconstructs its ROM component, with
+    `main_step` supplied solely by the component-owned fixed schema. -/
+private theorem eval_mainRawRow_rom_materialize
+    (index : Nat) (data : ProverData FGL) (row : MainRowWithRom FGL)
+    (h_main_step : row.rom.main_step = mainFixedColumns.fixedAt 1 index) :
+    Eval.eval
+      (Environment.fromArray (mainFixedColumns.materialize index (mainRawRow row)) data)
+      (varFromOffset (F := FGL) MainRomRow 18) = row.rom := by
+  rw [ProvableStruct.eval_eq_eval, ProvableStruct.varFromOffset_eq_varFromOffset]
+  unfold ProvableStruct.eval ProvableStruct.varFromOffset
+  simp only [instProvableStructMainRomRow, ProvableStruct.eval.go,
+    ProvableStruct.varFromOffset.go, ProvableType.eval_field,
+    ProvableType.varFromOffset_field, Expression.eval]
+  cases row with
+  | mk core rom =>
+    cases rom with
+    | mk a_offset_imm0 a_imm1 b_offset_imm0 b_imm1 store_offset a_src_imm a_src_mem
+        is_precompiled b_src_imm b_src_mem store_mem store_ind b_src_ind a_src_reg b_src_reg
+        store_reg addr0 addr1 addr2 main_step a_reg_prev_mem_step b_reg_prev_mem_step
+        store_reg_prev_mem_step store_reg_prev_value_0 store_reg_prev_value_1 =>
+      change main_step = mainFixedColumns.fixedAt 1 index at h_main_step
+      simp [IndexedFixedColumns.materialize, IndexedFixedColumns.fixedAt,
+        mainFixedColumns, mainFixedLayout, mainFixedValues, mainRawRow,
+        ProvableType.size]
+      simpa [IndexedFixedColumns.fixedAt, mainFixedColumns, mainFixedValues] using
+        h_main_step.symm
+
+/-- Materializing `mainRawRow` reconstructs the original Main row when its two
+    fixed cells agree with the component-owned fixed schema. -/
+theorem eval_mainRawRow_materialize
+    (index : Nat) (data : ProverData FGL) (row : MainRowWithRom FGL)
+    (h_segment_l1 : row.core.segment_l1 = mainFixedColumns.fixedAt 0 index)
+    (h_main_step : row.rom.main_step = mainFixedColumns.fixedAt 1 index) :
+    Eval.eval
+      (Environment.fromArray (mainFixedColumns.materialize index (mainRawRow row)) data)
+      (varFromOffset (F := FGL) MainRowWithRom 0) = row := by
+  have h_core := eval_mainRawRow_core_materialize index data row h_segment_l1
+  have h_rom := eval_mainRawRow_rom_materialize index data row h_main_step
+  rw [ProvableStruct.eval_eq_eval, ProvableStruct.varFromOffset_eq_varFromOffset]
+  change
+    { core := Eval.eval
+        (Environment.fromArray (mainFixedColumns.materialize index (mainRawRow row)) data)
+        (varFromOffset (F := FGL) MainRow 0)
+      rom := Eval.eval
+        (Environment.fromArray (mainFixedColumns.materialize index (mainRawRow row)) data)
+        (varFromOffset (F := FGL) MainRomRow 18) } = row
+  cases row
+  simp_all
+
+/-- Adapt Main's generated predecessor/current PC equation to Clean's
+    right-indexed transition API. The index is carried by the table contract;
+    this equation reads only the effective predecessor and current rows. At row
+    zero Clean saturates the predecessor to the current row, and the materialized
+    `SEGMENT_L1 = 1` gate makes the equation vacuous as in the PIL. -/
+def pcHandshakeTransition (_index : Nat) (prev curr : Environment FGL) : Prop :=
+  pcHandshakeBetween
+    (Eval.eval prev (varFromOffset (F := FGL) MainRowWithRom 0))
+    (Eval.eval curr (varFromOffset (F := FGL) MainRowWithRom 0))
+
 /-- Unified Main component used by the T7 full ensemble. -/
 def componentWithRomMemAndOpBus
     (length : ℕ) (program : Program length) :
     Air.Flat.Component FGL :=
   { circuit := circuitWithRomMemAndOpBus length program
-    transition := pcHandshakeBetween }
+    rawWidth := 41
+    fixedColumns := some mainFixedColumns
+    transition := pcHandshakeTransition }
+
+/-- The live Main component decodes a materialized raw row without any
+    caller-supplied representation equality. -/
+theorem componentWithRomMemAndOpBus_rowInput_materialize
+    (length : Nat) (program : Program length) (index : Nat) (data : ProverData FGL)
+    (row : MainRowWithRom FGL)
+    (h_segment_l1 : row.core.segment_l1 = mainFixedColumns.fixedAt 0 index)
+    (h_main_step : row.rom.main_step = mainFixedColumns.fixedAt 1 index) :
+    (componentWithRomMemAndOpBus length program).rowInput
+      (Environment.fromArray (mainFixedColumns.materialize index (mainRawRow row)) data) = row := by
+  simpa only [Component.rowInput, eval_varFromOffset_valueFromOffset] using
+    eval_mainRawRow_materialize index data row h_segment_l1 h_main_step
 
 /-- Project the generic Clean component `Spec` for the unified
     ROM/memory/op-bus Main component to the concrete Main-row `Spec`. -/

--- a/ZiskFv/AirsClean/Mem/Circuit.lean
+++ b/ZiskFv/AirsClean/Mem/Circuit.lean
@@ -1,4 +1,5 @@
 import ZiskFv.AirsClean.Mem.Constraints
+import ZiskFv.AirsClean.Mem.GeneratedTransition
 import ZiskFv.AirsClean.Mem.Soundness
 import ZiskFv.AirsClean.CompletenessHelpers
 import Clean.Air.FlatComponent
@@ -246,7 +247,20 @@ def circuitWithDualMemBus : GeneralFormalCircuit FGL MemRow unit :=
 
 /-- Mem as a Clean `Air.Flat.Component` exposing both primary and dual
     memory-bus provider emissions. -/
-def componentWithDualMemBus : Air.Flat.Component FGL := { circuit := circuitWithDualMemBus }
+def componentWithDualMemBus : Air.Flat.Component FGL :=
+  { circuit := circuitWithDualMemBus
+    rawWidth := 13
+    fixedColumns := some memFixedColumns
+    transition := generatedTransition memFixedColumns }
+
+/-- The live dual-Mem component decodes a materialized raw Mem row directly;
+    the appended fixed cells do not create an input-side premise. -/
+theorem componentWithDualMemBus_rowInput_materialize
+    (index : Nat) (data : ProverData FGL) (row : MemRow FGL) :
+    componentWithDualMemBus.rowInput
+      (Environment.fromArray (memFixedColumns.materialize index (memRawRow row)) data) = row := by
+  simpa only [Component.rowInput, eval_varFromOffset_valueFromOffset] using
+    eval_memRawRow_materialize index data row
 
 /-- Project the live dual-Mem static lookups to the row-level range facts they
     mirror in `mem.pil:384-385,397`. -/
@@ -260,6 +274,49 @@ theorem dualMemRowRangeFacts_of_componentWithDualMemBus_constraints
     componentWithDualMemBus.rowInputVar componentWithDualMemBus.rowOffset env (by
       simpa only [componentWithDualMemBus, circuitWithDualMemBus,
         Component.rowOperations] using h_row)
+
+/-- Project the nine row-local Mem equations from the live dual-Mem component.
+    The generated cross-row equations are supplied separately by this same
+    component's indexed transition. -/
+theorem spec_of_componentWithDualMemBus_constraints
+    (env : Environment FGL)
+    (h_holds : componentWithDualMemBus.operations.ConstraintsHold env) :
+    Spec (eval env componentWithDualMemBus.rowInputVar) := by
+  have h_row : componentWithDualMemBus.rowOperations.ConstraintsHold env :=
+    (Component.constraintsHold_iff (component := componentWithDualMemBus) env).mp h_holds
+  have h_mem : Operations.ConstraintsHold env
+      ((memWithDualMemBus componentWithDualMemBus.rowInputVar).operations
+      componentWithDualMemBus.rowOffset) := by
+    simpa only [componentWithDualMemBus, circuitWithDualMemBus,
+      memWithDualMemBusElaborated, Component.rowOperations] using h_row
+  generalize h_input : componentWithDualMemBus.rowInputVar = row at h_mem ⊢
+  simp only [memWithDualMemBus, main, rowRangeLookups,
+    gatedDualStepDeltaRangeLookup, MemBusChannel, circuit_norm] at h_mem
+  cases row with
+  | mk addr step sel addr_changes step_dual sel_dual value_0 value_1 wr previous_step
+      increment_0 increment_1 read_same_addr =>
+    simp only [Spec, ProvableStruct.eval_eq_eval, ProvableStruct.eval,
+      ProvableStruct.fromComponents, ProvableStruct.components,
+      ProvableStruct.toComponents, ProvableStruct.eval.go, ProvableType.eval_field] at *
+    exact
+      ⟨ by simpa [Expression.eval, sub_eq_add_neg] using
+          h_mem.1 (sel_dual * (1 - sel_dual)) (by simp)
+      , by simpa [Expression.eval, sub_eq_add_neg] using
+          h_mem.1 ((1 - sel) * sel_dual) (by simp)
+      , by simpa [Expression.eval, sub_eq_add_neg] using
+          h_mem.1 (sel * (1 - sel)) (by simp)
+      , by simpa [Expression.eval, sub_eq_add_neg] using
+          h_mem.1 (addr_changes * (1 - addr_changes)) (by simp)
+      , by simpa [Expression.eval, sub_eq_add_neg] using
+          h_mem.1 (wr * (1 - wr)) (by simp)
+      , by simpa [Expression.eval, sub_eq_add_neg] using
+          h_mem.1 (wr * (1 - sel)) (by simp)
+      , by simpa [Expression.eval, sub_eq_add_neg] using
+          h_mem.1 (read_same_addr - (1 - addr_changes) * (1 - wr)) (by simp)
+      , by simpa [Expression.eval, sub_eq_add_neg] using
+          h_mem.1 ((addr_changes * (1 - wr)) * value_0) (by simp)
+      , by simpa [Expression.eval, sub_eq_add_neg] using
+          h_mem.1 ((addr_changes * (1 - wr)) * value_1) (by simp) ⟩
 
 theorem eval_memRow_sel
     (env : Environment FGL) (row : Var MemRow FGL) :

--- a/ZiskFv/AirsClean/Mem/GeneratedTransition.lean
+++ b/ZiskFv/AirsClean/Mem/GeneratedTransition.lean
@@ -1,0 +1,145 @@
+import Clean.Air.FlatComponent
+import ZiskFv.Airs.Mem
+import ZiskFv.AirsClean.Mem.Row
+import ZiskFv.AirsClean.Mem.SidecarColumns
+
+/-!
+# Live generated Mem transition
+
+The local Mem component owns constraints 3--8, 18, 21, and 23. This module
+places the remaining generated Mem equations in the same component's indexed
+transition, using only the transition's predecessor/current environments, the
+shared `ProverData`, and component-owned physical fixed columns.
+-/
+
+namespace ZiskFv.AirsClean.Mem
+
+open Goldilocks
+open Air.Flat
+
+/-- ZisK's Mem witness and fixed traces have one physical `2^22`-row domain. -/
+def memFixedCapacity : Nat := 4194304
+
+/-- Map the 15 effective Mem slots to the 13 raw witness slots followed by
+`SEGMENT_L1` and `__L1__`. -/
+private def memFixedLayout (slot : Fin 15) : Sum (Fin 13) (Fin 2) :=
+  if h_raw : slot.val < 13 then
+    .inl ⟨slot.val, h_raw⟩
+  else if h_segment_l1 : slot.val = 13 then
+    .inr ⟨0, by decide⟩
+  else
+    .inr ⟨1, by decide⟩
+
+/-- Both fixed selectors are `[1, 0, ...]` over the physical Mem domain. -/
+private def memFixedValues (_slot : Fin 2) (row : Fin memFixedCapacity) : FGL :=
+  if row.val = 0 then 1 else 0
+
+/-- Component-owned physical Mem fixed schema. `fixedAt` rotates by its actual
+domain, while `Table.fixed_domain` prevents a materialized table from wrapping. -/
+def memFixedColumns : IndexedFixedColumns FGL 13 where
+  capacity := memFixedCapacity
+  capacity_pos := by decide
+  effectiveWidth := 15
+  fixedWidth := 2
+  layout := memFixedLayout
+  values := memFixedValues
+
+/-- Tiny physical-domain regression for indexed fixed columns. The value at
+    row three wraps to row zero of the schema's three-row domain; it does not
+    depend on a table prefix length. -/
+private def smallRotationRegressionColumns : IndexedFixedColumns FGL 0 where
+  capacity := 3
+  capacity_pos := by decide
+  effectiveWidth := 1
+  fixedWidth := 1
+  layout := fun _ => .inr ⟨0, by decide⟩
+  values := fun _ row => if row.val = 0 then 1 else 0
+
+/-- The indexed fixed-column facility preserves physical-domain rotation on a
+    small schema. `Table.fixed_domain` separately prevents a materialized
+    witness prefix from relying on this wrap. -/
+theorem indexedFixedColumns_smallDomain_rotation_regression :
+    smallRotationRegressionColumns.fixedAt 0 3 = 1 ∧
+      smallRotationRegressionColumns.fixedAt 0 2 = 0 := by
+  constructor <;> rfl
+
+/-- Materialization preserves every raw Mem witness slot; the two
+    component-owned fixed cells are appended after this 13-cell prefix. -/
+theorem memFixedColumns_materialize_raw
+    (index : Nat) (raw : Array FGL) (slot : Fin 13) :
+    (memFixedColumns.materialize index raw)[slot.val]'(by
+      change slot.val < 15
+      omega) = raw.getD slot.val 0 := by
+  simp [IndexedFixedColumns.materialize, memFixedColumns, memFixedLayout]
+
+/-- The 13 raw witness cells of a Mem row. The component-owned fixed columns
+    are appended after this exact AIR witness layout. -/
+def memRawRow (row : MemRow FGL) : Array FGL :=
+  #[row.addr, row.step, row.sel, row.addr_changes, row.step_dual, row.sel_dual,
+    row.value_0, row.value_1, row.wr, row.previous_step, row.increment_0,
+    row.increment_1, row.read_same_addr]
+
+@[simp] theorem memRawRow_size (row : MemRow FGL) : (memRawRow row).size = 13 := by
+  simp [memRawRow]
+
+/-- Materializing a raw Mem row preserves its thirteen witness cells; the
+    component-owned fixed cells are outside the `MemRow` input layout. -/
+theorem eval_memRawRow_materialize
+    (index : Nat) (data : ProverData FGL) (row : MemRow FGL) :
+    Eval.eval
+      (Environment.fromArray (memFixedColumns.materialize index (memRawRow row)) data)
+      (varFromOffset (F := FGL) MemRow 0) = row := by
+  rw [ProvableStruct.eval_eq_eval, ProvableStruct.varFromOffset_eq_varFromOffset]
+  unfold ProvableStruct.eval ProvableStruct.varFromOffset
+  simp only [instProvableStructMemRow, ProvableStruct.eval.go,
+    ProvableStruct.varFromOffset.go, ProvableType.eval_field,
+    ProvableType.varFromOffset_field, Expression.eval, Nat.zero_add]
+  cases row with
+  | mk addr step sel addr_changes step_dual sel_dual value_0 value_1 wr previous_step
+      increment_0 increment_1 read_same_addr =>
+    simp [IndexedFixedColumns.materialize, memFixedColumns, memFixedLayout, memRawRow,
+      ProvableType.size]
+
+/-- Decode the 13 raw Mem witness cells from an effective transition environment. -/
+@[reducible]
+def memRowFromEnvironment (env : Environment FGL) : MemRow FGL :=
+  Eval.eval env (varFromOffset (F := FGL) MemRow 0)
+
+/-- The generated equations at `index` use only that row and its saturated
+predecessor. Every other request is therefore the predecessor row; the named
+AIR formulas only request `index` or `index - 1`. -/
+@[reducible]
+def memWindow (index : Nat) (previous current : Environment FGL) :
+    ZiskFv.Airs.Mem.Valid_Mem FGL FGL :=
+  let rowAt := fun row => if row = index then memRowFromEnvironment current else
+    memRowFromEnvironment previous
+  { addr := fun row => (rowAt row).addr
+    step := fun row => (rowAt row).step
+    sel := fun row => (rowAt row).sel
+    addr_changes := fun row => (rowAt row).addr_changes
+    step_dual := fun row => (rowAt row).step_dual
+    sel_dual := fun row => (rowAt row).sel_dual
+    value_0 := fun row => (rowAt row).value_0
+    value_1 := fun row => (rowAt row).value_1
+    wr := fun row => (rowAt row).wr
+    previous_step := fun row => (rowAt row).previous_step
+    increment_0 := fun row => (rowAt row).increment_0
+    increment_1 := fun row => (rowAt row).increment_1
+    read_same_addr := fun row => (rowAt row).read_same_addr
+    gsum := memSidecarGsumOfProverData current.data
+    im_0 := memSidecarIm0OfProverData current.data
+    im_1 := memSidecarIm1OfProverData current.data }
+
+/-- All non-local generated Mem equations at one row, sourced from canonical
+live data and the component's fixed schema. -/
+def generatedTransition (columns : IndexedFixedColumns FGL 13)
+    (index : Nat) (previous current : Environment FGL) : Prop :=
+  let mem := memWindow index previous current
+  let segment := memSegmentColumnsOfProverDataAndFixed current.data
+    (fun row => columns.fixedAt MemFixedColumn.segmentL1 row)
+  let permutation := memPermutationColumnsOfProverDataAndFixed current.data
+    (fun row => columns.fixedAt MemFixedColumn.l1 row)
+  ZiskFv.Airs.Mem.segmentResidualEveryRow segment mem index
+    ∧ ZiskFv.Airs.Mem.permutation_every_row segment permutation mem index
+
+end ZiskFv.AirsClean.Mem

--- a/ZiskFv/AirsClean/Mem/SidecarColumns.lean
+++ b/ZiskFv/AirsClean/Mem/SidecarColumns.lean
@@ -1,0 +1,160 @@
+import Clean.Circuit.Expression
+import ZiskFv.Airs.Mem
+
+/-!
+# Mem sidecar column accessors
+
+Low-level decoding of the Mem AIR's stage-2 and scalar sidecar data.  This
+module deliberately depends only on Clean's prover-data carrier and the named
+Mem AIR types, so the live Mem component can use the same source without an
+import cycle through the full-ensemble balance layer.
+-/
+
+namespace ZiskFv.AirsClean.Mem
+
+open Goldilocks
+
+/-! `ProverData` keys for generated Mem sidecar columns. Each key stores a
+one-column array (`n = 1`); row zero supplies scalars and row indices supply
+table columns. -/
+namespace MemRawSidecarDataKey
+
+abbrev gsum : String := "Mem.sidecar.gsum"
+abbrev im0 : String := "Mem.sidecar.im0"
+abbrev im1 : String := "Mem.sidecar.im1"
+
+namespace Segment
+
+abbrev segmentId : String := "Mem.sidecar.segment.segment_id"
+abbrev isFirstSegment : String := "Mem.sidecar.segment.is_first_segment"
+abbrev isLastSegment : String := "Mem.sidecar.segment.is_last_segment"
+abbrev previousSegmentValue0 : String := "Mem.sidecar.segment.previous_segment_value_0"
+abbrev previousSegmentValue1 : String := "Mem.sidecar.segment.previous_segment_value_1"
+abbrev previousSegmentStep : String := "Mem.sidecar.segment.previous_segment_step"
+abbrev previousSegmentAddr : String := "Mem.sidecar.segment.previous_segment_addr"
+abbrev segmentLastValue0 : String := "Mem.sidecar.segment.segment_last_value_0"
+abbrev segmentLastValue1 : String := "Mem.sidecar.segment.segment_last_value_1"
+abbrev segmentLastStep : String := "Mem.sidecar.segment.segment_last_step"
+abbrev segmentLastAddr : String := "Mem.sidecar.segment.segment_last_addr"
+abbrev distanceBase0 : String := "Mem.sidecar.segment.distance_base_0"
+abbrev distanceBase1 : String := "Mem.sidecar.segment.distance_base_1"
+abbrev distanceEnd0 : String := "Mem.sidecar.segment.distance_end_0"
+abbrev distanceEnd1 : String := "Mem.sidecar.segment.distance_end_1"
+abbrev segmentL1 : String := "Mem.sidecar.segment.segment_l1"
+
+end Segment
+
+namespace Permutation
+
+abbrev stdAlpha : String := "Mem.sidecar.permutation.std_alpha"
+abbrev stdGamma : String := "Mem.sidecar.permutation.std_gamma"
+abbrev l1 : String := "Mem.sidecar.permutation.l1"
+abbrev imDirect0 : String := "Mem.sidecar.permutation.im_direct_0"
+abbrev imDirect1 : String := "Mem.sidecar.permutation.im_direct_1"
+abbrev imDirect2 : String := "Mem.sidecar.permutation.im_direct_2"
+abbrev imDirect3 : String := "Mem.sidecar.permutation.im_direct_3"
+abbrev imDirect4 : String := "Mem.sidecar.permutation.im_direct_4"
+abbrev imDirect5 : String := "Mem.sidecar.permutation.im_direct_5"
+
+end Permutation
+
+end MemRawSidecarDataKey
+
+/-! Fixed-column slots in the component-owned Mem schema. `SEGMENT_L1` and
+`__L1__` are physical fixed columns, not prover-data sidecars. -/
+namespace MemFixedColumn
+
+abbrev segmentL1 : Nat := 0
+abbrev l1 : Nat := 1
+
+end MemFixedColumn
+
+/-- Read one field element from a one-column `ProverData` array. Missing keys
+or out-of-range rows default to zero, matching Clean's `Environment.fromArray`
+convention for absent witness cells. -/
+@[reducible]
+def proverDataColumn (data : ProverData FGL) (key : String) (row : Nat) : FGL :=
+  match (data key 1)[row]? with
+  | some values => values[0]
+  | none => 0
+
+/-- Read a scalar sidecar value from row zero of a one-column `ProverData`
+array. -/
+@[reducible]
+def proverDataScalar (data : ProverData FGL) (key : String) : FGL :=
+  proverDataColumn data key 0
+
+@[reducible]
+def memSidecarGsumOfProverData (data : ProverData FGL) : Nat -> FGL :=
+  proverDataColumn data MemRawSidecarDataKey.gsum
+
+@[reducible]
+def memSidecarIm0OfProverData (data : ProverData FGL) : Nat -> FGL :=
+  proverDataColumn data MemRawSidecarDataKey.im0
+
+@[reducible]
+def memSidecarIm1OfProverData (data : ProverData FGL) : Nat -> FGL :=
+  proverDataColumn data MemRawSidecarDataKey.im1
+
+/-- Segment sidecar columns decoded from shared prover data, with
+`SEGMENT_L1` supplied by the component-owned fixed schema. -/
+@[reducible]
+def memSegmentColumnsOfProverDataAndFixed
+    (data : ProverData FGL) (segmentL1 : Nat -> FGL) :
+    ZiskFv.Airs.Mem.SegmentColumns FGL where
+  segment_id := proverDataScalar data MemRawSidecarDataKey.Segment.segmentId
+  is_first_segment := proverDataScalar data MemRawSidecarDataKey.Segment.isFirstSegment
+  is_last_segment := proverDataScalar data MemRawSidecarDataKey.Segment.isLastSegment
+  previous_segment_value_0 :=
+    proverDataScalar data MemRawSidecarDataKey.Segment.previousSegmentValue0
+  previous_segment_value_1 :=
+    proverDataScalar data MemRawSidecarDataKey.Segment.previousSegmentValue1
+  previous_segment_step := proverDataScalar data MemRawSidecarDataKey.Segment.previousSegmentStep
+  previous_segment_addr := proverDataScalar data MemRawSidecarDataKey.Segment.previousSegmentAddr
+  segment_last_value_0 := proverDataScalar data MemRawSidecarDataKey.Segment.segmentLastValue0
+  segment_last_value_1 := proverDataScalar data MemRawSidecarDataKey.Segment.segmentLastValue1
+  segment_last_step := proverDataScalar data MemRawSidecarDataKey.Segment.segmentLastStep
+  segment_last_addr := proverDataScalar data MemRawSidecarDataKey.Segment.segmentLastAddr
+  distance_base_0 := proverDataScalar data MemRawSidecarDataKey.Segment.distanceBase0
+  distance_base_1 := proverDataScalar data MemRawSidecarDataKey.Segment.distanceBase1
+  distance_end_0 := proverDataScalar data MemRawSidecarDataKey.Segment.distanceEnd0
+  distance_end_1 := proverDataScalar data MemRawSidecarDataKey.Segment.distanceEnd1
+  segment_l1 := segmentL1
+
+/-- Permutation/direct-update sidecar columns decoded from shared prover data,
+with `__L1__` supplied by the component-owned fixed schema. -/
+@[reducible]
+def memPermutationColumnsOfProverDataAndFixed
+    (data : ProverData FGL) (l1 : Nat -> FGL) :
+    ZiskFv.Airs.Mem.PermutationColumns FGL where
+  std_alpha := proverDataScalar data MemRawSidecarDataKey.Permutation.stdAlpha
+  std_gamma := proverDataScalar data MemRawSidecarDataKey.Permutation.stdGamma
+  l1 := l1
+  im_direct_0 := proverDataScalar data MemRawSidecarDataKey.Permutation.imDirect0
+  im_direct_1 := proverDataScalar data MemRawSidecarDataKey.Permutation.imDirect1
+  im_direct_2 := proverDataScalar data MemRawSidecarDataKey.Permutation.imDirect2
+  im_direct_3 := proverDataScalar data MemRawSidecarDataKey.Permutation.imDirect3
+  im_direct_4 := proverDataScalar data MemRawSidecarDataKey.Permutation.imDirect4
+  im_direct_5 := proverDataScalar data MemRawSidecarDataKey.Permutation.imDirect5
+
+/-- Legacy all-prover-data decoder retained for the existing high-level
+sidecar package. New live-component code must use
+`memSegmentColumnsOfProverDataAndFixed`. -/
+@[reducible]
+def memSegmentColumnsOfProverData
+    (data : ProverData FGL) :
+    ZiskFv.Airs.Mem.SegmentColumns FGL :=
+  memSegmentColumnsOfProverDataAndFixed data
+    (proverDataColumn data MemRawSidecarDataKey.Segment.segmentL1)
+
+/-- Legacy all-prover-data decoder retained for the existing high-level
+sidecar package. New live-component code must use
+`memPermutationColumnsOfProverDataAndFixed`. -/
+@[reducible]
+def memPermutationColumnsOfProverData
+    (data : ProverData FGL) :
+    ZiskFv.Airs.Mem.PermutationColumns FGL :=
+  memPermutationColumnsOfProverDataAndFixed data
+    (proverDataColumn data MemRawSidecarDataKey.Permutation.l1)
+
+end ZiskFv.AirsClean.Mem

--- a/ZiskFv/Compliance/AcceptedZiskTrace.lean
+++ b/ZiskFv/Compliance/AcceptedZiskTrace.lean
@@ -37,19 +37,6 @@ constructions) is built relative to one of these.
 
 namespace ZiskFv.Compliance
 
-@[reducible]
-def acceptedMemReplayMem
-    (table : Air.Flat.Table FGL)
-    (gsum im0 im1 : ℕ → FGL) :
-    ZiskFv.Airs.Mem.Valid_Mem FGL FGL :=
-  ZiskFv.AirsClean.FullEnsemble.memOfTable table gsum im0 im1
-
-@[reducible]
-def acceptedMemReplayFixedSegment
-    (segment : ZiskFv.Airs.Mem.SegmentColumns FGL) :
-    ZiskFv.Airs.Mem.SegmentColumns FGL :=
-  ZiskFv.AirsClean.FullEnsemble.segmentWithFixedL1 segment
-
 /-- Objective guard for mutable-Mem replay evidence.
 
     The accepted-trace Mem replay package is meaningful exactly when the concrete witness contains
@@ -70,8 +57,9 @@ def MutableMemPresent
 /-- Fixed-column/index certificate for Main's `main_step` ROM companion column.
 
     PIL defines `STEP = main_segment * N + SEGMENT_STEP` (`main.pil:90`), with
-    `SEGMENT_STEP` the deterministic row counter. Clean models `main_step` as a
-    witness column, so accepted traces carry the row-index pin here in the same
+    `SEGMENT_STEP` the deterministic row counter. Clean now materializes
+    `main_step` as component-owned indexed fixed data. Until S1b derives and
+    deletes this temporary accepted-trace pin, it remains in the same
     fixed-column class as `segment_l1_fixed`: real traces number Main rows by
     index, and the no-wrap evidence keeps the memory timestamp offsets
     `2 + 4*i` / `3 + 4*i` in their natural Goldilocks representatives. -/
@@ -122,44 +110,32 @@ structure AcceptedZiskTrace (numInstructions : Nat) where
       table ∈ witness.allTables ∧
         table.component = ZiskFv.AirsClean.Mem.componentWithDualMemBus ∧
           0 < table.table.length }
-  /-- Guarded Mem segment source columns for the selected mutable-Mem table. -/
+  /-- Guarded legacy Mem segment source columns. HELD for S3's lifecycle audit;
+      S2 deliberately derives its live source from selected table data instead. -/
   mem_replay_segment : ∀ (_h : MutableMemPresent witness),
     ZiskFv.Airs.Mem.SegmentColumns FGL
-  /-- Guarded Mem permutation source columns for the selected mutable-Mem table. -/
+  /-- Guarded legacy Mem permutation source columns. HELD for S3's lifecycle
+      audit; S2 deliberately derives its live source from selected table data. -/
   mem_replay_permutation : ∀ (_h : MutableMemPresent witness),
     ZiskFv.Airs.Mem.PermutationColumns FGL
-  /-- Guarded Mem stage-2 `gsum` source column for the selected mutable-Mem table. -/
+  /-- Guarded legacy Mem stage-2 `gsum` source column, HELD for S3's lifecycle
+      audit and not consumed by S2's canonical derivation. -/
   mem_replay_gsum : ∀ (_h : MutableMemPresent witness), ℕ → FGL
-  /-- Guarded Mem stage-2 `im0` source column for the selected mutable-Mem table. -/
+  /-- Guarded legacy Mem stage-2 `im0` source column, HELD for S3's lifecycle
+      audit and not consumed by S2's canonical derivation. -/
   mem_replay_im0 : ∀ (_h : MutableMemPresent witness), ℕ → FGL
-  /-- Guarded Mem stage-2 `im1` source column for the selected mutable-Mem table. -/
+  /-- Guarded legacy Mem stage-2 `im1` source column, HELD for S3's lifecycle
+      audit and not consumed by S2's canonical derivation. -/
   mem_replay_im1 : ∀ (_h : MutableMemPresent witness), ℕ → FGL
-  /-- Guarded split generated Mem constraint facts for the selected mutable-Mem table.
-
-      This is not a read-soundness predicate and does not carry the accepted replay bridge directly:
-      together with the sidecar columns above, it supplies the PIL-generated segment/permutation
-      constraints from which the typed Mem AIR source, replay bridge, and table-order replay
-      soundness are derived downstream. Witnesses with no mutable-Mem rows do not need or generally
-      have a nonempty Mem replay table, so the field is guarded by `MutableMemPresent`. -/
-  mem_replay_constraints : ∀ (h : MutableMemPresent witness),
-    ZiskFv.AirsClean.FullEnsemble.MemTableGeneratedConstraintFacts
-      (mem_replay_table h).1
-      (acceptedMemReplayMem
-        (mem_replay_table h).1
-        (mem_replay_gsum h)
-        (mem_replay_im0 h)
-        (mem_replay_im1 h))
-      (acceptedMemReplayFixedSegment (mem_replay_segment h))
-      (mem_replay_permutation h)
-  /-- Guarded segment range facts for the selected mutable-Mem sidecar segment.
+  /-- Guarded segment range facts for the selected canonical live Mem source.
 
       HELD for Project Closeout S3's lookup-wiring extraction. The sidecar
-      `distance_base_*` values are not component-row inputs, so S1a's live Mem
-      lookups do not derive this field. S3 must derive and delete this
-      caller-supplied promise hypothesis; it is not a permanent survivor. -/
+      `distance_base_*` values are not component-row inputs, so S2 derives the
+      generated equations but not this range fact. S3 must derive and delete
+      this caller-supplied promise hypothesis; it is not a permanent survivor. -/
   mem_replay_segment_ranges : ∀ (h : MutableMemPresent witness),
     ZiskFv.AirsClean.FullEnsemble.MemSegmentGeneratedRangeFacts
-      (acceptedMemReplayFixedSegment (mem_replay_segment h))
+      (ZiskFv.AirsClean.FullEnsemble.memSegmentOfTableData (mem_replay_table h).1)
   /-- Structural source-correlation certificate for the guarded Mem AIR source:
       every mutable-Mem table in the accepted witness is the selected source
       table. This is table identity only, not read-value agreement. It is kept
@@ -240,53 +216,78 @@ theorem AcceptedZiskTrace.memReplayRowRanges {n : Nat}
     (h_present : MutableMemPresent trace.witness) :
     ZiskFv.AirsClean.FullEnsemble.MemTableGeneratedRangeFacts
       (trace.memReplayTable h_present)
-      (acceptedMemReplayMem
-        (trace.memReplayTable h_present)
-        (trace.mem_replay_gsum h_present)
-        (trace.mem_replay_im0 h_present)
-        (trace.mem_replay_im1 h_present)) := by
-  apply ZiskFv.AirsClean.FullEnsemble.memTableGeneratedRangeFacts_of_component_constraints
+      (ZiskFv.AirsClean.FullEnsemble.memOfTableData
+        (trace.memReplayTable h_present)) := by
+  apply ZiskFv.AirsClean.FullEnsemble.memTableGeneratedRangeFacts_of_component_constraints_canonical
   · exact (trace.mem_replay_table h_present).2.2.1
   · exact trace.constraints_hold (trace.memReplayTable h_present)
       (trace.mem_replay_table h_present).2.1
 
-/-- The guarded raw Mem source sidecar rebuilt from accepted-trace factor fields. -/
-def AcceptedZiskTrace.memReplayRawSourceSidecar {n : Nat} (trace : AcceptedZiskTrace n)
+/-- The selected mutable-Mem table's generated constraints are derived from
+    its live row constraints and right-indexed transition. The source is the
+    same materialized table data and component-owned fixed schema consumed by
+    the verifier; no accepted-trace generated-constraint certificate remains. -/
+theorem AcceptedZiskTrace.memReplayGeneratedConstraintFacts {n : Nat}
+    (trace : AcceptedZiskTrace n)
     (h_present : MutableMemPresent trace.witness) :
-    ZiskFv.AirsClean.FullEnsemble.MemTableGeneratedRawSourceSidecar
-      (trace.memReplayTable h_present) where
-  segment := trace.mem_replay_segment h_present
-  permutation := trace.mem_replay_permutation h_present
-  gsum := trace.mem_replay_gsum h_present
-  im0 := trace.mem_replay_im0 h_present
-  im1 := trace.mem_replay_im1 h_present
-  facts :=
-    { constraints := trace.mem_replay_constraints h_present
-      rowRanges := trace.memReplayRowRanges h_present
-      segmentRanges := trace.mem_replay_segment_ranges h_present }
-
-/-- The guarded Mem AIR source selected when the accepted witness has mutable-Mem rows, rebuilt
-from the split table-selection, source-column, and generated-fact fields. -/
-def AcceptedZiskTrace.memReplaySource {n : Nat} (trace : AcceptedZiskTrace n)
-    (h_present : MutableMemPresent trace.witness) :
-    ZiskFv.AirsClean.FullEnsemble.FullWitnessMemAirSource trace.witness :=
-  { table := trace.memReplayTable h_present
-    table_mem := (trace.mem_replay_table h_present).2.1
-    component := (trace.mem_replay_table h_present).2.2.1
-    source := (trace.memReplayRawSourceSidecar h_present).toAirSource }
+    ZiskFv.AirsClean.FullEnsemble.MemTableGeneratedConstraintFacts
+      (trace.memReplayTable h_present)
+      (ZiskFv.AirsClean.FullEnsemble.memOfTableData
+        (trace.memReplayTable h_present))
+      (ZiskFv.AirsClean.FullEnsemble.memSegmentOfTableData
+        (trace.memReplayTable h_present))
+      (ZiskFv.AirsClean.FullEnsemble.memPermutationOfTableData
+        (trace.memReplayTable h_present)) := by
+  apply ZiskFv.AirsClean.FullEnsemble.memTableGeneratedConstraintFacts_of_component_constraints_transitions
+  · exact (trace.mem_replay_table h_present).2.2.1
+  · exact trace.constraints_hold (trace.memReplayTable h_present)
+      (trace.mem_replay_table h_present).2.1
+  · exact trace.transitions_hold (trace.memReplayTable h_present)
+      (trace.mem_replay_table h_present).2.1
 
 /-- The accepted Mem replay rows selected when the accepted witness has mutable-Mem rows. -/
 def AcceptedZiskTrace.memReplayRows {n : Nat} (trace : AcceptedZiskTrace n)
     (h_present : MutableMemPresent trace.witness) :
     List (Interaction.MemoryBusEntry FGL) :=
-  (trace.memReplaySource h_present).rows
+  ZiskFv.AirsClean.FullEnsemble.activeMemReplayRowsOfTable
+    (trace.memReplayTable h_present)
 
 /-- The accepted Mem replay bridge selected when the accepted witness has mutable-Mem rows. -/
 def AcceptedZiskTrace.memReplayBridge {n : Nat} (trace : AcceptedZiskTrace n)
     (h_present : MutableMemPresent trace.witness) :
     ZiskFv.AirsClean.FullEnsemble.FullWitnessMemReplayBridge
       trace.witness (trace.memReplayRows h_present) :=
-  (trace.memReplaySource h_present).replayBridge
+  ZiskFv.AirsClean.FullEnsemble.fullWitnessMemReplayBridge_of_memTable_with_fixedColumns
+    (segment := ZiskFv.AirsClean.FullEnsemble.memSegmentOfTableData
+      (trace.memReplayTable h_present))
+    (permutation := ZiskFv.AirsClean.FullEnsemble.memPermutationOfTableData
+      (trace.memReplayTable h_present))
+    (gsum := ZiskFv.AirsClean.Mem.memSidecarGsumOfProverData
+      (trace.memReplayTable h_present).data)
+    (im0 := ZiskFv.AirsClean.Mem.memSidecarIm0OfProverData
+      (trace.memReplayTable h_present).data)
+    (im1 := ZiskFv.AirsClean.Mem.memSidecarIm1OfProverData
+      (trace.memReplayTable h_present).data)
+    (trace.mem_replay_table h_present).2.1
+    (trace.mem_replay_table h_present).2.2.1
+    (by
+      simpa only [ZiskFv.AirsClean.FullEnsemble.memOfTableData] using
+        ZiskFv.AirsClean.FullEnsemble.generatedAt_of_memTableGeneratedConstraintFacts
+          (trace.memReplayGeneratedConstraintFacts h_present))
+    (by
+      simpa only [ZiskFv.AirsClean.FullEnsemble.memOfTableData] using
+        trace.memReplayRowRanges h_present)
+    (trace.mem_replay_segment_ranges h_present)
+    (ZiskFv.AirsClean.FullEnsemble.memTableGeneratedFixedColumnFacts_of_component_fixedColumns
+      (trace.memReplayTable h_present)
+      (trace.mem_replay_table h_present).2.2.1)
     (trace.mem_replay_table h_present).2.2.2
+
+@[simp]
+theorem AcceptedZiskTrace.memReplayBridge_table {n : Nat}
+    (trace : AcceptedZiskTrace n)
+    (h_present : MutableMemPresent trace.witness) :
+    (trace.memReplayBridge h_present).table = trace.memReplayTable h_present :=
+  rfl
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/AcceptedZiskTrace/MemProviders.lean
+++ b/ZiskFv/Compliance/AcceptedZiskTrace/MemProviders.lean
@@ -274,12 +274,7 @@ theorem AcceptedZiskTrace.memReplayBridge_coversMutableMemTables
       (trace.memReplayBridge h_present) := by
   intro table h_table h_component
   have h_eq := trace.mem_replay_source_covers h_present table h_table h_component
-  simpa [AcceptedZiskTrace.memReplayBridge, AcceptedZiskTrace.memReplayRows,
-    AcceptedZiskTrace.memReplaySource, FullWitnessMemAirSource.replayBridge,
-    fullWitnessMemReplayBridge_of_memAirSource,
-    fullWitnessMemReplayBridge_of_memTable_fixedL1_airFacts,
-    fullWitnessMemReplayBridge_of_memTable_fixedL1,
-    fullWitnessMemReplayBridge_of_memTable] using h_eq
+  simpa only [AcceptedZiskTrace.memReplayBridge_table] using h_eq
 
 /-- Accepted-trace wrapper using the trace-selected Mem replay bridge as the
     chronological row list.

--- a/ZiskFv/Compliance/AddAddiSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/AddAddiSpinRootSoundness.lean
@@ -106,36 +106,23 @@ private theorem addAddiSpinAcceptedTrace_program :
 private theorem addAddiSpinMainRowAt_zero :
     ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero addAddiSpinProgram
       addAddiSpinMainTable 0 = addAddiSpinAddRow := by
-  simp [ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero, addAddiSpinMainTable,
-    mainRowsTable, addAddiSpinMainRows]
-  change eval (addAddiSpinMainTable.environment (mainRowArray addAddiSpinAddRow))
-      (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus 3
-        addAddiSpinProgram).rowInputVar = addAddiSpinAddRow
-  simpa [addAddiSpinMainTable] using
-    mainRowsTable_eval_rowInputVar 3 addAddiSpinProgram addAddiSpinMainRows addAddiSpinAddRow
+  unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+  rw [dif_pos (by simp)]
+  exact addAddiSpinMainTable_eval_rowInputVar_zero (by simp)
 
 private theorem addAddiSpinMainRowAt_one :
     ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero addAddiSpinProgram
       addAddiSpinMainTable 1 = addAddiSpinAddiRow := by
-  simp [ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero, addAddiSpinMainTable,
-    mainRowsTable, addAddiSpinMainRows]
-  change eval (addAddiSpinMainTable.environment (mainRowArray addAddiSpinAddiRow))
-      (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus 3
-        addAddiSpinProgram).rowInputVar = addAddiSpinAddiRow
-  simpa [addAddiSpinMainTable] using
-    mainRowsTable_eval_rowInputVar 3 addAddiSpinProgram addAddiSpinMainRows addAddiSpinAddiRow
+  unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+  rw [dif_pos (by simp)]
+  exact addAddiSpinMainTable_eval_rowInputVar_one (by simp)
 
 private theorem addAddiSpinMainRowAt_two :
     ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero addAddiSpinProgram
       addAddiSpinMainTable 2 = addAddiSpinJalRow 2 := by
-  simp [ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero, addAddiSpinMainTable,
-    mainRowsTable, addAddiSpinMainRows]
-  change eval (addAddiSpinMainTable.environment (mainRowArray (addAddiSpinJalRow 2)))
-      (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus 3
-        addAddiSpinProgram).rowInputVar = addAddiSpinJalRow 2
-  simpa [addAddiSpinMainTable] using
-    mainRowsTable_eval_rowInputVar 3 addAddiSpinProgram addAddiSpinMainRows
-      (addAddiSpinJalRow 2)
+  unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+  rw [dif_pos (by simp)]
+  exact addAddiSpinMainTable_eval_rowInputVar_two (by simp)
 
 private theorem addAddiSpinMainPc_add :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinAcceptedTrace.program
@@ -191,7 +178,7 @@ def addAddiSpinAddProgramDecode :
   h_idx := by
     rw [addAddiSpinAcceptedTrace_mainTable_eq]
     change 0 + 1 < addAddiSpinMainTable.table.length
-    norm_num [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows]
+    simp
   bits := addAddiSpinAddBits
   h_bits_ieo := by simp [addAddiSpinAddBits, addX1RomFlagBits]
   h_bits_m32 := by simp [addAddiSpinAddBits, addX1RomFlagBits]
@@ -231,7 +218,7 @@ def addAddiSpinAddiProgramDecode :
   h_idx := by
     rw [addAddiSpinAcceptedTrace_mainTable_eq]
     change 1 + 1 < addAddiSpinMainTable.table.length
-    norm_num [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows]
+    simp
   bits := addAddiSpinAddiBits
   h_bits_ieo := by rfl
   h_bits_m32 := by rfl
@@ -273,7 +260,7 @@ def addAddiSpinJalProgramDecode :
   h_idx := by
     rw [addAddiSpinAcceptedTrace_mainTable_eq]
     change 2 + 1 < addAddiSpinMainTable.table.length
-    norm_num [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows]
+    simp
   bits := addAddiSpinJalBits
   h_bits_ieo := by rfl
   h_bits_m32 := by rfl

--- a/ZiskFv/Compliance/AddAddiSpinWitness.lean
+++ b/ZiskFv/Compliance/AddAddiSpinWitness.lean
@@ -113,6 +113,10 @@ def addAddiSpinProgram : Program 3
 def addAddiSpinMainRows : List (MainRowWithRom FGL) :=
   [addAddiSpinAddRow, addAddiSpinAddiRow, addAddiSpinJalRow 2, addAddiSpinJalRow 3]
 
+theorem addAddiSpinMainRows_fixed_domain :
+    addAddiSpinMainRows.length <= mainFixedCapacity := by
+  norm_num [addAddiSpinMainRows, mainFixedCapacity]
+
 def addAddiSpinBinaryAddRows : List (ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL) :=
   [addX1BinaryAddRow, addX1BinaryAddRow]
 
@@ -137,7 +141,24 @@ def addAddiSpinBinaryAddTable : Table FGL :=
   binaryAddRowsTable addAddiSpinBinaryAddRows
 
 def addAddiSpinMainTable : Table FGL :=
-  mainRowsTable 3 addAddiSpinProgram addAddiSpinMainRows
+  mainRowsTable 3 addAddiSpinProgram addAddiSpinMainRows addAddiSpinMainRows_fixed_domain
+
+private theorem addAddiSpinMainTable_effectiveRows :
+    addAddiSpinMainTable.table =
+      [ mainFixedColumns.materialize 0 (mainRawRow addAddiSpinAddRow)
+      , mainFixedColumns.materialize 1 (mainRawRow addAddiSpinAddiRow)
+      , mainFixedColumns.materialize 2 (mainRawRow (addAddiSpinJalRow 2))
+      , mainFixedColumns.materialize 3 (mainRawRow (addAddiSpinJalRow 3)) ] := by
+  simp [addAddiSpinMainTable, mainRowsTable, Table.table, componentWithRomMemAndOpBus,
+    addAddiSpinMainRows]
+
+@[simp] private theorem addAddiSpinMainTable_length : addAddiSpinMainTable.length = 4 := by
+  rfl
+
+@[simp] private theorem addAddiSpinMainTable_table_length :
+    addAddiSpinMainTable.table.length = 4 := by
+  rw [Table.table_length]
+  exact addAddiSpinMainTable_length
 
 theorem addAddiSpinAddMain_proverAssumptions :
     (componentWithRomMemAndOpBus 3 addAddiSpinProgram).circuit.ProverAssumptions
@@ -177,51 +198,149 @@ theorem addAddiSpinJalMain_proverAssumptions (step : FGL) :
       addAddiSpinJalFreeCols]
   · rfl
 
-private theorem addAddiSpinMainRow_constraints
-    {row : MainRowWithRom FGL}
-    (h_row : row = addAddiSpinAddRow ∨ row = addAddiSpinAddiRow ∨
-      row = addAddiSpinJalRow 2 ∨ row = addAddiSpinJalRow 3) :
+private def addAddiSpinProverEnvFromEnvironment (env : Environment FGL) :
+    ProverEnvironment FGL where
+  get := env.get
+  data := env.data
+  hint := ProverHint.empty FGL
+
+private theorem addAddiSpinFlatForAllWitness_of_localLength_zero
+    {env : ProverEnvironment FGL} {offset : Nat} {ops : List (FlatOperation FGL)}
+    (h_len : FlatOperation.localLength ops = 0) :
+    FlatOperation.forAll offset
+      { witness := fun offset _ compute => env.ExtendsVector (compute env) offset }
+      ops := by
+  induction ops generalizing offset with
+  | nil => trivial
+  | cons op ops ih =>
+      cases op with
+      | witness m compute =>
+          simp [FlatOperation.localLength] at h_len
+          have h_m : m = 0 := by omega
+          have h_ops : FlatOperation.localLength ops = 0 := by omega
+          subst m
+          constructor
+          · intro i
+            exact Fin.elim0 i
+          · simpa [Nat.zero_add] using ih (offset := offset) h_ops
+      | assert e =>
+          simp [FlatOperation.localLength] at h_len
+          simpa [FlatOperation.forAll] using ih (offset := offset) h_len
+      | lookup l =>
+          simp [FlatOperation.localLength] at h_len
+          simpa [FlatOperation.forAll] using ih (offset := offset) h_len
+      | interact i =>
+          simp [FlatOperation.localLength] at h_len
+          simpa [FlatOperation.forAll] using ih (offset := offset) h_len
+
+private theorem addAddiSpinUsesLocalWitnesses_of_localLength_zero
+    {env : ProverEnvironment FGL} {offset : Nat} {ops : Operations FGL}
+    (h_len : ops.localLength = 0) :
+    env.UsesLocalWitnesses offset ops := by
+  rw [ProverEnvironment.UsesLocalWitnesses, Operations.forAllFlat]
+  induction ops using Operations.induct generalizing offset with
+  | empty => trivial
+  | witness m compute ops ih =>
+      simp [Operations.localLength] at h_len
+      have h_m : m = 0 := by omega
+      have h_ops : ops.localLength = 0 := by omega
+      subst m
+      constructor
+      · intro i
+        exact Fin.elim0 i
+      · simpa [Nat.zero_add] using ih (offset := offset) h_ops
+  | assert e ops ih =>
+      simp [Operations.localLength] at h_len
+      simpa [Operations.forAll] using ih (offset := offset) h_len
+  | lookup l ops ih =>
+      simp [Operations.localLength] at h_len
+      simpa [Operations.forAll] using ih (offset := offset) h_len
+  | interact i ops ih =>
+      simp [Operations.localLength] at h_len
+      simpa [Operations.forAll] using ih (offset := offset) h_len
+  | subcircuit s ops ih =>
+      simp [Operations.localLength] at h_len
+      have h_s : s.localLength = 0 := by omega
+      have h_ops : ops.localLength = 0 := by omega
+      constructor
+      · apply addAddiSpinFlatForAllWitness_of_localLength_zero
+        rw [← s.localLength_eq]
+        exact h_s
+      · exact ih (offset := s.localLength + offset) h_ops
+
+private theorem addAddiSpinMain_constraintsHold_materialize
+    (index : Nat) (row : MainRowWithRom FGL)
+    (h_segment_l1 : row.core.segment_l1 = mainFixedColumns.fixedAt 0 index)
+    (h_main_step : row.rom.main_step = mainFixedColumns.fixedAt 1 index)
+    (h_assumptions :
+      (componentWithRomMemAndOpBus 3 addAddiSpinProgram).circuit.ProverAssumptions
+        row emptyData (ProverHint.empty FGL)) :
     (componentWithRomMemAndOpBus 3 addAddiSpinProgram).operations.ConstraintsHold
-      (Environment.fromInput row emptyData) := by
-  rcases h_row with rfl | rfl | rfl | rfl
-  · exact
-      (show (mainSingleRowTable 3 addAddiSpinProgram addAddiSpinAddRow).Constraints from
-        mainSingleRowTable_constraints_of_proverAssumptions 3 addAddiSpinProgram
-          addAddiSpinAddRow addAddiSpinAddMain_proverAssumptions)
-        (mainRowArray addAddiSpinAddRow) (by simp [mainSingleRowTable])
-  · exact
-      (show (mainSingleRowTable 3 addAddiSpinProgram addAddiSpinAddiRow).Constraints from
-        mainSingleRowTable_constraints_of_proverAssumptions 3 addAddiSpinProgram
-          addAddiSpinAddiRow addAddiSpinAddiMain_proverAssumptions)
-        (mainRowArray addAddiSpinAddiRow) (by simp [mainSingleRowTable])
-  · exact
-      (show (mainSingleRowTable 3 addAddiSpinProgram (addAddiSpinJalRow 2)).Constraints from
-        mainSingleRowTable_constraints_of_proverAssumptions 3 addAddiSpinProgram
-          (addAddiSpinJalRow 2) (addAddiSpinJalMain_proverAssumptions 2))
-        (mainRowArray (addAddiSpinJalRow 2)) (by simp [mainSingleRowTable])
-  · exact
-      (show (mainSingleRowTable 3 addAddiSpinProgram (addAddiSpinJalRow 3)).Constraints from
-        mainSingleRowTable_constraints_of_proverAssumptions 3 addAddiSpinProgram
-          (addAddiSpinJalRow 3) (addAddiSpinJalMain_proverAssumptions 3))
-        (mainRowArray (addAddiSpinJalRow 3)) (by simp [mainSingleRowTable])
+      (Environment.fromArray (mainFixedColumns.materialize index (mainRawRow row)) emptyData) := by
+  let env := Environment.fromArray (mainFixedColumns.materialize index (mainRawRow row)) emptyData
+  let proverEnv := addAddiSpinProverEnvFromEnvironment env
+  have h_localLength :
+      (componentWithRomMemAndOpBus 3 addAddiSpinProgram).circuit.localLength
+        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar = 0 := by
+    change (mainWithRomMemAndOpBusElaborated 3 addAddiSpinProgram).localLength
+        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar = 0
+    rfl
+  have h_env : proverEnv.UsesLocalWitnesses
+      (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowOffset
+      (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowOperations := by
+    apply addAddiSpinUsesLocalWitnesses_of_localLength_zero
+    change ((componentWithRomMemAndOpBus 3 addAddiSpinProgram).circuit.main
+      (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar).localLength
+        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowOffset = 0
+    rw [(componentWithRomMemAndOpBus 3 addAddiSpinProgram).circuit.localLength_eq]
+    exact h_localLength
+  have h_input_verifier : Eval.eval env
+      (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar = row := by
+    dsimp [env]
+    exact eval_mainRawRow_materialize index emptyData row h_segment_l1 h_main_step
+  have h_input : Eval.eval proverEnv
+      (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar = row := by
+    rw [ProvableType.eval_varFromOffset_prover]
+    rw [← h_input_verifier]
+    rw [ProvableType.eval_varFromOffset]
+    congr
+  have h_assumptions' :
+      (componentWithRomMemAndOpBus 3 addAddiSpinProgram).circuit.ProverAssumptions
+        (Eval.eval proverEnv (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar)
+        proverEnv.data proverEnv.hint := by
+    rw [h_input]
+    simpa [proverEnv, addAddiSpinProverEnvFromEnvironment, env] using h_assumptions
+  have h_full :=
+    (componentWithRomMemAndOpBus 3 addAddiSpinProgram).circuit.original_full_completeness
+      (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowOffset proverEnv
+      (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar h_env h_assumptions'
+  have h_row :
+      (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowOperations.ConstraintsHold
+        (proverEnv : Environment FGL) := by
+    simpa [Component.rowOperations, Component.rowInputVar, Component.rowOffset] using h_full.1
+  simpa [proverEnv, addAddiSpinProverEnvFromEnvironment, env] using
+    (Component.constraintsHold_iff (component := componentWithRomMemAndOpBus 3 addAddiSpinProgram)
+      (env := (proverEnv : Environment FGL))).mpr h_row
 
 theorem addAddiSpinMainTable_constraints : addAddiSpinMainTable.Constraints := by
-  rw [Table.Constraints]
+  change ∀ arr ∈
+      [ mainFixedColumns.materialize 0 (mainRawRow addAddiSpinAddRow)
+      , mainFixedColumns.materialize 1 (mainRawRow addAddiSpinAddiRow)
+      , mainFixedColumns.materialize 2 (mainRawRow (addAddiSpinJalRow 2))
+      , mainFixedColumns.materialize 3 (mainRawRow (addAddiSpinJalRow 3)) ],
+      (componentWithRomMemAndOpBus 3 addAddiSpinProgram).operations.ConstraintsHold
+        (Environment.fromArray arr emptyData)
   intro arr h_arr
-  simp [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows] at h_arr
-  rcases h_arr with h_arr | h_arr | h_arr | h_arr
-  · subst arr
-    simpa [addAddiSpinMainTable, mainRowsTable, mainRowArray] using
-      addAddiSpinMainRow_constraints (Or.inl rfl)
-  · subst arr
-    simpa [addAddiSpinMainTable, mainRowsTable, mainRowArray] using
-      addAddiSpinMainRow_constraints (Or.inr (Or.inl rfl))
-  · subst arr
-    simpa [addAddiSpinMainTable, mainRowsTable, mainRowArray] using
-      addAddiSpinMainRow_constraints (Or.inr (Or.inr (Or.inl rfl)))
-  · subst arr
-    simpa [addAddiSpinMainTable, mainRowsTable, mainRowArray] using
-      addAddiSpinMainRow_constraints (Or.inr (Or.inr (Or.inr rfl)))
+  simp only [List.mem_cons, List.not_mem_nil, or_false] at h_arr
+  rcases h_arr with rfl | rfl | rfl | rfl
+  · exact addAddiSpinMain_constraintsHold_materialize 0 addAddiSpinAddRow
+      (by rfl) (by rfl) addAddiSpinAddMain_proverAssumptions
+  · exact addAddiSpinMain_constraintsHold_materialize 1 addAddiSpinAddiRow
+      (by rfl) (by rfl) addAddiSpinAddiMain_proverAssumptions
+  · exact addAddiSpinMain_constraintsHold_materialize 2 (addAddiSpinJalRow 2)
+      (by rfl) (by rfl) (addAddiSpinJalMain_proverAssumptions 2)
+  · exact addAddiSpinMain_constraintsHold_materialize 3 (addAddiSpinJalRow 3)
+      (by rfl) (by rfl) (addAddiSpinJalMain_proverAssumptions 3)
 
 theorem addAddiSpinBinaryAddTable_constraints : addAddiSpinBinaryAddTable.Constraints := by
   apply binaryAddRowsTable_constraints_of_proverAssumptions
@@ -255,43 +374,6 @@ theorem addAddiSpinEnsemble_tables :
       , componentWithRomMemAndOpBus 3 addAddiSpinProgram ] := by
   rfl
 
-def addAddiSpinRows : Fin 11 → List (Array FGL) :=
-  fun i =>
-    if i.val = 0 then addAddiSpinBoundaryTable.table
-    else if i.val = 9 then addAddiSpinBinaryAddTable.table
-    else if i.val = 10 then addAddiSpinMainTable.table
-    else []
-
-theorem addAddiSpinRows_uniform :
-    ∀ i : Fin 11,
-      ∀ row ∈ addAddiSpinRows i,
-        row.size = (addAddiSpinEnsemble.tables[i.val]'i.isLt).width := by
-  intro i row h_row
-  fin_cases i
-  · have h_width := addAddiSpinBoundaryTable.uniform_width row (by
-      simpa [addAddiSpinRows] using h_row)
-    simpa only [addAddiSpinBoundaryTable, registerBoundaryRowsTableOf,
-      addAddiSpinEnsemble_tables] using h_width
-  · simp [addAddiSpinRows] at h_row
-  · simp [addAddiSpinRows] at h_row
-  · simp [addAddiSpinRows] at h_row
-  · simp [addAddiSpinRows] at h_row
-  · simp [addAddiSpinRows] at h_row
-  · simp [addAddiSpinRows] at h_row
-  · simp [addAddiSpinRows] at h_row
-  · simp [addAddiSpinRows] at h_row
-  · have h_width := addAddiSpinBinaryAddTable.uniform_width row (by
-      simpa [addAddiSpinRows] using h_row)
-    simpa only [addAddiSpinBinaryAddTable, binaryAddRowsTable,
-      addAddiSpinEnsemble_tables] using h_width
-  · have h_width := addAddiSpinMainTable.uniform_width row (by
-      simpa [addAddiSpinRows] using h_row)
-    simpa only [addAddiSpinMainTable, mainRowsTable, addAddiSpinEnsemble_tables] using h_width
-
-def addAddiSpinWitness : EnsembleWitness addAddiSpinEnsemble :=
-  EnsembleWitness.ofRows addAddiSpinEnsemble emptyData () addAddiSpinRows
-    addAddiSpinRows_uniform
-
 def addAddiSpinTables : List (Table FGL) :=
   [ addAddiSpinBoundaryTable
   , emptyComponentTable ZiskFv.AirsClean.MemAlignReadByte.component
@@ -304,6 +386,32 @@ def addAddiSpinTables : List (Table FGL) :=
   , emptyComponentTable ZiskFv.AirsClean.Binary.staticLookupComponent
   , addAddiSpinBinaryAddTable
   , addAddiSpinMainTable ]
+
+def addAddiSpinWitness : EnsembleWitness addAddiSpinEnsemble where
+  tables := addAddiSpinTables
+  data := emptyData
+  publicInput := ()
+  same_length := by
+    simp [addAddiSpinEnsemble, fullRv64imEnsemble, fullRv64imSoundEnsemble,
+      addAddiSpinTables, SoundEnsemble.toFormal, SoundEnsemble.addFinishedChannel_tables,
+      SoundEnsemble.addTable, SoundEnsemble.empty_tables, Ensemble.addTable]
+  same_circuits := by
+    intro i hi
+    have hi' : i < 11 := by
+      simpa [addAddiSpinTables] using hi
+    interval_cases i <;>
+      simp [addAddiSpinEnsemble, fullRv64imEnsemble, fullRv64imSoundEnsemble,
+        addAddiSpinTables, SoundEnsemble.toFormal, SoundEnsemble.addFinishedChannel_tables,
+        SoundEnsemble.addTable, SoundEnsemble.empty_tables, Ensemble.addTable,
+        addAddiSpinBoundaryTable, registerBoundaryRowsTableOf, emptyComponentTable,
+        addAddiSpinBinaryAddTable, binaryAddRowsTable, addAddiSpinMainTable, mainRowsTable]
+  same_data := by
+    intro table h_table
+    simp [addAddiSpinTables, addAddiSpinBoundaryTable, registerBoundaryRowsTableOf,
+      emptyComponentTable, addAddiSpinBinaryAddTable, binaryAddRowsTable,
+      addAddiSpinMainTable, mainRowsTable] at h_table
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
+      rfl
 
 theorem addAddiSpinWitness_tables :
     addAddiSpinWitness.tables = addAddiSpinTables := by
@@ -350,57 +458,160 @@ private theorem addAddiSpinMain_pcHandshake_jal_jal :
     addSpinJalBits, mainRomRowOf]
   ring
 
-private theorem addAddiSpinMainTable_transition (prev curr : MainRowWithRom FGL) :
-    addAddiSpinMainTable.component.transition prev curr = pcHandshakeBetween prev curr := by
-  rfl
-
-private theorem addAddiSpinMainTable_rowInput_zero
+@[simp] theorem addAddiSpinMainTable_eval_rowInputVar_zero
     (h : 0 < addAddiSpinMainTable.table.length) :
-    addAddiSpinMainTable.component.rowInput
-        (addAddiSpinMainTable.environment (addAddiSpinMainTable.table[0]'h)) =
+    Eval.eval (addAddiSpinMainTable.environment (addAddiSpinMainTable.table[0]'h))
+        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar =
       addAddiSpinAddRow := by
-  simpa [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows] using
-    mainRowsTable_rowInput 3 addAddiSpinProgram addAddiSpinMainRows addAddiSpinAddRow
+  change Eval.eval
+      (Environment.fromArray
+        (mainFixedColumns.materialize 0 (mainRawRow addAddiSpinAddRow)) emptyData)
+      (varFromOffset MainRowWithRom 0) = addAddiSpinAddRow
+  exact eval_mainRawRow_materialize 0 emptyData addAddiSpinAddRow (by rfl) (by rfl)
 
-private theorem addAddiSpinMainTable_rowInput_one
+@[simp] theorem addAddiSpinMainTable_eval_rowInputVar_one
     (h : 1 < addAddiSpinMainTable.table.length) :
-    addAddiSpinMainTable.component.rowInput
-        (addAddiSpinMainTable.environment (addAddiSpinMainTable.table[1]'h)) =
+    Eval.eval (addAddiSpinMainTable.environment (addAddiSpinMainTable.table[1]'h))
+        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar =
       addAddiSpinAddiRow := by
-  simpa [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows] using
-    mainRowsTable_rowInput 3 addAddiSpinProgram addAddiSpinMainRows addAddiSpinAddiRow
+  change Eval.eval
+      (Environment.fromArray
+        (mainFixedColumns.materialize 1 (mainRawRow addAddiSpinAddiRow)) emptyData)
+      (varFromOffset MainRowWithRom 0) = addAddiSpinAddiRow
+  exact eval_mainRawRow_materialize 1 emptyData addAddiSpinAddiRow (by rfl) (by rfl)
 
-private theorem addAddiSpinMainTable_rowInput_two
+@[simp] theorem addAddiSpinMainTable_eval_rowInputVar_two
     (h : 2 < addAddiSpinMainTable.table.length) :
-    addAddiSpinMainTable.component.rowInput
-        (addAddiSpinMainTable.environment (addAddiSpinMainTable.table[2]'h)) =
+    Eval.eval (addAddiSpinMainTable.environment (addAddiSpinMainTable.table[2]'h))
+        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar =
       addAddiSpinJalRow 2 := by
-  simpa [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows] using
-    mainRowsTable_rowInput 3 addAddiSpinProgram addAddiSpinMainRows (addAddiSpinJalRow 2)
+  change Eval.eval
+      (Environment.fromArray
+        (mainFixedColumns.materialize 2 (mainRawRow (addAddiSpinJalRow 2))) emptyData)
+      (varFromOffset MainRowWithRom 0) = addAddiSpinJalRow 2
+  exact eval_mainRawRow_materialize 2 emptyData (addAddiSpinJalRow 2) (by rfl) (by rfl)
 
-private theorem addAddiSpinMainTable_rowInput_three
+@[simp] theorem addAddiSpinMainTable_eval_rowInputVar_three
     (h : 3 < addAddiSpinMainTable.table.length) :
-    addAddiSpinMainTable.component.rowInput
-        (addAddiSpinMainTable.environment (addAddiSpinMainTable.table[3]'h)) =
+    Eval.eval (addAddiSpinMainTable.environment (addAddiSpinMainTable.table[3]'h))
+        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar =
       addAddiSpinJalRow 3 := by
-  simpa [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows] using
-    mainRowsTable_rowInput 3 addAddiSpinProgram addAddiSpinMainRows (addAddiSpinJalRow 3)
+  change Eval.eval
+      (Environment.fromArray
+        (mainFixedColumns.materialize 3 (mainRawRow (addAddiSpinJalRow 3))) emptyData)
+      (varFromOffset MainRowWithRom 0) = addAddiSpinJalRow 3
+  exact eval_mainRawRow_materialize 3 emptyData (addAddiSpinJalRow 3) (by rfl) (by rfl)
+
+@[simp] theorem addAddiSpinMainTable_evalAt_zero :
+    Eval.eval
+      (addAddiSpinMainTable.environmentAt
+        ⟨0, by simp⟩)
+      (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar =
+      addAddiSpinAddRow := by
+  simpa [Table.environmentAt] using
+    addAddiSpinMainTable_eval_rowInputVar_zero
+      (by simp)
+
+@[simp] theorem addAddiSpinMainTable_evalAt_one :
+    Eval.eval
+      (addAddiSpinMainTable.environmentAt
+        ⟨1, by simp⟩)
+      (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar =
+      addAddiSpinAddiRow := by
+  simpa [Table.environmentAt] using
+    addAddiSpinMainTable_eval_rowInputVar_one
+      (by simp)
+
+@[simp] theorem addAddiSpinMainTable_evalAt_two :
+    Eval.eval
+      (addAddiSpinMainTable.environmentAt
+        ⟨2, by simp⟩)
+      (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar =
+      addAddiSpinJalRow 2 := by
+  simpa [Table.environmentAt] using
+    addAddiSpinMainTable_eval_rowInputVar_two
+      (by simp)
+
+@[simp] theorem addAddiSpinMainTable_evalAt_three :
+    Eval.eval
+      (addAddiSpinMainTable.environmentAt
+        ⟨3, by simp⟩)
+      (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar =
+      addAddiSpinJalRow 3 := by
+  simpa [Table.environmentAt] using
+    addAddiSpinMainTable_eval_rowInputVar_three
+      (by simp)
 
 theorem addAddiSpinMainTable_transitions : addAddiSpinMainTable.TransitionConstraints := by
   rw [Table.TransitionConstraints]
-  intro i h_i
-  have h_len : addAddiSpinMainTable.table.length = 4 := by
-    simp [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows]
-  have h_i_lt : i < 3 := by omega
-  interval_cases i
-  · rw [addAddiSpinMainTable_transition, addAddiSpinMainTable_rowInput_zero,
-      addAddiSpinMainTable_rowInput_one]
+  intro index
+  have h_index_lt : index.val < 4 := by
+    rw [← addAddiSpinMainTable_length]
+    exact index.isLt
+  interval_cases h_index : index.val
+  · have h_index : index = ⟨0, by
+        simp⟩ :=
+      Fin.ext (by omega)
+    subst index
+    change pcHandshakeBetween
+      (Eval.eval
+        (addAddiSpinMainTable.previousEnvironment
+          ⟨0, by simp⟩)
+        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar)
+      (Eval.eval
+        (addAddiSpinMainTable.environmentAt
+          ⟨0, by simp⟩)
+        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar)
+    simp only [Table.previousEnvironment]
+    rw [addAddiSpinMainTable_evalAt_zero]
+    simp [pcHandshakeBetween, addAddiSpinAddRow, addX1Row]
+  · have h_index : index = ⟨1, by
+        simp⟩ :=
+      Fin.ext (by omega)
+    subst index
+    change pcHandshakeBetween
+      (Eval.eval
+        (addAddiSpinMainTable.previousEnvironment
+          ⟨1, by simp⟩)
+        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar)
+      (Eval.eval
+        (addAddiSpinMainTable.environmentAt
+          ⟨1, by simp⟩)
+        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar)
+    simp only [Table.previousEnvironment]
+    rw [addAddiSpinMainTable_evalAt_zero, addAddiSpinMainTable_evalAt_one]
     exact addAddiSpinMain_pcHandshake_add_addi
-  · rw [addAddiSpinMainTable_transition, addAddiSpinMainTable_rowInput_one,
-      addAddiSpinMainTable_rowInput_two]
+  · have h_index : index = ⟨2, by
+        simp⟩ :=
+      Fin.ext (by omega)
+    subst index
+    change pcHandshakeBetween
+      (Eval.eval
+        (addAddiSpinMainTable.previousEnvironment
+          ⟨2, by simp⟩)
+        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar)
+      (Eval.eval
+        (addAddiSpinMainTable.environmentAt
+          ⟨2, by simp⟩)
+        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar)
+    simp only [Table.previousEnvironment]
+    rw [addAddiSpinMainTable_evalAt_one, addAddiSpinMainTable_evalAt_two]
     exact addAddiSpinMain_pcHandshake_addi_jal
-  · rw [addAddiSpinMainTable_transition, addAddiSpinMainTable_rowInput_two,
-      addAddiSpinMainTable_rowInput_three]
+  · have h_index : index = ⟨3, by
+        simp⟩ :=
+      Fin.ext (by omega)
+    subst index
+    change pcHandshakeBetween
+      (Eval.eval
+        (addAddiSpinMainTable.previousEnvironment
+          ⟨3, by simp⟩)
+        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar)
+      (Eval.eval
+        (addAddiSpinMainTable.environmentAt
+          ⟨3, by simp⟩)
+        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar)
+    simp only [Table.previousEnvironment]
+    rw [addAddiSpinMainTable_evalAt_two, addAddiSpinMainTable_evalAt_three]
     exact addAddiSpinMain_pcHandshake_jal_jal
 
 theorem addAddiSpinWitness_transitions : addAddiSpinWitness.TransitionConstraints := by
@@ -409,43 +620,28 @@ theorem addAddiSpinWitness_transitions : addAddiSpinWitness.TransitionConstraint
   rcases h_table with h_verifier | h_table
   · subst table
     rw [Table.TransitionConstraints]
-    intro i h_i
-    simp [EnsembleWitness.verifierTable] at h_i
+    intro index
+    simp [EnsembleWitness.verifierTable]
   · rw [addAddiSpinWitness_tables] at h_table
     simp [addAddiSpinTables] at h_table
     rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
     · rw [Table.TransitionConstraints]
-      intro i h_i
+      intro index
       simp [addAddiSpinBoundaryTable, registerBoundaryRowsTableOf,
-        ZiskFv.AirsClean.RegisterBoundary.component] at h_i ⊢
+        ZiskFv.AirsClean.RegisterBoundary.component]
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignReadByte.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignByte.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlign.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.Mem.componentWithDualMemBus
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.ArithDiv.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.ArithMul.componentWithArithTable
+    · exact emptyComponentTable_transitions
+        ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.Binary.staticLookupComponent
     · rw [Table.TransitionConstraints]
-      intro i h_i
-      simp [emptyComponentTable] at h_i
-    · rw [Table.TransitionConstraints]
-      intro i h_i
-      simp [emptyComponentTable] at h_i
-    · rw [Table.TransitionConstraints]
-      intro i h_i
-      simp [emptyComponentTable] at h_i
-    · rw [Table.TransitionConstraints]
-      intro i h_i
-      simp [emptyComponentTable] at h_i
-    · rw [Table.TransitionConstraints]
-      intro i h_i
-      simp [emptyComponentTable] at h_i
-    · rw [Table.TransitionConstraints]
-      intro i h_i
-      simp [emptyComponentTable] at h_i
-    · rw [Table.TransitionConstraints]
-      intro i h_i
-      simp [emptyComponentTable] at h_i
-    · rw [Table.TransitionConstraints]
-      intro i h_i
-      simp [emptyComponentTable] at h_i
-    · rw [Table.TransitionConstraints]
-      intro i h_i
+      intro index
       simp [addAddiSpinBinaryAddTable, binaryAddRowsTable,
-        ZiskFv.AirsClean.BinaryAdd.component] at h_i ⊢
+        ZiskFv.AirsClean.BinaryAdd.component]
     · exact addAddiSpinMainTable_transitions
 
 private theorem not_addAddiSpin_main_component_of_name_ne
@@ -524,14 +720,14 @@ private theorem addAddiSpinWitness_mutable_mem_component_tables_empty
     rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
     · exfalso
       exact not_addAddiSpin_mutable_mem_component_of_name_ne (by decide) h_component
-    · simp [emptyComponentTable]
-    · simp [emptyComponentTable]
-    · simp [emptyComponentTable]
-    · simp [emptyComponentTable]
-    · simp [emptyComponentTable]
-    · simp [emptyComponentTable]
-    · simp [emptyComponentTable]
-    · simp [emptyComponentTable]
+    · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignReadByte.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignByte.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlign.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.Mem.componentWithDualMemBus
+    · exact emptyComponentTable_table ZiskFv.AirsClean.ArithDiv.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.ArithMul.componentWithArithTable
+    · exact emptyComponentTable_table ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+    · exact emptyComponentTable_table ZiskFv.AirsClean.Binary.staticLookupComponent
     · exfalso
       exact not_addAddiSpin_mutable_mem_component_of_name_ne (by decide) h_component
     · exfalso
@@ -559,10 +755,9 @@ private theorem addAddiSpinMain_segment_l1_first :
         addAddiSpinMainTable).segment_l1 0 = 1 := by
   simp [ZiskFv.AirsClean.FullEnsemble.mainOfTable_segment_l1]
   unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
-  change (Eval.eval (addAddiSpinMainTable.environment (mainRowArray addAddiSpinAddRow))
-      (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar).core.segment_l1 = 1
-  simpa [addAddiSpinMainTable] using congrArg (fun row : MainRowWithRom FGL => row.core.segment_l1)
-    (mainRowsTable_eval_rowInputVar 3 addAddiSpinProgram addAddiSpinMainRows addAddiSpinAddRow)
+  rw [dif_pos (by norm_num [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows])]
+  simpa [Table.environmentAt, addAddiSpinAddRow, addX1Row, mainRomRowOf] using
+    congrArg MainRowWithRom.core addAddiSpinMainTable_evalAt_zero
 
 private theorem addAddiSpinMain_segment_l1_later
     (idx : Fin addAddiSpinMainTable.table.length) (h_idx : 0 < idx.val) :
@@ -576,28 +771,23 @@ private theorem addAddiSpinMain_segment_l1_later
   interval_cases idx.val
   · simp [ZiskFv.AirsClean.FullEnsemble.mainOfTable_segment_l1]
     unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
-    change (Eval.eval (addAddiSpinMainTable.environment (mainRowArray addAddiSpinAddiRow))
-        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar).core.segment_l1 = 0
-    simpa [addAddiSpinMainTable] using
-      congrArg (fun row : MainRowWithRom FGL => row.core.segment_l1)
-        (mainRowsTable_eval_rowInputVar 3 addAddiSpinProgram addAddiSpinMainRows
-          addAddiSpinAddiRow)
+    rw [dif_pos (by norm_num [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows])]
+    simpa [Table.environmentAt, addAddiSpinAddiRow, addAddiSpinAddiRowTemplate,
+      addAddiSpinAddiFreeColsTemplate, addAddiSpinAddiProgramRow, addAddiSpinAddiBits,
+      mainRomRowOf] using
+      congrArg MainRowWithRom.core addAddiSpinMainTable_evalAt_one
   · simp [ZiskFv.AirsClean.FullEnsemble.mainOfTable_segment_l1]
     unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
-    change (Eval.eval (addAddiSpinMainTable.environment (mainRowArray (addAddiSpinJalRow 2)))
-        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar).core.segment_l1 = 0
-    simpa [addAddiSpinMainTable] using
-      congrArg (fun row : MainRowWithRom FGL => row.core.segment_l1)
-        (mainRowsTable_eval_rowInputVar 3 addAddiSpinProgram addAddiSpinMainRows
-          (addAddiSpinJalRow 2))
+    rw [dif_pos (by norm_num [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows])]
+    simpa [Table.environmentAt, addAddiSpinJalRow, addSpinJalRow, addSpinJalProgramRow,
+      addSpinJalBits, mainRomRowOf] using
+      congrArg MainRowWithRom.core addAddiSpinMainTable_evalAt_two
   · simp [ZiskFv.AirsClean.FullEnsemble.mainOfTable_segment_l1]
     unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
-    change (Eval.eval (addAddiSpinMainTable.environment (mainRowArray (addAddiSpinJalRow 3)))
-        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar).core.segment_l1 = 0
-    simpa [addAddiSpinMainTable] using
-      congrArg (fun row : MainRowWithRom FGL => row.core.segment_l1)
-        (mainRowsTable_eval_rowInputVar 3 addAddiSpinProgram addAddiSpinMainRows
-          (addAddiSpinJalRow 3))
+    rw [dif_pos (by norm_num [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows])]
+    simpa [Table.environmentAt, addAddiSpinJalRow, addSpinJalRow, addSpinJalProgramRow,
+      addSpinJalBits, mainRomRowOf] using
+      congrArg MainRowWithRom.core addAddiSpinMainTable_evalAt_three
 
 private theorem addAddiSpinMain_main_step_eq_index :
     ∀ i : Fin 3,
@@ -606,26 +796,20 @@ private theorem addAddiSpinMain_main_step_eq_index :
   intro i
   fin_cases i
   · unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
-    change (Eval.eval (addAddiSpinMainTable.environment (mainRowArray addAddiSpinAddRow))
-        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar).rom.main_step = 0
-    simpa [addAddiSpinMainTable] using
-      congrArg (fun row : MainRowWithRom FGL => row.rom.main_step)
-        (mainRowsTable_eval_rowInputVar 3 addAddiSpinProgram addAddiSpinMainRows
-          addAddiSpinAddRow)
+    rw [dif_pos (by norm_num [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows])]
+    simpa [Table.environmentAt, addAddiSpinAddRow, addX1Row, mainRomRowOf] using
+      congrArg MainRowWithRom.rom addAddiSpinMainTable_evalAt_zero
   · unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
-    change (Eval.eval (addAddiSpinMainTable.environment (mainRowArray addAddiSpinAddiRow))
-        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar).rom.main_step = 1
-    simpa [addAddiSpinMainTable] using
-      congrArg (fun row : MainRowWithRom FGL => row.rom.main_step)
-        (mainRowsTable_eval_rowInputVar 3 addAddiSpinProgram addAddiSpinMainRows
-          addAddiSpinAddiRow)
+    rw [dif_pos (by norm_num [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows])]
+    simpa [Table.environmentAt, addAddiSpinAddiRow, addAddiSpinAddiRowTemplate,
+      addAddiSpinAddiFreeColsTemplate, addAddiSpinAddiProgramRow, addAddiSpinAddiBits,
+      mainRomRowOf] using
+      congrArg MainRowWithRom.rom addAddiSpinMainTable_evalAt_one
   · unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
-    change (Eval.eval (addAddiSpinMainTable.environment (mainRowArray (addAddiSpinJalRow 2)))
-        (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar).rom.main_step = 2
-    simpa [addAddiSpinMainTable] using
-      congrArg (fun row : MainRowWithRom FGL => row.rom.main_step)
-        (mainRowsTable_eval_rowInputVar 3 addAddiSpinProgram addAddiSpinMainRows
-          (addAddiSpinJalRow 2))
+    rw [dif_pos (by norm_num [addAddiSpinMainTable, mainRowsTable, addAddiSpinMainRows])]
+    simpa [Table.environmentAt, addAddiSpinJalRow, addSpinJalRow, addSpinJalProgramRow,
+      addSpinJalBits, mainRomRowOf] using
+      congrArg MainRowWithRom.rom addAddiSpinMainTable_evalAt_two
 
 private theorem addAddiSpinMain_main_step_index_fixed :
     MainStepIndexFixedFacts 3 3 addAddiSpinProgram addAddiSpinMainTable where
@@ -675,6 +859,101 @@ theorem addAddiSpinWitness_segment_l1_fixed :
   subst table
   exact ⟨fun _ => addAddiSpinMain_segment_l1_first, addAddiSpinMain_segment_l1_later⟩
 
+private theorem addAddiSpinMainOpBusInteraction_eval_at
+    (env : Environment FGL) (row : MainRowWithRom FGL)
+    (h_input : Eval.eval env (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar = row) :
+    (((OpBusChannel.emitted
+        (-(componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar.core.is_external_op)
+        (opBusMessageExpr
+          (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar.core)).toRaw).eval env) =
+      mainOpBusInteraction row := by
+  let rowVar := (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar
+  have h_core : Eval.eval env rowVar.core = row.core := by
+    rw [ZiskFv.AirsClean.FullEnsemble.mainRowWithRom_eval_core]
+    exact congrArg MainRowWithRom.core h_input
+  have h_field := ZiskFv.AirsClean.FullEnsemble.mainRow_eval_is_external_op env rowVar.core
+  simp [mainOpBusInteraction, AbstractInteraction.eval, ChannelInteraction.toRaw]
+  constructor
+  · change Expression.eval env (-rowVar.core.is_external_op) = -row.core.is_external_op
+    simp [Expression.eval, h_field, h_core]
+  constructor
+  · have h_msg_eval :
+        Eval.eval env (opBusMessageExpr rowVar.core) = opBusMessage row.core := by
+      rw [eval_opBusMessageExpr, h_core]
+    rw [toElements_eval_toArray]
+    change (toElements (Eval.eval env (opBusMessageExpr rowVar.core))).toArray =
+      (toElements (opBusMessage row.core)).toArray
+    rw [h_msg_eval]
+  · rfl
+
+private theorem addAddiSpinMainOpBusInteractionsAt
+    (env : Environment FGL) (row : MainRowWithRom FGL)
+    (h_input : Eval.eval env (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar = row) :
+    (componentWithRomMemAndOpBus 3 addAddiSpinProgram).operations.interactionValuesWith
+        OpBusChannel.toRaw env = [mainOpBusInteraction row] := by
+  simp [Operations.interactionValuesWith_eq_map,
+    componentWithRomMemAndOpBus_interactionsWith_opBus]
+  exact addAddiSpinMainOpBusInteraction_eval_at env row h_input
+
+theorem addAddiSpinMainTable_interactionsWith_opBus :
+    addAddiSpinMainTable.interactionsWith OpBusChannel.toRaw =
+      [ mainOpBusInteraction addAddiSpinAddRow
+      , mainOpBusInteraction addAddiSpinAddiRow
+      , mainOpBusInteraction (addAddiSpinJalRow 2)
+      , mainOpBusInteraction (addAddiSpinJalRow 3) ] := by
+  rw [Table.interactionsWith, addAddiSpinMainTable_effectiveRows]
+  simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]
+  have h_add :
+      addAddiSpinMainTable.component.operations.interactionValuesWith
+          OpBusChannel.toRaw
+          (addAddiSpinMainTable.environment
+            (mainFixedColumns.materialize 0 (mainRawRow addAddiSpinAddRow))) =
+        [mainOpBusInteraction addAddiSpinAddRow] := by
+    simpa [addAddiSpinMainTable, mainRowsTable] using
+      (addAddiSpinMainOpBusInteractionsAt
+        (Environment.fromArray
+          (mainFixedColumns.materialize 0 (mainRawRow addAddiSpinAddRow)) emptyData)
+        addAddiSpinAddRow
+        (eval_mainRawRow_materialize 0 emptyData addAddiSpinAddRow (by rfl) (by rfl)))
+  have h_addi :
+      addAddiSpinMainTable.component.operations.interactionValuesWith
+          OpBusChannel.toRaw
+          (addAddiSpinMainTable.environment
+            (mainFixedColumns.materialize 1 (mainRawRow addAddiSpinAddiRow))) =
+        [mainOpBusInteraction addAddiSpinAddiRow] := by
+    simpa [addAddiSpinMainTable, mainRowsTable] using
+      (addAddiSpinMainOpBusInteractionsAt
+        (Environment.fromArray
+          (mainFixedColumns.materialize 1 (mainRawRow addAddiSpinAddiRow)) emptyData)
+        addAddiSpinAddiRow
+        (eval_mainRawRow_materialize 1 emptyData addAddiSpinAddiRow (by rfl) (by rfl)))
+  have h_jal_two :
+      addAddiSpinMainTable.component.operations.interactionValuesWith
+          OpBusChannel.toRaw
+          (addAddiSpinMainTable.environment
+            (mainFixedColumns.materialize 2 (mainRawRow (addAddiSpinJalRow 2)))) =
+        [mainOpBusInteraction (addAddiSpinJalRow 2)] := by
+    simpa [addAddiSpinMainTable, mainRowsTable] using
+      (addAddiSpinMainOpBusInteractionsAt
+        (Environment.fromArray
+          (mainFixedColumns.materialize 2 (mainRawRow (addAddiSpinJalRow 2))) emptyData)
+        (addAddiSpinJalRow 2)
+        (eval_mainRawRow_materialize 2 emptyData (addAddiSpinJalRow 2) (by rfl) (by rfl)))
+  have h_jal_three :
+      addAddiSpinMainTable.component.operations.interactionValuesWith
+          OpBusChannel.toRaw
+          (addAddiSpinMainTable.environment
+            (mainFixedColumns.materialize 3 (mainRawRow (addAddiSpinJalRow 3)))) =
+        [mainOpBusInteraction (addAddiSpinJalRow 3)] := by
+    simpa [addAddiSpinMainTable, mainRowsTable] using
+      (addAddiSpinMainOpBusInteractionsAt
+        (Environment.fromArray
+          (mainFixedColumns.materialize 3 (mainRawRow (addAddiSpinJalRow 3))) emptyData)
+        (addAddiSpinJalRow 3)
+        (eval_mainRawRow_materialize 3 emptyData (addAddiSpinJalRow 3) (by rfl) (by rfl)))
+  rw [h_add, h_addi, h_jal_two, h_jal_three]
+  rfl
+
 theorem addAddiSpinOpBus_interactions :
     addAddiSpinWitness.tables.flatMap (·.interactionsWith OpBusChannel.toRaw) =
       [ binaryAddOpBusInteraction addX1BinaryAddRow
@@ -690,8 +969,7 @@ theorem addAddiSpinOpBus_interactions :
   rw [addAddiSpinWitness_tables]
   simp [addAddiSpinTables, h_registerBoundary, emptyComponentTable_interactionsWith,
     addAddiSpinBinaryAddTable, binaryAddRowsTable_interactionsWith_opBus,
-    addAddiSpinBinaryAddRows, addAddiSpinMainTable, mainRowsTable_interactionsWith_opBus,
-    addAddiSpinMainRows]
+    addAddiSpinBinaryAddRows, addAddiSpinMainTable_interactionsWith_opBus]
 
 theorem addAddiSpinWitness_opBus_balanced :
     BalancedInteractions
@@ -882,17 +1160,253 @@ private theorem addAddiSpinIdleBoundaryInteractions_balanced :
   rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
   decide
 
-private theorem addAddiSpinJalMemBusInactive (step : FGL) :
-    MainMemBusInactive (addAddiSpinJalRow step) := by
-  constructor <;>
-    simp [addAddiSpinJalRow, addSpinJalRow, addSpinJalProgramRow, addSpinJalBits,
-      mainRomRowOf]
+private def addAddiSpinMainMemBusInteractionsAt (env : Environment FGL) : List (Interaction FGL) :=
+  let rowVar := (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar
+  [ ((MemBusChannel.emitted rowVar.rom.a_src_reg (aRegPreMessageExpr rowVar)).toRaw).eval env
+  , ((MemBusChannel.emitted (-(rowVar.rom.a_src_mem + rowVar.rom.a_src_reg))
+      (aMemMessageExpr rowVar)).toRaw).eval env
+  , ((MemBusChannel.emitted rowVar.rom.b_src_reg (bRegPreMessageExpr rowVar)).toRaw).eval env
+  , ((MemBusChannel.emitted
+      (-(rowVar.rom.b_src_mem + rowVar.rom.b_src_ind + rowVar.rom.b_src_reg))
+      (bMemMessageExpr rowVar)).toRaw).eval env
+  , ((MemBusChannel.emitted rowVar.rom.store_reg (cRegPreMessageExpr rowVar)).toRaw).eval env
+  , ((MemBusChannel.emitted
+      (-(rowVar.rom.store_mem + rowVar.rom.store_ind + rowVar.rom.store_reg))
+      (cMemMessageExpr rowVar)).toRaw).eval env ]
+
+private theorem addAddiSpinMainMemBusInteractionsAt_eq_valueLevel
+    (env : Environment FGL) (row : MainRowWithRom FGL)
+    (h_input : Eval.eval env (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar = row) :
+    addAddiSpinMainMemBusInteractionsAt env = addAddiSpinMainValueMemBusInteractions row := by
+  unfold addAddiSpinMainMemBusInteractionsAt
+  let rowVar := (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar
+  have h_rom : eval env rowVar.rom = row.rom := by
+    rw [mainRowWithRom_eval_rom]
+    exact congrArg MainRowWithRom.rom h_input
+  have h_aSrcReg : Expression.eval env rowVar.rom.a_src_reg = row.rom.a_src_reg := by
+    calc
+      Expression.eval env rowVar.rom.a_src_reg = (eval env rowVar.rom).a_src_reg :=
+        mainRomRow_eval_a_src_reg env rowVar.rom
+      _ = row.rom.a_src_reg := by rw [h_rom]
+  have h_aSrcMem : Expression.eval env rowVar.rom.a_src_mem = row.rom.a_src_mem := by
+    calc
+      Expression.eval env rowVar.rom.a_src_mem = (eval env rowVar.rom).a_src_mem :=
+        mainRomRow_eval_a_src_mem env rowVar.rom
+      _ = row.rom.a_src_mem := by rw [h_rom]
+  have h_bSrcReg : Expression.eval env rowVar.rom.b_src_reg = row.rom.b_src_reg := by
+    calc
+      Expression.eval env rowVar.rom.b_src_reg = (eval env rowVar.rom).b_src_reg :=
+        mainRomRow_eval_b_src_reg env rowVar.rom
+      _ = row.rom.b_src_reg := by rw [h_rom]
+  have h_bSrcMem : Expression.eval env rowVar.rom.b_src_mem = row.rom.b_src_mem := by
+    calc
+      Expression.eval env rowVar.rom.b_src_mem = (eval env rowVar.rom).b_src_mem :=
+        mainRomRow_eval_b_src_mem env rowVar.rom
+      _ = row.rom.b_src_mem := by rw [h_rom]
+  have h_bSrcInd : Expression.eval env rowVar.rom.b_src_ind = row.rom.b_src_ind := by
+    calc
+      Expression.eval env rowVar.rom.b_src_ind = (eval env rowVar.rom).b_src_ind :=
+        mainRomRow_eval_b_src_ind env rowVar.rom
+      _ = row.rom.b_src_ind := by rw [h_rom]
+  have h_storeReg : Expression.eval env rowVar.rom.store_reg = row.rom.store_reg := by
+    calc
+      Expression.eval env rowVar.rom.store_reg = (eval env rowVar.rom).store_reg :=
+        mainRomRow_eval_store_reg env rowVar.rom
+      _ = row.rom.store_reg := by rw [h_rom]
+  have h_storeMem : Expression.eval env rowVar.rom.store_mem = row.rom.store_mem := by
+    calc
+      Expression.eval env rowVar.rom.store_mem = (eval env rowVar.rom).store_mem :=
+        mainRomRow_eval_store_mem env rowVar.rom
+      _ = row.rom.store_mem := by rw [h_rom]
+  have h_storeInd : Expression.eval env rowVar.rom.store_ind = row.rom.store_ind := by
+    calc
+      Expression.eval env rowVar.rom.store_ind = (eval env rowVar.rom).store_ind :=
+        mainRomRow_eval_store_ind env rowVar.rom
+      _ = row.rom.store_ind := by rw [h_rom]
+  have h_aRegPreMessage : eval env (aRegPreMessageExpr rowVar) = aRegPreMessage row := by
+    rw [ZiskFv.AirsClean.Main.eval_aRegPreMessageExpr, h_input]
+  have h_aMemMessage : eval env (aMemMessageExpr rowVar) = aMemMessage row := by
+    rw [ZiskFv.AirsClean.Main.eval_aMemMessageExpr, h_input]
+  have h_bRegPreMessage : eval env (bRegPreMessageExpr rowVar) = bRegPreMessage row := by
+    rw [ZiskFv.AirsClean.Main.eval_bRegPreMessageExpr, h_input]
+  have h_bMemMessage : eval env (bMemMessageExpr rowVar) = bMemMessage row := by
+    rw [ZiskFv.AirsClean.Main.eval_bMemMessageExpr, h_input]
+  have h_cRegPreMessage : eval env (cRegPreMessageExpr rowVar) = cRegPreMessage row := by
+    rw [ZiskFv.AirsClean.Main.eval_cRegPreMessageExpr, h_input]
+  have h_cMemMessage : eval env (cMemMessageExpr rowVar) = cMemMessage row := by
+    rw [ZiskFv.AirsClean.Main.eval_cMemMessageExpr, h_input]
+  have h_aReg :
+      (((MemBusChannel.emitted rowVar.rom.a_src_reg
+          (aRegPreMessageExpr rowVar)).toRaw).eval env) =
+        mainARegPreInteraction row := by
+    simp [mainARegPreInteraction, AbstractInteraction.eval, ChannelInteraction.toRaw,
+      Channel.emitted, emitted]
+    constructor
+    · exact h_aSrcReg
+    · rw [toElements_eval_toArray, h_aRegPreMessage]
+  have h_aMem :
+      (((MemBusChannel.emitted (-(rowVar.rom.a_src_mem + rowVar.rom.a_src_reg))
+          (aMemMessageExpr rowVar)).toRaw).eval env) =
+        mainAMemInteraction row := by
+    simp [mainAMemInteraction, AbstractInteraction.eval, ChannelInteraction.toRaw,
+      Channel.emitted, emitted]
+    constructor
+    · simp [Expression.eval, h_aSrcMem, h_aSrcReg]
+    · rw [toElements_eval_toArray, h_aMemMessage]
+  have h_bReg :
+      (((MemBusChannel.emitted rowVar.rom.b_src_reg
+          (bRegPreMessageExpr rowVar)).toRaw).eval env) =
+        mainBRegPreInteraction row := by
+    simp [mainBRegPreInteraction, AbstractInteraction.eval, ChannelInteraction.toRaw,
+      Channel.emitted, emitted]
+    constructor
+    · exact h_bSrcReg
+    · rw [toElements_eval_toArray, h_bRegPreMessage]
+  have h_bMem :
+      (((MemBusChannel.emitted
+          (-(rowVar.rom.b_src_mem + rowVar.rom.b_src_ind + rowVar.rom.b_src_reg))
+          (bMemMessageExpr rowVar)).toRaw).eval env) =
+        mainBMemInteraction row := by
+    simp [mainBMemInteraction, AbstractInteraction.eval, ChannelInteraction.toRaw,
+      Channel.emitted, emitted]
+    constructor
+    · simp [Expression.eval, h_bSrcMem, h_bSrcInd, h_bSrcReg]
+    · rw [toElements_eval_toArray, h_bMemMessage]
+  have h_cReg :
+      (((MemBusChannel.emitted rowVar.rom.store_reg
+          (cRegPreMessageExpr rowVar)).toRaw).eval env) =
+        mainCRegPreInteraction row := by
+    simp [mainCRegPreInteraction, AbstractInteraction.eval, ChannelInteraction.toRaw,
+      Channel.emitted, emitted]
+    constructor
+    · exact h_storeReg
+    · rw [toElements_eval_toArray, h_cRegPreMessage]
+  have h_cMem :
+      (((MemBusChannel.emitted
+          (-(rowVar.rom.store_mem + rowVar.rom.store_ind + rowVar.rom.store_reg))
+          (cMemMessageExpr rowVar)).toRaw).eval env) =
+        mainCMemInteraction row := by
+    simp [mainCMemInteraction, AbstractInteraction.eval, ChannelInteraction.toRaw,
+      Channel.emitted, emitted]
+    constructor
+    · simp [Expression.eval, h_storeMem, h_storeInd, h_storeReg]
+    · rw [toElements_eval_toArray, h_cMemMessage]
+  change
+    [(((MemBusChannel.emitted rowVar.rom.a_src_reg (aRegPreMessageExpr rowVar)).toRaw).eval env),
+      (((MemBusChannel.emitted (-(rowVar.rom.a_src_mem + rowVar.rom.a_src_reg))
+        (aMemMessageExpr rowVar)).toRaw).eval env),
+      (((MemBusChannel.emitted rowVar.rom.b_src_reg (bRegPreMessageExpr rowVar)).toRaw).eval env),
+      (((MemBusChannel.emitted
+        (-(rowVar.rom.b_src_mem + rowVar.rom.b_src_ind + rowVar.rom.b_src_reg))
+        (bMemMessageExpr rowVar)).toRaw).eval env),
+      (((MemBusChannel.emitted rowVar.rom.store_reg (cRegPreMessageExpr rowVar)).toRaw).eval env),
+      (((MemBusChannel.emitted
+        (-(rowVar.rom.store_mem + rowVar.rom.store_ind + rowVar.rom.store_reg))
+        (cMemMessageExpr rowVar)).toRaw).eval env)] =
+      [mainARegPreInteraction row, mainAMemInteraction row, mainBRegPreInteraction row,
+        mainBMemInteraction row, mainCRegPreInteraction row, mainCMemInteraction row]
+  simp [h_aReg, h_aMem, h_bReg, h_bMem, h_cReg, h_cMem]
+
+private theorem addAddiSpinMainMemBusInteractionsAt_eq_component
+    (env : Environment FGL) :
+    (componentWithRomMemAndOpBus 3 addAddiSpinProgram).operations.interactionValuesWith
+        MemBusChannel.toRaw env = addAddiSpinMainMemBusInteractionsAt env := by
+  simp [addAddiSpinMainMemBusInteractionsAt, Operations.interactionValuesWith_eq_map,
+    componentWithRomMemAndOpBus_interactionsWith_memBus]
+
+theorem addAddiSpinMainTable_interactionsWith_memBus :
+    addAddiSpinMainTable.interactionsWith MemBusChannel.toRaw =
+      addAddiSpinMainValueMemBusInteractions addAddiSpinAddRow ++
+        addAddiSpinMainValueMemBusInteractions addAddiSpinAddiRow ++
+        addAddiSpinMainValueMemBusInteractions (addAddiSpinJalRow 2) ++
+        addAddiSpinMainValueMemBusInteractions (addAddiSpinJalRow 3) := by
+  rw [Table.interactionsWith, addAddiSpinMainTable_effectiveRows]
+  simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]
+  have h_add :
+      addAddiSpinMainTable.component.operations.interactionValuesWith
+          MemBusChannel.toRaw
+          (addAddiSpinMainTable.environment
+            (mainFixedColumns.materialize 0 (mainRawRow addAddiSpinAddRow))) =
+        addAddiSpinMainValueMemBusInteractions addAddiSpinAddRow := by
+    calc
+      _ = addAddiSpinMainMemBusInteractionsAt
+          (Environment.fromArray
+            (mainFixedColumns.materialize 0 (mainRawRow addAddiSpinAddRow)) emptyData) := by
+        simpa [addAddiSpinMainTable, mainRowsTable] using
+          (addAddiSpinMainMemBusInteractionsAt_eq_component
+            (Environment.fromArray
+              (mainFixedColumns.materialize 0 (mainRawRow addAddiSpinAddRow)) emptyData))
+      _ = addAddiSpinMainValueMemBusInteractions addAddiSpinAddRow :=
+        addAddiSpinMainMemBusInteractionsAt_eq_valueLevel _ addAddiSpinAddRow
+          (eval_mainRawRow_materialize 0 emptyData addAddiSpinAddRow (by rfl) (by rfl))
+  have h_addi :
+      addAddiSpinMainTable.component.operations.interactionValuesWith
+          MemBusChannel.toRaw
+          (addAddiSpinMainTable.environment
+            (mainFixedColumns.materialize 1 (mainRawRow addAddiSpinAddiRow))) =
+        addAddiSpinMainValueMemBusInteractions addAddiSpinAddiRow := by
+    calc
+      _ = addAddiSpinMainMemBusInteractionsAt
+          (Environment.fromArray
+            (mainFixedColumns.materialize 1 (mainRawRow addAddiSpinAddiRow)) emptyData) := by
+        simpa [addAddiSpinMainTable, mainRowsTable] using
+          (addAddiSpinMainMemBusInteractionsAt_eq_component
+            (Environment.fromArray
+              (mainFixedColumns.materialize 1 (mainRawRow addAddiSpinAddiRow)) emptyData))
+      _ = addAddiSpinMainValueMemBusInteractions addAddiSpinAddiRow :=
+        addAddiSpinMainMemBusInteractionsAt_eq_valueLevel _ addAddiSpinAddiRow
+          (eval_mainRawRow_materialize 1 emptyData addAddiSpinAddiRow (by rfl) (by rfl))
+  have h_jal_two :
+      addAddiSpinMainTable.component.operations.interactionValuesWith
+          MemBusChannel.toRaw
+          (addAddiSpinMainTable.environment
+            (mainFixedColumns.materialize 2 (mainRawRow (addAddiSpinJalRow 2)))) =
+        addAddiSpinMainValueMemBusInteractions (addAddiSpinJalRow 2) := by
+    calc
+      _ = addAddiSpinMainMemBusInteractionsAt
+          (Environment.fromArray
+            (mainFixedColumns.materialize 2 (mainRawRow (addAddiSpinJalRow 2))) emptyData) := by
+        simpa [addAddiSpinMainTable, mainRowsTable] using
+          (addAddiSpinMainMemBusInteractionsAt_eq_component
+            (Environment.fromArray
+              (mainFixedColumns.materialize 2 (mainRawRow (addAddiSpinJalRow 2))) emptyData))
+      _ = addAddiSpinMainValueMemBusInteractions (addAddiSpinJalRow 2) :=
+        addAddiSpinMainMemBusInteractionsAt_eq_valueLevel _ (addAddiSpinJalRow 2)
+          (eval_mainRawRow_materialize 2 emptyData (addAddiSpinJalRow 2) (by rfl) (by rfl))
+  have h_jal_three :
+      addAddiSpinMainTable.component.operations.interactionValuesWith
+          MemBusChannel.toRaw
+          (addAddiSpinMainTable.environment
+            (mainFixedColumns.materialize 3 (mainRawRow (addAddiSpinJalRow 3)))) =
+        addAddiSpinMainValueMemBusInteractions (addAddiSpinJalRow 3) := by
+    calc
+      _ = addAddiSpinMainMemBusInteractionsAt
+          (Environment.fromArray
+            (mainFixedColumns.materialize 3 (mainRawRow (addAddiSpinJalRow 3))) emptyData) := by
+        simpa [addAddiSpinMainTable, mainRowsTable] using
+          (addAddiSpinMainMemBusInteractionsAt_eq_component
+            (Environment.fromArray
+              (mainFixedColumns.materialize 3 (mainRawRow (addAddiSpinJalRow 3))) emptyData))
+      _ = addAddiSpinMainValueMemBusInteractions (addAddiSpinJalRow 3) :=
+        addAddiSpinMainMemBusInteractionsAt_eq_valueLevel _ (addAddiSpinJalRow 3)
+          (eval_mainRawRow_materialize 3 emptyData (addAddiSpinJalRow 3) (by rfl) (by rfl))
+  rw [h_add, h_addi, h_jal_two, h_jal_three]
+  simpa only [List.append_assoc]
 
 private theorem addAddiSpinJalMemBusInteractions_balanced (step : FGL) :
-    BalancedInteractions
-      (mainMemBusInteractionsFor 3 addAddiSpinProgram (addAddiSpinJalRow step)) := by
-  exact mainMemBusInteractionsFor_balanced_of_inactive 3 addAddiSpinProgram
-    (addAddiSpinJalRow step) (addAddiSpinJalMemBusInactive step)
+    BalancedInteractions (addAddiSpinMainValueMemBusInteractions (addAddiSpinJalRow step)) := by
+  refine zeroInteractions_balanced _ ?_ ?_
+  · intro interaction h_interaction
+    simp [addAddiSpinMainValueMemBusInteractions, mainValueMemBusInteractions] at h_interaction
+    rcases h_interaction with rfl | rfl | rfl | rfl | rfl | rfl <;>
+      simp [addAddiSpinMainValueMemBusInteractions, mainValueMemBusInteractions,
+        mainARegPreInteraction, mainAMemInteraction, mainBRegPreInteraction,
+        mainBMemInteraction, mainCRegPreInteraction, mainCMemInteraction, addAddiSpinJalRow,
+        addSpinJalRow, addSpinJalProgramRow, addSpinJalBits, mainRomRowOf]
+  · left
+    change 6 < ringChar FGL
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
 
 noncomputable def addAddiSpinMemBusInteractions : List (Interaction FGL) :=
   addAddiSpinWitness.tables.flatMap (·.interactionsWith MemBusChannel.toRaw)
@@ -901,8 +1415,8 @@ private noncomputable def addAddiSpinReducedMemBusInteractions : List (Interacti
   (boundaryInteractions addAddiSpinBoundaryRowX1 ++ idleBoundaryInteractions) ++
     addAddiSpinMainValueMemBusInteractions addAddiSpinAddRow ++
     addAddiSpinMainValueMemBusInteractions addAddiSpinAddiRow ++
-    mainMemBusInteractionsFor 3 addAddiSpinProgram (addAddiSpinJalRow 2) ++
-    mainMemBusInteractionsFor 3 addAddiSpinProgram (addAddiSpinJalRow 3)
+    addAddiSpinMainValueMemBusInteractions (addAddiSpinJalRow 2) ++
+    addAddiSpinMainValueMemBusInteractions (addAddiSpinJalRow 3)
 
 private theorem addAddiSpinMemBusInteractions_eq_tables :
     addAddiSpinMemBusInteractions =
@@ -968,39 +1482,19 @@ private theorem addAddiSpinBinaryAddTableMemBusInteractions_eq_nil :
 
 private theorem addAddiSpinMainTableMemBusInteractions_eq_rows :
     addAddiSpinMainTable.interactionsWith MemBusChannel.toRaw =
-      mainMemBusInteractionsForRows 3 addAddiSpinProgram addAddiSpinMainRows := by
-  unfold addAddiSpinMainTable
-  exact mainRowsTable_interactionsWith_memBus 3 addAddiSpinProgram addAddiSpinMainRows
-
-private theorem addAddiSpinMainRowsMemBusInteractions_eq_expanded :
-    mainMemBusInteractionsForRows 3 addAddiSpinProgram addAddiSpinMainRows =
-      mainMemBusInteractionsFor 3 addAddiSpinProgram addAddiSpinAddRow ++
-        mainMemBusInteractionsFor 3 addAddiSpinProgram addAddiSpinAddiRow ++
-        mainMemBusInteractionsFor 3 addAddiSpinProgram (addAddiSpinJalRow 2) ++
-        mainMemBusInteractionsFor 3 addAddiSpinProgram (addAddiSpinJalRow 3) := by
-  unfold addAddiSpinMainRows
-  exact mainMemBusInteractionsForRows_four 3 addAddiSpinProgram addAddiSpinAddRow
-    addAddiSpinAddiRow (addAddiSpinJalRow 2) (addAddiSpinJalRow 3)
-
-private theorem addAddiSpinExpandedMemBusInteractions_eq_reduced :
-    (boundaryInteractions addAddiSpinBoundaryRowX1 ++ idleBoundaryInteractions) ++
-      (mainMemBusInteractionsFor 3 addAddiSpinProgram addAddiSpinAddRow ++
-        mainMemBusInteractionsFor 3 addAddiSpinProgram addAddiSpinAddiRow ++
-        mainMemBusInteractionsFor 3 addAddiSpinProgram (addAddiSpinJalRow 2) ++
-        mainMemBusInteractionsFor 3 addAddiSpinProgram (addAddiSpinJalRow 3)) =
-      addAddiSpinReducedMemBusInteractions := by
-  unfold addAddiSpinReducedMemBusInteractions
-  rw [mainMemBusInteractionsFor_eq_valueLevel 3 addAddiSpinProgram addAddiSpinAddRow,
-    mainMemBusInteractionsFor_eq_valueLevel 3 addAddiSpinProgram addAddiSpinAddiRow]
-  rfl
+      addAddiSpinMainValueMemBusInteractions addAddiSpinAddRow ++
+        addAddiSpinMainValueMemBusInteractions addAddiSpinAddiRow ++
+        addAddiSpinMainValueMemBusInteractions (addAddiSpinJalRow 2) ++
+        addAddiSpinMainValueMemBusInteractions (addAddiSpinJalRow 3) :=
+  addAddiSpinMainTable_interactionsWith_memBus
 
 private theorem addAddiSpinReducedMemBusInteractions_balanced :
     BalancedInteractions addAddiSpinReducedMemBusInteractions := by
   unfold addAddiSpinReducedMemBusInteractions
   let addRows := addAddiSpinMainValueMemBusInteractions addAddiSpinAddRow ++
     addAddiSpinMainValueMemBusInteractions addAddiSpinAddiRow
-  let jalRows := mainMemBusInteractionsFor 3 addAddiSpinProgram (addAddiSpinJalRow 2) ++
-    mainMemBusInteractionsFor 3 addAddiSpinProgram (addAddiSpinJalRow 3)
+  let jalRows := addAddiSpinMainValueMemBusInteractions (addAddiSpinJalRow 2) ++
+    addAddiSpinMainValueMemBusInteractions (addAddiSpinJalRow 3)
   have h_perm : List.Perm
       ((boundaryInteractions addAddiSpinBoundaryRowX1 ++ idleBoundaryInteractions) ++
         addRows ++ jalRows)
@@ -1043,10 +1537,9 @@ theorem addAddiSpinWitness_memBus_balanced :
     addAddiSpinBinaryAddTableMemBusInteractions_eq_nil,
     addAddiSpinMainTableMemBusInteractions_eq_rows]
   simp only [List.append_nil]
-  rw [addAddiSpinBoundaryRows_interactions,
-    addAddiSpinMainRowsMemBusInteractions_eq_expanded,
-    addAddiSpinExpandedMemBusInteractions_eq_reduced]
-  exact addAddiSpinReducedMemBusInteractions_balanced
+  rw [addAddiSpinBoundaryRows_interactions]
+  simpa [addAddiSpinReducedMemBusInteractions, List.append_assoc] using
+    addAddiSpinReducedMemBusInteractions_balanced
 
 theorem addAddiSpinWitness_balancedChannels : addAddiSpinWitness.BalancedChannels := by
   refine addAddiSpinWitness.balancedChannels_of_tables addAddiSpinEnsemble_verifier ?_
@@ -1071,7 +1564,6 @@ def addAddiSpinAcceptedTrace : AcceptedZiskTrace 3 where
   mem_replay_gsum := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
   mem_replay_im0 := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
   mem_replay_im1 := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
-  mem_replay_constraints := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
   mem_replay_segment_ranges := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
   mem_replay_source_covers := fun h => absurd h addAddiSpinWitness_not_mutableMemPresent
   transitions_hold := addAddiSpinWitness_transitions

--- a/ZiskFv/Compliance/AddSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/AddSpinRootSoundness.lean
@@ -95,30 +95,26 @@ private theorem addSpinAcceptedTrace_program :
 
 private theorem addSpinMainRowAt_zero :
     ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero addSpinProgram
-      (mainRowsTable 2 addSpinProgram addSpinMainRows) 0 = addSpinAddRow := by
-  simp [ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero, mainRowsTable, addSpinMainRows]
-  change eval ((mainRowsTable 2 addSpinProgram addSpinMainRows).environment
-      (mainRowArray addSpinAddRow))
-        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar =
-    addSpinAddRow
-  rw [mainRowsTable_eval_rowInputVar]
+      addSpinMainTable 0 = addSpinAddRow := by
+  unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+  rw [dif_pos (by norm_num [addSpinMainTable, mainRowsTable, addSpinMainRows])]
+  exact addSpinMainTable_eval_rowInputVar_zero
+    (by norm_num [addSpinMainTable, mainRowsTable, addSpinMainRows])
 
 private theorem addSpinMainRowAt_one :
     ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero addSpinProgram
-      (mainRowsTable 2 addSpinProgram addSpinMainRows) 1 = addSpinJalRow 1 := by
-  simp [ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero, mainRowsTable, addSpinMainRows]
-  change eval ((mainRowsTable 2 addSpinProgram addSpinMainRows).environment
-      (mainRowArray (addSpinJalRow 1)))
-        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar =
-    addSpinJalRow 1
-  rw [mainRowsTable_eval_rowInputVar]
+      addSpinMainTable 1 = addSpinJalRow 1 := by
+  unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+  rw [dif_pos (by norm_num [addSpinMainTable, mainRowsTable, addSpinMainRows])]
+  exact addSpinMainTable_eval_rowInputVar_one
+    (by norm_num [addSpinMainTable, mainRowsTable, addSpinMainRows])
 
 private theorem addSpinMainPc_add :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinAcceptedTrace.program
         addSpinAcceptedTrace.mainTable).pc addSpinAddIndex.val = 0 := by
   rw [addSpinAcceptedTrace_mainTable_eq]
   change (ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
-      (mainRowsTable 2 addSpinProgram addSpinMainRows)).pc 0 = 0
+      addSpinMainTable).pc 0 = 0
   simp [addSpinMainRowAt_zero, addSpinAddRow, addX1Row]
 
 private theorem addSpinMainPc_jal :
@@ -126,7 +122,7 @@ private theorem addSpinMainPc_jal :
         addSpinAcceptedTrace.mainTable).pc addSpinJalIndex.val = 4 := by
   rw [addSpinAcceptedTrace_mainTable_eq]
   change (ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
-      (mainRowsTable 2 addSpinProgram addSpinMainRows)).pc 1 = 4
+      addSpinMainTable).pc 1 = 4
   simp [addSpinMainRowAt_one, addSpinJalRow, addSpinJalProgramRow, addSpinJalBits,
     addSpinJalFreeCols, ZiskFv.AirsClean.Main.mainRomRowOf]
 
@@ -185,8 +181,8 @@ def addSpinJalProgramDecode :
     ProgramDecode_jal addSpinAcceptedTrace addSpinJalIndex addSpinJalClaim where
   h_idx := by
     rw [addSpinAcceptedTrace_mainTable_eq]
-    change 1 + 1 < (mainRowsTable 2 addSpinProgram addSpinMainRows).table.length
-    norm_num [mainRowsTable, addSpinMainRows]
+    change 1 + 1 < addSpinMainTable.table.length
+    norm_num [addSpinMainTable, mainRowsTable, addSpinMainRows]
   bits := addSpinJalBits
   h_bits_ieo := by rfl
   h_bits_m32 := by rfl
@@ -220,7 +216,7 @@ private theorem addSpinAddLaneLo
     (field : ZiskFv.Airs.Main.Valid_Main FGL FGL → Nat → FGL)
     (h_field :
       (field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
-          (mainRowsTable 2 addSpinProgram addSpinMainRows)) 0) = 0) :
+          addSpinMainTable) 0) = 0) :
     field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinAcceptedTrace.program
         addSpinAcceptedTrace.mainTable) addSpinAddIndex.val =
       lane_lo ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64
@@ -229,7 +225,7 @@ private theorem addSpinAddLaneLo
     (addSpinSailTrace addSpinAddIndex) (regidx_to_fin x1) (0#64) addSpinReadX1_add]
   rw [addSpinAcceptedTrace_mainTable_eq]
   change field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
-      (mainRowsTable 2 addSpinProgram addSpinMainRows)) 0 = _
+      addSpinMainTable) 0 = _
   rw [h_field]
   simp [lane_lo]
 
@@ -237,7 +233,7 @@ private theorem addSpinAddLaneHi
     (field : ZiskFv.Airs.Main.Valid_Main FGL FGL → Nat → FGL)
     (h_field :
       (field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
-          (mainRowsTable 2 addSpinProgram addSpinMainRows)) 0) = 0) :
+          addSpinMainTable) 0) = 0) :
     field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinAcceptedTrace.program
         addSpinAcceptedTrace.mainTable) addSpinAddIndex.val =
       lane_hi ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64
@@ -246,7 +242,7 @@ private theorem addSpinAddLaneHi
     (addSpinSailTrace addSpinAddIndex) (regidx_to_fin x1) (0#64) addSpinReadX1_add]
   rw [addSpinAcceptedTrace_mainTable_eq]
   change field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
-      (mainRowsTable 2 addSpinProgram addSpinMainRows)) 0 = _
+      addSpinMainTable) 0 = _
   rw [h_field]
   simp [lane_hi]
 
@@ -293,7 +289,7 @@ def addSpinAddInputs :
   h_pc_bridge := by
     rw [addSpinAcceptedTrace_mainTable_eq]
     change ((ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
-          (mainRowsTable 2 addSpinProgram addSpinMainRows)).pc 0).val = _
+          addSpinMainTable).pc 0).val = _
     simp [addSpinMainRowAt_zero, addSpinAddRow, addX1Row, addSpinAddInput]
 
 def addSpinJalInputs :
@@ -303,7 +299,7 @@ def addSpinJalInputs :
   h_pc_bridge := by
     rw [addSpinAcceptedTrace_mainTable_eq]
     change ((ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
-          (mainRowsTable 2 addSpinProgram addSpinMainRows)).pc 1).val = _
+          addSpinMainTable).pc 1).val = _
     simp [addSpinMainRowAt_one, addSpinJalRow, addSpinJalProgramRow, addSpinJalBits,
       addSpinJalFreeCols, ZiskFv.AirsClean.Main.mainRomRowOf, addSpinJalInput]
   h_input_rd := by
@@ -424,7 +420,7 @@ private theorem addPaddedMainPc_add :
         addPaddedAcceptedTrace.mainTable).pc addPaddedAddIndex.val = 0 := by
   rw [addPaddedAcceptedTrace_mainTable_eq]
   change (ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
-      (mainRowsTable 2 addSpinProgram addSpinMainRows)).pc 0 = 0
+      addSpinMainTable).pc 0 = 0
   simp [addSpinMainRowAt_zero, addSpinAddRow, addX1Row]
 
 private theorem addPaddedReadX1 :
@@ -437,8 +433,8 @@ def addPaddedAddProgramDecode :
     ProgramDecode_add addPaddedAcceptedTrace addPaddedAddIndex addPaddedAddClaim where
   h_idx := by
     rw [addPaddedAcceptedTrace_mainTable_eq]
-    change 0 + 1 < (mainRowsTable 2 addSpinProgram addSpinMainRows).table.length
-    norm_num [mainRowsTable, addSpinMainRows]
+    change 0 + 1 < addSpinMainTable.table.length
+    norm_num [addSpinMainTable, mainRowsTable, addSpinMainRows]
   bits := addSpinAddBits
   h_bits_ieo := by simp [addSpinAddBits, addX1RomFlagBits]
   h_bits_m32 := by simp [addSpinAddBits, addX1RomFlagBits]
@@ -477,7 +473,7 @@ theorem addPaddedSuccessorRow_hasCommittedLookup :
   exact mainRomMessage_at_eq_program addPaddedAcceptedTrace
     ⟨1, by
       rw [addPaddedAcceptedTrace_mainTable_eq]
-      norm_num [mainRowsTable, addSpinMainRows]⟩
+      norm_num [addSpinMainTable, mainRowsTable, addSpinMainRows]⟩
 
 theorem addPaddedSuccessorRow_isCommittedJal :
     ZiskFv.AirsClean.Main.romMessage
@@ -492,7 +488,7 @@ private theorem addPaddedAddLaneLo
     (field : ZiskFv.Airs.Main.Valid_Main FGL FGL → Nat → FGL)
     (h_field :
       (field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
-          (mainRowsTable 2 addSpinProgram addSpinMainRows)) 0) = 0) :
+          addSpinMainTable) 0) = 0) :
     field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addPaddedAcceptedTrace.program
         addPaddedAcceptedTrace.mainTable) addPaddedAddIndex.val =
       lane_lo ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64
@@ -501,7 +497,7 @@ private theorem addPaddedAddLaneLo
     (addPaddedSailTrace addPaddedAddIndex) (regidx_to_fin x1) (0#64) addPaddedReadX1]
   rw [addPaddedAcceptedTrace_mainTable_eq]
   change field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
-      (mainRowsTable 2 addSpinProgram addSpinMainRows)) 0 = _
+      addSpinMainTable) 0 = _
   rw [h_field]
   simp [lane_lo]
 
@@ -509,7 +505,7 @@ private theorem addPaddedAddLaneHi
     (field : ZiskFv.Airs.Main.Valid_Main FGL FGL → Nat → FGL)
     (h_field :
       (field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
-          (mainRowsTable 2 addSpinProgram addSpinMainRows)) 0) = 0) :
+          addSpinMainTable) 0) = 0) :
     field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addPaddedAcceptedTrace.program
         addPaddedAcceptedTrace.mainTable) addPaddedAddIndex.val =
       lane_hi ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64
@@ -518,7 +514,7 @@ private theorem addPaddedAddLaneHi
     (addPaddedSailTrace addPaddedAddIndex) (regidx_to_fin x1) (0#64) addPaddedReadX1]
   rw [addPaddedAcceptedTrace_mainTable_eq]
   change field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
-      (mainRowsTable 2 addSpinProgram addSpinMainRows)) 0 = _
+      addSpinMainTable) 0 = _
   rw [h_field]
   simp [lane_hi]
 
@@ -565,7 +561,7 @@ def addPaddedAddInputs :
   h_pc_bridge := by
     rw [addPaddedAcceptedTrace_mainTable_eq]
     change ((ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
-          (mainRowsTable 2 addSpinProgram addSpinMainRows)).pc 0).val = _
+          addSpinMainTable).pc 0).val = _
     simp [addSpinMainRowAt_zero, addSpinAddRow, addX1Row, addSpinAddInput]
 
 def addPaddedProgramDecodes :

--- a/ZiskFv/Compliance/AddSpinWitness.lean
+++ b/ZiskFv/Compliance/AddSpinWitness.lean
@@ -79,80 +79,47 @@ def addSpinProgram : Program 2
 def addSpinMainRows : List (MainRowWithRom FGL) :=
   [addSpinAddRow, addSpinJalRow 1, addSpinJalRow 2]
 
+theorem addSpinMainRows_fixed_domain :
+    addSpinMainRows.length <= mainFixedCapacity := by
+  norm_num [addSpinMainRows, mainFixedCapacity]
+
 def mainRowsTable
-    (length : ℕ) (program : Program length) (rows : List (MainRowWithRom FGL)) :
+    (length : ℕ) (program : Program length) (rows : List (MainRowWithRom FGL))
+    (h_fixed_domain : rows.length <= mainFixedCapacity) :
     Table FGL where
   component := componentWithRomMemAndOpBus length program
-  width := size MainRowWithRom
-  table := rows.map mainRowArray
+  rawRows := rows.map mainRawRow
   data := emptyData
-  uniform_width := by
+  raw_uniform_width := by
     intro row h_row
     rcases List.mem_map.mp h_row with ⟨mainRow, _, rfl⟩
-    simp [mainRowArray]
+    change (mainRawRow mainRow).size = 41
+    simp
+  fixed_domain := by
+    intro columns h_columns
+    have h_columns' : columns = mainFixedColumns := by
+      simpa [componentWithRomMemAndOpBus] using h_columns.symm
+    subst columns
+    simpa only [List.length_map, mainFixedColumns] using h_fixed_domain
 
-theorem mainRowsTable_eval_rowInputVar
-    (length : ℕ) (program : Program length) (rows : List (MainRowWithRom FGL))
-    (row : MainRowWithRom FGL) :
-    Eval.eval ((mainRowsTable length program rows).environment (mainRowArray row))
-        (componentWithRomMemAndOpBus length program).rowInputVar =
-      row := by
-  change Eval.eval (Environment.fromInput row emptyData) (varFromOffset MainRowWithRom 0) = row
-  exact ProvableType.eval_fromInput_varFromOffset_zero row emptyData
+def addSpinMainTable : Table FGL :=
+  mainRowsTable 2 addSpinProgram addSpinMainRows addSpinMainRows_fixed_domain
 
-theorem mainRowsTable_rowInput
-    (length : ℕ) (program : Program length) (rows : List (MainRowWithRom FGL))
-    (row : MainRowWithRom FGL) :
-    (componentWithRomMemAndOpBus length program).rowInput
-        ((mainRowsTable length program rows).environment (mainRowArray row)) =
-      row := by
-  simpa [mainRowsTable, mainSingleRowTable] using mainSingleRowTable_rowInput length program row
+private theorem addSpinMainTable_effectiveRows :
+    addSpinMainTable.table =
+      [ mainFixedColumns.materialize 0 (mainRawRow addSpinAddRow)
+      , mainFixedColumns.materialize 1 (mainRawRow (addSpinJalRow 1))
+      , mainFixedColumns.materialize 2 (mainRawRow (addSpinJalRow 2)) ] := by
+  simp [addSpinMainTable, mainRowsTable, Table.table, componentWithRomMemAndOpBus,
+    addSpinMainRows]
 
-theorem mainRowsTable_transition
-    (length : ℕ) (program : Program length) (rows : List (MainRowWithRom FGL))
-    (prev curr : MainRowWithRom FGL) :
-    (mainRowsTable length program rows).component.transition prev curr =
-      pcHandshakeBetween prev curr := by
+@[simp] private theorem addSpinMainTable_length : addSpinMainTable.length = 3 := by
   rfl
 
-theorem mainRowsTable_opBus_row
-    (length : ℕ) (program : Program length) (rows : List (MainRowWithRom FGL))
-    (row : MainRowWithRom FGL) :
-    (componentWithRomMemAndOpBus length program).operations.interactionValuesWith
-        OpBusChannel.toRaw
-        ((mainRowsTable length program rows).environment (mainRowArray row)) =
-      [mainOpBusInteraction row] := by
-  simp [Operations.interactionValuesWith_eq_map,
-    componentWithRomMemAndOpBus_interactionsWith_opBus]
-  simpa [mainRowsTable, mainSingleRowTable] using
-    mainComponentOpBusInteraction_eval length program row
-
-private theorem mainRowsTable_interactionsWith_opBus_go
-    (length : ℕ) (program : Program length)
-    (allRows rows : List (MainRowWithRom FGL)) :
-    (rows.map mainRowArray).flatMap (fun arr =>
-        (componentWithRomMemAndOpBus length program).operations.interactionValuesWith
-          OpBusChannel.toRaw ((mainRowsTable length program allRows).environment arr)) =
-      rows.flatMap fun row => [mainOpBusInteraction row] := by
-  induction rows with
-  | nil => rfl
-  | cons row rest ih =>
-      simp [mainRowsTable_opBus_row, ih]
-
-theorem mainRowsTable_interactionsWith_opBus
-    (length : ℕ) (program : Program length) (rows : List (MainRowWithRom FGL)) :
-    (mainRowsTable length program rows).interactionsWith OpBusChannel.toRaw =
-      rows.flatMap fun row => [mainOpBusInteraction row] := by
-  change (rows.map mainRowArray).flatMap (fun arr =>
-        (componentWithRomMemAndOpBus length program).operations.interactionValuesWith
-          OpBusChannel.toRaw ((mainRowsTable length program rows).environment arr)) =
-      rows.flatMap fun row => [mainOpBusInteraction row]
-  exact mainRowsTable_interactionsWith_opBus_go length program rows rows
-
-def mainMemBusInteractionsFor
-    (length : ℕ) (program : Program length) (row : MainRowWithRom FGL) :
-    List (Interaction FGL) :=
-  mainMemBusInteractions length program row
+@[simp] private theorem addSpinMainTable_table_length :
+    addSpinMainTable.table.length = 3 := by
+  rw [Table.table_length]
+  exact addSpinMainTable_length
 
 def mainValueMemBusInteractions (row : MainRowWithRom FGL) : List (Interaction FGL) :=
   [ mainARegPreInteraction row
@@ -186,61 +153,11 @@ theorem mainValueMemBusInteractions_balanced_of_zero
     rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
     decide
 
-def mainMemBusInteractionsForRows
-    (length : ℕ) (program : Program length) :
-    List (MainRowWithRom FGL) → List (Interaction FGL)
-  | [] => []
-  | row :: rest =>
-      mainMemBusInteractionsFor length program row ++
-        mainMemBusInteractionsForRows length program rest
-
-theorem mainMemBusInteractionsForRows_four
-    (length : ℕ) (program : Program length)
-    (row₀ row₁ row₂ row₃ : MainRowWithRom FGL) :
-    mainMemBusInteractionsForRows length program [row₀, row₁, row₂, row₃] =
-      mainMemBusInteractionsFor length program row₀ ++
-        mainMemBusInteractionsFor length program row₁ ++
-        mainMemBusInteractionsFor length program row₂ ++
-        mainMemBusInteractionsFor length program row₃ := by
-  rfl
-
 def mainValueMemBusInteractionsForRows :
     List (MainRowWithRom FGL) → List (Interaction FGL)
   | [] => []
   | row :: rest =>
       mainValueMemBusInteractions row ++ mainValueMemBusInteractionsForRows rest
-
-theorem mainRowsTable_memBus_row
-    (length : ℕ) (program : Program length) (rows : List (MainRowWithRom FGL))
-    (row : MainRowWithRom FGL) :
-    (componentWithRomMemAndOpBus length program).operations.interactionValuesWith
-        MemBusChannel.toRaw
-        ((mainRowsTable length program rows).environment (mainRowArray row)) =
-      mainMemBusInteractionsFor length program row := by
-  simpa [Table.interactionsWith, mainSingleRowTable, mainRowsTable] using
-    mainSingleRowTable_interactionsWith_memBus length program row
-
-private theorem mainRowsTable_interactionsWith_memBus_go
-    (length : ℕ) (program : Program length)
-    (allRows rows : List (MainRowWithRom FGL)) :
-    (rows.map mainRowArray).flatMap (fun arr =>
-        (componentWithRomMemAndOpBus length program).operations.interactionValuesWith
-          MemBusChannel.toRaw ((mainRowsTable length program allRows).environment arr)) =
-      mainMemBusInteractionsForRows length program rows := by
-  induction rows with
-  | nil => rfl
-  | cons row rest ih =>
-      simp [mainRowsTable_memBus_row, mainMemBusInteractionsForRows, ih]
-
-theorem mainRowsTable_interactionsWith_memBus
-    (length : ℕ) (program : Program length) (rows : List (MainRowWithRom FGL)) :
-    (mainRowsTable length program rows).interactionsWith MemBusChannel.toRaw =
-      mainMemBusInteractionsForRows length program rows := by
-  change (rows.map mainRowArray).flatMap (fun arr =>
-        (componentWithRomMemAndOpBus length program).operations.interactionValuesWith
-          MemBusChannel.toRaw ((mainRowsTable length program rows).environment arr)) =
-      mainMemBusInteractionsForRows length program rows
-  exact mainRowsTable_interactionsWith_memBus_go length program rows rows
 
 theorem addSpinAddMain_proverAssumptions :
     (componentWithRomMemAndOpBus 2 addSpinProgram).circuit.ProverAssumptions
@@ -266,42 +183,128 @@ theorem addSpinJalMain_proverAssumptions (step : FGL) :
   · simp [MainRomAddressGuard, addSpinJalBits]
   · rfl
 
-private theorem addSpinMainRow_constraints
-    {row : MainRowWithRom FGL}
-    (h_row : row = addSpinAddRow ∨ row = addSpinJalRow 1 ∨ row = addSpinJalRow 2) :
-    (componentWithRomMemAndOpBus 2 addSpinProgram).operations.ConstraintsHold
-      (Environment.fromInput row emptyData) := by
-  rcases h_row with rfl | rfl | rfl
-  · exact
-      (show (mainSingleRowTable 2 addSpinProgram addSpinAddRow).Constraints from
-        mainSingleRowTable_constraints_of_proverAssumptions 2 addSpinProgram addSpinAddRow
-          addSpinAddMain_proverAssumptions) (mainRowArray addSpinAddRow) (by simp [mainSingleRowTable])
-  · exact
-      (show (mainSingleRowTable 2 addSpinProgram (addSpinJalRow 1)).Constraints from
-        mainSingleRowTable_constraints_of_proverAssumptions 2 addSpinProgram (addSpinJalRow 1)
-          (addSpinJalMain_proverAssumptions 1)) (mainRowArray (addSpinJalRow 1))
-          (by simp [mainSingleRowTable])
-  · exact
-      (show (mainSingleRowTable 2 addSpinProgram (addSpinJalRow 2)).Constraints from
-        mainSingleRowTable_constraints_of_proverAssumptions 2 addSpinProgram (addSpinJalRow 2)
-          (addSpinJalMain_proverAssumptions 2)) (mainRowArray (addSpinJalRow 2))
-          (by simp [mainSingleRowTable])
+private def addSpinProverEnvFromEnvironment (env : Environment FGL) : ProverEnvironment FGL where
+  get := env.get
+  data := env.data
+  hint := ProverHint.empty FGL
 
-theorem addSpinMainTable_constraints :
-    (mainRowsTable 2 addSpinProgram addSpinMainRows).Constraints := by
-  rw [Table.Constraints]
-  intro arr h_arr
-  simp [mainRowsTable, addSpinMainRows] at h_arr
-  rcases h_arr with h_arr | h_arr | h_arr
-  · subst arr
-    simpa [mainRowsTable, mainRowArray] using
-      addSpinMainRow_constraints (Or.inl rfl)
-  · subst arr
-    simpa [mainRowsTable, mainRowArray] using
-      addSpinMainRow_constraints (Or.inr (Or.inl rfl))
-  · subst arr
-    simpa [mainRowsTable, mainRowArray] using
-      addSpinMainRow_constraints (Or.inr (Or.inr rfl))
+private theorem addSpinFlatForAllWitness_of_localLength_zero
+    {env : ProverEnvironment FGL} {offset : ℕ} {ops : List (FlatOperation FGL)}
+    (h_len : FlatOperation.localLength ops = 0) :
+    FlatOperation.forAll offset
+      { witness := fun offset _ compute => env.ExtendsVector (compute env) offset }
+      ops := by
+  induction ops generalizing offset with
+  | nil => trivial
+  | cons op ops ih =>
+      cases op with
+      | witness m compute =>
+          simp [FlatOperation.localLength] at h_len
+          have h_m : m = 0 := by omega
+          have h_ops : FlatOperation.localLength ops = 0 := by omega
+          subst m
+          constructor
+          · intro i
+            exact Fin.elim0 i
+          · simpa [Nat.zero_add] using ih (offset := offset) h_ops
+      | assert e =>
+          simp [FlatOperation.localLength] at h_len
+          simpa [FlatOperation.forAll] using ih (offset := offset) h_len
+      | lookup l =>
+          simp [FlatOperation.localLength] at h_len
+          simpa [FlatOperation.forAll] using ih (offset := offset) h_len
+      | interact i =>
+          simp [FlatOperation.localLength] at h_len
+          simpa [FlatOperation.forAll] using ih (offset := offset) h_len
+
+private theorem addSpinUsesLocalWitnesses_of_localLength_zero
+    {env : ProverEnvironment FGL} {offset : ℕ} {ops : Operations FGL}
+    (h_len : ops.localLength = 0) :
+    env.UsesLocalWitnesses offset ops := by
+  rw [ProverEnvironment.UsesLocalWitnesses, Operations.forAllFlat]
+  induction ops using Operations.induct generalizing offset with
+  | empty => trivial
+  | witness m compute ops ih =>
+      simp [Operations.localLength] at h_len
+      have h_m : m = 0 := by omega
+      have h_ops : ops.localLength = 0 := by omega
+      subst m
+      constructor
+      · intro i
+        exact Fin.elim0 i
+      · simpa [Nat.zero_add] using ih (offset := offset) h_ops
+  | assert e ops ih =>
+      simp [Operations.localLength] at h_len
+      simpa [Operations.forAll] using ih (offset := offset) h_len
+  | lookup l ops ih =>
+      simp [Operations.localLength] at h_len
+      simpa [Operations.forAll] using ih (offset := offset) h_len
+  | interact i ops ih =>
+      simp [Operations.localLength] at h_len
+      simpa [Operations.forAll] using ih (offset := offset) h_len
+  | subcircuit s ops ih =>
+      simp [Operations.localLength] at h_len
+      have h_s : s.localLength = 0 := by omega
+      have h_ops : ops.localLength = 0 := by omega
+      constructor
+      · apply addSpinFlatForAllWitness_of_localLength_zero
+        rw [← s.localLength_eq]
+        exact h_s
+      · exact ih (offset := s.localLength + offset) h_ops
+
+private theorem addSpinMain_constraintsHold_materialize
+    (index : Nat) (row : MainRowWithRom FGL)
+    (h_segment_l1 : row.core.segment_l1 = mainFixedColumns.fixedAt 0 index)
+    (h_main_step : row.rom.main_step = mainFixedColumns.fixedAt 1 index)
+    (h_assumptions :
+      (componentWithRomMemAndOpBus 2 addSpinProgram).circuit.ProverAssumptions
+        row emptyData (ProverHint.empty FGL)) :
+    (componentWithRomMemAndOpBus 2 addSpinProgram).operations.ConstraintsHold
+      (Environment.fromArray (mainFixedColumns.materialize index (mainRawRow row)) emptyData) := by
+  let env := Environment.fromArray (mainFixedColumns.materialize index (mainRawRow row)) emptyData
+  let proverEnv := addSpinProverEnvFromEnvironment env
+  have h_localLength :
+      (componentWithRomMemAndOpBus 2 addSpinProgram).circuit.localLength
+        (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar = 0 := by
+    change (mainWithRomMemAndOpBusElaborated 2 addSpinProgram).localLength
+        (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar = 0
+    rfl
+  have h_env : proverEnv.UsesLocalWitnesses
+      (componentWithRomMemAndOpBus 2 addSpinProgram).rowOffset
+      (componentWithRomMemAndOpBus 2 addSpinProgram).rowOperations := by
+    apply addSpinUsesLocalWitnesses_of_localLength_zero
+    change ((componentWithRomMemAndOpBus 2 addSpinProgram).circuit.main
+      (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar).localLength
+        (componentWithRomMemAndOpBus 2 addSpinProgram).rowOffset = 0
+    rw [(componentWithRomMemAndOpBus 2 addSpinProgram).circuit.localLength_eq]
+    exact h_localLength
+  have h_input_verifier : Eval.eval env
+      (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar = row := by
+    dsimp [env]
+    exact eval_mainRawRow_materialize index emptyData row h_segment_l1 h_main_step
+  have h_input : Eval.eval proverEnv
+      (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar = row := by
+    rw [ProvableType.eval_varFromOffset_prover]
+    rw [← h_input_verifier]
+    rw [ProvableType.eval_varFromOffset]
+    congr
+  have h_assumptions' :
+      (componentWithRomMemAndOpBus 2 addSpinProgram).circuit.ProverAssumptions
+        (Eval.eval proverEnv (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar)
+        proverEnv.data proverEnv.hint := by
+    rw [h_input]
+    simpa [proverEnv, addSpinProverEnvFromEnvironment, env] using h_assumptions
+  have h_full :=
+    (componentWithRomMemAndOpBus 2 addSpinProgram).circuit.original_full_completeness
+      (componentWithRomMemAndOpBus 2 addSpinProgram).rowOffset proverEnv
+      (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar h_env h_assumptions'
+  have h_row :
+      (componentWithRomMemAndOpBus 2 addSpinProgram).rowOperations.ConstraintsHold
+        (proverEnv : Environment FGL) := by
+    simpa [Component.rowOperations, Component.rowInputVar, Component.rowOffset] using h_full.1
+  simpa [proverEnv, addSpinProverEnvFromEnvironment, env] using
+    (Component.constraintsHold_iff (component := componentWithRomMemAndOpBus 2 addSpinProgram)
+      (env := (proverEnv : Environment FGL))).mpr h_row
 
 theorem addSpinMain_pcHandshake_add_jal :
     pcHandshakeBetween addSpinAddRow (addSpinJalRow 1) := by
@@ -313,47 +316,172 @@ theorem addSpinMain_pcHandshake_jal_jal :
   simp [pcHandshakeBetween, addSpinJalRow, addSpinJalProgramRow, addSpinJalBits, mainRomRowOf]
   ring
 
-theorem addSpinMainTable_rowInput_zero
-    (h : 0 < (mainRowsTable 2 addSpinProgram addSpinMainRows).table.length) :
-    (mainRowsTable 2 addSpinProgram addSpinMainRows).component.rowInput
-        ((mainRowsTable 2 addSpinProgram addSpinMainRows).environment
-          ((mainRowsTable 2 addSpinProgram addSpinMainRows).table[0]'h)) =
+@[simp] theorem addSpinMainTable_eval_rowInputVar_zero
+    (h : 0 < addSpinMainTable.table.length) :
+    Eval.eval (addSpinMainTable.environment (addSpinMainTable.table[0]'h))
+        (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar =
       addSpinAddRow := by
-  simpa [mainRowsTable, addSpinMainRows] using
-    mainRowsTable_rowInput 2 addSpinProgram addSpinMainRows addSpinAddRow
+  change Eval.eval
+      (Environment.fromArray
+        (mainFixedColumns.materialize 0 (mainRawRow addSpinAddRow)) emptyData)
+      (varFromOffset MainRowWithRom 0) = addSpinAddRow
+  exact eval_mainRawRow_materialize 0 emptyData addSpinAddRow (by rfl) (by rfl)
+
+@[simp] theorem addSpinMainTable_eval_rowInputVar_one
+    (h : 1 < addSpinMainTable.table.length) :
+    Eval.eval (addSpinMainTable.environment (addSpinMainTable.table[1]'h))
+        (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar =
+      addSpinJalRow 1 := by
+  change Eval.eval
+      (Environment.fromArray
+        (mainFixedColumns.materialize 1 (mainRawRow (addSpinJalRow 1))) emptyData)
+      (varFromOffset MainRowWithRom 0) = addSpinJalRow 1
+  exact eval_mainRawRow_materialize 1 emptyData (addSpinJalRow 1) (by rfl) (by rfl)
+
+@[simp] theorem addSpinMainTable_eval_rowInputVar_two
+    (h : 2 < addSpinMainTable.table.length) :
+    Eval.eval (addSpinMainTable.environment (addSpinMainTable.table[2]'h))
+        (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar =
+      addSpinJalRow 2 := by
+  change Eval.eval
+      (Environment.fromArray
+        (mainFixedColumns.materialize 2 (mainRawRow (addSpinJalRow 2))) emptyData)
+      (varFromOffset MainRowWithRom 0) = addSpinJalRow 2
+  exact eval_mainRawRow_materialize 2 emptyData (addSpinJalRow 2) (by rfl) (by rfl)
+
+theorem addSpinMainTable_rowInput_zero
+    (h : 0 < addSpinMainTable.table.length) :
+    addSpinMainTable.component.rowInput
+        (addSpinMainTable.environment (addSpinMainTable.table[0]'h)) =
+      addSpinAddRow := by
+  change (componentWithRomMemAndOpBus 2 addSpinProgram).rowInput
+      (Environment.fromArray
+        (mainFixedColumns.materialize 0 (mainRawRow addSpinAddRow)) emptyData) = addSpinAddRow
+  exact componentWithRomMemAndOpBus_rowInput_materialize
+    2 addSpinProgram 0 emptyData addSpinAddRow (by rfl) (by rfl)
 
 theorem addSpinMainTable_rowInput_one
-    (h : 1 < (mainRowsTable 2 addSpinProgram addSpinMainRows).table.length) :
-    (mainRowsTable 2 addSpinProgram addSpinMainRows).component.rowInput
-        ((mainRowsTable 2 addSpinProgram addSpinMainRows).environment
-          ((mainRowsTable 2 addSpinProgram addSpinMainRows).table[1]'h)) =
+    (h : 1 < addSpinMainTable.table.length) :
+    addSpinMainTable.component.rowInput
+        (addSpinMainTable.environment (addSpinMainTable.table[1]'h)) =
       addSpinJalRow 1 := by
-  simpa [mainRowsTable, addSpinMainRows] using
-    mainRowsTable_rowInput 2 addSpinProgram addSpinMainRows (addSpinJalRow 1)
+  change (componentWithRomMemAndOpBus 2 addSpinProgram).rowInput
+      (Environment.fromArray
+        (mainFixedColumns.materialize 1 (mainRawRow (addSpinJalRow 1))) emptyData) =
+      addSpinJalRow 1
+  exact componentWithRomMemAndOpBus_rowInput_materialize
+    2 addSpinProgram 1 emptyData (addSpinJalRow 1) (by rfl) (by rfl)
 
 theorem addSpinMainTable_rowInput_two
-    (h : 2 < (mainRowsTable 2 addSpinProgram addSpinMainRows).table.length) :
-    (mainRowsTable 2 addSpinProgram addSpinMainRows).component.rowInput
-        ((mainRowsTable 2 addSpinProgram addSpinMainRows).environment
-          ((mainRowsTable 2 addSpinProgram addSpinMainRows).table[2]'h)) =
+    (h : 2 < addSpinMainTable.table.length) :
+    addSpinMainTable.component.rowInput
+        (addSpinMainTable.environment (addSpinMainTable.table[2]'h)) =
       addSpinJalRow 2 := by
-  simpa [mainRowsTable, addSpinMainRows] using
-    mainRowsTable_rowInput 2 addSpinProgram addSpinMainRows (addSpinJalRow 2)
+  change (componentWithRomMemAndOpBus 2 addSpinProgram).rowInput
+      (Environment.fromArray
+        (mainFixedColumns.materialize 2 (mainRawRow (addSpinJalRow 2))) emptyData) =
+      addSpinJalRow 2
+  exact componentWithRomMemAndOpBus_rowInput_materialize
+    2 addSpinProgram 2 emptyData (addSpinJalRow 2) (by rfl) (by rfl)
 
-theorem addSpinMainTable_transitions :
-    (mainRowsTable 2 addSpinProgram addSpinMainRows).TransitionConstraints := by
+theorem addSpinMainTable_constraints : addSpinMainTable.Constraints := by
+  change ∀ arr ∈
+      [ mainFixedColumns.materialize 0 (mainRawRow addSpinAddRow)
+      , mainFixedColumns.materialize 1 (mainRawRow (addSpinJalRow 1))
+      , mainFixedColumns.materialize 2 (mainRawRow (addSpinJalRow 2)) ],
+      (componentWithRomMemAndOpBus 2 addSpinProgram).operations.ConstraintsHold
+        (Environment.fromArray arr emptyData)
+  intro arr h_arr
+  simp only [List.mem_cons, List.not_mem_nil, or_false] at h_arr
+  rcases h_arr with rfl | rfl | rfl
+  · exact addSpinMain_constraintsHold_materialize 0 addSpinAddRow
+      (by rfl) (by rfl) addSpinAddMain_proverAssumptions
+  · exact addSpinMain_constraintsHold_materialize 1 (addSpinJalRow 1)
+      (by rfl) (by rfl) (addSpinJalMain_proverAssumptions 1)
+  · exact addSpinMain_constraintsHold_materialize 2 (addSpinJalRow 2)
+      (by rfl) (by rfl) (addSpinJalMain_proverAssumptions 2)
+
+@[simp] theorem addSpinMainTable_evalAt_zero :
+    Eval.eval
+      (addSpinMainTable.environmentAt
+        ⟨0, by simp⟩)
+      (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar =
+      addSpinAddRow := by
+  simpa [Table.environmentAt] using
+    addSpinMainTable_eval_rowInputVar_zero
+      (by simp)
+
+@[simp] theorem addSpinMainTable_evalAt_one :
+    Eval.eval
+      (addSpinMainTable.environmentAt
+        ⟨1, by simp⟩)
+      (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar =
+      addSpinJalRow 1 := by
+  simpa [Table.environmentAt] using
+    addSpinMainTable_eval_rowInputVar_one
+      (by simp)
+
+@[simp] theorem addSpinMainTable_evalAt_two :
+    Eval.eval
+      (addSpinMainTable.environmentAt
+        ⟨2, by simp⟩)
+      (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar =
+      addSpinJalRow 2 := by
+  simpa [Table.environmentAt] using
+    addSpinMainTable_eval_rowInputVar_two
+      (by simp)
+
+theorem addSpinMainTable_transitions : addSpinMainTable.TransitionConstraints := by
   rw [Table.TransitionConstraints]
-  intro i h_i
-  have h_len : (mainRowsTable 2 addSpinProgram addSpinMainRows).table.length = 3 := by
-    simp [mainRowsTable, addSpinMainRows]
-  have h_i_lt : i < 2 := by
-    omega
-  interval_cases i
-  · rw [mainRowsTable_transition, addSpinMainTable_rowInput_zero,
-      addSpinMainTable_rowInput_one]
+  intro index
+  have h_index_lt : index.val < 3 := by
+    rw [← addSpinMainTable_length]
+    exact index.isLt
+  interval_cases h_index : index.val
+  · have h_index : index = ⟨0, by
+        simp⟩ := Fin.ext (by omega)
+    subst index
+    change pcHandshakeBetween
+      (Eval.eval
+        (addSpinMainTable.previousEnvironment
+          ⟨0, by simp⟩)
+        (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar)
+      (Eval.eval
+        (addSpinMainTable.environmentAt
+          ⟨0, by simp⟩)
+        (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar)
+    simp only [Table.previousEnvironment]
+    rw [addSpinMainTable_evalAt_zero]
+    simp [pcHandshakeBetween, addSpinAddRow, addX1Row]
+  · have h_index : index = ⟨1, by
+        simp⟩ := Fin.ext (by omega)
+    subst index
+    change pcHandshakeBetween
+      (Eval.eval
+        (addSpinMainTable.previousEnvironment
+          ⟨1, by simp⟩)
+        (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar)
+      (Eval.eval
+        (addSpinMainTable.environmentAt
+          ⟨1, by simp⟩)
+        (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar)
+    simp only [Table.previousEnvironment]
+    rw [addSpinMainTable_evalAt_zero, addSpinMainTable_evalAt_one]
     exact addSpinMain_pcHandshake_add_jal
-  · rw [mainRowsTable_transition, addSpinMainTable_rowInput_one,
-      addSpinMainTable_rowInput_two]
+  · have h_index : index = ⟨2, by
+        simp⟩ := Fin.ext (by omega)
+    subst index
+    change pcHandshakeBetween
+      (Eval.eval
+        (addSpinMainTable.previousEnvironment
+          ⟨2, by simp⟩)
+        (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar)
+      (Eval.eval
+        (addSpinMainTable.environmentAt
+          ⟨2, by simp⟩)
+        (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar)
+    simp only [Table.previousEnvironment]
+    rw [addSpinMainTable_evalAt_one, addSpinMainTable_evalAt_two]
     exact addSpinMain_pcHandshake_jal_jal
 
 def addSpinTables : List (Table FGL) :=
@@ -367,7 +495,7 @@ def addSpinTables : List (Table FGL) :=
   , emptyComponentTable ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
   , emptyComponentTable ZiskFv.AirsClean.Binary.staticLookupComponent
   , binaryAddRowsTable [addX1BinaryAddRow]
-  , mainRowsTable 2 addSpinProgram addSpinMainRows ]
+  , addSpinMainTable ]
 
 def addSpinNonMainTables : List (Table FGL) :=
   [ registerBoundaryRowsTable
@@ -405,11 +533,11 @@ def addSpinWitness : EnsembleWitness addSpinEnsemble where
         SoundEnsemble.toFormal, SoundEnsemble.addFinishedChannel_tables, SoundEnsemble.addTable,
         SoundEnsemble.empty_tables, Ensemble.addTable, registerBoundaryRowsTable,
         registerBoundaryRowsTableOf, emptyComponentTable, binaryAddRowsTable,
-        mainRowsTable]
+        addSpinMainTable, mainRowsTable]
   same_data := by
     intro table h_table
     simp [addSpinTables, registerBoundaryRowsTable, registerBoundaryRowsTableOf,
-      emptyComponentTable, binaryAddRowsTable, mainRowsTable] at h_table
+      emptyComponentTable, binaryAddRowsTable, addSpinMainTable, mainRowsTable] at h_table
     rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
       rfl
 
@@ -441,41 +569,26 @@ theorem addSpinWitness_transitions : addSpinWitness.TransitionConstraints := by
   rcases h_table with h_verifier | h_table
   · subst table
     rw [Table.TransitionConstraints]
-    intro i h_i
-    simp [EnsembleWitness.verifierTable] at h_i
+    intro index
+    simp [EnsembleWitness.verifierTable]
   · simp [addSpinWitness, addSpinTables] at h_table
     rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
     · rw [Table.TransitionConstraints]
-      intro i h_i
+      intro index
       simp [registerBoundaryRowsTable, registerBoundaryRowsTableOf,
-        ZiskFv.AirsClean.RegisterBoundary.component] at h_i ⊢
+        ZiskFv.AirsClean.RegisterBoundary.component]
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignReadByte.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignByte.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlign.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.Mem.componentWithDualMemBus
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.ArithDiv.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.ArithMul.componentWithArithTable
+    · exact emptyComponentTable_transitions
+        ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.Binary.staticLookupComponent
     · rw [Table.TransitionConstraints]
-      intro i h_i
-      simp [emptyComponentTable] at h_i
-    · rw [Table.TransitionConstraints]
-      intro i h_i
-      simp [emptyComponentTable] at h_i
-    · rw [Table.TransitionConstraints]
-      intro i h_i
-      simp [emptyComponentTable] at h_i
-    · rw [Table.TransitionConstraints]
-      intro i h_i
-      simp [emptyComponentTable] at h_i
-    · rw [Table.TransitionConstraints]
-      intro i h_i
-      simp [emptyComponentTable] at h_i
-    · rw [Table.TransitionConstraints]
-      intro i h_i
-      simp [emptyComponentTable] at h_i
-    · rw [Table.TransitionConstraints]
-      intro i h_i
-      simp [emptyComponentTable] at h_i
-    · rw [Table.TransitionConstraints]
-      intro i h_i
-      simp [emptyComponentTable] at h_i
-    · rw [Table.TransitionConstraints]
-      intro i h_i
-      simp [binaryAddRowsTable, ZiskFv.AirsClean.BinaryAdd.component] at h_i ⊢
+      intro index
+      simp [binaryAddRowsTable, ZiskFv.AirsClean.BinaryAdd.component]
     · exact addSpinMainTable_transitions
 
 private theorem not_addSpin_main_component_of_name_ne
@@ -507,7 +620,7 @@ private theorem addSpinWitness_main_component_cases
     (h_table : table ∈ addSpinWitness.allTables)
     (h_component :
       table.component = componentWithRomMemAndOpBus 2 addSpinProgram) :
-    table = mainRowsTable 2 addSpinProgram addSpinMainRows := by
+    table = addSpinMainTable := by
   rw [EnsembleWitness.allTables, List.mem_cons] at h_table
   rcases h_table with h_verifier | h_table
   · subst table
@@ -556,14 +669,15 @@ private theorem addSpinWitness_mutable_mem_component_tables_empty (table : Table
     rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
     · exfalso
       exact not_addSpin_mutable_mem_component_of_name_ne (by decide) h_component
-    · simp [emptyComponentTable]
-    · simp [emptyComponentTable]
-    · simp [emptyComponentTable]
-    · simp [emptyComponentTable]
-    · simp [emptyComponentTable]
-    · simp [emptyComponentTable]
-    · simp [emptyComponentTable]
-    · simp [emptyComponentTable]
+    · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignReadByte.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignByte.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlign.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.Mem.componentWithDualMemBus
+    · exact emptyComponentTable_table ZiskFv.AirsClean.ArithDiv.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.ArithMul.componentWithArithTable
+    · exact emptyComponentTable_table
+        ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+    · exact emptyComponentTable_table ZiskFv.AirsClean.Binary.staticLookupComponent
     · exfalso
       exact not_addSpin_mutable_mem_component_of_name_ne (by decide) h_component
     · exfalso
@@ -584,69 +698,62 @@ theorem addSpinWitness_main_height :
   intro table h_table h_component i
   have h_main := addSpinWitness_main_component_cases h_table h_component
   subst table
-  fin_cases i <;> norm_num [mainRowsTable, addSpinMainRows]
+  fin_cases i <;> norm_num [addSpinMainTable, mainRowsTable, addSpinMainRows]
 
 theorem addSpinMain_segment_l1_first :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
-        (mainRowsTable 2 addSpinProgram addSpinMainRows)).segment_l1 0 = 1 := by
+        addSpinMainTable).segment_l1 0 = 1 := by
   simp [ZiskFv.AirsClean.FullEnsemble.mainOfTable_segment_l1]
   unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
-  change (Eval.eval ((mainRowsTable 2 addSpinProgram addSpinMainRows).environment
-      (mainRowArray addSpinAddRow))
-        (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar).core.segment_l1 = 1
-  rw [mainRowsTable_eval_rowInputVar]
-  rfl
+  rw [dif_pos (by norm_num [addSpinMainTable, mainRowsTable, addSpinMainRows])]
+  simpa [Table.environmentAt, addSpinAddRow, addX1Row, mainRomRowOf] using
+    congrArg MainRowWithRom.core addSpinMainTable_evalAt_zero
 
 theorem addSpinMain_segment_l1_later
-    (idx : Fin (mainRowsTable 2 addSpinProgram addSpinMainRows).table.length)
+    (idx : Fin addSpinMainTable.table.length)
     (h_idx : 0 < idx.val) :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
-        (mainRowsTable 2 addSpinProgram addSpinMainRows)).segment_l1 idx.val = 0 := by
+        addSpinMainTable).segment_l1 idx.val = 0 := by
   have h_idx_lt : idx.val < 3 := by
     have h_table_len :
-        (mainRowsTable 2 addSpinProgram addSpinMainRows).table.length = 3 := by
-      simp [mainRowsTable, addSpinMainRows]
+        addSpinMainTable.table.length = 3 := by
+      simp [addSpinMainTable, mainRowsTable, addSpinMainRows]
     rw [← h_table_len]
     exact idx.isLt
   interval_cases idx.val
   · simp [ZiskFv.AirsClean.FullEnsemble.mainOfTable_segment_l1]
     unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
-    change (Eval.eval ((mainRowsTable 2 addSpinProgram addSpinMainRows).environment
-        (mainRowArray (addSpinJalRow 1)))
-          (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar).core.segment_l1 = 0
-    rw [mainRowsTable_eval_rowInputVar]
-    rfl
+    rw [dif_pos (by norm_num [addSpinMainTable, mainRowsTable, addSpinMainRows])]
+    simpa [Table.environmentAt, addSpinJalRow, addSpinJalProgramRow, addSpinJalBits,
+      mainRomRowOf] using
+      congrArg MainRowWithRom.core addSpinMainTable_evalAt_one
   · simp [ZiskFv.AirsClean.FullEnsemble.mainOfTable_segment_l1]
     unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
-    change (Eval.eval ((mainRowsTable 2 addSpinProgram addSpinMainRows).environment
-        (mainRowArray (addSpinJalRow 2)))
-          (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar).core.segment_l1 = 0
-    rw [mainRowsTable_eval_rowInputVar]
-    rfl
+    rw [dif_pos (by norm_num [addSpinMainTable, mainRowsTable, addSpinMainRows])]
+    simpa [Table.environmentAt, addSpinJalRow, addSpinJalProgramRow, addSpinJalBits,
+      mainRomRowOf] using
+      congrArg MainRowWithRom.core addSpinMainTable_evalAt_two
 
 theorem addSpinMain_main_step_eq_index :
     ∀ i : Fin 2,
       (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero addSpinProgram
-          (mainRowsTable 2 addSpinProgram addSpinMainRows) i.val).rom.main_step =
+          addSpinMainTable i.val).rom.main_step =
         (i.val : FGL) := by
   intro i
   fin_cases i
   · unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
-    change (Eval.eval ((mainRowsTable 2 addSpinProgram addSpinMainRows).environment
-        (mainRowArray addSpinAddRow))
-          (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar).rom.main_step = 0
-    rw [mainRowsTable_eval_rowInputVar]
-    rfl
+    rw [dif_pos (by norm_num [addSpinMainTable, mainRowsTable, addSpinMainRows])]
+    simpa [Table.environmentAt, addSpinAddRow, addX1Row, mainRomRowOf] using
+      congrArg MainRowWithRom.rom addSpinMainTable_evalAt_zero
   · unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
-    change (Eval.eval ((mainRowsTable 2 addSpinProgram addSpinMainRows).environment
-        (mainRowArray (addSpinJalRow 1)))
-          (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar).rom.main_step = 1
-    rw [mainRowsTable_eval_rowInputVar]
-    rfl
+    rw [dif_pos (by norm_num [addSpinMainTable, mainRowsTable, addSpinMainRows])]
+    simpa [Table.environmentAt, addSpinJalRow, addSpinJalProgramRow, addSpinJalBits,
+      mainRomRowOf] using
+      congrArg MainRowWithRom.rom addSpinMainTable_evalAt_one
 
 theorem addSpinMain_main_step_index_fixed :
     MainStepIndexFixedFacts 2 2 addSpinProgram
-      (mainRowsTable 2 addSpinProgram addSpinMainRows) where
+      addSpinMainTable where
   main_step_eq_index := addSpinMain_main_step_eq_index
   timestamp_bound := by
     intro i
@@ -693,6 +800,87 @@ theorem addSpinWitness_segment_l1_fixed :
   · intro idx h_idx
     exact addSpinMain_segment_l1_later idx h_idx
 
+private theorem addSpinMainOpBusInteraction_eval_at
+    (env : Environment FGL) (row : MainRowWithRom FGL)
+    (h_input : Eval.eval env (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar = row) :
+    (((OpBusChannel.emitted
+        (-(componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar.core.is_external_op)
+        (opBusMessageExpr
+          (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar.core)).toRaw).eval env) =
+      mainOpBusInteraction row := by
+  let rowVar := (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar
+  have h_core : Eval.eval env rowVar.core = row.core := by
+    rw [ZiskFv.AirsClean.FullEnsemble.mainRowWithRom_eval_core]
+    exact congrArg MainRowWithRom.core h_input
+  have h_field := ZiskFv.AirsClean.FullEnsemble.mainRow_eval_is_external_op env rowVar.core
+  simp [mainOpBusInteraction, AbstractInteraction.eval, ChannelInteraction.toRaw]
+  constructor
+  · change Expression.eval env (-rowVar.core.is_external_op) = -row.core.is_external_op
+    simp [Expression.eval, h_field, h_core]
+  constructor
+  · have h_msg_eval :
+        Eval.eval env (opBusMessageExpr rowVar.core) = opBusMessage row.core := by
+      rw [eval_opBusMessageExpr, h_core]
+    rw [toElements_eval_toArray]
+    change (toElements (Eval.eval env (opBusMessageExpr rowVar.core))).toArray =
+      (toElements (opBusMessage row.core)).toArray
+    rw [h_msg_eval]
+  · rfl
+
+private theorem addSpinMainOpBusInteractionsAt
+    (env : Environment FGL) (row : MainRowWithRom FGL)
+    (h_input : Eval.eval env (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar = row) :
+    (componentWithRomMemAndOpBus 2 addSpinProgram).operations.interactionValuesWith
+        OpBusChannel.toRaw env = [mainOpBusInteraction row] := by
+  simp [Operations.interactionValuesWith_eq_map,
+    componentWithRomMemAndOpBus_interactionsWith_opBus]
+  exact addSpinMainOpBusInteraction_eval_at env row h_input
+
+theorem addSpinMainTable_interactionsWith_opBus :
+    addSpinMainTable.interactionsWith OpBusChannel.toRaw =
+      [mainOpBusInteraction addSpinAddRow, mainOpBusInteraction (addSpinJalRow 1),
+        mainOpBusInteraction (addSpinJalRow 2)] := by
+  rw [Table.interactionsWith, addSpinMainTable_effectiveRows]
+  simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]
+  have h_zero :
+      addSpinMainTable.component.operations.interactionValuesWith
+          OpBusChannel.toRaw
+          (addSpinMainTable.environment
+            (mainFixedColumns.materialize 0 (mainRawRow addSpinAddRow))) =
+        [mainOpBusInteraction addSpinAddRow] := by
+    simpa [addSpinMainTable, mainRowsTable] using
+      (addSpinMainOpBusInteractionsAt
+        (Environment.fromArray
+          (mainFixedColumns.materialize 0 (mainRawRow addSpinAddRow)) emptyData)
+        addSpinAddRow
+        (eval_mainRawRow_materialize 0 emptyData addSpinAddRow (by rfl) (by rfl)))
+  have h_one :
+      addSpinMainTable.component.operations.interactionValuesWith
+          OpBusChannel.toRaw
+          (addSpinMainTable.environment
+            (mainFixedColumns.materialize 1 (mainRawRow (addSpinJalRow 1)))) =
+        [mainOpBusInteraction (addSpinJalRow 1)] := by
+    simpa [addSpinMainTable, mainRowsTable] using
+      (addSpinMainOpBusInteractionsAt
+        (Environment.fromArray
+          (mainFixedColumns.materialize 1 (mainRawRow (addSpinJalRow 1))) emptyData)
+        (addSpinJalRow 1)
+        (eval_mainRawRow_materialize 1 emptyData (addSpinJalRow 1) (by rfl) (by rfl)))
+  have h_two :
+      addSpinMainTable.component.operations.interactionValuesWith
+          OpBusChannel.toRaw
+          (addSpinMainTable.environment
+            (mainFixedColumns.materialize 2 (mainRawRow (addSpinJalRow 2)))) =
+        [mainOpBusInteraction (addSpinJalRow 2)] := by
+    simpa [addSpinMainTable, mainRowsTable] using
+      (addSpinMainOpBusInteractionsAt
+        (Environment.fromArray
+          (mainFixedColumns.materialize 2 (mainRawRow (addSpinJalRow 2))) emptyData)
+        (addSpinJalRow 2)
+        (eval_mainRawRow_materialize 2 emptyData (addSpinJalRow 2) (by rfl) (by rfl)))
+  rw [h_zero, h_one, h_two]
+  rfl
+
 theorem addSpinOpBus_interactions :
     addSpinWitness.tables.flatMap (·.interactionsWith OpBusChannel.toRaw) =
       [binaryAddOpBusInteraction addX1BinaryAddRow, mainOpBusInteraction addSpinAddRow,
@@ -703,8 +891,7 @@ theorem addSpinOpBus_interactions :
       (table := registerBoundaryRowsTable) rfl
   rw [show addSpinWitness.tables = addSpinTables from rfl]
   simp [addSpinTables, h_registerBoundary, emptyComponentTable_interactionsWith,
-    binaryAddRowsTable_interactionsWith_opBus, mainRowsTable_interactionsWith_opBus,
-    addSpinMainRows]
+    binaryAddRowsTable_interactionsWith_opBus, addSpinMainTable_interactionsWith_opBus]
 
 theorem addSpinJalOpBusInteraction_zero (step : FGL) :
     (mainOpBusInteraction (addSpinJalRow step)).mult = 0 := by
@@ -739,16 +926,26 @@ theorem addSpinWitness_opBus_balanced :
       rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
       decide)
 
-theorem mainMemBusInteractions_eq_valueLevel
-    (length : ℕ) (program : Program length) (row : MainRowWithRom FGL) :
-    mainMemBusInteractions length program row =
-      [mainARegPreInteraction row, mainAMemInteraction row, mainBRegPreInteraction row,
-        mainBMemInteraction row, mainCRegPreInteraction row, mainCMemInteraction row] := by
-  let env := (mainSingleRowTable length program row).environment (mainRowArray row)
-  let rowVar := (componentWithRomMemAndOpBus length program).rowInputVar
-  have h_input : eval env rowVar = row := by
-    dsimp [env, rowVar]
-    exact mainSingleRowTable_eval_rowInputVar length program row
+private def addSpinMainMemBusInteractionsAt (env : Environment FGL) : List (Interaction FGL) :=
+  let rowVar := (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar
+  [ ((MemBusChannel.emitted rowVar.rom.a_src_reg (aRegPreMessageExpr rowVar)).toRaw).eval env
+  , ((MemBusChannel.emitted (-(rowVar.rom.a_src_mem + rowVar.rom.a_src_reg))
+      (aMemMessageExpr rowVar)).toRaw).eval env
+  , ((MemBusChannel.emitted rowVar.rom.b_src_reg (bRegPreMessageExpr rowVar)).toRaw).eval env
+  , ((MemBusChannel.emitted
+      (-(rowVar.rom.b_src_mem + rowVar.rom.b_src_ind + rowVar.rom.b_src_reg))
+      (bMemMessageExpr rowVar)).toRaw).eval env
+  , ((MemBusChannel.emitted rowVar.rom.store_reg (cRegPreMessageExpr rowVar)).toRaw).eval env
+  , ((MemBusChannel.emitted
+      (-(rowVar.rom.store_mem + rowVar.rom.store_ind + rowVar.rom.store_reg))
+      (cMemMessageExpr rowVar)).toRaw).eval env ]
+
+private theorem addSpinMainMemBusInteractionsAt_eq_valueLevel
+    (env : Environment FGL) (row : MainRowWithRom FGL)
+    (h_input : Eval.eval env (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar = row) :
+    addSpinMainMemBusInteractionsAt env = mainValueMemBusInteractions row := by
+  unfold addSpinMainMemBusInteractionsAt
+  let rowVar := (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar
   have h_rom : eval env rowVar.rom = row.rom := by
     rw [mainRowWithRom_eval_rom]
     exact congrArg MainRowWithRom.rom h_input
@@ -876,79 +1073,85 @@ theorem mainMemBusInteractions_eq_valueLevel
         mainBMemInteraction row, mainCRegPreInteraction row, mainCMemInteraction row]
   simp [h_aReg, h_aMem, h_bReg, h_bMem, h_cReg, h_cMem]
 
-theorem mainMemBusInteractionsFor_eq_valueLevel
-    (length : ℕ) (program : Program length) (row : MainRowWithRom FGL) :
-    mainMemBusInteractionsFor length program row = mainValueMemBusInteractions row := by
-  unfold mainMemBusInteractionsFor mainValueMemBusInteractions
-  exact mainMemBusInteractions_eq_valueLevel length program row
+private theorem addSpinMainMemBusInteractionsAt_eq_component
+    (env : Environment FGL) :
+    (componentWithRomMemAndOpBus 2 addSpinProgram).operations.interactionValuesWith
+        MemBusChannel.toRaw env = addSpinMainMemBusInteractionsAt env := by
+  simp [addSpinMainMemBusInteractionsAt, Operations.interactionValuesWith_eq_map,
+    componentWithRomMemAndOpBus_interactionsWith_memBus]
 
-theorem mainMemBusInteractionsFor_balanced_of_zero
-    (length : ℕ) (program : Program length) (row : MainRowWithRom FGL)
-    (h_aReg : (mainARegPreInteraction row).mult = 0)
-    (h_aMem : (mainAMemInteraction row).mult = 0)
-    (h_bReg : (mainBRegPreInteraction row).mult = 0)
-    (h_bMem : (mainBMemInteraction row).mult = 0)
-    (h_cReg : (mainCRegPreInteraction row).mult = 0)
-    (h_cMem : (mainCMemInteraction row).mult = 0) :
-    BalancedInteractions (mainMemBusInteractionsFor length program row) := by
-  rw [mainMemBusInteractionsFor_eq_valueLevel]
-  exact mainValueMemBusInteractions_balanced_of_zero row
-    h_aReg h_aMem h_bReg h_bMem h_cReg h_cMem
-
-structure MainMemBusInactive (row : MainRowWithRom FGL) : Prop where
-  aSrcReg : row.rom.a_src_reg = 0
-  aSrcMem : row.rom.a_src_mem = 0
-  bSrcReg : row.rom.b_src_reg = 0
-  bSrcMem : row.rom.b_src_mem = 0
-  bSrcInd : row.rom.b_src_ind = 0
-  storeReg : row.rom.store_reg = 0
-  storeMem : row.rom.store_mem = 0
-  storeInd : row.rom.store_ind = 0
-
-theorem mainMemBusInteractionsFor_balanced_of_inactive
-    (length : ℕ) (program : Program length) (row : MainRowWithRom FGL)
-    (h : MainMemBusInactive row) :
-    BalancedInteractions (mainMemBusInteractionsFor length program row) := by
-  apply mainMemBusInteractionsFor_balanced_of_zero
-  · simpa [mainARegPreInteraction] using h.aSrcReg
-  · simp [mainAMemInteraction, h.aSrcReg, h.aSrcMem]
-  · simpa [mainBRegPreInteraction] using h.bSrcReg
-  · simp [mainBMemInteraction, h.bSrcReg, h.bSrcMem, h.bSrcInd]
-  · simpa [mainCRegPreInteraction] using h.storeReg
-  · simp [mainCMemInteraction, h.storeReg, h.storeMem, h.storeInd]
-
-theorem mainMemBusInteractionsForRows_eq_valueLevel
-    (length : ℕ) (program : Program length) (rows : List (MainRowWithRom FGL)) :
-    mainMemBusInteractionsForRows length program rows =
-      mainValueMemBusInteractionsForRows rows := by
-  induction rows with
-  | nil => rfl
-  | cons row rest ih =>
-      exact (congrArg
-        (fun interactions => interactions ++
-          mainMemBusInteractionsForRows length program rest)
-        (mainMemBusInteractionsFor_eq_valueLevel length program row)).trans
-        (congrArg (fun interactions => mainValueMemBusInteractions row ++ interactions) ih)
-
-theorem mainRowsTable_interactionsWith_memBus_eq_valueLevel
-    (length : ℕ) (program : Program length) (rows : List (MainRowWithRom FGL)) :
-    (mainRowsTable length program rows).interactionsWith MemBusChannel.toRaw =
-      mainValueMemBusInteractionsForRows rows :=
-  (mainRowsTable_interactionsWith_memBus length program rows).trans
-    (mainMemBusInteractionsForRows_eq_valueLevel length program rows)
+theorem addSpinMainTable_interactionsWith_memBus :
+    addSpinMainTable.interactionsWith MemBusChannel.toRaw =
+      mainValueMemBusInteractions addSpinAddRow ++
+        mainValueMemBusInteractions (addSpinJalRow 1) ++
+        mainValueMemBusInteractions (addSpinJalRow 2) := by
+  rw [Table.interactionsWith, addSpinMainTable_effectiveRows]
+  simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]
+  have h_zero :
+      addSpinMainTable.component.operations.interactionValuesWith
+          MemBusChannel.toRaw
+          (addSpinMainTable.environment
+            (mainFixedColumns.materialize 0 (mainRawRow addSpinAddRow))) =
+        mainValueMemBusInteractions addSpinAddRow := by
+    calc
+      _ = addSpinMainMemBusInteractionsAt
+          (Environment.fromArray
+            (mainFixedColumns.materialize 0 (mainRawRow addSpinAddRow)) emptyData) := by
+        simpa [addSpinMainTable, mainRowsTable] using
+          (addSpinMainMemBusInteractionsAt_eq_component
+            (Environment.fromArray
+              (mainFixedColumns.materialize 0 (mainRawRow addSpinAddRow)) emptyData))
+      _ = mainValueMemBusInteractions addSpinAddRow :=
+        addSpinMainMemBusInteractionsAt_eq_valueLevel _ addSpinAddRow
+          (eval_mainRawRow_materialize 0 emptyData addSpinAddRow (by rfl) (by rfl))
+  have h_one :
+      addSpinMainTable.component.operations.interactionValuesWith
+          MemBusChannel.toRaw
+          (addSpinMainTable.environment
+            (mainFixedColumns.materialize 1 (mainRawRow (addSpinJalRow 1)))) =
+        mainValueMemBusInteractions (addSpinJalRow 1) := by
+    calc
+      _ = addSpinMainMemBusInteractionsAt
+          (Environment.fromArray
+            (mainFixedColumns.materialize 1 (mainRawRow (addSpinJalRow 1))) emptyData) := by
+        simpa [addSpinMainTable, mainRowsTable] using
+          (addSpinMainMemBusInteractionsAt_eq_component
+            (Environment.fromArray
+              (mainFixedColumns.materialize 1 (mainRawRow (addSpinJalRow 1))) emptyData))
+      _ = mainValueMemBusInteractions (addSpinJalRow 1) :=
+        addSpinMainMemBusInteractionsAt_eq_valueLevel _ (addSpinJalRow 1)
+          (eval_mainRawRow_materialize 1 emptyData (addSpinJalRow 1) (by rfl) (by rfl))
+  have h_two :
+      addSpinMainTable.component.operations.interactionValuesWith
+          MemBusChannel.toRaw
+          (addSpinMainTable.environment
+            (mainFixedColumns.materialize 2 (mainRawRow (addSpinJalRow 2)))) =
+        mainValueMemBusInteractions (addSpinJalRow 2) := by
+    calc
+      _ = addSpinMainMemBusInteractionsAt
+          (Environment.fromArray
+            (mainFixedColumns.materialize 2 (mainRawRow (addSpinJalRow 2))) emptyData) := by
+        simpa [addSpinMainTable, mainRowsTable] using
+          (addSpinMainMemBusInteractionsAt_eq_component
+            (Environment.fromArray
+              (mainFixedColumns.materialize 2 (mainRawRow (addSpinJalRow 2))) emptyData))
+      _ = mainValueMemBusInteractions (addSpinJalRow 2) :=
+        addSpinMainMemBusInteractionsAt_eq_valueLevel _ (addSpinJalRow 2)
+          (eval_mainRawRow_materialize 2 emptyData (addSpinJalRow 2) (by rfl) (by rfl))
+  rw [h_zero, h_one, h_two]
+  simpa only [List.append_assoc]
 
 theorem addSpinAddMainMemBusInteractions_eq :
-    mainMemBusInteractions 2 addSpinProgram addSpinAddRow =
+    mainValueMemBusInteractions addSpinAddRow =
       mainRegisterInteractionsFromTable := by
-  rw [mainMemBusInteractions_eq_valueLevel]
   rw [mainRegisterInteractionsFromTable_eq_mainRegisterInteractions]
   rfl
 
 theorem addSpinMemBus_interactions :
     addSpinWitness.tables.flatMap (·.interactionsWith MemBusChannel.toRaw) =
       singleAddMemBusInteractions ++
-        mainMemBusInteractions 2 addSpinProgram (addSpinJalRow 1) ++
-        mainMemBusInteractions 2 addSpinProgram (addSpinJalRow 2) := by
+        mainValueMemBusInteractions (addSpinJalRow 1) ++
+        mainValueMemBusInteractions (addSpinJalRow 2) := by
   have h_nonMain :
       addSpinNonMainTables.flatMap (·.interactionsWith MemBusChannel.toRaw) =
         singleAddBoundaryRows.flatMap registerBoundaryMemBusInteractions := by
@@ -964,26 +1167,24 @@ theorem addSpinMemBus_interactions :
     simp [addSpinNonMainTables, h_registerBoundary, h_binaryAdd,
       emptyComponentTable_interactionsWith]
   have h_main :
-      (mainRowsTable 2 addSpinProgram addSpinMainRows).interactionsWith MemBusChannel.toRaw =
-        mainMemBusInteractions 2 addSpinProgram addSpinAddRow ++
-        mainMemBusInteractions 2 addSpinProgram (addSpinJalRow 1) ++
-        mainMemBusInteractions 2 addSpinProgram (addSpinJalRow 2) := by
-    simp [mainRowsTable_interactionsWith_memBus, mainMemBusInteractionsForRows,
-      mainMemBusInteractionsFor, addSpinMainRows]
+      addSpinMainTable.interactionsWith MemBusChannel.toRaw =
+        mainValueMemBusInteractions addSpinAddRow ++
+        mainValueMemBusInteractions (addSpinJalRow 1) ++
+        mainValueMemBusInteractions (addSpinJalRow 2) :=
+    addSpinMainTable_interactionsWith_memBus
   rw [show addSpinWitness.tables = addSpinTables from rfl]
   rw [show addSpinTables =
-      addSpinNonMainTables ++ [mainRowsTable 2 addSpinProgram addSpinMainRows] from rfl]
+      addSpinNonMainTables ++ [addSpinMainTable] from rfl]
   simp only [List.flatMap_append, List.flatMap_cons, List.flatMap_nil, List.append_nil]
   rw [h_nonMain, h_main]
   rw [addSpinAddMainMemBusInteractions_eq]
   simp [singleAddMemBusInteractions]
 
 theorem addSpinJalMemBusInteractions_balanced (step : FGL) :
-    BalancedInteractions (mainMemBusInteractions 2 addSpinProgram (addSpinJalRow step)) := by
-  rw [mainMemBusInteractions_eq_valueLevel]
+    BalancedInteractions (mainValueMemBusInteractions (addSpinJalRow step)) := by
   refine zeroInteractions_balanced _ ?_ ?_
   · intro interaction h_interaction
-    simp at h_interaction
+    simp [mainValueMemBusInteractions] at h_interaction
     rcases h_interaction with rfl | rfl | rfl | rfl | rfl | rfl <;>
       simp [mainARegPreInteraction, mainAMemInteraction, mainBRegPreInteraction,
         mainBMemInteraction, mainCRegPreInteraction, mainCMemInteraction, addSpinJalRow,
@@ -1033,7 +1234,6 @@ def addSpinAcceptedTrace : AcceptedZiskTrace 2 where
   mem_replay_gsum := fun h => absurd h addSpinWitness_not_mutableMemPresent
   mem_replay_im0 := fun h => absurd h addSpinWitness_not_mutableMemPresent
   mem_replay_im1 := fun h => absurd h addSpinWitness_not_mutableMemPresent
-  mem_replay_constraints := fun h => absurd h addSpinWitness_not_mutableMemPresent
   mem_replay_segment_ranges := fun h => absurd h addSpinWitness_not_mutableMemPresent
   mem_replay_source_covers := fun h => absurd h addSpinWitness_not_mutableMemPresent
   transitions_hold := addSpinWitness_transitions
@@ -1042,7 +1242,7 @@ def addSpinAcceptedTrace : AcceptedZiskTrace 2 where
   main_step_index_fixed := addSpinWitness_main_step_index_fixed
 
 theorem addSpinAcceptedTrace_mainTable_eq :
-    addSpinAcceptedTrace.mainTable = mainRowsTable 2 addSpinProgram addSpinMainRows := by
+    addSpinAcceptedTrace.mainTable = addSpinMainTable := by
   exact addSpinWitness_main_component_cases
     (by simpa [addSpinAcceptedTrace] using addSpinAcceptedTrace.mainTable_mem)
     (by simpa [addSpinAcceptedTrace] using addSpinAcceptedTrace.mainTable_component)
@@ -1057,7 +1257,7 @@ theorem addSpinWitness_main_height_prefix_one :
 
 theorem addSpinMain_main_step_index_fixed_prefix_one :
     MainStepIndexFixedFacts 1 2 addSpinProgram
-      (mainRowsTable 2 addSpinProgram addSpinMainRows) where
+      addSpinMainTable where
   main_step_eq_index := by
     intro i
     fin_cases i
@@ -1097,7 +1297,6 @@ def addPaddedAcceptedTrace : AcceptedZiskTrace 1 where
   mem_replay_gsum := fun h => absurd h addSpinWitness_not_mutableMemPresent
   mem_replay_im0 := fun h => absurd h addSpinWitness_not_mutableMemPresent
   mem_replay_im1 := fun h => absurd h addSpinWitness_not_mutableMemPresent
-  mem_replay_constraints := fun h => absurd h addSpinWitness_not_mutableMemPresent
   mem_replay_segment_ranges := fun h => absurd h addSpinWitness_not_mutableMemPresent
   mem_replay_source_covers := fun h => absurd h addSpinWitness_not_mutableMemPresent
   transitions_hold := addSpinWitness_transitions
@@ -1106,7 +1305,7 @@ def addPaddedAcceptedTrace : AcceptedZiskTrace 1 where
   main_step_index_fixed := addSpinWitness_main_step_index_fixed_prefix_one
 
 theorem addPaddedAcceptedTrace_mainTable_eq :
-    addPaddedAcceptedTrace.mainTable = mainRowsTable 2 addSpinProgram addSpinMainRows := by
+    addPaddedAcceptedTrace.mainTable = addSpinMainTable := by
   exact addSpinWitness_main_component_cases
     (by simpa [addPaddedAcceptedTrace] using addPaddedAcceptedTrace.mainTable_mem)
     (by simpa [addPaddedAcceptedTrace] using addPaddedAcceptedTrace.mainTable_component)

--- a/ZiskFv/Compliance/EnsembleWitnessBuilder.lean
+++ b/ZiskFv/Compliance/EnsembleWitnessBuilder.lean
@@ -57,38 +57,45 @@ variable {PublicIO : TypeMap} [ProvableType PublicIO]
 def tableAt (ens : Ensemble F PublicIO) (data : ProverData F)
     (rows : Fin ens.tables.length → List (Array F))
     (huniform : ∀ i : Fin ens.tables.length,
-        ∀ row ∈ rows i, row.size = (ens.tables[i.val]'i.isLt).width)
+        ∀ row ∈ rows i, row.size = (ens.tables[i.val]'i.isLt).rawWidth)
+    (hfixed : ∀ i : Fin ens.tables.length, ∀ columns,
+        (ens.tables[i.val]'i.isLt).fixedColumns = some columns →
+          (rows i).length ≤ columns.capacity)
     (i : Fin ens.tables.length) : Table F where
   component := ens.tables[i.val]'i.isLt
-  width := (ens.tables[i.val]'i.isLt).width
-  table := rows i
+  rawRows := rows i
   data := data
-  uniform_width := huniform i
+  raw_uniform_width := huniform i
+  fixed_domain := hfixed i
 
 @[simp] lemma tableAt_component (ens : Ensemble F PublicIO) (data : ProverData F)
-    (rows : Fin ens.tables.length → List (Array F)) (huniform) (i) :
-    (tableAt ens data rows huniform i).component = ens.tables[i.val]'i.isLt := rfl
+    (rows : Fin ens.tables.length → List (Array F)) (huniform) (hfixed) (i) :
+    (tableAt ens data rows huniform hfixed i).component = ens.tables[i.val]'i.isLt := rfl
 
-@[simp] lemma tableAt_table (ens : Ensemble F PublicIO) (data : ProverData F)
-    (rows : Fin ens.tables.length → List (Array F)) (huniform) (i) :
-    (tableAt ens data rows huniform i).table = rows i := rfl
+@[simp] lemma tableAt_rawRows (ens : Ensemble F PublicIO) (data : ProverData F)
+    (rows : Fin ens.tables.length → List (Array F)) (huniform) (hfixed) (i) :
+    (tableAt ens data rows huniform hfixed i).rawRows = rows i := rfl
 
 @[simp] lemma tableAt_data (ens : Ensemble F PublicIO) (data : ProverData F)
-    (rows : Fin ens.tables.length → List (Array F)) (huniform) (i) :
-    (tableAt ens data rows huniform i).data = data := rfl
+    (rows : Fin ens.tables.length → List (Array F)) (huniform) (hfixed) (i) :
+    (tableAt ens data rows huniform hfixed i).data = data := rfl
 
 /-- Build an `EnsembleWitness ens` from a position-indexed row assignment. The
     `tables` list is `List.ofFn` over `Fin ens.tables.length`, so every built
     table's component is definitionally `ens.tables[i]` — making the three `same_*`
-    obligations one-liners. Callers supply `rows` (per-table row lists) and a
-    per-table `uniform_width` proof; #218/#219 supply non-empty `rows`, the
-    degenerate #217 witness supplies `fun _ => []`. -/
+    obligations one-liners. Callers supply `rows` (per-table raw row lists), a
+    per-table raw-width proof, and the structural capacity invariant required by a
+    component-owned fixed schema; #218/#219 supply non-empty `rows`, the degenerate
+    #217 witness supplies `fun _ => []`. -/
 def ofRows (ens : Ensemble F PublicIO) (data : ProverData F) (publicInput : PublicIO F)
     (rows : Fin ens.tables.length → List (Array F))
     (huniform : ∀ i : Fin ens.tables.length,
-        ∀ row ∈ rows i, row.size = (ens.tables[i.val]'i.isLt).width) :
+        ∀ row ∈ rows i, row.size = (ens.tables[i.val]'i.isLt).rawWidth)
+    (hfixed : ∀ i : Fin ens.tables.length, ∀ columns,
+        (ens.tables[i.val]'i.isLt).fixedColumns = some columns →
+          (rows i).length ≤ columns.capacity) :
     EnsembleWitness ens where
-  tables := List.ofFn (tableAt ens data rows huniform)
+  tables := List.ofFn (tableAt ens data rows huniform hfixed)
   data := data
   publicInput := publicInput
   same_length := by rw [List.length_ofFn]
@@ -97,17 +104,17 @@ def ofRows (ens : Ensemble F PublicIO) (data : ProverData F) (publicInput : Publ
     intro t h; rw [List.mem_ofFn] at h; obtain ⟨i, rfl⟩ := h; rfl
 
 @[simp] lemma ofRows_tables (ens : Ensemble F PublicIO) (data : ProverData F)
-    (publicInput : PublicIO F) (rows : Fin ens.tables.length → List (Array F)) (huniform) :
-    (ofRows ens data publicInput rows huniform).tables =
-      List.ofFn (tableAt ens data rows huniform) := rfl
+    (publicInput : PublicIO F) (rows : Fin ens.tables.length → List (Array F)) (huniform) (hfixed) :
+    (ofRows ens data publicInput rows huniform hfixed).tables =
+      List.ofFn (tableAt ens data rows huniform hfixed) := rfl
 
 @[simp] lemma ofRows_data (ens : Ensemble F PublicIO) (data : ProverData F)
-    (publicInput : PublicIO F) (rows : Fin ens.tables.length → List (Array F)) (huniform) :
-    (ofRows ens data publicInput rows huniform).data = data := rfl
+    (publicInput : PublicIO F) (rows : Fin ens.tables.length → List (Array F)) (huniform) (hfixed) :
+    (ofRows ens data publicInput rows huniform hfixed).data = data := rfl
 
 @[simp] lemma ofRows_publicInput (ens : Ensemble F PublicIO) (data : ProverData F)
-    (publicInput : PublicIO F) (rows : Fin ens.tables.length → List (Array F)) (huniform) :
-    (ofRows ens data publicInput rows huniform).publicInput = publicInput := rfl
+    (publicInput : PublicIO F) (rows : Fin ens.tables.length → List (Array F)) (huniform) (hfixed) :
+    (ofRows ens data publicInput rows huniform hfixed).publicInput = publicInput := rfl
 
 /-- With an empty verifier, `witness.Constraints` reduces to the per-`tables`
     obligation (the verifier table's own constraints are discharged by

--- a/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
+++ b/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
@@ -30,6 +30,11 @@ private def proverEnvFromInput {Input : TypeMap} [ProvableType Input]
   data := emptyData
   hint := ProverHint.empty FGL
 
+private def proverEnvFromEnvironment (env : Environment FGL) : ProverEnvironment FGL where
+  get := env.get
+  data := env.data
+  hint := ProverHint.empty FGL
+
 private theorem eval_proverEnvFromInput_varFromOffset_zero
     {Input : TypeMap} [ProvableType Input] (row : Input FGL) :
     Eval.eval (proverEnvFromInput row) (varFromOffset (F := FGL) Input 0) = row := by
@@ -132,39 +137,93 @@ private theorem component_constraintsHold_of_proverAssumptions
   rw [← h_env_eq]
   exact (Component.constraintsHold_iff (component := component) (env : Environment FGL)).mpr h_row
 
-def mainRowArray (row : MainRowWithRom FGL) : Array FGL :=
-  (toElements row).toArray
+private theorem component_constraintsHold_of_proverAssumptions_at
+    (component : Component FGL) (env : Environment FGL) (row : component.Input FGL)
+    (h_localLength : component.circuit.localLength component.rowInputVar = 0)
+    (h_input : Eval.eval env component.rowInputVar = row)
+    (h_data : env.data = emptyData)
+    (h_assumptions :
+      component.circuit.ProverAssumptions row emptyData (ProverHint.empty FGL)) :
+    component.operations.ConstraintsHold env := by
+  let proverEnv := proverEnvFromEnvironment env
+  have h_env : proverEnv.UsesLocalWitnesses component.rowOffset component.rowOperations := by
+    apply usesLocalWitnesses_of_localLength_zero
+    change ((component.circuit.main component.rowInputVar).localLength component.rowOffset) = 0
+    rw [component.circuit.localLength_eq]
+    exact h_localLength
+  have h_input' : Eval.eval proverEnv component.rowInputVar = row := by
+    rw [ProvableType.eval_varFromOffset_prover]
+    rw [← h_input]
+    rw [ProvableType.eval_varFromOffset]
+    congr
+  have h_assumptions' :
+      component.circuit.ProverAssumptions (Eval.eval proverEnv component.rowInputVar)
+        proverEnv.data proverEnv.hint := by
+    rw [h_input']
+    simpa [proverEnv, proverEnvFromEnvironment, h_data] using h_assumptions
+  have h_full :=
+    component.circuit.original_full_completeness component.rowOffset proverEnv component.rowInputVar
+      h_env h_assumptions'
+  have h_row : component.rowOperations.ConstraintsHold (proverEnv : Environment FGL) := by
+    simpa [Component.rowOperations, Component.rowInputVar, Component.rowOffset] using h_full.1
+  simpa [proverEnv, proverEnvFromEnvironment] using
+    (Component.constraintsHold_iff (component := component)
+      (env := (proverEnv : Environment FGL))).mpr h_row
+
+@[reducible] def mainRowArray (row : MainRowWithRom FGL) : Array FGL :=
+  mainRawRow row
 
 def mainSingleRowTable
     (length : ℕ) (program : Program length) (row : MainRowWithRom FGL) :
     Table FGL where
   component := componentWithRomMemAndOpBus length program
-  width := size MainRowWithRom
-  table := [mainRowArray row]
+  rawRows := [mainRowArray row]
   data := emptyData
-  uniform_width := by
+  raw_uniform_width := by
     intro arr h_arr
     simp [mainRowArray] at h_arr
     subst arr
-    simp
+    simpa [mainRowArray, componentWithRomMemAndOpBus] using mainRawRow_size row
+  fixed_domain := by
+    intro columns h_columns
+    have h_columns' : columns = mainFixedColumns := by
+      simpa [componentWithRomMemAndOpBus] using h_columns.symm
+    subst columns
+    norm_num [mainFixedColumns, mainFixedCapacity]
+
+private theorem mainSingleRowTable_effectiveRows
+    (length : ℕ) (program : Program length) (row : MainRowWithRom FGL) :
+    (mainSingleRowTable length program row).table =
+      [mainFixedColumns.materialize 0 (mainRawRow row)] := by
+  simp [mainSingleRowTable, Table.table, mainRowArray, componentWithRomMemAndOpBus]
+
+def mainSingleRowTableEnvironment
+    (length : ℕ) (program : Program length) (row : MainRowWithRom FGL) : Environment FGL :=
+  Environment.fromArray (mainFixedColumns.materialize 0 (mainRawRow row)) emptyData
 
 theorem mainSingleRowTable_rowInput
-    (length : ℕ) (program : Program length) (row : MainRowWithRom FGL) :
+    (length : ℕ) (program : Program length) (row : MainRowWithRom FGL)
+    (h_segment_l1 : row.core.segment_l1 = mainFixedColumns.fixedAt 0 0)
+    (h_main_step : row.rom.main_step = mainFixedColumns.fixedAt 1 0) :
     (componentWithRomMemAndOpBus length program).rowInput
-        ((mainSingleRowTable length program row).environment (mainRowArray row)) =
+        (mainSingleRowTableEnvironment length program row) =
       row := by
   change (componentWithRomMemAndOpBus length program).rowInput
-      (Environment.fromInput row emptyData) = row
-  simp [Air.Flat.Component.rowInput,
-    ProvableType.valueFromOffset_zero_fromInput_eq]
+      (Environment.fromArray (mainFixedColumns.materialize 0 (mainRawRow row)) emptyData) = row
+  exact componentWithRomMemAndOpBus_rowInput_materialize
+    length program 0 emptyData row h_segment_l1 h_main_step
 
 theorem mainSingleRowTable_eval_rowInputVar
-    (length : ℕ) (program : Program length) (row : MainRowWithRom FGL) :
-    Eval.eval ((mainSingleRowTable length program row).environment (mainRowArray row))
+    (length : ℕ) (program : Program length) (row : MainRowWithRom FGL)
+    (h_segment_l1 : row.core.segment_l1 = mainFixedColumns.fixedAt 0 0)
+    (h_main_step : row.rom.main_step = mainFixedColumns.fixedAt 1 0) :
+    Eval.eval (mainSingleRowTableEnvironment length program row)
         (componentWithRomMemAndOpBus length program).rowInputVar =
       row := by
-  change Eval.eval (Environment.fromInput row emptyData) (varFromOffset MainRowWithRom 0) = row
-  exact ProvableType.eval_fromInput_varFromOffset_zero row emptyData
+  change Eval.eval
+      (Environment.fromArray (mainFixedColumns.materialize 0 (mainRawRow row)) emptyData)
+      (varFromOffset MainRowWithRom 0) = row
+  exact eval_mainRawRow_materialize 0 emptyData row h_segment_l1 h_main_step
 
 def mainOpBusInteraction (row : MainRowWithRom FGL) : Interaction FGL where
   channel := OpBusChannel.toRaw
@@ -414,18 +473,20 @@ theorem mainOpBusAbstractInteraction_eval
   · rfl
 
 theorem mainComponentOpBusInteraction_eval
-    (length : ℕ) (program : Program length) (row : MainRowWithRom FGL) :
+    (length : ℕ) (program : Program length) (row : MainRowWithRom FGL)
+    (h_segment_l1 : row.core.segment_l1 = mainFixedColumns.fixedAt 0 0)
+    (h_main_step : row.rom.main_step = mainFixedColumns.fixedAt 1 0) :
     (((OpBusChannel.emitted
         (-(componentWithRomMemAndOpBus length program).rowInputVar.core.is_external_op)
         (opBusMessageExpr
           (componentWithRomMemAndOpBus length program).rowInputVar.core)).toRaw).eval
-      ((mainSingleRowTable length program row).environment (mainRowArray row))) =
+      (mainSingleRowTableEnvironment length program row)) =
       mainOpBusInteraction row := by
-  let env := (mainSingleRowTable length program row).environment (mainRowArray row)
+  let env := mainSingleRowTableEnvironment length program row
   let rowVar := (componentWithRomMemAndOpBus length program).rowInputVar
   have h_input : eval env rowVar = row := by
     dsimp [env, rowVar]
-    exact mainSingleRowTable_eval_rowInputVar length program row
+    exact mainSingleRowTable_eval_rowInputVar length program row h_segment_l1 h_main_step
   have h_core : eval env rowVar.core = row.core := by
     rw [ZiskFv.AirsClean.FullEnsemble.mainRowWithRom_eval_core]
     exact congrArg MainRowWithRom.core h_input
@@ -446,13 +507,21 @@ theorem mainComponentOpBusInteraction_eval
   · rfl
 
 theorem mainSingleRowTable_interactionsWith_opBus
-    (length : ℕ) (program : Program length) (row : MainRowWithRom FGL) :
+    (length : ℕ) (program : Program length) (row : MainRowWithRom FGL)
+    (h_segment_l1 : row.core.segment_l1 = mainFixedColumns.fixedAt 0 0)
+    (h_main_step : row.rom.main_step = mainFixedColumns.fixedAt 1 0) :
     (mainSingleRowTable length program row).interactionsWith OpBusChannel.toRaw =
       [mainOpBusInteraction row] := by
-  simp [Table.interactionsWith, mainSingleRowTable, mainRowArray,
-    Operations.interactionValuesWith_eq_map,
+  rw [Table.interactionsWith, mainSingleRowTable_effectiveRows]
+  simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]
+  change
+    (componentWithRomMemAndOpBus length program).operations.interactionValuesWith
+        OpBusChannel.toRaw (mainSingleRowTableEnvironment length program row) =
+      [mainOpBusInteraction row]
+  rw [Operations.interactionValuesWith_eq_map,
     componentWithRomMemAndOpBus_interactionsWith_opBus]
-  exact mainComponentOpBusInteraction_eval length program row
+  exact congrArg (fun interaction => [interaction])
+    (mainComponentOpBusInteraction_eval length program row h_segment_l1 h_main_step)
 
 def mainARegPreInteraction (row : MainRowWithRom FGL) : Interaction FGL where
   channel := MemBusChannel.toRaw
@@ -499,7 +568,7 @@ def mainCMemInteraction (row : MainRowWithRom FGL) : Interaction FGL where
 def mainMemBusInteractions
     (length : ℕ) (program : Program length) (row : MainRowWithRom FGL) :
     List (Interaction FGL) :=
-  let env := (mainSingleRowTable length program row).environment (mainRowArray row)
+  let env := mainSingleRowTableEnvironment length program row
   let rowVar := (componentWithRomMemAndOpBus length program).rowInputVar
   [ ((MemBusChannel.emitted rowVar.rom.a_src_reg (aRegPreMessageExpr rowVar)).toRaw).eval env
   , ((MemBusChannel.emitted (-(rowVar.rom.a_src_mem + rowVar.rom.a_src_reg))
@@ -517,12 +586,19 @@ theorem mainSingleRowTable_interactionsWith_memBus
     (length : ℕ) (program : Program length) (row : MainRowWithRom FGL) :
     (mainSingleRowTable length program row).interactionsWith MemBusChannel.toRaw =
       mainMemBusInteractions length program row := by
-  simp [Table.interactionsWith, mainSingleRowTable, mainRowArray, mainMemBusInteractions,
-    Operations.interactionValuesWith_eq_map,
+  rw [Table.interactionsWith, mainSingleRowTable_effectiveRows]
+  simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]
+  change
+    (componentWithRomMemAndOpBus length program).operations.interactionValuesWith
+        MemBusChannel.toRaw (mainSingleRowTableEnvironment length program row) =
+      mainMemBusInteractions length program row
+  simp [mainMemBusInteractions, Operations.interactionValuesWith_eq_map,
     componentWithRomMemAndOpBus_interactionsWith_memBus]
 
 theorem mainSingleRowTable_constraints_of_proverAssumptions
     (length : ℕ) (program : Program length) (row : MainRowWithRom FGL)
+    (h_segment_l1 : row.core.segment_l1 = mainFixedColumns.fixedAt 0 0)
+    (h_main_step : row.rom.main_step = mainFixedColumns.fixedAt 1 0)
     (h_assumptions :
       (componentWithRomMemAndOpBus length program).circuit.ProverAssumptions
         row emptyData (ProverHint.empty FGL)) :
@@ -535,14 +611,17 @@ theorem mainSingleRowTable_constraints_of_proverAssumptions
     rfl
   have h_component :
       (componentWithRomMemAndOpBus length program).operations.ConstraintsHold
-        (Environment.fromInput row emptyData) :=
-    component_constraintsHold_of_proverAssumptions
-      (componentWithRomMemAndOpBus length program) row h_localLength h_assumptions
-  rw [Table.Constraints]
+        (Environment.fromArray (mainFixedColumns.materialize 0 (mainRawRow row)) emptyData) :=
+    component_constraintsHold_of_proverAssumptions_at
+      (componentWithRomMemAndOpBus length program)
+      (Environment.fromArray (mainFixedColumns.materialize 0 (mainRawRow row)) emptyData)
+      row h_localLength (eval_mainRawRow_materialize 0 emptyData row h_segment_l1 h_main_step)
+      rfl h_assumptions
+  rw [Table.Constraints, mainSingleRowTable_effectiveRows]
   intro arr h_arr
-  simp [mainSingleRowTable, mainRowArray] at h_arr
+  simp only [List.mem_singleton] at h_arr
   subst arr
-  simpa [mainSingleRowTable, mainRowArray, Environment.fromInput] using h_component
+  simpa [mainSingleRowTable, Table.environment] using h_component
 
 private def mainSpikeProgram : Program 0 := nofun
 
@@ -566,22 +645,33 @@ example :
     ((mainSingleRowTable 0 mainSpikeProgram mainSpikeRow).interactionsWith
         OpBusChannel.toRaw).map (fun i => (i.mult, i.msg)) =
       [((-1 : FGL), #[7, 11, 0, 13, 0, 17, 19, 1, 0, 0, 0])] := by
-  rw [mainSingleRowTable_interactionsWith_opBus]
+  rw [mainSingleRowTable_interactionsWith_opBus
+    (length := 0) (program := mainSpikeProgram) (row := mainSpikeRow) (by rfl) (by rfl)]
   decide
 
 def binaryAddRowArray (row : ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL) : Array FGL :=
   (toElements row).toArray
 
+private theorem binaryAdd_component_rawWidth :
+    ZiskFv.AirsClean.BinaryAdd.component.rawWidth =
+      size ZiskFv.AirsClean.BinaryAdd.BinaryAddRow := by
+  change ZiskFv.AirsClean.BinaryAdd.circuit.size = size ZiskFv.AirsClean.BinaryAdd.BinaryAddRow
+  rw [GeneralFormalCircuit.size_eq]
+  rfl
+
 def binaryAddRowsTable
     (rows : List (ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL)) : Table FGL where
   component := ZiskFv.AirsClean.BinaryAdd.component
-  width := size ZiskFv.AirsClean.BinaryAdd.BinaryAddRow
-  table := rows.map binaryAddRowArray
+  rawRows := rows.map binaryAddRowArray
   data := emptyData
-  uniform_width := by
+  raw_uniform_width := by
     intro arr h_arr
     rcases List.mem_map.mp h_arr with ⟨row, _, rfl⟩
+    rw [binaryAdd_component_rawWidth]
     simp [binaryAddRowArray]
+  fixed_domain := by
+    intro columns h_columns
+    simp [ZiskFv.AirsClean.BinaryAdd.component] at h_columns
 
 theorem binaryAddRowsTable_rowInput
     (rows : List (ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL))
@@ -679,27 +769,46 @@ theorem binaryAddRowsTable_constraints_of_proverAssumptions
     rfl
   rw [Table.Constraints]
   intro arr h_arr
+  change arr ∈ rows.map binaryAddRowArray at h_arr
   rcases List.mem_map.mp h_arr with ⟨row, h_row, rfl⟩
   have h_component :
       ZiskFv.AirsClean.BinaryAdd.component.operations.ConstraintsHold
         (Environment.fromInput row emptyData) :=
     component_constraintsHold_of_proverAssumptions
       ZiskFv.AirsClean.BinaryAdd.component row h_localLength (h_assumptions row h_row)
-  simpa [binaryAddRowsTable, binaryAddRowArray, Environment.fromInput] using h_component
+  simpa [binaryAddRowsTable, binaryAddRowArray, Table.table, Environment.fromInput]
+    using h_component
 
 def binaryRowArray (row : ZiskFv.AirsClean.Binary.BinaryRow FGL) : Array FGL :=
   (toElements row).toArray
 
+private theorem binaryStaticLookup_component_rawWidth :
+    ZiskFv.AirsClean.Binary.staticLookupComponent.rawWidth =
+      size ZiskFv.AirsClean.Binary.BinaryRow := by
+  change ZiskFv.AirsClean.Binary.staticLookupCircuit.size =
+    size ZiskFv.AirsClean.Binary.BinaryRow
+  rw [GeneralFormalCircuit.size_eq]
+  rfl
+
 def binarySingleRowTable (row : ZiskFv.AirsClean.Binary.BinaryRow FGL) : Table FGL where
   component := ZiskFv.AirsClean.Binary.staticLookupComponent
-  width := size ZiskFv.AirsClean.Binary.BinaryRow
-  table := [binaryRowArray row]
+  rawRows := [binaryRowArray row]
   data := emptyData
-  uniform_width := by
+  raw_uniform_width := by
     intro arr h_arr
     simp [binaryRowArray] at h_arr
     subst arr
-    simp
+    rw [binaryStaticLookup_component_rawWidth]
+    simp [binaryRowArray]
+  fixed_domain := by
+    intro columns h_columns
+    simp [ZiskFv.AirsClean.Binary.staticLookupComponent] at h_columns
+
+private theorem binarySingleRowTable_effectiveRows
+    (row : ZiskFv.AirsClean.Binary.BinaryRow FGL) :
+    (binarySingleRowTable row).table = [binaryRowArray row] := by
+  simp [binarySingleRowTable, Table.table, binaryRowArray,
+    ZiskFv.AirsClean.Binary.staticLookupComponent]
 
 theorem binarySingleRowTable_rowInput
     (row : ZiskFv.AirsClean.Binary.BinaryRow FGL) :
@@ -751,10 +860,16 @@ theorem binarySingleRowTable_interactionsWith_opBus
     (row : ZiskFv.AirsClean.Binary.BinaryRow FGL) :
     (binarySingleRowTable row).interactionsWith OpBusChannel.toRaw =
       [binaryOpBusInteraction row] := by
-  simp [Table.interactionsWith, binarySingleRowTable, binaryRowArray,
-    Operations.interactionValuesWith_eq_map,
+  rw [Table.interactionsWith, binarySingleRowTable_effectiveRows]
+  simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]
+  change
+    ZiskFv.AirsClean.Binary.staticLookupComponent.operations.interactionValuesWith
+        OpBusChannel.toRaw
+        ((binarySingleRowTable row).environment (binaryRowArray row)) =
+      [binaryOpBusInteraction row]
+  rw [Operations.interactionValuesWith_eq_map,
     ZiskFv.AirsClean.Binary.staticLookupComponent_interactionsWith_opBus]
-  exact binaryComponentOpBusInteraction_eval row
+  exact congrArg (fun interaction => [interaction]) (binaryComponentOpBusInteraction_eval row)
 
 theorem binarySingleRowTable_constraints_of_proverAssumptions
     (row : ZiskFv.AirsClean.Binary.BinaryRow FGL)
@@ -773,11 +888,12 @@ theorem binarySingleRowTable_constraints_of_proverAssumptions
         (Environment.fromInput row emptyData) :=
     component_constraintsHold_of_proverAssumptions
       ZiskFv.AirsClean.Binary.staticLookupComponent row h_localLength h_assumptions
-  rw [Table.Constraints]
+  rw [Table.Constraints, binarySingleRowTable_effectiveRows]
   intro arr h_arr
-  simp [binarySingleRowTable, binaryRowArray] at h_arr
+  simp only [List.mem_singleton] at h_arr
   subst arr
-  simpa [binarySingleRowTable, binaryRowArray, Environment.fromInput] using h_component
+  simpa [binarySingleRowTable, binaryRowArray, Table.environment, Environment.fromInput]
+    using h_component
 
 private def binarySpikeRow : ZiskFv.AirsClean.Binary.BinaryRow FGL :=
   { aBytes :=
@@ -826,28 +942,50 @@ private theorem memRow_eval_sel_dual
       ProvableStruct.toComponents, ProvableStruct.eval.go] using
       (CircuitType.eval_expr env sel_dual).symm
 
-def memRowArray (row : ZiskFv.AirsClean.Mem.MemRow FGL) : Array FGL :=
-  (toElements row).toArray
+@[reducible] def memRowArray (row : ZiskFv.AirsClean.Mem.MemRow FGL) : Array FGL :=
+  ZiskFv.AirsClean.Mem.memRawRow row
 
 def memSingleRowTable (row : ZiskFv.AirsClean.Mem.MemRow FGL) : Table FGL where
   component := ZiskFv.AirsClean.Mem.componentWithDualMemBus
-  width := size ZiskFv.AirsClean.Mem.MemRow
-  table := [memRowArray row]
+  rawRows := [memRowArray row]
   data := emptyData
-  uniform_width := by
+  raw_uniform_width := by
     intro arr h_arr
     simp [memRowArray] at h_arr
     subst arr
-    simp
+    simpa [memRowArray, ZiskFv.AirsClean.Mem.componentWithDualMemBus] using
+      ZiskFv.AirsClean.Mem.memRawRow_size row
+  fixed_domain := by
+    intro columns h_columns
+    have h_columns' : columns = ZiskFv.AirsClean.Mem.memFixedColumns := by
+      simpa [ZiskFv.AirsClean.Mem.componentWithDualMemBus] using h_columns.symm
+    subst columns
+    norm_num [ZiskFv.AirsClean.Mem.memFixedColumns, ZiskFv.AirsClean.Mem.memFixedCapacity]
+
+private theorem memSingleRowTable_effectiveRows
+    (row : ZiskFv.AirsClean.Mem.MemRow FGL) :
+    (memSingleRowTable row).table =
+      [ZiskFv.AirsClean.Mem.memFixedColumns.materialize 0
+        (ZiskFv.AirsClean.Mem.memRawRow row)] := by
+  simp [memSingleRowTable, Table.table, memRowArray,
+    ZiskFv.AirsClean.Mem.componentWithDualMemBus]
+
+def memSingleRowTableEnvironment
+    (row : ZiskFv.AirsClean.Mem.MemRow FGL) : Environment FGL :=
+  Environment.fromArray
+    (ZiskFv.AirsClean.Mem.memFixedColumns.materialize 0
+      (ZiskFv.AirsClean.Mem.memRawRow row)) emptyData
 
 theorem memSingleRowTable_rowInput
     (row : ZiskFv.AirsClean.Mem.MemRow FGL) :
     ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInput
-        ((memSingleRowTable row).environment (memRowArray row)) =
+        (memSingleRowTableEnvironment row) =
       row := by
   change ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInput
-      (Environment.fromInput row emptyData) = row
-  simp [Air.Flat.Component.rowInput, ProvableType.valueFromOffset_zero_fromInput_eq]
+      (Environment.fromArray
+        (ZiskFv.AirsClean.Mem.memFixedColumns.materialize 0
+          (ZiskFv.AirsClean.Mem.memRawRow row)) emptyData) = row
+  exact ZiskFv.AirsClean.Mem.componentWithDualMemBus_rowInput_materialize 0 emptyData row
 
 def memBusInteraction (row : ZiskFv.AirsClean.Mem.MemRow FGL) : Interaction FGL where
   channel := MemBusChannel.toRaw
@@ -869,14 +1007,13 @@ theorem memComponentMemBusInteraction_eval
         ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar.sel
         (ZiskFv.AirsClean.Mem.memBusMessageExpr
           ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar)).toRaw).eval
-      ((memSingleRowTable row).environment (memRowArray row))) =
+      (memSingleRowTableEnvironment row)) =
       memBusInteraction row := by
-  let env := (memSingleRowTable row).environment (memRowArray row)
+  let env := memSingleRowTableEnvironment row
   let rowVar := ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar
   have h_input : eval env rowVar = row := by
-    change eval (Environment.fromInput row emptyData)
-        (varFromOffset ZiskFv.AirsClean.Mem.MemRow 0) = row
-    exact ProvableType.eval_fromInput_varFromOffset_zero row emptyData
+    dsimp [env, rowVar]
+    exact ZiskFv.AirsClean.Mem.eval_memRawRow_materialize 0 emptyData row
   have h_field := memRow_eval_sel env rowVar
   have h_msg_eval :
       eval env (ZiskFv.AirsClean.Mem.memBusMessageExpr rowVar) =
@@ -901,14 +1038,13 @@ theorem memComponentMemBusDualInteraction_eval
         ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar.sel_dual
         (ZiskFv.AirsClean.Mem.memBusDualMessageExpr
           ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar)).toRaw).eval
-      ((memSingleRowTable row).environment (memRowArray row))) =
+      (memSingleRowTableEnvironment row)) =
       memBusDualInteraction row := by
-  let env := (memSingleRowTable row).environment (memRowArray row)
+  let env := memSingleRowTableEnvironment row
   let rowVar := ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar
   have h_input : eval env rowVar = row := by
-    change eval (Environment.fromInput row emptyData)
-        (varFromOffset ZiskFv.AirsClean.Mem.MemRow 0) = row
-    exact ProvableType.eval_fromInput_varFromOffset_zero row emptyData
+    dsimp [env, rowVar]
+    exact ZiskFv.AirsClean.Mem.eval_memRawRow_materialize 0 emptyData row
   have h_field := memRow_eval_sel_dual env rowVar
   have h_msg_eval :
       eval env (ZiskFv.AirsClean.Mem.memBusDualMessageExpr rowVar) =
@@ -931,11 +1067,17 @@ theorem memSingleRowTable_interactionsWith_memBus
     (row : ZiskFv.AirsClean.Mem.MemRow FGL) :
     (memSingleRowTable row).interactionsWith MemBusChannel.toRaw =
       [memBusInteraction row, memBusDualInteraction row] := by
-  simp [Table.interactionsWith, memSingleRowTable, memRowArray,
-    Operations.interactionValuesWith_eq_map,
+  rw [Table.interactionsWith, memSingleRowTable_effectiveRows]
+  simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]
+  change
+    ZiskFv.AirsClean.Mem.componentWithDualMemBus.operations.interactionValuesWith
+        MemBusChannel.toRaw (memSingleRowTableEnvironment row) =
+      [memBusInteraction row, memBusDualInteraction row]
+  rw [Operations.interactionValuesWith_eq_map,
     ZiskFv.AirsClean.Mem.componentWithDualMemBus_interactionsWith_memBus]
-  exact ⟨memComponentMemBusInteraction_eval row,
-    memComponentMemBusDualInteraction_eval row⟩
+  simp only [List.map_cons, List.map_nil]
+  exact congrArg₂ (fun primary dual => [primary, dual])
+    (memComponentMemBusInteraction_eval row) (memComponentMemBusDualInteraction_eval row)
 
 theorem memSingleRowTable_constraints_of_proverAssumptions
     (row : ZiskFv.AirsClean.Mem.MemRow FGL)
@@ -951,14 +1093,21 @@ theorem memSingleRowTable_constraints_of_proverAssumptions
     rfl
   have h_component :
       ZiskFv.AirsClean.Mem.componentWithDualMemBus.operations.ConstraintsHold
-        (Environment.fromInput row emptyData) :=
-    component_constraintsHold_of_proverAssumptions
-      ZiskFv.AirsClean.Mem.componentWithDualMemBus row h_localLength h_assumptions
-  rw [Table.Constraints]
+        (Environment.fromArray
+          (ZiskFv.AirsClean.Mem.memFixedColumns.materialize 0
+            (ZiskFv.AirsClean.Mem.memRawRow row)) emptyData) :=
+    component_constraintsHold_of_proverAssumptions_at
+      ZiskFv.AirsClean.Mem.componentWithDualMemBus
+      (Environment.fromArray
+        (ZiskFv.AirsClean.Mem.memFixedColumns.materialize 0
+          (ZiskFv.AirsClean.Mem.memRawRow row)) emptyData)
+      row h_localLength (ZiskFv.AirsClean.Mem.eval_memRawRow_materialize 0 emptyData row)
+      rfl h_assumptions
+  rw [Table.Constraints, memSingleRowTable_effectiveRows]
   intro arr h_arr
-  simp [memSingleRowTable, memRowArray] at h_arr
+  simp only [List.mem_singleton] at h_arr
   subst arr
-  simpa [memSingleRowTable, memRowArray, Environment.fromInput] using h_component
+  simpa [memSingleRowTable, memRowArray, Table.environment] using h_component
 
 private def memSpikeRow : ZiskFv.AirsClean.Mem.MemRow FGL :=
   { addr := 4, step := 7, sel := 1, addr_changes := 0, step_dual := 8,
@@ -978,25 +1127,45 @@ def registerBoundaryRowArray (row : RegisterBoundaryRow FGL) : Array FGL :=
 
 def registerBoundaryRowsTableOf (rows : List (RegisterBoundaryRow FGL)) : Table FGL where
   component := ZiskFv.AirsClean.RegisterBoundary.component
-  width := size RegisterBoundaryRow
-  table := rows.map registerBoundaryRowArray
+  rawRows := rows.map registerBoundaryRowArray
   data := emptyData
-  uniform_width := by
+  raw_uniform_width := by
     intro arr h_arr
     simp [registerBoundaryRowArray] at h_arr
     rcases h_arr with ⟨row, _h_row, rfl⟩
-    simp
+    change size RegisterBoundaryRow = ZiskFv.AirsClean.RegisterBoundary.circuit.size
+    rw [GeneralFormalCircuit.size_eq]
+    rfl
+  fixed_domain := by
+    intro columns h_columns
+    simp [ZiskFv.AirsClean.RegisterBoundary.component] at h_columns
+
+private theorem registerBoundaryRowsTableOf_effectiveRows
+    (rows : List (RegisterBoundaryRow FGL)) :
+    (registerBoundaryRowsTableOf rows).table = rows.map registerBoundaryRowArray := by
+  simp [registerBoundaryRowsTableOf, Table.table, registerBoundaryRowArray,
+    ZiskFv.AirsClean.RegisterBoundary.component]
 
 def registerBoundarySingleRowTable (row : RegisterBoundaryRow FGL) : Table FGL where
   component := ZiskFv.AirsClean.RegisterBoundary.component
-  width := size RegisterBoundaryRow
-  table := [registerBoundaryRowArray row]
+  rawRows := [registerBoundaryRowArray row]
   data := emptyData
-  uniform_width := by
+  raw_uniform_width := by
     intro arr h_arr
     simp [registerBoundaryRowArray] at h_arr
     subst arr
-    simp
+    change size RegisterBoundaryRow = ZiskFv.AirsClean.RegisterBoundary.circuit.size
+    rw [GeneralFormalCircuit.size_eq]
+    rfl
+  fixed_domain := by
+    intro columns h_columns
+    simp [ZiskFv.AirsClean.RegisterBoundary.component] at h_columns
+
+private theorem registerBoundarySingleRowTable_effectiveRows
+    (row : RegisterBoundaryRow FGL) :
+    (registerBoundarySingleRowTable row).table = [registerBoundaryRowArray row] := by
+  simp [registerBoundarySingleRowTable, Table.table, registerBoundaryRowArray,
+    ZiskFv.AirsClean.RegisterBoundary.component]
 
 theorem registerBoundarySingleRowTable_rowInput
     (row : RegisterBoundaryRow FGL) :
@@ -1101,28 +1270,53 @@ theorem registerBoundarySingleRowTable_interactionsWith_memBus
     (row : RegisterBoundaryRow FGL) :
     (registerBoundarySingleRowTable row).interactionsWith MemBusChannel.toRaw =
       registerBoundaryMemBusInteractions row := by
-  simp [Table.interactionsWith, registerBoundarySingleRowTable, registerBoundaryRowArray,
-    registerBoundaryMemBusInteractions, Operations.interactionValuesWith_eq_map,
+  rw [Table.interactionsWith, registerBoundarySingleRowTable_effectiveRows]
+  simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]
+  change
+    ZiskFv.AirsClean.RegisterBoundary.component.operations.interactionValuesWith
+        MemBusChannel.toRaw
+        ((registerBoundarySingleRowTable row).environment (registerBoundaryRowArray row)) =
+      registerBoundaryMemBusInteractions row
+  rw [Operations.interactionValuesWith_eq_map,
     ZiskFv.AirsClean.RegisterBoundary.component_interactionsWith_memBus]
-  exact ⟨registerBoundaryComponentBootInteraction_eval row,
-    registerBoundaryComponentReloadInteraction_eval row⟩
+  simp only [registerBoundaryMemBusInteractions, List.map_cons, List.map_nil]
+  exact congrArg₂ (fun boot reload => [boot, reload])
+    (registerBoundaryComponentBootInteraction_eval row)
+    (registerBoundaryComponentReloadInteraction_eval row)
+
+private theorem registerBoundaryRowsTableOf_memBus_row
+    (rows : List (RegisterBoundaryRow FGL)) (row : RegisterBoundaryRow FGL) :
+    ZiskFv.AirsClean.RegisterBoundary.component.operations.interactionValuesWith
+        MemBusChannel.toRaw
+        ((registerBoundaryRowsTableOf rows).environment (registerBoundaryRowArray row)) =
+      registerBoundaryMemBusInteractions row := by
+  rw [Operations.interactionValuesWith_eq_map,
+    ZiskFv.AirsClean.RegisterBoundary.component_interactionsWith_memBus]
+  simp only [registerBoundaryMemBusInteractions, List.map_cons, List.map_nil]
+  apply congrArg₂ (fun boot reload => [boot, reload])
+  · simpa [registerBoundaryRowsTableOf, registerBoundaryRowArray, Table.environment,
+      Environment.fromInput] using registerBoundaryBootInteraction_eval_fromInput row
+  · simpa [registerBoundaryRowsTableOf, registerBoundaryRowArray, Table.environment,
+      Environment.fromInput] using registerBoundaryReloadInteraction_eval_fromInput row
+
+private theorem registerBoundaryRowsTableOf_interactionsWith_memBus_go
+    (allRows rows : List (RegisterBoundaryRow FGL)) :
+    (rows.map registerBoundaryRowArray).flatMap (fun arr =>
+      ZiskFv.AirsClean.RegisterBoundary.component.operations.interactionValuesWith
+        MemBusChannel.toRaw ((registerBoundaryRowsTableOf allRows).environment arr)) =
+      rows.flatMap registerBoundaryMemBusInteractions := by
+  induction rows with
+  | nil => rfl
+  | cons row rows ih =>
+      simp only [List.map_cons, List.flatMap_cons]
+      rw [registerBoundaryRowsTableOf_memBus_row, ih]
 
 theorem registerBoundaryRowsTableOf_interactionsWith_memBus
     (rows : List (RegisterBoundaryRow FGL)) :
     (registerBoundaryRowsTableOf rows).interactionsWith MemBusChannel.toRaw =
       rows.flatMap registerBoundaryMemBusInteractions := by
-  induction rows with
-  | nil =>
-      simp [Table.interactionsWith, registerBoundaryRowsTableOf]
-  | cons row rows ih =>
-      simp only [List.flatMap_cons]
-      rw [← ih]
-      simp [Table.interactionsWith, registerBoundaryRowsTableOf, registerBoundaryRowArray,
-        registerBoundaryMemBusInteractions, Table.environment,
-        Operations.interactionValuesWith_eq_map,
-        ZiskFv.AirsClean.RegisterBoundary.component_interactionsWith_memBus,
-        registerBoundaryBootInteraction_eval_fromInput,
-        registerBoundaryReloadInteraction_eval_fromInput]
+  rw [Table.interactionsWith, registerBoundaryRowsTableOf_effectiveRows]
+  exact registerBoundaryRowsTableOf_interactionsWith_memBus_go rows rows
 
 theorem registerBoundarySingleRowTable_constraints
     (row : RegisterBoundaryRow FGL) :
@@ -1138,12 +1332,12 @@ theorem registerBoundarySingleRowTable_constraints
         (Environment.fromInput row emptyData) :=
     component_constraintsHold_of_proverAssumptions
       ZiskFv.AirsClean.RegisterBoundary.component row h_localLength trivial
-  rw [Table.Constraints]
+  rw [Table.Constraints, registerBoundarySingleRowTable_effectiveRows]
   intro arr h_arr
-  simp [registerBoundarySingleRowTable, registerBoundaryRowArray] at h_arr
+  simp only [List.mem_singleton] at h_arr
   subst arr
-  simpa [registerBoundarySingleRowTable, registerBoundaryRowArray, Environment.fromInput]
-    using h_component
+  simpa [registerBoundarySingleRowTable, registerBoundaryRowArray, Table.environment,
+    Environment.fromInput] using h_component
 
 theorem registerBoundaryRowsTableOf_constraints
     (rows : List (RegisterBoundaryRow FGL)) :
@@ -1154,16 +1348,15 @@ theorem registerBoundaryRowsTableOf_constraints
     change ZiskFv.AirsClean.RegisterBoundary.registerBoundaryElaborated.localLength
         ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar = 0
     rfl
-  rw [Table.Constraints]
+  rw [Table.Constraints, registerBoundaryRowsTableOf_effectiveRows]
   intro arr h_arr
-  simp [registerBoundaryRowsTableOf, registerBoundaryRowArray] at h_arr
-  rcases h_arr with ⟨row, _h_row, rfl⟩
+  rcases List.mem_map.mp h_arr with ⟨row, _h_row, rfl⟩
   have h_component :
       ZiskFv.AirsClean.RegisterBoundary.component.operations.ConstraintsHold
         (Environment.fromInput row emptyData) :=
     component_constraintsHold_of_proverAssumptions
       ZiskFv.AirsClean.RegisterBoundary.component row h_localLength trivial
-  simpa [registerBoundaryRowsTableOf, registerBoundaryRowArray, Environment.fromInput]
-    using h_component
+  simpa [registerBoundaryRowsTableOf, registerBoundaryRowArray, Table.environment,
+    Environment.fromInput] using h_component
 
 end ZiskFv.Compliance.Instantiation

--- a/ZiskFv/Compliance/MainTransition.lean
+++ b/ZiskFv/Compliance/MainTransition.lean
@@ -44,6 +44,35 @@ theorem rowInput_eq_mainTableRowAtOrZero
   simp only [Air.Flat.Component.rowInput, Air.Flat.Component.rowInputVar,
     eval_varFromOffset_valueFromOffset]
 
+/-- The indexed effective-row environment projects to the corresponding Main row. -/
+private theorem rowInputAt_eq_mainTableRowAtOrZero
+    {length : ℕ} (program : Program length) (table : Table FGL)
+    (index : Fin table.length) :
+    (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program).rowInput
+        (table.environmentAt index) =
+      mainTableRowAtOrZero program table index.val := by
+  have h_index : index.val < table.table.length := by
+    simpa only [Table.table_length] using index.isLt
+  change (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program).rowInput
+      (table.environment (table.table[index.val]'h_index)) =
+    mainTableRowAtOrZero program table index.val
+  exact rowInput_eq_mainTableRowAtOrZero program table index.val h_index
+
+/-- The saturated predecessor environment projects to the preceding effective Main row. -/
+private theorem rowInputPrevious_eq_mainTableRowAtOrZero
+    {length : ℕ} (program : Program length) (table : Table FGL)
+    (index : Fin table.length) (h_positive : 0 < index.val) :
+    (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program).rowInput
+        (table.previousEnvironment index) =
+      mainTableRowAtOrZero program table (index.val - 1) := by
+  have h_index : index.val - 1 < table.table.length := by
+    have h_raw : index.val - 1 < table.length := by omega
+    simpa only [Table.table_length] using h_raw
+  change (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program).rowInput
+      (table.environment (table.table[index.val - 1]'h_index)) =
+    mainTableRowAtOrZero program table (index.val - 1)
+  exact rowInput_eq_mainTableRowAtOrZero program table (index.val - 1) h_index
+
 /-- **Trace-level next-PC handshake.** From the accepted trace's in-circuit
     PC-handshake transition certificate (`transitions_hold`), at a within-segment
     Main row `i + 1` (`segment_l1 (i + 1) = 0`), the named-column Main view
@@ -61,25 +90,43 @@ theorem AcceptedZiskTrace.mainTransition_to_next_pc
     ZiskFv.Airs.Main.pc_handshake_with_next_pc
       (mainOfTable trace.program trace.mainTable) i
       ((mainOfTable trace.program trace.mainTable).pc (i + 1)) := by
-  have h_trans := trace.transitions_hold trace.mainTable trace.mainTable_mem i h_idx
+  have h_transition_index_lt : i + 1 < trace.mainTable.length := by
+    simpa only [Table.length, Table.table_length] using h_idx
+  let transitionIndex : Fin trace.mainTable.length := ⟨i + 1, h_transition_index_lt⟩
+  have h_trans := trace.transitions_hold trace.mainTable trace.mainTable_mem transitionIndex
   have hcomp : trace.mainTable.component
       = ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.programLength trace.program :=
     trace.mainTable_component
   rw [hcomp] at h_trans
-  have hproj :
-      (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.programLength trace.program).transition
-        = ZiskFv.AirsClean.Main.pcHandshakeBetween := rfl
-  rw [hproj,
-      rowInput_eq_mainTableRowAtOrZero trace.program trace.mainTable i (by omega),
-      rowInput_eq_mainTableRowAtOrZero trace.program trace.mainTable (i + 1) h_idx] at h_trans
-  simp only [ZiskFv.AirsClean.Main.pcHandshakeBetween] at h_trans
+  change ZiskFv.AirsClean.Main.pcHandshakeTransition transitionIndex.val
+    (trace.mainTable.previousEnvironment transitionIndex)
+    (trace.mainTable.environmentAt transitionIndex) at h_trans
+  have h_transition : ZiskFv.AirsClean.Main.pcHandshakeBetween
+      ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.programLength trace.program).rowInput
+        (trace.mainTable.previousEnvironment transitionIndex))
+      ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.programLength trace.program).rowInput
+        (trace.mainTable.environmentAt transitionIndex)) := by
+    simpa only [ZiskFv.AirsClean.Main.pcHandshakeTransition, Air.Flat.Component.rowInput,
+      Air.Flat.Component.rowInputVar, eval_varFromOffset_valueFromOffset] using h_trans
+  have h_previous := rowInputPrevious_eq_mainTableRowAtOrZero trace.program trace.mainTable
+    transitionIndex (by simp [transitionIndex])
+  have h_current := rowInputAt_eq_mainTableRowAtOrZero trace.program trace.mainTable
+    transitionIndex
+  rw [h_previous, h_current] at h_transition
+  have h_trans_between : ZiskFv.AirsClean.Main.pcHandshakeBetween
+      (mainTableRowAtOrZero trace.program trace.mainTable i)
+      (mainTableRowAtOrZero trace.program trace.mainTable (i + 1)) := by
+    simpa [transitionIndex] using h_transition
+  simp only [ZiskFv.AirsClean.Main.pcHandshakeBetween] at h_trans_between
   have h_at :
       ZiskFv.AirsClean.Main.pc_handshake_at
         (mainOfTable trace.program trace.mainTable) (i + 1) := by
     simp only [ZiskFv.AirsClean.Main.pc_handshake_at, mainOfTable_segment_l1, mainOfTable_pc,
       mainOfTable_set_pc, mainOfTable_c_0, mainOfTable_jmp_offset1, mainOfTable_jmp_offset2,
       mainOfTable_flag, Nat.add_sub_cancel]
-    exact h_trans
+    exact h_trans_between
   rw [ZiskFv.AirsClean.Main.pc_handshake_at_iff_v1] at h_at
   exact ZiskFv.Airs.Main.pc_handshake_to_next_pc
     (mainOfTable trace.program trace.mainTable) i h_seg h_at

--- a/ZiskFv/Compliance/RegisterMemBusBalance.lean
+++ b/ZiskFv/Compliance/RegisterMemBusBalance.lean
@@ -393,14 +393,14 @@ theorem addX1Row_main_interactionsWith_memBus_eq_mainRegisterInteractionsFromTab
   rfl
 
 private def addX1MainEnv : Environment FGL :=
-  (mainSingleRowTable 1 addX1Program addX1Row).environment (mainRowArray addX1Row)
+  mainSingleRowTableEnvironment 1 addX1Program addX1Row
 
 private def addX1MainRowVar : Var MainRowWithRom FGL :=
   (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus 1 addX1Program).rowInputVar
 
 private theorem addX1MainRowVar_eval : eval addX1MainEnv addX1MainRowVar = addX1Row := by
   dsimp [addX1MainEnv, addX1MainRowVar]
-  exact mainSingleRowTable_eval_rowInputVar 1 addX1Program addX1Row
+  exact mainSingleRowTable_eval_rowInputVar 1 addX1Program addX1Row (by rfl) (by rfl)
 
 private theorem addX1MainRom_eval :
     eval addX1MainEnv addX1MainRowVar.rom = addX1Row.rom := by
@@ -576,7 +576,15 @@ private theorem addX1MainCMemInteraction_eval :
 
 theorem mainRegisterInteractionsFromTable_eq_mainRegisterInteractions :
     mainRegisterInteractionsFromTable = mainRegisterInteractions := by
-  simp [mainRegisterInteractionsFromTable, mainRegisterInteractions, mainMemBusInteractions]
+  change mainMemBusInteractions 1 addX1Program addX1Row =
+    [ mainARegPreInteraction addX1Row
+    , mainAMemInteraction addX1Row
+    , mainBRegPreInteraction addX1Row
+    , mainBMemInteraction addX1Row
+    , mainCRegPreInteraction addX1Row
+    , mainCMemInteraction addX1Row ]
+  unfold mainMemBusInteractions
+  simp only [List.cons.injEq, and_true]
   exact ⟨addX1MainARegPreInteraction_eval, addX1MainAMemInteraction_eval,
     addX1MainBRegPreInteraction_eval, addX1MainBMemInteraction_eval,
     addX1MainCRegPreInteraction_eval, addX1MainCMemInteraction_eval⟩

--- a/ZiskFv/Compliance/SingleAddWitness.lean
+++ b/ZiskFv/Compliance/SingleAddWitness.lean
@@ -27,22 +27,39 @@ namespace ZiskFv.Compliance.SingleAddWitness
 
 def emptyComponentTable (component : Component FGL) : Table FGL where
   component := component
-  width := component.width
-  table := []
+  rawRows := []
   data := emptyData
-  uniform_width := by
+  raw_uniform_width := by
     intro row h_row
     cases h_row
+  fixed_domain := by
+    intro columns h_columns
+    simp
 
 theorem emptyComponentTable_constraints (component : Component FGL) :
     (emptyComponentTable component).Constraints := by
-  rw [Table.Constraints]
-  intro row h_row
-  cases h_row
+  simp only [Table.Constraints, Table.table]
+  unfold emptyComponentTable
+  split <;> simp
 
 theorem emptyComponentTable_interactionsWith (component : Component FGL) (channel) :
     (emptyComponentTable component).interactionsWith channel = [] := by
-  simp [Table.interactionsWith, emptyComponentTable]
+  simp only [Table.interactionsWith, Table.table]
+  unfold emptyComponentTable
+  split <;> simp
+
+theorem emptyComponentTable_table (component : Component FGL) :
+    (emptyComponentTable component).table = [] := by
+  simp only [Table.table]
+  unfold emptyComponentTable
+  split <;> rfl
+
+theorem emptyComponentTable_transitions (component : Component FGL) :
+    (emptyComponentTable component).TransitionConstraints := by
+  rw [Table.TransitionConstraints]
+  intro index
+  change Fin 0 at index
+  exact Fin.elim0 index
 
 def addX1BinaryAddRow : ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL :=
   ZiskFv.AirsClean.BinaryAdd.binaryAddRowOf 0 0
@@ -83,7 +100,7 @@ theorem addX1Main_proverAssumptions :
 theorem addX1MainTable_constraints :
     (mainSingleRowTable 1 addX1Program addX1Row).Constraints :=
   mainSingleRowTable_constraints_of_proverAssumptions 1 addX1Program addX1Row
-    addX1Main_proverAssumptions
+    (by rfl) (by rfl) addX1Main_proverAssumptions
 
 theorem addX1BinaryAddTable_constraints :
     (binaryAddRowsTable [addX1BinaryAddRow]).Constraints := by
@@ -170,21 +187,62 @@ theorem singleAddWitness_constraints : singleAddWitness.Constraints :=
   singleAddWitness.constraints_of_tables singleAddEnsemble_verifier
     singleAddWitness_table_constraints
 
+private theorem mainSingleRowTable_transitions
+    (length : Nat) (program : Program length) (row : MainRowWithRom FGL)
+    (h_segment_l1 : row.core.segment_l1 = mainFixedColumns.fixedAt 0 0)
+    (h_main_step : row.rom.main_step = mainFixedColumns.fixedAt 1 0) :
+    (mainSingleRowTable length program row).TransitionConstraints := by
+  rw [Table.TransitionConstraints]
+  intro index
+  have h_index_lt := index.isLt
+  change index.val < 1 at h_index_lt
+  have h_index : index.val = 0 := by omega
+  have h_zero : 0 < (mainSingleRowTable length program row).length := by
+    change 0 < 1
+    decide
+  have h_index_eq : index = ⟨0, h_zero⟩ := Fin.ext h_index
+  subst index
+  change pcHandshakeTransition 0
+    (Environment.fromArray (mainFixedColumns.materialize 0 (mainRawRow row)) emptyData)
+    (Environment.fromArray (mainFixedColumns.materialize 0 (mainRawRow row)) emptyData)
+  unfold pcHandshakeTransition
+  rw [eval_mainRawRow_materialize 0 emptyData row h_segment_l1 h_main_step]
+  have h_segment_l1_one : row.core.segment_l1 = 1 := by
+    rw [h_segment_l1]
+    rfl
+  simp [pcHandshakeBetween, h_segment_l1_one]
+
+private theorem addX1MainTable_transitions :
+    (mainSingleRowTable 1 addX1Program addX1Row).TransitionConstraints :=
+  mainSingleRowTable_transitions 1 addX1Program addX1Row (by rfl) (by rfl)
+
 theorem singleAddWitness_transitions : singleAddWitness.TransitionConstraints := by
   intro table h_table
   rw [EnsembleWitness.allTables, List.mem_cons] at h_table
   rcases h_table with h_verifier | h_table
   · subst table
     rw [Table.TransitionConstraints]
-    intro i h_i
-    simp [EnsembleWitness.verifierTable] at h_i
+    intro index
+    simp [EnsembleWitness.verifierTable]
   · simp [singleAddWitness, singleAddTables] at h_table
-    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
-      rw [Table.TransitionConstraints] <;>
-      intro i h_i <;>
-      simp [registerBoundaryRowsTable, registerBoundaryRowsTableOf, emptyComponentTable,
-        binaryAddRowsTable, mainSingleRowTable, ZiskFv.AirsClean.RegisterBoundary.component,
-        ZiskFv.AirsClean.BinaryAdd.component] at h_i ⊢
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    · rw [Table.TransitionConstraints]
+      intro index
+      simp [registerBoundaryRowsTable, registerBoundaryRowsTableOf,
+        ZiskFv.AirsClean.RegisterBoundary.component]
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignReadByte.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignByte.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlign.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.Mem.componentWithDualMemBus
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.ArithDiv.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.ArithMul.componentWithArithTable
+    · exact emptyComponentTable_transitions
+        ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.Binary.staticLookupComponent
+    · rw [Table.TransitionConstraints]
+      intro index
+      simp [binaryAddRowsTable, ZiskFv.AirsClean.BinaryAdd.component]
+    · exact addX1MainTable_transitions
 
 private theorem not_main_component_of_name_ne
     {component : Component FGL}
@@ -264,14 +322,14 @@ private theorem singleAddWitness_mutable_mem_component_tables_empty (table : Tab
     rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
     · exfalso
       exact not_mutable_mem_component_of_name_ne (by decide) h_component
-    · simp [emptyComponentTable]
-    · simp [emptyComponentTable]
-    · simp [emptyComponentTable]
-    · simp [emptyComponentTable]
-    · simp [emptyComponentTable]
-    · simp [emptyComponentTable]
-    · simp [emptyComponentTable]
-    · simp [emptyComponentTable]
+    · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignReadByte.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignByte.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlign.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.Mem.componentWithDualMemBus
+    · exact emptyComponentTable_table ZiskFv.AirsClean.ArithDiv.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.ArithMul.componentWithArithTable
+    · exact emptyComponentTable_table ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+    · exact emptyComponentTable_table ZiskFv.AirsClean.Binary.staticLookupComponent
     · exfalso
       exact not_mutable_mem_component_of_name_ne (by decide) h_component
     · exfalso
@@ -300,10 +358,13 @@ theorem addX1Main_segment_l1_first :
   simp [ZiskFv.AirsClean.FullEnsemble.mainOfTable_segment_l1]
   unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
   simp [mainSingleRowTable, mainRowArray]
-  change (eval ((mainSingleRowTable 1 addX1Program addX1Row).environment
-      (mainRowArray addX1Row))
-        (componentWithRomMemAndOpBus 1 addX1Program).rowInputVar).core.segment_l1 = 1
-  rw [mainSingleRowTable_eval_rowInputVar]
+  change (eval (Environment.fromArray
+      (mainFixedColumns.materialize 0 (mainRawRow addX1Row)) emptyData)
+      (componentWithRomMemAndOpBus 1 addX1Program).rowInputVar).core.segment_l1 = 1
+  change (eval (Environment.fromArray
+      (mainFixedColumns.materialize 0 (mainRawRow addX1Row)) emptyData)
+      (varFromOffset (F := FGL) MainRowWithRom 0)).core.segment_l1 = 1
+  rw [eval_mainRawRow_materialize 0 emptyData addX1Row (by rfl) (by rfl)]
   rfl
 
 theorem addX1Main_main_step_eq_index :
@@ -314,10 +375,13 @@ theorem addX1Main_main_step_eq_index :
   fin_cases i
   unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
   simp [mainSingleRowTable, mainRowArray]
-  change (eval ((mainSingleRowTable 1 addX1Program addX1Row).environment
-      (mainRowArray addX1Row))
-        (componentWithRomMemAndOpBus 1 addX1Program).rowInputVar).rom.main_step = 0
-  rw [mainSingleRowTable_eval_rowInputVar]
+  change (eval (Environment.fromArray
+      (mainFixedColumns.materialize 0 (mainRawRow addX1Row)) emptyData)
+      (componentWithRomMemAndOpBus 1 addX1Program).rowInputVar).rom.main_step = 0
+  change (eval (Environment.fromArray
+      (mainFixedColumns.materialize 0 (mainRawRow addX1Row)) emptyData)
+      (varFromOffset (F := FGL) MainRowWithRom 0)).rom.main_step = 0
+  rw [eval_mainRawRow_materialize 0 emptyData addX1Row (by rfl) (by rfl)]
   rfl
 
 theorem addX1Main_main_step_index_fixed :
@@ -389,9 +453,13 @@ theorem singleAddWitness_opBus_interactions :
       registerBoundaryRowsTable.interactionsWith OpBusChannel.toRaw = [] := by
     exact ZiskFv.AirsClean.FullEnsemble.registerBoundary_table_interactionsWith_opBus_nil
       (table := registerBoundaryRowsTable) rfl
+  have h_main :
+      (mainSingleRowTable 1 addX1Program addX1Row).interactionsWith OpBusChannel.toRaw =
+        [mainOpBusInteraction addX1Row] :=
+    mainSingleRowTable_interactionsWith_opBus 1 addX1Program addX1Row (by rfl) (by rfl)
   rw [show singleAddWitness.tables = singleAddTables from rfl]
   simp [singleAddTables, h_registerBoundary, emptyComponentTable_interactionsWith,
-    binaryAddRowsTable_interactionsWith_opBus, mainSingleRowTable_interactionsWith_opBus]
+    binaryAddRowsTable_interactionsWith_opBus, h_main]
 
 theorem singleAddWitness_opBus_balanced :
     BalancedInteractions
@@ -483,7 +551,6 @@ def singleAddAcceptedTrace : AcceptedZiskTrace 1 where
   mem_replay_gsum := fun h => absurd h singleAddWitness_not_mutableMemPresent
   mem_replay_im0 := fun h => absurd h singleAddWitness_not_mutableMemPresent
   mem_replay_im1 := fun h => absurd h singleAddWitness_not_mutableMemPresent
-  mem_replay_constraints := fun h => absurd h singleAddWitness_not_mutableMemPresent
   mem_replay_segment_ranges := fun h => absurd h singleAddWitness_not_mutableMemPresent
   mem_replay_source_covers := fun h => absurd h singleAddWitness_not_mutableMemPresent
   transitions_hold := singleAddWitness_transitions

--- a/docs/clean-fork-divergences.md
+++ b/docs/clean-fork-divergences.md
@@ -11,17 +11,17 @@ merge.)
 
 ---
 
-## D1 — `Air.Flat` adjacent-row (transition) constraints  · zisk-fv #100  · **UPSTREAM CANDIDATE (strong)**
+## D1 — `Air.Flat` indexed adjacent-row (transition) constraints  · zisk-fv #100 / #226  · **UPSTREAM CANDIDATE (strong)**
 
-- **Branch / commit:** `air-flat-transition-constraints` @ `497e4a41` (off the pinned base).
-- **What:** an *additive* transition-constraint facility on the modern `Air.Flat` layer —
-  - `Air.Flat.Component.transition : Input F → Input F → Prop := fun _ _ => True` (a new field, defaults to
-    trivial so every existing component/proof is unaffected);
-  - `Air.Flat.Table.TransitionConstraints` — the transition holds on each consecutive row pair
-    (`∀ i, i+1 < len → component.transition (rowInput row_i) (rowInput row_{i+1})`);
-  - `Air.Flat.EnsembleWitness.TransitionConstraints` — folds that over `allTables`.
-  Plus the mechanical `⟨…⟩ → { circuit := … }` constructor sweep that adding a struct field forces
-  (3 sites in Clean: `FlatEnsemble.lean` verifierTable ×2 + `empty_allTables`; 4 in `FibonacciWithChannels.lean`).
+- **Branch / commit:** `air-flat-indexed-fixed-columns` @ `c87617d8` (which includes the prior
+  `air-flat-transition-constraints` commit `497e4a41`).
+- **What:** an *additive* transition-constraint facility on the modern `Air.Flat` layer:
+  - `Air.Flat.Component.transition : Nat → Environment F → Environment F → Prop := fun _ _ _ => True`;
+  - `Air.Flat.Table.TransitionConstraints` applies it at every row index to the canonical predecessor/current
+    effective environments, with row zero saturated to itself;
+  - `Air.Flat.EnsembleWitness.TransitionConstraints` folds that over `allTables`.
+  The indexed form is necessary for generated AIR expressions that read periodic fixed data at a successor
+  position. Existing components remain unaffected because the default predicate is trivial.
 - **Why:** `Air.Flat` is single-row *by design* (`FlatComponent.lean:8-10`: "There are no direct adjacent-row
   constraints; communication … is expressed by channel interactions"). But ZisK's Main AIR enforces a
   genuine cross-row **polynomial** PC-handshake constraint (`main.pil:409-410`), which is **not** a channel —
@@ -44,3 +44,23 @@ merge.)
   theorem consumes it); on the zisk-fv side it is carried as a verifier-checked accepted-trace certificate
   (`AcceptedZiskTrace.transitions_hold`), in the same epistemic class as `main_height`. The upstream version
   should instead thread the transition through the soundness lift.
+
+---
+
+## D2 — `Air.Flat` component-owned indexed fixed columns  · zisk-fv #243 / S1b  · **UPSTREAM CANDIDATE (strong)**
+
+- **Branch / commit:** `air-flat-indexed-fixed-columns` @ `c87617d8`.
+- **What:** `IndexedFixedColumns` declares a physical capacity, a raw-or-fixed layout for each effective
+  output cell, and periodic fixed values. `Component` owns an optional schema; `Table` stores only raw rows
+  and definitionally materializes canonical effective `table` rows. The same rows feed constraints, channel
+  interactions and balance, indexed transitions, and projections. `Table.fixed_domain` bounds a table to the
+  schema capacity, and `Table.index_lt_fixed_capacity` derives the no-wrap fact for an actual row.
+- **Why:** preprocessed PIL columns, including Main's `SEGMENT_L1`/`STEP` and Mem's appended
+  `SEGMENT_L1`/`__L1__`, are verifier-side data rather than caller-provided witness cells. A projection-only
+  override would prove chronology against data different from the balanced interaction trace. Making the
+  layout component-owned keeps all consumers on one canonical source and keeps the domain/no-wrap bound a
+  structural facility invariant rather than an accepted-trace certificate or caller-supplied promise.
+- **Upstream candidacy — strong.** It is a small, generic representation of standard AIR fixed columns and
+  makes the modern `Air.Flat` layer usable for preprocessed-column AIRs without introducing a parallel table
+  model. The eventual upstream convergence should establish a soundness lift for both D1 and D2; this fork
+  deliberately does not claim that larger result.

--- a/flake.lock
+++ b/flake.lock
@@ -54,17 +54,17 @@
     "clean-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1782534319,
-        "narHash": "sha256-ew/hlzT3OCAEKhgCNMnsIaIVGE+uJlckp2wVj4/S9n4=",
+        "lastModified": 1784035501,
+        "narHash": "sha256-1Be3MrWhDvH0gytR5UY5FhgRzifbL5UHEf9K5dxIz+E=",
         "owner": "codygunton",
         "repo": "clean",
-        "rev": "497e4a4192ae90485647778542636539ef03316d",
+        "rev": "c87617d8e29386e1e9e4f98cfbfb6940c2eb63df",
         "type": "github"
       },
       "original": {
         "owner": "codygunton",
+        "ref": "c87617d8",
         "repo": "clean",
-        "rev": "497e4a4192ae90485647778542636539ef03316d",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -41,12 +41,13 @@
       # Clean.Fin.foldl_eq_foldl_finRange, so Clean.Air.* can be imported
       # alongside Mathlib/Batteries), the C7
       # `exists_nonzero_push_of_pull` balance strengthening, and (zisk-fv #100)
-      # the additive `Air.Flat.Component.transition` adjacent-row constraint
-      # facility (branch air-flat-transition-constraints; see
-      # docs/clean-fork-divergences.md D1 — strong upstream-PR candidate). To be
-      # upstreamed; re-point at Verified-zkEVM/clean once all merge. Pinned by
-      # rev so the lock is immutable; fetched over HTTPS so CI needs no SSH key.
-      url = "github:codygunton/clean/497e4a4192ae90485647778542636539ef03316d";
+      # the D1 all-row predecessor/current transition plus D2 canonical
+      # component-owned indexed fixed-column materialization (branch
+      # air-flat-indexed-fixed-columns; see docs/clean-fork-divergences.md).
+      # To be upstreamed; re-point at Verified-zkEVM/clean once all merge.
+      # Pinned by rev so the lock is immutable; fetched over HTTPS so CI needs
+      # no SSH key.
+      url = "github:codygunton/clean/c87617d8";
       flake = false;
     };
 

--- a/nix/README.md
+++ b/nix/README.md
@@ -22,6 +22,14 @@ works as usual. The Clean dep is pulled as a *source* tree (no
 pre-built oleans inside Nix — Lake compiles it as part of the main
 build using the shared Mathlib v4.28.0 pin).
 
+For Project Closeout S2, `flake.lock` pins the immutable
+`codygunton/clean@c87617d8e29386e1e9e4f98cfbfb6940c2eb63df` fork input. It
+provides the all-row predecessor/current transition surface and canonical
+component-owned indexed fixed-column materialization used by the live Mem and
+Main components. The associated build-input trust note is maintained in
+`trust/trusted-base.md`; the pin is a source dependency, not an accepted-trace
+certificate.
+
 ## Why Nix and not Docker
 
 The previous Docker pipeline used `apt-get install` (unpinned),

--- a/trust/consistency/global_theorem_instantiation_add.lean
+++ b/trust/consistency/global_theorem_instantiation_add.lean
@@ -72,14 +72,19 @@ private def providerRow : Array FGL := (toElements binaryAddZeroRow).toArray
 
 private def providerTable : Air.Flat.Table FGL where
   component := staticLookupComponent
-  width := staticLookupComponent.width
-  table := [providerRow]
+  rawRows := [providerRow]
   data := emptyData
-  uniform_width := by
+  raw_uniform_width := by
     intro row h_row
     simp [providerRow] at h_row ⊢
     subst row
     rfl
+  fixed_domain := by
+    intro columns h_columns
+    simp [staticLookupComponent] at h_columns
+
+private theorem providerTable_effectiveRows : providerTable.table = [providerRow] := by
+  simp [providerTable, Air.Flat.Table.table, staticLookupComponent]
 
 private theorem rowInput_provider :
     staticLookupComponent.rowInput (providerTable.environment providerRow) =
@@ -91,7 +96,8 @@ private theorem rowInput_provider :
 
 private theorem providerTableSpec : providerTable.Spec := by
   intro row h_row
-  simp [providerTable] at h_row
+  rw [providerTable_effectiveRows] at h_row
+  simp only [List.mem_singleton] at h_row
   subst row
   change staticLookupComponent.Spec (Environment.fromArray providerRow emptyData)
   rw [staticLookupComponent_spec]
@@ -102,7 +108,8 @@ private theorem providerTableSpec : providerTable.Spec := by
   exact ⟨binaryAddZeroSpec, binaryAddZeroStaticFacts⟩
 
 private theorem providerRowMem : providerRow ∈ providerTable.table := by
-  simp [providerTable]
+  rw [providerTable_effectiveRows]
+  simp
 
 private def witnessMainRow : ZiskFv.AirsClean.Main.MainRow FGL :=
   { a_0 := 0, a_1 := 0, b_0 := 0, b_1 := 0, c_0 := 0, c_1 := 0, flag := 0,

--- a/trust/consistency/root_soundness_instantiation_degenerate.lean
+++ b/trust/consistency/root_soundness_instantiation_degenerate.lean
@@ -41,6 +41,7 @@ private def emptyData : ProverData FGL := fun _ _ => #[]
 private def wit : EnsembleWitness (fullRv64imEnsemble 0 prog).ensemble :=
   EnsembleWitness.ofRows (fullRv64imEnsemble 0 prog).ensemble emptyData ()
     (fun _ => []) (by intro i row hrow; simp at hrow)
+    (by intro i columns h_columns; simp)
 
 /-- The full ensemble's verifier is empty (it is `SoundEnsemble.empty`'s verifier,
     preserved by `addTable`/`addFinishedChannel`; `fullRv64imEnsemble` is
@@ -51,8 +52,8 @@ private theorem wit_verifier :
 
 /-- Every table of the degenerate witness has at most one row: the provider
     tables are empty (0 rows) and the verifier table carries the single public
-    input row. This is what makes `transitions_hold` vacuous (no consecutive row
-    pair exists). -/
+    input row. Provider transitions are vacuous; the verifier's row-zero-saturated
+    default transition is trivial. -/
 private theorem wit_tables_len_le_one (table : Table FGL)
     (hmem : table ∈ wit.allTables) : table.table.length ≤ 1 := by
   rw [EnsembleWitness.allTables, List.mem_cons] at hmem
@@ -60,7 +61,8 @@ private theorem wit_tables_len_le_one (table : Table FGL)
   · rw [hv]; simp [EnsembleWitness.verifierTable]
   · simp only [wit, EnsembleWitness.ofRows_tables, List.mem_ofFn] at ht
     obtain ⟨i, rfl⟩ := ht
-    simp [EnsembleWitness.tableAt_table]
+    simp [EnsembleWitness.tableAt, Table.table]
+    split <;> simp
 
 /-- The only table of the degenerate witness carrying the Main component has no
     rows. The provider tables are empty by construction; the single non-empty
@@ -85,7 +87,8 @@ private theorem main_component_tables_empty (table : Table FGL)
     exact absurd hv_nil (by simp)
   · simp only [wit, EnsembleWitness.ofRows_tables, List.mem_ofFn] at ht
     obtain ⟨i, rfl⟩ := ht
-    simp [EnsembleWitness.tableAt_table]
+    simp [EnsembleWitness.tableAt, Table.table]
+    split <;> rfl
 
 /-- Any mutable-Mem component table in the degenerate witness is empty. The verifier table is
     ruled out by its empty MemBus interaction list, while every provider table is empty by
@@ -105,7 +108,8 @@ private theorem mutable_mem_component_tables_empty (table : Table FGL)
     exact absurd hv_nil (by simp)
   · simp only [wit, EnsembleWitness.ofRows_tables, List.mem_ofFn] at ht
     obtain ⟨i, rfl⟩ := ht
-    simp [EnsembleWitness.tableAt_table]
+    simp [EnsembleWitness.tableAt, Table.table]
+    split <;> rfl
 
 private theorem wit_not_mutableMemPresent : ¬ MutableMemPresent wit := by
   intro h_present
@@ -118,7 +122,8 @@ private theorem wit_constraints : wit.Constraints := by
   intro t ht
   simp only [wit, EnsembleWitness.ofRows_tables, List.mem_ofFn] at ht
   obtain ⟨i, rfl⟩ := ht
-  simp [Air.Flat.Table.Constraints, EnsembleWitness.tableAt_table]
+  simp [Air.Flat.Table.Constraints, EnsembleWitness.tableAt, Table.table]
+  split <;> simp
 
 private theorem wit_balanced : wit.BalancedChannels := by
   refine wit.balancedChannels_of_tables wit_verifier ?_
@@ -128,14 +133,24 @@ private theorem wit_balanced : wit.BalancedChannels := by
     intro t ht
     simp only [wit, EnsembleWitness.ofRows_tables, List.mem_ofFn] at ht
     obtain ⟨i, rfl⟩ := ht
-    simp [Air.Flat.Table.interactionsWith, EnsembleWitness.tableAt_table]
+    simp [Air.Flat.Table.interactionsWith, EnsembleWitness.tableAt, Table.table]
+    split <;> simp
   rw [hnil]
   exact balancedInteractions_of_present (Or.symm (Nat.eq_zero_or_pos _)) []
     (by simp) (by simp)
 
 private theorem wit_transitions : wit.TransitionConstraints := by
-  intro table hmem i h
-  exact absurd h (by have := wit_tables_len_le_one table hmem; omega)
+  intro table hmem
+  rw [Table.TransitionConstraints]
+  intro index
+  rw [EnsembleWitness.allTables, List.mem_cons] at hmem
+  rcases hmem with h_verifier | h_table
+  · subst table
+    simp [EnsembleWitness.verifierTable]
+  · simp only [wit, EnsembleWitness.ofRows_tables, List.mem_ofFn] at h_table
+    obtain ⟨i, rfl⟩ := h_table
+    change Fin 0 at index
+    exact Fin.elim0 index
 
 private theorem wit_segment_l1 :
     ∀ table ∈ wit.allTables,
@@ -175,7 +190,6 @@ private def trace : AcceptedZiskTrace 0 where
   mem_replay_gsum := fun h => absurd h wit_not_mutableMemPresent
   mem_replay_im0 := fun h => absurd h wit_not_mutableMemPresent
   mem_replay_im1 := fun h => absurd h wit_not_mutableMemPresent
-  mem_replay_constraints := fun h => absurd h wit_not_mutableMemPresent
   mem_replay_segment_ranges := fun h => absurd h wit_not_mutableMemPresent
   mem_replay_source_covers := fun h => absurd h wit_not_mutableMemPresent
   transitions_hold := wit_transitions

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -243,8 +243,9 @@ the bridge is named as `MemTableGeneratedRowsBridge`, which connects Clean
 `table.table` positions to `rowAt mem idx` and the row-indexed
 `generated_every_row` constraints. `FullWitnessMemReplayBridge` packages the
 concrete full-ensemble Mem table, generated-row/range facts, active-row equality,
-and nonempty segment evidence; deterministic fixed-column shape is derived
-through `segmentWithFixedL1`. Its constructor derives the accepted replay
+and nonempty segment evidence; its actual segment carries a derived
+component-owned fixed-column fact (legacy compatibility constructors still use
+`segmentWithFixedL1`). Its constructor derives the accepted replay
 subobject, so `AcceptedMemoryReplayEvidence.prefixReadSound` is no longer a bare
 global-boundary assumption. The semantic trust gate includes a
 two-address witness with an addr-sorted/time-reversed prefix (write at byte
@@ -258,22 +259,19 @@ nonempty-table proof. Memory-less traces prove the guard impossible; they do not
 fabricate an empty replay bridge. The generated Mem source residue is now split across
 accepted-trace fields: stage-2 sidecar columns (`mem_replay_segment`,
 `mem_replay_permutation`, `mem_replay_gsum`, `mem_replay_im0`,
-`mem_replay_im1`), split generated constraint facts
-(`mem_replay_constraints`), and HELD segment range facts
-(`mem_replay_segment_ranges`). Row range facts are derived from live Mem
-`Table.fromStatic` lookups rather than carried as an accepted-trace field. The
-`memReplayRawSourceSidecar`/`memReplaySource`/`memReplayBridge` accessors
-rebuild the raw sidecar, `FullWitnessMemAirSource`, and `FullWitnessMemReplayBridge`
-downstream. This is narrower than carrying the replay bridge, a full
-`FullWitnessMemAirSource`, the typed `MemTableGeneratedAirSource`, or one raw
-sidecar field directly, and fixed-column shape is no longer accepted-trace
-residue, but it still strengthens memory-present `AcceptedZiskTrace` construction
-until the remaining Mem generated-source/cross-row facts are derived or
-explicitly approved. `mem_replay_segment_ranges` is HELD for Project Closeout S3
-lookup-wiring extraction, which must derive and delete it; it is not a permanent
-caller-supplied promise hypothesis. `mem_replay_source_covers` is the matching structural
-source-correlation certificate: every mutable-Mem table in the witness is the
-selected source table.
+`mem_replay_im1`), and HELD segment range facts (`mem_replay_segment_ranges`).
+The legacy sidecar fields are not consumed by S2's live derivation; S3 audits
+their lifecycle. `mem_replay_constraints` is deleted: its segment/permutation
+package is derived from the selected table's live constraints plus its
+right-indexed transition, using canonical table `ProverData` and
+component-owned fixed data. Row range facts are likewise derived from live Mem
+`Table.fromStatic` lookups. `memReplayRows`/`memReplayBridge` construct the
+canonical replay bridge directly, rather than rebuilding a raw sidecar or
+`FullWitnessMemAirSource`. The HELD range field is now over that same canonical
+segment source; S3 must derive and delete it, so it is not a permanent
+caller-supplied promise hypothesis. `mem_replay_source_covers` remains the
+matching structural source-correlation certificate: every mutable-Mem table in
+the witness is the selected source table.
 
 MemAlign scope note (#242): #115's closeout is direct-Mem only. MemAlign-routed
 accesses remain undischarged, named follow-on burdens rather than derived
@@ -442,11 +440,11 @@ explicit initial-memory, scoped direct-Mem placement/classification, source/targ
 chronology, and named row-count/order certificates. This reduces the seed-side
 read-value assumption, but it also adds a nonempty accepted-trace constructor
 burden: `mem_replay_table` must select the concrete mutable Mem AIR table and
-nonempty proof; the source-column fields, `mem_replay_constraints`,
-and HELD `mem_replay_segment_ranges` must provide the remaining raw generated
-Mem source factors for that selected table. Row range facts are derived from the
-live Mem component rather than supplied by the accepted trace; and `mem_replay_source_covers`
-must certify structural coverage of mutable-Mem tables by that selected table.
+nonempty proof; the HELD `mem_replay_segment_ranges` field must provide the
+remaining canonical segment range factor for that selected table. Generated
+constraints and row ranges are derived from the live Mem component rather than
+supplied by the accepted trace; `mem_replay_source_covers` must certify
+structural coverage of mutable-Mem tables by that selected table.
 The direct-Mem row-count equality is visible as `ScopedDirectMemReplayLengthCertificate`
 and belongs to the #219 whole-channel balance route for future derivation.
 **#119** reduced the store byte facts to the
@@ -696,9 +694,8 @@ trust surface even though they add no axiom.
 | `segment_l1_fixed` (**#100**) | `main.pil:19` | the `SEGMENT_L1` fixed column is `[1,0,0,…]` (row 0 = boundary, all later rows within-segment) |
 | `main_step_index_fixed` (**#115**) | `main.pil:90` (`STEP = main_segment*N + SEGMENT_STEP`) | the Main `main_step` companion column is pinned to the Main row index, with no-wrap evidence for the `2+4*i` / `3+4*i` memory timestamp offsets; this single fixed-column-class certificate replaces the two anticipated step-counter residues (`MainStepDistinct`, `CrossOffsetSeparated`) and also supports target execution chronology |
 | `mem_replay_table` (**#115**, guarded by `MutableMemPresent witness`) | Full-ensemble table selection for the mutable Mem component | selects the concrete mutable-Mem table, proves witness membership and component identity, and proves the table is nonempty |
-| `mem_replay_segment` / `mem_replay_permutation` / `mem_replay_gsum` / `mem_replay_im0` / `mem_replay_im1` (**#115**, guarded by `MutableMemPresent witness`) | Raw generated Mem sidecar columns for the selected mutable Mem table; deterministic Mem `SEGMENT_L1` shape is derived via `segmentWithFixedL1` | supplies the source columns used to rebuild the raw sidecar and typed Mem AIR source for `mem_replay_table` |
-| `mem_replay_constraints` (**#115**, guarded by `MutableMemPresent witness`) | split generated Mem constraints for the selected mutable Mem table | supplies the `segment_every_row` / `permutation_every_row` generated constraint facts used to derive replay rows |
-| `mem_replay_segment_ranges` (**#115**, guarded by `MutableMemPresent witness`) | segment range facts for the selected mutable Mem sidecar segment | **HELD** caller-supplied promise hypothesis for Project Closeout S3 lookup-wiring extraction; S3 must derive and delete it from extracted lookup wiring. Until then it supplies range facts over the fixed-`SEGMENT_L1` sidecar segment used by the replay bridge. |
+| `mem_replay_segment` / `mem_replay_permutation` / `mem_replay_gsum` / `mem_replay_im0` / `mem_replay_im1` (**#115**, guarded by `MutableMemPresent witness`) | Legacy generated Mem sidecar columns | **HELD** for S3's lifecycle audit. S2 does not correlate or consume them; its live source is selected table `ProverData` plus component-owned fixed columns. |
+| `mem_replay_segment_ranges` (**#115**, guarded by `MutableMemPresent witness`) | segment range facts for the selected canonical live Mem segment | **HELD** caller-supplied promise hypothesis for Project Closeout S3 lookup-wiring extraction; S3 must derive and delete it from extracted lookup wiring. Until then it supplies canonical segment range facts used by the replay bridge. |
 | `mem_replay_source_covers` (**#115**, guarded by `MutableMemPresent witness`) | Full-ensemble table/source correlation for the mutable Mem component | certifies that every mutable-Mem table in the accepted witness is the selected `mem_replay_table`; this is table identity only, not read-value agreement |
 
 **#115 constructor-burden note.** Removing the raw seed
@@ -707,10 +704,12 @@ replay evidence, but the current branch also strengthens `AcceptedZiskTrace` for
 memory-present traces. Constructors whose mutable-Mem table is empty, such as
 the degenerate base case and #219/#220's ADD witnesses, prove
 `MutableMemPresent` impossible instead of supplying replay fields. A constructor
-with mutable-Mem rows must build the guarded `mem_replay_table`, source-column,
-generated-constraint, and HELD segment-range fields in addition to
+with mutable-Mem rows must build the guarded `mem_replay_table`, the HELD legacy
+sidecar fields, the HELD canonical `mem_replay_segment_ranges` field, and
+`mem_replay_source_covers`, in addition to
 `constraints_hold`/`channels_balanced`/`transitions_hold`/`main_height`/fixed
-columns. Row range facts are derived from live Mem constraints. These fields are not read-value agreement predicates, and they no
+columns. Generated constraints and row ranges are derived from the live Mem
+component. These fields are not read-value agreement predicates, and they no
 longer carry deterministic Mem fixed columns. The paired
 `mem_replay_source_covers` field is a structural table-coverage certificate that
 removes this residue from seed-layer wrappers. For the #115 direct-Mem closeout,
@@ -758,3 +757,13 @@ The trust ledger does not enumerate the Lean kernel, mathlib,
 LeanZKCircuit, the Sail-to-Lean compiler output, or flake-pinned upstream
 inputs. Their audit surface is the Lake/Nix configuration and `flake.lock`,
 not `generated/baseline-axioms.txt`.
+
+Project Closeout S2 pins the immutable
+`codygunton/clean@c87617d8e29386e1e9e4f98cfbfb6940c2eb63df` source input.
+It provides D1's all-row predecessor/current transition contract and D2's
+canonical component-owned indexed fixed-column materialization. D1 remains
+inert to Clean's existing soundness theorem, so project-side accepted traces
+explicitly carry `transitions_hold`; D2 is consumed by canonical table
+materialization, constraints, interactions, transitions, and projections. The
+structural fixed-domain/no-wrap bound belongs to `Air.Flat.Table`, not to an
+accepted-trace field or caller-supplied promise hypothesis.


### PR DESCRIPTION
## Summary
- Pins `codygunton/clean@c87617d8` with D1 indexed predecessor/current transitions and D2 component-owned indexed fixed-column materialization.
- Uses canonical materialized rows consistently for Mem/Main constraints, channel interactions and balance, transitions, and table projections.
- Derives and deletes `mem_replay_constraints`; derives Mem row ranges from live `Table.fromStatic` lookups; retains canonical `mem_replay_segment_ranges` as HELD for S3.
- Migrates concrete witness tables, transition consumers, root witnesses, and semantic consistency fixtures to the raw-row/fixed-schema API.

## Trust Surface
The canonical replay derivation consumes selected table `ProverData`, component-owned fixed columns, live constraints, and the right-indexed transition. No accepted-trace replacement certificate, project axiom, `sorry`, `native_decide`, allowlist edit, or obligation weakening was introduced.

## Verification
- `nix run .#populate`
- focused serial Lake targets for the Mem/Main/projection/witness dependency chain
- `lake build`
- `trust/scripts/check-all.sh`
- `trust/scripts/check-all-semantic.sh`
- `nix run .#test`
- independent reviewer pass

Closes #243
Closes #226

Enables S1b for #249 but does not close #249; S3 remains responsible for deriving and deleting the HELD segment-range certificate.