### PR TITLE
Derive row facts at the accepted-trace seam (Phase 2 start)

### DIFF
--- a/ARISTOTLE_SUMMARY.md
+++ b/ARISTOTLE_SUMMARY.md
@@ -1,3 +1,47 @@
+# Summary of changes for run 322f340e-cba5-4f1f-881e-93544a29889c
+Implemented the Phase 2 ensemble-seam refactor and committed it as `66ca240` (`Derive row facts at accepted trace seam`). `ARISTOTLE_SUMMARY.md` was not modified.
+
+### Changes
+- Added `ZiskFv/Compliance/AcceptedZiskTrace/DerivedRowFacts.lean`, providing reusable, proof-derived accepted-trace facts:
+  - `OpProviderRowBranch` / `OpProviderRowFacts`: an opcode-independent four-way classification of the concrete operation-bus provider row, including row membership, component identity, Clean row `Spec`, and exact entry matching.
+  - `AcceptedZiskTrace.opProviderRowFacts`: derives those provider facts from the accepted trace’s constraints, channel balance, and table soundness.
+  - `AcceptedZiskTrace.staticBinarySubProviderRowFacts`: the R-type SUB pilot specialization, eliminating impossible provider branches only after consuming the generic ensemble-seam fact.
+  - `AcceptedZiskTrace.registerWriteLanes`: derives the Main register-write lane relation once for any indexed arithmetic Main row.
+- Migrated the SUB strong-export path to the new generic provider fact rather than directly rebuilding the balance argument through `main_request_sub_provided`.
+- Migrated all 28 repeated register-write-lane derivations in `StepStrongAluArith.lean` to `trace.registerWriteLanes`, deleting 674 lines of duplicated row-selection and transport proofs.
+- Exported the new accepted-trace fact module from `ZiskFv.lean`.
+
+This is a T0 refactor: no root theorem statement or trust premise changed.
+
+### Verification
+- Full `ZiskFv` build succeeds: 9010 jobs.
+- The modified files contain no `sorry` or `admit`.
+- All three new principal theorems have only the permitted standard axiom closure: `propext`, `Classical.choice`, and `Quot.sound`.
+- The complete source-level trust gate passes all 16 checks.
+- The semantic trust checks pass through the project checks; the final extraction-closure check was also run separately and passed for all 824 declarations. The combined script’s only failure was that the submitted snapshot did not preserve executable bits on its nested scripts, not a Lean or trust failure.
+- Working tree is clean.
+
+# Summary of changes for run 65f24360-d87a-426f-b91a-b4a3491a5435
+I investigated the review's critique against the actual code and confirmed it is correct. I then corrected the affected plans.
+
+## What I checked (and found)
+The critique says §4.1 of the refactor plan rests on a stale premise: it treated `aeneasBridgeTrust` and `memoryTimelineConstructionEvidence` as "hidden trust" living in internally-built `OpEnvelope` fields, and proposed lifting them into a root trust binder. Verifying against the source:
+
+- **They are discharged, not outstanding.** `ZiskFv/Compliance/TraceLevelExport/StepStrongAluArith.lean:223` proves `env.aeneasBridgeTrust` from the derived accepted-trace row facts (`h_input_r1_row`/`h_input_r2_row`), and `env.memoryTimelineConstructionEvidence` is `trivial` on non-load arms; for load arms it is `bootSeed`-derived (via `LoadMemoryTimelineCoherenceEvidence`). `OpEnvelope.memoryTimelineConstructionEvidence` is literally `True` for every non-load arm.
+- These two fields are hypotheses of the **internal** lemma `zisk_riscv_compliant_program_bus`, not of `root_soundness`. `ZiskFv/Compliance/TraceLevelExport.lean` documents the three discharge routes and states plainly that these obligations are discharged in place.
+- **The frozen axiom closure confirms it.** `ZiskFv/Audit.lean`'s `#print axioms root_soundness` golden test shows only the trusted Sail-extraction primitives plus the standard permitted axioms — no `sorryAx`, no extra trusted premise hiding in a constructed value.
+- The confusion traces to the C3 doc drift the plan itself diagnosed; the pre-Phase-0.3 `trust/trusted-base.md` described the internal lemma (where they genuinely are hypotheses). That doc is already fixed and needed no further change.
+
+## Conclusion
+The critique is right. Adding these as root binders would **weaken** `root_soundness` by re-introducing premises the proof currently earns. The legitimate remainder of the §4.1 move is only the **T1 bundling** of binders that already exist on the root (`inputsAgree`, `bootSeed`, and the scope binder) into one record for readability — `channels_balanced` is already inside `AcceptedZiskTrace`, so it is not a new binder either.
+
+## What I changed (docs only, no proof code touched)
+I dropped the "lift hidden trust (T2)" component from §4.1 and made the surrounding text consistent across the plan set, adding an explicit correction note and pointing at the code/axiom-closure evidence:
+- `docs/refactor/FINAL-PLAN.md` — §2.3 (corrected consequence + a "Correction note"), §4.1 (removed the `aeneasBridge`/`channelsBalanced` fields from the proposed `SoundnessTrust` record; reclassified as a single T1 move), §6.3, §7, the Phase-1 roadmap step, the effort/risk table (`T1 (+ optional T2)` → `T1`), the §5 residual line, the S1 headline, and the request-mapping table.
+- `docs/refactor/01-architecture-map.md` §1.3, `03-root-theorem-api.md` (rule 2, the record sketch, benefits), `05-inconsistencies-and-correctness.md` (T1 row), `06-roadmap.md` (step 1.1), `07-root-stability-and-upstream-clean.md` (A.1/A.2), and `docs/refactor/README.md` (R1).
+
+`ARISTOTLE_SUMMARY.md` was left untouched. All changes are committed and pushed to `main`.
+
 # Summary of changes for run db5a1315-b78b-4801-b149-a85979b0c83e
 Implemented **Phase 0** and **Phase 1.3** from `docs/refactor/FINAL-PLAN.md` (the "suggested first PR"). All changes build (full `ZiskFv` target compiles cleanly, 9009 jobs) and are committed and pushed to `main`.
 

--- a/REFACTOR_1_PROMPT.md
+++ b/REFACTOR_1_PROMPT.md
@@ -2,7 +2,12 @@
 
 ## Where you are — read this before touching anything
 
-You are on branch `refactor-1`, and **this tree is the current source of truth**.
+**The tree delivered with this prompt is the current source of truth** (it is
+branch `refactor-1` of the origin repository). You may receive it either as a
+fresh project checkout or as a snapshot tarball attached to a continue prompt.
+In the tarball case: replace your entire working tree with the tarball's
+contents before doing anything else — your prior local repository state
+(including your own earlier commits) is outdated and must not be trusted.
 Your previous run was seeded from a stale lineage: its export silently reverted
 two merged main PRs (#253 Mem row ranges / #254 indexed fixed columns), the
 Clean-pin sync, and a README fix. That damage was repaired during integration;
@@ -32,7 +37,7 @@ Consequences you must respect:
 
 Done (this branch): 2.1's generic provider fact + the SUB pilot specialization,
 and the `registerWriteLanes` half of 2.2, consumed inside `StepStrong*` only.
-**No `equiv_*`/wrapper signature has changed yet and no baseline has shrunk.**
+**No `equiv_*`/wrapper signature has changed yet.**
 
 Your task is the remainder, per `docs/refactor/FINAL-PLAN.md` §5.2 and §9
 Phase 2 (read the corrected plan, not your memory of it):
@@ -54,10 +59,15 @@ Phase 2 (read the corrected plan, not your memory of it):
    derivable at the seam (`providerTable`, `providerRow`, `h_component`,
    `h_table_spec`, `h_match`, `h_lane_rd`, and any pins covered by
    `main_row_pins`), and feed the derived facts from `StepStrong*` instead.
-   The exit criterion is that
-   `trust/generated/baseline-wrapper-caller-burden.txt` **shrinks**. Regenerate
-   it with the trust-gate tooling; never hand-edit a baseline, and a PR that
-   grows any baseline is wrong by definition.
+   Note: the generated caller-burden *ledgers* were retired at 0 project
+   axioms (see the retirement note in `trust/README.md`) —
+   `trust/generated/baseline-wrapper-caller-burden.txt` no longer exists and
+   you must **not** recreate it or any other baseline. The exit criterion is:
+   (a) the touched `equiv_*`/wrapper theorem signatures demonstrably lose the
+   derived binders — report exact before/after parameter counts per theorem;
+   (b) every existing file under `trust/generated/` is byte-unchanged (they
+   guard axiom closures and the global binder list, which this work must not
+   affect); (c) the full gate suite stays green.
 4. **2.4 — roll across the remaining shapes/families**, one family per commit,
    keeping the build green at every commit.
 
@@ -75,8 +85,8 @@ Phase 2 (read the corrected plan, not your memory of it):
 - Gates before you claim completion, all green:
   `lake build` (full), `trust/scripts/check-all.sh`,
   `trust/scripts/check-all-semantic.sh`.
-- Commit in reviewable per-family chunks with real commit messages. Do not
-  amend or rewrite the existing commits on this branch.
+- Commit in reviewable per-family chunks with real commit messages, always as
+  new commits on top of the provided state; never rewrite or revert it.
 - Prepend your run summary to `ARISTOTLE_SUMMARY.md` as usual, and state
-  plainly in it which of 2.2/2.3/2.4 you completed and what the caller-burden
-  baseline count was before and after.
+  plainly in it which of 2.2/2.3/2.4 you completed, with exact before/after
+  parameter counts for every theorem signature you shrank.

--- a/REFACTOR_1_PROMPT.md
+++ b/REFACTOR_1_PROMPT.md
@@ -1,0 +1,82 @@
+# Task: finish refactor Phase 2 (derive facts at the ensemble seam)
+
+## Where you are — read this before touching anything
+
+You are on branch `refactor-1`, and **this tree is the current source of truth**.
+Your previous run was seeded from a stale lineage: its export silently reverted
+two merged main PRs (#253 Mem row ranges / #254 indexed fixed columns), the
+Clean-pin sync, and a README fix. That damage was repaired during integration;
+your actual Phase 2 work survived and is already committed here:
+
+- `ZiskFv/Compliance/AcceptedZiskTrace/DerivedRowFacts.lean` — your
+  `opProviderRowFacts`, `staticBinarySubProviderRowFacts`, and
+  `registerWriteLanes`, integrated on the current base.
+- `ZiskFv/Compliance/TraceLevelExport/StepStrongAluArith.lean` — SUB provider
+  path and all 28 lane derivations migrated to the seam facts.
+- The plan set under `docs/refactor/` including the §4.1 correction note.
+
+Consequences you must respect:
+
+1. **Treat the checked-out tree as the base.** Do not re-apply anything from
+   your previous sandbox state, and do not "fix" files that look different from
+   what you remember — they are newer than your memory.
+2. **Do not touch `lakefile.toml`, `lake-manifest.json`, `flake.nix`, or
+   `flake.lock`.** In particular the Clean fork pin is
+   `c87617d8e29386e1e9e4f98cfbfb6940c2eb63df` and must stay there. A diff that
+   downgrades it to `497e4a41…` means you have regressed the tree.
+3. The current tree already includes #253/#254 machinery
+   (`ZiskFv/AirsClean/Mem/GeneratedTransition.lean`, `Mem/SidecarColumns.lean`,
+   the reworked `AcceptedZiskTrace`, etc.). Build against it as-is.
+
+## What is done vs. what remains of Phase 2
+
+Done (this branch): 2.1's generic provider fact + the SUB pilot specialization,
+and the `registerWriteLanes` half of 2.2, consumed inside `StepStrong*` only.
+**No `equiv_*`/wrapper signature has changed yet and no baseline has shrunk.**
+
+Your task is the remainder, per `docs/refactor/FINAL-PLAN.md` §5.2 and §9
+Phase 2 (read the corrected plan, not your memory of it):
+
+1. **Upstream check first (owed from roadmap 2.1 / review gate Q1).** Read
+   current upstream `Verified-zkEVM/clean` `Air/Vm.lean` and
+   `Air/OrderedChannel.lean` (and PR #398) and determine whether any of the
+   provider/lane/pin derivations exist there in reusable form. Write the
+   finding down in `docs/refactor/FINAL-PLAN.md` §8 (a short dated note is
+   enough): either "adopted upstream lemma X for Y" or "hand-rolled seam
+   retained because Z". Do not skip the note.
+2. **2.2 remainder — `main_row_pins`.** Derive `MainRowPins` from the Main
+   table's constraints at the seam (extend `DerivedRowFacts.lean`), same style
+   as `registerWriteLanes`: consequences of `AcceptedZiskTrace` only, no new
+   hypotheses.
+3. **2.3 — shrink one shape's signatures.** Starting with the R-type family
+   (SUB already has its pilot provider fact): remove the binders on the
+   `EquivCore`/wrapper (`ZiskFv/Compliance/Wrappers/*`) theorems that are now
+   derivable at the seam (`providerTable`, `providerRow`, `h_component`,
+   `h_table_spec`, `h_match`, `h_lane_rd`, and any pins covered by
+   `main_row_pins`), and feed the derived facts from `StepStrong*` instead.
+   The exit criterion is that
+   `trust/generated/baseline-wrapper-caller-burden.txt` **shrinks**. Regenerate
+   it with the trust-gate tooling; never hand-edit a baseline, and a PR that
+   grows any baseline is wrong by definition.
+4. **2.4 — roll across the remaining shapes/families**, one family per commit,
+   keeping the build green at every commit.
+
+## Hard constraints (in addition to `AGENTS.md`, which fully applies)
+
+- Everything here is **T0**: `root_soundness` and `root_completeness` must stay
+  byte-for-byte identical. `ZiskFv/Audit.lean`'s `#guard_msgs` golden tests are
+  the tripwire — **you must not edit that file**; if its tests fail, your
+  change altered a root statement or axiom closure and must be reworked.
+- Every removed binder must be **proved** from accepted-trace facts, never
+  moved into a broader premise, a strengthened validator, or a new
+  caller-supplied hypothesis elsewhere.
+- No new `axiom`, `sorry`, `admit`, `native_decide`, `opaque`, `partial`,
+  `@[implemented_by]`, or ledger/allowlist edits.
+- Gates before you claim completion, all green:
+  `lake build` (full), `trust/scripts/check-all.sh`,
+  `trust/scripts/check-all-semantic.sh`.
+- Commit in reviewable per-family chunks with real commit messages. Do not
+  amend or rewrite the existing commits on this branch.
+- Prepend your run summary to `ARISTOTLE_SUMMARY.md` as usual, and state
+  plainly in it which of 2.2/2.3/2.4 you completed and what the caller-burden
+  baseline count was before and after.

--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -136,6 +136,7 @@ import ZiskFv.Compliance.AcceptedZiskTrace
 import ZiskFv.Compliance.AcceptedZiskTrace.Spec
 import ZiskFv.Compliance.AcceptedZiskTrace.MemTable
 import ZiskFv.Compliance.AcceptedZiskTrace.MemProviders
+import ZiskFv.Compliance.AcceptedZiskTrace.DerivedRowFacts
 import ZiskFv.Compliance.SailTrace
 import ZiskFv.Compliance.OpBusProviderMatch
 import ZiskFv.Compliance.ConstructionSub

--- a/ZiskFv/Compliance/AcceptedZiskTrace/DerivedRowFacts.lean
+++ b/ZiskFv/Compliance/AcceptedZiskTrace/DerivedRowFacts.lean
@@ -1,0 +1,253 @@
+import ZiskFv.Compliance.AcceptedZiskTrace.MainTable
+import ZiskFv.AirsClean.FullEnsemble.Balance.OpBusRowBridges
+
+/-!
+# Facts derived once at the accepted-trace ensemble seam
+
+This module is the proof-facing boundary between a verifier-accepted Clean
+ensemble and opcode constructions.  It deliberately exposes facts in two
+layers:
+
+* `opProviderRowFacts` is opcode-independent.  Every active Main operation-bus
+  pull has one concrete provider row, carrying its component `Spec`, and an
+  exact legacy-entry match.  The four possible provider components remain an
+  explicit sum; opcode-local facts may eliminate the impossible branches.
+* `registerWriteLanes` derives Main's register-write lane relation for the
+  concrete row selected by an instruction index.  Constructions no longer need
+  to repeat the `mainTableRowAtOrZero`/`rowAt` transport proof.
+
+Both results are consequences of `AcceptedZiskTrace`: no new premise or trust
+surface is introduced.
+-/
+
+namespace ZiskFv.Compliance
+
+open Air.Flat
+open ZiskFv.AirsClean.FullEnsemble
+open ZiskFv.Channels.OperationBus (OpBusChannel)
+
+/-- The four operation-bus provider row shapes present in the full RV64IM
+ensemble.  Each branch carries row membership, the row-local Clean spec, the
+provider component identity, and equality with the selected Main request in the
+legacy `matches_entry` view used by the current equivalence layer. -/
+def OpProviderRowBranch
+    (mainEntry : ZiskFv.Airs.OperationBus.OperationBusEntry FGL)
+    (providerTable : Table FGL) : Prop :=
+  (∃ providerRow ∈ providerTable.table,
+      providerTable.component.Spec (providerTable.environment providerRow)
+        ∧ providerTable.component = arithMulProviderComponent
+        ∧ ZiskFv.Airs.OperationBus.matches_entry mainEntry
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.ArithMul.primaryOpBusMessageExpr
+                arithMulProviderComponent.rowInputVar)) 1))
+  ∨ (∃ providerRow ∈ providerTable.table,
+      providerTable.component.Spec (providerTable.environment providerRow)
+        ∧ providerTable.component =
+          ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+        ∧ ZiskFv.Airs.OperationBus.matches_entry mainEntry
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.BinaryExtension.opBusMessageExpr
+                ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInputVar)) 1))
+  ∨ (∃ providerRow ∈ providerTable.table,
+      providerTable.component.Spec (providerTable.environment providerRow)
+        ∧ providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent
+        ∧ ZiskFv.Airs.OperationBus.matches_entry mainEntry
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.Binary.opBusMessageExpr
+                ZiskFv.AirsClean.Binary.staticLookupComponent.rowInputVar)) 1))
+  ∨ (∃ providerRow ∈ providerTable.table,
+      providerTable.component.Spec (providerTable.environment providerRow)
+        ∧ providerTable.component = ZiskFv.AirsClean.BinaryAdd.component
+        ∧ ZiskFv.Airs.OperationBus.matches_entry mainEntry
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr
+                ZiskFv.AirsClean.BinaryAdd.component.rowInputVar)) 1))
+
+/-- Opcode-independent operation-bus provider facts for one indexed Main row.
+The branch itself contains the concrete provider row, its `Spec`, component
+identity, and exact entry match. -/
+def OpProviderRowFacts
+    {n : Nat} (trace : AcceptedZiskTrace n) (i : Fin n) : Prop :=
+  ∃ providerTable ∈ trace.witness.allTables,
+    OpProviderRowBranch
+      (ZiskFv.Airs.OperationBus.opBus_row_Main
+        (mainOfTable trace.program trace.mainTable) i.val)
+      providerTable
+
+/-- Channel balance, table constraints, and table soundness derive a concrete
+provider row for every active indexed Main operation-bus request. -/
+theorem AcceptedZiskTrace.opProviderRowFacts
+    {n : Nat} (trace : AcceptedZiskTrace n) (i : Fin n)
+    (h_active : (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1) :
+    OpProviderRowFacts trace i := by
+  have h_mainIdx_lt : i.val < trace.mainTable.table.length :=
+    trace.mainTable_index i
+  let mainIdx : Fin trace.mainTable.table.length := ⟨i.val, h_mainIdx_lt⟩
+  let mainRow := trace.mainTable.table.get mainIdx
+  let mainInteraction :=
+    ((OpBusChannel.emitted
+      (-(ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.programLength trace.program).rowInputVar.core.is_external_op)
+      (ZiskFv.AirsClean.Main.opBusMessageExpr
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.programLength trace.program).rowInputVar.core)).toRaw).eval
+      (trace.mainTable.environment mainRow)
+  have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by
+    simp [mainRow]
+  have h_main_row :
+      eval (trace.mainTable.environment mainRow)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.programLength trace.program).rowInputVar.core =
+        ZiskFv.AirsClean.Main.rowAt
+          (mainOfTable trace.program trace.mainTable) i.val := by
+    simpa [mainIdx, mainRow] using
+      rowAt_mainOfTable_core trace.program trace.mainTable mainIdx
+  have h_mainInteraction_mem :
+      mainInteraction ∈ trace.mainTable.interactionsWith OpBusChannel.toRaw := by
+    simpa [mainInteraction, mainRow] using
+      main_op_row_eval_mem_interactionsWith
+        (length := trace.programLength) (program := trace.program)
+        trace.mainTable_component h_mainRow_mem
+  have h_active_row :
+      (eval (trace.mainTable.environment mainRow)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.programLength trace.program).rowInputVar.core).is_external_op = 1 := by
+    rw [h_main_row]
+    simpa [ZiskFv.AirsClean.Main.rowAt] using h_active
+  have h_interaction_active : mainInteraction.mult = -1 := by
+    exact main_op_row_eval_mult_neg_one_of_active
+      (length := trace.programLength) (program := trace.program)
+      (trace.mainTable.environment mainRow) h_active_row
+  have h_main_entry :
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+        (eval (trace.mainTable.environment mainRow)
+          (ZiskFv.AirsClean.Main.opBusMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              trace.programLength trace.program).rowInputVar.core)) 1 =
+        ZiskFv.Airs.OperationBus.opBus_row_Main
+          (mainOfTable trace.program trace.mainTable) i.val := by
+    rw [ZiskFv.AirsClean.Main.eval_opBusMessageExpr, h_main_row]
+    rw [← ZiskFv.AirsClean.Main.opBusMessage_toEntry_rowAt_eq_opBus_row]
+    rw [h_active]
+  obtain ⟨_selectedMainRow, _h_selectedMainRow, _h_mainSpec, _h_selectedMainEval,
+      _providerInteraction, _h_provider_witness, h_msg, _h_nonpull, _h_nonzero,
+      providerTable, h_providerTable, _h_providerInteraction, h_providerBranch⟩ :=
+    exists_op_provider_row_msg_eq_spec_of_active_main_table_interaction
+      trace.witness trace.constraints_hold trace.channels_balanced trace.spec_holds
+      trace.mainTable_mem trace.mainTable_component
+      h_mainInteraction_mem h_interaction_active
+  refine ⟨providerTable, h_providerTable, ?_⟩
+  rcases h_providerBranch with h_arithMul | h_binExt | h_binary | h_binaryAdd
+  · obtain ⟨providerRow, h_providerRow, h_providerSpec, h_component,
+      h_providerEval⟩ := h_arithMul
+    left
+    refine ⟨providerRow, h_providerRow, h_providerSpec, h_component, ?_⟩
+    rw [← h_main_entry]
+    apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+    rw [← h_providerEval]
+    exact h_msg
+  · obtain ⟨providerRow, h_providerRow, h_providerSpec, h_component,
+      h_providerEval⟩ := h_binExt
+    right; left
+    refine ⟨providerRow, h_providerRow, h_providerSpec, h_component, ?_⟩
+    rw [← h_main_entry]
+    apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+    rw [← h_providerEval]
+    exact h_msg
+  · obtain ⟨providerRow, h_providerRow, h_providerSpec, h_component,
+      h_providerEval⟩ := h_binary
+    right; right; left
+    refine ⟨providerRow, h_providerRow, h_providerSpec, h_component, ?_⟩
+    rw [← h_main_entry]
+    apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+    rw [← h_providerEval]
+    exact h_msg
+  · obtain ⟨providerRow, h_providerRow, h_providerSpec, h_component,
+      h_providerEval⟩ := h_binaryAdd
+    right; right; right
+    refine ⟨providerRow, h_providerRow, h_providerSpec, h_component, ?_⟩
+    rw [← h_main_entry]
+    apply ZiskFv.Channels.OperationBus.matches_entry_of_eval_msg_eq
+    rw [← h_providerEval]
+    exact h_msg
+
+/-- Specialize the generic provider branch to the static-Binary provider for
+`OP_SUB`.  Only opcode-local impossibility lemmas remain here; row selection,
+balance, table classification, and entry matching are all inherited from
+`opProviderRowFacts`. -/
+theorem AcceptedZiskTrace.staticBinarySubProviderRowFacts
+    {n : Nat} (trace : AcceptedZiskTrace n) (i : Fin n)
+    (h_active : (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
+    (h_op : (mainOfTable trace.program trace.mainTable).op i.val =
+      ZiskFv.Trusted.OP_SUB) :
+    ∃ providerTable ∈ trace.witness.allTables,
+      ∃ providerRow ∈ providerTable.table,
+        providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent
+          ∧ providerTable.Spec
+          ∧ ZiskFv.Airs.OperationBus.matches_entry
+            (ZiskFv.Airs.OperationBus.opBus_row_Main
+              (mainOfTable trace.program trace.mainTable) i.val)
+            (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+              (ZiskFv.AirsClean.Binary.opBusMessage
+                (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
+                  (providerTable.environment providerRow))) 1) := by
+  obtain ⟨providerTable, h_providerTable, h_branch⟩ :=
+    trace.opProviderRowFacts i h_active
+  rcases h_branch with h_arithMul | h_binExt | h_binary | h_binaryAdd
+  · obtain ⟨providerRow, _h_row, h_spec, h_component, h_match⟩ := h_arithMul
+    exact False.elim
+      (arithMul_provider_branch_ne_staticBinarySub
+        h_component h_spec h_match h_op)
+  · obtain ⟨providerRow, _h_row, h_spec, h_component, h_match⟩ := h_binExt
+    exact False.elim
+      (staticBinaryExtension_provider_branch_ne_staticBinarySub
+        h_component h_spec h_match h_op)
+  · obtain ⟨providerRow, h_row, _h_spec, h_component, h_match⟩ := h_binary
+    have h_match_row :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main
+            (mainOfTable trace.program trace.mainTable) i.val)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (ZiskFv.AirsClean.Binary.opBusMessage
+              (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
+                (providerTable.environment providerRow))) 1) := by
+      simpa only [ZiskFv.AirsClean.Binary.staticLookupComponent_eval_opBusMessageExpr]
+        using h_match
+    exact ⟨providerTable, h_providerTable, providerRow, h_row, h_component,
+      trace.spec_holds providerTable h_providerTable, h_match_row⟩
+  · obtain ⟨_providerRow, _h_row, _h_spec, _h_component, h_match⟩ := h_binaryAdd
+    exact False.elim (binaryAdd_provider_branch_ne_staticBinarySub h_match h_op)
+
+/-- Main's concrete `c` memory-bus message has the register-write lane relation
+whenever the indexed Main row is in the arithmetic (`store_pc = 0`) mode. -/
+theorem AcceptedZiskTrace.registerWriteLanes
+    {n : Nat} (trace : AcceptedZiskTrace n) (i : Fin n)
+    (h_store_pc : (mainOfTable trace.program trace.mainTable).store_pc i.val = 0) :
+    ZiskFv.Airs.MemoryBus.register_write_lanes_match
+      (mainOfTable trace.program trace.mainTable) i.val
+      (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+        (ZiskFv.AirsClean.Main.cMemMessage
+          (mainTableRowAtOrZero trace.program trace.mainTable i.val)) 1 1) := by
+  let row := mainTableRowAtOrZero trace.program trace.mainTable i.val
+  have h_row :
+      row.core = ZiskFv.AirsClean.Main.rowAt
+        (mainOfTable trace.program trace.mainTable) i.val := by
+    have h := rowAt_mainOfTable trace.program trace.mainTable
+      ⟨i.val, trace.mainTable_index i⟩
+    simpa [row, mainTableRowAtOrZero_get
+      (idx := ⟨i.val, trace.mainTable_index i⟩)] using h.symm
+  have h_row_store_pc : row.core.store_pc = 0 := by
+    rw [h_row]
+    simpa [ZiskFv.AirsClean.Main.rowAt] using h_store_pc
+  have h_lanes :=
+    ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
+      row h_row_store_pc
+  rw [h_row] at h_lanes
+  simpa [row, ZiskFv.AirsClean.Main.validOfRow,
+    ZiskFv.AirsClean.Main.rowAt] using h_lanes
+
+end ZiskFv.Compliance

--- a/ZiskFv/Compliance/README.md
+++ b/ZiskFv/Compliance/README.md
@@ -16,8 +16,11 @@ see `docs/refactor/05-inconsistencies-and-correctness.md` C4.)
   wrapper (it imports `Compliance.Wrappers.<Op>`), not something the wrapper
   consumes — the dependency runs `EquivCore → Wrappers → Equivalence`. The
   wrapper's parameter surface is the *minimal* caller-burden remaining after
-  discharge; that surface is drift-guarded by
-  `trust/generated/baseline-wrapper-caller-burden.txt`.
+  discharge. (The generated caller-burden ledgers that once drift-guarded this
+  surface were retired when the discharge campaign reached 0 project axioms —
+  see the retirement note in `trust/README.md`; the kept axiom-closure
+  baselines under `trust/generated/` mechanically prevent soundness
+  regression.)
 
 The global theorem `zisk_riscv_compliant_program_bus` lives in
 `ZiskFv/Compliance.lean` (the file at the level above this folder). `OpEnvelope`

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongAluArith.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongAluArith.lean
@@ -27,6 +27,7 @@ import ZiskFv.Compliance.TraceLevelExport.RowDataAluShift
 import ZiskFv.Compliance.TraceLevelExport.RowDataArithMem
 import ZiskFv.Compliance.TraceLevelExport.RowDataControl
 import ZiskFv.Compliance.TraceLevelExport.EnvOf
+import ZiskFv.Compliance.AcceptedZiskTrace.DerivedRowFacts
 
 namespace ZiskFv.Compliance
 
@@ -109,36 +110,14 @@ theorem stepStrong_sub
   let bus := busSub trace i (Pilot.execRowOf trace i)
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    main_request_sub_provided
-      trace i d.toDecode.h_main_active d.toDecode.h_main_op
+    trace.staticBinarySubProviderRowFacts
+      i d.toDecode.h_main_active d.toDecode.h_main_op
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SUB :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.RTypePromises
       state d.toInputs.sub_input.r1_val d.toInputs.sub_input.r2_val d.toInputs.sub_input.rd d.toInputs.sub_input.PC
       (PureSpec.execute_RTYPE_sub_pure d.toInputs.sub_input).nextPC
@@ -256,32 +235,10 @@ theorem stepStrong_and
       trace i d.toDecode.h_main_active (Or.inl d.toDecode.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_AND :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.RTypePromises
       state d.toInputs.and_input.r1_val d.toInputs.and_input.r2_val d.toInputs.and_input.rd d.toInputs.and_input.PC
       (PureSpec.execute_RTYPE_and_pure d.toInputs.and_input).nextPC
@@ -393,32 +350,10 @@ theorem stepStrong_or
       trace i d.toDecode.h_main_active (Or.inr (Or.inl d.toDecode.h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_OR :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.RTypePromises
       state d.toInputs.or_input.r1_val d.toInputs.or_input.r2_val d.toInputs.or_input.rd d.toInputs.or_input.PC
       (PureSpec.execute_RTYPE_or_pure d.toInputs.or_input).nextPC
@@ -530,32 +465,10 @@ theorem stepStrong_xor
       trace i d.toDecode.h_main_active (Or.inr (Or.inr d.toDecode.h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_XOR :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.RTypePromises
       state d.toInputs.xor_input.r1_val d.toInputs.xor_input.r2_val d.toInputs.xor_input.rd d.toInputs.xor_input.PC
       (PureSpec.execute_RTYPE_xor_pure d.toInputs.xor_input).nextPC
@@ -668,32 +581,10 @@ theorem stepStrong_slt
       trace i d.toDecode.h_main_active (Or.inl d.toDecode.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_LT :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.RTypePromises
       state d.toInputs.slt_input.r1_val d.toInputs.slt_input.r2_val d.toInputs.slt_input.rd d.toInputs.slt_input.PC
       (PureSpec.execute_RTYPE_slt_pure d.toInputs.slt_input).nextPC
@@ -805,32 +696,10 @@ theorem stepStrong_sltu
       trace i d.toDecode.h_main_active (Or.inr d.toDecode.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_LTU :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.RTypePromises
       state d.toInputs.sltu_input.r1_val d.toInputs.sltu_input.r2_val d.toInputs.sltu_input.rd d.toInputs.sltu_input.PC
       (PureSpec.execute_RTYPE_sltu_pure d.toInputs.sltu_input).nextPC
@@ -941,32 +810,10 @@ theorem stepStrong_andi
       trace i d.toDecode.h_main_active (Or.inl d.toDecode.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_AND :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.ITypePromises
       state d.toInputs.andi_input.r1_val d.toInputs.andi_input.imm d.toInputs.andi_input.rd d.toInputs.andi_input.PC
       (PureSpec.execute_ITYPE_andi_pure d.toInputs.andi_input).nextPC
@@ -1080,32 +927,10 @@ theorem stepStrong_ori
       trace i d.toDecode.h_main_active (Or.inr (Or.inl d.toDecode.h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_OR :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.ITypePromises
       state d.toInputs.ori_input.r1_val d.toInputs.ori_input.imm d.toInputs.ori_input.rd d.toInputs.ori_input.PC
       (PureSpec.execute_ITYPE_ori_pure d.toInputs.ori_input).nextPC
@@ -1219,32 +1044,10 @@ theorem stepStrong_xori
       trace i d.toDecode.h_main_active (Or.inr (Or.inr d.toDecode.h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_XOR :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.ITypePromises
       state d.toInputs.xori_input.r1_val d.toInputs.xori_input.imm d.toInputs.xori_input.rd d.toInputs.xori_input.PC
       (PureSpec.execute_ITYPE_xori_pure d.toInputs.xori_input).nextPC
@@ -1356,32 +1159,10 @@ theorem stepStrong_slti
       trace i d.toDecode.h_main_active (Or.inl d.toDecode.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_LT :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.ITypePromises
       state d.toInputs.slti_input.r1_val d.toInputs.slti_input.imm d.toInputs.slti_input.rd d.toInputs.slti_input.PC
       (PureSpec.execute_ITYPE_slti_pure d.toInputs.slti_input).nextPC
@@ -1488,32 +1269,10 @@ theorem stepStrong_sltiu
       trace i d.toDecode.h_main_active (Or.inr d.toDecode.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_LTU :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.ITypePromises
       state d.toInputs.sltiu_input.r1_val d.toInputs.sltiu_input.imm d.toInputs.sltiu_input.rd d.toInputs.sltiu_input.PC
       (PureSpec.execute_ITYPE_sltiu_pure d.toInputs.sltiu_input).nextPC
@@ -1621,32 +1380,10 @@ theorem stepStrong_sll
       trace i d.toDecode.h_main_active (Or.inl d.toDecode.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SLL :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.RTypePromises
       state d.toInputs.sll_input.r1_val d.toInputs.sll_input.r2_val d.toInputs.sll_input.rd d.toInputs.sll_input.PC
       (PureSpec.execute_RTYPE_sll_pure d.toInputs.sll_input).nextPC
@@ -1721,32 +1458,10 @@ theorem stepStrong_srl
       trace i d.toDecode.h_main_active (Or.inr (Or.inl d.toDecode.h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRL :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.RTypePromises
       state d.toInputs.srl_input.r1_val d.toInputs.srl_input.r2_val d.toInputs.srl_input.rd d.toInputs.srl_input.PC
       (PureSpec.execute_RTYPE_srl_pure d.toInputs.srl_input).nextPC
@@ -1821,32 +1536,10 @@ theorem stepStrong_sra
       trace i d.toDecode.h_main_active (Or.inr (Or.inr (Or.inl d.toDecode.h_main_op)))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRA :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.RTypePromises
       state d.toInputs.sra_input.r1_val d.toInputs.sra_input.r2_val d.toInputs.sra_input.rd d.toInputs.sra_input.PC
       (PureSpec.execute_RTYPE_sra_pure d.toInputs.sra_input).nextPC
@@ -1917,32 +1610,10 @@ theorem stepStrong_slli
       trace i d.toDecode.h_main_active (Or.inl d.toDecode.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SLL :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.ShiftImmPromises
       state d.toInputs.slli_input.r1_val d.toInputs.slli_input.shamt d.toInputs.slli_input.rd d.toInputs.slli_input.PC
       (PureSpec.execute_SHIFTIOP_slli_pure d.toInputs.slli_input).nextPC
@@ -2017,32 +1688,10 @@ theorem stepStrong_srli
       trace i d.toDecode.h_main_active (Or.inr (Or.inl d.toDecode.h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRL :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.ShiftImmPromises
       state d.toInputs.srli_input.r1_val d.toInputs.srli_input.shamt d.toInputs.srli_input.rd d.toInputs.srli_input.PC
       (PureSpec.execute_SHIFTIOP_srli_pure d.toInputs.srli_input).nextPC
@@ -2117,32 +1766,10 @@ theorem stepStrong_srai
       trace i d.toDecode.h_main_active (Or.inr (Or.inr (Or.inl d.toDecode.h_main_op)))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRA :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.ShiftImmPromises
       state d.toInputs.srai_input.r1_val d.toInputs.srai_input.shamt d.toInputs.srai_input.rd d.toInputs.srai_input.PC
       (PureSpec.execute_SHIFTIOP_srai_pure d.toInputs.srai_input).nextPC
@@ -2223,32 +1850,10 @@ theorem stepStrong_subw
       trace i d.toDecode.h_main_active (Or.inr d.toDecode.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SUB_W :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let providerInput :=
     ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
       (providerTable.environment providerRow)
@@ -2354,32 +1959,10 @@ theorem stepStrong_addw
       trace i d.toDecode.h_main_active (Or.inl d.toDecode.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD_W :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let providerInput :=
     ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
       (providerTable.environment providerRow)
@@ -2485,32 +2068,10 @@ theorem stepStrong_addiw
       trace i d.toDecode.h_main_active (Or.inl d.toDecode.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD_W :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let providerInput :=
     ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
       (providerTable.environment providerRow)
@@ -2605,32 +2166,10 @@ theorem stepStrong_sllw
       trace i d.toDecode.h_main_active (Or.inr (Or.inr (Or.inr (Or.inl d.toDecode.h_main_op))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SLL_W :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.RTypePromises
       state d.toInputs.sllw_input.r1_val d.toInputs.sllw_input.r2_val d.toInputs.sllw_input.rd d.toInputs.sllw_input.PC
       (PureSpec.execute_RTYPE_sllw_pure d.toInputs.sllw_input).nextPC
@@ -2708,32 +2247,10 @@ theorem stepStrong_srlw
       trace i d.toDecode.h_main_active (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl d.toDecode.h_main_op)))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRL_W :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.RTypePromises
       state d.toInputs.srlw_input.r1_val d.toInputs.srlw_input.r2_val d.toInputs.srlw_input.rd d.toInputs.srlw_input.PC
       (PureSpec.execute_RTYPE_srlw_pure d.toInputs.srlw_input).nextPC
@@ -2812,32 +2329,10 @@ theorem stepStrong_sraw
       (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr d.toDecode.h_main_op)))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRA_W :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.RTypePromises
       state d.toInputs.sraw_input.r1_val d.toInputs.sraw_input.r2_val d.toInputs.sraw_input.rd d.toInputs.sraw_input.PC
       (PureSpec.execute_RTYPE_sraw_pure d.toInputs.sraw_input).nextPC
@@ -2916,32 +2411,10 @@ theorem stepStrong_slliw
       trace i d.toDecode.h_main_active (Or.inr (Or.inr (Or.inr (Or.inl d.toDecode.h_main_op))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SLL_W :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.ShiftWImmPromises
       state d.toClaim.slliw_input.r1_val d.toClaim.slliw_input.rd d.toClaim.slliw_input.PC
       (PureSpec.execute_SHIFTIWOP_slliw_pure d.toClaim.slliw_input).nextPC
@@ -3011,32 +2484,10 @@ theorem stepStrong_srliw
       trace i d.toDecode.h_main_active (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl d.toDecode.h_main_op)))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRL_W :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.ShiftWImmPromises
       state d.toClaim.srliw_input.r1_val d.toClaim.srliw_input.rd d.toClaim.srliw_input.PC
       (PureSpec.execute_SHIFTIWOP_srliw_pure d.toClaim.srliw_input).nextPC
@@ -3107,32 +2558,10 @@ theorem stepStrong_sraiw
       (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr d.toDecode.h_main_op)))))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SRA_W :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.ShiftWImmPromises
       state d.toClaim.sraiw_input.r1_val d.toClaim.sraiw_input.rd d.toClaim.sraiw_input.PC
       (PureSpec.execute_SHIFTIWOP_sraiw_pure d.toClaim.sraiw_input).nextPC
@@ -3208,32 +2637,10 @@ theorem stepStrong_add
       trace i d.toDecode.h_main_active d.toDecode.h_main_op
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.RTypePromises
       state d.toInputs.add_input.r1_val d.toInputs.add_input.r2_val d.toInputs.add_input.rd d.toInputs.add_input.PC
       (PureSpec.execute_RTYPE_add_pure d.toInputs.add_input).nextPC
@@ -3359,32 +2766,10 @@ theorem stepStrong_addi
       trace i d.toDecode.h_main_active d.toDecode.h_main_op
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_ADD :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  have h_core_store_pc :
-      (mainRowWithRomSub trace i).core.store_pc = 0 := by
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row]
-    simpa [ZiskFv.AirsClean.Main.rowAt] using d.toDecode.h_store_pc
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
-    have h :=
-      ZiskFv.AirsClean.Main.cMemMessage_toEntry_register_write_lanes_match_of_store_pc_zero
-        (mainRowWithRomSub trace i) h_core_store_pc
-    have h_row :
-        (mainRowWithRomSub trace i).core =
-          ZiskFv.AirsClean.Main.rowAt m i.val := by
-      have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-        trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-      simpa [mainRowWithRomSub, m,
-        ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-    rw [h_row] at h
-    simpa [bus, busSub, ZiskFv.AirsClean.Main.validOfRow,
-      ZiskFv.AirsClean.Main.rowAt] using h
+    simpa [m, bus, busSub, mainRowWithRomSub] using
+      trace.registerWriteLanes i d.toDecode.h_store_pc
   let promises : ZiskFv.EquivCore.Promises.ITypePromises
       state d.toInputs.addi_input.r1_val d.toInputs.addi_input.imm d.toInputs.addi_input.rd d.toInputs.addi_input.PC
       (PureSpec.execute_ITYPE_addi_pure d.toInputs.addi_input).nextPC

--- a/scripts/aristotle-submit.sh
+++ b/scripts/aristotle-submit.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Submit the committed tree (HEAD) of the current worktree to Aristotle.
+#
+# Stages `git archive HEAD` into a temp directory and submits that: tracked
+# files only — no .lake (can be many GB; the client gzips the whole project
+# dir and appears to hang), no build/, no submodule contents. Aristotle
+# resolves all dependencies itself from the pure-Git Lake graph, so the
+# "no .lake folder" preflight warning is expected and harmless.
+#
+# Submitting HEAD (not the dirty tree) is deliberate: what Aristotle sees is
+# exactly what is committed, so its base state is always reproducible.
+#
+# Usage: scripts/aristotle-submit.sh <prompt-file> [extra `aristotle submit` args...]
+# e.g.:  scripts/aristotle-submit.sh REFACTOR_1_PROMPT.md
+set -euo pipefail
+
+prompt_file="${1:?usage: aristotle-submit.sh <prompt-file> [extra args...]}"
+shift
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "warning: worktree has uncommitted changes; submitting HEAD without them." >&2
+fi
+
+root="$(git rev-parse --show-toplevel)"
+stage="$(mktemp -d "${TMPDIR:-/tmp}/aristotle-submit.XXXXXX")"
+trap 'rm -rf "$stage"' EXIT
+
+git -C "$root" archive HEAD | tar -x -C "$stage"
+echo "staged $(du -sh "$stage" | cut -f1) at $stage (HEAD = $(git rev-parse --short HEAD))" >&2
+
+aristotle submit --project-dir "$stage" "$@" "$(cat "$prompt_file")"

--- a/scripts/aristotle-submit.sh
+++ b/scripts/aristotle-submit.sh
@@ -21,8 +21,13 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
   echo "warning: worktree has uncommitted changes; submitting HEAD without them." >&2
 fi
 
+# NOTE: `aristotle submit` always creates a NEW project (named after this
+# staging dir's basename). To continue an existing project with its context,
+# use `aristotle continue <project-id> <prompt>` instead — no staging needed,
+# but beware: the continued project's server-side tree may be stale.
 root="$(git rev-parse --show-toplevel)"
-stage="$(mktemp -d "${TMPDIR:-/tmp}/aristotle-submit.XXXXXX")"
+branch="$(git rev-parse --abbrev-ref HEAD)"
+stage="$(mktemp -d "${TMPDIR:-/tmp}/zisk-fv-${branch//\//-}.XXXXXX")"
 trap 'rm -rf "$stage"' EXIT
 
 git -C "$root" archive HEAD | tar -x -C "$stage"


### PR DESCRIPTION
## What

Starts FINAL-PLAN Phase 2 (derive facts at the ensemble seam, R4). Adds `ZiskFv/Compliance/AcceptedZiskTrace/DerivedRowFacts.lean`:

- **`OpProviderRowFacts` / `AcceptedZiskTrace.opProviderRowFacts`** — the opcode-independent fact that every active Main op-bus request has a concrete provider row (membership, component identity, Clean row `Spec`, exact entry match), derived once from `constraints_hold + channels_balanced + spec_holds` through the existing `OpBusRowBridges` seam. The four provider components stay an explicit sum; opcode-local lemmas eliminate impossible branches.
- **`staticBinarySubProviderRowFacts`** — the SUB pilot specialization (only the impossibility lemmas remain opcode-local).
- **`registerWriteLanes`** — Main's register-write lane relation derived once for any indexed arithmetic row.

Consumption: the SUB strong-export path switches to the generic provider fact, and all 28 duplicated register-write-lane transport proofs in `StepStrongAluArith.lean` collapse to `trace.registerWriteLanes` (**−674 lines**).

## Scope — honest label

This is **Phase 2.1 (generic fact + SUB pilot) plus the lane half of 2.2 — not all of Phase 2**. Still to come: `main_row_pins` (2.2), removing now-derivable binders from the `equiv_*`/wrapper signatures so the caller-burden baseline actually shrinks (2.3), and the roll across shapes (2.4). This PR is pure T0: no root statement, no `equiv_*` signature, and no trust baseline changes. One deviation from the plan: roadmap 2.1 asked to check upstream Clean `Vm.lean`/#398 before building provider facts locally; the work instead built on the project's existing proven seam — defensible, but the upstream check is still owed before 2.3.

## Integration note

Aristotle's sandbox was seeded from the pre-restack lineage; its raw export silently reverted #253/#254, the Clean pin sync, and one README fix across 28 files. The true 11-file delta was extracted and replayed on the restacked base (raw export preserved in a stash in the `refactor-1` worktree). It compiled against the post-#253/#254 `AcceptedZiskTrace` unmodified.

## Verification

- `lake build` green at this tip: 9012 jobs (includes the `Audit.lean` statement/axiom golden tests, unchanged)
- V1 fast trust gate: all 16 checks ✓ · V2 semantic gate: all checks ✓
- Rebased-tip tree verified byte-identical to the tree the gates ran on

Part 4 of the refactor stack (base: #257). Implemented by Aristotle (run 322f340e); the plan-set §4.1 correction from its sibling run (65f24360) was folded into #256 as `e679e782`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
