### PR TITLE
Seam-derived logic provider facts + Main pins (Phase 2.2 complete)

### DIFF
--- a/ARISTOTLE_SUMMARY.md
+++ b/ARISTOTLE_SUMMARY.md
@@ -1,3 +1,22 @@
+# Summary of changes for run 3b98c185-02f3-4cec-bed7-a7d0f8803d23
+Continued the Phase 2 accepted-trace ensemble-seam refactor without changing either root theorem or its trust surface.
+
+### Implemented
+- Added and proved `AcceptedZiskTrace.staticBinaryLogicProviderRowFacts` in `ZiskFv/Compliance/AcceptedZiskTrace/DerivedRowFacts.lean`.
+  - It handles the AND/OR/XOR shape family once at the accepted Clean ensemble seam.
+  - Generic channel-balance row selection comes from `opProviderRowFacts`.
+  - Impossible ArithMul, BinaryExtension, and BinaryAdd branches are eliminated only in the shape specialization.
+  - The surviving static-Binary row carries table/row membership, component identity, table `Spec`, and exact operation-bus matching.
+- Migrated all six AND/OR/XOR strong-export paths in `StepStrongAluArith.lean`—both register and immediate forms—to this seam fact instead of rebuilding balance through `main_request_logic_provided`.
+- Added the direct `SharedBundles` import required by the derived-row-facts module, removing reliance on accidental transitive imports.
+
+### Verification
+- Full `ZiskFv` build succeeds: 9012 jobs.
+- The modified files contain no `sorry` or `admit`.
+- `staticBinaryLogicProviderRowFacts` has only the permitted standard axiom closure: `propext`, `Classical.choice`, and `Quot.sound`.
+- Trust checks 1–12 and 14–16 pass. Check 13 cannot run in this submitted snapshot because the external source file `zisk/core/src/aeneas_extract.rs` is absent; this is unrelated to the Lean changes.
+- All changes are committed and pushed. Working tree is clean.
+
 # Summary of changes for run 322f340e-cba5-4f1f-881e-93544a29889c
 Implemented the Phase 2 ensemble-seam refactor and committed it as `66ca240` (`Derive row facts at accepted trace seam`). `ARISTOTLE_SUMMARY.md` was not modified.
 

--- a/ZiskFv/Compliance/AcceptedZiskTrace/DerivedRowFacts.lean
+++ b/ZiskFv/Compliance/AcceptedZiskTrace/DerivedRowFacts.lean
@@ -1,4 +1,5 @@
 import ZiskFv.Compliance.AcceptedZiskTrace.MainTable
+import ZiskFv.Compliance.SharedBundles
 import ZiskFv.AirsClean.FullEnsemble.Balance.OpBusRowBridges
 
 /-!
@@ -15,6 +16,8 @@ layers:
 * `registerWriteLanes` derives Main's register-write lane relation for the
   concrete row selected by an instruction index.  Constructions no longer need
   to repeat the `mainTableRowAtOrZero`/`rowAt` transport proof.
+* `mainRowPins` packages the accepted trace's indexed Main activation/opcode
+  facts after transporting them to the canonical `mainOfTable` view.
 
 Both results are consequences of `AcceptedZiskTrace`: no new premise or trust
 surface is introduced.
@@ -221,6 +224,77 @@ theorem AcceptedZiskTrace.staticBinarySubProviderRowFacts
       trace.spec_holds providerTable h_providerTable, h_match_row⟩
   · obtain ⟨_providerRow, _h_row, _h_spec, _h_component, h_match⟩ := h_binaryAdd
     exact False.elim (binaryAdd_provider_branch_ne_staticBinarySub h_match h_op)
+
+/-- Specialize the generic provider branch to the static-Binary provider for
+Boolean logic operations.  This is the shape-level counterpart of
+`staticBinarySubProviderRowFacts`: balance and row selection stay generic while
+only the opcode-family branch eliminations are specialized. -/
+theorem AcceptedZiskTrace.staticBinaryLogicProviderRowFacts
+    {n : Nat} (trace : AcceptedZiskTrace n) (i : Fin n)
+    (h_active : (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
+    (h_op :
+      (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_AND
+        ∨ (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_OR
+        ∨ (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_XOR) :
+    ∃ providerTable ∈ trace.witness.allTables,
+      ∃ providerRow ∈ providerTable.table,
+        providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent
+          ∧ providerTable.Spec
+          ∧ ZiskFv.Airs.OperationBus.matches_entry
+            (ZiskFv.Airs.OperationBus.opBus_row_Main
+              (mainOfTable trace.program trace.mainTable) i.val)
+            (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+              (ZiskFv.AirsClean.Binary.opBusMessage
+                (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
+                  (providerTable.environment providerRow))) 1) := by
+  obtain ⟨providerTable, h_providerTable, h_branch⟩ :=
+    trace.opProviderRowFacts i h_active
+  rcases h_branch with h_arithMul | h_binExt | h_binary | h_binaryAdd
+  · obtain ⟨providerRow, _h_row, h_spec, h_component, h_match⟩ := h_arithMul
+    exact False.elim
+      (arithMul_provider_branch_ne_staticBinaryLogic
+        h_component h_spec h_match h_op)
+  · obtain ⟨providerRow, _h_row, h_spec, h_component, h_match⟩ := h_binExt
+    exact False.elim
+      (staticBinaryExtension_provider_branch_ne_staticBinaryLogic
+        h_component h_spec h_match h_op)
+  · obtain ⟨providerRow, h_row, _h_spec, h_component, h_match⟩ := h_binary
+    have h_match_row :
+        ZiskFv.Airs.OperationBus.matches_entry
+          (ZiskFv.Airs.OperationBus.opBus_row_Main
+            (mainOfTable trace.program trace.mainTable) i.val)
+          (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+            (ZiskFv.AirsClean.Binary.opBusMessage
+              (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
+                (providerTable.environment providerRow))) 1) := by
+      simpa only [ZiskFv.AirsClean.Binary.staticLookupComponent_eval_opBusMessageExpr]
+        using h_match
+    exact ⟨providerTable, h_providerTable, providerRow, h_row, h_component,
+      trace.spec_holds providerTable h_providerTable, h_match_row⟩
+  · obtain ⟨_providerRow, _h_row, _h_spec, _h_component, h_match⟩ := h_binaryAdd
+    exact False.elim (binaryAdd_provider_branch_ne_staticBinaryLogic h_match h_op)
+
+/-- The canonical indexed Main row pins its own activation and opcode columns.
+This is the hypothesis-free seam fact; an opcode arm specializes the two indices
+using the decode equalities already derived from the accepted Main/ROM row. -/
+theorem AcceptedZiskTrace.mainRowPins
+    {n : Nat} (trace : AcceptedZiskTrace n) (i : Fin n) :
+    ZiskFv.Compliance.MainRowPins
+      (mainOfTable trace.program trace.mainTable) i.val
+      ((mainOfTable trace.program trace.mainTable).is_external_op i.val)
+      ((mainOfTable trace.program trace.mainTable).op i.val) := by
+  exact ⟨rfl, rfl⟩
+
+/-- Specialize the hypothesis-free Main pins to literals established by an
+accepted instruction arm's decode facts. -/
+theorem AcceptedZiskTrace.mainRowPinsOfEq
+    {n : Nat} (trace : AcceptedZiskTrace n) (i : Fin n)
+    (active opKind : FGL)
+    (h_active : (mainOfTable trace.program trace.mainTable).is_external_op i.val = active)
+    (h_op : (mainOfTable trace.program trace.mainTable).op i.val = opKind) :
+    ZiskFv.Compliance.MainRowPins
+      (mainOfTable trace.program trace.mainTable) i.val active opKind := by
+  exact ⟨h_active, h_op⟩
 
 /-- Main's concrete `c` memory-bus message has the register-write lane relation
 whenever the indexed Main row is in the arithmetic (`store_pc = 0`) mode. -/

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongAluArith.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongAluArith.lean
@@ -112,8 +112,9 @@ theorem stepStrong_sub
       h_component, h_table_spec, h_match⟩ :=
     trace.staticBinarySubProviderRowFacts
       i d.toDecode.h_main_active d.toDecode.h_main_op
-  let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SUB :=
-    ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
+  let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_SUB := by
+    simpa [m] using trace.mainRowPinsOfEq i 1 OP_SUB
+      d.toDecode.h_main_active d.toDecode.h_main_op
   have h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m i.val bus.e2 := by
     simpa [m, bus, busSub, mainRowWithRomSub] using
@@ -231,8 +232,8 @@ theorem stepStrong_and
   let bus := busSub trace i (Pilot.execRowOf trace i)
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    main_request_logic_provided
-      trace i d.toDecode.h_main_active (Or.inl d.toDecode.h_main_op)
+    trace.staticBinaryLogicProviderRowFacts
+      i d.toDecode.h_main_active (Or.inl d.toDecode.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_AND :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
   have h_lane_rd :
@@ -346,8 +347,8 @@ theorem stepStrong_or
   let bus := busSub trace i (Pilot.execRowOf trace i)
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    main_request_logic_provided
-      trace i d.toDecode.h_main_active (Or.inr (Or.inl d.toDecode.h_main_op))
+    trace.staticBinaryLogicProviderRowFacts
+      i d.toDecode.h_main_active (Or.inr (Or.inl d.toDecode.h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_OR :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
   have h_lane_rd :
@@ -461,8 +462,8 @@ theorem stepStrong_xor
   let bus := busSub trace i (Pilot.execRowOf trace i)
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    main_request_logic_provided
-      trace i d.toDecode.h_main_active (Or.inr (Or.inr d.toDecode.h_main_op))
+    trace.staticBinaryLogicProviderRowFacts
+      i d.toDecode.h_main_active (Or.inr (Or.inr d.toDecode.h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_XOR :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
   have h_lane_rd :
@@ -806,8 +807,8 @@ theorem stepStrong_andi
   let bus := busSub trace i (Pilot.execRowOf trace i)
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    main_request_logic_provided
-      trace i d.toDecode.h_main_active (Or.inl d.toDecode.h_main_op)
+    trace.staticBinaryLogicProviderRowFacts
+      i d.toDecode.h_main_active (Or.inl d.toDecode.h_main_op)
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_AND :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
   have h_lane_rd :
@@ -923,8 +924,8 @@ theorem stepStrong_ori
   let bus := busSub trace i (Pilot.execRowOf trace i)
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    main_request_logic_provided
-      trace i d.toDecode.h_main_active (Or.inr (Or.inl d.toDecode.h_main_op))
+    trace.staticBinaryLogicProviderRowFacts
+      i d.toDecode.h_main_active (Or.inr (Or.inl d.toDecode.h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_OR :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
   have h_lane_rd :
@@ -1040,8 +1041,8 @@ theorem stepStrong_xori
   let bus := busSub trace i (Pilot.execRowOf trace i)
   obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
       h_component, h_table_spec, h_match⟩ :=
-    main_request_logic_provided
-      trace i d.toDecode.h_main_active (Or.inr (Or.inr d.toDecode.h_main_op))
+    trace.staticBinaryLogicProviderRowFacts
+      i d.toDecode.h_main_active (Or.inr (Or.inr d.toDecode.h_main_op))
   let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_XOR :=
     ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
   have h_lane_rd :

--- a/docs/ai/PROJECTS.md
+++ b/docs/ai/PROJECTS.md
@@ -1,5 +1,13 @@
 # Projects
 
+## Aristotle Drive
+
+Operator guide for driving the remaining FINAL-PLAN refactor phases through the Aristotle
+service: one continued project (`9c5aee26`), tarball re-seed per turn, phase-scale numbered
+work orders with a completion contract, and Claude running submit → monitor → receive →
+decontaminate → verify → stacked PR autonomously. Remaining schedule T3–T7 maps plan
+Phases 2.3/2.4 through 4. Plan: `docs/ai/plan/PLAN_ARISTOTLE_DRIVE.md`.
+
 ## Aristotle Portability
 
 Plan: `docs/ai/plan/PLAN_ARISTOTLE_PORTABILITY.md`. Active worktree:

--- a/docs/ai/plan/PLAN_ARISTOTLE_DRIVE.md
+++ b/docs/ai/plan/PLAN_ARISTOTLE_DRIVE.md
@@ -1,0 +1,121 @@
+# PLAN: Driving the refactor with Aristotle (operator guide)
+
+Claude is the operator: it scopes turns, submits, monitors, receives, verifies, and opens
+PRs. Cody reviews PRs and approves anything touching protected surfaces. Aristotle executes
+phase-scale work orders. The refactor plan itself is `docs/refactor/FINAL-PLAN.md`; this
+document is only about how to drive it.
+
+## Fixed facts (learned the hard way)
+
+- **One project, always continued**: `9c5aee26-2cfe-4a9c-92b6-b9c304c66afa`. `aristotle
+  submit` always creates a NEW project with no context — never use it for this stream.
+- **Its server-side tree is whatever we last re-seeded.** Every turn must attach a fresh
+  snapshot tarball and open with the re-seed bootstrap instruction. Skipping this caused
+  the #253/#254 revert contamination.
+- **Snapshot = `git archive HEAD`** of the turn's base commit (~1.8 MB). Never
+  `--project-dir`/attach a live checkout (13 GB `.lake` → apparent hang). The archive has
+  no branch history (prompts must not reference commits/branches as available) and no
+  `zisk` submodule (trust check 13 cannot run in its sandbox — the prompt must
+  pre-authorize deferring exactly that check, nothing else).
+- **Known benign residue in downloads** (decontaminate on receive, anything else = stop):
+  `lake-manifest.json` Clean-pin reverts (its Lake cache regenerates it; discard via
+  `git show HEAD:lake-manifest.json > lake-manifest.json`) and lost executable bits
+  (`git diff --summary | grep 'mode change 100755 => 100644'` → `chmod +x`).
+- **Prompt lint before submitting**: every file path, gate name, and baseline the prompt
+  references must exist at the submitted commit (`git grep` against the tarball tree).
+  The retired caller-burden ledger reference cost us a full turn refusal.
+- **Turns take ~2h+.** `aristotle show <project> | head -1` reports the latest task state
+  (`RUNNING` / `COMPLETE (started …)`), which is the polling surface.
+
+## Turn lifecycle
+
+1. **Prepare** — new worktree `refactor-N`, branch `refactor-N`, at the exact tip of
+   `refactor-(N-1)`; copy `.lake` from the previous worktree; init the `zisk` submodule.
+   Write `REFACTOR_N_PROMPT.md` (template below), prompt-lint it, commit, push.
+2. **Submit** —
+   ```bash
+   cd .worktrees/refactor-N
+   tarball=/tmp/refactor-N-$(git rev-parse --short HEAD).tar.gz
+   git archive --format=tar.gz -o "$tarball" HEAD
+   atl continue 9c5aee26-2cfe-4a9c-92b6-b9c304c66afa --files "$tarball" \
+     "Your local repository state is outdated — do not trust your local tree or your own
+      earlier commits. Attached is $(basename "$tarball"), a snapshot of the current
+      source-of-truth tree (it integrates all of your prior accepted work). Replace your
+      entire working tree with its contents, then read REFACTOR_N_PROMPT.md at its root
+      and carry out that work order in full."
+   ```
+3. **Monitor** — background watcher, harness notifies on exit:
+   ```bash
+   until aristotle show 9c5aee26-… | head -1 | grep -qE 'COMPLETE|FAILED'; do sleep 600; done
+   ```
+   After a session restart, recover with `aristotle list` + `show`.
+4. **Receive** — `aristotle download 9c5aee26-… --destination <scratch>/turn-N.tar.gz`;
+   extract with `--strip-components=1` over the `refactor-N` worktree.
+5. **Decontaminate** — apply the known-residue fixes; diff must then contain only files the
+   run's summary accounts for. Unexpected files → stop, investigate, never commit them.
+6. **Verify** — full `lake build`; V1 (must be 16/16 locally, including check 13); V2;
+   `trust/generated/` byte-unchanged unless the work order explicitly said otherwise;
+   `Audit.lean` golden tests untouched and passing.
+7. **Land** — commit with a real message crediting the run, push, open the stacked PR
+   (base `refactor-(N-1)`), update `STATUS.md`. Merging is always Cody's.
+8. **Prep the next turn immediately** while context is fresh: re-enumerate what remains.
+
+## Scope calibration — the core fix
+
+Evidence so far: given an open-ended "finish Phase 2", Aristotle delivers one coherent
+lemma family (~+120 lines) and stops at the first clean commit, despite capability for far
+more. The correction is contractual, not motivational:
+
+- **One turn = one full plan phase** (or an explicitly enumerated half of an L-rated
+  phase), expressed as a **numbered deliverables list** (5–12 items), each with its own
+  acceptance criterion. Never "finish phase X" as the whole instruction.
+- Every prompt carries a **completion contract**, verbatim:
+  > The turn is complete when every numbered item is either done or carries a verified
+  > blocker note. A clean build or a committed chunk is a checkpoint, not a stop
+  > condition: after finishing an item, proceed immediately to the next. Committing and
+  > reporting with items silently unattempted is a failed turn.
+- **Blocked-item protocol**: skip it, document the precise blocker (file, theorem, error),
+  continue with the next item.
+- **Reporting contract**: the run summary must contain a per-item status table
+  (done / blocked+why / not reached) plus the metrics the item's criterion names
+  (e.g. before/after binder counts).
+- **On receive, measure**: if fewer than ~60% of items were attempted and no blockers are
+  documented, the next turn's prompt opens with that gap, and a `--mode ask` follow-up
+  ("what stopped you after item k?") is cheap and worth it.
+
+## Remaining schedule (maps FINAL-PLAN §9)
+
+| Turn | Work order | Exit criteria |
+| --- | --- | --- |
+| T3 | Phase 2.3 + 2.4 in full: remove seam-derivable binders (`providerTable`, `providerRow`, `h_component`, `h_table_spec`, `h_match`, `h_lane_rd`, pins) from the equiv/wrapper signatures of EVERY shape family (enumerate the ten Dispatch families in the prompt), feeding StepStrong* from `DerivedRowFacts` | per-family before/after parameter counts; `trust/generated/` byte-unchanged; gates green |
+| T4 | Phase 3 pilot on BinaryAdd: generic `rowAt`-view lemma, EquivCore consumes the Clean `Spec`, delete `AirsClean/BinaryAdd/Bridge.lean`; document the Q2 constraint-agreement spot-check | bridge file gone; no `Valid_BinaryAdd` consumer added; Q2 note in the run summary |
+| T5 | Phase 3 roll: remaining families; delete each `Valid_<AIR>` as it becomes consumer-free | `AirsClean/*/Bridge` count →0 trend; `Valid_Main` reference count reported |
+| T6 | Phase 4.1–4.2: per-shape envelopes (`OpEnvelope` → ~12 shape arms), one parametric `equiv_S` per shape + instance table; unify `EquivCore/`/`Equivalence/` | new-opcode cost = 1 instance row; naming hazard N1 resolved |
+| T7 | Phase 4.3–4.4: dependent-match dispatch replaces `Dispatch/` fan-out; split >1000-line files by shape | `exec_eq` conjunction gone from the internal lemma's conclusion shape (still T0/T1 discipline) |
+
+L-rated phases may legitimately need two turns; scope the full phase anyway, expect an
+honest partial with blocker notes, and re-enumerate the remainder as the next turn.
+
+Separate, human-gated (never an autonomous Aristotle turn): upstream #398 adoption and any
+Clean pin move; anything T2-tier per FINAL-PLAN §7.
+
+## Autonomy defaults
+
+Claude drives steps 3–8 for every turn without asking, and auto-submits the next turn when
+(a) the previous turn landed green through V2, (b) the work order matches this schedule,
+and (c) nothing touches protected surfaces (root statements, trust ledgers/baselines,
+Clean/flake pins, `Audit.lean`). Claude stops and asks Cody when any of those fail, when
+decontamination finds unexpected files, or when a turn must deviate from the schedule.
+Every landed turn is reported with worktree path, branch, PR number, and gate results.
+
+## Prompt template (`REFACTOR_N_PROMPT.md`)
+
+1. **Situation** — tree-truth + tarball re-seed instruction (delivery-mode robust);
+   sandbox limitations (no branch history; no `zisk` submodule → check 13 deferred to the
+   operator, all other checks mandatory).
+2. **Done vs. remaining** — updated each turn; name the seam facts that now exist.
+3. **Numbered work order** — items with per-item acceptance criteria.
+4. **Completion contract + blocked-item protocol** — verbatim from above.
+5. **Hard constraints** — T0 discipline, `Audit.lean` untouchable, no new trust markers,
+   no baseline creation/edits, gates that must pass, new-commits-only.
+6. **Reporting contract** — per-item table + required metrics in the run summary.

--- a/docs/refactor/FINAL-PLAN.md
+++ b/docs/refactor/FINAL-PLAN.md
@@ -620,6 +620,20 @@ cosmetic.
    capability.
 7. Gadget/infra PRs (#372 sha256, #406, bench/CI) — low relevance.
 
+### 8.3.1 Phase-2 seam check (2026-07-16)
+
+Checked upstream `main` at `1e563b9c` and PR #398 at `50f0366`, including
+`Air/Vm.lean` and `Air/OrderedChannel.lean`.  The upstream developments provide
+generic ordering, active-interaction, multiplicity, and pull/push matching
+machinery, but no reusable theorem identifies a ZisK operation-bus provider
+component/row, proves Main register-write lane placement, or packages
+opcode-specific Main pins.  Those conclusions depend on this project's
+full-ensemble component classification and ZisK Main/operation/memory message
+layouts.  The hand-rolled `AcceptedZiskTrace` seam lemmas are therefore retained;
+they are the project-specific specialization on top of Clean's generic balance
+facts.  PR #398 should still be adopted separately when the Clean pin is
+reconciled, but it does not replace these three derivations.
+
 ### 8.4 The transition-constraint divergence — resolve upstream-first
 
 The fork's `FlatComponent.transition` field duplicates a capability upstream


### PR DESCRIPTION
## What

Second Aristotle turn on the Phase 2 ensemble-seam refactor (project `9c5aee26`, tarball-re-seeded continue — the stale-tree failure mode from the first turn is closed):

- **`staticBinaryLogicProviderRowFacts`** — the AND/OR/XOR shape-family specialization of the generic `opProviderRowFacts`: balance and row selection stay generic, only the family's impossible-branch eliminations are local.
- **`mainRowPins` / `mainRowPinsOfEq`** — the indexed Main activation/opcode pins packaged as hypothesis-free seam facts with decode-literal transport. This completes plan **Phase 2.2** (provider facts, lanes, and pins all derived at the seam).
- All six AND/OR/XOR strong-export paths (register + immediate) leave `main_request_logic_provided` for the seam fact; pins route through `mainRowPinsOfEq`.
- The owed upstream check is documented as FINAL-PLAN §8.3.1: upstream `main` @ `1e563b9c` and PR #398 @ `50f0366` provide generic balance machinery but nothing that replaces these project-specific derivations; the seam lemmas are retained, #398 adoption stays a separate step.

T0 throughout: no root statement, `equiv_*` signature, or trust baseline change. Phase 2.3 (signature shrink with before/after counts) is the next turn.

## Receive notes

Download residue discarded before commit: a one-file `lake-manifest.json` Clean-pin revert (its sandbox Lake cache regenerates it at the old rev) and ~37 lost executable bits. The committed diff is exactly the four files the run's summary accounts for.

## Verification

- `lake build` 9012 jobs green on Clean `c87617d8` (its sandbox built on the older pin; verified here against the current one)
- V1 fast gate **16/16 locally** — including check 13, which its sandbox cannot run (`git archive` snapshots exclude the `zisk` submodule)
- V2 semantic gate: all checks ✓ · `Audit.lean` golden tests untouched and passing

Part 5 of the refactor stack (base: #260 / `refactor-1`). Implemented by Aristotle (task `3b98c185`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
