### PR TITLE
feat: extract MemAlign ROM provider and pin cyclic transitions

### DIFF
--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -8,6 +8,7 @@ import ZiskFv.AirsClean.Binary.Wiring
 import ZiskFv.AirsClean.BinaryExtension.Wiring
 import ZiskFv.AirsClean.BinaryTableSlice
 import ZiskFv.AirsClean.BinaryExtensionTableSlice
+import ZiskFv.AirsClean.MemAlignRomSlice
 import ZiskFv.Airs.Main.Main
 import ZiskFv.Airs.OperationBus.OperationBus
 

--- a/ZiskFv/AirsClean/MemAlignRomSlice.lean
+++ b/ZiskFv/AirsClean/MemAlignRomSlice.lean
@@ -1,0 +1,76 @@
+import Clean.Air.FlatComponent
+import Clean.Utils.Tactics
+import ZiskFv.AirsClean.MemAlignRomTable
+import ZiskFv.Channels.MemAlignRom
+
+/-!
+# `MemAlignRom` static provider slice
+
+The bus-133 provider is backed by the exact 256-row `memAlignRomTable` model.
+It owns membership; a later MemAlign consumer emits the matching negative
+message and a finished channel transports membership through balance.
+
+This provider is deliberately not inserted into `FullEnsemble` yet: without
+the consumer, finishing bus 133 would create an unbalanced channel.
+
+## Trust note
+
+No axioms. Soundness derives exact `memAlignRomTable.Spec` membership from the
+static lookup. The identical completeness-side membership premise supplies a
+constructible static-table index and is not a soundness assumption.
+-/
+
+namespace ZiskFv.AirsClean.MemAlignRomSlice
+
+open Goldilocks
+open Air.Flat
+open Circuit (lookup)
+open ZiskFv.AirsClean.MemAlignRomTable
+open ZiskFv.Channels.MemAlignRom
+
+@[circuit_norm]
+def main (message : MemAlignRomMessage (Expression FGL)) : Circuit FGL Unit := do
+  lookup (Table.fromStatic memAlignRomTable) message
+  MemAlignRomChannel.push message
+
+@[reducible]
+def elaborated : ElaboratedCircuit FGL MemAlignRomMessage unit where
+  name := "MemAlignRomSlice133"
+  main := main
+  localLength _ := 0
+  output _ _ := ()
+  channelsWithRequirements := [MemAlignRomChannel.toRaw]
+  exposedChannels message _ :=
+    expose MemAlignRomChannel [MemAlignRomChannel.pushed message]
+  channelsLawful := by
+    simp only [circuit_norm, main, MemAlignRomChannel]
+
+def circuit : GeneralFormalCircuit FGL MemAlignRomMessage unit :=
+  { elaborated with
+    Assumptions := fun _ _ => True
+    Spec := fun message _ _ => memAlignRomTable.Spec message
+    ProverAssumptions := fun message _ _ => memAlignRomTable.Spec message
+    ProverSpec := fun _ _ _ => True
+    soundness := by
+      circuit_proof_start
+      refine ⟨?_, ?_⟩
+      · simpa only [Table.fromStatic, StaticTable.toTable] using h_holds
+      · intro _
+        simp [MemAlignRomChannel]
+    completeness := by
+      circuit_proof_start [Lookup.completeness_def]
+      simpa only [Table.fromStatic, StaticTable.toTable] using h_assumptions }
+
+def component : Component FGL := { circuit }
+
+theorem component_interactionsWith_memAlignRomChannel :
+    component.operations.interactionsWith MemAlignRomChannel.toRaw =
+      [((MemAlignRomChannel.pushed component.rowInputVar).toRaw)] := by
+  apply Component.interactionsWith_of_exposedChannels
+  change ⟨MemAlignRomChannel.toRaw,
+      [((MemAlignRomChannel.pushed component.rowInputVar).toRaw)]⟩ ∈
+    component.exposedChannels
+  simp only [component, circuit, elaborated, Component.exposedChannels, expose,
+    List.mem_singleton, List.map_cons, List.map_nil]
+
+end ZiskFv.AirsClean.MemAlignRomSlice

--- a/ZiskFv/AirsClean/MemAlignRomTable.lean
+++ b/ZiskFv/AirsClean/MemAlignRomTable.lean
@@ -1,0 +1,52 @@
+import Clean.Circuit.Lookup
+import Extraction.MemAlignRom
+import ZiskFv.Channels.MemAlignRom
+
+/-!
+# MemAlignRom — exact extracted static-table provider
+
+The virtual MemAlign ROM is absent from pilout's AIR list. Its 256 physical
+rows are extracted from the fixed `OFFSET`/`WIDTH` columns and row builder in
+`zisk/state-machines/mem/pil/mem_align_rom.pil:6-313`, with table id/size and
+padding-row index checked against
+`zisk/state-machines/mem/src/mem_align_rom_sm.rs::MemAlignRomSM`.
+
+All physical rows are preserved. In particular, the 68 reset-padding rows are
+the exact tuple `[0, 0, 0, 0, 0, 512]`, not an all-zero row.
+
+## Trust note
+
+No axioms. `Spec` is exact membership in the 256 extracted rows and
+`contains_iff` is definitional.
+-/
+
+namespace ZiskFv.AirsClean.MemAlignRomTable
+
+open Goldilocks
+open ZiskFv.Channels.MemAlignRom
+
+def tableSize : ℕ := Extraction.MemAlignRom.tableSize
+
+/-- The extracted fixed row at a valid physical MemAlign ROM index. -/
+def rowOfIndex (i : Fin tableSize) : MemAlignRomMessage FGL :=
+  let row := Extraction.MemAlignRom.rows[i]
+  { pc := row.pc
+    deltaPc := row.deltaPc
+    deltaAddr := row.deltaAddr
+    offset := row.offset
+    width := row.width
+    flags := row.flags }
+
+/-- Exact membership in the extracted 256-row virtual table. -/
+def memAlignRomTable : StaticTable FGL MemAlignRomMessage where
+  name := "mem_align_rom"
+  length := tableSize
+  row i := rowOfIndex i
+  index t := t.pc.val
+  Spec t := ∃ i : Fin tableSize, t = rowOfIndex i
+  contains_iff := by intro t; rfl
+
+theorem spec_iff (t : MemAlignRomMessage FGL) :
+    memAlignRomTable.Spec t ↔ ∃ i : Fin tableSize, t = rowOfIndex i := Iff.rfl
+
+end ZiskFv.AirsClean.MemAlignRomTable

--- a/ZiskFv/Channels/MemAlignRom.lean
+++ b/ZiskFv/Channels/MemAlignRom.lean
@@ -1,0 +1,43 @@
+import Clean.Circuit.Channel
+import Clean.Circuit.Provable
+import Clean.Utils.Tactics.ProvableStructDeriving
+import ZiskFv.Field.Goldilocks
+
+/-!
+# MemAlignRom typed channel
+
+Clean channel wrapper for ZisK's virtual MemAlign ROM lookup (`bus_id = 133`).
+The static provider owns membership in the six-column ROM; consumers make no
+local membership claim and finished-channel balance transports that fact.
+
+PIL citation: `zisk/state-machines/mem/pil/mem_align_rom.pil:6-313`.
+
+## Trust note
+
+No axioms. `MemAlignRomChannel.Guarantees` is `True`; exact membership comes
+from the static provider and the finished-channel protocol, not from a
+consumer-side promise.
+-/
+
+namespace ZiskFv.Channels.MemAlignRom
+
+open Goldilocks
+
+/-- The bus-133 MemAlign ROM payload in its upstream lookup order:
+`[PC, DELTA_PC, DELTA_ADDR, OFFSET, WIDTH, FLAGS]`. -/
+structure MemAlignRomMessage (F : Type) where
+  pc : F
+  deltaPc : F
+  deltaAddr : F
+  offset : F
+  width : F
+  flags : F
+deriving ProvableStruct
+
+/-- Consumer messages on bus 133 carry no local table-membership guarantee.
+The static provider and finished balance are the membership route. -/
+instance MemAlignRomChannel : Channel FGL MemAlignRomMessage where
+  name := "MemAlignRom133"
+  Guarantees _msg _data := True
+
+end ZiskFv.Channels.MemAlignRom

--- a/docs/clean-fork-divergences.md
+++ b/docs/clean-fork-divergences.md
@@ -67,3 +67,28 @@ merge.)
   makes the modern `Air.Flat` layer usable for preprocessed-column AIRs without introducing a parallel table
   model. The eventual upstream convergence should establish a soundness lift for both D1 and D2; this fork
   deliberately does not claim that larger result.
+
+---
+
+## D3 — `Air.Flat` intrinsic cyclic successor transitions  · zisk-fv #242 / S4  · **UPSTREAM CANDIDATE (strong)**
+
+- **Branch / commit:** `air-flat-cyclic-successor` @ `8edf71f8` (PR
+  [codygunton/clean#2](https://github.com/codygunton/clean/pull/2)), stacked on
+  `air-flat-indexed-fixed-columns` @ `c87617d8`.
+- **What:** an additive `Component.cyclicSuccessorTransition` predicate with a
+  trivial default, `Table.successorIndex` and `successorEnvironment` over the
+  component's materialized effective rows, and table/ensemble predicates that
+  apply it at every row. The `Fin table.length` successor is modulo the effective
+  length, so the final effective row maps definitionally to row zero.
+- **Why:** D1 deliberately retains predecessor/current semantics, including
+  row-zero predecessor saturation. MemAlign's unmasked bus-133 lookup reads
+  `DELTA_PC = pc' - pc` at every physical row, including the last-to-first
+  rotation; modeling that with D1 would omit the required wrap or move it into a
+  caller-supplied boundary promise. D3 owns that indexing relation structurally
+  while leaving D1 and every existing D1 consumer unchanged.
+- **Upstream candidacy — strong.** This is a small, general flat-AIR primitive
+  for circuits whose next-row rotation is semantically cyclic. As with D1, the
+  current predicate is inert in Clean's own soundness lift; any zisk-fv use must
+  be carried by a verifier-checked accepted-trace certificate, never by a caller
+  assumption. The longer-term upstream design should thread it through the
+  ensemble soundness theorem alongside the D1 transition surface.

--- a/docs/clean-fork-divergences.md
+++ b/docs/clean-fork-divergences.md
@@ -11,10 +11,29 @@ merge.)
 
 ---
 
+## D0 — `Air.Flat` nonzero-balance helpers and namespace hygiene  · zisk-fv S2  · **UPSTREAM CANDIDATE (strong)**
+
+- **Fork main / provenance:** `main` @ `8edf71f8`; the base-patch commits are
+  `8b1f8cb4` (nonzero push from a balanced pull) and `ef6dfbcd` (namespace
+  hygiene plus incidental Keccak/Utils adjustments).
+- **What:** `Clean.Air.Balance` gains the helpers that derive a nonzero provider
+  push from a balanced consumer pull. The same lineage qualifies
+  `Fin.foldl_eq_foldl_finRange` under `Clean.Fin`, avoiding an import collision
+  with Mathlib/Batteries; `Clean.Gadgets.Keccak.Permutation` and
+  `Clean.Utils.Misc` carry the small supporting adjustments.
+- **Why:** the balance helper is the existing protocol-soundness route used by
+  the static lookup providers, while the namespace qualification permits their
+  `Clean.Air.*` imports to coexist with Zisk's Mathlib imports. These are
+  build-input changes, not accepted-trace facts or caller-supplied promises.
+- **Upstream candidacy — strong.** Both are general Clean infrastructure and
+  have no Zisk-specific semantic dependency.
+
+---
+
 ## D1 — `Air.Flat` indexed adjacent-row (transition) constraints  · zisk-fv #100 / #226  · **UPSTREAM CANDIDATE (strong)**
 
-- **Branch / commit:** `air-flat-indexed-fixed-columns` @ `c87617d8` (which includes the prior
-  `air-flat-transition-constraints` commit `497e4a41`).
+- **Fork main / provenance:** `main` @ `8edf71f8`; introduced by commit
+  `497e4a41`.
 - **What:** an *additive* transition-constraint facility on the modern `Air.Flat` layer:
   - `Air.Flat.Component.transition : Nat → Environment F → Environment F → Prop := fun _ _ _ => True`;
   - `Air.Flat.Table.TransitionConstraints` applies it at every row index to the canonical predecessor/current
@@ -52,7 +71,8 @@ merge.)
 
 ## D2 — `Air.Flat` component-owned indexed fixed columns  · zisk-fv #243 / S1b  · **UPSTREAM CANDIDATE (strong)**
 
-- **Branch / commit:** `air-flat-indexed-fixed-columns` @ `c87617d8`.
+- **Fork main / provenance:** `main` @ `8edf71f8`; introduced by commit
+  `c87617d8`.
 - **What:** `IndexedFixedColumns` declares a physical capacity, a raw-or-fixed layout for each effective
   output cell, and periodic fixed values. `Component` owns an optional schema; `Table` stores only raw rows
   and definitionally materializes canonical effective `table` rows. The same rows feed constraints, channel
@@ -72,9 +92,8 @@ merge.)
 
 ## D3 — `Air.Flat` intrinsic cyclic successor transitions  · zisk-fv #242 / S4  · **UPSTREAM CANDIDATE (strong)**
 
-- **Branch / commit:** `air-flat-cyclic-successor` @ `8edf71f8` (PR
-  [codygunton/clean#2](https://github.com/codygunton/clean/pull/2)), stacked on
-  `air-flat-indexed-fixed-columns` @ `c87617d8`.
+- **Fork main / provenance:** `main` @ `8edf71f8`, introduced by the same
+  commit (PR [codygunton/clean#2](https://github.com/codygunton/clean/pull/2)).
 - **What:** an additive `Component.cyclicSuccessorTransition` predicate with a
   trivial default, `Table.successorIndex` and `successorEnvironment` over the
   component's materialized effective rows, and table/ensemble predicates that

--- a/flake.lock
+++ b/flake.lock
@@ -54,16 +54,16 @@
     "clean-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1784035501,
-        "narHash": "sha256-1Be3MrWhDvH0gytR5UY5FhgRzifbL5UHEf9K5dxIz+E=",
+        "lastModified": 1784743095,
+        "narHash": "sha256-tWqgVz9OCVRbmUEtErrYwNGMIRk6avez88XGEnE9QPQ=",
         "owner": "codygunton",
         "repo": "clean",
-        "rev": "c87617d8e29386e1e9e4f98cfbfb6940c2eb63df",
+        "rev": "8edf71f8023dbe70d07004bd081a913be41e2af0",
         "type": "github"
       },
       "original": {
         "owner": "codygunton",
-        "ref": "c87617d8",
+        "ref": "8edf71f8",
         "repo": "clean",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
       # `exists_nonzero_push_of_pull` balance strengthening, the D1 all-row
       # predecessor/current transition, D2 canonical component-owned indexed
       # fixed-column materialization, and D3 cyclic successor transitions
-      # (branch air-flat-cyclic-successor; see docs/clean-fork-divergences.md).
+      # (fork main @ 8edf71f8; see docs/clean-fork-divergences.md).
       # To be upstreamed; re-point at Verified-zkEVM/clean once all merge.
       # Pinned by rev so the lock is immutable; fetched over HTTPS so CI needs
       # no SSH key.

--- a/flake.nix
+++ b/flake.nix
@@ -36,18 +36,18 @@
     clean-src = {
       # Public fork codygunton/clean: a squashed snapshot of upstream
       # Verified-zkEVM/clean @ 95c8cc2e (= upstream main HEAD; Lean/Mathlib
-      # v4.28.0, matches zisk-fv) plus three zisk-fv integration patches:
+      # v4.28.0, matches zisk-fv) plus zisk-fv integration patches:
       # namespace hygiene (Fin.foldl_eq_foldl_finRange →
       # Clean.Fin.foldl_eq_foldl_finRange, so Clean.Air.* can be imported
       # alongside Mathlib/Batteries), the C7
-      # `exists_nonzero_push_of_pull` balance strengthening, and (zisk-fv #100)
-      # the D1 all-row predecessor/current transition plus D2 canonical
-      # component-owned indexed fixed-column materialization (branch
-      # air-flat-indexed-fixed-columns; see docs/clean-fork-divergences.md).
+      # `exists_nonzero_push_of_pull` balance strengthening, the D1 all-row
+      # predecessor/current transition, D2 canonical component-owned indexed
+      # fixed-column materialization, and D3 cyclic successor transitions
+      # (branch air-flat-cyclic-successor; see docs/clean-fork-divergences.md).
       # To be upstreamed; re-point at Verified-zkEVM/clean once all merge.
       # Pinned by rev so the lock is immutable; fetched over HTTPS so CI needs
       # no SSH key.
-      url = "github:codygunton/clean/c87617d8";
+      url = "github:codygunton/clean/8edf71f8";
       flake = false;
     };
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -29,9 +29,9 @@ path = "build/sail-lean"
 [[lean_lib]]
 name = "Extraction"
 srcDir = "build/extraction"
-roots = ["Extraction.LookupWiring", "Extraction.MemGeneratedConstraintBridge"]
+roots = ["Extraction.LookupWiring", "Extraction.MemGeneratedConstraintBridge", "Extraction.MemAlignRom"]
 globs = ["Extraction.Circuit", "Extraction.Mem", "Extraction.MemGeneratedArtifact",
-  "Extraction.LookupWiring", "Extraction.MemGeneratedConstraintBridge"]
+  "Extraction.LookupWiring", "Extraction.MemGeneratedConstraintBridge", "Extraction.MemAlignRom"]
 
 # Clean DSL (Verified-zkEVM/clean) source tree. Populated by
 # `nix run .#populate` from the pinned `clean-src` flake input.

--- a/nix/README.md
+++ b/nix/README.md
@@ -22,13 +22,13 @@ works as usual. The Clean dep is pulled as a *source* tree (no
 pre-built oleans inside Nix — Lake compiles it as part of the main
 build using the shared Mathlib v4.28.0 pin).
 
-For Project Closeout S2, `flake.lock` pins the immutable
-`codygunton/clean@c87617d8e29386e1e9e4f98cfbfb6940c2eb63df` fork input. It
-provides the all-row predecessor/current transition surface and canonical
-component-owned indexed fixed-column materialization used by the live Mem and
-Main components. The associated build-input trust note is maintained in
-`trust/trusted-base.md`; the pin is a source dependency, not an accepted-trace
-certificate.
+For Project Closeout S2/S4, `flake.lock` pins the immutable
+`codygunton/clean@8edf71f8023dbe70d07004bd081a913be41e2af0` fork input. It
+provides all-row predecessor/current transitions, canonical component-owned
+indexed fixed-column materialization, and intrinsic cyclic successor
+transitions for the MemAlign bus-133 route. The associated build-input trust
+note is maintained in `trust/trusted-base.md`; the pin is a source dependency,
+not an accepted-trace certificate.
 
 ## Why Nix and not Docker
 

--- a/nix/extracted-lean.nix
+++ b/nix/extracted-lean.nix
@@ -4,9 +4,9 @@
 # arith-table data / original PIL source) to produce the generated extraction
 # circuit shim, per-AIR Lean files, the operation-bus `Buses.lean`, the
 # memory-bus `MemoryBuses.lean`, the 74-row `ArithTable.lean` lookup data, the
-# Mem AIR sidecar source report, the typed Mem generated-artifact wrapper, the
-# generated Mem constraint bridge, and a constraint-linked lookup-wiring
-# manifest. All output lands in $out/.
+# 256-row virtual `MemAlignRom.lean`, the Mem AIR sidecar source report, the
+# typed Mem generated-artifact wrapper, the generated Mem constraint bridge,
+# and a constraint-linked lookup-wiring manifest. All output lands in $out/.
 
 stdenv.mkDerivation {
   pname = "zisk-fv-extracted-lean";
@@ -73,6 +73,14 @@ stdenv.mkDerivation {
     ${pil-extract}/bin/pil-extract arith-table \
       --rust-source ${zisk-src}/state-machines/arith/src/arith_table_data.rs \
       --output $out/ArithTable.lean
+
+    # MemAlignRom is virtual and therefore absent from pilout. Extract its
+    # 256 physical fixed rows from the upstream PIL fixed columns and verify
+    # the physical table parameters against the state-machine builder.
+    ${pil-extract}/bin/pil-extract mem-align-rom \
+      --pil-source ${zisk-src}/state-machines/mem/pil/mem_align_rom.pil \
+      --rust-source ${zisk-src}/state-machines/mem/src/mem_align_rom_sm.rs \
+      --output $out/MemAlignRom.lean
 
     # Mem generated AIR facts and sidecar source map. This is not a Lake
     # dependency; it is the reproducible source manifest for the generated

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -87,6 +87,7 @@ writeShellApplication {
       test -f build/extraction/Extraction/MemGeneratedArtifact.lean
       test -f build/extraction/Extraction/MemGeneratedConstraintBridge.lean
       test -f build/extraction/Extraction/LookupWiring.lean
+      test -f build/extraction/Extraction/MemAlignRom.lean
       # The lookup-wiring artifact is deliberately not allowed to inherit the
       # legacy bus-emission renderer's ExtF -> 0 fallback. Mem's range lookup
       # has an AirValue tuple member, so this is a concrete regeneration gate.
@@ -101,6 +102,10 @@ writeShellApplication {
       # MemAlign's zero-tail and assumes-neg forms are separate exact
       # templates; retain a composed-form kernel-rfl regression gate.
       grep -Fq 'example : constraint_MemAlignByte_14 = template_MemAlignByte_14 := by rfl' build/extraction/Extraction/LookupWiring.lean
+      # MemAlignRom is virtual and extracted from its source fixed columns;
+      # retain the physical table key and nonzero reset-padding row.
+      grep -Fq 'def tableId : Nat := 133' build/extraction/Extraction/MemAlignRom.lean
+      grep -Fq 'flags := (512 : FGL)' build/extraction/Extraction/MemAlignRom.lean
       generated_lean_path="$(pwd)/build/extraction:$(lake env printenv LEAN_PATH)"
       LEAN_PATH="$generated_lean_path" lake env lean -R build/extraction \
         -o build/extraction/Extraction/Circuit.olean \
@@ -114,6 +119,9 @@ writeShellApplication {
       LEAN_PATH="$generated_lean_path" lake env lean -R build/extraction \
         -o build/extraction/Extraction/LookupWiring.olean \
         build/extraction/Extraction/LookupWiring.lean
+      LEAN_PATH="$generated_lean_path" lake env lean -R build/extraction \
+        -o build/extraction/Extraction/MemAlignRom.olean \
+        build/extraction/Extraction/MemAlignRom.lean
       LEAN_PATH="$generated_lean_path" lake env lean -R build/extraction \
         build/extraction/Extraction/MemGeneratedConstraintBridge.lean
     }

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -98,6 +98,9 @@ writeShellApplication {
       # Binary c10 has no gsum hint. Its constraint-derived mixed template
       # must nevertheless be checked by the generated Lean rfl example.
       grep -Fq 'example : constraint_Binary_10 = template_Binary_10 := by rfl' build/extraction/Extraction/LookupWiring.lean
+      # MemAlign's zero-tail and assumes-neg forms are separate exact
+      # templates; retain a composed-form kernel-rfl regression gate.
+      grep -Fq 'example : constraint_MemAlignByte_14 = template_MemAlignByte_14 := by rfl' build/extraction/Extraction/LookupWiring.lean
       generated_lean_path="$(pwd)/build/extraction:$(lake env printenv LEAN_PATH)"
       LEAN_PATH="$generated_lean_path" lake env lean -R build/extraction \
         -o build/extraction/Extraction/Circuit.olean \

--- a/tools/pil-extract/src/lookup_wiring.rs
+++ b/tools/pil-extract/src/lookup_wiring.rs
@@ -108,6 +108,10 @@ enum LinkShape {
     Direct,
     Cluster2,
     DerivedMixed2,
+    DirectZeroTail,
+    Cluster2ZeroTail,
+    DirectAssumesNegForm,
+    DirectAssumesNegFormZeroTail,
 }
 
 #[derive(Clone)]
@@ -526,6 +530,7 @@ fn find_links(
     let mut links = Vec::new();
     let mut consumed = HashSet::new();
     let mut by_mix: HashMap<Ast, Vec<MixCandidate>> = HashMap::new();
+    let mut zero_tail_by_mix: HashMap<Ast, Vec<MixCandidate>> = HashMap::new();
     for (index, hint) in hints.iter().enumerate() {
         for alpha in challenges {
             for gamma in challenges {
@@ -538,6 +543,16 @@ fn find_links(
                         alpha: alpha.clone(),
                         gamma: gamma.clone(),
                     });
+                }
+                if let Some(mix) = zero_tail_std_mix(hint, alpha, gamma) {
+                    zero_tail_by_mix
+                        .entry(normalise(mix))
+                        .or_default()
+                        .push(MixCandidate {
+                            hint: index,
+                            alpha: alpha.clone(),
+                            gamma: gamma.clone(),
+                        });
                 }
             }
         }
@@ -588,12 +603,130 @@ fn find_links(
             continue;
         }
 
+        if zero_tail_template_scope(air_name) {
+            let pair_matches = zero_tail_pair_matches(
+                constraint,
+                hints,
+                &consumed,
+                &zero_tail_by_mix,
+            );
+            if pair_matches.len() > 1 {
+                bail!(
+                    "constraint #{constraint_index} has {} possible two-hint zero-tail template links",
+                    pair_matches.len()
+                );
+            }
+            if let Some((left, right, accumulator, alpha, gamma)) = pair_matches.into_iter().next() {
+                consumed.insert(left);
+                consumed.insert(right);
+                links.push(LinkedConstraint {
+                    constraint_index: *constraint_index,
+                    constraint: constraint.clone(),
+                    accumulator,
+                    alpha,
+                    gamma,
+                    hints: vec![hints[left].clone(), hints[right].clone()],
+                    derived_tuples: Vec::new(),
+                    shape: LinkShape::Cluster2ZeroTail,
+                });
+                continue;
+            }
+
+            let single_matches = zero_tail_single_matches(
+                constraint,
+                hints,
+                &consumed,
+                &zero_tail_by_mix,
+            );
+            if single_matches.len() > 1 {
+                bail!(
+                    "constraint #{constraint_index} has {} possible direct zero-tail template links",
+                    single_matches.len()
+                );
+            }
+            if let Some((hint, accumulator, alpha, gamma)) = single_matches.into_iter().next() {
+                consumed.insert(hint);
+                links.push(LinkedConstraint {
+                    constraint_index: *constraint_index,
+                    constraint: constraint.clone(),
+                    accumulator,
+                    alpha,
+                    gamma,
+                    hints: vec![hints[hint].clone()],
+                    derived_tuples: Vec::new(),
+                    shape: LinkShape::DirectZeroTail,
+                });
+                continue;
+            }
+
+            let sign_form_matches = direct_assumes_neg_form_matches(
+                constraint,
+                hints,
+                &consumed,
+                &by_mix,
+            );
+            if sign_form_matches.len() > 1 {
+                bail!(
+                    "constraint #{constraint_index} has {} possible direct assumes-neg template links",
+                    sign_form_matches.len()
+                );
+            }
+            if let Some((hint, accumulator, alpha, gamma)) = sign_form_matches.into_iter().next() {
+                consumed.insert(hint);
+                links.push(LinkedConstraint {
+                    constraint_index: *constraint_index,
+                    constraint: constraint.clone(),
+                    accumulator,
+                    alpha,
+                    gamma,
+                    hints: vec![hints[hint].clone()],
+                    derived_tuples: Vec::new(),
+                    shape: LinkShape::DirectAssumesNegForm,
+                });
+                continue;
+            }
+
+            let composed_matches = direct_assumes_neg_form_zero_tail_matches(
+                constraint,
+                hints,
+                &consumed,
+                &zero_tail_by_mix,
+            );
+            if composed_matches.len() > 1 {
+                bail!(
+                    "constraint #{constraint_index} has {} possible direct assumes-neg zero-tail template links",
+                    composed_matches.len()
+                );
+            }
+            if let Some((hint, accumulator, alpha, gamma)) = composed_matches.into_iter().next() {
+                consumed.insert(hint);
+                links.push(LinkedConstraint {
+                    constraint_index: *constraint_index,
+                    constraint: constraint.clone(),
+                    accumulator,
+                    alpha,
+                    gamma,
+                    hints: vec![hints[hint].clone()],
+                    derived_tuples: Vec::new(),
+                    shape: LinkShape::DirectAssumesNegFormZeroTail,
+                });
+                continue;
+            }
+        }
+
         if let Some(link) = derived_mixed_link(air_name, *constraint_index, constraint) {
             links.push(link);
         }
     }
     let unlinked = constraints.len().saturating_sub(links.len());
     Ok((links, unlinked))
+}
+
+/// The approved zero-tail route is deliberately bounded to the MemAlign
+/// family. Other unlinked shapes, including Arith c61/c62, retain their
+/// recorded disposition until separately approved.
+fn zero_tail_template_scope(air_name: &str) -> bool {
+    matches!(air_name, "MemAlign" | "MemAlignByte" | "MemAlignReadByte")
 }
 
 /// The Binary c10 final-byte lookup shares its accumulator constraint with
@@ -825,6 +958,155 @@ fn pair_matches(
     matches
 }
 
+fn zero_tail_single_matches(
+    constraint: &Ast,
+    hints: &[HintData],
+    consumed: &HashSet<usize>,
+    by_mix: &HashMap<Ast, Vec<MixCandidate>>,
+) -> Vec<(usize, Ast, Ast, Ast)> {
+    let Some(mix) = direct_mix(constraint) else {
+        return Vec::new();
+    };
+    by_mix
+        .get(mix)
+        .into_iter()
+        .flatten()
+        .filter(|candidate| !consumed.contains(&candidate.hint))
+        .filter(|candidate| has_literal_zero_tail(&hints[candidate.hint]))
+        .filter_map(|candidate| {
+            zero_tail_direct_accumulator(
+                constraint,
+                &hints[candidate.hint],
+                &candidate.alpha,
+                &candidate.gamma,
+            )
+            .map(|accumulator| {
+                (
+                    candidate.hint,
+                    accumulator,
+                    candidate.alpha.clone(),
+                    candidate.gamma.clone(),
+                )
+            })
+        })
+        .collect()
+}
+
+fn zero_tail_pair_matches(
+    constraint: &Ast,
+    hints: &[HintData],
+    consumed: &HashSet<usize>,
+    by_mix: &HashMap<Ast, Vec<MixCandidate>>,
+) -> Vec<(usize, usize, Ast, Ast, Ast)> {
+    let Some((left_mix, right_mix)) = cluster_mixes(constraint) else {
+        return Vec::new();
+    };
+    let mut matches = Vec::new();
+    for left in by_mix.get(left_mix).into_iter().flatten() {
+        if consumed.contains(&left.hint) {
+            continue;
+        }
+        for right in by_mix.get(right_mix).into_iter().flatten() {
+            if left.hint == right.hint
+                || left.alpha != right.alpha
+                || left.gamma != right.gamma
+                || consumed.contains(&right.hint)
+                || !(has_literal_zero_tail(&hints[left.hint])
+                    || has_literal_zero_tail(&hints[right.hint]))
+            {
+                continue;
+            }
+            if let Some(accumulator) = zero_tail_cluster_accumulator(
+                constraint,
+                &hints[left.hint],
+                &hints[right.hint],
+                &left.alpha,
+                &left.gamma,
+            ) {
+                matches.push((
+                    left.hint,
+                    right.hint,
+                    accumulator,
+                    left.alpha.clone(),
+                    left.gamma.clone(),
+                ));
+            }
+        }
+    }
+    matches
+}
+
+fn direct_assumes_neg_form_matches(
+    constraint: &Ast,
+    hints: &[HintData],
+    consumed: &HashSet<usize>,
+    by_mix: &HashMap<Ast, Vec<MixCandidate>>,
+) -> Vec<(usize, Ast, Ast, Ast)> {
+    let Some(mix) = direct_mix(constraint) else {
+        return Vec::new();
+    };
+    by_mix
+        .get(mix)
+        .into_iter()
+        .flatten()
+        .filter(|candidate| !consumed.contains(&candidate.hint))
+        .filter(|candidate| !hints[candidate.hint].proves)
+        .filter_map(|candidate| {
+            direct_assumes_neg_form_accumulator(
+                constraint,
+                &hints[candidate.hint],
+                &candidate.alpha,
+                &candidate.gamma,
+            )
+            .map(|accumulator| {
+                (
+                    candidate.hint,
+                    accumulator,
+                    candidate.alpha.clone(),
+                    candidate.gamma.clone(),
+                )
+            })
+        })
+        .collect()
+}
+
+fn direct_assumes_neg_form_zero_tail_matches(
+    constraint: &Ast,
+    hints: &[HintData],
+    consumed: &HashSet<usize>,
+    by_mix: &HashMap<Ast, Vec<MixCandidate>>,
+) -> Vec<(usize, Ast, Ast, Ast)> {
+    let Some(mix) = direct_mix(constraint) else {
+        return Vec::new();
+    };
+    by_mix
+        .get(mix)
+        .into_iter()
+        .flatten()
+        .filter(|candidate| !consumed.contains(&candidate.hint))
+        .filter(|candidate| {
+            let hint = &hints[candidate.hint];
+            !hint.proves && has_literal_zero_tail(hint)
+        })
+        .filter_map(|candidate| {
+            direct_assumes_neg_form_zero_tail_accumulator(
+                constraint,
+                &hints[candidate.hint],
+                &candidate.alpha,
+                &candidate.gamma,
+            )
+            .map(|accumulator| {
+                (
+                    candidate.hint,
+                    accumulator,
+                    candidate.alpha.clone(),
+                    candidate.gamma.clone(),
+                )
+            })
+        })
+        .collect()
+}
+
 fn direct_mix(constraint: &Ast) -> Option<&Ast> {
     match constraint {
         Ast::Add(lhs, _) | Ast::Sub(lhs, _) => match lhs.as_ref() {
@@ -870,6 +1152,93 @@ fn direct_accumulator(constraint: &Ast, hint: &HintData, alpha: &Ast, gamma: &As
     }
 }
 
+fn zero_tail_direct_accumulator(
+    constraint: &Ast,
+    hint: &HintData,
+    alpha: &Ast,
+    gamma: &Ast,
+) -> Option<Ast> {
+    match (hint.proves, constraint) {
+        (false, Ast::Add(lhs, rhs)) => match lhs.as_ref() {
+            Ast::Mul(accumulator, _) if **rhs == normalise(hint.multiplicity.clone()) => {
+                let accumulator = (**accumulator).clone();
+                (normalise(zero_tail_direct_template(
+                    accumulator.clone(),
+                    hint,
+                    alpha,
+                    gamma,
+                )) == *constraint)
+                    .then_some(accumulator)
+            }
+            _ => None,
+        },
+        (true, Ast::Sub(lhs, rhs)) => match lhs.as_ref() {
+            Ast::Mul(accumulator, _) if **rhs == normalise(hint.multiplicity.clone()) => {
+                let accumulator = (**accumulator).clone();
+                (normalise(zero_tail_direct_template(
+                    accumulator.clone(),
+                    hint,
+                    alpha,
+                    gamma,
+                )) == *constraint)
+                    .then_some(accumulator)
+            }
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn direct_assumes_neg_form_accumulator(
+    constraint: &Ast,
+    hint: &HintData,
+    alpha: &Ast,
+    gamma: &Ast,
+) -> Option<Ast> {
+    let Ast::Sub(lhs, rhs) = constraint else {
+        return None;
+    };
+    let Ast::Mul(accumulator, _) = lhs.as_ref() else {
+        return None;
+    };
+    if **rhs != normalise(assumes_neg_multiplicity(hint)) {
+        return None;
+    }
+    let accumulator = (**accumulator).clone();
+    (normalise(direct_assumes_neg_form_template(
+        accumulator.clone(),
+        hint,
+        alpha,
+        gamma,
+    )) == *constraint)
+        .then_some(accumulator)
+}
+
+fn direct_assumes_neg_form_zero_tail_accumulator(
+    constraint: &Ast,
+    hint: &HintData,
+    alpha: &Ast,
+    gamma: &Ast,
+) -> Option<Ast> {
+    let Ast::Sub(lhs, rhs) = constraint else {
+        return None;
+    };
+    let Ast::Mul(accumulator, _) = lhs.as_ref() else {
+        return None;
+    };
+    if **rhs != normalise(assumes_neg_multiplicity(hint)) {
+        return None;
+    }
+    let accumulator = (**accumulator).clone();
+    (normalise(direct_assumes_neg_form_zero_tail_template(
+        accumulator.clone(),
+        hint,
+        alpha,
+        gamma,
+    )) == *constraint)
+        .then_some(accumulator)
+}
+
 fn cluster_accumulator(
     constraint: &Ast,
     left: &HintData,
@@ -889,8 +1258,37 @@ fn cluster_accumulator(
         .then_some(accumulator)
 }
 
+fn zero_tail_cluster_accumulator(
+    constraint: &Ast,
+    left: &HintData,
+    right: &HintData,
+    alpha: &Ast,
+    gamma: &Ast,
+) -> Option<Ast> {
+    let product = match constraint {
+        Ast::Sub(product, _) => product.as_ref(),
+        _ => return None,
+    };
+    let Ast::Mul(accumulator, _) = product else {
+        return None;
+    };
+    let accumulator = (**accumulator).clone();
+    (normalise(zero_tail_cluster_template(
+        accumulator.clone(),
+        left,
+        right,
+        alpha,
+        gamma,
+    )) == *constraint)
+        .then_some(accumulator)
+}
+
 fn std_mix(hint: &HintData, alpha: &Ast, gamma: &Ast) -> Option<Ast> {
-    let mut values = hint.slots.iter().rev();
+    std_mix_slots(&hint.slots, &hint.bus_id, alpha, gamma)
+}
+
+fn std_mix_slots(slots: &[Slot], bus_id: &Ast, alpha: &Ast, gamma: &Ast) -> Option<Ast> {
+    let mut values = slots.iter().rev();
     let mut value = values.next()?.value.clone();
     for slot in values {
         value = Ast::add(Ast::mul(value, alpha.clone()), slot.value.clone());
@@ -898,10 +1296,26 @@ fn std_mix(hint: &HintData, alpha: &Ast, gamma: &Ast) -> Option<Ast> {
     Some(Ast::add(
         Ast::add(
             Ast::mul(value, alpha.clone()),
-            hint.bus_id.clone(),
+            bus_id.clone(),
         ),
         gamma.clone(),
     ))
+}
+
+/// Mirror the upstream macro's exact compression: remove a contiguous tail
+/// of literal-zero slots before the Horner fold, while retaining literal zero
+/// slots that occur before a nonzero slot. This is a template constructor,
+/// not an algebraic normalization.
+fn zero_tail_std_mix(hint: &HintData, alpha: &Ast, gamma: &Ast) -> Option<Ast> {
+    let end = hint
+        .slots
+        .iter()
+        .rposition(|slot| !is_zero(&slot.value))?;
+    std_mix_slots(&hint.slots[..=end], &hint.bus_id, alpha, gamma)
+}
+
+fn has_literal_zero_tail(hint: &HintData) -> bool {
+    matches!(hint.slots.last(), Some(slot) if is_zero(&slot.value))
 }
 
 fn signed_multiplicity(hint: &HintData) -> Ast {
@@ -910,6 +1324,13 @@ fn signed_multiplicity(hint: &HintData) -> Ast {
     } else {
         field_neg(hint.multiplicity.clone())
     }
+}
+
+/// PIL's assumes-side direct update renders the correction as `0 - m` and
+/// subtracts that term. Preserve the spelling exactly; this is not field
+/// negation normalization.
+fn assumes_neg_multiplicity(hint: &HintData) -> Ast {
+    Ast::sub(Ast::constant("0"), hint.multiplicity.clone())
 }
 
 fn direct_template(accumulator: Ast, hint: &HintData, alpha: &Ast, gamma: &Ast) -> Ast {
@@ -921,6 +1342,55 @@ fn direct_template(accumulator: Ast, hint: &HintData, alpha: &Ast, gamma: &Ast) 
     }
 }
 
+fn zero_tail_direct_template(
+    accumulator: Ast,
+    hint: &HintData,
+    alpha: &Ast,
+    gamma: &Ast,
+) -> Ast {
+    let product = Ast::mul(
+        accumulator,
+        zero_tail_std_mix(hint, alpha, gamma).expect("hint has a nonzero slot"),
+    );
+    if hint.proves {
+        Ast::sub(product, hint.multiplicity.clone())
+    } else {
+        Ast::add(product, hint.multiplicity.clone())
+    }
+}
+
+fn direct_assumes_neg_form_template(
+    accumulator: Ast,
+    hint: &HintData,
+    alpha: &Ast,
+    gamma: &Ast,
+) -> Ast {
+    debug_assert!(!hint.proves);
+    Ast::sub(
+        Ast::mul(
+            accumulator,
+            std_mix(hint, alpha, gamma).expect("hint has a slot"),
+        ),
+        assumes_neg_multiplicity(hint),
+    )
+}
+
+fn direct_assumes_neg_form_zero_tail_template(
+    accumulator: Ast,
+    hint: &HintData,
+    alpha: &Ast,
+    gamma: &Ast,
+) -> Ast {
+    debug_assert!(!hint.proves);
+    Ast::sub(
+        Ast::mul(
+            accumulator,
+            zero_tail_std_mix(hint, alpha, gamma).expect("hint has a nonzero slot"),
+        ),
+        assumes_neg_multiplicity(hint),
+    )
+}
+
 fn cluster_template(
     accumulator: Ast,
     left: &HintData,
@@ -930,6 +1400,24 @@ fn cluster_template(
 ) -> Ast {
     let left_mix = std_mix(left, alpha, gamma).expect("hint has a slot");
     let right_mix = std_mix(right, alpha, gamma).expect("hint has a slot");
+    Ast::sub(
+        Ast::mul(accumulator, Ast::mul(left_mix.clone(), right_mix.clone())),
+        Ast::add(
+            Ast::mul(signed_multiplicity(left), right_mix),
+            Ast::mul(signed_multiplicity(right), left_mix),
+        ),
+    )
+}
+
+fn zero_tail_cluster_template(
+    accumulator: Ast,
+    left: &HintData,
+    right: &HintData,
+    alpha: &Ast,
+    gamma: &Ast,
+) -> Ast {
+    let left_mix = zero_tail_std_mix(left, alpha, gamma).expect("hint has a nonzero slot");
+    let right_mix = zero_tail_std_mix(right, alpha, gamma).expect("hint has a nonzero slot");
     Ast::sub(
         Ast::mul(accumulator, Ast::mul(left_mix.clone(), right_mix.clone())),
         Ast::add(
@@ -1065,7 +1553,7 @@ fn write_prelude(out: &mut String) {
     out.push_str("structure DerivedTuple where\n");
     out.push_str("  piop : String\n  proves : Bool\n  busId : Expr\n");
     out.push_str("  multiplicity : Expr\n  slots : List Slot\n\n");
-    out.push_str("inductive LinkShape where\n  | direct\n  | cluster2\n  | derivedMixed2\n  deriving Repr, DecidableEq\n\n");
+    out.push_str("inductive LinkShape where\n  | direct\n  | cluster2\n  | derivedMixed2\n  | directZeroTail\n  | cluster2ZeroTail\n  | directAssumesNegForm\n  | directAssumesNegFormZeroTail\n  deriving Repr, DecidableEq\n\n");
     out.push_str("structure ValidatedLink where\n");
     out.push_str("  air : String\n  constraintIndex : Nat\n  shape : LinkShape\n");
     out.push_str("  accumulator : Expr\n  alpha : Expr\n  gamma : Expr\n  constraint : Expr\n  template : Expr\n");
@@ -1082,6 +1570,11 @@ fn write_prelude(out: &mut String) {
     out.push_str("  | [] => .add busId gamma\n");
     out.push_str("  | first :: rest =>\n");
     out.push_str("    .add (.add (.mul (rest.foldl (fun acc slot => .add (.mul acc alpha) slot.value) first.value) alpha) busId) gamma\n\n");
+    out.push_str("def literalZeroSlot : Slot → Bool\n");
+    out.push_str("  | ⟨_, .constant \"0\"⟩ => true\n");
+    out.push_str("  | _ => false\n\n");
+    out.push_str("def zeroTailSlots (slots : List Slot) : List Slot :=\n");
+    out.push_str("  (slots.reverse.dropWhile literalZeroSlot).reverse\n\n");
     out.push_str("def normalise : Expr → Expr\n");
     out.push_str("  | .add lhs rhs =>\n");
     out.push_str("    match normalise lhs, normalise rhs with\n");
@@ -1104,6 +1597,17 @@ fn write_prelude(out: &mut String) {
     out.push_str("    .sub (.mul accumulator (stdMix alpha gamma hint.busId hint.slots)) hint.multiplicity\n");
     out.push_str("  else\n");
     out.push_str("    .add (.mul accumulator (stdMix alpha gamma hint.busId hint.slots)) hint.multiplicity\n\n");
+    out.push_str("def directZeroTailTemplate (alpha gamma accumulator : Expr) (hint : HintTuple) : Expr :=\n");
+    out.push_str("  if hint.proves then\n");
+    out.push_str("    .sub (.mul accumulator (stdMix alpha gamma hint.busId (zeroTailSlots hint.slots))) hint.multiplicity\n");
+    out.push_str("  else\n");
+    out.push_str("    .add (.mul accumulator (stdMix alpha gamma hint.busId (zeroTailSlots hint.slots))) hint.multiplicity\n\n");
+    out.push_str("def assumesNegMultiplicity (hint : HintTuple) : Expr :=\n");
+    out.push_str("  .sub (.constant \"0\") hint.multiplicity\n\n");
+    out.push_str("def directAssumesNegFormTemplate (alpha gamma accumulator : Expr) (hint : HintTuple) : Expr :=\n");
+    out.push_str("  .sub (.mul accumulator (stdMix alpha gamma hint.busId hint.slots)) (assumesNegMultiplicity hint)\n\n");
+    out.push_str("def directAssumesNegFormZeroTailTemplate (alpha gamma accumulator : Expr) (hint : HintTuple) : Expr :=\n");
+    out.push_str("  .sub (.mul accumulator (stdMix alpha gamma hint.busId (zeroTailSlots hint.slots))) (assumesNegMultiplicity hint)\n\n");
     out.push_str("def negSelector : Expr → Expr\n");
     out.push_str("  | .constant \"1\" => .constant \"18446744069414584320\"\n");
     out.push_str("  | value => .sub (.constant \"0\") value\n\n");
@@ -1112,6 +1616,11 @@ fn write_prelude(out: &mut String) {
     out.push_str("def cluster2Template (alpha gamma accumulator : Expr) (left right : HintTuple) : Expr :=\n");
     out.push_str("  let leftMix := stdMix alpha gamma left.busId left.slots\n");
     out.push_str("  let rightMix := stdMix alpha gamma right.busId right.slots\n");
+    out.push_str("  .sub (.mul accumulator (.mul leftMix rightMix))\n");
+    out.push_str("    (.add (.mul (signedSelector left) rightMix) (.mul (signedSelector right) leftMix))\n\n");
+    out.push_str("def cluster2ZeroTailTemplate (alpha gamma accumulator : Expr) (left right : HintTuple) : Expr :=\n");
+    out.push_str("  let leftMix := stdMix alpha gamma left.busId (zeroTailSlots left.slots)\n");
+    out.push_str("  let rightMix := stdMix alpha gamma right.busId (zeroTailSlots right.slots)\n");
     out.push_str("  .sub (.mul accumulator (.mul leftMix rightMix))\n");
     out.push_str("    (.add (.mul (signedSelector left) rightMix) (.mul (signedSelector right) leftMix))\n\n");
     out.push_str("def signedDerivedSelector (tuple : DerivedTuple) : Expr :=\n");
@@ -1197,6 +1706,43 @@ fn write_link(out: &mut String, air: &AirManifest, link: &LinkedConstraint) -> R
             label,
             label
         )?,
+        LinkShape::DirectZeroTail => writeln!(
+            out,
+            "def template_{} : Expr := normalise (directZeroTailTemplate ({}) ({}) ({}) hint_{}_0)",
+            label,
+            lean_expr(&link.alpha),
+            lean_expr(&link.gamma),
+            lean_expr(&link.accumulator),
+            label
+        )?,
+        LinkShape::Cluster2ZeroTail => writeln!(
+            out,
+            "def template_{} : Expr := normalise (cluster2ZeroTailTemplate ({}) ({}) ({}) hint_{}_0 hint_{}_1)",
+            label,
+            lean_expr(&link.alpha),
+            lean_expr(&link.gamma),
+            lean_expr(&link.accumulator),
+            label,
+            label
+        )?,
+        LinkShape::DirectAssumesNegForm => writeln!(
+            out,
+            "def template_{} : Expr := normalise (directAssumesNegFormTemplate ({}) ({}) ({}) hint_{}_0)",
+            label,
+            lean_expr(&link.alpha),
+            lean_expr(&link.gamma),
+            lean_expr(&link.accumulator),
+            label
+        )?,
+        LinkShape::DirectAssumesNegFormZeroTail => writeln!(
+            out,
+            "def template_{} : Expr := normalise (directAssumesNegFormZeroTailTemplate ({}) ({}) ({}) hint_{}_0)",
+            label,
+            lean_expr(&link.alpha),
+            lean_expr(&link.gamma),
+            lean_expr(&link.accumulator),
+            label
+        )?,
     }
     writeln!(
         out,
@@ -1213,6 +1759,10 @@ fn write_link(out: &mut String, air: &AirManifest, link: &LinkedConstraint) -> R
             LinkShape::Direct => "direct",
             LinkShape::Cluster2 => "cluster2",
             LinkShape::DerivedMixed2 => "derivedMixed2",
+            LinkShape::DirectZeroTail => "directZeroTail",
+            LinkShape::Cluster2ZeroTail => "cluster2ZeroTail",
+            LinkShape::DirectAssumesNegForm => "directAssumesNegForm",
+            LinkShape::DirectAssumesNegFormZeroTail => "directAssumesNegFormZeroTail",
         }
     )?;
     writeln!(out, "  accumulator := {},", lean_expr(&link.accumulator))?;
@@ -1388,6 +1938,142 @@ mod tests {
         assert_eq!(
             cluster_accumulator(&constraint, &left, &right, &alpha, &gamma),
             Some(accumulator)
+        );
+    }
+
+    #[test]
+    fn zero_tail_mix_trims_only_terminal_literal_zero_slots() {
+        let tail_hint = hint(
+            true,
+            vec![
+                Ast::constant("1"),
+                Ast::constant("0"),
+                Ast::constant("0"),
+                Ast::constant("8"),
+                Ast::constant("0"),
+                Ast::constant("0"),
+            ],
+        );
+        let expected = hint(
+            true,
+            vec![
+                Ast::constant("1"),
+                Ast::constant("0"),
+                Ast::constant("0"),
+                Ast::constant("8"),
+            ],
+        );
+        let alpha = Ast::Challenge { stage: 1, index: 0 };
+        let gamma = Ast::Challenge { stage: 1, index: 1 };
+
+        assert!(has_literal_zero_tail(&tail_hint));
+        assert_eq!(
+            zero_tail_std_mix(&tail_hint, &alpha, &gamma),
+            std_mix(&expected, &alpha, &gamma),
+        );
+        assert_ne!(
+            zero_tail_std_mix(&tail_hint, &alpha, &gamma),
+            std_mix(&tail_hint, &alpha, &gamma),
+        );
+    }
+
+    #[test]
+    fn zero_tail_cluster_requires_a_terminal_zero_hint() {
+        let left = hint(false, vec![Ast::Witness {
+            stage: 1,
+            column: 4,
+            row_offset: 0,
+        }]);
+        let right = hint(
+            true,
+            vec![
+                Ast::Witness {
+                    stage: 1,
+                    column: 5,
+                    row_offset: 0,
+                },
+                Ast::constant("0"),
+            ],
+        );
+        let accumulator = Ast::Witness {
+            stage: 2,
+            column: 6,
+            row_offset: 0,
+        };
+        let alpha = Ast::Challenge { stage: 1, index: 0 };
+        let gamma = Ast::Challenge { stage: 1, index: 1 };
+        let constraint = normalise(zero_tail_cluster_template(
+            accumulator.clone(),
+            &left,
+            &right,
+            &alpha,
+            &gamma,
+        ));
+
+        assert_eq!(
+            zero_tail_cluster_accumulator(&constraint, &left, &right, &alpha, &gamma),
+            Some(accumulator),
+        );
+    }
+
+    #[test]
+    fn direct_assumes_neg_form_preserves_the_pilout_sign_spelling() {
+        let hint = HintData {
+            multiplicity: Ast::add(Ast::AirValue(0), Ast::constant("0")),
+            ..hint(false, vec![Ast::constant("1")])
+        };
+        let accumulator = Ast::Witness {
+            stage: 2,
+            column: 6,
+            row_offset: 0,
+        };
+        let alpha = Ast::Challenge { stage: 1, index: 0 };
+        let gamma = Ast::Challenge { stage: 1, index: 1 };
+        let constraint = normalise(direct_assumes_neg_form_template(
+            accumulator.clone(),
+            &hint,
+            &alpha,
+            &gamma,
+        ));
+
+        assert_eq!(
+            direct_assumes_neg_form_accumulator(&constraint, &hint, &alpha, &gamma),
+            Some(accumulator),
+        );
+        assert!(matches!(
+            constraint,
+            Ast::Sub(_, rhs) if *rhs == Ast::sub(Ast::constant("0"), Ast::AirValue(0))
+        ));
+    }
+
+    #[test]
+    fn direct_assumes_neg_form_zero_tail_composes_exactly() {
+        let hint = HintData {
+            multiplicity: Ast::add(Ast::AirValue(0), Ast::constant("0")),
+            ..hint(false, vec![Ast::constant("1"), Ast::constant("0")])
+        };
+        let accumulator = Ast::Witness {
+            stage: 2,
+            column: 6,
+            row_offset: 0,
+        };
+        let alpha = Ast::Challenge { stage: 1, index: 0 };
+        let gamma = Ast::Challenge { stage: 1, index: 1 };
+        let constraint = normalise(direct_assumes_neg_form_zero_tail_template(
+            accumulator.clone(),
+            &hint,
+            &alpha,
+            &gamma,
+        ));
+
+        assert_eq!(
+            direct_assumes_neg_form_zero_tail_accumulator(
+                &constraint,
+                &hint,
+                &alpha,
+                &gamma,
+            ),
+            Some(accumulator),
         );
     }
 

--- a/tools/pil-extract/src/main.rs
+++ b/tools/pil-extract/src/main.rs
@@ -10,6 +10,7 @@ use prost::Message;
 mod arith_table;
 mod clean_component;
 mod lookup_wiring;
+mod mem_align_rom;
 
 pub mod pilout {
     include!(concat!(env!("OUT_DIR"), "/pilout.rs"));
@@ -44,6 +45,8 @@ enum Cmd {
     LookupWiring(LookupWiringCmd),
     /// Parse `arith_table_data.rs` and emit `Extraction.ArithTable`.
     ArithTable(ArithTableCmd),
+    /// Parse MemAlignRom's PIL fixed columns and emit `Extraction.MemAlignRom`.
+    MemAlignRom(MemAlignRomCmd),
     /// Emit the Clean `Air.Flat.Component` source for one AIR — the `Row`
     /// `ProvableStruct` and the `main` do-block (assertZero constraints +
     /// the operation-bus `OpBusChannel.push`). Plan step C0g / D-EXT.
@@ -149,6 +152,21 @@ struct ArithTableCmd {
 }
 
 #[derive(Args, Debug)]
+struct MemAlignRomCmd {
+    /// Path to upstream `state-machines/mem/pil/mem_align_rom.pil`.
+    #[arg(long)]
+    pil_source: PathBuf,
+
+    /// Path to upstream `state-machines/mem/src/mem_align_rom_sm.rs`.
+    #[arg(long)]
+    rust_source: PathBuf,
+
+    /// Output path for the generated Lean module. If omitted, prints to stdout.
+    #[arg(long)]
+    output: Option<PathBuf>,
+}
+
+#[derive(Args, Debug)]
 struct CleanComponentCmd {
     /// Path to the .pilout file.
     #[arg(long)]
@@ -240,6 +258,17 @@ fn main() -> Result<()> {
     match cli.cmd {
         Cmd::ArithTable(args) => {
             let rendered = arith_table::run(&args.rust_source, args.output.as_deref())?;
+            if args.output.is_none() {
+                print!("{}", rendered);
+            }
+            Ok(())
+        }
+        Cmd::MemAlignRom(args) => {
+            let rendered = mem_align_rom::run(
+                &args.pil_source,
+                &args.rust_source,
+                args.output.as_deref(),
+            )?;
             if args.output.is_none() {
                 print!("{}", rendered);
             }

--- a/tools/pil-extract/src/mem_align_rom.rs
+++ b/tools/pil-extract/src/mem_align_rom.rs
@@ -1,0 +1,520 @@
+//! Extract the fixed 256-row MemAlign ROM from its upstream PIL definition.
+//!
+//! `MemAlignRom` is virtual, so it is intentionally absent from pilout's AIR
+//! list. Its authoritative rows instead come from the `OFFSET` and `WIDTH`
+//! fixed-column definitions plus the fixed-column builder in
+//! `mem_align_rom.pil`. The Rust state-machine source supplies the separately
+//! checked physical table parameters (id, size, and padding-row index).
+
+use std::fmt::Write;
+use std::path::Path;
+
+use anyhow::{bail, ensure, Context, Result};
+use regex::Regex;
+
+const EXPECTED_TABLE_ID: usize = 133;
+const EXPECTED_TABLE_SIZE: usize = 256;
+const EXPECTED_PADDING_ROW: usize = 0;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Row {
+    pc: i64,
+    delta_pc: i64,
+    delta_addr: i64,
+    offset: i64,
+    width: i64,
+    flags: i64,
+}
+
+/// Parse the upstream PIL fixed columns and emit `Extraction.MemAlignRom`.
+pub fn run(pil_source: &Path, rust_source: &Path, output: Option<&Path>) -> Result<String> {
+    let pil = std::fs::read_to_string(pil_source)
+        .with_context(|| format!("failed to read {}", pil_source.display()))?;
+    let rust = std::fs::read_to_string(rust_source)
+        .with_context(|| format!("failed to read {}", rust_source.display()))?;
+
+    let table_id = rust_const(&rust, "TABLE_ID")?;
+    let table_size = rust_const(&rust, "TABLE_SIZE")?;
+    let padding_row = rust_const(&rust, "PADDING_ROW")?;
+    ensure!(
+        table_id == EXPECTED_TABLE_ID,
+        "MemAlignRomSM::TABLE_ID changed: expected {EXPECTED_TABLE_ID}, got {table_id}"
+    );
+    ensure!(
+        table_size == EXPECTED_TABLE_SIZE,
+        "MemAlignRomSM::TABLE_SIZE changed: expected {EXPECTED_TABLE_SIZE}, got {table_size}"
+    );
+    ensure!(
+        padding_row == EXPECTED_PADDING_ROW,
+        "MemAlignRomSM::PADDING_ROW changed: expected {EXPECTED_PADDING_ROW}, got {padding_row}"
+    );
+    ensure!(
+        pil.contains("lookup_proves(MEMORY_ALIGN_ROM_ID, [PC, DELTA_PC, DELTA_ADDR, OFFSET, WIDTH, FLAGS], multiplicity)"),
+        "MemAlignRom lookup_proves tuple no longer has the expected six-column shape"
+    );
+
+    let offsets = fixed_column(&pil, "OFFSET", table_size)?;
+    let widths = fixed_column(&pil, "WIDTH", table_size)?;
+    let program_rows = program_rows(&pil)?;
+    let rows = build_rows(&offsets, &widths, program_rows)?;
+    ensure!(rows.len() == table_size, "row builder emitted {} rows", rows.len());
+
+    let lean = emit_lean(&rows, table_id, table_size, padding_row, program_rows);
+    if let Some(path) = output {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        std::fs::write(path, &lean)
+            .with_context(|| format!("failed to write {}", path.display()))?;
+        tracing::info!(path = %path.display(), rows = rows.len(), "wrote MemAlignRom extraction");
+    }
+    Ok(lean)
+}
+
+fn rust_const(source: &str, name: &str) -> Result<usize> {
+    let pattern = format!(r"pub const {name}: \w+\s*=\s*(\d+)");
+    let re = Regex::new(&pattern).expect("constant regex is valid");
+    let capture = re
+        .captures(source)
+        .with_context(|| format!("MemAlignRomSM::{name} declaration not found"))?;
+    capture[1]
+        .parse()
+        .with_context(|| format!("MemAlignRomSM::{name} is not a natural number"))
+}
+
+fn program_rows(source: &str) -> Result<usize> {
+    let sizes = int_array(source, "spsize")?;
+    ensure!(sizes.len() == 4, "spsize must have four operation lengths");
+    let one_word = const_int(source, "one_word_combinations")?;
+    let two_word = const_int(source, "two_word_combinations")?;
+    Ok(one_word * sizes[0] + one_word * sizes[1] + two_word * sizes[2] + two_word * sizes[3])
+}
+
+fn const_int(source: &str, name: &str) -> Result<usize> {
+    let pattern = format!(r"const int {name}\s*=\s*(\d+)");
+    let re = Regex::new(&pattern).expect("constant regex is valid");
+    let capture = re
+        .captures(source)
+        .with_context(|| format!("PIL constant {name} not found"))?;
+    capture[1]
+        .parse()
+        .with_context(|| format!("PIL constant {name} is not a natural number"))
+}
+
+fn int_array(source: &str, name: &str) -> Result<Vec<usize>> {
+    let pattern = format!(r"const int {name}\s*\[\d+\]\s*=\s*\[([^\]]+)\]");
+    let re = Regex::new(&pattern).expect("array regex is valid");
+    let capture = re
+        .captures(source)
+        .with_context(|| format!("PIL integer array {name} not found"))?;
+    capture[1]
+        .split(',')
+        .map(|value| value.trim().parse().with_context(|| format!("invalid {name} entry {value}")))
+        .collect()
+}
+
+fn fixed_column(source: &str, name: &str, length: usize) -> Result<Vec<usize>> {
+    let without_comments = source
+        .lines()
+        .map(|line| line.split_once("//").map_or(line, |(before, _)| before))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let declaration = format!("col fixed {name}");
+    let start = without_comments
+        .find(&declaration)
+        .with_context(|| format!("fixed column {name} not found"))?;
+    let tail = &without_comments[start + declaration.len()..];
+    let equals = tail
+        .find('=')
+        .with_context(|| format!("fixed column {name} has no initializer"))?;
+    let semicolon = tail[equals + 1..]
+        .find(';')
+        .with_context(|| format!("fixed column {name} has no terminating semicolon"))?;
+    let initializer = &tail[equals + 1..equals + 1 + semicolon];
+    let mut parser = FixedColumnParser::new(initializer);
+    let (mut values, tail_fill) = parser.list(true)?;
+    parser.finish()?;
+    if let Some(fill) = tail_fill {
+        ensure!(values.len() <= length, "fixed column {name} prefix exceeds {length} rows");
+        values.resize(length, fill);
+    }
+    ensure!(
+        values.len() == length,
+        "fixed column {name} has {} rows, expected {length}",
+        values.len()
+    );
+    Ok(values)
+}
+
+struct FixedColumnParser<'a> {
+    input: &'a [u8],
+    position: usize,
+}
+
+impl<'a> FixedColumnParser<'a> {
+    fn new(input: &'a str) -> Self {
+        Self {
+            input: input.as_bytes(),
+            position: 0,
+        }
+    }
+
+    fn list(&mut self, allow_tail: bool) -> Result<(Vec<usize>, Option<usize>)> {
+        self.skip_space();
+        self.expect(b'[')?;
+        let mut values = Vec::new();
+        let mut tail_fill = None;
+        loop {
+            self.skip_space_and_commas();
+            if self.consume(b']') {
+                break;
+            }
+            let (item, item_tail) = if self.peek() == Some(b'[') {
+                self.list(false)?
+            } else {
+                let value = self.natural()?;
+                if self.consume_bytes(b"...") {
+                    ensure!(allow_tail, "ellipsis is only supported in the outer fixed-column list");
+                    (Vec::new(), Some(value))
+                } else {
+                    (vec![value], None)
+                }
+            };
+            ensure!(item_tail.is_none() || tail_fill.is_none(), "multiple fixed-column ellipses");
+            if let Some(fill) = item_tail {
+                tail_fill = Some(fill);
+            } else {
+                let repeat = if self.consume(b':') { self.natural()? } else { 1 };
+                for _ in 0..repeat {
+                    values.extend_from_slice(&item);
+                }
+            }
+        }
+        Ok((values, tail_fill))
+    }
+
+    fn finish(&mut self) -> Result<()> {
+        self.skip_space();
+        ensure!(self.position == self.input.len(), "unexpected fixed-column syntax after initializer");
+        Ok(())
+    }
+
+    fn natural(&mut self) -> Result<usize> {
+        self.skip_space();
+        let start = self.position;
+        while self.peek().is_some_and(|byte| byte.is_ascii_digit()) {
+            self.position += 1;
+        }
+        ensure!(start != self.position, "expected a natural-number fixed-column value");
+        std::str::from_utf8(&self.input[start..self.position])
+            .expect("digits are UTF-8")
+            .parse()
+            .context("fixed-column value does not fit usize")
+    }
+
+    fn skip_space_and_commas(&mut self) {
+        loop {
+            self.skip_space();
+            if !self.consume(b',') {
+                break;
+            }
+        }
+    }
+
+    fn skip_space(&mut self) {
+        while self.peek().is_some_and(|byte| byte.is_ascii_whitespace()) {
+            self.position += 1;
+        }
+    }
+
+    fn expect(&mut self, byte: u8) -> Result<()> {
+        ensure!(self.consume(byte), "expected `{}` in fixed-column initializer", byte as char);
+        Ok(())
+    }
+
+    fn consume(&mut self, byte: u8) -> bool {
+        self.skip_space();
+        if self.peek() == Some(byte) {
+            self.position += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn consume_bytes(&mut self, bytes: &[u8]) -> bool {
+        if self.input[self.position..].starts_with(bytes) {
+            self.position += bytes.len();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.input.get(self.position).copied()
+    }
+}
+
+fn build_rows(offsets: &[usize], widths: &[usize], program_rows: usize) -> Result<Vec<Row>> {
+    ensure!(offsets.len() == widths.len(), "OFFSET/WIDTH length mismatch");
+    ensure!(program_rows == 188, "MemAlignRom program size changed: expected 188, got {program_rows}");
+    ensure!(offsets.len() == EXPECTED_TABLE_SIZE, "MemAlignRom must have 256 fixed rows");
+
+    let mut rows = Vec::with_capacity(offsets.len());
+    for line in 0..offsets.len() {
+        let mut pc = 0i64;
+        let mut delta_pc = 0i64;
+        let mut delta_addr = 0i64;
+        let mut is_write = 0i64;
+        let mut reset = 0i64;
+        let mut selectors = [0i64; 8];
+        let mut up_to_down = 0i64;
+        let mut down_to_up = 0i64;
+
+        if line == 0 || line > program_rows {
+            reset = 1;
+        } else if line < 41 {
+            if line % 2 == 1 {
+                delta_pc = line as i64;
+                reset = 1;
+                mark_range(&mut selectors, offsets[line + 1], widths[line + 1]);
+                up_to_down = 1;
+            } else {
+                pc = (line - 1) as i64;
+                delta_pc = -pc;
+                mark_one(&mut selectors, offsets[line]);
+            }
+        } else if line < 101 {
+            if line % 3 == 2 {
+                delta_pc = line as i64;
+                reset = 1;
+                mark_complement_range(&mut selectors, offsets[line + 2], widths[line + 2]);
+                up_to_down = 1;
+            } else if line % 3 == 0 {
+                pc = (line - 1) as i64;
+                delta_pc = 1;
+                is_write = 1;
+                mark_range(&mut selectors, offsets[line + 1], widths[line + 1]);
+                up_to_down = 1;
+            } else {
+                pc = (line - 1) as i64;
+                delta_pc = -pc;
+                is_write = 1;
+                mark_one(&mut selectors, offsets[line]);
+            }
+        } else if line < 134 {
+            if line % 3 == 2 {
+                delta_pc = line as i64;
+                reset = 1;
+                mark_from(&mut selectors, offsets[line + 1]);
+                up_to_down = 1;
+            } else if line % 3 == 0 {
+                pc = (line - 1) as i64;
+                delta_pc = 1;
+                mark_one(&mut selectors, offsets[line]);
+            } else {
+                pc = (line - 1) as i64;
+                delta_pc = -pc;
+                delta_addr = 1;
+                mark_before(&mut selectors, (offsets[line - 1] + widths[line - 1]) % 8);
+                down_to_up = 1;
+            }
+        } else if line < 189 {
+            if line % 5 == 4 {
+                delta_pc = line as i64;
+                reset = 1;
+                mark_before(&mut selectors, offsets[line + 2]);
+                up_to_down = 1;
+            } else if line % 5 == 0 {
+                pc = (line - 1) as i64;
+                delta_pc = 1;
+                is_write = 1;
+                mark_from(&mut selectors, offsets[line + 1]);
+                up_to_down = 1;
+            } else if line % 5 == 1 {
+                pc = (line - 1) as i64;
+                delta_pc = 1;
+                is_write = 1;
+                mark_one(&mut selectors, offsets[line]);
+            } else if line % 5 == 2 {
+                pc = (line - 1) as i64;
+                delta_pc = 1;
+                delta_addr = 1;
+                is_write = 1;
+                mark_before(&mut selectors, (offsets[line - 1] + widths[line - 1]) % 8);
+                down_to_up = 1;
+            } else {
+                pc = (line - 1) as i64;
+                delta_pc = -pc;
+                mark_from(&mut selectors, (offsets[line - 2] + widths[line - 2]) % 8);
+                down_to_up = 1;
+            }
+        } else {
+            bail!("MemAlignRom row {line} has no source builder case");
+        }
+
+        let flags = selectors
+            .iter()
+            .enumerate()
+            .map(|(index, selector)| selector * (1i64 << index))
+            .sum::<i64>()
+            + is_write * 256
+            + reset * 512
+            + up_to_down * 1024
+            + down_to_up * 2048;
+        rows.push(Row {
+            pc,
+            delta_pc,
+            delta_addr,
+            offset: offsets[line] as i64,
+            width: widths[line] as i64,
+            flags,
+        });
+    }
+    Ok(rows)
+}
+
+fn mark_one(selectors: &mut [i64; 8], index: usize) {
+    selectors[index] = 1;
+}
+
+fn mark_range(selectors: &mut [i64; 8], offset: usize, width: usize) {
+    for (index, selector) in selectors.iter_mut().enumerate() {
+        if index >= offset && index < offset + width {
+            *selector = 1;
+        }
+    }
+}
+
+fn mark_complement_range(selectors: &mut [i64; 8], offset: usize, width: usize) {
+    for (index, selector) in selectors.iter_mut().enumerate() {
+        if index < offset || index >= offset + width {
+            *selector = 1;
+        }
+    }
+}
+
+fn mark_from(selectors: &mut [i64; 8], offset: usize) {
+    for (index, selector) in selectors.iter_mut().enumerate() {
+        if index >= offset {
+            *selector = 1;
+        }
+    }
+}
+
+fn mark_before(selectors: &mut [i64; 8], end: usize) {
+    for selector in selectors.iter_mut().take(end) {
+        *selector = 1;
+    }
+}
+
+fn emit_lean(
+    rows: &[Row],
+    table_id: usize,
+    table_size: usize,
+    padding_row: usize,
+    program_rows: usize,
+) -> String {
+    let mut out = String::new();
+    writeln!(out, "import ZiskFv.Field.Goldilocks").unwrap();
+    out.push('\n');
+    writeln!(out, "/-!").unwrap();
+    writeln!(out, "# Extracted MemAlignRom fixed table.").unwrap();
+    out.push('\n');
+    writeln!(out, "Auto-generated by `pil-extract mem-align-rom` from the fixed").unwrap();
+    writeln!(out, "`OFFSET`/`WIDTH` columns and row builder in").unwrap();
+    writeln!(out, "`zisk/state-machines/mem/pil/mem_align_rom.pil:6-313`.").unwrap();
+    writeln!(out, "The physical table parameters are checked against").unwrap();
+    writeln!(out, "`zisk/state-machines/mem/src/mem_align_rom_sm.rs::MemAlignRomSM`.").unwrap();
+    writeln!(out, "The six fields retain the `lookup_proves` order:").unwrap();
+    writeln!(out, "`[PC, DELTA_PC, DELTA_ADDR, OFFSET, WIDTH, FLAGS]` on bus 133.").unwrap();
+    writeln!(
+        out,
+        "The {} physical rows include {} program rows and {} reset-padding rows",
+        rows.len(),
+        program_rows,
+        rows.len() - program_rows
+    )
+    .unwrap();
+    writeln!(out, "whose exact tuple is `[0, 0, 0, 0, 0, 512]`.").unwrap();
+    writeln!(out, "-/").unwrap();
+    out.push('\n');
+    writeln!(out, "namespace Extraction.MemAlignRom").unwrap();
+    out.push('\n');
+    writeln!(out, "open Goldilocks").unwrap();
+    out.push('\n');
+    writeln!(out, "structure Row where").unwrap();
+    writeln!(out, "  pc : FGL").unwrap();
+    writeln!(out, "  deltaPc : FGL").unwrap();
+    writeln!(out, "  deltaAddr : FGL").unwrap();
+    writeln!(out, "  offset : FGL").unwrap();
+    writeln!(out, "  width : FGL").unwrap();
+    writeln!(out, "  flags : FGL").unwrap();
+    writeln!(out, "  deriving DecidableEq").unwrap();
+    out.push('\n');
+    writeln!(out, "def tableId : Nat := {table_id}").unwrap();
+    writeln!(out, "def tableSize : Nat := {table_size}").unwrap();
+    writeln!(out, "def paddingRowIndex : Nat := {padding_row}").unwrap();
+    writeln!(out, "def programRowCount : Nat := {program_rows}").unwrap();
+    out.push('\n');
+    writeln!(out, "set_option maxRecDepth 100000 in").unwrap();
+    writeln!(out, "def rows : Vector Row {table_size} := #v[").unwrap();
+    for (index, row) in rows.iter().enumerate() {
+        let comma = if index + 1 == rows.len() { "" } else { "," };
+        writeln!(
+            out,
+            "  {{ pc := {}, deltaPc := {}, deltaAddr := {}, offset := {}, width := {}, flags := {} }}{}",
+            lean_fgl(row.pc),
+            lean_fgl(row.delta_pc),
+            lean_fgl(row.delta_addr),
+            lean_fgl(row.offset),
+            lean_fgl(row.width),
+            lean_fgl(row.flags),
+            comma,
+        )
+        .unwrap();
+    }
+    writeln!(out, "]").unwrap();
+    out.push('\n');
+    writeln!(out, "end Extraction.MemAlignRom").unwrap();
+    out
+}
+
+fn lean_fgl(value: i64) -> String {
+    format!("({value} : FGL)")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_nested_repetition_and_outer_padding() {
+        let source = "col fixed OFFSET = [0, [[0, 1]:2, 3], 0...];";
+        assert_eq!(
+            fixed_column(source, "OFFSET", 8).unwrap(),
+            vec![0, 0, 1, 0, 1, 3, 0, 0],
+        );
+    }
+
+    #[test]
+    fn builder_preserves_the_reset_padding_tuple() {
+        let offsets = vec![0; EXPECTED_TABLE_SIZE];
+        let widths = vec![0; EXPECTED_TABLE_SIZE];
+        let rows = build_rows(&offsets, &widths, 188).unwrap();
+        assert_eq!(rows.len(), EXPECTED_TABLE_SIZE);
+        assert_eq!(
+            rows[0],
+            Row {
+                pc: 0,
+                delta_pc: 0,
+                delta_addr: 0,
+                offset: 0,
+                width: 0,
+                flags: 512,
+            }
+        );
+        assert_eq!(rows[189].flags, 512);
+    }
+}

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -815,12 +815,16 @@ LeanZKCircuit, the Sail-to-Lean compiler output, or flake-pinned upstream
 inputs. Their audit surface is the Lake/Nix configuration and `flake.lock`,
 not `generated/baseline-axioms.txt`.
 
-Project Closeout S2 pins the immutable
-`codygunton/clean@c87617d8e29386e1e9e4f98cfbfb6940c2eb63df` source input.
-It provides D1's all-row predecessor/current transition contract and D2's
-canonical component-owned indexed fixed-column materialization. D1 remains
-inert to Clean's existing soundness theorem, so project-side accepted traces
-explicitly carry `transitions_hold`; D2 is consumed by canonical table
-materialization, constraints, interactions, transitions, and projections. The
-structural fixed-domain/no-wrap bound belongs to `Air.Flat.Table`, not to an
-accepted-trace field or caller-supplied promise hypothesis.
+Project Closeout S2/S4 pins the immutable
+`codygunton/clean@8edf71f8023dbe70d07004bd081a913be41e2af0` source input.
+It provides D1's all-row predecessor/current transition contract, D2's
+canonical component-owned indexed fixed-column materialization, and D3's
+intrinsic cyclic current/successor transition surface. D1 remains inert to
+Clean's existing soundness theorem, so project-side accepted traces explicitly
+carry `transitions_hold`; D2 is consumed by canonical table materialization,
+constraints, interactions, transitions, and projections. D3 is not cited by a
+derivation yet; when MemAlign consumes it, the cyclic relation must likewise be
+carried by a verifier-checked accepted-trace certificate, never by a caller
+assumption. The structural fixed-domain/no-wrap bound and cyclic successor
+indexing belong to `Air.Flat.Table`, not to an accepted-trace field or
+caller-supplied promise hypothesis.

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -681,6 +681,21 @@ Active conclusions:
   bus-125/bus-124 ensembles carry table membership through balance. No
   consumer promise or soundness-side `ProverAssumptions` is introduced;
   provider `ProverAssumptions` is completeness-only.
+- **MemAlign byte-assembly exact lookup wiring (#242).** This is a cited
+  application of the existing lookup/permutation protocol-soundness class,
+  not a new trust kind. The shared MemAlignByte PIL template emits the live
+  byte-memory permutation at `mem_align_byte.pil:66-100`, the 16-bit/byte
+  range and lookup facts at `:103-104`, and the direct padding updates at
+  `:106-118`; MemAlignReadByte instantiates that same template through its
+  Rust witness builder. The generated `ValidatedLink` entries kernel-check
+  the normal byte links plus the exact zero-tail routes
+  `MemAlignByte c9/c13` and `MemAlignReadByte c6/c7` at std_sum
+  `:590/:656/:599/:656`, and their composed exact assumes-neg/zero-tail
+  routes `MemAlignByte c14` and `MemAlignReadByte c8` at `:656`, each by
+  `constraint = template := by rfl` with the real hints #1025/#1027,
+  #1031/#1032, #1050, and #1054/#1055. The terminal std_sum constraints
+  c15/c9 (`:696`) remain explicitly global finalizers, not lookup links.
+  No caller promise or soundness-side `ProverAssumptions` is introduced.
 
 The active defect boundaries and retirement criteria are in
 [`defects.md`](defects.md).


### PR DESCRIPTION
## Summary

- Extract the 256-row `MemAlignRom` virtual fixed table from `mem_align_rom.pil` and the Rust builder, then add its exact static bus-133 provider slice.
- Preserve all 68 reset-padding rows as `[0, 0, 0, 0, 0, 512]`; no row is synthesized or normalized away.
- Pin Clean D3 cyclic successor transitions and document both D3 and the previously omitted D0 base patch using fork-main provenance.

## Trust surface

The provider owns exact static-table membership; its `ProverAssumptions` remains completeness-only. D3 owns cyclic successor indexing intrinsically, leaving D1 untouched; its later use is required to be an accepted-trace certificate, never a caller premise. The unmasked h998 fact is recorded from `mem_align.pil:139-143` and generated hint #998.

## Verification

- `nix run .#populate` regenerated and was reviewed for the provider extraction.
- V1, full `lake build ZiskFv`, V2, and `nix run .#test` pass on this stack.
- Independent review: approved; the 68 padding rows, static-provider boundary, and D3 pin/divergence accounting were verified.

This repository has no GitHub check-rollup configured; the commands above are the recorded local gate evidence.

Part 2 of the #242 stack, based on #285. The following PR consumes this provider through finished bus-133 balance.