### PR TITLE
Salvage T5: BinaryAdd Clean-row Interface, verified locally (Phase 3 pilot start)

### DIFF
--- a/ARISTOTLE_SUMMARY.md
+++ b/ARISTOTLE_SUMMARY.md
@@ -1,3 +1,64 @@
+# Summary of changes for run 38ee2eb7-8349-4552-b0c5-ec050cae6128
+You’re right—the direct answer is:
+
+## Recommended top-level API
+
+Keep exactly two advertised endpoints, collected in `ZiskFv/Audit.lean`:
+
+1. **`root_soundness`** — the unconditional soundness result over an `AcceptedZiskTrace`.
+2. **`root_completeness`** — explicitly conditional on one named `ZiskCompletenessObligations` record until each construction obligation is proved.
+
+For `root_soundness`, preserve the theorem’s meaning and bundle only premises that are already explicit root binders, such as input agreement, boot-memory seed, and scope/defect exclusions. Do **not** add channel balance, Aeneas-bridge evidence, or memory-timeline evidence as new root assumptions: channel balance is already part of `AcceptedZiskTrace`, while the other evidence is derived internally. Adding it to the root would weaken the theorem.
+
+The old `zisk_riscv_compliant_program_bus` theorem should remain an internal per-operation implementation lemma, not a second public soundness endpoint. Freeze both root statements and their axiom closures in `Audit.lean`, so accidental API or trust changes fail the build.
+
+## Recommended proof architecture
+
+The target dependency structure should be:
+
+```text
+Sail semantics + PIL constraints
+          ↓
+Clean component Specs
+          ↓
+Clean FormalEnsemble / channel balance / table soundness
+          ↓
+AcceptedZiskTrace-derived row and lane facts
+          ↓
+~12 instruction-shape theorems
+          ↓
+thin generated opcode instances
+          ↓
+root_soundness
+```
+
+The key changes are:
+
+- **Make Clean `Spec`s the canonical circuit model.** The legacy `Airs/Valid_*` records should become generated compatibility views and ultimately disappear. Equivalence proofs should consume Clean component specifications directly rather than translating each opcode through bespoke `Bridge.lean` files.
+- **Derive facts once at the accepted-trace seam.** Provider-row existence, component identity, row membership, exact entry matching, register lanes, pins, and memory rows should follow from ensemble soundness and channel balance. They should not be repeated as caller-supplied “promises” in every opcode theorem.
+- **Factor by instruction shape, not opcode.** Create reusable families for R-type arithmetic, I-type arithmetic, shifts, branches, loads, stores, binary logic, multiplication, division, and similar shapes. Each family gets one evidence record and one canonical parametric theorem; individual opcode theorems become small instantiations.
+- **Separate evidence from semantics.** A family evidence package should contain only trace-derived structural facts. The canonical family theorem combines that package with the relevant Clean `Spec` to prove the architectural transition. This makes dependencies visible and prevents large positional hypothesis lists.
+- **Keep wrappers one-way and thin.** Compatibility wrappers may project old hypotheses into a family evidence package during migration, but canonical theorems must never depend on wrappers. Delete wrappers once callers move.
+- **Treat caller-burden reduction as the progress metric.** A migration is complete only when premises have been derived from accepted-trace invariants—not merely renamed or bundled.
+
+## Assessment of current Clean usage
+
+The low-level Clean components are substantially idiomatic: they use `GeneralFormalCircuit`, `ProvableStruct`, `assertZero`, lookups, channel pushes, `FormalEnsemble`, and `TableSoundness`. The main divergence is **above** that layer: Clean facts are translated into a parallel legacy AIR model, then reconstructed through per-opcode bridges and large promise surfaces. Thus the best refactor is not to rewrite the circuits; it is to make their `Spec`s the proof spine.
+
+The local Clean fork should also be reconciled deliberately with upstream work, especially zero-multiplicity channel handling and VM/ordered-channel soundness. The bespoke adjacent-row transition extension should either use Clean’s `InductiveTable` abstraction or be upstreamed rather than remain an undocumented fork divergence.
+
+## Safe migration order
+
+1. Keep the root theorem frozen and retain statement/axiom golden tests.
+2. Add generic accepted-trace derivation lemmas at the ensemble seam.
+3. Introduce one evidence package and canonical theorem per instruction shape.
+4. Migrate opcode callers family by family, measuring removed explicit parameters.
+5. Make Clean `Spec`s canonical and demote the legacy `Valid_*` model.
+6. Remove obsolete bridges, wrappers, `OpEnvelope` duplication, and trust-ledger entries.
+7. Only after the lower architecture stabilizes, optionally repackage existing root binders behind a proved old/new equivalence theorem.
+
+The detailed, self-contained version is in `docs/refactor/FINAL-PLAN.md`; `docs/refactor/01-architecture-map.md` through `07-root-stability-and-upstream-clean.md` contain the supporting analysis. Some of this redesign is already implemented: the audit surface and completeness obligations record exist, and accepted-trace row/lane derivations plus several family migrations have begun. The remaining Shift, arithmetic, and load/store migrations require richer typed provider evidence rather than more opcode-specific premises.
+
 # Summary of changes for run af154c69-dade-4a18-bbcf-9d542b3fdfc7
 Installed the supplied source-of-truth snapshot and attempted all nine work-order items.
 

--- a/REFACTOR_5_PROMPT.md
+++ b/REFACTOR_5_PROMPT.md
@@ -1,0 +1,85 @@
+# Task: Phase 3 pilot — Clean `Spec` becomes the interface for BinaryAdd; delete its bridge
+
+## Situation
+
+**The tree delivered with this prompt is the current source of truth.** If it arrived as a
+tarball attached to a continue prompt, replace your entire working tree with the tarball's
+contents before doing anything else — your prior local repository state (including your own
+earlier commits) is outdated and must not be trusted.
+
+Sandbox limitations, pre-acknowledged: no git branch history; no `zisk` submodule, so trust
+check 13 cannot run for you — defer exactly that check, every other gate is mandatory. Do
+not touch `lakefile.toml`, `lake-manifest.json`, `flake.nix`, `flake.lock`, or
+`ZiskFv/Audit.lean`.
+
+## Context
+
+Phase 2 is closed at its natural T0 boundary (your blocker analysis was accepted: the
+remaining wrapper shrinks fold into Phase 4's `OpEnvelope` restructure). This turn begins
+Phase 3 of `docs/refactor/FINAL-PLAN.md` (§5.1, roadmap 3.1–3.2): make the Clean
+`GeneralFormalCircuit.Spec` the interface the equivalence layer consumes, retiring the
+legacy `Airs/` record model family by family. Pilot family: **BinaryAdd** (full Clean
+component exists under `ZiskFv/AirsClean/BinaryAdd/{Spec,Row,Constraints,Circuit,
+Soundness,Bridge}.lean`; `Valid_BinaryAdd` is currently consumed by 16 files;
+`Bridge.lean` provides `rowAt` / `soundness_of_valid`).
+
+Standing decision from your own T4 analysis: do NOT change `OpEnvelope` constructor
+arities this turn — that exhaustive-pattern restructure is Phase 4's, done once.
+
+## Numbered work order
+
+1. **Q2 constraint-agreement spot-check — do this FIRST.** Verify that the
+   `Valid_BinaryAdd` constraint predicates exactly mirror the Clean BinaryAdd component's
+   constraints (`AirsClean/BinaryAdd/Constraints.lean` vs the `Airs/` record model).
+   Produce a per-constraint correspondence table in your summary. If ANY divergence is
+   found: stop this family immediately and report the divergence precisely — it is a
+   potential soundness gap and must never be papered over by choosing either side.
+2. **Generic row-view lemma.** One lemma (or a small lemma family stated once, not
+   per-consumer copies) establishing that `Valid_BinaryAdd` facts about row `r` are
+   equivalent to the Clean `Spec` of the row projection (`rowAt`-view), in the direction(s)
+   consumers actually need. Derivation side: `AcceptedZiskTrace` already yields the Clean
+   `Spec` per table row (`spec_holds` / `witness_spec_of_constraints`), so the Clean side
+   is the supply and the record side is the demand being retired.
+3. **Rewire the BinaryAdd-family consumers.** Move the BinaryAdd-specific consumers of
+   `Valid_BinaryAdd` (EquivCore bridge lemmas, construction/StepStrong feeds, the
+   `add_via_binaryadd` route) onto the Clean `Spec` interface. You MAY restate EquivCore
+   hypotheses from record-model facts to Clean-`Spec` facts — that is this phase's point —
+   but the Sail-space `execute = bus_effect` conclusion shapes and the promise discipline
+   must be preserved, and no hypothesis may be weakened or added.
+4. **Delete `ZiskFv/AirsClean/BinaryAdd/Bridge.lean`** once it is consumer-free. If a
+   consumer genuinely cannot be rewired this turn, blocker-note it precisely and leave the
+   bridge in place — never delete with live consumers.
+5. **Delete `Valid_BinaryAdd`** (its definition and its `Airs/` constraint predicates) if
+   and only if consumer-free after items 3–4; otherwise report the remaining consumer
+   list verbatim.
+6. **Final sweep.** Report `Valid_BinaryAdd` consumer count before/after and bridge
+   status; `trust/generated/` byte-for-byte unchanged; full `lake build`,
+   `trust/scripts/check-all.sh` (minus check 13), `trust/scripts/check-all-semantic.sh`
+   all green.
+
+## Completion contract
+
+The turn is complete when every numbered item is either done or carries a verified blocker
+note. A clean build or a committed chunk is a checkpoint, not a stop condition: after
+finishing an item, proceed immediately to the next. Committing and reporting with items
+silently unattempted is a failed turn. If an item is blocked, skip it, document the precise
+blocker (file, theorem, error), and continue with the next item.
+
+## Hard constraints (in addition to `AGENTS.md`, which fully applies)
+
+- T0 at the roots: `root_soundness` and `root_completeness` byte-for-byte identical;
+  `ZiskFv/Audit.lean` untouched and passing.
+- Item 1's outcome gates items 3–5: no bridge or record-model deletion is sound unless the
+  constraint sets agree exactly.
+- Every rewired hypothesis must be **proved** from the Clean `Spec`/accepted-trace supply —
+  never weakened, never moved to a broader premise, never replaced by a new caller
+  obligation. Zero new `axiom`, `sorry`, `admit`, `native_decide`, `opaque`, `partial`,
+  `@[implemented_by]`. No file under `trust/generated/` may change; no baseline created.
+- No `OpEnvelope` constructor-arity changes.
+- Work in new commits on top of the provided state; never rewrite or revert it.
+
+## Reporting contract
+
+Prepend your run summary to `ARISTOTLE_SUMMARY.md` with: the per-item status table for
+items 1–6; the Q2 per-constraint correspondence table; the `Valid_BinaryAdd` consumer
+count before/after with the remaining-consumer list if nonzero; and exact gate results.

--- a/ZiskFv/AirsClean/BinaryAdd/Interface.lean
+++ b/ZiskFv/AirsClean/BinaryAdd/Interface.lean
@@ -1,0 +1,93 @@
+import ZiskFv.AirsClean.BinaryAdd.Circuit
+import ZiskFv.Channels.OperationBus
+
+/-!
+# Consumer-facing BinaryAdd interface
+
+This module contains the row-local API consumed by the equivalence and
+compliance layers.  It is stated entirely in terms of the Clean row and
+`GeneralFormalCircuit.Spec`; no legacy named-column validator is involved.
+-/
+
+namespace ZiskFv.AirsClean.BinaryAdd
+
+open Goldilocks
+open Air.Flat
+open ZiskFv.Channels.OperationBus
+
+/-- The concrete operation-bus message emitted by a Clean BinaryAdd row. -/
+@[reducible]
+def opBusMessage (row : BinaryAddRow FGL) : OpBusMessage FGL :=
+  { op := 10
+    a_lo := row.a_0
+    a_hi := row.a_1
+    b_lo := row.b_0
+    b_hi := row.b_1
+    c_lo := row.c_chunks_1 * 65536 + row.c_chunks_0
+    c_hi := row.c_chunks_3 * 65536 + row.c_chunks_2
+    flag := 0
+    main_step := 0
+    extended_arg := 0
+    extra_args_0 := 0 }
+
+/-- Evaluation commutes with the BinaryAdd operation-bus row projection. -/
+theorem eval_opBusMessageExpr
+    (env : Environment FGL) (row : Var BinaryAddRow FGL) :
+    eval env (opBusMessageExpr row) = opBusMessage (eval env row) := by
+  rw [OpBusMessage.mk.injEq]
+  simp only [opBusMessageExpr, ProvableStruct.eval_eq_eval,
+    ProvableStruct.eval, ProvableStruct.fromComponents,
+    ProvableStruct.components, ProvableStruct.toComponents,
+    ProvableStruct.eval.go, ProvableType.eval_field, Expression.eval]
+  repeat constructor
+
+/-- Component-specialized form of `eval_opBusMessageExpr`. -/
+theorem component_eval_opBusMessageExpr
+    (env : Environment FGL) :
+    eval env (opBusMessageExpr component.rowInputVar) =
+      opBusMessage (component.rowInput env) := by
+  rw [eval_opBusMessageExpr]
+  exact congrArg opBusMessage
+    (by
+      simpa only [Air.Flat.Component.rowInput, Air.Flat.Component.rowInputVar] using
+        (eval_varFromOffset_valueFromOffset component.Input 0 env))
+
+/-- The semantic `Spec`, together with its lookup-derived range facts, gives
+exactly the RV64 wrapping-add equation needed by instruction equivalence. -/
+theorem binary_add_chunks_eq_bv_add
+    (row : BinaryAddRow FGL)
+    (h_spec : Spec row)
+    (h_range : RangeFacts row) :
+    BitVec.ofNat 64 (row.a_0.val + row.a_1.val * 4294967296)
+      + BitVec.ofNat 64 (row.b_0.val + row.b_1.val * 4294967296)
+      = BitVec.ofNat 64
+          (row.c_chunks_0.val
+            + row.c_chunks_1.val * 65536
+            + row.c_chunks_2.val * 4294967296
+            + row.c_chunks_3.val * 281474976710656) := by
+  simp only [Spec, cPacked, packed32, Nat.reducePow] at h_spec
+  obtain ⟨h_a0, h_a1, h_b0, h_b1, h_c0, h_c1, h_c2, h_c3⟩ := h_range
+  have h_av : row.a_0.val + row.a_1.val * 4294967296 < 18446744073709551616 := by omega
+  have h_bv : row.b_0.val + row.b_1.val * 4294967296 < 18446744073709551616 := by omega
+  have h_cv : row.c_chunks_0.val + row.c_chunks_1.val * 65536
+      + row.c_chunks_2.val * 4294967296
+      + row.c_chunks_3.val * 281474976710656 < 18446744073709551616 := by omega
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_add, BitVec.toNat_ofNat, BitVec.toNat_ofNat, BitVec.toNat_ofNat,
+      Nat.mod_eq_of_lt h_av, Nat.mod_eq_of_lt h_bv, Nat.mod_eq_of_lt h_cv, ← h_spec]
+  ring
+
+/-- A component `Spec` packages both the semantic addition equation and all
+lookup-derived range bounds required by `binary_add_chunks_eq_bv_add`. -/
+theorem binary_add_chunks_eq_bv_add_of_component_spec
+    (row : BinaryAddRow FGL) (h : ComponentSpecFacts row) :
+    BitVec.ofNat 64 (row.a_0.val + row.a_1.val * 4294967296)
+      + BitVec.ofNat 64 (row.b_0.val + row.b_1.val * 4294967296)
+      = BitVec.ofNat 64
+          (row.c_chunks_0.val
+            + row.c_chunks_1.val * 65536
+            + row.c_chunks_2.val * 4294967296
+            + row.c_chunks_3.val * 281474976710656) := by
+  exact binary_add_chunks_eq_bv_add row h.1 h.2.2
+
+end ZiskFv.AirsClean.BinaryAdd

--- a/docs/ai/plan/PLAN_ARISTOTLE_DRIVE.md
+++ b/docs/ai/plan/PLAN_ARISTOTLE_DRIVE.md
@@ -69,6 +69,13 @@ document is only about how to drive it.
    `Audit.lean` golden tests untouched and passing.
 7. **Land** — commit with a real message crediting the run, push, open the stacked PR
    (base `refactor-(N-1)`), update `STATUS.md`. Merging is always Cody's.
+   Then **review the PR** (not just the gates) and post findings as a PR comment:
+   (a) mechanical conclusion check — no diff line may touch a theorem conclusion
+   (`state_effect_via_channels`/`execute_instruction`/`bus_effect` grep over the commit);
+   (b) full read of every NEW module/structure (laundering check: derived, not renamed);
+   (c) spot-read the largest changed file per category (canonical/wrapper/construction/
+   dispatch) for hypothesis-set preservation; (d) zero added `sorry`/`admit`;
+   (e) note cosmetic issues for a later pass instead of churning the PR.
 8. **Prep the next turn immediately** while context is fresh: re-enumerate what remains.
 
 ## Scope calibration — the core fix

--- a/docs/ai/plan/PLAN_ARISTOTLE_DRIVE.md
+++ b/docs/ai/plan/PLAN_ARISTOTLE_DRIVE.md
@@ -12,6 +12,15 @@ document is only about how to drive it.
 - **Its server-side tree is whatever we last re-seeded.** Every turn must attach a fresh
   snapshot tarball and open with the re-seed bootstrap instruction. Skipping this caused
   the #253/#254 revert contamination.
+- **Re-seeding must NOT destroy its build artifacts.** T5 revealed the dominant cost: a
+  naive tree replacement discards `.lake`, forcing a cold ~9k-job build inside its
+  22-minute command windows (progress persists across windows, but hours are burned
+  before its own edits even compile). The bootstrap prompt must instruct: preserve
+  `.lake` across the replacement (extract the tarball OVER the tree; Lake is
+  content-addressed, so artifacts for unchanged modules stay valid), run
+  `lake exe cache get` after installing (mathlib artifacts), and size every build
+  command to complete within the ~22-minute execution window (per-module/per-directory
+  slices for deep-import edits, re-invoking as needed since progress is cached).
 - **Snapshot = `git archive HEAD`** of the turn's base commit (~1.8 MB). Never
   `--project-dir`/attach a live checkout (13 GB `.lake` → apparent hang). The archive has
   no branch history (prompts must not reference commits/branches as available) and no

--- a/docs/ai/plan/PLAN_ARISTOTLE_DRIVE.md
+++ b/docs/ai/plan/PLAN_ARISTOTLE_DRIVE.md
@@ -28,8 +28,17 @@ document is only about how to drive it.
   pre-authorize deferring exactly that check, nothing else).
 - **Known benign residue in downloads** (decontaminate on receive, anything else = stop):
   `lake-manifest.json` Clean-pin reverts (its Lake cache regenerates it; discard via
-  `git show HEAD:lake-manifest.json > lake-manifest.json`) and lost executable bits
-  (`git diff --summary | grep 'mode change 100755 => 100644'` → `chmod +x`).
+  `git show HEAD:lake-manifest.json > lake-manifest.json`), lost executable bits
+  (`git diff --summary | grep 'mode change 100755 => 100644'` → `chmod +x`), and
+  **reverts of operator commits made AFTER the submitted tarball** (its tree predates
+  them; restore each such file from HEAD).
+- **Mid-task messages can CANCEL the in-flight work task.** A follow-up prompt to the
+  project while a task runs may supersede it (observed: T5's work task CANCELED at
+  ~11.5h by a user follow-up; a 34-minute Q&A task replaced it). Some Q&A reaches the
+  running task without cancelling it, but the safe assumption is: do not message the
+  project mid-task unless prepared to lose the run; committed checkpoints survive
+  (server-side repo persists), uncommitted and unverified work may not. Salvage path:
+  `download` the project tree, verify locally on the warm cache, land the partial.
 - **Prompt lint before submitting**: every file path, gate name, and baseline the prompt
   references must exist at the submitted commit (`git grep` against the tarball tree).
   The retired caller-burden ledger reference cost us a full turn refusal.
@@ -46,13 +55,18 @@ document is only about how to drive it.
    cd .worktrees/refactor-N
    tarball=/tmp/refactor-N-$(git rev-parse --short HEAD).tar.gz
    git archive --format=tar.gz -o "$tarball" HEAD
-   atl continue 9c5aee26-2cfe-4a9c-92b6-b9c304c66afa --files "$tarball" \
-     "Your local repository state is outdated — do not trust your local tree or your own
-      earlier commits. Attached is $(basename "$tarball"), a snapshot of the current
-      source-of-truth tree (it integrates all of your prior accepted work). Replace your
-      entire working tree with its contents, then read REFACTOR_N_PROMPT.md at its root
-      and carry out that work order in full."
+   atl continue 9c5aee26-2cfe-4a9c-92b6-b9c304c66afa "PROMPT" --files "$tarball"
    ```
+   (positionals BEFORE `--files` — it is greedy). The bootstrap PROMPT must use the
+   NON-DESTRUCTIVE install wording: *"Attached is <tarball>, the authoritative
+   source-of-truth tree (it integrates all of your prior accepted work). Install it by
+   extracting OVER your existing tree — do NOT delete `.lake` or other build artifacts;
+   Lake is content-addressed, so unchanged files keep their cache and only real deltas
+   rebuild. If the build is cold anyway, try `lake exe cache get` first. After
+   installing, every tracked file's content must exactly match the tarball. Then read
+   REFACTOR_N_PROMPT.md at its root and carry out that work order in full."*
+   Never say "replace your working tree" — T5 showed that wording destroys the sandbox
+   build cache and costs the whole turn.
 3. **Monitor** — background watcher, harness notifies on exit. Hard-won details: the
    CLI's retry path emits to **stderr** (capture `2>&1` or the state is invisible), DNS
    blips must not kill the loop, the state can be `COMPLETE_WITH_ERRORS` (still done —


### PR DESCRIPTION
## What

The salvaged Phase 3 pilot start (T5), plus the operator-protocol hardening its failure taught us.

- **`ZiskFv/AirsClean/BinaryAdd/Interface.lean`** — the consumer-facing Clean-row API meant to replace `Bridge.lean`: the op-bus message projection, eval-commutation lemmas, and the key theorem deriving the 64-bit wrapping-add equation from the Clean `Spec` + lookup-derived range facts (`binary_add_chunks_eq_bv_add`, plus the `ComponentSpecFacts` convenience form). **Verified locally**: the module and its 8,077-job closure build green on our warm cache — in 14 seconds, after its sandbox spent ~11 hours unable to reach it (see below). Deliberately **not** imported from the library root yet: it intentionally redefines `BinaryAdd.opBusMessage`, colliding with `Bridge.lean` until the rewiring turn deletes the bridge — the collision resolves atomically then.
- **Q2 pilot finding** (from its mid-task report; the written correspondence report is owed next turn): all four legacy `Valid_BinaryAdd` constraint predicates correspond to the four Clean assertions up to notation (`1 - x` vs `1 + -x`); Clean's additional range lookups and op-bus push map to legacy side predicates. **No divergence found so far** — the finding that gates the whole Phase 3 deletion campaign.
- **Drive-plan hardening** from the turn's post-mortem: non-destructive snapshot installs (extract over tree, never delete `.lake` — the "replace your working tree" wording was destroying the sandbox build cache and forcing cold ~9k-job builds inside its 22-minute command windows), `lake exe cache get` on cold starts, window-sized build slices, two new receive-residue classes, and the observed hazard that mid-task messages can cancel the in-flight work task (which is how this turn ended at ~11.5h; its committed checkpoints survived server-side and are what this PR lands).

## Verification

- `lake build` 9012 jobs green at the tip; Interface's closure additionally built standalone
- V1 fast gate all-pass (incl. check 13) · V2 semantic gate all-pass
- Roots, `Audit.lean`, `trust/generated/` byte-identical; receive residue (manifest pin-revert, exec bits, post-tarball operator-commit reverts) discarded before commit

Part 8 of the refactor stack (base: #264 / `refactor-4`). Implemented by Aristotle (task `64830a58`, cancelled mid-run); salvaged, verified, and landed by the operator. Next turn (T5b): consumer rewiring onto the Interface, bridge deletion, `Valid_BinaryAdd` retirement, and the written Q2 report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
