### PR TITLE
Phase 3: remove Arith mode-boolean caller conjuncts; Mul wrappers on Clean supply (T12)

### DIFF
--- a/ARISTOTLE_SUMMARY.md
+++ b/ARISTOTLE_SUMMARY.md
@@ -1,3 +1,36 @@
+# Summary of changes for run a1b57c95-a03e-4bff-8a9f-34483b10ac1d
+Completed Refactor 13 to the verified boundary and documented the full audit in `REFACTOR_13_REPORT.md`.
+
+Key results:
+- Installed and byte-verified all 836 archived files/symlinks non-destructively while preserving `.lake`; the tarball was not committed.
+- Removed all 12 mode-boolean caller conjuncts across ArithMul and ArithDiv circuit/archetype surfaces.
+- Added `ArithMulTableWitness.row_constraints`, derived from `mainComplete`, and changed Mul wrapper proofs to use this Clean supply rather than caller evidence.
+- Removed row-constraint obligations from the five public Mul forwarding wrappers. Five ignored compatibility binders remain on `_of_table` declarations because removing their positional parameters would require modifying byte-frozen `Equivalence/` callers.
+- Corrected both Arith Q2 interface tables to name `mainComplete` as the true supplier of appended generated constraints.
+- Verified an ArithDiv blocker: the delivered `ArithDivTableWitness` still carries `mainWithArithTable` soundness, whereas the needed projection requires `mainComplete`; its old `FullSpec` also omits C46 and the appended local constraints. The remaining 16 Div wrapper obligations therefore cannot be honestly removed without strengthening the upstream provider contract.
+- Code delta: +41/−49, net −8 lines, excluding the report.
+
+Verification:
+- Full `lake build` passes.
+- Standard trust checks 1–12 and 14–16 pass; check 13 alone was deferred because the supplied tree lacks `zisk/core/src/aeneas_extract.rs`.
+- All 16 semantic checks pass; long-running checks were resumed using the suite’s exact component commands after command cutoffs.
+- Roots, `Equivalence/`, `ZiskFv/Audit.lean`, `Compliance/Defects.lean`, build pins/lockfiles, and `trust/generated/` are unchanged.
+- No prohibited constructs were introduced.
+
+All changes are committed and pushed.
+
+# Summary of changes for Refactor 13
+Installed and byte-verified the authoritative tarball non-destructively (836 archived files/symlinks), preserving `.lake`; the attached tarball was not committed.
+
+Completed the Refactor 13 audit and implementation to the verified boundary documented in `REFACTOR_13_REPORT.md`:
+- Removed all six ArithMul and all six ArithDiv mode-boolean caller conjuncts from circuit/archetype surfaces.
+- Added `ArithMulTableWitness.row_constraints`, derived from `mainComplete`, and made all Mul wrapper proofs use that supply rather than their caller argument. Public forwarding wrappers no longer request the argument; five `_of_table` compatibility binders remain ignored because byte-frozen `Equivalence/` callers require their positional API.
+- Corrected both Arith Q2 interface tables to identify `mainComplete` as the supplier of appended generated constraints.
+- Verified and documented the ArithDiv blocker: the delivered `ArithDivTableWitness` still carries `mainWithArithTable` soundness, while the required projection consumes `mainComplete`; its old `FullSpec` also lacks C46 and appended local constraints. Sixteen Div wrapper obligations therefore cannot be honestly removed without strengthening the upstream provider contract.
+- Code delta is +41/-49, net -8 lines. Roots, `Equivalence/`, `ZiskFv/Audit.lean`, `Compliance/Defects.lean`, build pins/lockfiles, and `trust/generated/` are unchanged.
+
+Verification: full `lake build` passes. Standard trust checks 1–12 and 14–16 pass; check 13 alone is deferred because the supplied tree lacks `zisk/core/src/aeneas_extract.rs`. All 16 semantic checks pass (the long suite was resumed using its exact component commands after command cutoffs). No prohibited construct was introduced.
+
 # Summary of changes for run 3e61ccfd-594f-461c-865f-ae3cd3bade4c
 Installed the authoritative tarball non-destructively and verified all 832 archived regular files byte-for-byte. Preserved `.lake`, removed the uncommitted tarball, and left `ARISTOTLE_SUMMARY.md` untouched as requested.
 

--- a/REFACTOR_13_PROMPT.md
+++ b/REFACTOR_13_PROMPT.md
@@ -1,0 +1,92 @@
+# Task: Phase 3 — derive the Arith record predicates from the Clean supply; remove caller obligations
+
+## Situation
+
+**The tree delivered with this prompt is the authoritative source of truth** (it integrates
+all of your prior accepted work: `Airs/Arith/` is dissolved, the record models live in
+`AirsClean/Arith{Mul,Div}/Semantics.lean` under their original namespaces, and the
+`Arith{Mul,Div}TableWitness` bundles in `Compliance/SharedBundles.lean` now carry
+`mainComplete` soundness with constructors proving the appended constraints from static
+table membership).
+
+Install it NON-DESTRUCTIVELY: extract the tarball OVER your existing tree; never delete
+`.lake` or build artifacts; `lake exe cache get` first if cold. After installing, every
+tracked file's content must exactly match the tarball. Your ~22-minute command window:
+size build commands to complete within it and re-invoke; a cutoff is never a proof error.
+Never commit an attached tarball.
+
+Sandbox limitations, pre-acknowledged: no branch history; no `zisk` submodule → defer
+exactly trust check 13. Do not touch `lakefile.toml`, `lake-manifest.json`, `flake.nix`,
+`flake.lock`, or `ZiskFv/Audit.lean`.
+
+## Context
+
+The Arith supply chain is complete and live: `mainComplete` (all generated constraints,
+cited), the named projection layer (`complete_local_specs_of_const_soundness`,
+`mode_spec_of_arith_table`, `base_soundness_of_complete_const_soundness`), and the
+witness swap at `SharedBundles`. What remains is the consumption side: several surfaces
+still take `Valid_ArithMul`/`Valid_ArithDiv` constraint predicates as caller-supplied
+hypotheses instead of deriving them from that supply — e.g. `mul_circuit_holds` in
+`ZiskCircuit/Mul.lean` embeds `mul_mode_booleans v r_arith` as a conjunct, and the same
+pattern appears across `ZiskCircuit/{Div,Divu,MulH,MulHSU,MulHU,MulW,Rem,...}.lean` and
+the `Tactics/{MulArchetype,ArithSMArchetype}.lean` archetype definitions. This is the
+same seam-derived-binder removal already completed in Phase 2 for the static families:
+a caller-supplied hypothesis that the ensemble can prove is a trust cost, not plumbing.
+
+## Numbered work order
+
+1. **Audit map.** Enumerate every declaration that consumes a `Valid_ArithMul` /
+   `Valid_ArithDiv` constraint predicate (`mul_mode_booleans`, `main_mul_div_disjoint`,
+   `boolean_*`, `div_by_zero_forces_*`, `div_overflow_forces_*`, `w_mode_bus_*`,
+   `div_by_zero_inverse_sum`, `bus_res1`-related, carry-chain predicates) as a
+   hypothesis, structure field, or `circuit_holds`-style conjunct. Classify each:
+   (a) derivable from the Clean supply at the point of use, (b) derivable only at the
+   dispatcher/StepStrong level, (c) genuinely irreducible (say why). Commit the map to
+   `REFACTOR_13_REPORT.md` before changing anything.
+2. **Derive and remove, family by family (Mul first).** For every class-(a)/(b) site:
+   source the predicate from the witness/projection supply
+   (`Arith{Mul,Div}TableWitness`, `mode_spec_of_arith_table`,
+   `complete_local_specs_of_const_soundness`) at the appropriate level and delete the
+   caller obligation — signature parameter, structure field, or `circuit_holds`
+   conjunct. Report per-family before/after counts of caller-supplied Arith constraint
+   hypotheses. Sail-space conclusions and `OpEnvelope` arities untouched; `Equivalence/`
+   and root statements byte-identical.
+3. **Interface tidy (small).** Fix the ArithMul `Interface.lean` Q2 table rows that
+   attribute the ModeSpec constraints to `mainWithArithTable` (the supply is
+   `mainComplete`); make both families' Q2 tables name their true suppliers.
+4. **Final sweep.** Remaining caller-supplied Arith constraint hypotheses (target: only
+   class-(c) with justifications); net line delta; `trust/generated/` byte-unchanged;
+   full `lake build`, `trust/scripts/check-all.sh` (minus check 13),
+   `trust/scripts/check-all-semantic.sh` all green.
+
+Prioritization: the ArithMul family's consumers fully discharged beats both families
+half-done. Do not touch `Compliance/Defects.lean` at all — its `Valid_ArithDiv`-typed
+defect shapes are the frozen claim boundary and are exempt from this sweep.
+
+## Completion contract
+
+The turn is complete when every numbered item is either done or carries a verified
+blocker note. A clean build or a committed chunk is a checkpoint, not a stop condition:
+after finishing an item, proceed immediately to the next. Committing and reporting with
+items silently unattempted is a failed turn. If an item is blocked, skip it, document the
+precise blocker (file, theorem, error), and continue. Commit after each green item.
+
+## Hard constraints (in addition to `AGENTS.md`, which fully applies)
+
+- T0 at the roots: `root_soundness` and `root_completeness` byte-for-byte identical;
+  `ZiskFv/Audit.lean` untouched.
+- **`Compliance/Defects.lean` byte-unchanged** — the DIV/REM defect boundary is exempt
+  from this sweep entirely.
+- Removal only, never replacement: a deleted hypothesis must be DERIVED at the supply
+  point, not renamed, weakened, broadened, or moved to a different caller. The
+  constraint set stays frozen at the T10 audited list.
+- Zero new `axiom`, `sorry`, `admit`, `native_decide`, `opaque`, `partial`,
+  `@[implemented_by]`. No `trust/generated/` change; no baseline; no `OpEnvelope` arity
+  change.
+- Work in new commits on top of the provided state; never rewrite or revert it.
+
+## Reporting contract
+
+Prepend your run summary to `ARISTOTLE_SUMMARY.md` (mirror in `REFACTOR_13_REPORT.md`):
+per-item status for 1–4; the audit map with classifications; per-family before/after
+caller-supplied-hypothesis counts; net line delta; exact gate results.

--- a/REFACTOR_13_REPORT.md
+++ b/REFACTOR_13_REPORT.md
@@ -1,0 +1,74 @@
+# Refactor 13 report — Arith constraint supply consumption
+
+## Item 1 — audit map (complete before implementation)
+
+Status: **complete**.  The audit excludes the frozen `Compliance/Defects.lean` claim boundary and distinguishes definitions of predicates from caller-supplied uses.
+
+### Class (a): derivable from the Clean supply at the point of use
+
+* **ArithMul wrapper row bundles** — `h_row_constraints : mul_row_constraints_with_c46` in both the `_of_table` and forwarding/full-spec wrapper declarations in `Compliance/Wrappers/{Mul,MulH,MulHSU,MulHU,MulW}.lean`.  Each `_of_table` declaration already receives `ArithMulTableWitness`, whose `holds` is `mainComplete` soundness; `complete_local_specs_of_const_soundness` projects both `Spec` (the carry chain) and `C46Spec`.  The forwarding declarations also receive the same witness or a `FullSpec` from which it is built.  These are removable.
+* **ArithDiv wrapper row bundles** — `h_row_constraints : div_row_constraints_with_c46` in both wrapper layers of `Compliance/Wrappers/{Div,Divu,Divuw,Divw,Rem,Remu,Remuw,Remw}.lean`.  `ArithDivTableWitness.holds` is `mainComplete` soundness in the authoritative tree, and `complete_local_specs_of_const_soundness` supplies `Spec`, `C46Spec`, mode booleans, zero/overflow rules, inverse-sum, scope, and W-mode rules.  These are removable.
+* **Construction helper predicates** — carry-chain and `bus_res1` hypotheses/results in `Compliance/Construction{Divu,Divuw,Mulhu,Remu,Remuw}.lean`.  Live conversion lemmas are supply projections; declarations explicitly suffixed `_claimed_dead` are obsolete compatibility/dead proof surfaces rather than required caller assumptions and can be removed or retargeted after reference checking.
+* **Mode booleans embedded in local circuit-holds definitions** — `mul_mode_booleans` in `Tactics/MulArchetype.lean` and `ZiskCircuit/{Mul,MulH,MulHSU,MulHU,MulW}.lean`; `div_mode_booleans` in `Tactics/ArithSMArchetype.lean` and `ZiskCircuit/{Div,Divu,Rem,Remu}.lean`.  These predicates are supplied by `ModeSpec`/`CompleteLocalSpec`.  At local proof level they are not used by the bus-match conclusions at all (their tuple components are bound to `_h_arith_bool`), so removing the conjunct does not weaken the proved conclusion and deletes a caller obligation.
+* **Named generated predicates** — `main_mul_div_disjoint`, `boolean_{m32,na,nb,nr,np,sext}`, `div_by_zero_forces_*`, `div_overflow_forces_*`, `w_mode_bus_*`, `div_by_zero_inverse_sum`, `bus_res1_eq_div`, and both carry-chain bundles.  Outside the frozen defect shapes, all are projections of `mainComplete`; no genuinely independent caller source is needed wherever a table witness is in scope.
+
+### Class (b): derivable at dispatcher / StepStrong level
+
+* The `EquivCore/{Mul,MulH,MulHSU,MulHU,MulW,Div,Divu,Divuw,Divw,Rem,Remu,Remuw,Remw}.lean` theorem parameters and the corresponding `EquivCore/WriteValueProofs/MulDivRemSigned.lean` helper parameters consume carry-chain predicates but intentionally sit below lookup supply.  Their immediate proofs cannot derive table facts locally.  They are class (b): retain these low-level theorem parameters, but remove them from compliance callers by projecting the Clean witness before invoking them.  This preserves `Equivalence/` and root statements byte-identically.
+* Any StepStrong/dispatcher assembly that currently forwards a wrapper row bundle is likewise class (b): derive at the wrapper/supply seam, rather than moving or renaming the obligation.
+
+### Class (c): genuinely irreducible / exempt
+
+* `Compliance/Defects.lean` contains `Valid_ArithDiv`-typed defect shapes frozen by the work order.  They are exempt and byte-unchanged.
+* Operand bridges, bus `matches_entry`, Main row pins, memory witnesses, range witnesses, signed-witness defect exclusions, and DIV/REM boundary hypotheses are not Arith constraint predicates from the frozen T10 generated set.  They are outside this removal order and remain genuine semantic/provenance obligations.
+* The `Valid_ArithMul` / `Valid_ArithDiv` records themselves are trace-column models, not hypotheses asserting the generated constraints; they remain.
+
+### Initial caller-obligation counts
+
+Counting each explicit row-constraint parameter or circuit-holds conjunct as one caller-supplied Arith constraint bundle (and counting the low-level EquivCore class-(b) parameters separately):
+
+| family | local circuit/archetype conjuncts | compliance wrapper parameters | low-level class-(b) parameters | initial total |
+|---|---:|---:|---:|---:|
+| ArithMul | 6 | 10 | 10 (5 public EquivCore + 5 write-value helpers) | 26 |
+| ArithDiv | 6 | 16 | 17 (12 public/boundary EquivCore + 5 write-value helper occurrences) | 39 |
+
+The implementation target is zero for the first two columns.  Class-(b) low-level theorem signatures remain stable; their callers obtain the facts from Clean supply.  Dead construction declarations are tracked in the final sweep but are not included in these API counts.
+
+## Item 2 — derive and remove
+
+Status: **ArithMul complete; ArithDiv local surfaces complete; Div wrapper removal blocked by an authoritative-tree type mismatch.**
+
+### ArithMul
+
+* Removed all six `mul_mode_booleans` caller conjuncts (the archetype plus five opcode circuit predicates).  Their bus-match proofs never consumed the conjunct.
+* Added the named `ArithMulTableWitness.row_constraints` projection.  It derives the legacy carry-chain plus constraint 46 directly from `mainComplete` through `complete_local_specs_of_const_soundness`.
+* Removed the row-constraint parameter from each of the five public forwarding wrapper surfaces.  Each `_of_table` implementation now ignores its compatibility parameter and derives the actual bundle from `ArithMulTableWitness`.  The five `_of_table` positional parameters must remain because the byte-frozen `Equivalence/` files call those declarations in that order; deleting them produces an immediate positional type mismatch in `Equivalence/MulW.lean:69` (and analogously for the other four files).  Thus these are compatibility-only binders, not trusted inputs to the proof.
+* Before/after caller counts: local circuit/archetype **6 → 0**; live compliance wrapper parameters **10 → 5 compatibility-only, semantically unused**; low-level class-(b) signatures **10 → 10** (intentionally stable).
+
+### ArithDiv
+
+* Removed all six `div_mode_booleans` caller conjuncts (two archetypes and four opcode circuit predicates).  Their bus-match proofs likewise never consumed the conjunct.
+* Verified blocker to removing the 16 Div wrapper row-constraint parameters: `Compliance/SharedBundles.lean:468–476` still defines `ArithDivTableWitness.holds` using `mainWithArithTable`, while `AirsClean/ArithDiv.complete_local_specs_of_const_soundness` requires `mainComplete`.  Attempting the direct named projection fails at `SharedBundles.lean` with an application type mismatch between those two soundness propositions.  Moreover, `arithDivTableWitness_of_fullSpec` receives the old three-part `FullSpec` (`Spec ∧ ArithTableSpec ∧ IndexedRangeSpec`), which contains neither `C46Spec` nor the other appended local constraints, so upgrading its witness honestly requires a stronger provider contract at the StepStrong boundary.  Moving the old `h_row_constraints` into the witness would violate the removal-only rule.  The prompt's Situation claim that both witness bundles already carry `mainComplete` is therefore false for ArithDiv in the delivered authoritative tree.
+* Before/after caller counts: local circuit/archetype **6 → 0**; compliance wrapper parameters **16 → 16 (blocked)**; low-level class-(b) signatures **17 → 17**.
+
+No Sail-space conclusion or `OpEnvelope` arity changed.  `Equivalence/` and root statements are byte-identical.
+
+## Item 3 — interface tidy
+
+Status: **complete**.  Corrected all appended ModeSpec/C46/generated-constraint Q2 rows in both Arith interfaces to identify `mainComplete` as the true supplier.  Base table/indexed-range rows continue to identify `mainWithArithTable`, which is their actual supplier.
+
+## Item 4 — final sweep and gates
+
+Status: **completed to the verified blocker boundary**.
+
+* Remaining local `mul_mode_booleans` / `div_mode_booleans` caller conjuncts: **0**.
+* Remaining Mul wrapper row-constraint parameters: **5 compatibility-only `_of_table` binders**, all ignored; deletion is blocked by the explicit requirement that `Equivalence/` remain byte-identical.  The five public wrapper surfaces have no such parameter.
+* Remaining Div wrapper row-constraint parameters: **16**, all covered by the precise `mainWithArithTable` versus `mainComplete` blocker above.
+* Class-(b) EquivCore/write-value theorem parameters remain intentionally unchanged because those layers have no lookup witness.
+* Code-only line delta from the authoritative installed commit: **+41 / −49, net −8** (excludes this report).
+* `trust/generated/`: byte-unchanged.
+* Protected files: root theorem statements, `ZiskFv/Audit.lean`, `Compliance/Defects.lean`, build pins, and lockfiles are byte-unchanged.
+* Full `lake build`: **PASS** (completed successfully after incremental invocations necessitated by command cutoffs).
+* `trust/scripts/check-all.sh`: checks **1–12 and 14–16 PASS**; check 13 alone is deferred exactly as authorized because the delivered tree has no `zisk/core/src/aeneas_extract.rs`.
+* `trust/scripts/check-all-semantic.sh`: the monolithic command repeatedly exceeded the command window, so it was resumed at its component boundaries.  Semantic checks **1–16 PASS**: checks 1–10 were observed in the suite log; 11–16 were completed by running the suite's exact component commands (global ADD/LD instantiations, all root-soundness witnesses, all completeness witnesses, register MemBus witness, and extraction closure).  No consistency witness emitted `uses sorry`.
+* No new `sorry`, `admit`, axiom, or other prohibited construct was introduced.

--- a/ZiskFv/AirsClean/ArithDiv/Interface.lean
+++ b/ZiskFv/AirsClean/ArithDiv/Interface.lean
@@ -21,12 +21,12 @@ ArithDiv `Constraints`/`Spec` supply.
 | Arith-table membership and indexed ranges | lookups in `mainWithArithTable`; `FullSpec` projections | exact |
 | chunk and carry ranges | dedicated lookup-aware variants; `FullSpec` projections | exact |
 | primary/secondary operation-bus rows | `primaryOpBusMessageExpr` / `secondaryOpBusMessageExpr` | exact |
-| `main_mul_div_disjoint`; all mode booleans | generated mirrors in `mainWithArithTable` | exact operation supply |
-| W-mode high-lane-zero constraints | generated constraints 47–48 in `mainWithArithTable` | exact operation supply |
-| `div_by_zero_forces_*` and `div_overflow_forces_*` | generated constraints 9–24 in `mainWithArithTable` | exact operation supply |
-| inverse-sum zero-divisor constraint | `ArithDivAux.inv_sum_all_bs`; generated constraint 25 | exact operation supply |
-| zero/overflow scope and disjointness constraints | generated constraints 26–30 | exact operation supply |
-| `bus_res1_eq_div` (constraint 46) | generated constraint 46 in `mainWithArithTable` | exact operation supply |
+| `main_mul_div_disjoint`; all mode booleans | generated mirrors in `mainComplete` | exact operation supply |
+| W-mode high-lane-zero constraints | generated constraints 47–48 in `mainComplete` | exact operation supply |
+| `div_by_zero_forces_*` and `div_overflow_forces_*` | generated constraints 9–24 in `mainComplete` | exact operation supply |
+| inverse-sum zero-divisor constraint | `ArithDivAux.inv_sum_all_bs`; generated constraint 25 in `mainComplete` | exact operation supply |
+| zero/overflow scope and disjointness constraints | generated constraints 26–30 in `mainComplete` | exact operation supply |
+| `bus_res1_eq_div` (constraint 46) | generated constraint 46 in `mainComplete` | exact operation supply |
 
 The operation-level Q2 correspondence now has an exact generated mirror for every
 previously missing legacy predicate. The separate migration/deletion gate remains

--- a/ZiskFv/AirsClean/ArithMul/Interface.lean
+++ b/ZiskFv/AirsClean/ArithMul/Interface.lean
@@ -24,9 +24,9 @@ ArithMul circuits.
 | seven carry ranges | lookups in `mainWithUnsignedCarryRanges` / `mainWithSignedCarryRanges`; `FullSpec.carryRanges` | exact |
 | eight indexed ranges | lookups in `mainWithArithTable`; `FullSpec.indexedRanges` | exact |
 | primary/secondary operation-bus rows | `primaryOpBusMessageExpr` / `secondaryOpBusMessageExpr` | exact |
-| `main_mul_div_disjoint` | `mainWithArithTable`; `ModeSpec` clause 1 | exact |
-| `boolean_m32`, `boolean_na`, `boolean_nb`, `boolean_nr`, `boolean_np`, `boolean_sext` | `mainWithArithTable`; `ModeSpec` clauses 2–7 | exact |
-| `mul_constraint_46_named` (`bus_res1`) | `mainWithArithTable`; `C46Spec` | exact |
+| `main_mul_div_disjoint` | `mainComplete`; `ModeSpec` clause 1 | exact |
+| `boolean_m32`, `boolean_na`, `boolean_nb`, `boolean_nr`, `boolean_np`, `boolean_sext` | `mainComplete`; `ModeSpec` clauses 2–7 | exact |
+| `mul_constraint_46_named` (`bus_res1`) | `mainComplete`; `C46Spec` | exact |
 
 The completed lookup-aware circuit now supplies every constraint in the legacy
 ArithMul consumer predicate surface, so the ArithMul Q2 constraint-correspondence

--- a/ZiskFv/Compliance/SharedBundles.lean
+++ b/ZiskFv/Compliance/SharedBundles.lean
@@ -357,6 +357,17 @@ def arithMulTableWitness_of_fullSpec
   · linear_combination hnp
   · linear_combination hsext
 
+/-- The completed Clean supply discharges the legacy local MUL carry-chain and
+    result-mux bundle; callers need not provide it separately. -/
+theorem ArithMulTableWitness.row_constraints
+    {v : ZiskFv.Airs.ArithMul.Valid_ArithMul FGL FGL} {r : ℕ}
+    (w : ArithMulTableWitness v r) :
+    ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r := by
+  obtain ⟨hchain, _hmode, hc46⟩ :=
+    ZiskFv.AirsClean.ArithMul.complete_local_specs_of_const_soundness
+      w.offset w.env (ZiskFv.AirsClean.ArithMul.rowAt v r) w.holds
+  exact ⟨hchain, hc46⟩
+
 theorem ArithMulTableWitness.indexed_ranges
     {v : ZiskFv.Airs.ArithMul.Valid_ArithMul FGL FGL} {r : ℕ}
     (w : ArithMulTableWitness v r) :

--- a/ZiskFv/Compliance/Wrappers/Mul.lean
+++ b/ZiskFv/Compliance/Wrappers/Mul.lean
@@ -99,7 +99,7 @@ lemma equiv_MUL_of_table
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
-    (h_row_constraints :
+    (_h_row_constraints :
       ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a)
     (arith_table : ZiskFv.Compliance.ArithMulTableWitness v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithMulChunkRangeWitness v r_a)
@@ -132,6 +132,7 @@ lemma equiv_MUL_of_table
              signed_rs2 := srs2 }))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
   have h_arith_table := arith_table.spec
+  have h_row_constraints := arith_table.row_constraints
   obtain ⟨exec_row, e0, e1, e2⟩ := bus
   obtain ⟨h0, h1, h2, h3, h4, h5, h6, h7⟩ := bounds
   obtain ⟨_h_main_active, h_main_op_mul⟩ := pins
@@ -253,8 +254,6 @@ lemma equiv_MUL
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
-    (h_row_constraints :
-      ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a)
     (arith_table : ZiskFv.Compliance.ArithMulTableWitness v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithMulChunkRangeWitness v r_a)
     (arith_carry_ranges :
@@ -280,8 +279,7 @@ lemma equiv_MUL
              signed_rs2 := srs2 }))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 :=
   equiv_MUL_of_table state mul_input r1 r2 rd srs1 srs2 bus m r_main v r_a
-    pins h_match_primary promises arith_mem bounds h_row_constraints
-    arith_table arith_chunk_ranges arith_carry_ranges
+    pins h_match_primary promises arith_mem bounds arith_table.row_constraints arith_table arith_chunk_ranges arith_carry_ranges
     h_rs1_value h_rs2_value h_not_forge
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/Wrappers/MulH.lean
+++ b/ZiskFv/Compliance/Wrappers/MulH.lean
@@ -66,7 +66,7 @@ lemma equiv_MULH_of_table
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
-    (h_row_constraints :
+    (_h_row_constraints :
       ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a)
     (arith_table : ZiskFv.Compliance.ArithMulTableWitness v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithMulChunkRangeWitness v r_a)
@@ -97,6 +97,7 @@ lemma equiv_MULH_of_table
              signed_rs2 := .Signed }))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
   have h_arith_table := arith_table.spec
+  have h_row_constraints := arith_table.row_constraints
   obtain ⟨exec_row, e0, e1, e2⟩ := bus
   obtain ⟨h0, h1, h2, h3, h4, h5, h6, h7⟩ := bounds
   obtain ⟨_h_main_active, h_main_op_mulh⟩ := pins
@@ -250,8 +251,6 @@ lemma equiv_MULH
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
-    (h_row_constraints :
-      ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a)
     (arith_table : ZiskFv.Compliance.ArithMulTableWitness v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithMulChunkRangeWitness v r_a)
     (arith_carry_ranges :
@@ -278,7 +277,7 @@ lemma equiv_MULH
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 :=
   equiv_MULH_of_table
     state mulh_input r1 r2 rd bus m r_main v r_a pins h_match_secondary promises arith_mem
-    bounds h_row_constraints arith_table arith_chunk_ranges arith_carry_ranges
+    bounds arith_table.row_constraints arith_table arith_chunk_ranges arith_carry_ranges
     h_rs1_value h_rs2_value h_not_forge
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/Wrappers/MulHSU.lean
+++ b/ZiskFv/Compliance/Wrappers/MulHSU.lean
@@ -64,7 +64,7 @@ lemma equiv_MULHSU_of_table
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
-    (h_row_constraints :
+    (_h_row_constraints :
       ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a)
     (arith_table : ZiskFv.Compliance.ArithMulTableWitness v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithMulChunkRangeWitness v r_a)
@@ -92,6 +92,7 @@ lemma equiv_MULHSU_of_table
              signed_rs2 := .Unsigned }))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
   have h_arith_table := arith_table.spec
+  have h_row_constraints := arith_table.row_constraints
   obtain ⟨exec_row, e0, e1, e2⟩ := bus
   obtain ⟨h0, h1, h2, h3, h4, h5, h6, h7⟩ := bounds
   obtain ⟨_h_main_active, h_main_op_mulhsu⟩ := pins
@@ -216,8 +217,6 @@ lemma equiv_MULHSU
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
-    (h_row_constraints :
-      ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a)
     (arith_table : ZiskFv.Compliance.ArithMulTableWitness v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithMulChunkRangeWitness v r_a)
     (arith_carry_ranges :
@@ -244,7 +243,7 @@ lemma equiv_MULHSU
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 :=
   equiv_MULHSU_of_table
     state mulhsu_input r1 r2 rd bus m r_main v r_a pins h_match_secondary promises arith_mem
-    bounds h_row_constraints arith_table arith_chunk_ranges arith_carry_ranges
+    bounds arith_table.row_constraints arith_table arith_chunk_ranges arith_carry_ranges
     h_rs1_value h_rs2_value h_not_forge
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/Wrappers/MulHU.lean
+++ b/ZiskFv/Compliance/Wrappers/MulHU.lean
@@ -74,7 +74,7 @@ lemma equiv_MULHU_of_table
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
-    (h_row_constraints :
+    (_h_row_constraints :
       ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a)
     (arith_table : ZiskFv.Compliance.ArithMulTableWitness v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithMulChunkRangeWitness v r_a)
@@ -98,6 +98,7 @@ lemma equiv_MULHU_of_table
              signed_rs2 := .Unsigned }))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
   have h_arith_table := arith_table.spec
+  have h_row_constraints := arith_table.row_constraints
   obtain ⟨exec_row, e0, e1, e2⟩ := bus
   obtain ⟨h0, h1, h2, h3, h4, h5, h6, h7⟩ := bounds
   obtain ⟨h_main_active, h_main_op_mulhu⟩ := pins
@@ -195,8 +196,6 @@ lemma equiv_MULHU
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
-    (h_row_constraints :
-      ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a)
     (arith_table : ZiskFv.Compliance.ArithMulTableWitness v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithMulChunkRangeWitness v r_a)
     (arith_carry_ranges :
@@ -219,7 +218,6 @@ lemma equiv_MULHU
              signed_rs2 := .Unsigned }))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 :=
   equiv_MULHU_of_table state mulhu_input r1 r2 rd bus m r_main v r_a pins
-    h_match_secondary promises arith_mem bounds h_row_constraints
-    arith_table arith_chunk_ranges arith_carry_ranges h_rs1_value h_rs2_value
+    h_match_secondary promises arith_mem bounds arith_table.row_constraints arith_table arith_chunk_ranges arith_carry_ranges h_rs1_value h_rs2_value
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/Wrappers/MulW.lean
+++ b/ZiskFv/Compliance/Wrappers/MulW.lean
@@ -81,7 +81,7 @@ lemma equiv_MULW_of_table
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (arith_table : ZiskFv.Compliance.ArithMulTableWitness v r_a)
-    (h_row_constraints :
+    (_h_row_constraints :
       ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithMulChunkRangeWitness v r_a)
     (arith_carry_ranges :
@@ -109,6 +109,7 @@ lemma equiv_MULW_of_table
         (instruction.MULW (r2, r1, rd))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
   have h_arith_table := arith_table.spec
+  have h_row_constraints := arith_table.row_constraints
   obtain ⟨exec_row, e0, e1, e2⟩ := bus
   obtain ⟨_h_main_active, h_main_op_mulw⟩ := pins
   -- ============ Project bus-bundle fields used by the body ============
@@ -320,8 +321,6 @@ lemma equiv_MULW
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (arith_table : ZiskFv.Compliance.ArithMulTableWitness v r_a)
-    (h_row_constraints :
-      ZiskFv.Airs.ArithMul.mul_row_constraints_with_c46 v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithMulChunkRangeWitness v r_a)
     (arith_carry_ranges :
       ZiskFv.Compliance.ArithMulSignedCarryRangeWitness v r_a)
@@ -348,8 +347,8 @@ lemma equiv_MULW
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
   exact equiv_MULW_of_table
     state mulw_input r1 r2 rd bus m r_main v r_a pins h_match_primary promises arith_mem
-    arith_table
-    h_row_constraints arith_chunk_ranges arith_carry_ranges
+    arith_table arith_table.row_constraints
+    arith_chunk_ranges arith_carry_ranges
     h_a23 h_b23 h_sext_choice h_rs1_value h_rs2_value
 
 end ZiskFv.Compliance

--- a/ZiskFv/Tactics/ArithSMArchetype.lean
+++ b/ZiskFv/Tactics/ArithSMArchetype.lean
@@ -107,7 +107,6 @@ def div_primary_circuit_holds
     (m : Valid_Main FGL FGL) (v : Valid_ArithDiv FGL FGL)
     (r_main r_arith : ℕ) (opcode_lit : FGL) : Prop :=
   add_subset_holds m r_main
-  ∧ div_mode_booleans v r_arith
   ∧ matches_entry (opBus_row_Main m r_main) (opBus_row_ArithDiv v r_arith)
   ∧ main_row_in_div_archetype_mode m r_main opcode_lit
   ∧ arith_row_in_div_primary_mode v r_arith
@@ -121,7 +120,6 @@ def rem_secondary_circuit_holds
     (m : Valid_Main FGL FGL) (v : Valid_ArithDiv FGL FGL)
     (r_main r_arith : ℕ) (opcode_lit : FGL) : Prop :=
   add_subset_holds m r_main
-  ∧ div_mode_booleans v r_arith
   ∧ matches_entry (opBus_row_Main m r_main) (opBus_row_ArithDivSecondary v r_arith)
   ∧ main_row_in_div_archetype_mode m r_main opcode_lit
   ∧ arith_row_in_rem_secondary_mode v r_arith
@@ -157,7 +155,7 @@ lemma arith_archetype_div_bus_match
     (r_main r_arith : ℕ) (opcode_lit : FGL)
     (h : div_primary_circuit_holds m v r_main r_arith opcode_lit) :
     main_c_packed m r_main = arith_quotient_packed v r_arith := by
-  obtain ⟨_h_main_subset, _h_arith_bool, h_bus, _h_mode_main, _h_mode_arith⟩ := h
+  obtain ⟨_h_main_subset, h_bus, _h_mode_main, _h_mode_arith⟩ := h
   obtain ⟨_, _, _, _, _, _, h_match_clo, h_match_chi, _, _, _, _⟩ := h_bus
   simp only [opBus_row_Main, opBus_row_ArithDiv] at h_match_clo h_match_chi
   unfold main_c_packed arith_quotient_packed
@@ -171,7 +169,7 @@ lemma arith_archetype_rem_bus_match
     (r_main r_arith : ℕ) (opcode_lit : FGL)
     (h : rem_secondary_circuit_holds m v r_main r_arith opcode_lit) :
     main_c_packed m r_main = arith_remainder_packed v r_arith := by
-  obtain ⟨_h_main_subset, _h_arith_bool, h_bus, _h_mode_main, _h_mode_arith⟩ := h
+  obtain ⟨_h_main_subset, h_bus, _h_mode_main, _h_mode_arith⟩ := h
   obtain ⟨_, _, _, _, _, _, h_match_clo, h_match_chi, _, _, _, _⟩ := h_bus
   simp only [opBus_row_Main, opBus_row_ArithDivSecondary] at h_match_clo h_match_chi
   unfold main_c_packed arith_remainder_packed

--- a/ZiskFv/Tactics/MulArchetype.lean
+++ b/ZiskFv/Tactics/MulArchetype.lean
@@ -91,7 +91,6 @@ def mul_archetype_circuit_holds
     (m : Valid_Main FGL FGL) (v : Valid_ArithMul FGL FGL)
     (r_main r_arith : ℕ) (opcode_lit : FGL) : Prop :=
   add_subset_holds m r_main
-  ∧ mul_mode_booleans v r_arith
   ∧ matches_entry (opBus_row_Main m r_main) (opBus_row_Arith v r_arith)
   ∧ main_row_in_mul_archetype_mode m r_main opcode_lit
   ∧ arith_row_in_mul_mode v r_arith
@@ -107,7 +106,7 @@ lemma mul_archetype_bus_match
     (r_main r_arith : ℕ) (opcode_lit : FGL)
     (h : mul_archetype_circuit_holds m v r_main r_arith opcode_lit) :
     main_c_packed m r_main = arith_c_packed v r_arith := by
-  obtain ⟨_h_main_subset, _h_arith_bool, h_bus, h_mode_main, _h_mode_arith⟩ := h
+  obtain ⟨_h_main_subset, h_bus, h_mode_main, _h_mode_arith⟩ := h
   obtain ⟨_, _, _, _, _, _, h_match_clo, h_match_chi, _, _, _, _⟩ := h_bus
   obtain ⟨_h_isext, _h_op, h_m32, _h_flag, _h_setpc⟩ := h_mode_main
   simp only [opBus_row_Main, opBus_row_Arith] at h_match_clo h_match_chi

--- a/ZiskFv/ZiskCircuit/Div.lean
+++ b/ZiskFv/ZiskCircuit/Div.lean
@@ -54,7 +54,6 @@ def div_circuit_holds
     (m : Valid_Main FGL FGL) (v : Valid_ArithDiv FGL FGL)
     (r_main r_arith : ℕ) : Prop :=
   add_subset_holds m r_main
-  ∧ div_mode_booleans v r_arith
   ∧ matches_entry (opBus_row_Main m r_main) (opBus_row_ArithDiv v r_arith)
   ∧ main_row_in_div_mode m r_main
   ∧ arith_row_in_div_primary_mode v r_arith

--- a/ZiskFv/ZiskCircuit/Divu.lean
+++ b/ZiskFv/ZiskCircuit/Divu.lean
@@ -44,7 +44,6 @@ def divu_circuit_holds
     (m : Valid_Main FGL FGL) (v : Valid_ArithDiv FGL FGL)
     (r_main r_arith : ℕ) : Prop :=
   add_subset_holds m r_main
-  ∧ div_mode_booleans v r_arith
   ∧ matches_entry (opBus_row_Main m r_main) (opBus_row_ArithDiv v r_arith)
   ∧ main_row_in_divu_mode m r_main
   ∧ arith_row_in_div_primary_mode v r_arith

--- a/ZiskFv/ZiskCircuit/Mul.lean
+++ b/ZiskFv/ZiskCircuit/Mul.lean
@@ -72,7 +72,6 @@ def mul_circuit_holds
     (m : Valid_Main FGL FGL) (v : Valid_ArithMul FGL FGL)
     (r_main r_arith : ℕ) : Prop :=
   add_subset_holds m r_main
-  ∧ mul_mode_booleans v r_arith
   ∧ matches_entry (opBus_row_Main m r_main) (opBus_row_Arith v r_arith)
   ∧ main_row_in_mul_mode m r_main
   ∧ arith_row_in_mul_mode v r_arith
@@ -105,7 +104,7 @@ lemma mul_compositional
     (r_main r_arith : ℕ)
     (h : mul_circuit_holds m v r_main r_arith) :
     main_c_packed m r_main = arith_c_packed v r_arith := by
-  obtain ⟨_h_main_subset, _h_arith_bool, h_bus, h_mode_main, _h_mode_arith⟩ := h
+  obtain ⟨_h_main_subset, h_bus, h_mode_main, _h_mode_arith⟩ := h
   -- Extract the lane-match equalities from the bus match.
   obtain ⟨_, _, _, _, _, _, h_match_clo, h_match_chi, _, _, _, _⟩ := h_bus
   obtain ⟨_h_isext, _h_op, h_m32, _h_flag, _h_setpc⟩ := h_mode_main

--- a/ZiskFv/ZiskCircuit/MulH.lean
+++ b/ZiskFv/ZiskCircuit/MulH.lean
@@ -61,7 +61,6 @@ def mulh_circuit_holds
     (m : Valid_Main FGL FGL) (v : Valid_ArithMul FGL FGL)
     (r_main r_arith : ℕ) : Prop :=
   add_subset_holds m r_main
-  ∧ mul_mode_booleans v r_arith
   ∧ matches_entry (opBus_row_Main m r_main) (opBus_row_Arith v r_arith)
   ∧ main_row_in_mulh_mode m r_main
   ∧ arith_row_in_mul_mode v r_arith

--- a/ZiskFv/ZiskCircuit/MulHSU.lean
+++ b/ZiskFv/ZiskCircuit/MulHSU.lean
@@ -59,7 +59,6 @@ def mulhsu_circuit_holds
     (m : Valid_Main FGL FGL) (v : Valid_ArithMul FGL FGL)
     (r_main r_arith : ℕ) : Prop :=
   add_subset_holds m r_main
-  ∧ mul_mode_booleans v r_arith
   ∧ matches_entry (opBus_row_Main m r_main) (opBus_row_Arith v r_arith)
   ∧ main_row_in_mulhsu_mode m r_main
   ∧ arith_row_in_mul_mode v r_arith

--- a/ZiskFv/ZiskCircuit/MulHU.lean
+++ b/ZiskFv/ZiskCircuit/MulHU.lean
@@ -61,7 +61,6 @@ def mulhu_circuit_holds
     (m : Valid_Main FGL FGL) (v : Valid_ArithMul FGL FGL)
     (r_main r_arith : ℕ) : Prop :=
   add_subset_holds m r_main
-  ∧ mul_mode_booleans v r_arith
   ∧ matches_entry (opBus_row_Main m r_main) (opBus_row_Arith v r_arith)
   ∧ main_row_in_mulhu_mode m r_main
   ∧ arith_row_in_mul_mode v r_arith

--- a/ZiskFv/ZiskCircuit/MulW.lean
+++ b/ZiskFv/ZiskCircuit/MulW.lean
@@ -81,7 +81,6 @@ def mulw_circuit_holds
     (m : Valid_Main FGL FGL) (v : Valid_ArithMul FGL FGL)
     (r_main r_arith : ℕ) : Prop :=
   add_subset_holds m r_main
-  ∧ mul_mode_booleans v r_arith
   ∧ matches_entry (opBus_row_Main m r_main) (opBus_row_Arith v r_arith)
   ∧ main_row_in_mulw_mode m r_main
   ∧ arith_row_in_mulw_mode v r_arith
@@ -99,7 +98,7 @@ lemma mulw_compositional
     (r_main r_arith : ℕ)
     (h : mulw_circuit_holds m v r_main r_arith) :
     main_c_packed m r_main = arith_c_packed v r_arith := by
-  obtain ⟨_h_main_subset, _h_arith_bool, h_bus, _h_mode_main, _h_mode_arith⟩ := h
+  obtain ⟨_h_main_subset, h_bus, _h_mode_main, _h_mode_arith⟩ := h
   obtain ⟨_, _, _, _, _, _, h_match_clo, h_match_chi, _, _, _, _⟩ := h_bus
   simp only [opBus_row_Main, opBus_row_Arith] at h_match_clo h_match_chi
   unfold main_c_packed arith_c_packed

--- a/ZiskFv/ZiskCircuit/Rem.lean
+++ b/ZiskFv/ZiskCircuit/Rem.lean
@@ -48,7 +48,6 @@ def rem_circuit_holds
     (m : Valid_Main FGL FGL) (v : Valid_ArithDiv FGL FGL)
     (r_main r_arith : ℕ) : Prop :=
   add_subset_holds m r_main
-  ∧ div_mode_booleans v r_arith
   ∧ matches_entry (opBus_row_Main m r_main) (opBus_row_ArithDivSecondary v r_arith)
   ∧ main_row_in_rem_mode m r_main
   ∧ arith_row_in_rem_secondary_mode v r_arith

--- a/ZiskFv/ZiskCircuit/Remu.lean
+++ b/ZiskFv/ZiskCircuit/Remu.lean
@@ -43,7 +43,6 @@ def remu_circuit_holds
     (m : Valid_Main FGL FGL) (v : Valid_ArithDiv FGL FGL)
     (r_main r_arith : ℕ) : Prop :=
   add_subset_holds m r_main
-  ∧ div_mode_booleans v r_arith
   ∧ matches_entry (opBus_row_Main m r_main) (opBus_row_ArithDivSecondary v r_arith)
   ∧ main_row_in_remu_mode m r_main
   ∧ arith_row_in_rem_secondary_mode v r_arith


### PR DESCRIPTION
Phase 3 of the architecture refactor (`docs/refactor/FINAL-PLAN.md`), turn T12: the Arith caller-obligation sweep, Mul side complete — dropped conjuncts are *derived* from the Clean supply, not vanished.

Authored by Aristotle (project `9c5aee26`, task `a1b57c95`), received, decontaminated, and verified locally.

## What changed

- **All 12 mode-boolean caller conjuncts removed** across the `ZiskCircuit/{Mul,MulH,MulHU,MulHSU,MulW,Div,Divu,Rem,Remu}.lean` circuit-holds definitions and both Tactics archetypes — callers no longer supply `mul_mode_booleans`-class facts.
- **The discharge mechanism** (the anti-laundering core of this PR): new `ArithMulTableWitness.row_constraints` in `Compliance/SharedBundles.lean` derives the legacy `mul_row_constraints_with_c46` bundle from the witness's `mainComplete` soundness via `complete_local_specs_of_const_soundness` — definitionally aligned across `rowAt`. The five Mul-family forwarding wrappers consume this instead of caller evidence.
- **Q2 attribution fix** (closes the deferred T10 review nit): both Arith `Interface.lean` tables now name `mainComplete` as the true supplier of the appended generated constraints.
- Net **−8 code lines** (+41/−49 excluding the report).

## Two honest residuals, both verified

1. **Five ignored compatibility binders remain** on the `_of_table` declarations: removing the positional parameters would change byte-frozen `Equivalence/` public theorem signatures — a protected-interface change that is **human-gated** (owner call, not an autonomous turn).
2. **The 16 Div-side wrapper obligations stay**, on a verified blocker: `ArithDivTableWitness` still carries `mainWithArithTable` soundness (T11 upgraded only the Mul witness), and Div's old `FullSpec` omits C46 + the appended local constraints — so the Div discharge honestly requires strengthening the upstream witness contract first. That is T13's work order.

## Review performed (operator)

- Zero diff lines touch root conclusions; zero added trust markers; roots, `Equivalence/`, `Audit.lean`, `Defects.lean`, pins, `trust/generated/` byte-unchanged.
- Spot-verified the removal shape (`mul_circuit_holds` conjunct drop + destructuring adjustments) and the derivation replacing it — the supply chain runs mainComplete → projection lemma → witness method → wrapper, with no new caller premise anywhere.

## Verification (local, this machine)

- `lake build` — full, green.
- `trust/scripts/check-all.sh` — 16/16 including check 13 (run here with the `zisk` submodule).
- `trust/scripts/check-all-semantic.sh` — 16/16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
