### PR TITLE
Phase 3: live Arith provider completed; ensemble swapped to componentComplete (R15)

### DIFF
--- a/ARISTOTLE_SUMMARY.md
+++ b/ARISTOTLE_SUMMARY.md
@@ -1,3 +1,40 @@
+# Summary of changes for run f1bb6e7f-eec5-4d3b-8a81-c9e1e49bee44
+Completed Refactor 15 through the verified live-provider boundary and documented the result in `REFACTOR_15_REPORT.md`; prepended the required summary to `ARISTOTLE_SUMMARY.md`.
+
+Key results:
+- Installed and byte-verified all 840 archived files/symlinks non-destructively, preserving `.lake`; attached tarballs were not committed.
+- Audited every shared Arith provider row family. No unsatisfiable row was found. Active nonzero DIV/REM rows require the actual inverse of the divisor-chunk sum; multiplication and division-by-zero rows may use zero.
+- Added and mechanically propagated the physical `inv_sum_all_bs` witness column.
+- Added the full frozen generated local-constraint set to a completed shared Arith circuit and proved its component sound.
+- Swapped the live ensemble, construction modules, and fixtures to the completed provider.
+- Updated `vOfDivuRow` to project the committed inverse witness rather than fabricate zero.
+- Precisely identified the remaining item-4 seam: selected provider-row construction currently retains stable `FullSpec` but does not transport that row’s complete `constraints_hold` proof into the ArithDiv view. Therefore the eight Div-family wrappers honestly remain at 2 → 2 obligations; removing them now would still launder obligations. The required follow-up projection is detailed in the report.
+- Proof-code delta excluding reports: +259/−98, net +161 lines.
+
+Verification:
+- Full `lake build ZiskFv` passed (9,015 jobs).
+- Standard trust checks 1–12 and 14–16 passed; check 13 was deferred as authorized because the supplied tree lacks the `zisk` submodule.
+- All 16 semantic trust checks passed.
+- The non-generated zero-sorry gate passed.
+- Roots, `ZiskFv/Audit.lean`, `Compliance/Defects.lean`, `Equivalence/`, build pins/lockfiles, and `trust/generated/` remain byte-unchanged.
+
+All retained changes were committed and pushed.
+
+# Summary of changes for Refactor 15
+
+Completed the Refactor 15 work order through the green live-provider boundary, with the remaining wrapper migration precisely blocked and documented in `REFACTOR_15_REPORT.md`.
+
+- Installed and byte-verified all 840 archived files/symlinks non-destructively while preserving `.lake`; attached tarballs remain untracked.
+- Completed the constructibility precheck for all six concrete balance-selected Arith rows, ordinary shared MUL rows, the generic fixture, and spin/fixture search. No genuinely unsatisfiable row was found. Active nonzero DIV/REM rows require the real inverse of the divisor-chunk sum; multiplication and div-by-zero rows may use zero.
+- Added the physical `inv_sum_all_bs` column to `ArithMulRow` and propagated it mechanically.
+- Added the complete frozen generated local constraint set to the shared Arith circuit and proved a completed component sound.
+- Swapped the live full ensemble and all concrete construction/fixture consumers to the completed provider.
+- Changed `vOfDivuRow` to project the committed inverse witness instead of fabricating zero.
+- Verified the remaining item-4 blocker: construction selection retains stable `FullSpec` but does not yet transport the selected table row's complete `constraints_hold` into the ArithDiv view. Consequently all eight Div-family wrappers honestly remain at 2 → 2 obligations; deleting them now would still launder obligations. The exact remediation seam is recorded.
+- Code delta excluding reports: +259/−98, net +161 lines.
+
+Verification: full `lake build ZiskFv` passed (9,015 jobs); standard trust checks 1–12 and 14–16 passed, with check 13 deferred because the supplied tree lacks the `zisk` submodule; all 16 semantic checks passed; zero-sorry passed. Protected roots, `Audit.lean`, `Compliance/Defects.lean`, `Equivalence/`, build pins/lockfiles, and `trust/generated/` are byte-unchanged.
+
 # Summary of changes for run e1d22ee1-db39-4a62-bdeb-99cf4f2a1aae
 Completed the Refactor 14 work order to its verified boundary.
 

--- a/REFACTOR_15_PROMPT.md
+++ b/REFACTOR_15_PROMPT.md
@@ -1,0 +1,107 @@
+# Task: Phase 3 — complete the LIVE shared Arith provider; then the Div contract upgrade your R14 audit unblocked
+
+## Situation
+
+**The tree delivered with this prompt is the authoritative source of truth** (it integrates
+all of your prior accepted work, including your R14 blocker audit — accepted in full; this
+work order is the remediation you named in `REFACTOR_14_REPORT.md`).
+
+Install it NON-DESTRUCTIVELY: extract the tarball OVER your existing tree; never delete
+`.lake` or build artifacts; `lake exe cache get` first if cold. After installing, every
+tracked file's content must exactly match the tarball. Your ~22-minute command window:
+size build commands to complete within it and re-invoke; a cutoff is never a proof error.
+Never commit an attached tarball.
+
+Sandbox limitations, pre-acknowledged: no branch history; no `zisk` submodule → defer
+exactly trust check 13. Do not touch `lakefile.toml`, `lake-manifest.json`, `flake.nix`,
+`flake.lock`, or `ZiskFv/Audit.lean`.
+
+## Context
+
+Your R14 audit established: the live ensemble validates the shared
+`ArithMul.componentWithArithTable` provider; `ArithMulRow` lacks the Arith AIR's
+`inv_sum_all_bs` column (stage-1 col 38); `vOfDivuRow` zeroes it, so
+`ArithDiv.mainComplete`'s inverse-sum equation is false on ordinary nonzero DIV/REM
+rows. The remediation you named is this turn: make the ONE physical Arith AIR's full
+generated local-constraint set live in the shared provider, with real witness values,
+then complete the contract upgrade and wrapper discharge that R14 correctly refused.
+
+The license is unchanged: every constraint involved is an already-audited generated
+mirror (the T10/R11 cited list — nothing new, nothing dropped). The witnesses are the
+constructibility proof: real AIR rows satisfy all generated constraints, so every
+concrete witness row must be repairable with REAL values, never with weakened
+constraints.
+
+## Numbered work order
+
+1. **Constructibility precheck (audit before code).** Enumerate every concrete row that
+   instantiates the shared Arith provider (the Construction* modules' rows — divu/
+   divuw/remu/remuw AND the mul/mulw/mulhu families — plus any spin-witness or fixture
+   rows). For each, check it against each constraint the completed circuit will add
+   (Div block: booleans/disjointness, boundary 9–24, inverse-sum 25, scope 26–30,
+   mode 39–45, c46, W-mode 47–48). Record per-row: already-satisfied / needs a real
+   value fix (say which — e.g. the actual divisor-chunk-sum inverse on active DIV rows;
+   `inv_sum_all_bs = 0` is correct only where `div = div_by_zero`) / genuinely
+   unsatisfiable (STOP that row and report — that would be a model finding). Commit the
+   table to `REFACTOR_15_REPORT.md` before changing proof code.
+2. **Complete the shared row and circuit.** Add `inv_sum_all_bs` to `ArithMulRow`
+   (docstring: Arith AIR stage-1 col 38, used by `constraint_25_every_row`,
+   `arith.pil:143`) with mechanical propagation (FreeCols, builders, `constVar`,
+   adapters). Extend the shared complete circuit so its appended operations carry the
+   FULL audited generated local-constraint set of the Arith AIR (dedupe against what
+   `ArithMul.mainComplete` already appends; every `assertZero` cited: extraction fact +
+   arith.pil line). `ArithDiv`'s family mirror may then re-export or alias rather than
+   duplicate.
+3. **Swap the live provider.** Point `arithMulProviderComponent`
+   (`FullEnsemble/Balance/Classification.lean`, definitionally
+   `componentWithArithTable`) and the ensemble at the completed circuit. Repair every
+   item-1 row with its real values; update `vOfDivuRow` to project the now-present
+   column instead of fabricating 0; update `FullSpec`/
+   `arithMul_fullSpec_of_component_spec` and consumers, keeping everything green via
+   `base_soundness`-style projections. No caller-supplied premise may appear anywhere
+   in this — the facts flow from the live table's `constraints_hold`.
+4. **The R14-blocked upgrade, now honest.** Upgrade `ArithDivTableWitness.holds` to the
+   completed supply; extend `arithDivTableWitness_of_fullSpec` and its four
+   `StepStrongLoadMext` call sites; add `ArithDivTableWitness.row_constraints` (+
+   boundary/inverse/scope/W-mode projections as needed) mirroring the Mul method; then
+   remove the 16 Div-family wrapper row-bundle obligations. Per-wrapper before/after
+   counts.
+5. **Final sweep.** Remaining caller-supplied Arith constraint hypotheses (target: only
+   the five owner-gated `Equivalence/` compatibility binders); net line delta;
+   `trust/generated/` byte-unchanged; full `lake build`, `trust/scripts/check-all.sh`
+   (minus check 13), `trust/scripts/check-all-semantic.sh` all green.
+
+Prioritization: items 2–3 landed clean and green beat a rushed item 4 — the provider
+swap is the load-bearing move; a single unsatisfiable witness row stops that row's
+repair, not the whole swap, unless it indicates a genuine model defect (then STOP and
+report). If the budget runs short, the precheck table plus a green partial swap is a
+good turn.
+
+## Completion contract
+
+The turn is complete when every numbered item is either done or carries a verified
+blocker note. A clean build or a committed chunk is a checkpoint, not a stop condition:
+after finishing an item, proceed immediately to the next. Committing and reporting with
+items silently unattempted is a failed turn. If an item is blocked, skip it, document the
+precise blocker (file, theorem, error), and continue. Commit after each green item.
+
+## Hard constraints (in addition to `AGENTS.md`, which fully applies)
+
+- T0 at the roots: `root_soundness` and `root_completeness` byte-for-byte identical;
+  `ZiskFv/Audit.lean` untouched.
+- **`Compliance/Defects.lean` and `Equivalence/` byte-unchanged** (defect boundary and
+  public per-opcode signatures are exempt/owner-gated).
+- The constraint set stays FROZEN at the audited generated list — the completed circuit
+  adds exactly the cited mirrors, nothing else; witness repairs use real values only.
+  A row that cannot be honestly repaired is a reported finding, never a reason to
+  weaken, special-case, or drop a constraint.
+- Every removed obligation DERIVED from the live supply; zero new `axiom`, `sorry`,
+  `admit`, `native_decide`, `opaque`, `partial`, `@[implemented_by]`. No
+  `trust/generated/` change; no baseline; no `OpEnvelope` arity change.
+- Work in new commits on top of the provided state; never rewrite or revert it.
+
+## Reporting contract
+
+Prepend your run summary to `ARISTOTLE_SUMMARY.md` (mirror in `REFACTOR_15_REPORT.md`):
+per-item status for 1–5; the precheck table; the per-row repair list with the real
+values used; per-wrapper before/after counts; net line delta; exact gate results.

--- a/REFACTOR_15_REPORT.md
+++ b/REFACTOR_15_REPORT.md
@@ -1,0 +1,51 @@
+# Refactor 15 report
+
+## Item 1 — constructibility precheck (completed before proof-code changes)
+
+The shared physical provider is instantiated in the compliance construction layer by six balance-selected rows: `mulwArow`, `mulhuArow`, `divuArow`, `divuwArow`, `remuArow`, and `remuwArow`. The ordinary MUL-family path uses the same physical Arith provider through the accepted ensemble; there is no additional literal `mulArow` constructor. A repository-wide constructor search found one non-live generic completeness fixture, `arithMulRowOf`, and no Arith spin witness. All six named `*Arow` definitions are `Classical.choose` projections of a row already present in the live provider table, rather than independently synthesized literals. Thus the load-bearing repair is to put the missing physical column in `ArithMulRow` and validate it in the live component; selected rows then carry the committed value rather than construction code fabricating one.
+
+### Completed-constraint precheck
+
+Legend: **S** = already satisfied from existing table flags/chunks or existing C46 supply; **V** = needs the real `inv_sum_all_bs` witness value; **N/A** = gated to zero for that mode. No row was found genuinely unsatisfiable.
+
+| Concrete/live row family | bool/disjoint 0–5 | boundary 9–24 | inverse 25 | scope 26–30 | mode 39–45 | C46 | W-mode 47–48 | repair |
+|---|---:|---:|---:|---:|---:|---:|---:|---|
+| MUL (shared accepted-table rows) | S | N/A | N/A | N/A | S | S | N/A | add committed column; value `0` is valid because `div = 0` |
+| `mulwArow` | S | N/A | N/A | N/A | S | S | S (high operand lanes already zero) | committed value `0` |
+| `mulhuArow` (covers high-MUL family selection) | S | N/A | N/A | N/A | S | S | N/A | committed value `0` |
+| `divuArow` | S | S | **V** | S | S | S | N/A | if divisor chunk sum `s ≠ 0`, use `s⁻¹`; if `div_by_zero = 1`, use `0` |
+| `remuArow` | S | S | **V** | S | S | S | N/A | same real inverse rule as DIVU |
+| `divuwArow` | S | S | **V** | S | S | S | S (32-bit high-lane equations) | same inverse rule, with W-mode zero high divisor lanes |
+| `remuwArow` | S | S | **V** | S | S | S | S | same inverse rule, with W-mode zero high divisor lanes |
+| `arithMulRowOf` generic completeness fixture (not live) | mode-dependent | mode-dependent | mode-dependent | mode-dependent | mode-dependent | mode-dependent | mode-dependent | its free columns must mechanically gain `inv_sum_all_bs`; `0` remains valid for its multiplication-only assumptions |
+| spin/other fixture rows | — | — | — | — | — | — | — | none found by repository-wide `ArithMulRow` constructor search |
+
+Here `s = b_0 + b_1 + b_2 + b_3` in `FGL`. The required equation is `(div - div_by_zero) * (1 - inv_sum_all_bs * s) = 0`. Therefore `s⁻¹` is the real value on active nonzero DIV/REM rows, while `0` is valid precisely on multiplication rows and division-by-zero rows. The prior `vOfDivuRow` constant `0` is invalid for ordinary nonzero DIV/REM and must be replaced by projection of the committed physical column.
+
+The precheck also confirms why validation must occur at the provider: because the named construction rows are selected from the ensemble, no caller premise or post-selection patch can honestly repair them. The completed provider's `constraints_hold` must establish every listed fact.
+
+## Item 2 — shared row and complete circuit: done
+
+Added `ArithMulCarries.inv_sum_all_bs`, with the required stage-1-column/constraint/PIL provenance, and propagated it through the generic unsigned constructor, constant-expression adapters, legacy-row adapter, and component proofs. `sharedMainComplete` now carries the full frozen generated local list: 0–5, 9–30, 39–48, with the existing `mainWithArithTable` prefix supplying carry constraints, C46/ranges/lookups (the duplicate C46 in the full list is the cited generated assertion). `ArithDiv.mainComplete` remains the equivalent family view. No generated file changed.
+
+## Item 3 — live provider swap: done
+
+Added the completed elaborated circuit/component and proved its soundness by projecting the exact `mainWithArithTable` prefix and reusing the established `FullSpec` soundness. Swapped `fullRv64imSoundEnsemble`, `arithMulProviderComponent`, classification, row extraction, Arith balance proofs, concrete fixtures, and all six Construction modules to `componentComplete`. `vOfDivuRow` now projects `arow.carries.inv_sum_all_bs`; it no longer fabricates zero. All selected rows therefore retain the real committed physical witness, and the full appended assertions are checked by the live table's `constraints_hold`, without a caller premise.
+
+## Item 4 — R14 contract/wrapper follow-through: verified remaining blocker
+
+The load-bearing provider remediation is live and green, but the `ArithDivTableWitness` API upgrade and deletion of wrapper binders were not landed. The precise remaining seam is `FullEnsemble/Balance/RowExtraction.lean:arithMul_fullSpec_of_component_spec`: the stable component `Spec` deliberately remains the old six-part `ArithMul.FullSpec`, while the complete local facts exist in the table's `constraints_hold`. The six construction modules currently retain only `h_spec` after selecting the provider row; they do not transport that row's `constraints_hold` proof into an ArithDiv-view `mainComplete` proof. Extending `ArithMul.FullSpec` itself would break its established conjunction ABI across the construction layer; instead a follow-up must add a named complete-local projection from the selected table constraints, transport it through `vOfDivuRow`, and feed that to an upgraded `arithDivTableWitness_of_fullSpec` (or a renamed builder). Deleting wrapper obligations before that projection would still be obligation laundering.
+
+Per wrapper, the requested two bundles therefore remain **2 → 2**: `Div`, `Divu`, `Divw`, `Divuw`, `Rem`, `Remu`, `Remw`, and `Remuw`. The four `StepStrongLoadMext` call sites continue to build the old witness. This item was attempted after the green provider swap and stopped at this exact data-flow boundary rather than weakening the contract.
+
+## Item 5 — final sweep
+
+- Proof-code delta from the authoritative checkpoint (excluding this report/summary): **+259 / −98, net +161 lines**.
+- Remaining Div wrapper bundle obligations: eight wrappers at 2 each (16 total); unchanged because item 4's projection seam remains.
+- The owner-gated `Equivalence/` tree is byte-unchanged. No new compatibility binder was introduced.
+- `trust/generated/` is byte-unchanged.
+- `root_soundness`, `root_completeness`, `ZiskFv/Audit.lean`, `Compliance/Defects.lean`, `Equivalence/`, build pins, and lockfiles are byte-unchanged.
+- Full `lake build ZiskFv`: passed (9,015 jobs).
+- Standard trust checks 1–12 and 14–16: all passed. Check 13 was deferred exactly as authorized because the supplied tree has no `zisk` submodule.
+- Semantic trust checks 1–16: all passed (the expected false-consistency probe was rejected).
+- Non-generated zero-sorry gate: passed; no prohibited construct was introduced.

--- a/ZiskFv/AirsClean/ArithCompleteConstraints.lean
+++ b/ZiskFv/AirsClean/ArithCompleteConstraints.lean
@@ -25,6 +25,84 @@ open Goldilocks Circuit
   assertZero (row.flags.sext * (1 - row.flags.sext))
 end ZiskFv.AirsClean.ArithMul
 
+namespace ZiskFv.AirsClean.ArithMul
+open Goldilocks Circuit
+@[circuit_norm] def sharedMainComplete (row : Var ArithMulRow FGL) : Circuit FGL Unit := do
+  mainWithArithTable row
+  -- Generated constraints 0--5 (`constraint_N_every_row`, PIL `arith.pil:46-53`).
+  assertZero (row.flags.main_div * (row.flags.main_div - 1))
+  assertZero (row.flags.main_mul * (row.flags.main_mul - 1))
+  assertZero (row.flags.main_mul * row.flags.main_div)
+  assertZero (row.flags.signed * (1 - row.flags.signed))
+  assertZero (row.flags.div_by_zero * (1 - row.flags.div_by_zero))
+  assertZero (row.flags.div_overflow * (1 - row.flags.div_overflow))
+  -- Generated boundary constraints 9--24 (`constraint_N_every_row`, PIL `arith.pil:130-141`).
+  assertZero (row.flags.div_by_zero * row.chunks.b_0)
+  assertZero (row.flags.div_by_zero * row.chunks.b_1)
+  assertZero (row.flags.div_by_zero * row.chunks.b_2)
+  assertZero (row.flags.div_by_zero * row.chunks.b_3)
+  assertZero (row.flags.div_by_zero * (row.chunks.a_0 - 65535))
+  assertZero (row.flags.div_by_zero * (row.chunks.a_1 - 65535))
+  assertZero (row.flags.div_by_zero * (row.chunks.a_2 - (1 - row.flags.m32) * 65535))
+  assertZero (row.flags.div_by_zero * (row.chunks.a_3 - (1 - row.flags.m32) * 65535))
+  assertZero (row.flags.div_overflow * (row.chunks.b_0 - 65535))
+  assertZero (row.flags.div_overflow * (row.chunks.b_1 - 65535))
+  assertZero (row.flags.div_overflow * (row.chunks.b_2 - (1 - row.flags.m32) * 65535))
+  assertZero (row.flags.div_overflow * (row.chunks.b_3 - (1 - row.flags.m32) * 65535))
+  assertZero (row.flags.div_overflow * row.chunks.c_0)
+  assertZero (row.flags.div_overflow * (row.chunks.c_1 - row.flags.m32 * 32768))
+  assertZero (row.flags.div_overflow * row.chunks.c_2)
+  assertZero (row.flags.div_overflow * (row.chunks.c_3 - (1 - row.flags.m32) * 32768))
+  -- Generated inverse/scope constraints 25--30 (`constraint_N_every_row`, PIL `arith.pil:143-153`).
+  assertZero ((row.flags.div - row.flags.div_by_zero) *
+    (1 - row.carries.inv_sum_all_bs *
+      (((row.chunks.b_0 + row.chunks.b_1) + row.chunks.b_2) + row.chunks.b_3)))
+  assertZero (row.flags.div_by_zero * (1 - row.flags.div))
+  assertZero (row.flags.div_overflow * (1 - row.flags.div))
+  assertZero (row.flags.div_overflow * (1 - row.flags.signed))
+  assertZero (row.flags.div_overflow * row.flags.div_by_zero)
+  assertZero (row.flags.div_by_zero * row.flags.div_overflow)
+  -- Generated mode booleans 39--45 (`constraint_N_every_row`, PIL `arith.pil:237-243`).
+  assertZero (row.flags.div * (1 - row.flags.div))
+  assertZero (row.flags.m32 * (1 - row.flags.m32))
+  assertZero (row.flags.na * (1 - row.flags.na))
+  assertZero (row.flags.nb * (1 - row.flags.nb))
+  assertZero (row.flags.nr * (1 - row.flags.nr))
+  assertZero (row.flags.np * (1 - row.flags.np))
+  assertZero (row.flags.sext * (1 - row.flags.sext))
+  -- Generated result mux 46 (`constraint_46_every_row`, PIL `arith.pil:263`).
+  assertZero (row.flags.bus_res1 -
+    (row.flags.sext * 4294967295 + (1 - row.flags.m32) *
+      (((1 - row.flags.main_mul - row.flags.main_div) *
+          (row.chunks.d_2 + row.chunks.d_3 * 65536)) +
+       row.flags.main_mul * (row.chunks.c_2 + row.chunks.c_3 * 65536) +
+       row.flags.main_div * (row.chunks.a_2 + row.chunks.a_3 * 65536))))
+  -- Generated W-mode lane constraints 47--48 (`constraint_N_every_row`, PIL `arith.pil:265-266`).
+  assertZero (row.flags.m32 *
+    (row.flags.div * (row.chunks.c_2 + row.chunks.c_3 * 65536) +
+      (1 - row.flags.div) * (row.chunks.a_2 + row.chunks.a_3 * 65536)))
+  assertZero (row.flags.m32 * (row.chunks.b_2 + row.chunks.b_3 * 65536))
+
+/-- Forget the appended complete local assertions while retaining the lookup-aware
+base provider constraints. -/
+theorem sharedMainComplete_base_soundness
+    (offset : ℕ) (env : Environment FGL) (row : Var ArithMulRow FGL)
+    (h : ConstraintsHold.Soundness env ((sharedMainComplete row).operations offset)) :
+    ConstraintsHold.Soundness env ((mainWithArithTable row).operations offset) := by
+  simp only [sharedMainComplete, mainWithArithTable, main, circuit_norm] at h ⊢
+  rcases h with
+    ⟨h6, h7, h8, h31, h32, h33, h34, h35, h36, h37, h38,
+      h46, hlookup, hra1, hrb1, hrc1, hrd1, hra3, hrb3, hrc3, hrd3,
+      ha0, ha1, ha2, ha3, hb0, hb1, hb2, hb3,
+      hc0, hc1, hc2, hc3, hd0, hd1, hd2, hd3,
+      hcy0, hcy1, hcy2, hcy3, hcy4, hcy5, hcy6, _⟩
+  exact ⟨h6, h7, h8, h31, h32, h33, h34, h35, h36, h37, h38,
+    h46, hlookup, hra1, hrb1, hrc1, hrd1, hra3, hrb3, hrc3, hrd3,
+    ha0, ha1, ha2, ha3, hb0, hb1, hb2, hb3,
+    hc0, hc1, hc2, hc3, hd0, hd1, hd2, hd3,
+    hcy0, hcy1, hcy2, hcy3, hcy4, hcy5, hcy6⟩
+end ZiskFv.AirsClean.ArithMul
+
 namespace ZiskFv.AirsClean.ArithDiv
 open Goldilocks Circuit
 @[circuit_norm] def mainComplete (row : Var ArithDivRow FGL) : Circuit FGL Unit := do

--- a/ZiskFv/AirsClean/ArithMul/Circuit.lean
+++ b/ZiskFv/AirsClean/ArithMul/Circuit.lean
@@ -1,4 +1,5 @@
 import ZiskFv.AirsClean.ArithMul.Constraints
+import ZiskFv.AirsClean.ArithCompleteConstraints
 import ZiskFv.AirsClean.ArithMul.Soundness
 import ZiskFv.AirsClean.ArithShared.CarryChainCompleteness
 import Clean.Air.FlatComponent
@@ -158,7 +159,8 @@ def arithMulRowOf (a b : ℕ) (free : ArithMulFreeCols) : ArithMulRow FGL :=
           (arithMulE3 a b) (arithMulE4 a b) (arithMulE5 a b) (arithMulE6 a b)
         fab := 1
         na_fb := 0
-        nb_fa := 0 } }
+        nb_fa := 0
+        inv_sum_all_bs := 0 } }
 
 set_option maxHeartbeats 4000000 in
 /-- ArithMul as a Clean `GeneralFormalCircuit`. `Assumptions := True` —
@@ -213,7 +215,7 @@ def circuit : GeneralFormalCircuit FGL ArithMulRow unit :=
         h_div_overflow h_main_div h_main_mul h_signed h_range_ab h_range_cd h_op h_bus_res1
         h_multiplicity
       injection h_carries with h_carry_0 h_carry_1 h_carry_2 h_carry_3 h_carry_4
-        h_carry_5 h_carry_6 h_fab h_na_fb h_nb_fa
+        h_carry_5 h_carry_6 h_fab h_na_fb h_nb_fa h_inv_sum_all_bs
       subst_vars
       simp only [h_a_0, h_a_1, h_a_2, h_a_3, h_b_0, h_b_1, h_b_2, h_b_3,
         h_c_0, h_c_1, h_c_2, h_c_3, h_d_0, h_d_1, h_d_2, h_d_3, h_na, h_nb,
@@ -345,7 +347,7 @@ def circuitWithArithTable : GeneralFormalCircuit FGL ArithMulRow unit :=
         · -- CarryRangeSpec: seven signed-carry range lookups (arith.pil:17,280).
           obtain ⟨_, _, h_carries⟩ := h_input
           obtain ⟨h_icy0, h_icy1, h_icy2, h_icy3, h_icy4, h_icy5, h_icy6,
-                  _h_fab, _h_na_fb, _h_nb_fa⟩ := h_carries
+                  _h_fab, _h_na_fb, _h_nb_fa, _h_inv_sum_all_bs⟩ := h_carries
           exact ⟨by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
                     Table.toRaw, signedCarryRangeTable, h_icy0] using h_cy0,
                  by simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable,
@@ -589,11 +591,87 @@ theorem spec_via_component (row : ArithMulRow FGL)
           carry_2 := .const row.carries.carry_2, carry_3 := .const row.carries.carry_3,
           carry_4 := .const row.carries.carry_4, carry_5 := .const row.carries.carry_5,
           carry_6 := .const row.carries.carry_6, fab := .const row.carries.fab,
-          na_fb := .const row.carries.na_fb, nb_fa := .const row.carries.nb_fa } }
+          na_fb := .const row.carries.na_fb, nb_fa := .const row.carries.nb_fa,
+          inv_sum_all_bs := .const row.carries.inv_sum_all_bs } }
     row ?_ ?_).1
   · simp [circuit_norm]
   · simp only [circuit_norm]
     exact ⟨h_c6, h_c7, h_c8, h_c31, h_c32, h_c33, h_c34, h_c35,
       h_c36, h_c37, h_c38⟩
+
+end ZiskFv.AirsClean.ArithMul
+
+namespace ZiskFv.AirsClean.ArithMul
+
+open Goldilocks
+open Air.Flat
+open ZiskFv.Channels.OperationBus (OpBusChannel)
+
+/-- Elaborated shared Arith provider carrying the complete audited generated local
+constraint set. -/
+@[reducible] def arithMulCompleteElaborated :
+    ElaboratedCircuit FGL ArithMulRow unit where
+  name := "ArithComplete"
+  main := sharedMainComplete
+  localLength _ := 0
+  output _ _ := ()
+  channelsWithRequirements := [OpBusChannel.toRaw]
+  exposedChannels row _ :=
+    expose OpBusChannel [OpBusChannel.pushed (primaryOpBusMessageExpr row)]
+  channelsLawful := by
+    simp only [circuit_norm, sharedMainComplete, mainWithArithTable, main,
+      primaryOpBusMessageExpr, OpBusChannel]
+
+/-- Live shared Arith provider: the previous lookup/range-aware contract plus every
+local generated Arith constraint audited in `ArithCompleteConstraints`. -/
+def circuitComplete : GeneralFormalCircuit FGL ArithMulRow unit :=
+  { arithMulCompleteElaborated with
+    Assumptions := fun _ _ => True
+    Spec := fun row _ _ => FullSpec row
+    ProverAssumptions := fun _ _ _ => False
+    ProverSpec := fun _ _ _ => True
+    soundness := by
+      intro offset env input_var input h_input _h_assumptions h_holds
+      have h_base := sharedMainComplete_base_soundness offset env input_var h_holds
+      have h_old := circuitWithArithTable.soundness offset env input_var input
+        h_input trivial h_base
+      exact ⟨h_old.1, by
+        unfold Operations.Requirements at h_old ⊢
+        simp only [circuitWithArithTable, arithMulWithArithTableElaborated,
+          sharedMainComplete, mainWithArithTable,
+          main, circuit_norm] at h_old ⊢
+        intro _hne
+        exact h_old.2 (by omega)⟩
+    completeness := by
+      circuit_proof_start_core
+      exact False.elim h_assumptions }
+
+/-- Completed shared Arith provider component. -/
+def componentComplete : Air.Flat.Component FGL := { circuit := circuitComplete }
+
+/-- The completed shared provider participates only in the operation bus. -/
+theorem componentComplete_channels :
+    componentComplete.circuit.channels = [OpBusChannel.toRaw] := by
+  rfl
+
+/-- Project completed-provider generic `Spec` to the stable `FullSpec`. -/
+theorem componentComplete_spec (env : Environment FGL) :
+    componentComplete.Spec env = FullSpec (componentComplete.rowInput env) := by
+  rfl
+
+set_option maxHeartbeats 1000000 in
+/-- The completed provider exposes the same primary operation-bus interaction. -/
+theorem componentComplete_interactionsWith_opBus :
+    componentComplete.operations.interactionsWith OpBusChannel.toRaw =
+      [((OpBusChannel.pushed
+        (primaryOpBusMessageExpr componentComplete.rowInputVar)).toRaw)] := by
+  apply Component.interactionsWith_of_exposedChannels
+  change ⟨OpBusChannel.toRaw,
+      [((OpBusChannel.pushed
+        (primaryOpBusMessageExpr componentComplete.rowInputVar)).toRaw)]⟩ ∈
+    componentComplete.exposedChannels
+  simp only [componentComplete, circuitComplete, arithMulCompleteElaborated,
+    Component.exposedChannels, expose, List.mem_singleton, List.map_cons, List.map_nil,
+    primaryOpBusMessageExpr]
 
 end ZiskFv.AirsClean.ArithMul

--- a/ZiskFv/AirsClean/ArithMul/ConsumerFacts.lean
+++ b/ZiskFv/AirsClean/ArithMul/ConsumerFacts.lean
@@ -58,7 +58,8 @@ def constVar (row : ArithMulRow FGL) : Var ArithMulRow FGL where
       carry_2 := .const row.carries.carry_2, carry_3 := .const row.carries.carry_3,
       carry_4 := .const row.carries.carry_4, carry_5 := .const row.carries.carry_5,
       carry_6 := .const row.carries.carry_6, fab := .const row.carries.fab,
-      na_fb := .const row.carries.na_fb, nb_fa := .const row.carries.nb_fa }
+      na_fb := .const row.carries.na_fb, nb_fa := .const row.carries.nb_fa,
+      inv_sum_all_bs := .const row.carries.inv_sum_all_bs }
 
 /-- Named local projection from the completed generated mirror.  Consumers use this
     theorem rather than depending on the positional conjunction emitted by `mainComplete`. -/
@@ -352,6 +353,7 @@ def rowAt (v : ZiskFv.Airs.ArithMul.Valid_ArithMul FGL FGL) (r : ℕ) :
     carry_0 := v.cy_0 r, carry_1 := v.cy_1 r, carry_2 := v.cy_2 r
     carry_3 := v.cy_3 r, carry_4 := v.cy_4 r, carry_5 := v.cy_5 r
     carry_6 := v.cy_6 r, fab := v.fab r, na_fb := v.na_fb r, nb_fa := v.nb_fa r
+    inv_sum_all_bs := 0
   }
 
 /-- Lookup-aware Clean witness for the sixteen `bits(16)` chunk lookups in

--- a/ZiskFv/AirsClean/ArithMul/ConsumerFacts.lean
+++ b/ZiskFv/AirsClean/ArithMul/ConsumerFacts.lean
@@ -132,6 +132,201 @@ theorem complete_local_specs_of_const_soundness
   · linear_combination h45
   · linear_combination h46
 
+set_option maxHeartbeats 1600000 in
+/-- Project the completed shared provider circuit's row-local generated assertions
+    to their named bundles: the carry chain (`Spec`), the MUL-view selector block
+    (`ModeSpec`), the result mux (`C46Spec`), and the appended Div block
+    (`SharedDivBlockSpec`).  Same live-constraint projection pattern as
+    `Mem.spec_of_componentWithDualMemBus_constraints`: every fact is read off the
+    flattened `sharedMainComplete` constraint list, not supplied by a caller. -/
+theorem completeLocal_of_sharedMainComplete_constraints
+    (offset : ℕ) (env : Environment FGL) (row : Var ArithMulRow FGL)
+    (h_main : Operations.ConstraintsHold env
+      ((sharedMainComplete row).operations offset)) :
+    Spec (eval env row) ∧ ModeSpec (eval env row) ∧ C46Spec (eval env row)
+      ∧ SharedDivBlockSpec (eval env row) := by
+  simp only [sharedMainComplete, mainWithArithTable, main, circuit_norm] at h_main
+  cases row with
+  | mk chunks flags carries =>
+    cases chunks with
+    | mk a_0 a_1 a_2 a_3 b_0 b_1 b_2 b_3 c_0 c_1 c_2 c_3 d_0 d_1 d_2 d_3 =>
+    cases flags with
+    | mk na nb nr np sext m32 div div_by_zero div_overflow main_div main_mul signed
+        range_ab range_cd op bus_res1 multiplicity =>
+    cases carries with
+    | mk carry_0 carry_1 carry_2 carry_3 carry_4 carry_5 carry_6 fab na_fb nb_fa
+        inv_sum_all_bs =>
+    simp only [Spec, ModeSpec, C46Spec, SharedDivBlockSpec, DivModeSpec, DivBoundarySpec,
+      DivInverseSumSpec, DivScopeSpec, DivWModeSpec,
+      ProvableStruct.eval_eq_eval, ProvableStruct.eval, ProvableStruct.fromComponents,
+      ProvableStruct.components, ProvableStruct.toComponents, ProvableStruct.eval.go,
+      ProvableType.eval_field] at *
+    refine ⟨⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩,
+      ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩, ?_,
+      ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩,
+      ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩,
+      ?_, ⟨?_, ?_, ?_, ?_, ?_⟩, ⟨?_, ?_⟩⟩
+    -- Carry chain (constraints 6, 7, 8, 31--38).
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (fab - ((1 - 2 * na) - 2 * nb + 4 * na * nb)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (na_fb - na * (1 - 2 * nb)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (nb_fa - nb * (1 - 2 * na)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (fab * a_0 * b_0 - c_0 + 2 * np * c_0 + div * d_0 - 2 * nr * d_0
+          - carry_0 * 65536) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (fab * a_1 * b_0 + fab * a_0 * b_1 - c_1 + 2 * np * c_1 + div * d_1
+          - 2 * nr * d_1 + carry_0 - carry_1 * 65536) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (fab * a_2 * b_0 + fab * a_1 * b_1 + fab * a_0 * b_2
+          + a_0 * nb_fa * m32 + b_0 * na_fb * m32 - c_2 + 2 * np * c_2 + div * d_2
+          - 2 * nr * d_2 - np * div * m32 + nr * m32 + carry_1 - carry_2 * 65536)
+          (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (fab * a_3 * b_0 + fab * a_2 * b_1 + fab * a_1 * b_2 + fab * a_0 * b_3
+          + a_1 * nb_fa * m32 + b_1 * na_fb * m32 - c_3 + 2 * np * c_3 + div * d_3
+          - 2 * nr * d_3 + carry_2 - carry_3 * 65536) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (fab * a_3 * b_1 + fab * a_2 * b_2 + fab * a_1 * b_3 + na * nb * m32
+          + b_0 * na_fb * (1 - m32) + a_0 * nb_fa * (1 - m32)
+          - np * m32 * (1 - div) - np * (1 - m32) * div + nr * (1 - m32)
+          - d_0 * (1 - div) + 2 * np * d_0 * (1 - div) + carry_3 - carry_4 * 65536)
+          (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (fab * a_3 * b_2 + fab * a_2 * b_3 + b_1 * na_fb * (1 - m32)
+          + a_1 * nb_fa * (1 - m32) - d_1 * (1 - div) + d_1 * 2 * np * (1 - div)
+          + carry_4 - carry_5 * 65536) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (fab * a_3 * b_3 + a_2 * nb_fa * (1 - m32) + b_2 * na_fb * (1 - m32)
+          - d_2 * (1 - div) + 2 * np * d_2 * (1 - div) + carry_5 - carry_6 * 65536)
+          (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (65536 * na * nb * (1 - m32) + a_3 * nb_fa * (1 - m32)
+          + b_3 * na_fb * (1 - m32) - 65536 * np * (1 - div) * (1 - m32)
+          - d_3 * (1 - div) + 2 * np * d_3 * (1 - div) + carry_6) (by simp)
+    -- MUL-view selector block (constraints 2 and 40--45).
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (main_mul * main_div) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (m32 * (1 - m32)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (na * (1 - na)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (nb * (1 - nb)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (nr * (1 - nr)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (np * (1 - np)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (sext * (1 - sext)) (by simp)
+    -- Result mux (constraint 46).
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (bus_res1 - (sext * 4294967295
+          + (1 - m32) * ((1 - main_mul - main_div) * (d_2 + d_3 * 65536)
+            + main_mul * (c_2 + c_3 * 65536) + main_div * (a_2 + a_3 * 65536))))
+          (by simp)
+    -- Div selector booleans (constraints 0--5 and 39--45).
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (main_div * (main_div - 1)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (main_mul * (main_mul - 1)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (main_mul * main_div) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (signed * (1 - signed)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_by_zero * (1 - div_by_zero)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_overflow * (1 - div_overflow)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div * (1 - div)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (m32 * (1 - m32)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (na * (1 - na)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (nb * (1 - nb)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (nr * (1 - nr)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (np * (1 - np)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (sext * (1 - sext)) (by simp)
+    -- Boundary equations (constraints 9--24).
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_by_zero * b_0) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_by_zero * b_1) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_by_zero * b_2) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_by_zero * b_3) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_by_zero * (a_0 - 65535)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_by_zero * (a_1 - 65535)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_by_zero * (a_2 - (1 - m32) * 65535)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_by_zero * (a_3 - (1 - m32) * 65535)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_overflow * (b_0 - 65535)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_overflow * (b_1 - 65535)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_overflow * (b_2 - (1 - m32) * 65535)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_overflow * (b_3 - (1 - m32) * 65535)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_overflow * c_0) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_overflow * (c_1 - m32 * 32768)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_overflow * c_2) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_overflow * (c_3 - (1 - m32) * 32768)) (by simp)
+    -- Inverse-sum witness equation (constraint 25).
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 ((div - div_by_zero)
+          * (1 - inv_sum_all_bs * (((b_0 + b_1) + b_2) + b_3))) (by simp)
+    -- Scope equations (constraints 26--30).
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_by_zero * (1 - div)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_overflow * (1 - div)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_overflow * (1 - signed)) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_overflow * div_by_zero) (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (div_by_zero * div_overflow) (by simp)
+    -- W-mode high-lane equations (constraints 47--48).
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (m32 * (div * (c_2 + c_3 * 65536) + (1 - div) * (a_2 + a_3 * 65536)))
+          (by simp)
+    · simpa [Expression.eval, sub_eq_add_neg] using
+        h_main.1 (m32 * (b_2 + b_3 * 65536)) (by simp)
+
+/-- Component-level entry point of
+    `completeLocal_of_sharedMainComplete_constraints`: transport a live
+    `componentComplete` table row's `constraints_hold` into the named local
+    bundles over the provider row. -/
+theorem completeLocal_of_componentComplete_constraints
+    (env : Environment FGL)
+    (h_holds : componentComplete.operations.ConstraintsHold env) :
+    Spec (eval env componentComplete.rowInputVar)
+    ∧ ModeSpec (eval env componentComplete.rowInputVar)
+    ∧ C46Spec (eval env componentComplete.rowInputVar)
+    ∧ SharedDivBlockSpec (eval env componentComplete.rowInputVar) := by
+  have h_row : componentComplete.rowOperations.ConstraintsHold env :=
+    (Air.Flat.Component.constraintsHold_iff (component := componentComplete) env).mp h_holds
+  exact completeLocal_of_sharedMainComplete_constraints
+    componentComplete.rowOffset env componentComplete.rowInputVar (by
+      simpa only [componentComplete, circuitComplete, arithMulCompleteElaborated,
+        Air.Flat.Component.rowOperations] using h_row)
+
 /-- The lookup-aware Clean circuit sources ArithTable membership from its
     `lookup (Table.fromStatic ArithTable.arithTable) ...` operation.
 

--- a/ZiskFv/AirsClean/ArithMul/Row.lean
+++ b/ZiskFv/AirsClean/ArithMul/Row.lean
@@ -73,6 +73,9 @@ structure ArithMulCarries (F : Type) where
   fab : F
   na_fb : F
   nb_fa : F
+  /-- Arith AIR stage-1 column 38, used by `constraint_25_every_row`
+      (`arith.pil:143`) to witness the inverse of the divisor-chunk sum. -/
+  inv_sum_all_bs : F
 deriving ProvableStruct
 
 structure ArithMulRow (F : Type) where

--- a/ZiskFv/AirsClean/ArithMul/Spec.lean
+++ b/ZiskFv/AirsClean/ArithMul/Spec.lean
@@ -249,4 +249,91 @@ def FullSpec (row : ArithMulRow FGL) : Prop :=
   Spec row ∧ ArithTableSpec row ∧ C46Spec row ∧ ChunkRangeSpec row ∧ CarryRangeSpec row
     ∧ IndexedRangeSpec row
 
+/-! ## Div-block bundles over the shared provider row
+
+The completed shared Arith provider (`sharedMainComplete`) checks every
+generated local constraint, including the Div-family block that the narrower
+`ArithDiv` view names in `ArithDiv.{ModeSpec, BoundarySpec, InverseSumSpec,
+ScopeSpec, WModeSpec}`.  These bundles restate that block clause-for-clause
+over the shared `ArithMulRow`, so the ArithDiv view facts can be transported
+from the live provider row without a caller premise. -/
+
+/-- Booleanity and selector-disjointness of the Div-relevant flags
+    (generated constraints 0--5 and 39--45; PIL `arith.pil:46-53,237-243`),
+    mirroring `ArithDiv.ModeSpec` clause-for-clause. -/
+@[reducible]
+def DivModeSpec (row : ArithMulRow FGL) : Prop :=
+  row.flags.main_div * (row.flags.main_div - 1) = 0
+  ∧ row.flags.main_mul * (row.flags.main_mul - 1) = 0
+  ∧ row.flags.main_mul * row.flags.main_div = 0
+  ∧ row.flags.signed * (1 - row.flags.signed) = 0
+  ∧ row.flags.div_by_zero * (1 - row.flags.div_by_zero) = 0
+  ∧ row.flags.div_overflow * (1 - row.flags.div_overflow) = 0
+  ∧ row.flags.div * (1 - row.flags.div) = 0
+  ∧ row.flags.m32 * (1 - row.flags.m32) = 0
+  ∧ row.flags.na * (1 - row.flags.na) = 0
+  ∧ row.flags.nb * (1 - row.flags.nb) = 0
+  ∧ row.flags.nr * (1 - row.flags.nr) = 0
+  ∧ row.flags.np * (1 - row.flags.np) = 0
+  ∧ row.flags.sext * (1 - row.flags.sext) = 0
+
+/-- Div-by-zero and signed-overflow boundary equations (generated
+    constraints 9--24; PIL `arith.pil:130-141`), mirroring
+    `ArithDiv.BoundarySpec` clause-for-clause. -/
+@[reducible]
+def DivBoundarySpec (row : ArithMulRow FGL) : Prop :=
+  row.flags.div_by_zero * row.chunks.b_0 = 0
+  ∧ row.flags.div_by_zero * row.chunks.b_1 = 0
+  ∧ row.flags.div_by_zero * row.chunks.b_2 = 0
+  ∧ row.flags.div_by_zero * row.chunks.b_3 = 0
+  ∧ row.flags.div_by_zero * (row.chunks.a_0 - 65535) = 0
+  ∧ row.flags.div_by_zero * (row.chunks.a_1 - 65535) = 0
+  ∧ row.flags.div_by_zero * (row.chunks.a_2 - (1 - row.flags.m32) * 65535) = 0
+  ∧ row.flags.div_by_zero * (row.chunks.a_3 - (1 - row.flags.m32) * 65535) = 0
+  ∧ row.flags.div_overflow * (row.chunks.b_0 - 65535) = 0
+  ∧ row.flags.div_overflow * (row.chunks.b_1 - 65535) = 0
+  ∧ row.flags.div_overflow * (row.chunks.b_2 - (1 - row.flags.m32) * 65535) = 0
+  ∧ row.flags.div_overflow * (row.chunks.b_3 - (1 - row.flags.m32) * 65535) = 0
+  ∧ row.flags.div_overflow * row.chunks.c_0 = 0
+  ∧ row.flags.div_overflow * (row.chunks.c_1 - row.flags.m32 * 32768) = 0
+  ∧ row.flags.div_overflow * row.chunks.c_2 = 0
+  ∧ row.flags.div_overflow * (row.chunks.c_3 - (1 - row.flags.m32) * 32768) = 0
+
+/-- Inverse-sum witness equation detecting a nonzero divisor (generated
+    constraint 25; PIL `arith.pil:143`), mirroring `ArithDiv.InverseSumSpec`
+    over the shared committed column `carries.inv_sum_all_bs`. -/
+@[reducible]
+def DivInverseSumSpec (row : ArithMulRow FGL) : Prop :=
+  (row.flags.div - row.flags.div_by_zero) *
+    (1 - row.carries.inv_sum_all_bs *
+      (((row.chunks.b_0 + row.chunks.b_1) + row.chunks.b_2) + row.chunks.b_3)) = 0
+
+/-- Scope and exceptional-mode disjointness equations (generated constraints
+    26--30; PIL `arith.pil:145-153`), mirroring `ArithDiv.ScopeSpec`. -/
+@[reducible]
+def DivScopeSpec (row : ArithMulRow FGL) : Prop :=
+  row.flags.div_by_zero * (1 - row.flags.div) = 0
+  ∧ row.flags.div_overflow * (1 - row.flags.div) = 0
+  ∧ row.flags.div_overflow * (1 - row.flags.signed) = 0
+  ∧ row.flags.div_overflow * row.flags.div_by_zero = 0
+  ∧ row.flags.div_by_zero * row.flags.div_overflow = 0
+
+/-- W-mode high-lane equations (generated constraints 47--48;
+    PIL `arith.pil:265-266`), mirroring `ArithDiv.WModeSpec`. -/
+@[reducible]
+def DivWModeSpec (row : ArithMulRow FGL) : Prop :=
+  row.flags.m32 *
+    (row.flags.div * (row.chunks.c_2 + row.chunks.c_3 * 65536) +
+      (1 - row.flags.div) * (row.chunks.a_2 + row.chunks.a_3 * 65536)) = 0
+  ∧ row.flags.m32 * (row.chunks.b_2 + row.chunks.b_3 * 65536) = 0
+
+/-- The appended Div-block facts supplied by the completed shared provider
+    (`sharedMainComplete`) beyond `Spec`/`ModeSpec`/`C46Spec`: exactly the
+    `ArithDiv.CompleteLocalSpec` content minus the carry chain and the
+    result mux, stated over the shared `ArithMulRow`. -/
+@[reducible]
+def SharedDivBlockSpec (row : ArithMulRow FGL) : Prop :=
+  DivModeSpec row ∧ DivBoundarySpec row ∧ DivInverseSumSpec row ∧ DivScopeSpec row
+    ∧ DivWModeSpec row
+
 end ZiskFv.AirsClean.ArithMul

--- a/ZiskFv/AirsClean/FullEnsemble.lean
+++ b/ZiskFv/AirsClean/FullEnsemble.lean
@@ -82,10 +82,10 @@ def fullRv64imSoundEnsemble (length : ℕ) (program : Program length) :
         (by
           intro channel h
           simp [circuit_norm] at h)
-    |>.addTable ZiskFv.AirsClean.ArithMul.componentWithArithTable
-        (by simp [ZiskFv.AirsClean.ArithMul.componentWithArithTable,
-          ZiskFv.AirsClean.ArithMul.circuitWithArithTable,
-          ZiskFv.AirsClean.ArithMul.arithMulWithArithTableElaborated])
+    |>.addTable ZiskFv.AirsClean.ArithMul.componentComplete
+        (by simp [ZiskFv.AirsClean.ArithMul.componentComplete,
+          ZiskFv.AirsClean.ArithMul.circuitComplete,
+          ZiskFv.AirsClean.ArithMul.arithMulCompleteElaborated])
         (by
           intro channel h
           simp [circuit_norm] at h)

--- a/ZiskFv/AirsClean/FullEnsemble/ArithBalance.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/ArithBalance.lean
@@ -178,7 +178,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_mulw_active_main_row_int
             (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
             (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
               (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
-                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                (ZiskFv.AirsClean.ArithMul.componentComplete.rowInput
                   (providerTable.environment providerRow))) 1) := by
   have h_main_entry :
       ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
@@ -216,7 +216,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_mulw_active_main_row_int
           (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
           (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
             (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
-              (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+              (ZiskFv.AirsClean.ArithMul.componentComplete.rowInput
                 (providerTable.environment providerRow))) 1) := by
       rw [ZiskFv.AirsClean.ArithMul.eval_primaryOpBusMessageExpr] at h_match
       have h_row_eq :
@@ -440,7 +440,7 @@ theorem exists_arithMul_provider_row_matches_secondary_of_mulhu_active_main_row_
             (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
             (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
               (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
-                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                (ZiskFv.AirsClean.ArithMul.componentComplete.rowInput
                   (providerTable.environment providerRow))) 1) := by
   have h_main_entry :
       ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
@@ -478,7 +478,7 @@ theorem exists_arithMul_provider_row_matches_secondary_of_mulhu_active_main_row_
           (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
           (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
             (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
-              (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+              (ZiskFv.AirsClean.ArithMul.componentComplete.rowInput
                 (providerTable.environment providerRow))) 1) := by
       rw [ZiskFv.AirsClean.ArithMul.eval_primaryOpBusMessageExpr] at h_match
       have h_row_eq :
@@ -704,7 +704,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_divu_active_main_row_int
             (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
             (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
               (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
-                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                (ZiskFv.AirsClean.ArithMul.componentComplete.rowInput
                   (providerTable.environment providerRow))) 1) := by
   have h_main_entry :
       ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
@@ -742,7 +742,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_divu_active_main_row_int
           (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
           (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
             (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
-              (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+              (ZiskFv.AirsClean.ArithMul.componentComplete.rowInput
                 (providerTable.environment providerRow))) 1) := by
       rw [ZiskFv.AirsClean.ArithMul.eval_primaryOpBusMessageExpr] at h_match
       have h_row_eq :
@@ -967,7 +967,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_divuw_active_main_row_in
             (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
             (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
               (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
-                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                (ZiskFv.AirsClean.ArithMul.componentComplete.rowInput
                   (providerTable.environment providerRow))) 1) := by
   have h_main_entry :
       ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
@@ -1005,7 +1005,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_divuw_active_main_row_in
           (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
           (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
             (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
-              (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+              (ZiskFv.AirsClean.ArithMul.componentComplete.rowInput
                 (providerTable.environment providerRow))) 1) := by
       rw [ZiskFv.AirsClean.ArithMul.eval_primaryOpBusMessageExpr] at h_match
       have h_row_eq :
@@ -1231,7 +1231,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_remu_active_main_row_int
             (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
             (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
               (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
-                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                (ZiskFv.AirsClean.ArithMul.componentComplete.rowInput
                   (providerTable.environment providerRow))) 1) := by
   have h_main_entry :
       ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
@@ -1269,7 +1269,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_remu_active_main_row_int
           (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
           (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
             (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
-              (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+              (ZiskFv.AirsClean.ArithMul.componentComplete.rowInput
                 (providerTable.environment providerRow))) 1) := by
       rw [ZiskFv.AirsClean.ArithMul.eval_primaryOpBusMessageExpr] at h_match
       have h_row_eq :
@@ -1496,7 +1496,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_remuw_active_main_row_in
             (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
             (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
               (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
-                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                (ZiskFv.AirsClean.ArithMul.componentComplete.rowInput
                   (providerTable.environment providerRow))) 1) := by
   have h_main_entry :
       ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
@@ -1534,7 +1534,7 @@ theorem exists_arithMul_provider_row_matches_primary_of_remuw_active_main_row_in
           (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
           (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
             (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
-              (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+              (ZiskFv.AirsClean.ArithMul.componentComplete.rowInput
                 (providerTable.environment providerRow))) 1) := by
       rw [ZiskFv.AirsClean.ArithMul.eval_primaryOpBusMessageExpr] at h_match
       have h_row_eq :

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/Classification.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/Classification.lean
@@ -18,7 +18,7 @@ open ZiskFv.AirsClean.BinaryExtension (shiftStaticLookupComponent)
 /-- The lookup-aware ArithMul provider component used by the full ensemble. -/
 @[reducible]
 def arithMulProviderComponent : Component FGL :=
-  ZiskFv.AirsClean.ArithMul.componentWithArithTable
+  ZiskFv.AirsClean.ArithMul.componentComplete
 
 /-- Concrete component classification for the row-coherent full Clean
     ensemble. Components appear newest-first after the empty verifier table,
@@ -349,7 +349,7 @@ theorem arithMul_table_interactionsWith_memBus_nil
       MemBusChannel.toRaw ∉
         arithMulProviderComponent.circuit.channels := by
     rw [arithMulProviderComponent,
-      ZiskFv.AirsClean.ArithMul.componentWithArithTable_channels]
+      ZiskFv.AirsClean.ArithMul.componentComplete_channels]
     simp only [List.mem_singleton]
     intro h
     have h_name := congrArg (fun c : RawChannel FGL => c.name) h

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/RowExtraction.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/RowExtraction.lean
@@ -309,7 +309,7 @@ theorem exists_arithMul_row_eval_of_interaction_mem
           (table.environment row) := by
   apply exists_opBus_row_eval_of_singleton_interactionsWith
   · simpa [h_component] using
-      ZiskFv.AirsClean.ArithMul.componentWithArithTable_interactionsWith_opBus
+      ZiskFv.AirsClean.ArithMul.componentComplete_interactionsWith_opBus
   · exact h_mem
 
 /-- Project the lookup-aware ArithMul provider branch's generic component
@@ -323,7 +323,7 @@ theorem arithMul_fullSpec_of_component_spec
         (table.environment row)) := by
   rw [h_component] at h_spec
   simpa [arithMulProviderComponent,
-    ZiskFv.AirsClean.ArithMul.componentWithArithTable_spec] using h_spec
+    ZiskFv.AirsClean.ArithMul.componentComplete_spec] using h_spec
 
 /-- A lookup-aware ArithMul provider branch can only match Main rows whose
     operation-bus opcode lies in the Arith ROM opcode range. -/

--- a/ZiskFv/Compliance/AddAddiSpinWitness.lean
+++ b/ZiskFv/Compliance/AddAddiSpinWitness.lean
@@ -367,7 +367,7 @@ theorem addAddiSpinEnsemble_tables :
       , ZiskFv.AirsClean.MemAlign.component
       , ZiskFv.AirsClean.Mem.componentWithDualMemBus
       , ZiskFv.AirsClean.ArithDiv.component
-      , ZiskFv.AirsClean.ArithMul.componentWithArithTable
+      , ZiskFv.AirsClean.ArithMul.componentComplete
       , ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
       , ZiskFv.AirsClean.Binary.staticLookupComponent
       , ZiskFv.AirsClean.BinaryAdd.component
@@ -381,7 +381,7 @@ def addAddiSpinTables : List (Table FGL) :=
   , emptyComponentTable ZiskFv.AirsClean.MemAlign.component
   , emptyComponentTable ZiskFv.AirsClean.Mem.componentWithDualMemBus
   , emptyComponentTable ZiskFv.AirsClean.ArithDiv.component
-  , emptyComponentTable ZiskFv.AirsClean.ArithMul.componentWithArithTable
+  , emptyComponentTable ZiskFv.AirsClean.ArithMul.componentComplete
   , emptyComponentTable ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
   , emptyComponentTable ZiskFv.AirsClean.Binary.staticLookupComponent
   , addAddiSpinBinaryAddTable
@@ -429,7 +429,7 @@ theorem addAddiSpinWitness_table_constraints :
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlign.component
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.Mem.componentWithDualMemBus
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.ArithDiv.component
-  · exact emptyComponentTable_constraints ZiskFv.AirsClean.ArithMul.componentWithArithTable
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.ArithMul.componentComplete
   · exact emptyComponentTable_constraints
       ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.Binary.staticLookupComponent
@@ -634,7 +634,7 @@ theorem addAddiSpinWitness_transitions : addAddiSpinWitness.TransitionConstraint
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlign.component
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.Mem.componentWithDualMemBus
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.ArithDiv.component
-    · exact emptyComponentTable_transitions ZiskFv.AirsClean.ArithMul.componentWithArithTable
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.ArithMul.componentComplete
     · exact emptyComponentTable_transitions
         ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.Binary.staticLookupComponent
@@ -725,7 +725,7 @@ private theorem addAddiSpinWitness_mutable_mem_component_tables_empty
     · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlign.component
     · exact emptyComponentTable_table ZiskFv.AirsClean.Mem.componentWithDualMemBus
     · exact emptyComponentTable_table ZiskFv.AirsClean.ArithDiv.component
-    · exact emptyComponentTable_table ZiskFv.AirsClean.ArithMul.componentWithArithTable
+    · exact emptyComponentTable_table ZiskFv.AirsClean.ArithMul.componentComplete
     · exact emptyComponentTable_table ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
     · exact emptyComponentTable_table ZiskFv.AirsClean.Binary.staticLookupComponent
     · exfalso
@@ -1448,7 +1448,7 @@ private theorem addAddiSpinTablesMemBusInteractions_eq_active :
     (e₂ := emptyComponentTable ZiskFv.AirsClean.MemAlign.component)
     (e₃ := emptyComponentTable ZiskFv.AirsClean.Mem.componentWithDualMemBus)
     (e₄ := emptyComponentTable ZiskFv.AirsClean.ArithDiv.component)
-    (e₅ := emptyComponentTable ZiskFv.AirsClean.ArithMul.componentWithArithTable)
+    (e₅ := emptyComponentTable ZiskFv.AirsClean.ArithMul.componentComplete)
     (e₆ := emptyComponentTable ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
     (e₇ := emptyComponentTable ZiskFv.AirsClean.Binary.staticLookupComponent)
     (last₀ := addAddiSpinBinaryAddTable) (last₁ := addAddiSpinMainTable)
@@ -1463,7 +1463,7 @@ private theorem addAddiSpinTablesMemBusInteractions_eq_active :
     (h₄ := emptyComponentTable_interactionsWith
       ZiskFv.AirsClean.ArithDiv.component MemBusChannel.toRaw)
     (h₅ := emptyComponentTable_interactionsWith
-      ZiskFv.AirsClean.ArithMul.componentWithArithTable MemBusChannel.toRaw)
+      ZiskFv.AirsClean.ArithMul.componentComplete MemBusChannel.toRaw)
     (h₆ := emptyComponentTable_interactionsWith
       ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent MemBusChannel.toRaw)
     (h₇ := emptyComponentTable_interactionsWith

--- a/ZiskFv/Compliance/AddSpinWitness.lean
+++ b/ZiskFv/Compliance/AddSpinWitness.lean
@@ -491,7 +491,7 @@ def addSpinTables : List (Table FGL) :=
   , emptyComponentTable ZiskFv.AirsClean.MemAlign.component
   , emptyComponentTable ZiskFv.AirsClean.Mem.componentWithDualMemBus
   , emptyComponentTable ZiskFv.AirsClean.ArithDiv.component
-  , emptyComponentTable ZiskFv.AirsClean.ArithMul.componentWithArithTable
+  , emptyComponentTable ZiskFv.AirsClean.ArithMul.componentComplete
   , emptyComponentTable ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
   , emptyComponentTable ZiskFv.AirsClean.Binary.staticLookupComponent
   , binaryAddRowsTable [addX1BinaryAddRow]
@@ -504,7 +504,7 @@ def addSpinNonMainTables : List (Table FGL) :=
   , emptyComponentTable ZiskFv.AirsClean.MemAlign.component
   , emptyComponentTable ZiskFv.AirsClean.Mem.componentWithDualMemBus
   , emptyComponentTable ZiskFv.AirsClean.ArithDiv.component
-  , emptyComponentTable ZiskFv.AirsClean.ArithMul.componentWithArithTable
+  , emptyComponentTable ZiskFv.AirsClean.ArithMul.componentComplete
   , emptyComponentTable ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
   , emptyComponentTable ZiskFv.AirsClean.Binary.staticLookupComponent
   , binaryAddRowsTable [addX1BinaryAddRow] ]
@@ -552,7 +552,7 @@ theorem addSpinWitness_table_constraints :
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlign.component
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.Mem.componentWithDualMemBus
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.ArithDiv.component
-  · exact emptyComponentTable_constraints ZiskFv.AirsClean.ArithMul.componentWithArithTable
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.ArithMul.componentComplete
   · exact emptyComponentTable_constraints
       ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.Binary.staticLookupComponent
@@ -582,7 +582,7 @@ theorem addSpinWitness_transitions : addSpinWitness.TransitionConstraints := by
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlign.component
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.Mem.componentWithDualMemBus
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.ArithDiv.component
-    · exact emptyComponentTable_transitions ZiskFv.AirsClean.ArithMul.componentWithArithTable
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.ArithMul.componentComplete
     · exact emptyComponentTable_transitions
         ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.Binary.staticLookupComponent
@@ -674,7 +674,7 @@ private theorem addSpinWitness_mutable_mem_component_tables_empty (table : Table
     · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlign.component
     · exact emptyComponentTable_table ZiskFv.AirsClean.Mem.componentWithDualMemBus
     · exact emptyComponentTable_table ZiskFv.AirsClean.ArithDiv.component
-    · exact emptyComponentTable_table ZiskFv.AirsClean.ArithMul.componentWithArithTable
+    · exact emptyComponentTable_table ZiskFv.AirsClean.ArithMul.componentComplete
     · exact emptyComponentTable_table
         ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
     · exact emptyComponentTable_table ZiskFv.AirsClean.Binary.staticLookupComponent

--- a/ZiskFv/Compliance/ConstructionDivu.lean
+++ b/ZiskFv/Compliance/ConstructionDivu.lean
@@ -19,14 +19,14 @@ Unsigned RV64M DIVU (`OP_DIVU = 184`), mirroring the MULW / MULHU
 constructions.  The Arith provider witnesses (ArithTable membership, chunk
 ranges, signed-carry ranges, c46, carry-chain) are **DERIVED FROM BALANCE**
 via the SHARED ArithMul provider component's lookup-aware
-`componentWithArithTable.Spec = FullSpec`, not carried as caller binders.
+`componentComplete.Spec = FullSpec`, not carried as caller binders.
 
 ## Why the shared ArithMul provider (not ArithDiv)
 
 `ArithDiv.component` carries NO operation-bus interactions in the full
 ensemble (`arithDiv_table_interactionsWith_opBus_nil`): its
 `circuit.channels = []`.  The DIVU Main op-bus emission is therefore balanced
-by the SHARED ArithMul provider (`componentWithArithTable`), whose `FullSpec`
+by the SHARED ArithMul provider (`componentComplete`), whose `FullSpec`
 covers div rows too (the carry chain is mode-shared via the `div` flag).  The
 muxed primary op-bus message, at the DIVU mode pins (`div = 1`,
 `main_div = 1`, `main_mul = 0`), reduces to the div quotient-lane message
@@ -73,7 +73,7 @@ open ZiskFv.Airs.Main
 open ZiskFv.Airs.OperationBus
 open ZiskFv.Channels.MemoryBusBytes (byteAt)
 open ZiskFv.AirsClean.FullEnsemble
-open ZiskFv.AirsClean.ArithMul (componentWithArithTable primaryOpBusMessage rowAt)
+open ZiskFv.AirsClean.ArithMul (componentComplete primaryOpBusMessage rowAt)
 
 set_option maxHeartbeats 4000000
 set_option maxRecDepth 8000
@@ -130,7 +130,7 @@ def vOfDivuRow (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL) :
   signed := fun _ => arow.flags.signed
   div_by_zero := fun _ => arow.flags.div_by_zero
   div_overflow := fun _ => arow.flags.div_overflow
-  inv_sum_all_bs := fun _ => 0
+  inv_sum_all_bs := fun _ => arow.carries.inv_sum_all_bs
   op := fun _ => arow.flags.op
   bus_res1 := fun _ => arow.flags.bus_res1
   multiplicity := fun _ => 1
@@ -436,7 +436,7 @@ private lemma divu_carry_bounds_claimed_dead
 
 /-- The balance-selected Arith-Mul provider row at trace index `i` for a DIVU
     operation, as a concrete `ArithMulRow`.  It is the
-    `componentWithArithTable.rowInput` of the provider row chosen by the DIVU
+    `componentComplete.rowInput` of the provider row chosen by the DIVU
     keep-arithMul balance wrapper
     `main_request_divu_provided`.
     Mirrors `mulwArow`. -/
@@ -449,10 +449,10 @@ noncomputable def divuArow
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
   let h := main_request_divu_provided
     trace i h_main_active h_main_op
-  componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
+  componentComplete.rowInput (h.choose.environment h.choose_spec.2.choose)
 
 /-- `FullSpec` of the balance-selected DIVU provider row, derived from the
-    provider component's proven soundness (`componentWithArithTable.Spec`). -/
+    provider component's proven soundness (`componentComplete.Spec`). -/
 theorem divuArow_fullSpec_row
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
@@ -544,7 +544,7 @@ open ZiskFv.EquivCore.Promises in
 /-- **F4 extraction bridge for `equiv_DIVU`.**  Mirror of
     `equiv_MULHU_of_fullSpec`: the four lookup-aware Arith witness records are
     replaced by the single `FullSpec arow` hypothesis (the SHARED ArithMul
-    provider's `componentWithArithTable.Spec`), with the ArithDiv-view facts
+    provider's `componentComplete.Spec`), with the ArithDiv-view facts
     read off the same row through `vOfDivuRow arow`.
 
     Like MULHU, DIVU's `equiv_DIVU` demands the *unsigned* carry bound
@@ -727,7 +727,7 @@ lemma equiv_DIVU_of_fullSpec_claimed_dead
     The Arith provider witnesses (ArithTable membership, chunk ranges, signed
     carry ranges, c46, carry-chain) are DERIVED inside the body from
     `trace.channels_balanced` / `trace.spec_holds` via the SHARED ArithMul provider's
-    lookup-aware `componentWithArithTable.Spec = FullSpec`, NOT supplied as
+    lookup-aware `componentComplete.Spec = FullSpec`, NOT supplied as
     binders.
 
     The ONE non-balance-derived residual is `remainder_bound`

--- a/ZiskFv/Compliance/ConstructionDivu.lean
+++ b/ZiskFv/Compliance/ConstructionDivu.lean
@@ -172,6 +172,106 @@ theorem arithDiv_fullSpec_of_arithMul_fullSpec
       ZiskFv.AirsClean.ArithDiv.rowAt, vOfDivuRow,
       ZiskFv.AirsClean.ArithMul.IndexedRangeSpec] using h_indexed
 
+/-- The ArithDiv-view `CompleteLocalSpec` of a provider `ArithMulRow`, transported
+    from the SHARED provider's live complete-local supply: the carry chain and c46
+    (already named on the ArithMul side) plus the appended Div block
+    (`SharedDivBlockSpec`).  Pure algebraic re-view of the same facts over the
+    `vOfDivuRow` field mapping — no new trust, no caller premise. -/
+theorem arithDiv_completeLocal_of_sharedDivBlock
+    (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL)
+    (h_spec : ZiskFv.AirsClean.ArithMul.Spec arow)
+    (h_c46 : ZiskFv.AirsClean.ArithMul.C46Spec arow)
+    (h_div : ZiskFv.AirsClean.ArithMul.SharedDivBlockSpec arow) :
+    ZiskFv.AirsClean.ArithDiv.CompleteLocalSpec
+      (ZiskFv.AirsClean.ArithDiv.rowAt (vOfDivuRow arow) 0) := by
+  obtain ⟨hc6, hc7, hc8, hc31, hc32, hc33, hc34, hc35, hc36, hc37, hc38⟩ := h_spec
+  obtain ⟨⟨hm0, hm1, hm2, hm3, hm4, hm5, hm39, hm40, hm41, hm42, hm43, hm44, hm45⟩,
+    ⟨hb1, hb2, hb3, hb4, hb5, hb6, hb7, hb8,
+      hb9, hb10, hb11, hb12, hb13, hb14, hb15, hb16⟩,
+    hinv, ⟨hs1, hs2, hs3, hs4, hs5⟩, hw1, hw2⟩ := h_div
+  refine ⟨⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩,
+    ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩,
+    ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩,
+    ?_, ⟨?_, ?_, ?_, ?_, ?_⟩, ?_, ?_, ?_⟩
+  · linear_combination hc6
+  · linear_combination hc7
+  · linear_combination hc8
+  · linear_combination hc31
+  · linear_combination hc32
+  · linear_combination hc33
+  · linear_combination hc34
+  · linear_combination hc35
+  · linear_combination hc36
+  · linear_combination hc37
+  · linear_combination hc38
+  · linear_combination hm0
+  · linear_combination hm1
+  · linear_combination hm2
+  · linear_combination hm3
+  · linear_combination hm4
+  · linear_combination hm5
+  · linear_combination hm39
+  · linear_combination hm40
+  · linear_combination hm41
+  · linear_combination hm42
+  · linear_combination hm43
+  · linear_combination hm44
+  · linear_combination hm45
+  · linear_combination hb1
+  · linear_combination hb2
+  · linear_combination hb3
+  · linear_combination hb4
+  · linear_combination hb5
+  · linear_combination hb6
+  · linear_combination hb7
+  · linear_combination hb8
+  · linear_combination hb9
+  · linear_combination hb10
+  · linear_combination hb11
+  · linear_combination hb12
+  · linear_combination hb13
+  · linear_combination hb14
+  · linear_combination hb15
+  · linear_combination hb16
+  · linear_combination hinv
+  · linear_combination hs1
+  · linear_combination hs2
+  · linear_combination hs3
+  · linear_combination hs4
+  · linear_combination hs5
+  · linear_combination h_c46
+  · linear_combination hw1
+  · linear_combination hw2
+
+/-- `CompleteLocalSpec` of the ArithDiv view of a balance-selected live provider
+    row, read off the selected table's `constraints_hold`.  This is the seam the
+    R14/R15 audits identified: the appended Div-block facts are validated by the
+    live `componentComplete` table, so the view needs no caller premise. -/
+theorem arithDiv_completeLocal_of_selected_provider
+    {providerTable : Air.Flat.Table FGL} {providerRow : Array FGL}
+    (h_constraints : providerTable.Constraints)
+    (h_pr_mem : providerRow ∈ providerTable.table)
+    (h_component : providerTable.component
+      = ZiskFv.AirsClean.FullEnsemble.arithMulProviderComponent) :
+    ZiskFv.AirsClean.ArithDiv.CompleteLocalSpec
+      (ZiskFv.AirsClean.ArithDiv.rowAt
+        (vOfDivuRow (componentComplete.rowInput
+          (providerTable.environment providerRow))) 0) := by
+  have h_holds : componentComplete.operations.ConstraintsHold
+      (providerTable.environment providerRow) := by
+    have h := h_constraints providerRow h_pr_mem
+    rwa [h_component] at h
+  have h_facts := ZiskFv.AirsClean.ArithMul.completeLocal_of_componentComplete_constraints
+    (providerTable.environment providerRow) h_holds
+  have h_row_eq :
+      eval (providerTable.environment providerRow) componentComplete.rowInputVar
+        = componentComplete.rowInput (providerTable.environment providerRow) := by
+    simpa only [Air.Flat.Component.rowInput, Air.Flat.Component.rowInputVar] using
+      eval_varFromOffset_valueFromOffset componentComplete.Input 0
+        (providerTable.environment providerRow)
+  rw [h_row_eq] at h_facts
+  exact arithDiv_completeLocal_of_sharedDivBlock _ h_facts.1 h_facts.2.2.1 h_facts.2.2.2
+
 /-- The ArithDiv-view `div_row_constraints_with_c46` of a provider `ArithMulRow`,
     derived from the SHARED-ArithMul-provider `FullSpec arow`.  The 11-clause
     `div_carry_chain_holds` is the same algebra as the ArithMul `Spec` (carry
@@ -467,6 +567,27 @@ theorem divuArow_fullSpec_row
   obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
   exact ZiskFv.AirsClean.FullEnsemble.arithMul_fullSpec_of_component_spec
     h_component (h_spec h_rest.choose h_pr_mem)
+
+/-- `CompleteLocalSpec` of the ArithDiv view of the balance-selected DIVU
+    provider row, DERIVED from the live table's `constraints_hold`
+    (`trace.constraints_hold`) — the transported complete-local supply that
+    upgrades `ArithDivTableWitness` without a caller premise. -/
+theorem divuArow_completeLocal
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (h_main_active :
+      (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU) :
+    ZiskFv.AirsClean.ArithDiv.CompleteLocalSpec
+      (ZiskFv.AirsClean.ArithDiv.rowAt
+        (vOfDivuRow (divuArow trace binding i h_main_active h_main_op)) 0) := by
+  unfold divuArow
+  set H := main_request_divu_provided
+    trace i h_main_active h_main_op with hH
+  obtain ⟨h_pt_mem, h_rest⟩ := H.choose_spec
+  obtain ⟨h_pr_mem, h_component, _h_spec, _h_match⟩ := h_rest.choose_spec
+  exact arithDiv_completeLocal_of_selected_provider
+    (trace.constraints_hold H.choose h_pt_mem) h_pr_mem h_component
 
 /-- The op-bus match of the balance-selected DIVU provider row against the Main
     row's emission, in `toEntry (primaryOpBusMessage …) 1` form (cheap: free

--- a/ZiskFv/Compliance/ConstructionDivuw.lean
+++ b/ZiskFv/Compliance/ConstructionDivuw.lean
@@ -20,7 +20,7 @@ Unsigned RV64M **DIVUW** (`OP_DIVU_W = 188`, W-mode `m32 = 1`), the W-mode
 sibling of DIVU — exactly as MULW relates to a 64-bit multiply.  The Arith
 provider witnesses (ArithTable membership, chunk ranges, signed-carry ranges,
 c46, carry-chain) are **DERIVED FROM BALANCE** via the SHARED ArithMul provider
-component's lookup-aware `componentWithArithTable.Spec = FullSpec`, not carried
+component's lookup-aware `componentComplete.Spec = FullSpec`, not carried
 as caller binders.
 
 ## Why the shared ArithMul provider (not ArithDiv)
@@ -28,7 +28,7 @@ as caller binders.
 `ArithDiv.component` carries NO operation-bus interactions in the full ensemble
 (`arithDiv_table_interactionsWith_opBus_nil`): its `circuit.channels = []`.  The
 DIVUW Main op-bus emission is therefore balanced by the SHARED ArithMul provider
-(`componentWithArithTable`), whose `FullSpec` covers div rows too.  The muxed
+(`componentComplete`), whose `FullSpec` covers div rows too.  The muxed
 primary op-bus message, at the DIVUW mode pins (`div = 1`, `main_div = 1`,
 `main_mul = 0` — all uniform for op 188), reduces to the div quotient-lane
 message `opBus_row_ArithDiv`.  These three mux selectors are the SAME as DIVU's,
@@ -102,7 +102,7 @@ open ZiskFv.Airs.Main
 open ZiskFv.Airs.OperationBus
 open ZiskFv.Channels.MemoryBusBytes (byteAt)
 open ZiskFv.AirsClean.FullEnsemble
-open ZiskFv.AirsClean.ArithMul (componentWithArithTable primaryOpBusMessage rowAt)
+open ZiskFv.AirsClean.ArithMul (componentComplete primaryOpBusMessage rowAt)
 
 set_option maxHeartbeats 4000000
 set_option maxRecDepth 8000
@@ -297,7 +297,7 @@ private lemma divuw_carry_bounds_claimed_dead
 
 /-- The balance-selected Arith-Mul provider row at trace index `i` for a DIVUW
     operation, as a concrete `ArithMulRow`.  It is the
-    `componentWithArithTable.rowInput` of the provider row chosen by the DIVUW
+    `componentComplete.rowInput` of the provider row chosen by the DIVUW
     keep-arithMul balance wrapper
     `main_request_divuw_provided`.
     Mirrors `divuArow`. -/
@@ -310,10 +310,10 @@ noncomputable def divuwArow
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
   let h := main_request_divuw_provided
     trace i h_main_active h_main_op
-  componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
+  componentComplete.rowInput (h.choose.environment h.choose_spec.2.choose)
 
 /-- `FullSpec` of the balance-selected DIVUW provider row, derived from the
-    provider component's proven soundness (`componentWithArithTable.Spec`). -/
+    provider component's proven soundness (`componentComplete.Spec`). -/
 theorem divuwArow_fullSpec_row
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
@@ -406,7 +406,7 @@ open ZiskFv.EquivCore.Promises in
 /-- **F4 extraction bridge for `equiv_DIVUW`.**  Mirror of `equiv_DIVU_of_fullSpec`
     for the W-mode (`m32 = 1`) sibling.  The four lookup-aware Arith witness
     records are replaced by the single `FullSpec arow` hypothesis (the SHARED
-    ArithMul provider's `componentWithArithTable.Spec`), with the ArithDiv-view
+    ArithMul provider's `componentComplete.Spec`), with the ArithDiv-view
     facts read off the same row through `vOfDivuRow arow`.
 
     Like DIVU, this derives the looser balance bound `< 983041` (via
@@ -626,7 +626,7 @@ lemma equiv_DIVUW_of_fullSpec_claimed_dead
     The Arith provider witnesses (ArithTable membership, chunk ranges, signed
     carry ranges, c46, carry-chain) are DERIVED inside the body from
     `trace.channels_balanced` / `trace.spec_holds` via the SHARED ArithMul provider's
-    lookup-aware `componentWithArithTable.Spec = FullSpec`, NOT supplied as
+    lookup-aware `componentComplete.Spec = FullSpec`, NOT supplied as
     binders.  The W-mode high-lane zeros (`b_2=b_3=c_2=c_3=0`) and the
     low-quotient byte match are also DERIVED.
 

--- a/ZiskFv/Compliance/ConstructionDivuw.lean
+++ b/ZiskFv/Compliance/ConstructionDivuw.lean
@@ -330,6 +330,26 @@ theorem divuwArow_fullSpec_row
   exact ZiskFv.AirsClean.FullEnsemble.arithMul_fullSpec_of_component_spec
     h_component (h_spec h_rest.choose h_pr_mem)
 
+/-- `CompleteLocalSpec` of the ArithDiv view of the balance-selected DIVUW
+    provider row, DERIVED from the live table's `constraints_hold`.
+    Mirrors `divuArow_completeLocal`. -/
+theorem divuwArow_completeLocal
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (h_main_active :
+      (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_DIVU_W) :
+    ZiskFv.AirsClean.ArithDiv.CompleteLocalSpec
+      (ZiskFv.AirsClean.ArithDiv.rowAt
+        (vOfDivuRow (divuwArow trace binding i h_main_active h_main_op)) 0) := by
+  unfold divuwArow
+  set H := main_request_divuw_provided
+    trace i h_main_active h_main_op with hH
+  obtain ⟨h_pt_mem, h_rest⟩ := H.choose_spec
+  obtain ⟨h_pr_mem, h_component, _h_spec, _h_match⟩ := h_rest.choose_spec
+  exact arithDiv_completeLocal_of_selected_provider
+    (trace.constraints_hold H.choose h_pt_mem) h_pr_mem h_component
+
 /-- The op-bus match of the balance-selected DIVUW provider row against the Main
     row's emission, in `toEntry (primaryOpBusMessage …) 1` form. -/
 theorem divuwArow_match_row

--- a/ZiskFv/Compliance/ConstructionMulhu.lean
+++ b/ZiskFv/Compliance/ConstructionMulhu.lean
@@ -17,7 +17,7 @@ Unsigned high-half RV64M MULHU (`OP_MULUH = 177`), mirroring the MULW
 construction (`ConstructionMulw.lean`).  The Arith provider witnesses
 (ArithTable membership, chunk ranges, signed-carry ranges, c46, carry-chain)
 are **DERIVED FROM BALANCE** via the provider component's lookup-aware
-`componentWithArithTable.Spec = FullSpec`, not carried as caller binders.
+`componentComplete.Spec = FullSpec`, not carried as caller binders.
 
 ## The carry-range subtlety (vs MULW)
 
@@ -50,7 +50,7 @@ open ZiskFv.Airs.Main
 open ZiskFv.Airs.OperationBus
 open ZiskFv.Channels.MemoryBusBytes (byteAt)
 open ZiskFv.AirsClean.FullEnsemble
-open ZiskFv.AirsClean.ArithMul (componentWithArithTable primaryOpBusMessage rowAt)
+open ZiskFv.AirsClean.ArithMul (componentComplete primaryOpBusMessage rowAt)
 
 set_option maxHeartbeats 4000000
 set_option maxRecDepth 8000
@@ -463,7 +463,7 @@ open ZiskFv.EquivCore.Promises in
 /-- **F4 extraction bridge for `equiv_MULHU`.**  Mirror of
     `equiv_MULW_of_fullSpec`: the four lookup-aware Arith witness records are
     replaced by the single `FullSpec (rowAt v r_a)` hypothesis, which is exactly
-    what the lookup-aware ArithMul provider's `componentWithArithTable.Spec`
+    what the lookup-aware ArithMul provider's `componentComplete.Spec`
     yields.  A P4 construction hands the balance-derived `FullSpec` here directly.
 
     Unlike MULW (which routes through `EquivCore.MulW.equiv_MULW`), MULHU's
@@ -613,7 +613,7 @@ lemma equiv_MULHU_of_fullSpec_claimed_dead
 
 /-- The balance-selected Arith-Mul provider row at trace index `i` for a MULHU
     operation, as a concrete `ArithMulRow`.  It is the
-    `componentWithArithTable.rowInput` of the provider row chosen by the MULHU
+    `componentComplete.rowInput` of the provider row chosen by the MULHU
     keep-arithMul balance wrapper
     `main_request_mulhu_provided`.
     Mirrors `mulwArow`. -/
@@ -626,10 +626,10 @@ noncomputable def mulhuArow
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
   let h := main_request_mulhu_provided
     trace i h_main_active h_main_op
-  componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
+  componentComplete.rowInput (h.choose.environment h.choose_spec.2.choose)
 
 /-- `FullSpec` of the balance-selected MULHU provider row, derived from the
-    provider component's proven soundness (`componentWithArithTable.Spec`). -/
+    provider component's proven soundness (`componentComplete.Spec`). -/
 theorem mulhuArow_fullSpec_row
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
@@ -747,7 +747,7 @@ theorem mulhuArow_match
     The Arith provider witnesses (ArithTable membership, chunk ranges, signed
     carry ranges, c46, carry-chain) are DERIVED inside the body from
     `trace.channels_balanced` / `trace.spec_holds` via the provider's lookup-aware
-    `componentWithArithTable.Spec = FullSpec`, NOT supplied as binders. -/
+    `componentComplete.Spec = FullSpec`, NOT supplied as binders. -/
 theorem construction_mulhu_sound_claimed_dead
     (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)

--- a/ZiskFv/Compliance/ConstructionMulw.lean
+++ b/ZiskFv/Compliance/ConstructionMulw.lean
@@ -16,7 +16,7 @@ binders.
 
 This is the anti-laundering payoff of the c46 + chunk-range + carry-range
 composition into the shared ArithMul component: the provider's
-`componentWithArithTable.Spec` is now exactly
+`componentComplete.Spec` is now exactly
 `FullSpec = Spec ∧ ArithTableSpec ∧ C46Spec ∧ ChunkRangeSpec ∧ CarryRangeSpec`,
 which contains everything the MULW wrapper needs from the multiplier AIR. The
 construction reads that `FullSpec` straight off the balance-derived provider row
@@ -31,7 +31,7 @@ construction reads that `FullSpec` straight off the balance-derived provider row
   - the row-native `Valid_ArithMul` view `vOfMulwRow (mulwArow …)` of the
     balance-selected provider row,
   - **the arith witnesses** — `FullSpec (rowAt v 0)` from the provider's
-    `componentWithArithTable.Spec` (carry-chain + ArithTable membership + c46 +
+    `componentComplete.Spec` (carry-chain + ArithTable membership + c46 +
     chunk ranges + signed-carry ranges, ALL balance-derived),
   - the MemBus rd-write witness (`ExternalArithMemoryWitness`, from
     `store_pc = 0`),
@@ -76,7 +76,7 @@ open ZiskFv.Airs.OperationBus
 open ZiskFv.EquivCore.Promises
 open ZiskFv.Channels.MemoryBusBytes (byteAt)
 open ZiskFv.AirsClean.FullEnsemble
-open ZiskFv.AirsClean.ArithMul (componentWithArithTable primaryOpBusMessage rowAt)
+open ZiskFv.AirsClean.ArithMul (componentComplete primaryOpBusMessage rowAt)
 
 set_option maxHeartbeats 4000000
 set_option maxRecDepth 8000
@@ -136,7 +136,7 @@ def vOfMulwRow (arow : ZiskFv.AirsClean.ArithMul.ArithMulRow FGL) :
   range_cd := fun _ => arow.flags.range_cd
 
 /-- The balance-selected Arith-Mul provider row at trace index `i`, as a concrete
-    `ArithMulRow`. It is the `componentWithArithTable.rowInput` of the provider
+    `ArithMulRow`. It is the `componentComplete.rowInput` of the provider
     row chosen by the keep-arithMul balance wrapper
     `main_request_mulw_provided`.
 
@@ -153,7 +153,7 @@ noncomputable def mulwArow
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
   let h := main_request_mulw_provided
     trace i h_main_active h_main_op
-  componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
+  componentComplete.rowInput (h.choose.environment h.choose_spec.2.choose)
 
 /-- `FullSpec` transports along the row-native view: a `FullSpec` for a concrete
     `ArithMulRow` carries over to `rowAt (vOfMulwRow arow) 0`, because the two
@@ -165,7 +165,7 @@ theorem fullSpec_rowAt_vOfMulwRow
     ZiskFv.AirsClean.ArithMul.FullSpec (rowAt (vOfMulwRow arow) 0) := h
 
 /-- `FullSpec` of the balance-selected MULW provider row, derived from the
-    provider component's proven soundness (`componentWithArithTable.Spec`).
+    provider component's proven soundness (`componentComplete.Spec`).
 
     Proved here, at the `mulwArow` definition site, so the `Classical.choose`
     underlying `mulwArow` matches the one this proof picks — keeping the defeq
@@ -183,7 +183,7 @@ theorem mulwArow_fullSpec_row
   obtain ⟨_h_pt_mem, h_rest⟩ := H.choose_spec
   obtain ⟨h_pr_mem, h_component, h_spec, _h_match⟩ := h_rest.choose_spec
   -- Cheap projection of the provider component's generic `Spec` to `FullSpec`
-  -- (the heavy `componentWithArithTable.Spec` unfold lives once in `Balance`).
+  -- (the heavy `componentComplete.Spec` unfold lives once in `Balance`).
   exact ZiskFv.AirsClean.FullEnsemble.arithMul_fullSpec_of_component_spec
     h_component (h_spec h_rest.choose h_pr_mem)
 
@@ -258,7 +258,7 @@ theorem mulwArow_match_row
     application whose fields explode under whnf.  We therefore `set arow := …`
     so `arow` is an opaque fvar — `ArithTableSpec`, the op-pin, and the ROM
     `fin_cases` all act on `arow.flags.*` SYMBOLICALLY, never forcing the row's
-    `componentWithArithTable.rowInput` evaluation.  The op-pin is read off the
+    `componentComplete.rowInput` evaluation.  The op-pin is read off the
     op-bus match via the CHEAP `rfl`-projection lemma `primaryOpBusMessage_toEntry_op`
     (a rewrite, not a reduction). -/
 theorem mulwArow_mode_pins
@@ -311,7 +311,7 @@ theorem mulwArow_match
     The Arith provider witnesses (ArithTable membership, chunk ranges, signed
     carry ranges, c46, carry-chain) are DERIVED inside the body from
     `trace.channels_balanced` / `trace.spec_holds` via the provider's lookup-aware
-    `componentWithArithTable.Spec = FullSpec`, NOT supplied as binders. -/
+    `componentComplete.Spec = FullSpec`, NOT supplied as binders. -/
 theorem construction_mulw_sound_claimed_dead
     (trace : AcceptedZiskTrace numInstructions)
     (binding : SailTrace trace.numInstructions)

--- a/ZiskFv/Compliance/ConstructionRemu.lean
+++ b/ZiskFv/Compliance/ConstructionRemu.lean
@@ -20,14 +20,14 @@ Unsigned RV64M **REMU** (`OP_REMU = 185`), the remainder sibling of DIVU.
 The Arith provider witnesses (ArithTable membership, chunk ranges,
 signed-carry ranges, c46, carry-chain) are **DERIVED FROM BALANCE** via the
 SHARED ArithMul provider component's lookup-aware
-`componentWithArithTable.Spec = FullSpec`, not carried as caller binders.
+`componentComplete.Spec = FullSpec`, not carried as caller binders.
 
 ## Why the shared ArithMul provider (not ArithDiv)
 
 `ArithDiv.component` carries NO operation-bus interactions in the full
 ensemble (`arithDiv_table_interactionsWith_opBus_nil`): its
 `circuit.channels = []`.  The REMU Main op-bus emission is therefore balanced
-by the SHARED ArithMul provider (`componentWithArithTable`), whose `FullSpec`
+by the SHARED ArithMul provider (`componentComplete`), whose `FullSpec`
 covers div rows too (the carry chain is mode-shared via the `div` flag).
 
 ## The REMU SECONDARY lane (delta from DIVU)
@@ -80,7 +80,7 @@ open ZiskFv.Airs.Main
 open ZiskFv.Airs.OperationBus
 open ZiskFv.Channels.MemoryBusBytes (byteAt)
 open ZiskFv.AirsClean.FullEnsemble
-open ZiskFv.AirsClean.ArithMul (componentWithArithTable primaryOpBusMessage rowAt)
+open ZiskFv.AirsClean.ArithMul (componentComplete primaryOpBusMessage rowAt)
 
 set_option maxHeartbeats 4000000
 set_option maxRecDepth 8000
@@ -133,7 +133,7 @@ theorem match_opBus_row_ArithDivSecondary_vOfDivuRow
 
 /-- The balance-selected Arith-Mul provider row at trace index `i` for a REMU
     operation, as a concrete `ArithMulRow`.  It is the
-    `componentWithArithTable.rowInput` of the provider row chosen by the REMU
+    `componentComplete.rowInput` of the provider row chosen by the REMU
     keep-arithMul balance wrapper
     `main_request_remu_provided`.
     Mirrors `divuArow`. -/
@@ -146,10 +146,10 @@ noncomputable def remuArow
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
   let h := main_request_remu_provided
     trace i h_main_active h_main_op
-  componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
+  componentComplete.rowInput (h.choose.environment h.choose_spec.2.choose)
 
 /-- `FullSpec` of the balance-selected REMU provider row, derived from the
-    provider component's proven soundness (`componentWithArithTable.Spec`). -/
+    provider component's proven soundness (`componentComplete.Spec`). -/
 theorem remuArow_fullSpec_row
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
@@ -428,7 +428,7 @@ open ZiskFv.EquivCore.Promises in
 /-- **F4 extraction bridge for `equiv_REMU`.**  Mirror of
     `equiv_DIVU_of_fullSpec` for the remainder (secondary) lane.  The four
     lookup-aware Arith witness records are replaced by the single `FullSpec arow`
-    hypothesis (the SHARED ArithMul provider's `componentWithArithTable.Spec`),
+    hypothesis (the SHARED ArithMul provider's `componentComplete.Spec`),
     with the ArithDiv-view facts read off the same row through `vOfDivuRow arow`.
 
     Like DIVU, this derives the looser balance bound `< 983041` (via
@@ -608,7 +608,7 @@ lemma equiv_REMU_of_fullSpec_claimed_dead
     The Arith provider witnesses (ArithTable membership, chunk ranges, signed
     carry ranges, c46, carry-chain) are DERIVED inside the body from
     `trace.channels_balanced` / `trace.spec_holds` via the SHARED ArithMul provider's
-    lookup-aware `componentWithArithTable.Spec = FullSpec`, NOT supplied as
+    lookup-aware `componentComplete.Spec = FullSpec`, NOT supplied as
     binders.
 
     The ONE non-balance-derived residual is `remainder_bound`

--- a/ZiskFv/Compliance/ConstructionRemu.lean
+++ b/ZiskFv/Compliance/ConstructionRemu.lean
@@ -166,6 +166,26 @@ theorem remuArow_fullSpec_row
   exact ZiskFv.AirsClean.FullEnsemble.arithMul_fullSpec_of_component_spec
     h_component (h_spec h_rest.choose h_pr_mem)
 
+/-- `CompleteLocalSpec` of the ArithDiv view of the balance-selected REMU
+    provider row, DERIVED from the live table's `constraints_hold`.
+    Mirrors `divuArow_completeLocal`. -/
+theorem remuArow_completeLocal
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (h_main_active :
+      (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_REMU) :
+    ZiskFv.AirsClean.ArithDiv.CompleteLocalSpec
+      (ZiskFv.AirsClean.ArithDiv.rowAt
+        (vOfDivuRow (remuArow trace binding i h_main_active h_main_op)) 0) := by
+  unfold remuArow
+  set H := main_request_remu_provided
+    trace i h_main_active h_main_op with hH
+  obtain ⟨h_pt_mem, h_rest⟩ := H.choose_spec
+  obtain ⟨h_pr_mem, h_component, _h_spec, _h_match⟩ := h_rest.choose_spec
+  exact arithDiv_completeLocal_of_selected_provider
+    (trace.constraints_hold H.choose h_pt_mem) h_pr_mem h_component
+
 /-- The op-bus match of the balance-selected REMU provider row against the Main
     row's emission, in `toEntry (primaryOpBusMessage …) 1` form. -/
 theorem remuArow_match_row

--- a/ZiskFv/Compliance/ConstructionRemuw.lean
+++ b/ZiskFv/Compliance/ConstructionRemuw.lean
@@ -328,6 +328,26 @@ theorem remuwArow_fullSpec_row
   exact ZiskFv.AirsClean.FullEnsemble.arithMul_fullSpec_of_component_spec
     h_component (h_spec h_rest.choose h_pr_mem)
 
+/-- `CompleteLocalSpec` of the ArithDiv view of the balance-selected REMUW
+    provider row, DERIVED from the live table's `constraints_hold`.
+    Mirrors `divuArow_completeLocal`. -/
+theorem remuwArow_completeLocal
+    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
+    (h_main_active :
+      (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1)
+    (h_main_op :
+      (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_REMU_W) :
+    ZiskFv.AirsClean.ArithDiv.CompleteLocalSpec
+      (ZiskFv.AirsClean.ArithDiv.rowAt
+        (vOfDivuRow (remuwArow trace binding i h_main_active h_main_op)) 0) := by
+  unfold remuwArow
+  set H := main_request_remuw_provided
+    trace i h_main_active h_main_op with hH
+  obtain ⟨h_pt_mem, h_rest⟩ := H.choose_spec
+  obtain ⟨h_pr_mem, h_component, _h_spec, _h_match⟩ := h_rest.choose_spec
+  exact arithDiv_completeLocal_of_selected_provider
+    (trace.constraints_hold H.choose h_pt_mem) h_pr_mem h_component
+
 /-- The op-bus match of the balance-selected REMUW provider row against the Main
     row's emission, in `toEntry (primaryOpBusMessage …) 1` form. -/
 theorem remuwArow_match_row

--- a/ZiskFv/Compliance/ConstructionRemuw.lean
+++ b/ZiskFv/Compliance/ConstructionRemuw.lean
@@ -23,14 +23,14 @@ sibling of REMU — exactly as DIVUW relates to DIVU.  REMUW consumes the
 W width (`m32 = 1`, like DIVUW).  The Arith provider witnesses (ArithTable
 membership, chunk ranges, signed-carry ranges, c46, carry-chain) are **DERIVED
 FROM BALANCE** via the SHARED ArithMul provider component's lookup-aware
-`componentWithArithTable.Spec = FullSpec`, not carried as caller binders.
+`componentComplete.Spec = FullSpec`, not carried as caller binders.
 
 ## Why the shared ArithMul provider (not ArithDiv)
 
 `ArithDiv.component` carries NO operation-bus interactions in the full ensemble
 (`arithDiv_table_interactionsWith_opBus_nil`): its `circuit.channels = []`.  The
 REMUW Main op-bus emission is therefore balanced by the SHARED ArithMul provider
-(`componentWithArithTable`), whose `FullSpec` covers div rows too.  At the REMUW
+(`componentComplete`), whose `FullSpec` covers div rows too.  At the REMUW
 mode pins (`div = 1`, `main_div = 0`, `main_mul = 0`; `m32 = 1` plays no role in
 the mux) the muxed primary op-bus message's `c_lo` lane collapses to the
 remainder low half `d_0 + d_1·2^16`, so the muxed message reduces to the div
@@ -98,7 +98,7 @@ open ZiskFv.Airs.Main
 open ZiskFv.Airs.OperationBus
 open ZiskFv.Channels.MemoryBusBytes (byteAt)
 open ZiskFv.AirsClean.FullEnsemble
-open ZiskFv.AirsClean.ArithMul (componentWithArithTable primaryOpBusMessage rowAt)
+open ZiskFv.AirsClean.ArithMul (componentComplete primaryOpBusMessage rowAt)
 
 set_option maxHeartbeats 4000000
 set_option maxRecDepth 8000
@@ -295,7 +295,7 @@ private lemma remuw_carry_bounds_claimed_dead
 
 /-- The balance-selected Arith-Mul provider row at trace index `i` for a REMUW
     operation, as a concrete `ArithMulRow`.  It is the
-    `componentWithArithTable.rowInput` of the provider row chosen by the REMUW
+    `componentComplete.rowInput` of the provider row chosen by the REMUW
     keep-arithMul balance wrapper
     `main_request_remuw_provided`.
     Mirrors `remuArow` / `divuwArow`. -/
@@ -308,10 +308,10 @@ noncomputable def remuwArow
     ZiskFv.AirsClean.ArithMul.ArithMulRow FGL :=
   let h := main_request_remuw_provided
     trace i h_main_active h_main_op
-  componentWithArithTable.rowInput (h.choose.environment h.choose_spec.2.choose)
+  componentComplete.rowInput (h.choose.environment h.choose_spec.2.choose)
 
 /-- `FullSpec` of the balance-selected REMUW provider row, derived from the
-    provider component's proven soundness (`componentWithArithTable.Spec`). -/
+    provider component's proven soundness (`componentComplete.Spec`). -/
 theorem remuwArow_fullSpec_row
     (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
     (h_main_active :
@@ -405,7 +405,7 @@ open ZiskFv.EquivCore.Promises in
 /-- **F4 extraction bridge for `equiv_REMUW`.**  Mirror of `equiv_REMU_of_fullSpec`
     for the W-mode (`m32 = 1`) sibling.  The four lookup-aware Arith witness
     records are replaced by the single `FullSpec arow` hypothesis (the SHARED
-    ArithMul provider's `componentWithArithTable.Spec`), with the ArithDiv-view
+    ArithMul provider's `componentComplete.Spec`), with the ArithDiv-view
     facts read off the same row through `vOfDivuRow arow`.
 
     Like REMU / DIVUW, this derives the looser balance bound `< 983041` (via
@@ -625,7 +625,7 @@ lemma equiv_REMUW_of_fullSpec_claimed_dead
     The Arith provider witnesses (ArithTable membership, chunk ranges, signed
     carry ranges, c46, carry-chain) are DERIVED inside the body from
     `trace.channels_balanced` / `trace.spec_holds` via the SHARED ArithMul provider's
-    lookup-aware `componentWithArithTable.Spec = FullSpec`, NOT supplied as
+    lookup-aware `componentComplete.Spec = FullSpec`, NOT supplied as
     binders.  The low-remainder byte match is also DERIVED.
 
     The THREE non-balance-derived residuals are `remainder_bound`

--- a/ZiskFv/Compliance/OpBusProviderMatch.lean
+++ b/ZiskFv/Compliance/OpBusProviderMatch.lean
@@ -688,7 +688,7 @@ theorem main_request_shift_provided
     `exists_arithMul_provider_row_matches_primary_of_mulw_active_main_row_interaction`.
 
     Unlike the static-Binary wrappers, the provider here is the lookup-aware
-    `arithMulProviderComponent` (= `ArithMul.componentWithArithTable`), so
+    `arithMulProviderComponent` (= `ArithMul.componentComplete`), so
     `providerTable.Spec` is `FullSpec (rowInput …)` and the match is against the
     ArithMul primary op-bus message. -/
 theorem main_request_mulw_provided
@@ -712,7 +712,7 @@ theorem main_request_mulw_provided
               i.val)
             (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
               (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
-                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                (ZiskFv.AirsClean.ArithMul.componentComplete.rowInput
                   (providerTable.environment providerRow))) 1) := by
   have h_mainIdx_lt : i.val < trace.mainTable.table.length :=
     trace.mainTable_index i
@@ -806,7 +806,7 @@ theorem main_request_mulhu_provided
               i.val)
             (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
               (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
-                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                (ZiskFv.AirsClean.ArithMul.componentComplete.rowInput
                   (providerTable.environment providerRow))) 1) := by
   have h_mainIdx_lt : i.val < trace.mainTable.table.length :=
     trace.mainTable_index i
@@ -902,7 +902,7 @@ theorem main_request_divu_provided
               i.val)
             (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
               (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
-                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                (ZiskFv.AirsClean.ArithMul.componentComplete.rowInput
                   (providerTable.environment providerRow))) 1) := by
   have h_mainIdx_lt : i.val < trace.mainTable.table.length :=
     trace.mainTable_index i
@@ -997,7 +997,7 @@ theorem main_request_divuw_provided
               i.val)
             (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
               (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
-                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                (ZiskFv.AirsClean.ArithMul.componentComplete.rowInput
                   (providerTable.environment providerRow))) 1) := by
   have h_mainIdx_lt : i.val < trace.mainTable.table.length :=
     trace.mainTable_index i
@@ -1093,7 +1093,7 @@ theorem main_request_remu_provided
               i.val)
             (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
               (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
-                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                (ZiskFv.AirsClean.ArithMul.componentComplete.rowInput
                   (providerTable.environment providerRow))) 1) := by
   have h_mainIdx_lt : i.val < trace.mainTable.table.length :=
     trace.mainTable_index i
@@ -1190,7 +1190,7 @@ theorem main_request_remuw_provided
               i.val)
             (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
               (ZiskFv.AirsClean.ArithMul.primaryOpBusMessage
-                (ZiskFv.AirsClean.ArithMul.componentWithArithTable.rowInput
+                (ZiskFv.AirsClean.ArithMul.componentComplete.rowInput
                   (providerTable.environment providerRow))) 1) := by
   have h_mainIdx_lt : i.val < trace.mainTable.table.length :=
     trace.mainTable_index i

--- a/ZiskFv/Compliance/SharedBundles.lean
+++ b/ZiskFv/Compliance/SharedBundles.lean
@@ -464,14 +464,17 @@ theorem ArithMulSignedCarryRangeWitness.ranges
 
 /-- Lookup-aware Clean witness for a selected ArithDiv row's
     `arith_table_assumes` tuple. Same shape as `ArithMulTableWitness`,
-    specialized to the Div view of the Arith AIR. -/
+    specialized to the Div view of the Arith AIR: `holds` carries the
+    COMPLETED circuit (`ArithDiv.mainComplete`), i.e. the base
+    carry-chain/lookup supply plus every appended generated local
+    constraint audited in `ArithCompleteConstraints`. -/
 structure ArithDivTableWitness
     (v : ZiskFv.Airs.ArithDiv.Valid_ArithDiv FGL FGL) (r : ℕ) where
   offset : ℕ
   env : Environment FGL
   holds :
     ConstraintsHold.Soundness env
-      ((ZiskFv.AirsClean.ArithDiv.mainWithArithTable
+      ((ZiskFv.AirsClean.ArithDiv.mainComplete
         (ZiskFv.AirsClean.ArithDiv.constVar
           (ZiskFv.AirsClean.ArithDiv.rowAt v r))).operations offset)
 
@@ -482,7 +485,8 @@ theorem ArithDivTableWitness.spec
       (ZiskFv.AirsClean.ArithDiv.rowAt v r) :=
   ZiskFv.AirsClean.ArithDiv.arith_table_spec_of_lookup_aware_const_soundness
     w.offset w.env (ZiskFv.AirsClean.ArithDiv.rowAt v r)
-    w.holds
+    (ZiskFv.AirsClean.ArithDiv.base_soundness_of_complete_const_soundness
+      w.offset w.env (ZiskFv.AirsClean.ArithDiv.rowAt v r) w.holds)
 
 theorem ArithDivTableWitness.indexed_ranges
     {v : ZiskFv.Airs.ArithDiv.Valid_ArithDiv FGL FGL} {r : ℕ}
@@ -491,25 +495,68 @@ theorem ArithDivTableWitness.indexed_ranges
       (ZiskFv.AirsClean.ArithDiv.rowAt v r) :=
   ZiskFv.AirsClean.ArithDiv.indexed_ranges_of_arith_table_const_soundness
     w.offset w.env (ZiskFv.AirsClean.ArithDiv.rowAt v r)
-    w.holds
+    (ZiskFv.AirsClean.ArithDiv.base_soundness_of_complete_const_soundness
+      w.offset w.env (ZiskFv.AirsClean.ArithDiv.rowAt v r) w.holds)
 
-/-- Build an `ArithDivTableWitness` from the row's `FullSpec` (its three conjuncts:
-    carry-chain `Spec`, `ArithTableSpec`, and `IndexedRangeSpec`).  The witness's
-    `holds` is a constant-row proof for `mainWithArithTable`: carry-chain
-    constraints, the ArithTable lookup, and the eight indexed Arith range-table
-    lookups. -/
+/-- The completed Clean supply discharges the legacy local DIV carry-chain and
+    result-mux bundle; callers need not provide it separately.  Mirror of
+    `ArithMulTableWitness.row_constraints`. -/
+theorem ArithDivTableWitness.row_constraints
+    {v : ZiskFv.Airs.ArithDiv.Valid_ArithDiv FGL FGL} {r : ℕ}
+    (w : ArithDivTableWitness v r) :
+    ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r := by
+  obtain ⟨h_spec, _h_mode, _h_boundary, _h_inv, _h_scope, h_c46, _h_wmode⟩ :=
+    ZiskFv.AirsClean.ArithDiv.complete_local_specs_of_const_soundness
+      w.offset w.env (ZiskFv.AirsClean.ArithDiv.rowAt v r) w.holds
+  obtain ⟨hc6, hc7, hc8, hc31, hc32, hc33, hc34, hc35, hc36, hc37, hc38⟩ := h_spec
+  refine ⟨⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩, ?_⟩
+  · simp only [ZiskFv.Airs.ArithDiv.fab_eq_div]; linear_combination hc6
+  · simp only [ZiskFv.Airs.ArithDiv.na_fb_eq_div]; linear_combination hc7
+  · simp only [ZiskFv.Airs.ArithDiv.nb_fa_eq_div]; linear_combination hc8
+  · simp only [ZiskFv.Airs.ArithDiv.carry_eq_0_div]; linear_combination hc31
+  · simp only [ZiskFv.Airs.ArithDiv.carry_eq_1_div]; linear_combination hc32
+  · simp only [ZiskFv.Airs.ArithDiv.carry_eq_2_div]; linear_combination hc33
+  · simp only [ZiskFv.Airs.ArithDiv.carry_eq_3_div]; linear_combination hc34
+  · simp only [ZiskFv.Airs.ArithDiv.carry_eq_4_div]; linear_combination hc35
+  · simp only [ZiskFv.Airs.ArithDiv.carry_eq_5_div]; linear_combination hc36
+  · simp only [ZiskFv.Airs.ArithDiv.carry_eq_6_div]; linear_combination hc37
+  · simp only [ZiskFv.Airs.ArithDiv.carry_eq_7_div]; linear_combination hc38
+  · simp only [ZiskFv.Airs.ArithDiv.bus_res1_eq_div,
+      ZiskFv.AirsClean.ArithDiv.C46Spec] at h_c46 ⊢
+    linear_combination h_c46
+
+/-- Build an `ArithDivTableWitness` from the row's `FullSpec` (carry-chain
+    `Spec`, `ArithTableSpec`, `IndexedRangeSpec`) plus the transported
+    complete-local supply `CompleteLocalSpec` (the appended generated local
+    constraints, read off the live provider row's `constraints_hold` and
+    transported through the `vOfDivuRow` view).  The witness's `holds` is a
+    constant-row proof for the COMPLETED `mainComplete` circuit. -/
 def arithDivTableWitness_of_fullSpec
     {v : ZiskFv.Airs.ArithDiv.Valid_ArithDiv FGL FGL} {r : ℕ}
-    (h : ZiskFv.AirsClean.ArithDiv.FullSpec (ZiskFv.AirsClean.ArithDiv.rowAt v r)) :
+    (h : ZiskFv.AirsClean.ArithDiv.FullSpec (ZiskFv.AirsClean.ArithDiv.rowAt v r))
+    (h_complete :
+      ZiskFv.AirsClean.ArithDiv.CompleteLocalSpec (ZiskFv.AirsClean.ArithDiv.rowAt v r)) :
     ArithDivTableWitness v r := by
   refine ⟨0, ⟨fun _ => 0, fun _ _ => #[]⟩, ?_⟩
   obtain ⟨h_spec, h_table, h_indexed⟩ := h
+  obtain ⟨_h_spec', h_mode, h_boundary, h_inv, h_scope, h_c46, h_wmode⟩ := h_complete
   obtain ⟨hc6, hc7, hc8, hc31, hc32, hc33, hc34, hc35, hc36, hc37, hc38⟩ := h_spec
   obtain ⟨hra1, hrb1, hrc1, hrd1, hra3, hrb3, hrc3, hrd3⟩ := h_indexed
-  simp only [ZiskFv.AirsClean.ArithDiv.mainWithArithTable,
+  obtain ⟨hm0, hm1, hm2, hm3, hm4, hm5, hm39, hm40, hm41, hm42, hm43, hm44, hm45⟩ := h_mode
+  obtain ⟨hb1, hb2, hb3, hb4, hb5, hb6, hb7, hb8,
+    hb9, hb10, hb11, hb12, hb13, hb14, hb15, hb16⟩ := h_boundary
+  obtain ⟨hs1, hs2, hs3, hs4, hs5⟩ := h_scope
+  obtain ⟨hw1, hw2⟩ := h_wmode
+  simp only [ZiskFv.AirsClean.ArithDiv.mainComplete,
+    ZiskFv.AirsClean.ArithDiv.mainWithArithTable,
     ZiskFv.AirsClean.ArithDiv.main, circuit_norm]
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_,
-    ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+    ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_,
+    ?_, ?_, ?_, ?_, ?_, ?_,
+    ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_,
+    ?_, ?_, ?_, ?_, ?_, ?_,
+    ?_, ?_, ?_, ?_, ?_, ?_, ?_,
+    ?_, ?_, ?_⟩
   · linear_combination hc6
   · linear_combination hc7
   · linear_combination hc8
@@ -542,6 +589,44 @@ def arithDivTableWitness_of_fullSpec
       Lookup.Soundness, Table.fromStatic, StaticTable.toTable, Table.toRaw] using hrc3
   · simpa [ZiskFv.AirsClean.ArithDiv.constVar, ZiskFv.AirsClean.ArithDiv.rowAt,
       Lookup.Soundness, Table.fromStatic, StaticTable.toTable, Table.toRaw] using hrd3
+  · linear_combination hm0
+  · linear_combination hm1
+  · linear_combination hm2
+  · linear_combination hm3
+  · linear_combination hm4
+  · linear_combination hm5
+  · linear_combination hb1
+  · linear_combination hb2
+  · linear_combination hb3
+  · linear_combination hb4
+  · linear_combination hb5
+  · linear_combination hb6
+  · linear_combination hb7
+  · linear_combination hb8
+  · linear_combination hb9
+  · linear_combination hb10
+  · linear_combination hb11
+  · linear_combination hb12
+  · linear_combination hb13
+  · linear_combination hb14
+  · linear_combination hb15
+  · linear_combination hb16
+  · linear_combination h_inv
+  · linear_combination hs1
+  · linear_combination hs2
+  · linear_combination hs3
+  · linear_combination hs4
+  · linear_combination hs5
+  · linear_combination hm39
+  · linear_combination hm40
+  · linear_combination hm41
+  · linear_combination hm42
+  · linear_combination hm43
+  · linear_combination hm44
+  · linear_combination hm45
+  · linear_combination h_c46
+  · linear_combination hw1
+  · linear_combination hw2
 
 /-- Lookup-aware Clean witness for a selected ArithDiv row's sixteen
     `bits(16)` chunk checks. This is the Div-family counterpart of

--- a/ZiskFv/Compliance/SingleAddWitness.lean
+++ b/ZiskFv/Compliance/SingleAddWitness.lean
@@ -127,7 +127,7 @@ def singleAddTables : List (Table FGL) :=
   , emptyComponentTable ZiskFv.AirsClean.MemAlign.component
   , emptyComponentTable ZiskFv.AirsClean.Mem.componentWithDualMemBus
   , emptyComponentTable ZiskFv.AirsClean.ArithDiv.component
-  , emptyComponentTable ZiskFv.AirsClean.ArithMul.componentWithArithTable
+  , emptyComponentTable ZiskFv.AirsClean.ArithMul.componentComplete
   , emptyComponentTable ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
   , emptyComponentTable ZiskFv.AirsClean.Binary.staticLookupComponent
   , binaryAddRowsTable [addX1BinaryAddRow]
@@ -176,7 +176,7 @@ theorem singleAddWitness_table_constraints :
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlign.component
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.Mem.componentWithDualMemBus
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.ArithDiv.component
-  · exact emptyComponentTable_constraints ZiskFv.AirsClean.ArithMul.componentWithArithTable
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.ArithMul.componentComplete
   · exact emptyComponentTable_constraints
       ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.Binary.staticLookupComponent
@@ -235,7 +235,7 @@ theorem singleAddWitness_transitions : singleAddWitness.TransitionConstraints :=
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlign.component
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.Mem.componentWithDualMemBus
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.ArithDiv.component
-    · exact emptyComponentTable_transitions ZiskFv.AirsClean.ArithMul.componentWithArithTable
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.ArithMul.componentComplete
     · exact emptyComponentTable_transitions
         ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.Binary.staticLookupComponent
@@ -327,7 +327,7 @@ private theorem singleAddWitness_mutable_mem_component_tables_empty (table : Tab
     · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlign.component
     · exact emptyComponentTable_table ZiskFv.AirsClean.Mem.componentWithDualMemBus
     · exact emptyComponentTable_table ZiskFv.AirsClean.ArithDiv.component
-    · exact emptyComponentTable_table ZiskFv.AirsClean.ArithMul.componentWithArithTable
+    · exact emptyComponentTable_table ZiskFv.AirsClean.ArithMul.componentComplete
     · exact emptyComponentTable_table ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
     · exact emptyComponentTable_table ZiskFv.AirsClean.Binary.staticLookupComponent
     · exfalso

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongLoadMext.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongLoadMext.lean
@@ -1106,10 +1106,14 @@ theorem stepStrong_divu
   have h_full_div : ZiskFv.AirsClean.ArithDiv.FullSpec
       (ZiskFv.AirsClean.ArithDiv.rowAt v 0) :=
     arithDiv_fullSpec_of_arithMul_fullSpec arow h_full_mul
+  have h_complete_div : ZiskFv.AirsClean.ArithDiv.CompleteLocalSpec
+      (ZiskFv.AirsClean.ArithDiv.rowAt v 0) := by
+    rw [hv, harow]
+    exact divuArow_completeLocal trace binding i d.toDecode.h_main_active d.toDecode.h_main_op
   obtain ⟨h_mul_spec, h_mul_table, h_mul_c46, h_mul_chunks, h_mul_carry,
     h_mul_indexed_ranges⟩ := h_full_mul
   let arith_table : ZiskFv.Compliance.ArithDivTableWitness v 0 :=
-    arithDivTableWitness_of_fullSpec h_full_div
+    arithDivTableWitness_of_fullSpec h_full_div h_complete_div
   let arith_chunk_ranges : ZiskFv.Compliance.ArithDivChunkRangeWitness v 0 :=
     ZiskFv.AirsClean.ArithDiv.chunkRangeLookupWitness_of_spec h_full_div.1 h_mul_chunks
   let arith_carry_ranges : ZiskFv.Compliance.ArithDivSignedCarryRangeWitness v 0 :=
@@ -1215,10 +1219,14 @@ theorem stepStrong_divuw
   have h_full_div : ZiskFv.AirsClean.ArithDiv.FullSpec
       (ZiskFv.AirsClean.ArithDiv.rowAt v 0) :=
     arithDiv_fullSpec_of_arithMul_fullSpec arow h_full_mul
+  have h_complete_div : ZiskFv.AirsClean.ArithDiv.CompleteLocalSpec
+      (ZiskFv.AirsClean.ArithDiv.rowAt v 0) := by
+    rw [hv, harow]
+    exact divuwArow_completeLocal trace binding i d.toDecode.h_main_active d.toDecode.h_main_op
   obtain ⟨h_mul_spec, h_mul_table, h_mul_c46, h_mul_chunks, h_mul_carry,
     h_mul_indexed_ranges⟩ := h_full_mul
   let arith_table : ZiskFv.Compliance.ArithDivTableWitness v 0 :=
-    arithDivTableWitness_of_fullSpec h_full_div
+    arithDivTableWitness_of_fullSpec h_full_div h_complete_div
   let arith_chunk_ranges : ZiskFv.Compliance.ArithDivChunkRangeWitness v 0 :=
     ZiskFv.AirsClean.ArithDiv.chunkRangeLookupWitness_of_spec h_full_div.1 h_mul_chunks
   let arith_carry_ranges : ZiskFv.Compliance.ArithDivSignedCarryRangeWitness v 0 :=
@@ -1321,10 +1329,14 @@ theorem stepStrong_remu
   have h_full_div : ZiskFv.AirsClean.ArithDiv.FullSpec
       (ZiskFv.AirsClean.ArithDiv.rowAt v 0) :=
     arithDiv_fullSpec_of_arithMul_fullSpec arow h_full_mul
+  have h_complete_div : ZiskFv.AirsClean.ArithDiv.CompleteLocalSpec
+      (ZiskFv.AirsClean.ArithDiv.rowAt v 0) := by
+    rw [hv, harow]
+    exact remuArow_completeLocal trace binding i d.toDecode.h_main_active d.toDecode.h_main_op
   obtain ⟨h_mul_spec, h_mul_table, h_mul_c46, h_mul_chunks, h_mul_carry,
     h_mul_indexed_ranges⟩ := h_full_mul
   let arith_table : ZiskFv.Compliance.ArithDivTableWitness v 0 :=
-    arithDivTableWitness_of_fullSpec h_full_div
+    arithDivTableWitness_of_fullSpec h_full_div h_complete_div
   let arith_chunk_ranges : ZiskFv.Compliance.ArithDivChunkRangeWitness v 0 :=
     ZiskFv.AirsClean.ArithDiv.chunkRangeLookupWitness_of_spec h_full_div.1 h_mul_chunks
   let arith_carry_ranges : ZiskFv.Compliance.ArithDivSignedCarryRangeWitness v 0 :=
@@ -1426,10 +1438,14 @@ theorem stepStrong_remuw
   have h_full_div : ZiskFv.AirsClean.ArithDiv.FullSpec
       (ZiskFv.AirsClean.ArithDiv.rowAt v 0) :=
     arithDiv_fullSpec_of_arithMul_fullSpec arow h_full_mul
+  have h_complete_div : ZiskFv.AirsClean.ArithDiv.CompleteLocalSpec
+      (ZiskFv.AirsClean.ArithDiv.rowAt v 0) := by
+    rw [hv, harow]
+    exact remuwArow_completeLocal trace binding i d.toDecode.h_main_active d.toDecode.h_main_op
   obtain ⟨h_mul_spec, h_mul_table, h_mul_c46, h_mul_chunks, h_mul_carry,
     h_mul_indexed_ranges⟩ := h_full_mul
   let arith_table : ZiskFv.Compliance.ArithDivTableWitness v 0 :=
-    arithDivTableWitness_of_fullSpec h_full_div
+    arithDivTableWitness_of_fullSpec h_full_div h_complete_div
   let arith_chunk_ranges : ZiskFv.Compliance.ArithDivChunkRangeWitness v 0 :=
     ZiskFv.AirsClean.ArithDiv.chunkRangeLookupWitness_of_spec h_full_div.1 h_mul_chunks
   let arith_carry_ranges : ZiskFv.Compliance.ArithDivSignedCarryRangeWitness v 0 :=

--- a/ZiskFv/Compliance/Wrappers/Div.lean
+++ b/ZiskFv/Compliance/Wrappers/Div.lean
@@ -116,7 +116,11 @@ lemma equiv_DIV_of_table
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
-    (h_row_constraints :
+    -- Compatibility-only binder: the row bundle is DERIVED from
+    -- `arith_table.row_constraints` below.  The positional parameter must
+    -- remain because the byte-frozen `Equivalence/Div.lean` calls this
+    -- declaration in this order.
+    (_h_row_constraints :
       ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     (h_boundary : ZiskFv.Airs.ArithDiv.div_boundary_constraints v r_a)
     (arith_table : ZiskFv.Compliance.ArithDivTableWitness v r_a)
@@ -167,6 +171,7 @@ lemma equiv_DIV_of_table
       LeanRV64D.Functions.execute (instruction.DIV (r2, r1, rd, false))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
   have h_arith_table := arith_table.spec
+  have h_row_constraints := arith_table.row_constraints
   obtain ⟨exec_row, e0, e1, e2⟩ := bus
   obtain ⟨h0, h1, h2, h3, h4, h5, h6, h7⟩ := bounds
   obtain ⟨_h_main_active, h_main_op_div⟩ := pins
@@ -245,8 +250,6 @@ lemma equiv_DIV
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
-    (h_row_constraints :
-      ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     (h_boundary : ZiskFv.Airs.ArithDiv.div_boundary_constraints v r_a)
     (arith_table : ZiskFv.Compliance.ArithDivTableWitness v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithDivChunkRangeWitness v r_a)
@@ -293,7 +296,7 @@ lemma equiv_DIV
       LeanRV64D.Functions.execute (instruction.DIV (r2, r1, rd, false))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 :=
   equiv_DIV_of_table state div_input r1 r2 rd bus m r_main v r_a pins h_match_primary
-    promises arith_mem bounds h_row_constraints h_boundary arith_table
+    promises arith_mem bounds arith_table.row_constraints h_boundary arith_table
     arith_chunk_ranges arith_carry_ranges h_na_bool h_nb_bool h_nr_bool h_np_xor h_nr_pin
     h_rs1_value h_rs2_value h_r_abs_of_ne h_r_sign
 

--- a/ZiskFv/Compliance/Wrappers/Divu.lean
+++ b/ZiskFv/Compliance/Wrappers/Divu.lean
@@ -62,7 +62,11 @@ lemma equiv_DIVU_of_table
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
-    (h_row_constraints :
+    -- Compatibility-only binder: the row bundle is DERIVED from
+    -- `arith_table.row_constraints` below.  The positional parameter must
+    -- remain because the byte-frozen `Equivalence/Divu.lean` calls this
+    -- declaration in this order.
+    (_h_row_constraints :
       ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     (arith_table : ZiskFv.Compliance.ArithDivTableWitness v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithDivChunkRangeWitness v r_a)
@@ -82,6 +86,7 @@ lemma equiv_DIVU_of_table
       LeanRV64D.Functions.execute (instruction.DIV (r2, r1, rd, true))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
   have h_arith_table := arith_table.spec
+  have h_row_constraints := arith_table.row_constraints
   obtain ⟨exec_row, e0, e1, e2⟩ := bus
   obtain ⟨h0, h1, h2, h3, h4, h5, h6, h7⟩ := bounds
   obtain ⟨_h_main_active, h_main_op_divu⟩ := pins
@@ -163,8 +168,6 @@ lemma equiv_DIVU
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
-    (h_row_constraints :
-      ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     (arith_table : ZiskFv.Compliance.ArithDivTableWitness v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithDivChunkRangeWitness v r_a)
     (arith_carry_ranges :
@@ -183,7 +186,7 @@ lemma equiv_DIVU
       LeanRV64D.Functions.execute (instruction.DIV (r2, r1, rd, true))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
   exact equiv_DIVU_of_table state divu_input r1 r2 rd bus m r_main v r_a
-    pins h_match_primary promises arith_mem bounds h_row_constraints arith_table
+    pins h_match_primary promises arith_mem bounds arith_table.row_constraints arith_table
     arith_chunk_ranges arith_carry_ranges remainder_bound h_rs1_value h_rs2_value
 
 

--- a/ZiskFv/Compliance/Wrappers/Divuw.lean
+++ b/ZiskFv/Compliance/Wrappers/Divuw.lean
@@ -73,7 +73,11 @@ lemma equiv_DIVUW_of_table
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
     (arith_table : ZiskFv.Compliance.ArithDivTableWitness v r_a)
-    (h_row_constraints :
+    -- Compatibility-only binder: the row bundle is DERIVED from
+    -- `arith_table.row_constraints` below.  The positional parameter must
+    -- remain because the byte-frozen `Equivalence/Divuw.lean` calls this
+    -- declaration in this order.
+    (_h_row_constraints :
       ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithDivChunkRangeWitness v r_a)
     (arith_carry_ranges :
@@ -99,6 +103,7 @@ lemma equiv_DIVUW_of_table
       LeanRV64D.Functions.execute (instruction.DIVW (r2, r1, rd, true))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
   have h_arith_table := arith_table.spec
+  have h_row_constraints := arith_table.row_constraints
   obtain ⟨exec_row, e0, e1, e2⟩ := bus
   obtain ⟨h0, h1, h2, h3, h4, h5, h6, h7⟩ := bounds
   obtain ⟨_h_main_active, h_main_op_divuw⟩ := pins
@@ -158,8 +163,6 @@ lemma equiv_DIVUW
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
     (arith_table : ZiskFv.Compliance.ArithDivTableWitness v r_a)
-    (h_row_constraints :
-      ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithDivChunkRangeWitness v r_a)
     (arith_carry_ranges :
       ZiskFv.Compliance.ArithDivSignedCarryRangeWitness v r_a)
@@ -184,7 +187,7 @@ lemma equiv_DIVUW
       LeanRV64D.Functions.execute (instruction.DIVW (r2, r1, rd, true))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
   exact equiv_DIVUW_of_table state divuw_input r1 r2 rd bus m r_main v r_a
-    pins h_match_primary promises arith_mem bounds arith_table h_row_constraints
+    pins h_match_primary promises arith_mem bounds arith_table arith_table.row_constraints
     arith_chunk_ranges arith_carry_ranges remainder_bound
     h_b23 h_c23 h_sext_choice h_rs1_value h_rs2_value
 

--- a/ZiskFv/Compliance/Wrappers/Divw.lean
+++ b/ZiskFv/Compliance/Wrappers/Divw.lean
@@ -69,11 +69,15 @@ lemma equiv_DIVW_of_table
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (_arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
-    (h_row_constraints :
+    -- Compatibility-only binder: the row bundle is DERIVED from
+    -- `arith_table.row_constraints` below.  The positional parameter must
+    -- remain because the byte-frozen `Equivalence/Divw.lean` calls this
+    -- declaration in this order.
+    (_h_row_constraints :
       ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     (h_boundary :
       ZiskFv.Airs.ArithDiv.div_boundary_constraints v r_a)
-    (_arith_table : ZiskFv.Compliance.ArithDivTableWitness v r_a)
+    (arith_table : ZiskFv.Compliance.ArithDivTableWitness v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithDivChunkRangeWitness v r_a)
     (arith_carry_ranges :
       ZiskFv.Compliance.ArithDivSignedCarryRangeWitness v r_a)
@@ -126,6 +130,7 @@ lemma equiv_DIVW_of_table
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.DIVW (r2, r1, rd, false))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
+  have h_row_constraints := arith_table.row_constraints
   have h_chain : ZiskFv.Airs.ArithDiv.div_carry_chain_holds v r_a :=
     ZiskFv.Airs.ArithDiv.div_carry_chain_holds_of_extended v r_a h_row_constraints
   exact ZiskFv.EquivCore.Divw.equiv_DIVW_boundary_split
@@ -153,8 +158,6 @@ lemma equiv_DIVW
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
-    (h_row_constraints :
-      ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     (h_boundary :
       ZiskFv.Airs.ArithDiv.div_boundary_constraints v r_a)
     (arith_table : ZiskFv.Compliance.ArithDivTableWitness v r_a)
@@ -207,7 +210,7 @@ lemma equiv_DIVW
       LeanRV64D.Functions.execute (instruction.DIVW (r2, r1, rd, false))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 :=
   equiv_DIVW_of_table state divw_input r1 r2 rd bus m r_main v r_a pins h_match_primary
-    promises arith_mem bounds h_row_constraints h_boundary arith_table
+    promises arith_mem bounds arith_table.row_constraints h_boundary arith_table
     arith_chunk_ranges arith_carry_ranges h_na_bool h_nb_bool h_nr_bool h_np_xor h_nr_pin
     h_m32 h_div h_a23 h_b23 h_d23 h_c23 h_byte_lo h_sext_choice
     h_rs1_value h_rs2_value h_r_abs_of_ne h_r_sign

--- a/ZiskFv/Compliance/Wrappers/MulW.lean
+++ b/ZiskFv/Compliance/Wrappers/MulW.lean
@@ -182,7 +182,7 @@ lemma equiv_MULW_of_table
     hypothesis.
 
     `FullSpec` is exactly what the lookup-aware ArithMul provider's
-    `componentWithArithTable.Spec` yields (`componentWithArithTable_spec`), so a
+    `componentComplete.Spec` yields (`componentComplete_spec`), so a
     P4 construction can hand the provider's balance-derived `Spec` here directly
     instead of re-packaging it as four caller witnesses. Its five conjuncts map
     1:1 onto what the body needs:

--- a/ZiskFv/Compliance/Wrappers/Rem.lean
+++ b/ZiskFv/Compliance/Wrappers/Rem.lean
@@ -59,7 +59,11 @@ lemma equiv_REM_of_table
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
-    (h_row_constraints :
+    -- Compatibility-only binder: the row bundle is DERIVED from
+    -- `arith_table.row_constraints` below.  The positional parameter must
+    -- remain because the byte-frozen `Equivalence/Rem.lean` calls this
+    -- declaration in this order.
+    (_h_row_constraints :
       ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     (arith_table : ZiskFv.Compliance.ArithDivTableWitness v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithDivChunkRangeWitness v r_a)
@@ -106,6 +110,7 @@ lemma equiv_REM_of_table
       LeanRV64D.Functions.execute (instruction.REM (r2, r1, rd, false))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
   have h_arith_table := arith_table.spec
+  have h_row_constraints := arith_table.row_constraints
   obtain ⟨exec_row, e0, e1, e2⟩ := bus
   obtain ⟨h0, h1, h2, h3, h4, h5, h6, h7⟩ := bounds
   obtain ⟨_h_main_active, h_main_op_rem⟩ := pins
@@ -184,8 +189,6 @@ lemma equiv_REM
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
-    (h_row_constraints :
-      ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     (arith_table : ZiskFv.Compliance.ArithDivTableWitness v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithDivChunkRangeWitness v r_a)
     (arith_carry_ranges :
@@ -231,7 +234,7 @@ lemma equiv_REM
       LeanRV64D.Functions.execute (instruction.REM (r2, r1, rd, false))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 :=
   equiv_REM_of_table state rem_input r1 r2 rd bus m r_main v r_a pins h_match_secondary
-    promises arith_mem bounds h_row_constraints arith_table
+    promises arith_mem bounds arith_table.row_constraints arith_table
     arith_chunk_ranges arith_carry_ranges h_na_bool h_nb_bool h_nr_bool h_np_xor h_nr_pin
     h_rs1_value h_rs2_value h_r_abs_of_ne h_r_sign
 

--- a/ZiskFv/Compliance/Wrappers/Remu.lean
+++ b/ZiskFv/Compliance/Wrappers/Remu.lean
@@ -53,7 +53,11 @@ lemma equiv_REMU_of_table
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
-    (h_row_constraints :
+    -- Compatibility-only binder: the row bundle is DERIVED from
+    -- `arith_table.row_constraints` below.  The positional parameter must
+    -- remain because the byte-frozen `Equivalence/Remu.lean` calls this
+    -- declaration in this order.
+    (_h_row_constraints :
       ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     (arith_table : ZiskFv.Compliance.ArithDivTableWitness v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithDivChunkRangeWitness v r_a)
@@ -73,6 +77,7 @@ lemma equiv_REMU_of_table
       LeanRV64D.Functions.execute (instruction.REM (r2, r1, rd, true))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
   have h_arith_table := arith_table.spec
+  have h_row_constraints := arith_table.row_constraints
   obtain ⟨exec_row, e0, e1, e2⟩ := bus
   obtain ⟨h0, h1, h2, h3, h4, h5, h6, h7⟩ := bounds
   obtain ⟨_h_main_active, h_main_op_remu⟩ := pins
@@ -155,8 +160,6 @@ lemma equiv_REMU
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
-    (h_row_constraints :
-      ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     (arith_table : ZiskFv.Compliance.ArithDivTableWitness v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithDivChunkRangeWitness v r_a)
     (arith_carry_ranges :
@@ -175,7 +178,7 @@ lemma equiv_REMU
       LeanRV64D.Functions.execute (instruction.REM (r2, r1, rd, true))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
   exact equiv_REMU_of_table state remu_input r1 r2 rd bus m r_main v r_a
-    pins h_match_secondary promises arith_mem bounds h_row_constraints arith_table
+    pins h_match_secondary promises arith_mem bounds arith_table.row_constraints arith_table
     arith_chunk_ranges arith_carry_ranges remainder_bound h_rs1_value h_rs2_value
 
 

--- a/ZiskFv/Compliance/Wrappers/Remuw.lean
+++ b/ZiskFv/Compliance/Wrappers/Remuw.lean
@@ -56,7 +56,11 @@ lemma equiv_REMUW_of_table
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
     (arith_table : ZiskFv.Compliance.ArithDivTableWitness v r_a)
-    (h_row_constraints :
+    -- Compatibility-only binder: the row bundle is DERIVED from
+    -- `arith_table.row_constraints` below.  The positional parameter must
+    -- remain because the byte-frozen `Equivalence/Remuw.lean` calls this
+    -- declaration in this order.
+    (_h_row_constraints :
       ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithDivChunkRangeWitness v r_a)
     (arith_carry_ranges :
@@ -82,6 +86,7 @@ lemma equiv_REMUW_of_table
       LeanRV64D.Functions.execute (instruction.REMW (r2, r1, rd, true))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
   have h_arith_table := arith_table.spec
+  have h_row_constraints := arith_table.row_constraints
   obtain ⟨exec_row, e0, e1, e2⟩ := bus
   obtain ⟨h0, h1, h2, h3, h4, h5, h6, h7⟩ := bounds
   obtain ⟨_h_main_active, h_main_op_remuw⟩ := pins
@@ -141,8 +146,6 @@ lemma equiv_REMUW
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
     (arith_table : ZiskFv.Compliance.ArithDivTableWitness v r_a)
-    (h_row_constraints :
-      ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithDivChunkRangeWitness v r_a)
     (arith_carry_ranges :
       ZiskFv.Compliance.ArithDivSignedCarryRangeWitness v r_a)
@@ -167,7 +170,7 @@ lemma equiv_REMUW
       LeanRV64D.Functions.execute (instruction.REMW (r2, r1, rd, true))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
   exact equiv_REMUW_of_table state remuw_input r1 r2 rd bus m r_main v r_a
-    pins h_match_secondary promises arith_mem bounds arith_table h_row_constraints
+    pins h_match_secondary promises arith_mem bounds arith_table arith_table.row_constraints
     arith_chunk_ranges arith_carry_ranges remainder_bound
     h_b23 h_c23 h_sext_choice h_rs1_value h_rs2_value
 

--- a/ZiskFv/Compliance/Wrappers/Remw.lean
+++ b/ZiskFv/Compliance/Wrappers/Remw.lean
@@ -55,9 +55,13 @@ lemma equiv_REMW_of_table
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (_arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
-    (h_row_constraints :
+    -- Compatibility-only binder: the row bundle is DERIVED from
+    -- `arith_table.row_constraints` below.  The positional parameter must
+    -- remain because the byte-frozen `Equivalence/Remw.lean` calls this
+    -- declaration in this order.
+    (_h_row_constraints :
       ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
-    (_arith_table : ZiskFv.Compliance.ArithDivTableWitness v r_a)
+    (arith_table : ZiskFv.Compliance.ArithDivTableWitness v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithDivChunkRangeWitness v r_a)
     (arith_carry_ranges :
       ZiskFv.Compliance.ArithDivSignedCarryRangeWitness v r_a)
@@ -107,6 +111,7 @@ lemma equiv_REMW_of_table
         (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
       LeanRV64D.Functions.execute (instruction.REMW (r2, r1, rd, false))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
+  have h_row_constraints := arith_table.row_constraints
   have h_chain : ZiskFv.Airs.ArithDiv.div_carry_chain_holds v r_a :=
     ZiskFv.Airs.ArithDiv.div_carry_chain_holds_of_extended v r_a h_row_constraints
   exact ZiskFv.EquivCore.Remw.equiv_REMW
@@ -134,8 +139,6 @@ lemma equiv_REMW
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness m r_main bus.e2)
     (bounds : ZiskFv.Compliance.ByteBounds bus.e2)
-    (h_row_constraints :
-      ZiskFv.Airs.ArithDiv.div_row_constraints_with_c46 v r_a)
     (arith_table : ZiskFv.Compliance.ArithDivTableWitness v r_a)
     (arith_chunk_ranges : ZiskFv.Compliance.ArithDivChunkRangeWitness v r_a)
     (arith_carry_ranges :
@@ -186,7 +189,7 @@ lemma equiv_REMW
       LeanRV64D.Functions.execute (instruction.REMW (r2, r1, rd, false))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 :=
   equiv_REMW_of_table state remw_input r1 r2 rd bus m r_main v r_a pins h_match_secondary
-    promises arith_mem bounds h_row_constraints arith_table
+    promises arith_mem bounds arith_table.row_constraints arith_table
     arith_chunk_ranges arith_carry_ranges h_na_bool h_nb_bool h_nr_bool h_np_xor h_nr_pin
     h_m32 h_div h_a23 h_b23 h_d23 h_c23 h_byte_lo h_sext_choice
     h_rs1_value h_rs2_value h_r_abs_of_ne h_r_sign


### PR DESCRIPTION
Phase 3 turn R15 — the remediation for #279, and the load-bearing move of the whole Arith arc: **the live ensemble now validates the completed Arith provider circuit.**

Authored by Aristotle (task `f1bb6e7f`), received, decontaminated, and verified locally.

## What changed

- **Constructibility precheck first (item 1, committed before code):** every shared provider row family audited against every constraint to be added — **no unsatisfiable row**. Active nonzero DIV/REM rows require the actual inverse of the divisor-chunk sum; multiplication and division-by-zero rows legitimately use zero.
- **`inv_sum_all_bs`** (the physical Arith AIR's stage-1 col 38, which `ArithMulRow` never modeled — the root cause found in R14/#279) added with mechanical propagation.
- **`componentComplete`**: the shared circuit extended with the full frozen generated local-constraint set (every `assertZero` cited), proven component-sound.
- **The swap**: ensemble, balance layer, six construction modules, and fixtures moved uniformly from `componentWithArithTable` to `componentComplete`; `vOfDivuRow` projects the committed inverse witness instead of fabricating `0`.
- Net **+161** proof-code lines (the completed circuit + soundness; deletions resume with the wrapper discharge).

## Reviewer note: what the swap means

The modeled acceptance predicate is now a strictly more faithful mirror of the real AIR (it validates constraints the physical AIR has always enforced). Constructibility is proven by the repaired witnesses, per the item-1 precheck. Root statements, `Audit.lean`, `Defects.lean`, `Equivalence/`, and `trust/generated/` are byte-unchanged; V1 16/16 (check 13 run locally with the submodule) + V2 green.

## Honest residual

The ArithDiv-view witness upgrade and the 16 Div wrapper discharges remain blocked on one precisely-named seam (`RowExtraction.arithMul_fullSpec_of_component_spec` deliberately keeps the six-part `FullSpec` ABI; the complete facts live in the table's `constraints_hold` but aren't yet transported through the row view). Per the ROI plan, that seam is being closed **locally** by the operator rather than with another Aristotle turn; it lands as the next commit on this stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)