### PR TITLE
Phase 3: R14 audit — ArithDiv witness upgrade blocked on live-provider model gap

### DIFF
--- a/ARISTOTLE_SUMMARY.md
+++ b/ARISTOTLE_SUMMARY.md
@@ -1,3 +1,37 @@
+# Summary of changes for run e1d22ee1-db39-4a62-bdeb-99cf4f2a1aae
+Completed the Refactor 14 work order to its verified boundary.
+
+- Installed and byte-verified all 838 archived files/symlinks non-destructively while preserving `.lake`; the attached tarball was not committed.
+- Audited the complete `ArithDivTableWitness` construction path and documented it in `REFACTOR_14_REPORT.md`.
+- Verified a precise blocker: the live ensemble validates the shared `ArithMul.mainWithArithTable` provider, not `ArithDiv.mainComplete`; moreover, `vOfDivuRow` sets the unavailable inverse witness `inv_sum_all_bs` to zero, making the required inverse-sum equation false for ordinary nonzero DIV/REM rows. Therefore upgrading the contract or deleting the 16 wrapper obligations would be unsound obligation laundering.
+- Documented all eight wrappers at 2 → 2 obligations, the necessary architectural remediation, zero proof-code line delta, and all protected-file invariants.
+- Prepended the same run summary to `ARISTOTLE_SUMMARY.md` as required.
+
+Verification:
+- Full `lake build` passed.
+- Trust checks 1–12 and 14–16 passed; check 13 was deferred because the supplied tree lacks `zisk/core/src/aeneas_extract.rs`, as authorized by the work order.
+- All 16 semantic trust checks passed.
+- Roots, `ZiskFv/Audit.lean`, `Compliance/Defects.lean`, `Equivalence/`, build pins/lockfiles, and `trust/generated/` remain unchanged from the delivered tree.
+
+All retained changes were committed and pushed.
+
+# Summary of changes for Refactor 14
+
+Installed and byte-verified all 838 archived files/symlinks non-destructively while preserving `.lake`; the attached tarball remains untracked and was not committed.
+
+Per-item status:
+1. **Construction-path audit complete.** `REFACTOR_14_REPORT.md` maps the sole `ArithDivTableWitness` constructor, its four trace-level call sites, the four balance-selected shared-ArithMul provider facts, and the `FullEnsemble` projection supplying them.
+2. **Contract upgrade blocked by a verified provider-model mismatch.** The live ensemble validates `ArithMul.componentWithArithTable` / `ArithMul.mainWithArithTable`, not `ArithDiv.mainComplete`. More decisively, `vOfDivuRow` has no source inverse-sum column and sets `inv_sum_all_bs := 0`; for an ordinary active nonzero DIV/REM row, the required inverse-sum equation then reduces to `1 = 0`. Upgrading `ArithDivTableWitness.holds` would therefore make its only constructor impossible. No caller premise or trust escape hatch was added.
+3. **The 16 Div wrapper obligations remain blocked by item 2.** Each of `Div`, `Divu`, `Divw`, `Divuw`, `Rem`, `Remu`, `Remw`, and `Remuw` remains at 2 → 2 obligations. Removing them before the live shared provider preserves the inverse witness and validates the completed generated constraints would launder the obligation rather than derive it.
+4. **Final sweep complete.** Proof-code net delta is 0 lines. Roots, `ZiskFv/Audit.lean`, `Compliance/Defects.lean`, `Equivalence/`, and `trust/generated/` are byte-unchanged from the delivered tree. No prohibited construct was introduced. The target of only five owner-gated compatibility binders is not reachable until the provider blocker is fixed.
+
+Verification:
+- Full `lake build` passed (the build made incremental progress across four command cutoffs and completed on the fifth invocation).
+- Standard trust checks 1–12 and 14–16 passed; check 13 alone was deferred exactly as authorized because the supplied tree lacks `zisk/core/src/aeneas_extract.rs`.
+- All 16 semantic trust checks passed.
+
+The precise blocker, construction-site map, per-wrapper counts, remediation boundary, and gate results are in `REFACTOR_14_REPORT.md`.
+
 # Summary of changes for run a1b57c95-a03e-4bff-8a9f-34483b10ac1d
 Completed Refactor 13 to the verified boundary and documented the full audit in `REFACTOR_13_REPORT.md`.
 

--- a/REFACTOR_14_PROMPT.md
+++ b/REFACTOR_14_PROMPT.md
@@ -1,0 +1,90 @@
+# Task: Phase 3 — upgrade the ArithDiv witness contract to mainComplete; discharge the Div wrapper obligations
+
+## Situation
+
+**The tree delivered with this prompt is the authoritative source of truth** (it integrates
+all of your prior accepted work: T12 landed verbatim — the 12 mode-boolean conjuncts are
+gone, `ArithMulTableWitness.row_constraints` discharges the Mul wrappers, and your
+verified ArithDiv blocker note is accepted as this turn's work order).
+
+Install it NON-DESTRUCTIVELY: extract the tarball OVER your existing tree; never delete
+`.lake` or build artifacts; `lake exe cache get` first if cold. After installing, every
+tracked file's content must exactly match the tarball. Your ~22-minute command window:
+size build commands to complete within it and re-invoke; a cutoff is never a proof error.
+Never commit an attached tarball.
+
+Sandbox limitations, pre-acknowledged: no branch history; no `zisk` submodule → defer
+exactly trust check 13. Do not touch `lakefile.toml`, `lake-manifest.json`, `flake.nix`,
+`flake.lock`, or `ZiskFv/Audit.lean`.
+
+## Context
+
+Your T12 audit verified: `ArithDivTableWitness` still carries `mainWithArithTable`
+soundness, and the Div `FullSpec` omits C46 and the appended local constraints — so the
+16 Div-side wrapper obligations cannot honestly discharge yet. The Mul side shows the
+exact finished shape: witness field carries `mainComplete` soundness; the constructor
+(`arithMulTableWitness_of_fullSpec`) proves the appended constraints at construction;
+consumers project down via `base_soundness_of_complete_const_soundness`; and
+`ArithMulTableWitness.row_constraints` hands wrappers the legacy bundle with zero caller
+premises. This turn replicates that for Div. Div's appended constraints include
+chunk-dependent facts (boundary, inverse-sum, W-mode) that CANNOT come from static table
+membership alone — they must flow from where the witness is actually constructed, i.e.
+the live provider row's `constraints_hold` in the balance/table layer.
+
+## Numbered work order
+
+1. **Audit the Div witness construction path.** Enumerate every site that constructs an
+   `ArithDivTableWitness` (or the `FullSpec` it is built from) — expected in
+   `AirsClean/ArithTableProjections.lean`, the `FullEnsemble/Balance/*` layer, and
+   construction modules. For each, identify the live source that already carries the
+   appended-constraint facts (`mainComplete` soundness of the selected provider row).
+   Commit the map to `REFACTOR_14_REPORT.md` before changing anything.
+2. **Upgrade the contract.** Change `ArithDivTableWitness.holds` to
+   `ConstraintsHold.Soundness … (mainComplete …)`, extend the Div `FullSpec` (or the
+   constructor inputs) so construction sites prove the appended constraints from their
+   live source — never as new caller premises at public surfaces. Keep every existing
+   consumer green via `base_soundness_of_complete_const_soundness` exactly as the Mul
+   side does. If a construction site's live source genuinely lacks a needed fact, STOP
+   that site and report it precisely — do not add a caller-supplied hypothesis.
+3. **Discharge the 16 Div wrapper obligations.** Add
+   `ArithDivTableWitness.row_constraints` (and boundary/inverse/scope/W-mode projection
+   variants as consumers need them) mirroring the Mul method, then remove the
+   caller-supplied row-constraint obligations from the Div-family forwarding wrappers
+   (`Div`, `Divu`, `Divw`, `Divuw`, `Rem`, `Remu`, `Remw`, `Remuw` surfaces).
+   Per-wrapper before/after obligation counts in the report.
+4. **Final sweep.** Remaining caller-supplied Arith constraint hypotheses (target: only
+   the five `Equivalence/`-frozen compatibility binders, which are OWNER-GATED — do not
+   touch `Equivalence/`); net line delta; `trust/generated/` byte-unchanged; full
+   `lake build`, `trust/scripts/check-all.sh` (minus check 13),
+   `trust/scripts/check-all-semantic.sh` all green.
+
+Prioritization: item 2 done cleanly for the witness contract beats a partial item 3 —
+the contract upgrade is the enabling move and must not be rushed into caller premises.
+
+## Completion contract
+
+The turn is complete when every numbered item is either done or carries a verified
+blocker note. A clean build or a committed chunk is a checkpoint, not a stop condition:
+after finishing an item, proceed immediately to the next. Committing and reporting with
+items silently unattempted is a failed turn. If an item is blocked, skip it, document the
+precise blocker (file, theorem, error), and continue. Commit after each green item.
+
+## Hard constraints (in addition to `AGENTS.md`, which fully applies)
+
+- T0 at the roots: `root_soundness` and `root_completeness` byte-for-byte identical;
+  `ZiskFv/Audit.lean` untouched.
+- **`Compliance/Defects.lean` and `Equivalence/` byte-unchanged** — the DIV/REM defect
+  boundary and the public per-opcode theorem signatures are exempt/owner-gated.
+- The constraint set stays frozen at the T10 audited list. Strengthened contracts must
+  be proved at construction from live sources; a deleted obligation must be DERIVED, not
+  renamed, weakened, or moved to a different caller.
+- Zero new `axiom`, `sorry`, `admit`, `native_decide`, `opaque`, `partial`,
+  `@[implemented_by]`. No `trust/generated/` change; no baseline; no `OpEnvelope` arity
+  change.
+- Work in new commits on top of the provided state; never rewrite or revert it.
+
+## Reporting contract
+
+Prepend your run summary to `ARISTOTLE_SUMMARY.md` (mirror in `REFACTOR_14_REPORT.md`):
+per-item status for 1–4; the construction-site map; per-wrapper before/after obligation
+counts; net line delta; exact gate results.

--- a/REFACTOR_14_REPORT.md
+++ b/REFACTOR_14_REPORT.md
@@ -1,0 +1,136 @@
+# Summary of changes for Refactor 14
+
+Installed and byte-verified all 838 archived files/symlinks non-destructively while preserving `.lake`; the attached tarball remains untracked and was not committed.
+
+Per-item status:
+1. **Construction-path audit complete.** `REFACTOR_14_REPORT.md` maps the sole `ArithDivTableWitness` constructor, its four trace-level call sites, the four balance-selected shared-ArithMul provider facts, and the `FullEnsemble` projection supplying them.
+2. **Contract upgrade blocked by a verified provider-model mismatch.** The live ensemble validates `ArithMul.componentWithArithTable` / `ArithMul.mainWithArithTable`, not `ArithDiv.mainComplete`. More decisively, `vOfDivuRow` has no source inverse-sum column and sets `inv_sum_all_bs := 0`; for an ordinary active nonzero DIV/REM row, the required inverse-sum equation then reduces to `1 = 0`. Upgrading `ArithDivTableWitness.holds` would therefore make its only constructor impossible. No caller premise or trust escape hatch was added.
+3. **The 16 Div wrapper obligations remain blocked by item 2.** Each of `Div`, `Divu`, `Divw`, `Divuw`, `Rem`, `Remu`, `Remw`, and `Remuw` remains at 2 → 2 obligations. Removing them before the live shared provider preserves the inverse witness and validates the completed generated constraints would launder the obligation rather than derive it.
+4. **Final sweep complete.** Proof-code net delta is 0 lines. Roots, `ZiskFv/Audit.lean`, `Compliance/Defects.lean`, `Equivalence/`, and `trust/generated/` are byte-unchanged from the delivered tree. No prohibited construct was introduced. The target of only five owner-gated compatibility binders is not reachable until the provider blocker is fixed.
+
+Verification:
+- Full `lake build` passed (the build made incremental progress across four command cutoffs and completed on the fifth invocation).
+- Standard trust checks 1–12 and 14–16 passed; check 13 alone was deferred exactly as authorized because the supplied tree lacks `zisk/core/src/aeneas_extract.rs`.
+- All 16 semantic trust checks passed.
+
+The precise blocker, construction-site map, per-wrapper counts, remediation boundary, and gate results are in `REFACTOR_14_REPORT.md`.
+
+# Refactor 14 report — ArithDiv `mainComplete` witness audit
+
+## Item 1 — construction-path audit (completed before proof-code changes)
+
+### Direct witness construction sites
+
+There is exactly one declaration that constructs the structure:
+
+- `ZiskFv/Compliance/SharedBundles.lean` —
+  `arithDivTableWitness_of_fullSpec` constructs `ArithDivTableWitness` from
+  `AirsClean.ArithDiv.FullSpec` by making a constant-row environment.  In the
+  delivered tree, `FullSpec` has only `Spec ∧ ArithTableSpec ∧ IndexedRangeSpec`,
+  and the witness stores soundness of `mainWithArithTable`, not `mainComplete`.
+
+There are exactly four call sites of that constructor:
+
+- `ZiskFv/Compliance/TraceLevelExport/StepStrongLoadMext.lean`, in
+  `stepStrong_divu`, `stepStrong_divuw`, `stepStrong_remu`, and
+  `stepStrong_remuw`.
+
+Each call first obtains a shared ArithMul provider row and its
+`AirsClean.ArithMul.FullSpec`, transports that through
+`arithDiv_fullSpec_of_arithMul_fullSpec` in
+`ZiskFv/Compliance/ConstructionDivu.lean`, and then calls the sole constructor.
+The four provider facts are supplied respectively by:
+
+- `divuArow_fullSpec_row` in `ConstructionDivu.lean`;
+- `divuwArow_fullSpec_row` in `ConstructionDivuw.lean`;
+- `remuArow_fullSpec_row` in `ConstructionRemu.lean`;
+- `remuwArow_fullSpec_row` in `ConstructionRemuw.lean`.
+
+Each of those facts comes from the selected row's generic component `Spec` via
+`FullEnsemble.arithMul_fullSpec_of_component_spec` in
+`AirsClean/FullEnsemble/Balance/RowExtraction.lean`.  Balance selects the shared
+`arithMulProviderComponent`, which is definitionally
+`ArithMul.componentWithArithTable` (`Balance/Classification.lean`).  Its circuit
+is `circuitWithArithTable`; its `Spec` is exactly `ArithMul.FullSpec`.
+
+### What the live source actually carries
+
+The live selected provider table proves `componentWithArithTable.Spec`, hence
+ArithMul `FullSpec`.  Its operation list is produced by
+`ArithMul.mainWithArithTable`, not by either family’s `mainComplete`.  Thus the
+live table's `constraints_hold` carries the base carry-chain/lookups but does
+**not** carry the appended ArithDiv constraints.
+
+The ArithDiv view transport makes the gap concrete:
+`vOfDivuRow` in `ConstructionDivu.lean` sets `inv_sum_all_bs := 0`, because the
+shared `ArithMulRow` has no inverse-sum witness column.  For an ordinary active
+DIV/REM row (`div = 1`, `div_by_zero = 0`), ArithDiv `InverseSumSpec` would then
+reduce to `1 = 0`.  Consequently the selected shared provider row not only
+lacks a proof of ArithDiv `mainComplete`; its current view cannot satisfy that
+circuit for ordinary nonzero division.
+
+No other `ArithDivTableWitness` structure literal or constructor call exists.
+The remaining occurrences are consumers/record fields in wrappers,
+`OpEnvelope`, defect declarations, Aeneas bridge trust, and trace row-data
+records.
+
+## Item 2 — contract upgrade (verified blocker; no unsound change made)
+
+The requested upgrade cannot be implemented honestly against the delivered
+ensemble.  The exact blocker is the mismatch between:
+
+- `AirsClean/ArithCompleteConstraints.lean`:
+  `ArithDiv.mainComplete` requires `InverseSumSpec` and the remaining appended
+  local constraints;
+- `AirsClean/FullEnsemble.lean` and
+  `AirsClean/FullEnsemble/Balance/Classification.lean`: the live arithmetic
+  provider is `ArithMul.componentWithArithTable`, whose operations are
+  `ArithMul.mainWithArithTable`, not `ArithDiv.mainComplete`;
+- `Compliance/ConstructionDivu.lean:104-139`: `vOfDivuRow` has no source
+  inverse-sum column and defines `inv_sum_all_bs := 0`.
+
+Substituting that definition into the generated inverse-sum equation gives
+`(div - div_by_zero) * 1 = 0`.  On the normal nonzero DIV/REM branch, where the
+ROM-selected mode has `div = 1` and `div_by_zero = 0`, this is false.  This is
+stronger than merely lacking a conveniently packaged theorem: the current live
+view cannot be a sound row of `ArithDiv.mainComplete`.
+
+Accordingly, changing `ArithDivTableWitness.holds` now would make its sole
+constructor impossible.  Extending `FullSpec` would only move the missing fact
+to callers, which the work order expressly forbids.  No caller premise, axiom,
+trusted escape hatch, weakened constraint, or renamed obligation was added.
+The enabling architectural fix is to preserve/materialize the Arith AIR's
+`inv_sum_all_bs` column (and all generated local constraints) in the live
+shared-provider row and make the full ensemble validate a complete arithmetic
+component before attempting this contract upgrade.
+
+## Item 3 — Div wrapper obligations (blocked by item 2)
+
+Each Div-family file has two public forwarding surfaces carrying the row bundle,
+for 16 obligations total.  Because `ArithDivTableWitness` cannot yet supply
+`mainComplete`, no honest `row_constraints` projection can be added and none of
+these premises can be deleted.
+
+| Wrapper | Before | After | Status |
+|---|---:|---:|---|
+| `Div` | 2 | 2 | blocked |
+| `Divu` | 2 | 2 | blocked |
+| `Divw` | 2 | 2 | blocked |
+| `Divuw` | 2 | 2 | blocked |
+| `Rem` | 2 | 2 | blocked |
+| `Remu` | 2 | 2 | blocked |
+| `Remw` | 2 | 2 | blocked |
+| `Remuw` | 2 | 2 | blocked |
+| **Total** | **16** | **16** | **blocked** |
+
+## Item 4 — final sweep and gates
+
+The final source sweep confirms that the 16 Div wrapper binders remain for the
+verified reason above; therefore the target of only five owner-gated
+`Equivalence/` compatibility binders is not reachable in this tree.  The
+owner-gated `Equivalence/` directory, `Compliance/Defects.lean`, roots,
+`ZiskFv/Audit.lean`, build pins/lockfiles, and `trust/generated/` were not
+changed by this turn.
+
+Net proof-code line delta: **0**.  Final report size: **136 lines** (new file).
+The exact gate results are recorded in the prepended run summary.


### PR DESCRIPTION
Docs-only blocker turn (R14 / alias T13, Aristotle task \`e1d22ee1\`): the requested ArithDiv witness-contract upgrade was **correctly refused** as unconstructible.

The audit (in \`REFACTOR_14_REPORT.md\`) pins it precisely: there is exactly one \`ArithDivTableWitness\` constructor with four call sites, all fed by the **shared ArithMul-typed provider** that the live ensemble actually validates (\`componentWithArithTable\` / \`mainWithArithTable\`). \`ArithDiv.mainComplete\` is never validated by the ensemble, and \`vOfDivuRow\` fabricates \`inv_sum_all_bs := 0\` (the shared row has no such column), which makes the generated inverse-sum equation reduce to \`1 = 0\` on ordinary nonzero DIV/REM rows. Upgrading the contract against that supply would have made the witness unconstructible — obligation laundering — so nothing was changed: zero proof-code delta, all protected surfaces byte-identical, all 16 Div wrapper obligations honestly retained (2→2 per wrapper).

Named remediation (next turn, R15): materialize the Arith AIR's \`inv_sum_all_bs\` column (stage-1 col 38) and the full generated local-constraint set in the **shared provider row/circuit**, swap the live ensemble onto the completed component with real witness values, then re-attempt the contract upgrade and Div wrapper discharge.

Operator note: this is the Q2/anti-laundering gate working as designed for the third time (T9's family gates, T13's refusal here) — the agent chose a zero-delta honest report over a constructible-looking but vacuous discharge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)