### PR TITLE
feat: complete MemAlign component fidelity

### DIFF
--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -142,6 +142,7 @@ import ZiskFv.Compliance.AcceptedZiskTrace.Spec
 import ZiskFv.Compliance.AcceptedZiskTrace.MemTable
 import ZiskFv.Compliance.AcceptedZiskTrace.MemSegmentRanges
 import ZiskFv.Compliance.AcceptedZiskTrace.MemProviders
+import ZiskFv.Compliance.AcceptedZiskTrace.MemAlignRanges
 import ZiskFv.Compliance.SailTrace
 import ZiskFv.Compliance.OpBusProviderMatch
 import ZiskFv.Compliance.ConstructionSub

--- a/ZiskFv/AirsClean/FullEnsemble.lean
+++ b/ZiskFv/AirsClean/FullEnsemble.lean
@@ -9,6 +9,7 @@ import ZiskFv.AirsClean.Mem.Circuit
 import ZiskFv.AirsClean.SpecifiedRangesSlice
 import ZiskFv.AirsClean.MemAlign.Circuit
 import ZiskFv.AirsClean.MemAlignRomSlice
+import ZiskFv.AirsClean.MemAlignRangeSlice
 import ZiskFv.AirsClean.MemAlignByte.Circuit
 import ZiskFv.AirsClean.MemAlignReadByte.Circuit
 import ZiskFv.AirsClean.RegisterBoundary
@@ -46,6 +47,7 @@ open ZiskFv.Channels.OperationBus (OpBusChannel)
 open ZiskFv.Channels.MemoryBus (MemBusChannel)
 open ZiskFv.Channels.SpecifiedRanges (SpecifiedRangesSliceChannel)
 open ZiskFv.Channels.MemAlignRom (MemAlignRomChannel)
+open ZiskFv.Channels.MemAlignRanges (MemAlignRangeChannel)
 open ZiskFv.AirsClean.ZiskInstructionRom (Program)
 
 private theorem specifiedRangesSliceChannel_ne_memBus :
@@ -60,6 +62,13 @@ private theorem specifiedRangesSliceChannel_ne_memAlignRom :
   intro h
   have h_name := congrArg (fun raw : RawChannel FGL => raw.name) h
   change "SpecifiedRangesSlice103" = "MemAlignRom133" at h_name
+  simp at h_name
+
+private theorem specifiedRangesSliceChannel_ne_memAlignRange :
+    SpecifiedRangesSliceChannel.toRaw ≠ MemAlignRangeChannel.toRaw := by
+  intro h
+  have h_name := congrArg (fun raw : RawChannel FGL => raw.name) h
+  change "SpecifiedRangesSlice103" = "MemAlignRange107" at h_name
   simp at h_name
 
 private theorem memAlignRomChannel_ne_memBus :
@@ -148,6 +157,20 @@ def fullRv64imSoundEnsemble (length : ℕ) (program : Program length) :
           intro h_channel
           apply specifiedRangesSliceChannel_ne_memAlignRom
           simpa only [List.mem_cons, List.not_mem_nil, or_false] using h_channel)
+    |>.addTable ZiskFv.AirsClean.MemAlignRangeSlice.component
+        (by
+          change ([] : List (RawChannel FGL)) ⊆ _
+          simp)
+        (by
+          intro channel h
+          change channel ∈ [SpecifiedRangesSliceChannel.toRaw] at h
+          have h_range : channel = SpecifiedRangesSliceChannel.toRaw := by
+            simpa only [List.mem_cons, List.not_mem_nil, or_false] using h
+          subst channel
+          change SpecifiedRangesSliceChannel.toRaw ∉ [MemAlignRangeChannel.toRaw]
+          intro h_channel
+          apply specifiedRangesSliceChannel_ne_memAlignRange
+          simpa only [List.mem_cons, List.not_mem_nil, or_false] using h_channel)
     |>.addTable ZiskFv.AirsClean.MemAlign.component
         (by
           change ([] : List (RawChannel FGL)) ⊆ _
@@ -159,14 +182,16 @@ def fullRv64imSoundEnsemble (length : ℕ) (program : Program length) :
             simpa only [List.mem_cons, List.not_mem_nil, or_false] using h
           subst channel
           change SpecifiedRangesSliceChannel.toRaw ∉ [MemBusChannel.toRaw,
-            MemAlignRomChannel.toRaw]
+            MemAlignRomChannel.toRaw, MemAlignRangeChannel.toRaw]
           intro h_channel
           have h_channel' : SpecifiedRangesSliceChannel.toRaw = MemBusChannel.toRaw ∨
-              SpecifiedRangesSliceChannel.toRaw = MemAlignRomChannel.toRaw := by
+              SpecifiedRangesSliceChannel.toRaw = MemAlignRomChannel.toRaw ∨
+              SpecifiedRangesSliceChannel.toRaw = MemAlignRangeChannel.toRaw := by
             simpa only [List.mem_cons, List.not_mem_nil, or_false] using h_channel
-          rcases h_channel' with h_channel | h_channel
+          rcases h_channel' with h_channel | h_channel | h_channel
           · exact specifiedRangesSliceChannel_ne_memBus h_channel
-          · exact specifiedRangesSliceChannel_ne_memAlignRom h_channel)
+          · exact specifiedRangesSliceChannel_ne_memAlignRom h_channel
+          · exact specifiedRangesSliceChannel_ne_memAlignRange h_channel)
     |>.addFinishedChannel MemAlignRomChannel.toRaw
     |>.addTable ZiskFv.AirsClean.MemAlignByte.component
         (by simp [circuit_norm, ZiskFv.AirsClean.MemAlignByte.component,
@@ -242,6 +267,7 @@ def fullRv64imSoundEnsemble (length : ℕ) (program : Program length) :
           · exact specifiedRangesSliceChannel_ne_memBus h_finished.symm)
     |>.addFinishedChannel OpBusChannel.toRaw
     |>.addFinishedChannel MemBusChannel.toRaw
+    |>.addFinishedChannel MemAlignRangeChannel.toRaw
 
 /-- Per-table assumptions discharge for the full ensemble: each migrated
     component's per-row `Assumptions` reduce to `True`, so the ensemble-level
@@ -254,7 +280,7 @@ theorem fullRv64imSoundEnsemble_assumptionsConsistency (length : ℕ) (program :
   clear h_mem
   simp only [fullRv64imSoundEnsemble, circuit_norm, Ensemble.allTables] at h
   rcases h with
-    h | h | h | h | h | h | h | h | h | h | h | h | h | h <;>
+    h | h | h | h | h | h | h | h | h | h | h | h | h | h | h <;>
     (rw [h]
      trivial)
 

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/Classification.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/Classification.lean
@@ -15,6 +15,7 @@ open ZiskFv.Channels.OperationBus (OpBusChannel)
 open ZiskFv.Channels.MemoryBus (MemBusChannel)
 open ZiskFv.Channels.SpecifiedRanges (SpecifiedRangesSliceChannel)
 open ZiskFv.Channels.MemAlignRom (MemAlignRomChannel)
+open ZiskFv.Channels.MemAlignRanges (MemAlignRangeChannel)
 open ZiskFv.AirsClean.ZiskInstructionRom (Program)
 open ZiskFv.AirsClean.BinaryExtension (shiftStaticLookupComponent)
 
@@ -35,6 +36,7 @@ theorem component_mem_fullRv64im_cases
       ∨ component = ZiskFv.AirsClean.MemAlignReadByte.component
       ∨ component = ZiskFv.AirsClean.MemAlignByte.component
       ∨ component = ZiskFv.AirsClean.MemAlign.component
+      ∨ component = ZiskFv.AirsClean.MemAlignRangeSlice.component
       ∨ component = ZiskFv.AirsClean.MemAlignRomSlice.component
       ∨ component = ZiskFv.AirsClean.Mem.componentWithDualMemBus
       ∨ component = ZiskFv.AirsClean.SpecifiedRangesSlice.component
@@ -231,16 +233,37 @@ theorem memAlign_table_interactionsWith_opBus_nil
   have h_not :
       OpBusChannel.toRaw ∉
         ZiskFv.AirsClean.MemAlign.component.circuit.channels := by
-    change OpBusChannel.toRaw ∉ [MemBusChannel.toRaw, MemAlignRomChannel.toRaw]
+    change OpBusChannel.toRaw ∉ [MemBusChannel.toRaw, MemAlignRomChannel.toRaw,
+      MemAlignRangeChannel.toRaw]
     intro h
     have h' : OpBusChannel.toRaw = MemBusChannel.toRaw ∨
-        OpBusChannel.toRaw = MemAlignRomChannel.toRaw := by
+        OpBusChannel.toRaw = MemAlignRomChannel.toRaw ∨
+        OpBusChannel.toRaw = MemAlignRangeChannel.toRaw := by
       simpa only [List.mem_cons, List.not_mem_nil, or_false] using h
-    rcases h' with h | h
+    rcases h' with h | h | h
     · have h_name := congrArg (fun c : RawChannel FGL => c.name) h
       simp [OpBusChannel, MemBusChannel, Channel.toRaw] at h_name
     · have h_name := congrArg (fun c : RawChannel FGL => c.name) h
       simp [OpBusChannel, MemAlignRomChannel, Channel.toRaw] at h_name
+    · have h_name := congrArg (fun c : RawChannel FGL => c.name) h
+      simp [OpBusChannel, MemAlignRangeChannel, Channel.toRaw] at h_name
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  rw [h_component]
+  exact h_not
+
+/-- The bus-133 static slice owns no operation-bus interaction. -/
+theorem memAlignRangeSlice_table_interactionsWith_opBus_nil
+    {table : Table FGL}
+    (h_component : table.component = ZiskFv.AirsClean.MemAlignRangeSlice.component) :
+    table.interactionsWith OpBusChannel.toRaw = [] := by
+  have h_not :
+      OpBusChannel.toRaw ∉ ZiskFv.AirsClean.MemAlignRangeSlice.component.circuit.channels := by
+    change OpBusChannel.toRaw ∉ [MemAlignRangeChannel.toRaw]
+    intro h
+    have h_name := congrArg (fun c : RawChannel FGL => c.name)
+      (by simpa only [List.mem_singleton] using h :
+        OpBusChannel.toRaw = MemAlignRangeChannel.toRaw)
+    simp [OpBusChannel, MemAlignRangeChannel, Channel.toRaw] at h_name
   apply Table.interactionsWith_nil_of_channel_not_mem
   rw [h_component]
   exact h_not
@@ -440,6 +463,23 @@ theorem specifiedRangesSlice_table_interactionsWith_memBus_nil
   exact h_not
 
 /-- The bus-133 static slice owns no memory-bus interaction. -/
+theorem memAlignRangeSlice_table_interactionsWith_memBus_nil
+    {table : Table FGL}
+    (h_component : table.component = ZiskFv.AirsClean.MemAlignRangeSlice.component) :
+    table.interactionsWith MemBusChannel.toRaw = [] := by
+  have h_not :
+      MemBusChannel.toRaw ∉ ZiskFv.AirsClean.MemAlignRangeSlice.component.circuit.channels := by
+    change MemBusChannel.toRaw ∉ [MemAlignRangeChannel.toRaw]
+    intro h
+    have h_name := congrArg (fun c : RawChannel FGL => c.name)
+      (by simpa only [List.mem_singleton] using h :
+        MemBusChannel.toRaw = MemAlignRangeChannel.toRaw)
+    simp [MemBusChannel, MemAlignRangeChannel, Channel.toRaw] at h_name
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  rw [h_component]
+  exact h_not
+
+/-- The bus-133 static slice owns no memory-bus interaction. -/
 theorem memAlignRomSlice_table_interactionsWith_memBus_nil
     {table : Table FGL}
     (h_component : table.component = ZiskFv.AirsClean.MemAlignRomSlice.component) :
@@ -475,6 +515,38 @@ private theorem memAlignRomChannel_ne_ranges :
   intro h
   have h_name := congrArg (fun c : RawChannel FGL => c.name) h
   simp [MemAlignRomChannel, SpecifiedRangesSliceChannel, Channel.toRaw] at h_name
+
+private theorem memAlignRomChannel_ne_memAlignRange :
+    MemAlignRomChannel.toRaw ≠ MemAlignRangeChannel.toRaw := by
+  intro h
+  have h_name := congrArg (fun c : RawChannel FGL => c.name) h
+  simp [MemAlignRomChannel, MemAlignRangeChannel, Channel.toRaw] at h_name
+
+theorem memAlignRangeSlice_table_interactionsWith_memAlignRom_nil
+    {table : Table FGL}
+    (h_component : table.component = ZiskFv.AirsClean.MemAlignRangeSlice.component) :
+    table.interactionsWith MemAlignRomChannel.toRaw = [] := by
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  rw [h_component]
+  change MemAlignRomChannel.toRaw ∉ [MemAlignRangeChannel.toRaw]
+  simp only [List.mem_singleton]
+  exact memAlignRomChannel_ne_memAlignRange
+
+private theorem specifiedRangesSliceChannel_ne_memAlignRange :
+    SpecifiedRangesSliceChannel.toRaw ≠ MemAlignRangeChannel.toRaw := by
+  intro h
+  have h_name := congrArg (fun c : RawChannel FGL => c.name) h
+  simp [SpecifiedRangesSliceChannel, MemAlignRangeChannel, Channel.toRaw] at h_name
+
+theorem memAlignRangeSlice_table_interactionsWith_specifiedRanges_nil
+    {table : Table FGL}
+    (h_component : table.component = ZiskFv.AirsClean.MemAlignRangeSlice.component) :
+    table.interactionsWith SpecifiedRangesSliceChannel.toRaw = [] := by
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  rw [h_component]
+  change SpecifiedRangesSliceChannel.toRaw ∉ [MemAlignRangeChannel.toRaw]
+  simp only [List.mem_singleton]
+  exact specifiedRangesSliceChannel_ne_memAlignRange
 
 theorem registerBoundary_table_interactionsWith_memAlignRom_nil
     {table : Table FGL}

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/CounterpartClassification.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/CounterpartClassification.lean
@@ -137,7 +137,7 @@ theorem exists_matching_op_component_of_active_main_interaction
       table.component ∈ (fullRv64imEnsemble length program).ensemble.allTables :=
     EnsembleWitness.mem_allTables_component_of_mem_allTables h_table
   rcases component_mem_fullRv64im_cases h_component_mem with
-    h_verifier | h_regBoundary | h_marb | h_mab | h_memAlign | h_memAlignRom | h_mem | h_ranges |
+    h_verifier | h_regBoundary | h_marb | h_mab | h_memAlign | h_memAlignRange | h_memAlignRom | h_mem | h_ranges |
     h_arithDiv | h_arithMul | h_binExt | h_binary | h_binaryAdd | h_main
   · have h_nil : table.interactionsWith OpBusChannel.toRaw = [] := by
       have h_ops_nil :
@@ -156,6 +156,9 @@ theorem exists_matching_op_component_of_active_main_interaction
     simp [h_nil] at h_mem_table
   · have h_nil : table.interactionsWith OpBusChannel.toRaw = [] := by
       exact memAlign_table_interactionsWith_opBus_nil h_memAlign
+    simp [h_nil] at h_mem_table
+  · have h_nil : table.interactionsWith OpBusChannel.toRaw = [] := by
+      exact memAlignRangeSlice_table_interactionsWith_opBus_nil h_memAlignRange
     simp [h_nil] at h_mem_table
   · have h_nil : table.interactionsWith OpBusChannel.toRaw = [] := by
       exact memAlignRomSlice_table_interactionsWith_opBus_nil h_memAlignRom
@@ -293,7 +296,7 @@ theorem exists_matching_mem_component_of_active_main_interaction
       table.component ∈ (fullRv64imEnsemble length program).ensemble.allTables :=
     EnsembleWitness.mem_allTables_component_of_mem_allTables h_table
   rcases component_mem_fullRv64im_cases h_component_mem with
-    h_verifier | h_regBoundary | h_marb | h_mab | h_memAlign | h_memAlignRom | h_mem | h_ranges |
+    h_verifier | h_regBoundary | h_marb | h_mab | h_memAlign | h_memAlignRange | h_memAlignRom | h_mem | h_ranges |
     h_arithDiv | h_arithMul | h_binExt | h_binary | h_binaryAdd | h_main
   · have h_nil : table.interactionsWith MemBusChannel.toRaw = [] := by
       have h_ops_nil :
@@ -322,6 +325,9 @@ theorem exists_matching_mem_component_of_active_main_interaction
         exact ⟨table, h_table, h_mem_table⟩,
       h_msg, h_nonpull, h_nonzero, table, h_table, h_mem_table,
       Or.inr (Or.inr (Or.inl h_memAlign))⟩
+  · have h_nil : table.interactionsWith MemBusChannel.toRaw = [] := by
+      exact memAlignRangeSlice_table_interactionsWith_memBus_nil h_memAlignRange
+    simp [h_nil] at h_mem_table
   · have h_nil : table.interactionsWith MemBusChannel.toRaw = [] := by
       exact memAlignRomSlice_table_interactionsWith_memBus_nil h_memAlignRom
     simp [h_nil] at h_mem_table

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/MemAlignRangeProviderMatch.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/MemAlignRangeProviderMatch.lean
@@ -1,0 +1,363 @@
+import ZiskFv.AirsClean.FullEnsemble.Balance.Classification
+import ZiskFv.AirsClean.FullEnsemble.Balance.RowExtraction
+
+/-!
+# Full-ensemble MemAlign bus-107 provider match
+
+Each of MemAlign's eight source Range Check consumer emissions
+(`#982/#984/#986/#988/#990/#992/#994/#996`,
+`mem_align.pil:113-118`) is a negative one-slot bus-107 interaction.  The
+finished-channel protocol selects a same-message static provider push, and
+that provider's constrained `rangeTable8` lookup derives byte membership.
+The consumer channel carries no membership guarantee and no caller premise.
+-/
+
+namespace ZiskFv.AirsClean.FullEnsemble
+
+open Goldilocks
+open Air.Flat
+open ZiskFv.Channels.MemoryBus (MemBusChannel)
+open ZiskFv.Channels.OperationBus (OpBusChannel)
+open ZiskFv.Channels.SpecifiedRanges (SpecifiedRangesSliceChannel)
+open ZiskFv.Channels.MemAlignRom (MemAlignRomChannel)
+open ZiskFv.Channels.MemAlignRanges (MemAlignRangeChannel MemAlignRangeMessage)
+open ZiskFv.AirsClean.RangeTables (rangeTable8)
+open ZiskFv.AirsClean.ZiskInstructionRom (Program)
+
+private theorem memAlignRangeChannel_ne_memBus :
+    MemAlignRangeChannel.toRaw ≠ MemBusChannel.toRaw := by
+  intro h
+  have h_name := congrArg (fun channel : RawChannel FGL => channel.name) h
+  change "MemAlignRange107" = "MemoryBus" at h_name
+  simp at h_name
+
+private theorem memAlignRangeChannel_ne_opBus :
+    MemAlignRangeChannel.toRaw ≠ OpBusChannel.toRaw := by
+  intro h
+  have h_name := congrArg (fun channel : RawChannel FGL => channel.name) h
+  change "MemAlignRange107" = "OperationBus" at h_name
+  simp at h_name
+
+private theorem memAlignRangeChannel_ne_memAlignRom :
+    MemAlignRangeChannel.toRaw ≠ MemAlignRomChannel.toRaw := by
+  intro h
+  have h_name := congrArg (fun channel : RawChannel FGL => channel.name) h
+  change "MemAlignRange107" = "MemAlignRom133" at h_name
+  simp at h_name
+
+private theorem memAlignRangeChannel_ne_specifiedRanges :
+    MemAlignRangeChannel.toRaw ≠ SpecifiedRangesSliceChannel.toRaw := by
+  intro h
+  have h_name := congrArg (fun channel : RawChannel FGL => channel.name) h
+  change "MemAlignRange107" = "SpecifiedRangesSlice103" at h_name
+  simp at h_name
+
+/-- Project finished bus-107 balance from the full ensemble. -/
+theorem memAlignRange_balanced_of_witness
+    {length : Nat} {program : Program length}
+    (witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble)
+    (h_balanced : witness.BalancedChannels) :
+    BalancedInteractions (witness.interactionsWith MemAlignRangeChannel.toRaw) := by
+  have h := h_balanced MemAlignRangeChannel.toRaw (by
+    change MemAlignRangeChannel.toRaw ∈
+      [ MemAlignRangeChannel.toRaw
+      , MemBusChannel.toRaw
+      , OpBusChannel.toRaw
+      , MemAlignRomChannel.toRaw
+      , SpecifiedRangesSliceChannel.toRaw ]
+    simp)
+  simpa [EnsembleWitness.BalancedChannel,
+    EnsembleWitness.interactionsWith_allTablesWitness] using h
+
+/-- Every bus-107 interaction of MemAlign is one of the eight fixed negative
+    register-byte consumers. -/
+theorem memAlign_table_memAlignRange_mult_neg_one
+    {table : Table FGL}
+    (h_component : table.component = ZiskFv.AirsClean.MemAlign.component) :
+    ∀ {interaction : Interaction FGL},
+      interaction ∈ table.interactionsWith MemAlignRangeChannel.toRaw →
+        interaction.mult = -1 := by
+  intro interaction h_interaction
+  refine ((Table.forall_interactionsWith_iff table MemAlignRangeChannel.toRaw
+    (fun interaction => interaction.mult = -1)).mpr ?_) interaction h_interaction
+  intro row h_row abstractInteraction h_abstract h_channel
+  have h_member :
+      abstractInteraction ∈ table.component.operations.interactionsWith
+        MemAlignRangeChannel.toRaw := by
+    simp [Operations.interactionsWith, h_abstract, h_channel]
+  have h_interactions :
+      table.component.operations.interactionsWith MemAlignRangeChannel.toRaw =
+        [ ((MemAlignRangeChannel.emitted (-1)
+              (ZiskFv.AirsClean.MemAlign.memAlignRangeMessageExpr
+                ZiskFv.AirsClean.MemAlign.component.rowInputVar.reg_0)).toRaw)
+        , ((MemAlignRangeChannel.emitted (-1)
+              (ZiskFv.AirsClean.MemAlign.memAlignRangeMessageExpr
+                ZiskFv.AirsClean.MemAlign.component.rowInputVar.reg_1)).toRaw)
+        , ((MemAlignRangeChannel.emitted (-1)
+              (ZiskFv.AirsClean.MemAlign.memAlignRangeMessageExpr
+                ZiskFv.AirsClean.MemAlign.component.rowInputVar.reg_2)).toRaw)
+        , ((MemAlignRangeChannel.emitted (-1)
+              (ZiskFv.AirsClean.MemAlign.memAlignRangeMessageExpr
+                ZiskFv.AirsClean.MemAlign.component.rowInputVar.reg_3)).toRaw)
+        , ((MemAlignRangeChannel.emitted (-1)
+              (ZiskFv.AirsClean.MemAlign.memAlignRangeMessageExpr
+                ZiskFv.AirsClean.MemAlign.component.rowInputVar.reg_4)).toRaw)
+        , ((MemAlignRangeChannel.emitted (-1)
+              (ZiskFv.AirsClean.MemAlign.memAlignRangeMessageExpr
+                ZiskFv.AirsClean.MemAlign.component.rowInputVar.reg_5)).toRaw)
+        , ((MemAlignRangeChannel.emitted (-1)
+              (ZiskFv.AirsClean.MemAlign.memAlignRangeMessageExpr
+                ZiskFv.AirsClean.MemAlign.component.rowInputVar.reg_6)).toRaw)
+        , ((MemAlignRangeChannel.emitted (-1)
+              (ZiskFv.AirsClean.MemAlign.memAlignRangeMessageExpr
+                ZiskFv.AirsClean.MemAlign.component.rowInputVar.reg_7)).toRaw) ] := by
+    simpa [h_component] using
+      ZiskFv.AirsClean.MemAlign.component_interactionsWith_memAlignRangeChannel
+  simp [h_interactions] at h_member
+  rcases h_member with h | h | h | h | h | h | h | h
+  all_goals subst abstractInteraction
+  all_goals rfl
+
+/-- The only non-pull bus-107 counterpart of a MemAlign range consumer is
+    the constrained byte-range provider slice. -/
+theorem exists_memAlignRangeSlice_provider_of_memAlign_interaction
+    {length : Nat} {program : Program length}
+    (witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble)
+    (h_balanced : witness.BalancedChannels)
+    {memAlignTable : Table FGL}
+    (h_memAlignTable : memAlignTable ∈ witness.allTables)
+    {memAlignInteraction : Interaction FGL}
+    (h_memAlignInteraction :
+      memAlignInteraction ∈ memAlignTable.interactionsWith MemAlignRangeChannel.toRaw)
+    (h_active : memAlignInteraction.mult = -1) :
+    ∃ providerInteraction ∈ witness.interactionsWith MemAlignRangeChannel.toRaw,
+      providerInteraction.msg = memAlignInteraction.msg
+        ∧ providerInteraction.mult ≠ -1
+        ∧ providerInteraction.mult ≠ 0
+        ∧ ∃ providerTable ∈ witness.allTables,
+          providerInteraction ∈ providerTable.interactionsWith MemAlignRangeChannel.toRaw
+            ∧ providerTable.component = ZiskFv.AirsClean.MemAlignRangeSlice.component := by
+  have h_memWitness :
+      memAlignInteraction ∈ witness.interactionsWith MemAlignRangeChannel.toRaw := by
+    rw [EnsembleWitness.mem_interactionsWith]
+    exact ⟨memAlignTable, h_memAlignTable, h_memAlignInteraction⟩
+  obtain ⟨providerInteraction, h_providerWitness, h_message, h_nonpull, h_nonzero⟩ :=
+    exists_nonzero_push_of_pull
+      (witness.interactionsWith MemAlignRangeChannel.toRaw)
+      (memAlignRange_balanced_of_witness witness h_balanced)
+      memAlignInteraction h_memWitness h_active
+  rw [EnsembleWitness.mem_interactionsWith] at h_providerWitness
+  obtain ⟨providerTable, h_providerTable, h_providerInteraction⟩ := h_providerWitness
+  have h_component_mem :
+      providerTable.component ∈ (fullRv64imEnsemble length program).ensemble.allTables :=
+    EnsembleWitness.mem_allTables_component_of_mem_allTables h_providerTable
+  rcases component_mem_fullRv64im_cases h_component_mem with
+    h_verifier | h_boundary | h_alignRead | h_alignByte | h_align | h_range | h_rom | h_mem |
+      h_ranges | h_div | h_mul | h_extension | h_binary | h_binaryAdd | h_main
+  · have h_nil : providerTable.interactionsWith MemAlignRangeChannel.toRaw = [] := by
+      apply Table.interactionsWith_nil_of_channel_not_mem
+      rw [h_verifier]
+      change MemAlignRangeChannel.toRaw ∉ []
+      simp
+    simp [h_nil] at h_providerInteraction
+  · have h_nil : providerTable.interactionsWith MemAlignRangeChannel.toRaw = [] := by
+      apply Table.interactionsWith_nil_of_channel_not_mem
+      rw [h_boundary]
+      change MemAlignRangeChannel.toRaw ∉ [MemBusChannel.toRaw]
+      simp only [List.mem_singleton]
+      exact memAlignRangeChannel_ne_memBus
+    simp [h_nil] at h_providerInteraction
+  · have h_nil : providerTable.interactionsWith MemAlignRangeChannel.toRaw = [] := by
+      apply Table.interactionsWith_nil_of_channel_not_mem
+      rw [h_alignRead]
+      change MemAlignRangeChannel.toRaw ∉ [MemBusChannel.toRaw]
+      simp only [List.mem_singleton]
+      exact memAlignRangeChannel_ne_memBus
+    simp [h_nil] at h_providerInteraction
+  · have h_nil : providerTable.interactionsWith MemAlignRangeChannel.toRaw = [] := by
+      apply Table.interactionsWith_nil_of_channel_not_mem
+      rw [h_alignByte]
+      change MemAlignRangeChannel.toRaw ∉ [MemBusChannel.toRaw]
+      simp only [List.mem_singleton]
+      exact memAlignRangeChannel_ne_memBus
+    simp [h_nil] at h_providerInteraction
+  · exact False.elim (h_nonpull
+      (memAlign_table_memAlignRange_mult_neg_one h_align h_providerInteraction))
+  · refine ⟨providerInteraction, ?_, h_message, h_nonpull, h_nonzero,
+      providerTable, h_providerTable, h_providerInteraction, h_range⟩
+    rw [EnsembleWitness.mem_interactionsWith]
+    exact ⟨providerTable, h_providerTable, h_providerInteraction⟩
+  · have h_nil : providerTable.interactionsWith MemAlignRangeChannel.toRaw = [] := by
+      apply Table.interactionsWith_nil_of_channel_not_mem
+      rw [h_rom]
+      change MemAlignRangeChannel.toRaw ∉ [MemAlignRomChannel.toRaw]
+      simp only [List.mem_singleton]
+      exact memAlignRangeChannel_ne_memAlignRom
+    simp [h_nil] at h_providerInteraction
+  · have h_nil : providerTable.interactionsWith MemAlignRangeChannel.toRaw = [] := by
+      apply Table.interactionsWith_nil_of_channel_not_mem
+      rw [h_mem]
+      change MemAlignRangeChannel.toRaw ∉ [MemBusChannel.toRaw, SpecifiedRangesSliceChannel.toRaw]
+      intro h
+      have h' : MemAlignRangeChannel.toRaw = MemBusChannel.toRaw ∨
+          MemAlignRangeChannel.toRaw = SpecifiedRangesSliceChannel.toRaw := by
+        simpa only [List.mem_cons, List.not_mem_nil, or_false] using h
+      rcases h' with h | h
+      · exact memAlignRangeChannel_ne_memBus h
+      · exact memAlignRangeChannel_ne_specifiedRanges h
+    simp [h_nil] at h_providerInteraction
+  · have h_nil : providerTable.interactionsWith MemAlignRangeChannel.toRaw = [] := by
+      apply Table.interactionsWith_nil_of_channel_not_mem
+      rw [h_ranges]
+      change MemAlignRangeChannel.toRaw ∉ [SpecifiedRangesSliceChannel.toRaw]
+      simp only [List.mem_singleton]
+      exact memAlignRangeChannel_ne_specifiedRanges
+    simp [h_nil] at h_providerInteraction
+  · have h_nil : providerTable.interactionsWith MemAlignRangeChannel.toRaw = [] := by
+      apply Table.interactionsWith_nil_of_channel_not_mem
+      rw [h_div]
+      change MemAlignRangeChannel.toRaw ∉ []
+      simp
+    simp [h_nil] at h_providerInteraction
+  · have h_nil : providerTable.interactionsWith MemAlignRangeChannel.toRaw = [] := by
+      apply Table.interactionsWith_nil_of_channel_not_mem
+      rw [h_mul, arithMulProviderComponent]
+      change MemAlignRangeChannel.toRaw ∉ [OpBusChannel.toRaw]
+      simp only [List.mem_singleton]
+      exact memAlignRangeChannel_ne_opBus
+    simp [h_nil] at h_providerInteraction
+  · have h_nil : providerTable.interactionsWith MemAlignRangeChannel.toRaw = [] := by
+      apply Table.interactionsWith_nil_of_channel_not_mem
+      rw [h_extension]
+      change MemAlignRangeChannel.toRaw ∉ [OpBusChannel.toRaw]
+      simp only [List.mem_singleton]
+      exact memAlignRangeChannel_ne_opBus
+    simp [h_nil] at h_providerInteraction
+  · have h_nil : providerTable.interactionsWith MemAlignRangeChannel.toRaw = [] := by
+      apply Table.interactionsWith_nil_of_channel_not_mem
+      rw [h_binary]
+      change MemAlignRangeChannel.toRaw ∉ [OpBusChannel.toRaw]
+      simp only [List.mem_singleton]
+      exact memAlignRangeChannel_ne_opBus
+    simp [h_nil] at h_providerInteraction
+  · have h_nil : providerTable.interactionsWith MemAlignRangeChannel.toRaw = [] := by
+      apply Table.interactionsWith_nil_of_channel_not_mem
+      rw [h_binaryAdd]
+      change MemAlignRangeChannel.toRaw ∉ [OpBusChannel.toRaw]
+      simp only [List.mem_singleton]
+      exact memAlignRangeChannel_ne_opBus
+    simp [h_nil] at h_providerInteraction
+  · have h_nil : providerTable.interactionsWith MemAlignRangeChannel.toRaw = [] := by
+      apply Table.interactionsWith_nil_of_channel_not_mem
+      rw [h_main]
+      change MemAlignRangeChannel.toRaw ∉ [MemBusChannel.toRaw, OpBusChannel.toRaw]
+      intro h
+      have h' : MemAlignRangeChannel.toRaw = MemBusChannel.toRaw ∨
+          MemAlignRangeChannel.toRaw = OpBusChannel.toRaw := by
+        simpa only [List.mem_cons, List.not_mem_nil, or_false] using h
+      rcases h' with h | h
+      · exact memAlignRangeChannel_ne_memBus h
+      · exact memAlignRangeChannel_ne_opBus h
+    simp [h_nil] at h_providerInteraction
+
+/-- Unpack a static bus-107 provider interaction to its concrete provider row. -/
+theorem exists_memAlignRangeSlice_provider_row_of_interaction
+    {table : Table FGL}
+    (h_component : table.component = ZiskFv.AirsClean.MemAlignRangeSlice.component)
+    {interaction : Interaction FGL}
+    (h_interaction : interaction ∈ table.interactionsWith MemAlignRangeChannel.toRaw) :
+    ∃ row ∈ table.table,
+      interaction =
+        ((MemAlignRangeChannel.pushed
+          ZiskFv.AirsClean.MemAlignRangeSlice.component.rowInputVar).toRaw).eval
+          (table.environment row) := by
+  have h_singleton :
+      table.component.operations.interactionsWith MemAlignRangeChannel.toRaw =
+        [((MemAlignRangeChannel.pushed
+          ZiskFv.AirsClean.MemAlignRangeSlice.component.rowInputVar).toRaw)] := by
+    simpa [h_component] using
+      ZiskFv.AirsClean.MemAlignRangeSlice.component_interactionsWith_memAlignRangeChannel
+  simp [Table.interactionsWith, Operations.interactionValuesWith_eq_map,
+    h_singleton] at h_interaction
+  exact h_interaction
+
+/-- The constrained provider row selected by bus-107 balance satisfies exact
+    `rangeTable8` membership. -/
+theorem memAlignRangeTable_spec_of_memAlignRangeSlice_provider_row
+    {length : Nat} {program : Program length}
+    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
+    (h_specs : witness.Spec)
+    {providerTable : Table FGL}
+    (h_providerTable : providerTable ∈ witness.allTables)
+    (h_providerComponent :
+      providerTable.component = ZiskFv.AirsClean.MemAlignRangeSlice.component)
+    {providerRow : Array FGL}
+    (h_providerRow : providerRow ∈ providerTable.table) :
+    rangeTable8.Spec
+      (Eval.eval (providerTable.environment providerRow)
+        ZiskFv.AirsClean.MemAlignRangeSlice.component.rowInputVar).value := by
+  have h_spec := h_specs providerTable h_providerTable providerRow h_providerRow
+  rw [h_providerComponent] at h_spec
+  simpa only [Component.Spec, Component.rowInput, eval_varFromOffset_valueFromOffset,
+    ZiskFv.AirsClean.MemAlignRangeSlice.component,
+    ZiskFv.AirsClean.MemAlignRangeSlice.circuit,
+    ZiskFv.AirsClean.MemAlignRangeSlice.elaborated] using h_spec
+
+/-- Raw finished-channel equality restores equality of the one-slot typed
+    provider and consumer messages. -/
+theorem memAlignRangeMessage_eq_of_eval_pushed_provider_msg_eq
+    {consumerMsg providerMsg : MemAlignRangeMessage (Expression FGL)}
+    {consumerEnv providerEnv : Environment FGL}
+    (h_msg :
+      (((MemAlignRangeChannel.pushed providerMsg).toRaw).eval providerEnv).msg =
+        (((MemAlignRangeChannel.emitted (-1) consumerMsg).toRaw).eval consumerEnv).msg) :
+    Eval.eval providerEnv providerMsg = Eval.eval consumerEnv consumerMsg := by
+  have h_vec :
+      Vector.map (Expression.eval providerEnv) (toElements providerMsg) =
+        Vector.map (Expression.eval consumerEnv) (toElements consumerMsg) := by
+    apply Vector.toArray_injective
+    simpa [ChannelInteraction.toRaw, AbstractInteraction.eval] using h_msg
+  have h_from := congrArg
+    (fun xs => (fromElements xs : MemAlignRangeMessage FGL)) h_vec
+  simpa [ProvableType.fromElements_eval_toElements] using h_from
+
+/-- Every explicit bus-107 MemAlign consumer interaction is matched to a
+    constrained byte provider, so the evaluated one-slot tuple has exact
+    membership. -/
+theorem rangeTable8_spec_of_memAlign_range_interaction
+    {length : Nat} {program : Program length}
+    (witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble)
+    (h_constraints : witness.Constraints)
+    (h_balanced : witness.BalancedChannels)
+    {memAlignTable : Table FGL}
+    (h_memAlignTable : memAlignTable ∈ witness.allTables)
+    {consumerMsg : MemAlignRangeMessage (Expression FGL)}
+    {memAlignRow : Array FGL}
+    (h_consumerInteraction :
+      ((MemAlignRangeChannel.emitted (-1) consumerMsg).toRaw).eval
+          (memAlignTable.environment memAlignRow) ∈
+        memAlignTable.interactionsWith MemAlignRangeChannel.toRaw) :
+    rangeTable8.Spec
+      (Eval.eval (memAlignTable.environment memAlignRow) consumerMsg).value := by
+  let consumerInteraction : Interaction FGL :=
+    ((MemAlignRangeChannel.emitted (-1) consumerMsg).toRaw).eval
+      (memAlignTable.environment memAlignRow)
+  have h_consumer :
+      consumerInteraction ∈ memAlignTable.interactionsWith MemAlignRangeChannel.toRaw := by
+    exact h_consumerInteraction
+  obtain ⟨providerInteraction, _, h_message, _, _, providerTable, h_providerTable,
+      h_providerInteraction, h_providerComponent⟩ :=
+    exists_memAlignRangeSlice_provider_of_memAlign_interaction witness h_balanced
+      h_memAlignTable h_consumer (by rfl)
+  obtain ⟨providerRow, h_providerRow, h_providerEval⟩ :=
+    exists_memAlignRangeSlice_provider_row_of_interaction
+      h_providerComponent h_providerInteraction
+  have h_providerSpec := memAlignRangeTable_spec_of_memAlignRangeSlice_provider_row
+    (witness_spec_of_constraints witness h_constraints h_balanced)
+    h_providerTable h_providerComponent h_providerRow
+  rw [h_providerEval] at h_message
+  have h_typed := memAlignRangeMessage_eq_of_eval_pushed_provider_msg_eq h_message
+  rw [← h_typed]
+  exact h_providerSpec
+
+end ZiskFv.AirsClean.FullEnsemble

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/MemAlignRomProviderMatch.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/MemAlignRomProviderMatch.lean
@@ -54,7 +54,8 @@ theorem memAlignRom_balanced_of_witness
     BalancedInteractions (witness.interactionsWith MemAlignRomChannel.toRaw) := by
   have h := h_balanced MemAlignRomChannel.toRaw (by
     change MemAlignRomChannel.toRaw ∈
-      [ ZiskFv.Channels.MemoryBus.MemBusChannel.toRaw
+      [ ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.toRaw
+      , ZiskFv.Channels.MemoryBus.MemBusChannel.toRaw
       , ZiskFv.Channels.OperationBus.OpBusChannel.toRaw
       , MemAlignRomChannel.toRaw
       , ZiskFv.Channels.SpecifiedRanges.SpecifiedRangesSliceChannel.toRaw ]
@@ -123,7 +124,7 @@ theorem exists_memAlignRomSlice_provider_of_memAlign_interaction
       providerTable.component ∈ (fullRv64imEnsemble length program).ensemble.allTables :=
     EnsembleWitness.mem_allTables_component_of_mem_allTables h_providerTable
   rcases component_mem_fullRv64im_cases h_component_mem with
-    h_verifier | h_boundary | h_alignRead | h_alignByte | h_align | h_rom | h_mem | h_ranges |
+    h_verifier | h_boundary | h_alignRead | h_alignByte | h_align | h_range107 | h_rom | h_mem | h_ranges |
       h_div | h_mul | h_extension | h_binary | h_binaryAdd | h_main
   · have h_nil : providerTable.interactionsWith MemAlignRomChannel.toRaw = [] := by
       apply Table.interactionsWith_nil_of_channel_not_mem
@@ -136,6 +137,7 @@ theorem exists_memAlignRomSlice_provider_of_memAlign_interaction
   · simp [memAlignByte_table_interactionsWith_memAlignRom_nil h_alignByte] at h_providerInteraction
   · exact False.elim (h_nonpull
       (memAlign_table_memAlignRom_mult_neg_one h_align h_providerInteraction))
+  · simp [memAlignRangeSlice_table_interactionsWith_memAlignRom_nil h_range107] at h_providerInteraction
   · refine ⟨providerInteraction, ?_, h_message, h_nonpull, h_nonzero,
       providerTable, h_providerTable, h_providerInteraction, h_rom⟩
     rw [EnsembleWitness.mem_interactionsWith]

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean
@@ -419,11 +419,11 @@ theorem exists_mem_provider_row_msg_eq_of_active_main_table_interaction
   rcases h_providerComponent with h_marb | h_mab | h_memAlign | h_mem | h_main | h_regBoundary
   · obtain ⟨providerRow, h_providerRow, h_providerEval⟩ :=
       exists_memAlignReadByte_row_eval_of_interaction_mem
-        h_marb h_providerInteraction
+        h_marb h_providerInteraction h_nonpull
     left
     exact ⟨providerRow, h_providerRow, h_marb, h_providerEval⟩
   · obtain ⟨providerRow, h_providerRow, h_providerEval⟩ :=
-      exists_memAlignByte_row_eval_of_interaction_mem h_mab h_providerInteraction
+      exists_memAlignByte_row_eval_of_interaction_mem h_mab h_providerInteraction h_nonpull
     right
     left
     exact ⟨providerRow, h_providerRow, h_mab, h_providerEval⟩
@@ -753,7 +753,7 @@ theorem exists_mem_provider_row_matches_entry_spec_of_active_main_eval
   rcases h_providerComponent with h_marb | h_mab | h_memAlign | h_mem | h_main | h_regBoundary
   · obtain ⟨providerRow, h_providerRow, h_providerEval⟩ :=
       exists_memAlignReadByte_row_eval_of_interaction_mem
-        h_marb h_providerInteraction
+        h_marb h_providerInteraction h_nonpull
     left
     refine ⟨providerRow, h_providerRow,
       h_providerSpecs providerRow h_providerRow, h_marb, h_providerEval, ?_⟩
@@ -761,7 +761,7 @@ theorem exists_mem_provider_row_matches_entry_spec_of_active_main_eval
     rw [← h_providerEval, ← h_mainEval]
     exact h_msg
   · obtain ⟨providerRow, h_providerRow, h_providerEval⟩ :=
-      exists_memAlignByte_row_eval_of_interaction_mem h_mab h_providerInteraction
+      exists_memAlignByte_row_eval_of_interaction_mem h_mab h_providerInteraction h_nonpull
     right
     left
     refine ⟨providerRow, h_providerRow,

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/MemRowReplayProjections.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/MemRowReplayProjections.lean
@@ -85,41 +85,67 @@ theorem exists_memAlign_row_eval_of_interaction_mem
       ZiskFv.AirsClean.MemAlign.component_interactionsWith_memBus
   · exact h_mem
 
-/-- Row extraction for a MemAlignByte memory-bus provider interaction in the
-    full ensemble. -/
+/-- A non-pull MemAlignByte interaction is its source-faithful positive byte
+    emission.  The component also carries the h1022 aligned-read pull; the
+    explicit multiplicity premise distinguishes the provider route without
+    pretending that the consumer interaction is a provider. -/
 theorem exists_memAlignByte_row_eval_of_interaction_mem
     {table : Table FGL}
     (h_component : table.component = ZiskFv.AirsClean.MemAlignByte.component)
     {interaction : Interaction FGL}
-    (h_mem : interaction ∈ table.interactionsWith MemBusChannel.toRaw) :
+    (h_mem : interaction ∈ table.interactionsWith MemBusChannel.toRaw)
+    (h_nonpull : interaction.mult ≠ -1) :
     ∃ row ∈ table.table,
       interaction =
         ((MemBusChannel.pushed
           (ZiskFv.AirsClean.MemAlignByte.memBusMessageExpr
             ZiskFv.AirsClean.MemAlignByte.component.rowInputVar)).toRaw).eval
           (table.environment row) := by
-  apply exists_memBus_row_eval_of_singleton_interactionsWith
-  · simpa [h_component] using
+  have h_pair :
+      table.component.operations.interactionsWith MemBusChannel.toRaw =
+        [ ((MemBusChannel.pulled
+        (ZiskFv.AirsClean.MemAlignByte.memReadMessageExpr
+          ZiskFv.AirsClean.MemAlignByte.component.rowInputVar)).toRaw)
+        , ((MemBusChannel.pushed
+        (ZiskFv.AirsClean.MemAlignByte.memBusMessageExpr
+          ZiskFv.AirsClean.MemAlignByte.component.rowInputVar)).toRaw) ] := by
+    simpa [h_component] using
       ZiskFv.AirsClean.MemAlignByte.component_interactionsWith_memBus
-  · exact h_mem
+  rcases exists_memBus_row_eval_of_pair_interactionsWith h_pair h_mem with
+    h_read | h_push
+  · obtain ⟨row, h_row, h_eval⟩ := h_read
+    exact False.elim (h_nonpull (by rw [h_eval]; rfl))
+  · exact h_push
 
-/-- Row extraction for a MemAlignReadByte memory-bus provider interaction in
-    the full ensemble. -/
+/-- A non-pull MemAlignReadByte interaction is its positive byte emission.
+    The h1049 aligned-read pull is intentionally kept distinct. -/
 theorem exists_memAlignReadByte_row_eval_of_interaction_mem
     {table : Table FGL}
     (h_component : table.component = ZiskFv.AirsClean.MemAlignReadByte.component)
     {interaction : Interaction FGL}
-    (h_mem : interaction ∈ table.interactionsWith MemBusChannel.toRaw) :
+    (h_mem : interaction ∈ table.interactionsWith MemBusChannel.toRaw)
+    (h_nonpull : interaction.mult ≠ -1) :
     ∃ row ∈ table.table,
       interaction =
         ((MemBusChannel.pushed
           (ZiskFv.AirsClean.MemAlignReadByte.memBusMessageExpr
             ZiskFv.AirsClean.MemAlignReadByte.component.rowInputVar)).toRaw).eval
           (table.environment row) := by
-  apply exists_memBus_row_eval_of_singleton_interactionsWith
-  · simpa [h_component] using
+  have h_pair :
+      table.component.operations.interactionsWith MemBusChannel.toRaw =
+        [ ((MemBusChannel.pulled
+        (ZiskFv.AirsClean.MemAlignReadByte.memReadMessageExpr
+          ZiskFv.AirsClean.MemAlignReadByte.component.rowInputVar)).toRaw)
+        , ((MemBusChannel.pushed
+        (ZiskFv.AirsClean.MemAlignReadByte.memBusMessageExpr
+          ZiskFv.AirsClean.MemAlignReadByte.component.rowInputVar)).toRaw) ] := by
+    simpa [h_component] using
       ZiskFv.AirsClean.MemAlignReadByte.component_interactionsWith_memBus
-  · exact h_mem
+  rcases exists_memBus_row_eval_of_pair_interactionsWith h_pair h_mem with
+    h_read | h_push
+  · obtain ⟨row, h_row, h_eval⟩ := h_read
+    exact False.elim (h_nonpull (by rw [h_eval]; rfl))
+  · exact h_push
 
 /-! ## Full-ensemble Mem read-replay row projections -/
 

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/RangeProviderMatch.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/RangeProviderMatch.lean
@@ -41,6 +41,14 @@ private theorem specifiedRangesSliceChannel_ne_memAlignRom :
   change "SpecifiedRangesSlice103" = "MemAlignRom133" at h_name
   simp at h_name
 
+private theorem specifiedRangesSliceChannel_ne_memAlignRange :
+    SpecifiedRangesSliceChannel.toRaw ≠
+      ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.toRaw := by
+  intro h
+  have h_name := congrArg (fun channel : RawChannel FGL => channel.name) h
+  change "SpecifiedRangesSlice103" = "MemAlignRange107" at h_name
+  simp at h_name
+
 /-- Project finished bus-103 balance from the full ensemble. -/
 theorem specifiedRangesSlice_balanced_of_witness
     {length : Nat} {program : Program length}
@@ -49,7 +57,8 @@ theorem specifiedRangesSlice_balanced_of_witness
     BalancedInteractions (witness.interactionsWith SpecifiedRangesSliceChannel.toRaw) := by
   have h := h_balanced SpecifiedRangesSliceChannel.toRaw (by
     change SpecifiedRangesSliceChannel.toRaw ∈
-      [MemBusChannel.toRaw, OpBusChannel.toRaw, MemAlignRomChannel.toRaw,
+      [ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.toRaw,
+        MemBusChannel.toRaw, OpBusChannel.toRaw, MemAlignRomChannel.toRaw,
         SpecifiedRangesSliceChannel.toRaw]
     simp)
   simpa [EnsembleWitness.BalancedChannel,
@@ -122,7 +131,7 @@ theorem exists_specifiedRangesSlice_provider_of_mem_interaction
       providerTable.component ∈ (fullRv64imEnsemble length program).ensemble.allTables :=
     EnsembleWitness.mem_allTables_component_of_mem_allTables h_providerTable
   rcases component_mem_fullRv64im_cases h_component_mem with
-    h_verifier | h_boundary | h_alignRead | h_alignByte | h_align | h_memAlignRom | h_mem | h_ranges |
+    h_verifier | h_boundary | h_alignRead | h_alignByte | h_align | h_range107 | h_memAlignRom | h_mem | h_ranges |
       h_div | h_mul | h_extension | h_binary | h_binaryAdd | h_main
   · have h_nil : providerTable.interactionsWith SpecifiedRangesSliceChannel.toRaw = [] := by
       apply Table.interactionsWith_nil_of_channel_not_mem
@@ -154,15 +163,20 @@ theorem exists_specifiedRangesSlice_provider_of_mem_interaction
   · have h_nil : providerTable.interactionsWith SpecifiedRangesSliceChannel.toRaw = [] := by
       apply Table.interactionsWith_nil_of_channel_not_mem
       rw [h_align]
-      change SpecifiedRangesSliceChannel.toRaw ∉ [MemBusChannel.toRaw, MemAlignRomChannel.toRaw]
+      change SpecifiedRangesSliceChannel.toRaw ∉ [MemBusChannel.toRaw, MemAlignRomChannel.toRaw,
+        ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.toRaw]
       intro h
-      simp only [List.mem_cons] at h
-      rcases h with h | h
+      have h' : SpecifiedRangesSliceChannel.toRaw = MemBusChannel.toRaw ∨
+          SpecifiedRangesSliceChannel.toRaw = MemAlignRomChannel.toRaw ∨
+          SpecifiedRangesSliceChannel.toRaw =
+            ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.toRaw := by
+        simpa only [List.mem_cons, List.not_mem_nil, or_false] using h
+      rcases h' with h | h | h
       · exact specifiedRangesSliceChannel_ne_memBus h
-      · rcases h with h | h
-        · exact specifiedRangesSliceChannel_ne_memAlignRom h
-        · simp at h
+      · exact specifiedRangesSliceChannel_ne_memAlignRom h
+      · exact specifiedRangesSliceChannel_ne_memAlignRange h
     simp [h_nil] at h_providerInteraction
+  · simp [memAlignRangeSlice_table_interactionsWith_specifiedRanges_nil h_range107] at h_providerInteraction
   · have h_nil : providerTable.interactionsWith SpecifiedRangesSliceChannel.toRaw = [] := by
       apply Table.interactionsWith_nil_of_channel_not_mem
       rw [h_memAlignRom]

--- a/ZiskFv/AirsClean/MemAlign/Circuit.lean
+++ b/ZiskFv/AirsClean/MemAlign/Circuit.lean
@@ -7,19 +7,21 @@ import Clean.Utils.Tactics
 /-!
 # MemAlign Clean Component
 
-Packages the MemAlign AIR per-row constraints and its unified memory-bus
-interaction as a Clean `Air.Flat.Component`.
+Packages the MemAlign AIR per-row constraints, intrinsic D1/D3 source
+transitions, and its unified memory/ROM/range interactions as a Clean
+`Air.Flat.Component`.
 
-The channel emission is structural: it adds no new row-level soundness
-obligation because `MemBusChannel.Guarantees` is `True`. Cross-row
-continuity remains in `CrossRow.lean`.
+The channel emissions are structural: their consumer guarantees are `True`.
+Exact ROM and byte-range membership is supplied by their static providers and
+finished-channel balance, not by the consumer or caller.
 
 ## Trust note
 
 No axioms. Completeness is a constructibility claim for rows equal to
 `memAlignRowOf ...`: a concrete phase, Boolean flags/selectors, registers, and
 address fields with `value_0`, `value_1`, `preL1`, and `pc` computed by the
-builder. Cross-row continuity remains outside this row-local proof.
+builder. Source predecessor/successor constraints are separately certified
+by the component-owned D1/D3 accepted-trace predicates.
 -/
 
 namespace ZiskFv.AirsClean.MemAlign
@@ -140,10 +142,21 @@ def memAlignRowOf (phase : MemAlignPhase) (isBoot wr reset : Bool)
     value_1 := memAlignValue1Of phase sel_0 sel_1 sel_2 sel_3 sel_4 sel_5 sel_6 sel_7
       reg_0 reg_1 reg_2 reg_3 reg_4 reg_5 reg_6 reg_7 }
 
+/-- A concrete source-shaped padding/idle row.  All eight bytes are zero,
+    `reset` is asserted, and the row is closed under both source transition
+    families.  This is the non-vacuous base case for the strengthened
+    component's honest-row construction; arbitrary real trace rows use the
+    same `memAlignRowOf` builder with their source-provided adjacent values. -/
+def memAlignIdleRow : MemAlignRow FGL :=
+  memAlignRowOf .idle true false true
+    false false false false false false false false
+    0 0 0 0 0 0 0 0
+    0 0 0 0 0 0 0
+
 set_option maxRecDepth 2000 in
 set_option maxHeartbeats 4000000 in
 def circuit : GeneralFormalCircuit FGL MemAlignRow unit :=
-  { memAlignWithMemBusAndMemAlignRomElaborated with
+  { memAlignWithMemBusAndMemAlignRomAndRangesElaborated with
     Assumptions := fun _ _ => True
     Spec := fun row _ _ => Spec row
     -- Completeness covers rows built by `memAlignRowOf`: phase and Boolean
@@ -182,9 +195,11 @@ def circuit : GeneralFormalCircuit FGL MemAlignRow unit :=
         trivial
     completeness := by
       circuit_proof_start_core
-      simp only [mainWithMemBusAndMemAlignRom, mainWithMemBus, main, circuit_norm,
+      simp only [mainWithMemBusAndMemAlignRomAndRanges, mainWithMemBus, main, circuit_norm,
         selAssumeExpr, memBusMessageExpr, memAlignRomMessageExpr, memAlignRomFlagsExpr,
-        MemBusChannel, ZiskFv.Channels.MemAlignRom.MemAlignRomChannel]
+        memAlignRangeMessageExpr, MemBusChannel,
+        ZiskFv.Channels.MemAlignRom.MemAlignRomChannel,
+        ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel]
       obtain ⟨phase, isBoot, wr, reset, sel_0, sel_1, sel_2, sel_3,
         sel_4, sel_5, sel_6, sel_7, reg_0, reg_1, reg_2, reg_3,
         reg_4, reg_5, reg_6, reg_7, addr, offset, width, step,
@@ -205,19 +220,65 @@ def circuit : GeneralFormalCircuit FGL MemAlignRow unit :=
         ring_nf <;>
         simp }
 
-/-- The exact source-linked `pc' - pc` relation for MemAlign hint #998.
-    `successor` is selected by Clean's D3 cyclic table semantics, so the final
-    effective row is checked against row zero rather than against a caller
-    supplied boundary fact. -/
+/-- The source's predecessor/current MemAlign constraints: c29's gated
+    `delta_addr` relation and c1/c3/.../c15's register continuity.
+
+    This is the exact `mem_align.pil:116-117,142` / extracted c1/c29 spelling.
+    D1's saturated row zero is sound here only because the source's own
+    `(1 - reset)` gate remains part of c29; no boundary condition is supplied
+    by a caller. -/
 def rowInputOfEnvironment (environment : Environment FGL) : MemAlignRow FGL :=
   valueFromOffset MemAlignRow 0 environment
 
+def transitionRows (previous current : MemAlignRow FGL) : Prop :=
+  current.delta_addr - (current.addr - previous.addr) * (1 - current.reset) = 0
+  ∧ (previous.reg_0 - current.reg_0) * current.sel_0 * current.sel_down_to_up = 0
+  ∧ (previous.reg_1 - current.reg_1) * current.sel_1 * current.sel_down_to_up = 0
+  ∧ (previous.reg_2 - current.reg_2) * current.sel_2 * current.sel_down_to_up = 0
+  ∧ (previous.reg_3 - current.reg_3) * current.sel_3 * current.sel_down_to_up = 0
+  ∧ (previous.reg_4 - current.reg_4) * current.sel_4 * current.sel_down_to_up = 0
+  ∧ (previous.reg_5 - current.reg_5) * current.sel_5 * current.sel_down_to_up = 0
+  ∧ (previous.reg_6 - current.reg_6) * current.sel_6 * current.sel_down_to_up = 0
+  ∧ (previous.reg_7 - current.reg_7) * current.sel_7 * current.sel_down_to_up = 0
+
+def transition (_ : Nat) (previous current : Environment FGL) : Prop :=
+  transitionRows (rowInputOfEnvironment previous) (rowInputOfEnvironment current)
+
+/-- The exact source-linked successor/current MemAlign constraints: h998's
+    `pc' - pc` relation and c0/c2/.../c14's register continuity.
+
+    The generated terms are every-row expressions with no last-row mask
+    (`Extraction/MemAlign.lean:51`); D3 therefore checks the final effective
+    row against row zero, rather than omitting it or accepting a boundary
+    promise. -/
+def cyclicSuccessorTransitionRows (current successor : MemAlignRow FGL) : Prop :=
+  current.delta_pc = successor.pc - current.pc
+  ∧ (successor.reg_0 - current.reg_0) * current.sel_0 * current.sel_up_to_down = 0
+  ∧ (successor.reg_1 - current.reg_1) * current.sel_1 * current.sel_up_to_down = 0
+  ∧ (successor.reg_2 - current.reg_2) * current.sel_2 * current.sel_up_to_down = 0
+  ∧ (successor.reg_3 - current.reg_3) * current.sel_3 * current.sel_up_to_down = 0
+  ∧ (successor.reg_4 - current.reg_4) * current.sel_4 * current.sel_up_to_down = 0
+  ∧ (successor.reg_5 - current.reg_5) * current.sel_5 * current.sel_up_to_down = 0
+  ∧ (successor.reg_6 - current.reg_6) * current.sel_6 * current.sel_up_to_down = 0
+  ∧ (successor.reg_7 - current.reg_7) * current.sel_7 * current.sel_up_to_down = 0
+
 def cyclicSuccessorTransition (_ : Nat) (current successor : Environment FGL) : Prop :=
-  (rowInputOfEnvironment current).delta_pc =
-    (rowInputOfEnvironment successor).pc - (rowInputOfEnvironment current).pc
+  cyclicSuccessorTransitionRows (rowInputOfEnvironment current)
+    (rowInputOfEnvironment successor)
+
+theorem transitionRows_memAlignIdleRow :
+    transitionRows memAlignIdleRow memAlignIdleRow := by
+  norm_num [transitionRows, memAlignIdleRow, memAlignRowOf, memAlignValue0Of,
+    memAlignValue1Of, memAlignLane]
+
+theorem cyclicSuccessorTransitionRows_memAlignIdleRow :
+    cyclicSuccessorTransitionRows memAlignIdleRow memAlignIdleRow := by
+  norm_num [cyclicSuccessorTransitionRows, memAlignIdleRow, memAlignRowOf,
+    memAlignValue0Of, memAlignValue1Of, memAlignLane]
 
 def component : Air.Flat.Component FGL :=
   { circuit := circuit
+    transition := transition
     cyclicSuccessorTransition := cyclicSuccessorTransition }
 
 /-- Project the generic Clean component `Spec` to the concrete MemAlign row
@@ -248,7 +309,24 @@ theorem component_interactionsWith_memBus :
         (memBusMessageExpr component.rowInputVar)] ++
     expose ZiskFv.Channels.MemAlignRom.MemAlignRomChannel
       [ZiskFv.Channels.MemAlignRom.MemAlignRomChannel.emitted (-1)
-        (memAlignRomMessageExpr component.rowInputVar)]
+        (memAlignRomMessageExpr component.rowInputVar)] ++
+    expose ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel
+      [ ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_0)
+      , ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_1)
+      , ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_2)
+      , ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_3)
+      , ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_4)
+      , ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_5)
+      , ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_6)
+      , ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_7)]
   simp [expose]
 
 /-- MemAlign's h998 consumer emission is exactly one negative bus-133
@@ -271,7 +349,90 @@ theorem component_interactionsWith_memAlignRomChannel :
         (memBusMessageExpr component.rowInputVar)] ++
     expose ZiskFv.Channels.MemAlignRom.MemAlignRomChannel
       [ZiskFv.Channels.MemAlignRom.MemAlignRomChannel.emitted (-1)
-        (memAlignRomMessageExpr component.rowInputVar)]
+        (memAlignRomMessageExpr component.rowInputVar)] ++
+    expose ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel
+      [ ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_0)
+      , ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_1)
+      , ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_2)
+      , ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_3)
+      , ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_4)
+      , ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_5)
+      , ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_6)
+      , ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_7)]
+  simp [expose]
+
+/-- MemAlign's eight source Range Check hints are exactly eight negative
+    one-slot bus-107 consumer interactions, in `reg[0]` through `reg[7]`
+    order (`mem_align.pil:113-118`; #982/#984/#986/#988/#990/#992/#994/#996). -/
+theorem component_interactionsWith_memAlignRangeChannel :
+    component.operations.interactionsWith
+        ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.toRaw =
+      [ ((ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+            (memAlignRangeMessageExpr component.rowInputVar.reg_0)).toRaw)
+      , ((ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+            (memAlignRangeMessageExpr component.rowInputVar.reg_1)).toRaw)
+      , ((ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+            (memAlignRangeMessageExpr component.rowInputVar.reg_2)).toRaw)
+      , ((ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+            (memAlignRangeMessageExpr component.rowInputVar.reg_3)).toRaw)
+      , ((ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+            (memAlignRangeMessageExpr component.rowInputVar.reg_4)).toRaw)
+      , ((ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+            (memAlignRangeMessageExpr component.rowInputVar.reg_5)).toRaw)
+      , ((ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+            (memAlignRangeMessageExpr component.rowInputVar.reg_6)).toRaw)
+      , ((ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+            (memAlignRangeMessageExpr component.rowInputVar.reg_7)).toRaw) ] := by
+  apply Component.interactionsWith_of_exposedChannels
+  change ⟨ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.toRaw,
+      [ ((ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+            (memAlignRangeMessageExpr component.rowInputVar.reg_0)).toRaw)
+      , ((ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+            (memAlignRangeMessageExpr component.rowInputVar.reg_1)).toRaw)
+      , ((ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+            (memAlignRangeMessageExpr component.rowInputVar.reg_2)).toRaw)
+      , ((ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+            (memAlignRangeMessageExpr component.rowInputVar.reg_3)).toRaw)
+      , ((ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+            (memAlignRangeMessageExpr component.rowInputVar.reg_4)).toRaw)
+      , ((ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+            (memAlignRangeMessageExpr component.rowInputVar.reg_5)).toRaw)
+      , ((ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+            (memAlignRangeMessageExpr component.rowInputVar.reg_6)).toRaw)
+      , ((ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+            (memAlignRangeMessageExpr component.rowInputVar.reg_7)).toRaw) ]⟩ ∈
+    expose MemBusChannel
+      [MemBusChannel.emitted
+        (component.rowInputVar.sel_prove - selAssumeExpr component.rowInputVar)
+        (memBusMessageExpr component.rowInputVar)] ++
+    expose ZiskFv.Channels.MemAlignRom.MemAlignRomChannel
+      [ZiskFv.Channels.MemAlignRom.MemAlignRomChannel.emitted (-1)
+        (memAlignRomMessageExpr component.rowInputVar)] ++
+    expose ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel
+      [ ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_0)
+      , ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_1)
+      , ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_2)
+      , ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_3)
+      , ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_4)
+      , ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_5)
+      , ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_6)
+      , ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel.emitted (-1)
+          (memAlignRangeMessageExpr component.rowInputVar.reg_7)]
   simp [expose]
 
 /-- Read `delta_pc` from the intrinsic cyclic successor view. -/
@@ -286,7 +447,7 @@ theorem delta_pc_eq_successor_pc_sub_pc
   rw [h_component] at h
   change cyclicSuccessorTransition index.val (table.environmentAt index)
     (table.successorEnvironment index) at h
-  exact h
+  exact h.1
 
 theorem spec_via_component (row : MemAlignRow FGL)
     (_h_assumptions : Assumptions row)

--- a/ZiskFv/AirsClean/MemAlign/Constraints.lean
+++ b/ZiskFv/AirsClean/MemAlign/Constraints.lean
@@ -2,14 +2,16 @@ import ZiskFv.AirsClean.MemAlign.Spec
 import Clean.Circuit.Basic
 import ZiskFv.Channels.MemoryBus
 import ZiskFv.Channels.MemAlignRom
+import ZiskFv.Channels.MemAlignRanges
 
 /-!
 # MemAlign circuit operations
 
-The 16 per-row F-typed constraints captured here. The cross-row
-constraints (`delta_addr_definition` + 8 `down_to_up_continuity_N`,
-referencing `reg_*` / `addr` of `row - 1`) live in `CrossRow.lean`
-as a standalone adjacency predicate consumed by downstream callers.
+The 16 per-row F-typed constraints captured here. The source's nine
+predecessor/current constraints and eight successor/current constraints live
+intrinsically on `MemAlign.component`'s D1/D3 transition predicates
+(`Circuit.lean`), so accepted-trace certificates check them without a
+caller-supplied adjacency promise.
 
 The memory-bus extension below mirrors `mem_align.pil:189`:
 
@@ -33,6 +35,7 @@ open Goldilocks
 open Circuit (assertZero)
 open ZiskFv.Channels.MemoryBus (MemBusChannel MemBusMessage)
 open ZiskFv.Channels.MemAlignRom (MemAlignRomChannel MemAlignRomMessage)
+open ZiskFv.Channels.MemAlignRanges (MemAlignRangeChannel MemAlignRangeMessage)
 
 @[circuit_norm]
 def main (row : Var MemAlignRow FGL) : Circuit FGL Unit := do
@@ -117,15 +120,30 @@ def memAlignRomMessageExpr (row : Var MemAlignRow FGL) :
     width := row.width
     flags := memAlignRomFlagsExpr row }
 
+/-- One exact one-slot bus-107 tuple for a MemAlign register range hint.
+    `mem_align.pil:113-118` emits one such Range Check for each `reg[i]`; the
+    manifest records their actual hints as #982/#984/#986/#988/#990/#992/#994/#996. -/
+@[reducible]
+def memAlignRangeMessageExpr (value : Expression FGL) : MemAlignRangeMessage (Expression FGL) :=
+  { value }
+
 @[circuit_norm]
 def mainWithMemBus (row : Var MemAlignRow FGL) : Circuit FGL Unit := do
   main row
   MemBusChannel.emit (row.sel_prove - selAssumeExpr row) (memBusMessageExpr row)
 
 @[circuit_norm]
-def mainWithMemBusAndMemAlignRom (row : Var MemAlignRow FGL) : Circuit FGL Unit := do
+def mainWithMemBusAndMemAlignRomAndRanges (row : Var MemAlignRow FGL) : Circuit FGL Unit := do
   mainWithMemBus row
   MemAlignRomChannel.emit (-1) (memAlignRomMessageExpr row)
+  MemAlignRangeChannel.emit (-1) (memAlignRangeMessageExpr row.reg_0)
+  MemAlignRangeChannel.emit (-1) (memAlignRangeMessageExpr row.reg_1)
+  MemAlignRangeChannel.emit (-1) (memAlignRangeMessageExpr row.reg_2)
+  MemAlignRangeChannel.emit (-1) (memAlignRangeMessageExpr row.reg_3)
+  MemAlignRangeChannel.emit (-1) (memAlignRangeMessageExpr row.reg_4)
+  MemAlignRangeChannel.emit (-1) (memAlignRangeMessageExpr row.reg_5)
+  MemAlignRangeChannel.emit (-1) (memAlignRangeMessageExpr row.reg_6)
+  MemAlignRangeChannel.emit (-1) (memAlignRangeMessageExpr row.reg_7)
 
 @[reducible] def memAlignWithMemBusElaborated :
     ElaboratedCircuit FGL MemAlignRow unit where
@@ -141,21 +159,31 @@ def mainWithMemBusAndMemAlignRom (row : Var MemAlignRow FGL) : Circuit FGL Unit 
     simp only [circuit_norm, mainWithMemBus, main, selAssumeExpr,
       memBusMessageExpr, MemBusChannel]
 
-@[reducible] def memAlignWithMemBusAndMemAlignRomElaborated :
+@[reducible] def memAlignWithMemBusAndMemAlignRomAndRangesElaborated :
     ElaboratedCircuit FGL MemAlignRow unit where
-  name := "MemAlignWithMemBusAndMemAlignRom"
-  main := mainWithMemBusAndMemAlignRom
+  name := "MemAlignWithMemBusAndMemAlignRomAndRanges"
+  main := mainWithMemBusAndMemAlignRomAndRanges
   localLength _ := 0
   output _ _ := ()
-  channelsWithRequirements := [MemBusChannel.toRaw, MemAlignRomChannel.toRaw]
+  channelsWithRequirements := [MemBusChannel.toRaw, MemAlignRomChannel.toRaw,
+    MemAlignRangeChannel.toRaw]
   exposedChannels row _ :=
     expose MemBusChannel
       [MemBusChannel.emitted (row.sel_prove - selAssumeExpr row) (memBusMessageExpr row)] ++
     expose MemAlignRomChannel
-      [MemAlignRomChannel.emitted (-1) (memAlignRomMessageExpr row)]
+      [MemAlignRomChannel.emitted (-1) (memAlignRomMessageExpr row)] ++
+    expose MemAlignRangeChannel
+      [ MemAlignRangeChannel.emitted (-1) (memAlignRangeMessageExpr row.reg_0)
+      , MemAlignRangeChannel.emitted (-1) (memAlignRangeMessageExpr row.reg_1)
+      , MemAlignRangeChannel.emitted (-1) (memAlignRangeMessageExpr row.reg_2)
+      , MemAlignRangeChannel.emitted (-1) (memAlignRangeMessageExpr row.reg_3)
+      , MemAlignRangeChannel.emitted (-1) (memAlignRangeMessageExpr row.reg_4)
+      , MemAlignRangeChannel.emitted (-1) (memAlignRangeMessageExpr row.reg_5)
+      , MemAlignRangeChannel.emitted (-1) (memAlignRangeMessageExpr row.reg_6)
+      , MemAlignRangeChannel.emitted (-1) (memAlignRangeMessageExpr row.reg_7) ]
   channelsLawful := by
-    simp [circuit_norm, mainWithMemBusAndMemAlignRom, mainWithMemBus, main,
+    simp [circuit_norm, mainWithMemBusAndMemAlignRomAndRanges, mainWithMemBus, main,
       selAssumeExpr, memBusMessageExpr, memAlignRomMessageExpr, memAlignRomFlagsExpr,
-      MemBusChannel, MemAlignRomChannel]
+      memAlignRangeMessageExpr, MemBusChannel, MemAlignRomChannel, MemAlignRangeChannel]
 
 end ZiskFv.AirsClean.MemAlign

--- a/ZiskFv/AirsClean/MemAlign/Soundness.lean
+++ b/ZiskFv/AirsClean/MemAlign/Soundness.lean
@@ -7,10 +7,9 @@ import Mathlib.Tactic.LinearCombination
 Each per-row Spec clause is 1:1 with its constraint hypothesis; the
 proof is structural.
 
-The cross-row constraints (`delta_addr_definition` + 8
-`down_to_up_continuity_N`) live as a separate `cross_row_at`
-adjacency predicate in `CrossRow.lean`. They are consumed by
-downstream callers directly, not via per-row Soundness.
+The source's cross-row constraints are component-owned D1/D3 transition
+predicates in `Circuit.lean`; their verifier-checked certificates are consumed
+from `AcceptedZiskTrace`, not supplied by downstream callers.
 
 ## Trust note
 

--- a/ZiskFv/AirsClean/MemAlign/Spec.lean
+++ b/ZiskFv/AirsClean/MemAlign/Spec.lean
@@ -14,11 +14,9 @@ multiplexers and the register-byte chain. This Spec captures the
 * `value_0_reconstruction`, `value_1_reconstruction` — 9-term selector
   multiplexers over `reg_0..7`
 
-Cross-row constraints (`delta_addr_definition` + 8
-`down_to_up_continuity_N`) live in a separate `cross_row_at`
-adjacency predicate in `CrossRow.lean`. The per-row Spec below is
-what the Clean `Air.Flat.Component`'s constraint-emitting `main`
-captures.
+The source's predecessor/current and successor/current constraints are
+component-owned D1/D3 transition predicates in `Circuit.lean`; this per-row
+Spec contains only the source's 16 single-row constraints.
 
 ## Constructibility audit
 

--- a/ZiskFv/AirsClean/MemAlignByte/Bridge.lean
+++ b/ZiskFv/AirsClean/MemAlignByte/Bridge.lean
@@ -133,11 +133,10 @@ def constraints_at
       - (v.is_write r * (v.written_byte_value r - v.byte_value r)
          + v.byte_value r) = 0
 
-/-- Lookup-aware Clean witness for the range lookups in a selected
-    MemAlignByte row. This exposes the `lookup (rangeTable8) bus_byte`,
-    `lookup (rangeTable8) byte_value`, and `lookup (rangeTable1) is_write`
-    obligations from `main`; it is structural evidence, not a replacement
-    range axiom. -/
+/-- Lookup-aware Clean witness for the static byte-assembly lookups in a
+    selected MemAlignByte row.  It includes the exact source h1029
+    16-bit lookup and h1030 `DualByte` tuple, in addition to the existing
+    byte and selector lookups; it is structural evidence, not a range axiom. -/
 structure RangeLookupWitness
     (v : ZiskFv.Airs.MemAlignByte.Valid_MemAlignByte FGL FGL) (r : ℕ) where
   offset : ℕ
@@ -146,22 +145,32 @@ structure RangeLookupWitness
     ConstraintsHold.Soundness env
       ((main (constVar (rowAt v r))).operations offset)
 
-/-- Project the three range facts supplied by the Clean lookup operations
-    in `MemAlignByte.main`. -/
+/-- Project all range facts supplied by the source-faithful static lookup
+    operations in `MemAlignByte.main`. -/
 theorem ranges_of_lookup_aware_const_soundness
     {v : ZiskFv.Airs.MemAlignByte.Valid_MemAlignByte FGL FGL} {r : ℕ}
     (w : RangeLookupWitness v r) :
     (v.bus_byte r).val < 2 ^ 8
     ∧ (v.byte_value r).val < 2 ^ 8
-    ∧ (v.is_write r).val < 2 ^ 1 := by
+    ∧ (v.is_write r).val < 2 ^ 1
+    ∧ (v.value_16b r).val < 2 ^ 16
+    ∧ (v.value_8b r).val < 2 ^ 8 := by
   have h_holds := w.holds
   simp only [main, circuit_norm] at h_holds
   rcases h_holds with
-    ⟨h_bus_range, h_byte_range, h_is_write_range,
+    ⟨h_bus_range, h_byte_range, h_is_write_range, h_value16_range,
+      h_dual_byte_range,
       _h0, _h1, _h2, _h_composed, _h4, _h_written, _h_m0, _h_m1, _h_bus⟩
+  have h_dual :
+      (v.byte_value r).val < 2 ^ 8 ∧ (v.value_8b r).val < 2 ^ 8 := by
+    simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable, Table.toRaw,
+      rowAt, constVar, ZiskFv.AirsClean.RangeTables.dualByteTable] using
+      h_dual_byte_range
   exact ⟨by simpa [rowAt, constVar] using h_bus_range,
     by simpa [rowAt, constVar] using h_byte_range,
-    by simpa [rowAt, constVar] using h_is_write_range⟩
+    by simpa [rowAt, constVar] using h_is_write_range,
+    by simpa [rowAt, constVar] using h_value16_range,
+    h_dual.2⟩
 
 /-- **Bridge theorem.** -/
 theorem spec_of_valid
@@ -204,7 +213,8 @@ theorem bus_byte_in_range_via_component
     (h_lookup : RangeLookupWitness v r) :
     (v.bus_byte r).val < 2 ^ 8 := by
   obtain ⟨h_b0, h_b1, h_b2, h_composed, h_b4, h_written, h_m0, h_m1, h_bus⟩ := h_core
-  obtain ⟨h_bus_byte_range, h_byte_value_range, h_is_write_range⟩ :=
+  obtain ⟨h_bus_byte_range, h_byte_value_range, h_is_write_range,
+    h_value16_range, h_value8_range⟩ :=
     ranges_of_lookup_aware_const_soundness h_lookup
   -- `rowAt v r` projects the AIR row into the Clean Component row;
   -- each `rowAt` field is `@[reducible]`-defeq to `v.<col> r`.
@@ -212,7 +222,7 @@ theorem bus_byte_in_range_via_component
       Spec (rowAt v r) :=
     spec_via_component (rowAt v r) h_composed h_written h_m0 h_m1 h_bus
       h_b0 h_b1 h_b2 h_b4
-      h_bus_byte_range h_byte_value_range h_is_write_range
+      h_bus_byte_range h_byte_value_range h_is_write_range h_value16_range h_value8_range
   exact h_spec.2.2.2.2.2.1
 
 end ZiskFv.AirsClean.MemAlignByte

--- a/ZiskFv/AirsClean/MemAlignByte/Circuit.lean
+++ b/ZiskFv/AirsClean/MemAlignByte/Circuit.lean
@@ -115,6 +115,7 @@ def circuit : GeneralFormalCircuit FGL MemAlignByteRow unit :=
       ∃ sel_high_4b sel_high_2b sel_high_b isWrite byteVal writtenByteVal
         direct_value value_16b value_8b addr_w step,
         byteVal < 2 ^ 8 ∧ writtenByteVal < 2 ^ 8 ∧
+          value_16b.val < 2 ^ 16 ∧ value_8b.val < 2 ^ 8 ∧
           row = memAlignByteRowOf sel_high_4b sel_high_2b sel_high_b isWrite
             byteVal writtenByteVal direct_value value_16b value_8b addr_w step
     ProverSpec := fun _ _ _ => True
@@ -127,7 +128,9 @@ def circuit : GeneralFormalCircuit FGL MemAlignByteRow unit :=
         -- range lookups prepended to `main`. The 4 boolean constraints
         -- (0, 1, 2, 4) are unused.
         obtain ⟨h_bus_range, h_byte_range, h_is_write_range,
-          _h0, _h1, _h2, h_composed, _h4, h_written, h_m0, h_m1, h_bus⟩ := h_holds
+          _h_value16_range, _h_dual_byte_range,
+          _h0, _h1, _h2, h_composed, _h4, h_written, h_m0, h_m1,
+          h_bus, _h_aligned_read⟩ := h_holds
         simp only [byte_value_factor, value_8b_factor, value_16b_factor]
         refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
         · linear_combination h_composed
@@ -145,7 +148,8 @@ def circuit : GeneralFormalCircuit FGL MemAlignByteRow unit :=
     completeness := by
       circuit_proof_start [MemBusChannel, Lookup.completeness_def]
       obtain ⟨sel_high_4b, sel_high_2b, sel_high_b, isWrite, byteVal, writtenByteVal,
-        direct_value, value_16b, value_8b, addr_w, step, h_byte, h_written, hrow⟩ :=
+        direct_value, value_16b, value_8b, addr_w, step, h_byte, h_written,
+        h_value16, h_value8, hrow⟩ :=
         h_assumptions
       injection hrow with h_sel_high_4b h_sel_high_2b h_sel_high_b h_direct_value
         h_composed_value h_written_composed_value h_written_byte_value h_value_16b
@@ -155,7 +159,7 @@ def circuit : GeneralFormalCircuit FGL MemAlignByteRow unit :=
       simp [memAlignByteComposedValueOf, memAlignByteMemWriteValues0Of,
         memAlignByteMemWriteValues1Of, byte_value_factor, value_8b_factor,
         value_16b_factor] at h_input ⊢
-      refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+      refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
       · simp only [RangeTables.rangeTable8, RangeTables.rangeStaticTable]
         rw [memAlignByteBusByteOf_eq]
         cases isWrite
@@ -165,6 +169,12 @@ def circuit : GeneralFormalCircuit FGL MemAlignByteRow unit :=
         exact fgl_natCast_val_lt_of_lt (by decide) h_byte
       · simp only [RangeTables.rangeTable1, RangeTables.rangeStaticTable]
         cases isWrite <;> simp [boolF]
+      · simp only [RangeTables.rangeTable16, RangeTables.rangeStaticTable]
+        exact h_value16
+      · simpa [Lookup.Completeness, Table.fromStatic, StaticTable.toTable, Table.toRaw,
+          RangeTables.dualByteTable, h_input] using
+          (show ((byteVal : FGL).val < 2 ^ 8 ∧ value_8b.val < 2 ^ 8) from
+            ⟨fgl_natCast_val_lt_of_lt (by decide) h_byte, h_value8⟩)
       · ring
       · ring
       · ring
@@ -183,10 +193,12 @@ theorem component_spec (env : Environment FGL) :
 
 theorem component_interactionsWith_memBus :
     component.operations.interactionsWith MemBusChannel.toRaw =
-      [((MemBusChannel.pushed (memBusMessageExpr component.rowInputVar)).toRaw)] := by
+      [ ((MemBusChannel.pulled (memReadMessageExpr component.rowInputVar)).toRaw)
+      , ((MemBusChannel.pushed (memBusMessageExpr component.rowInputVar)).toRaw) ] := by
   apply Component.interactionsWith_of_exposedChannels
   change ⟨MemBusChannel.toRaw,
-      [((MemBusChannel.pushed (memBusMessageExpr component.rowInputVar)).toRaw)]⟩ ∈
+      [ ((MemBusChannel.pulled (memReadMessageExpr component.rowInputVar)).toRaw)
+      , ((MemBusChannel.pushed (memBusMessageExpr component.rowInputVar)).toRaw) ]⟩ ∈
     component.exposedChannels
   simp only [component, circuit, memAlignByteElaborated,
     Component.exposedChannels, expose, List.mem_singleton, List.map_cons,
@@ -232,7 +244,9 @@ theorem spec_via_component (row : MemAlignByteRow FGL)
     (h_b4 : row.is_write * (1 - row.is_write) = 0)
     (h_bus_byte_range : row.bus_byte.val < 2 ^ 8)
     (h_byte_value_range : row.byte_value.val < 2 ^ 8)
-    (h_is_write_range : row.is_write.val < 2 ^ 1) :
+    (h_is_write_range : row.is_write.val < 2 ^ 1)
+    (h_value16_range : row.value_16b.val < 2 ^ 16)
+    (h_value8_range : row.value_8b.val < 2 ^ 8) :
     Spec row := by
   have hsound := circuit.soundness
   simp only [GeneralFormalCircuit.Soundness, circuit, memAlignByteElaborated,
@@ -257,6 +271,12 @@ theorem spec_via_component (row : MemAlignByteRow FGL)
   · simp [circuit_norm]
   · simp only [circuit_norm]
     exact ⟨h_bus_byte_range, h_byte_value_range, h_is_write_range,
-      h_b0, h_b1, h_b2, h_composed, h_b4, h_written, h_m0, h_m1, h_bus⟩
+      h_value16_range, by
+        simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable, Table.toRaw,
+          RangeTables.dualByteTable] using
+          (show (row.byte_value.val < 2 ^ 8 ∧ row.value_8b.val < 2 ^ 8) from
+            ⟨h_byte_value_range, h_value8_range⟩),
+      h_b0, h_b1, h_b2, h_composed, h_b4, h_written, h_m0, h_m1,
+      ⟨h_bus, trivial⟩⟩
 
 end ZiskFv.AirsClean.MemAlignByte

--- a/ZiskFv/AirsClean/MemAlignByte/Constraints.lean
+++ b/ZiskFv/AirsClean/MemAlignByte/Constraints.lean
@@ -37,6 +37,20 @@ def memBusMessageExpr (row : Var MemAlignByteRow FGL) :
     value_0 := row.bus_byte
     value_1 := 0 }
 
+/-- The source-faithful aligned read consumed by MemAlignByte before it
+    proves the selected byte to Main.  This is the exact h1022
+    `permutation_assumes` tuple from `mem_align_byte.pil:61-66`; its two
+    reconstructed lanes are expressions, not detached row fields. -/
+@[reducible]
+def memReadMessageExpr (row : Var MemAlignByteRow FGL) :
+    MemBusMessage (Expression FGL) :=
+  { mem_op := 1
+    ptr := row.addr_w * 8
+    timestamp := row.step
+    width := 8
+    value_0 := row.sel_high_4b * (row.direct_value - row.composed_value) + row.composed_value
+    value_1 := row.sel_high_4b * (row.composed_value - row.direct_value) + row.direct_value }
+
 /-- The 9 F-constraints and memory bus push, taking the row's slot
     values as `Expression FGL`s. Returns `Unit` (MemAlignByte is a pure
     assertion — no fresh witnesses introduced inside the circuit). -/
@@ -46,6 +60,12 @@ def main (row : Var MemAlignByteRow FGL) : Circuit FGL Unit := do
   lookup (Table.fromStatic rangeTable8) row.bus_byte
   lookup (Table.fromStatic rangeTable8) row.byte_value
   lookup (Table.fromStatic rangeTable1) row.is_write
+  -- h1029: `range_check(value_16b)` on source virtual bus 103
+  -- (`mem_align_byte.pil:103`) through the local static S1a route.
+  lookup (Table.fromStatic rangeTable16) row.value_16b
+  -- h1030: exact `DualByte` membership in source tuple order
+  -- `[byte_value, value_8b]` (`zisk.pil:62-76`, `mem_align_byte.pil:104`).
+  lookup (Table.fromStatic dualByteTable) #v[row.byte_value, row.value_8b]
   -- constraint 0 (mem/pil/mem_align_byte.pil:35)
   assertZero (row.sel_high_4b * (1 - row.sel_high_4b))
   -- constraint 1 (mem/pil/mem_align_byte.pil:36)
@@ -64,6 +84,9 @@ def main (row : Var MemAlignByteRow FGL) : Circuit FGL Unit := do
   assertZero (row.mem_write_values_1 - ((row.sel_high_4b * (row.written_composed_value - row.direct_value)) + row.direct_value))
   -- constraint 8 (mem/pil/mem_align_byte.pil:95)
   assertZero (row.bus_byte - ((row.is_write * (row.written_byte_value - row.byte_value)) + row.byte_value))
+  -- Bus consumer: the aligned 8-byte load consumed by this byte assembly
+  -- (`permutation_assumes`, mem/pil/mem_align_byte.pil:66; h1022).
+  MemBusChannel.pull (memReadMessageExpr row)
   -- Bus emission: MemAlignByte pushes its proves-side tuple onto memory bus 10.
   -- Reconstructed from the proves-side `gsum_debug_data` hint;
   -- slot-for-slot faithful to the hand-written reference.
@@ -80,8 +103,10 @@ def main (row : Var MemAlignByteRow FGL) : Circuit FGL Unit := do
   output _ _ := ()
   channelsWithRequirements := [MemBusChannel.toRaw]
   exposedChannels row _ :=
-    expose MemBusChannel [MemBusChannel.pushed (memBusMessageExpr row)]
+    expose MemBusChannel
+      [ MemBusChannel.pulled (memReadMessageExpr row)
+      , MemBusChannel.pushed (memBusMessageExpr row) ]
   channelsLawful := by
-    simp only [circuit_norm, main, memBusMessageExpr, MemBusChannel]
+    simp only [circuit_norm, main, memBusMessageExpr, memReadMessageExpr, MemBusChannel]
 
 end ZiskFv.AirsClean.MemAlignByte

--- a/ZiskFv/AirsClean/MemAlignRangeSlice.lean
+++ b/ZiskFv/AirsClean/MemAlignRangeSlice.lean
@@ -1,0 +1,77 @@
+import Clean.Air.FlatComponent
+import Clean.Utils.Tactics
+import ZiskFv.AirsClean.RangeTables
+import ZiskFv.Channels.MemAlignRanges
+
+/-!
+# MemAlign bus-107 byte-range provider slice
+
+This provider is the exact static-table side of MemAlign's eight register
+range checks (`mem_align.pil:113-118`, hints
+#982/#984/#986/#988/#990/#992/#994/#996).  It models the upstream range
+surface as `rangeTable8`: the 256 accepted byte values, not a stronger
+semantic predicate or a caller promise.  The consumer's negative emissions
+are matched by the finished bus-107 balance in `FullEnsemble`.
+-/
+
+namespace ZiskFv.AirsClean.MemAlignRangeSlice
+
+open Goldilocks
+open Air.Flat
+open Circuit (lookup)
+open ZiskFv.AirsClean.RangeTables
+open ZiskFv.Channels.MemAlignRanges
+
+/-- The provider's static lookup is the exact 8-bit range table. -/
+@[circuit_norm]
+def main (message : MemAlignRangeMessage (Expression FGL)) : Circuit FGL Unit := do
+  lookup (Table.fromStatic rangeTable8) message.value
+  MemAlignRangeChannel.push message
+
+@[reducible]
+def elaborated : ElaboratedCircuit FGL MemAlignRangeMessage unit where
+  name := "MemAlignRangeSlice107"
+  main := main
+  localLength _ := 0
+  output _ _ := ()
+  channelsWithRequirements := [MemAlignRangeChannel.toRaw]
+  exposedChannels message _ :=
+    expose MemAlignRangeChannel [MemAlignRangeChannel.pushed message]
+  channelsLawful := by
+    simp only [circuit_norm, main, MemAlignRangeChannel]
+
+/-- The bounded provider derives exact byte membership locally.  Its one
+    completeness-side premise constructs the static-table witness; it is not
+    a consumer or accepted-trace assumption. -/
+def circuit : GeneralFormalCircuit FGL MemAlignRangeMessage unit :=
+  { elaborated with
+    Assumptions := fun _ _ => True
+    Spec := fun message _ _ => rangeTable8.Spec message.value
+    ProverAssumptions := fun message _ _ => rangeTable8.Spec message.value
+    ProverSpec := fun _ _ _ => True
+    soundness := by
+      circuit_proof_start
+      refine ⟨?_, ?_⟩
+      · simpa only [Table.fromStatic, StaticTable.toTable, rangeTable8,
+          rangeStaticTable] using h_holds
+      · intro _
+        trivial
+    completeness := by
+      circuit_proof_start [Lookup.completeness_def]
+      simpa only [Table.fromStatic, StaticTable.toTable, rangeTable8,
+        rangeStaticTable] using h_assumptions }
+
+/-- The bus-107 static provider component for the full ensemble. -/
+def component : Component FGL := { circuit }
+
+theorem component_interactionsWith_memAlignRangeChannel :
+    component.operations.interactionsWith MemAlignRangeChannel.toRaw =
+      [((MemAlignRangeChannel.pushed component.rowInputVar).toRaw)] := by
+  apply Component.interactionsWith_of_exposedChannels
+  change ⟨MemAlignRangeChannel.toRaw,
+      [((MemAlignRangeChannel.pushed component.rowInputVar).toRaw)]⟩ ∈
+    component.exposedChannels
+  simp only [component, circuit, elaborated, Component.exposedChannels, expose,
+    List.mem_singleton, List.map_cons, List.map_nil]
+
+end ZiskFv.AirsClean.MemAlignRangeSlice

--- a/ZiskFv/AirsClean/MemAlignReadByte/Bridge.lean
+++ b/ZiskFv/AirsClean/MemAlignReadByte/Bridge.lean
@@ -105,10 +105,10 @@ def constraints_at
       + v.value_8b r * value_8b_factor (v.sel_high_2b r) (v.sel_high_b r)
       + v.value_16b r * value_16b_factor (v.sel_high_2b r)) = 0
 
-/-- Lookup-aware Clean witness for the byte-value range lookup in a
-    selected MemAlignReadByte row. This exposes the real
-    `lookup (rangeTable8) byte_value` operation from `main`; it is
-    structural evidence, not a replacement range axiom. -/
+/-- Lookup-aware Clean witness for the byte-assembly static lookups in a
+    selected MemAlignReadByte row. It includes the source h1052 16-bit
+    lookup and h1053 ordered `DualByte` tuple; it is structural evidence,
+    not a replacement range axiom. -/
 structure RangeLookupWitness
     (v : ZiskFv.Airs.MemAlignReadByte.Valid_MemAlignReadByte FGL FGL) (r : ℕ) where
   offset : ℕ
@@ -117,16 +117,33 @@ structure RangeLookupWitness
     ConstraintsHold.Soundness env
       ((main (constVar (rowAt v r))).operations offset)
 
-/-- Project the byte-value range fact supplied by the Clean lookup
-    operation in `MemAlignReadByte.main`. -/
+/-- Project the byte-assembly range facts supplied by the source-faithful
+    static lookup operations in `MemAlignReadByte.main`. -/
+theorem ranges_of_lookup_aware_const_soundness
+    {v : ZiskFv.Airs.MemAlignReadByte.Valid_MemAlignReadByte FGL FGL} {r : ℕ}
+    (w : RangeLookupWitness v r) :
+    (v.byte_value r).val < 2 ^ 8
+    ∧ (v.value_16b r).val < 2 ^ 16
+    ∧ (v.value_8b r).val < 2 ^ 8 := by
+  have h_holds := w.holds
+  simp only [main, circuit_norm] at h_holds
+  rcases h_holds with ⟨h_byte_range, h_value16_range, h_dual_byte_range,
+    _h0, _h1, _h2, _h_composed⟩
+  have h_dual :
+      (v.byte_value r).val < 2 ^ 8 ∧ (v.value_8b r).val < 2 ^ 8 := by
+    simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable, Table.toRaw,
+      rowAt, constVar, ZiskFv.AirsClean.RangeTables.dualByteTable] using
+      h_dual_byte_range
+  exact ⟨by simpa [rowAt, constVar] using h_byte_range,
+    by simpa [rowAt, constVar] using h_value16_range, h_dual.2⟩
+
+/-- The byte component's source-faithful lookup bundle supplies the existing
+    byte-value range projection. -/
 theorem byte_value_range_of_lookup_aware_const_soundness
     {v : ZiskFv.Airs.MemAlignReadByte.Valid_MemAlignReadByte FGL FGL} {r : ℕ}
     (w : RangeLookupWitness v r) :
-    (v.byte_value r).val < 2 ^ 8 := by
-  have h_holds := w.holds
-  simp only [main, circuit_norm] at h_holds
-  rcases h_holds with ⟨h_byte_range, _h0, _h1, _h2, _h_composed⟩
-  simpa [rowAt, constVar] using h_byte_range
+    (v.byte_value r).val < 2 ^ 8 :=
+  (ranges_of_lookup_aware_const_soundness w).1
 
 /-- **Bridge theorem.** Given a row of a `Valid_MemAlignReadByte`
     satisfying the 4 Clean Component constraints + the boolean
@@ -170,13 +187,13 @@ theorem byte_value_in_range_via_component
     (h_lookup : RangeLookupWitness v r) :
     (v.byte_value r).val < 2 ^ 8 := by
   obtain ⟨h_b0, h_b1, h_b2, h_composed⟩ := h_core
-  have h_byte_value_range :=
-    byte_value_range_of_lookup_aware_const_soundness h_lookup
+  obtain ⟨h_byte_value_range, h_value16_range, h_value8_range⟩ :=
+    ranges_of_lookup_aware_const_soundness h_lookup
   -- `rowAt v r` projects the AIR row into the Clean Component row;
   -- each `rowAt` field is `@[reducible]`-defeq to `v.<col> r`.
   have h_spec : Spec (rowAt v r) :=
     spec_via_component (rowAt v r) h_composed h_b0 h_b1 h_b2
-      h_byte_value_range
+      h_byte_value_range h_value16_range h_value8_range
   exact h_spec.2
 
 end ZiskFv.AirsClean.MemAlignReadByte

--- a/ZiskFv/AirsClean/MemAlignReadByte/Circuit.lean
+++ b/ZiskFv/AirsClean/MemAlignReadByte/Circuit.lean
@@ -82,7 +82,7 @@ def circuit : GeneralFormalCircuit FGL MemAlignReadByteRow unit :=
     ProverAssumptions := fun row _ _ =>
       ∃ sel_high_4b sel_high_2b sel_high_b byteVal
         direct_value value_16b value_8b addr_w step,
-        byteVal < 2 ^ 8 ∧
+        byteVal < 2 ^ 8 ∧ value_16b.val < 2 ^ 16 ∧ value_8b.val < 2 ^ 8 ∧
           row = memAlignReadByteRowOf sel_high_4b sel_high_2b sel_high_b
             byteVal direct_value value_16b value_8b addr_w step
     ProverSpec := fun _ _ _ => True
@@ -94,7 +94,8 @@ def circuit : GeneralFormalCircuit FGL MemAlignReadByteRow unit :=
         -- the `bits(8)` range clause comes from the static range lookup
         -- prepended to `main`. The 3 boolean constraints (0, 1, 2) are
         -- unused.
-        obtain ⟨h_byte_range, _h0, _h1, _h2, h_composed⟩ := h_holds
+        obtain ⟨h_byte_range, _h_value16_range, _h_dual_byte_range,
+          _h0, _h1, _h2, h_composed, _h_aligned_read⟩ := h_holds
         simp only [byte_value_factor, value_8b_factor, value_16b_factor]
         refine ⟨?_, ?_⟩
         · linear_combination h_composed
@@ -106,16 +107,23 @@ def circuit : GeneralFormalCircuit FGL MemAlignReadByteRow unit :=
     completeness := by
       circuit_proof_start [MemBusChannel, Lookup.completeness_def]
       obtain ⟨sel_high_4b, sel_high_2b, sel_high_b, byteVal,
-        direct_value, value_16b, value_8b, addr_w, step, h_byte, hrow⟩ :=
+        direct_value, value_16b, value_8b, addr_w, step, h_byte, h_value16,
+        h_value8, hrow⟩ :=
         h_assumptions
       injection hrow with h_sel_high_4b h_sel_high_2b h_sel_high_b h_direct_value
         h_composed_value h_value_16b h_value_8b h_byte_value h_addr_w h_step
       subst_vars
       simp [memAlignReadByteComposedValueOf, byte_value_factor, value_8b_factor,
         value_16b_factor] at h_input ⊢
-      refine ⟨?_, ?_⟩
+      refine ⟨?_, ?_, ?_, ?_⟩
       · simp only [RangeTables.rangeTable8, RangeTables.rangeStaticTable]
         exact fgl_natCast_val_lt_of_lt (by decide) h_byte
+      · simp only [RangeTables.rangeTable16, RangeTables.rangeStaticTable]
+        exact h_value16
+      · simpa [Lookup.Completeness, Table.fromStatic, StaticTable.toTable, Table.toRaw,
+          RangeTables.dualByteTable, h_input] using
+          (show ((byteVal : FGL).val < 2 ^ 8 ∧ value_8b.val < 2 ^ 8) from
+            ⟨fgl_natCast_val_lt_of_lt (by decide) h_byte, h_value8⟩)
       · ring }
 
 /-- MemAlignReadByte as a Clean `Air.Flat.Component`. -/
@@ -129,10 +137,12 @@ theorem component_spec (env : Environment FGL) :
 
 theorem component_interactionsWith_memBus :
     component.operations.interactionsWith MemBusChannel.toRaw =
-      [((MemBusChannel.pushed (memBusMessageExpr component.rowInputVar)).toRaw)] := by
+      [ ((MemBusChannel.pulled (memReadMessageExpr component.rowInputVar)).toRaw)
+      , ((MemBusChannel.pushed (memBusMessageExpr component.rowInputVar)).toRaw) ] := by
   apply Component.interactionsWith_of_exposedChannels
   change ⟨MemBusChannel.toRaw,
-      [((MemBusChannel.pushed (memBusMessageExpr component.rowInputVar)).toRaw)]⟩ ∈
+      [ ((MemBusChannel.pulled (memReadMessageExpr component.rowInputVar)).toRaw)
+      , ((MemBusChannel.pushed (memBusMessageExpr component.rowInputVar)).toRaw) ]⟩ ∈
     component.exposedChannels
   simp only [component, circuit, memAlignReadByteElaborated,
     Component.exposedChannels, expose, List.mem_singleton, List.map_cons,
@@ -158,7 +168,9 @@ theorem spec_via_component (row : MemAlignReadByteRow FGL)
     (h_b0 : row.sel_high_4b * (1 - row.sel_high_4b) = 0)
     (h_b1 : row.sel_high_2b * (1 - row.sel_high_2b) = 0)
     (h_b2 : row.sel_high_b * (1 - row.sel_high_b) = 0)
-    (h_byte_value_range : row.byte_value.val < 2 ^ 8) :
+    (h_byte_value_range : row.byte_value.val < 2 ^ 8)
+    (h_value16_range : row.value_16b.val < 2 ^ 16)
+    (h_value8_range : row.value_8b.val < 2 ^ 8) :
     Spec row := by
   have hsound := circuit.soundness
   simp only [GeneralFormalCircuit.Soundness, circuit, memAlignReadByteElaborated,
@@ -177,6 +189,12 @@ theorem spec_via_component (row : MemAlignReadByteRow FGL)
     row ?_ ?_).1
   · simp [circuit_norm]
   · simp only [circuit_norm]
-    exact ⟨h_byte_value_range, h_b0, h_b1, h_b2, h_composed⟩
+    exact ⟨h_byte_value_range, h_value16_range,
+      by
+        simpa [Lookup.Soundness, Table.fromStatic, StaticTable.toTable, Table.toRaw,
+          RangeTables.dualByteTable] using
+          (show (row.byte_value.val < 2 ^ 8 ∧ row.value_8b.val < 2 ^ 8) from
+            ⟨h_byte_value_range, h_value8_range⟩),
+      h_b0, h_b1, h_b2, ⟨h_composed, trivial⟩⟩
 
 end ZiskFv.AirsClean.MemAlignReadByte

--- a/ZiskFv/AirsClean/MemAlignReadByte/Constraints.lean
+++ b/ZiskFv/AirsClean/MemAlignReadByte/Constraints.lean
@@ -37,6 +37,21 @@ def memBusMessageExpr (row : Var MemAlignReadByteRow FGL) :
     value_0 := row.byte_value
     value_1 := 0 }
 
+/-- The source-faithful aligned read consumed by MemAlignReadByte before it
+    proves the selected byte to Main.  This is the exact h1049
+    `permutation_assumes` tuple from the MemAlignByte template's read-only
+    specialization; its two reconstructed lanes are expressions, not
+    detached row fields. -/
+@[reducible]
+def memReadMessageExpr (row : Var MemAlignReadByteRow FGL) :
+    MemBusMessage (Expression FGL) :=
+  { mem_op := 1
+    ptr := row.addr_w * 8
+    timestamp := row.step
+    width := 8
+    value_0 := row.sel_high_4b * (row.direct_value - row.composed_value) + row.composed_value
+    value_1 := row.sel_high_4b * (row.composed_value - row.direct_value) + row.direct_value }
+
 /-- The 4 F-constraints and memory bus push, taking the row's slot
     values as `Expression FGL`s. Returns `Unit` (MemAlignReadByte is a pure
     assertion — no fresh witnesses introduced inside the circuit). -/
@@ -44,6 +59,12 @@ def memBusMessageExpr (row : Var MemAlignReadByteRow FGL) :
 def main (row : Var MemAlignReadByteRow FGL) : Circuit FGL Unit := do
   -- range lookup for the byte value bits declaration
   lookup (Table.fromStatic rangeTable8) row.byte_value
+  -- h1052: `range_check(value_16b)` on virtual bus 103
+  -- (`mem_align_byte.pil:103`) through the local static S1a route.
+  lookup (Table.fromStatic rangeTable16) row.value_16b
+  -- h1053: exact `DualByte` membership in source tuple order
+  -- `[byte_value, value_8b]` (`zisk.pil:62-76`, `mem_align_byte.pil:104`).
+  lookup (Table.fromStatic dualByteTable) #v[row.byte_value, row.value_8b]
   -- constraint 0 (mem/pil/mem_align_byte.pil:35)
   assertZero (row.sel_high_4b * (1 - row.sel_high_4b))
   -- constraint 1 (mem/pil/mem_align_byte.pil:36)
@@ -52,6 +73,9 @@ def main (row : Var MemAlignReadByteRow FGL) : Circuit FGL Unit := do
   assertZero (row.sel_high_b * (1 - row.sel_high_b))
   -- constraint 3 (mem/pil/mem_align_byte.pil:59)
   assertZero (row.composed_value - (((row.byte_value * (((((16777216 * row.sel_high_2b) * row.sel_high_b) + ((65536 * row.sel_high_2b) * (1 - row.sel_high_b))) + ((256 * (1 - row.sel_high_2b)) * row.sel_high_b)) + ((1 - row.sel_high_2b) * (1 - row.sel_high_b)))) + (row.value_8b * (((((16777216 * row.sel_high_2b) * (1 - row.sel_high_b)) + ((65536 * row.sel_high_2b) * row.sel_high_b)) + ((256 * (1 - row.sel_high_2b)) * (1 - row.sel_high_b))) + ((1 - row.sel_high_2b) * row.sel_high_b)))) + (row.value_16b * ((65536 * (1 - row.sel_high_2b)) + row.sel_high_2b))))
+  -- Bus consumer: the aligned 8-byte load consumed by this read-only byte
+  -- assembly (`permutation_assumes`, h1049).
+  MemBusChannel.pull (memReadMessageExpr row)
   -- Bus emission: MemAlignReadByte pushes its proves-side tuple onto memory bus 10.
   -- Reconstructed from the proves-side `gsum_debug_data` hint;
   -- slot-for-slot faithful to the hand-written reference.
@@ -68,8 +92,10 @@ def main (row : Var MemAlignReadByteRow FGL) : Circuit FGL Unit := do
   output _ _ := ()
   channelsWithRequirements := [MemBusChannel.toRaw]
   exposedChannels row _ :=
-    expose MemBusChannel [MemBusChannel.pushed (memBusMessageExpr row)]
+    expose MemBusChannel
+      [ MemBusChannel.pulled (memReadMessageExpr row)
+      , MemBusChannel.pushed (memBusMessageExpr row) ]
   channelsLawful := by
-    simp only [circuit_norm, main, memBusMessageExpr, MemBusChannel]
+    simp only [circuit_norm, main, memBusMessageExpr, memReadMessageExpr, MemBusChannel]
 
 end ZiskFv.AirsClean.MemAlignReadByte

--- a/ZiskFv/AirsClean/RangeTables.lean
+++ b/ZiskFv/AirsClean/RangeTables.lean
@@ -55,6 +55,49 @@ def rangeTable7 : StaticTable FGL field :=
 def rangeTable8 : StaticTable FGL field :=
   rangeStaticTable (2 ^ 8) (by decide) "range-8"
 
+/-- Exact static model of ZisK's virtual `DualRange` byte table.  The source
+    declares `DualByte` as two independently bounded byte coordinates
+    (`zisk/pil/zisk.pil:62-76`), and MemAlignByte consumes its ordered tuple
+    as `[byte_value, value_8b]` at `mem_align_byte.pil:104`. -/
+def dualByteTable : StaticTable FGL (fields 2) where
+  name := "dual-range-byte"
+  length := 2 ^ 16
+  row i := #v[((i.val % 256 : ℕ) : FGL), ((i.val / 256 : ℕ) : FGL)]
+  index t := t[0].val + 256 * t[1].val
+  Spec t := t[0].val < 256 ∧ t[1].val < 256
+  contains_iff := by
+    intro t
+    constructor
+    · rintro ⟨i, rfl⟩
+      constructor
+      · have h_byte : ((i.val % 256 : ℕ) : FGL).val < 256 := by
+          rw [Fin.val_natCast, Nat.mod_eq_of_lt (by omega)]
+          exact Nat.mod_lt _ (by omega)
+        simpa using h_byte
+      · have h_byte : ((i.val / 256 : ℕ) : FGL).val < 256 := by
+          rw [Fin.val_natCast, Nat.mod_eq_of_lt (by omega)]
+          have hi := i.isLt
+          omega
+        simpa using h_byte
+    · rintro ⟨h0, h1⟩
+      let i : Fin (2 ^ 16) := ⟨t[0].val + 256 * t[1].val, by omega⟩
+      refine ⟨i, ?_⟩
+      apply Vector.ext
+      intro j hj
+      interval_cases j
+      · apply Fin.ext
+        have h_byte : t[0].val = ((i.val % 256 : ℕ) : FGL).val := by
+          rw [Fin.val_natCast, Nat.mod_eq_of_lt (by omega)]
+          dsimp [i]
+          omega
+        simpa using h_byte
+      · apply Fin.ext
+        have h_byte : t[1].val = ((i.val / 256 : ℕ) : FGL).val := by
+          rw [Fin.val_natCast, Nat.mod_eq_of_lt (by omega)]
+          dsimp [i]
+          omega
+        simpa using h_byte
+
 def rangeTable16 : StaticTable FGL field :=
   rangeStaticTable (2 ^ 16) (by decide) "range-16"
 

--- a/ZiskFv/Channels/MemAlignRanges.lean
+++ b/ZiskFv/Channels/MemAlignRanges.lean
@@ -1,0 +1,32 @@
+import Clean.Circuit.Channel
+import Clean.Circuit.Provable
+import Clean.Utils.Tactics.ProvableStructDeriving
+import ZiskFv.Field.Goldilocks
+
+/-!
+# MemAlign byte-range channel
+
+Clean's typed wrapper for the eight single-value Range Check lookups emitted
+by `MemAlign` on bus 107.  The static provider owns membership in the exact
+byte table; consumers make no local membership claim, and the finished
+channel transports that fact through balance.
+
+PIL citation: `zisk/state-machines/mem/pil/mem_align.pil:113-118`; manifest
+hints #982/#984/#986/#988/#990/#992/#994/#996.
+-/
+
+namespace ZiskFv.Channels.MemAlignRanges
+
+open Goldilocks
+
+/-- The one-slot bus-107 payload: one MemAlign register byte. -/
+structure MemAlignRangeMessage (F : Type) where
+  value : F
+deriving ProvableStruct
+
+/-- The MemAlign register-byte range-check channel. -/
+instance MemAlignRangeChannel : Channel FGL MemAlignRangeMessage where
+  name := "MemAlignRange107"
+  Guarantees _msg _data := True
+
+end ZiskFv.Channels.MemAlignRanges

--- a/ZiskFv/Compliance/AcceptedZiskTrace.lean
+++ b/ZiskFv/Compliance/AcceptedZiskTrace.lean
@@ -117,19 +117,18 @@ structure AcceptedZiskTrace (numInstructions : Nat) where
     ∀ table ∈ witness.allTables,
       table.component = ZiskFv.AirsClean.Mem.componentWithDualMemBus →
         table = (mem_replay_table h).1
-  /-- The Main AIR's cross-row PC-handshake transition constraint (`main.pil:409-410`) holds on every
-      consecutive Main-table row pair. This polynomial transition CANNOT be expressed by the single-row
-      Clean `Air.Flat` per-row `Constraints` (which is exactly why it was dropped from the per-row Spec);
-      it is declared on the Main component via `Air.Flat.Component.transition` and carried here as a
-      verifier-checked certificate, in the same epistemic class as `main_height` — a PIL-faithful,
-      constructible accepted-trace obligation. It consolidates the per-opcode cross-world
-      `h_nextPC_matches` promises into one in-circuit constraint. See `trust/trusted-base.md`. -/
+  /-- Component-owned predecessor/current transitions hold on every table row.
+      This includes Main's PC handshake (`main.pil:409-410`) and MemAlign's
+      gated predecessor `delta_addr` plus `down_to_up` register continuity
+      (`mem_align.pil:116-117,142`). These polynomial relations are declared
+      by their components' intrinsic D1 predicates and are verifier-checked,
+      constructible accepted-trace obligations—not caller assumptions. -/
   transitions_hold : witness.TransitionConstraints
-  /-- The MemAlign h998 successor-PC relation (`mem_align.pil:139-143`) holds
-      on every effective MemAlign row, including the intrinsic final-row to
-      row-zero wrap. This is a verifier-checked D3 certificate over the
-      materialized witness table, parallel to `transitions_hold`; it is never
-      a caller assumption. -/
+  /-- MemAlign's D3 successor/current relations hold on every effective row:
+      h998 `DELTA_PC = pc' - pc` and the `up_to_down` register continuity
+      constraints (`mem_align.pil:113-118,139-143`), including the intrinsic
+      final-row to row-zero wrap. This is a verifier-checked certificate over
+      component-owned predicates, never a caller assumption. -/
   cyclic_successor_transitions_hold : witness.CyclicSuccessorTransitionConstraints
   /-- The Main execution table covers every instruction: any witness table with
       the Main component has a row for each instruction. This is the one genuine

--- a/ZiskFv/Compliance/AcceptedZiskTrace/MemAlignRanges.lean
+++ b/ZiskFv/Compliance/AcceptedZiskTrace/MemAlignRanges.lean
@@ -1,0 +1,38 @@
+import ZiskFv.Compliance.AcceptedZiskTrace.Spec
+import ZiskFv.AirsClean.FullEnsemble.Balance.MemAlignRangeProviderMatch
+
+/-!
+# Accepted-trace MemAlign byte-range membership
+
+MemAlign's eight bus-107 Range Check consumers are source-linked in its live
+component. The static `rangeTable8` provider and finished-channel balance
+derive membership; no consumer or caller provides it.
+-/
+
+namespace ZiskFv.Compliance
+
+open Goldilocks
+open Air.Flat
+open ZiskFv.AirsClean.FullEnsemble
+open ZiskFv.Channels.MemAlignRanges (MemAlignRangeChannel MemAlignRangeMessage)
+
+/-- Any exact MemAlign bus-107 consumer interaction in an accepted trace has
+    a byte-range fact derived from verifier constraints and channel balance.
+    The component's interaction theorem fixes these consumers to hints
+    #982/#984/#986/#988/#990/#992/#994/#996 at `mem_align.pil:113-118`. -/
+theorem AcceptedZiskTrace.memAlignRangeMembership
+    {n : Nat} (trace : AcceptedZiskTrace n)
+    {table : Table FGL}
+    (h_table : table ∈ trace.witness.allTables)
+    {consumerMsg : MemAlignRangeMessage (Expression FGL)}
+    {row : Array FGL}
+    (h_interaction :
+      ((MemAlignRangeChannel.emitted (-1) consumerMsg).toRaw).eval
+          (table.environment row) ∈
+        table.interactionsWith MemAlignRangeChannel.toRaw) :
+    ZiskFv.AirsClean.RangeTables.rangeTable8.Spec
+      (Eval.eval (table.environment row) consumerMsg).value := by
+  exact rangeTable8_spec_of_memAlign_range_interaction trace.witness
+    trace.constraints_hold trace.channels_balanced h_table h_interaction
+
+end ZiskFv.Compliance

--- a/ZiskFv/Compliance/AddAddiSpinWitness.lean
+++ b/ZiskFv/Compliance/AddAddiSpinWitness.lean
@@ -19,6 +19,7 @@ open ZiskFv.AirsClean.Main
 open ZiskFv.AirsClean.ZiskInstructionRom (Program)
 open ZiskFv.Channels.MemoryBus (MemBusChannel MemBusMessage)
 open ZiskFv.Channels.MemAlignRom (MemAlignRomChannel)
+open ZiskFv.Channels.MemAlignRanges (MemAlignRangeChannel)
 open ZiskFv.Channels.OperationBus (OpBusChannel)
 open ZiskFv.Channels.SpecifiedRanges (SpecifiedRangesSliceChannel)
 open ZiskFv.Channels.ZiskRomBus (ZiskRomMessage)
@@ -367,6 +368,7 @@ theorem addAddiSpinEnsemble_tables :
       , ZiskFv.AirsClean.MemAlignReadByte.component
       , ZiskFv.AirsClean.MemAlignByte.component
       , ZiskFv.AirsClean.MemAlign.component
+      , ZiskFv.AirsClean.MemAlignRangeSlice.component
       , ZiskFv.AirsClean.MemAlignRomSlice.component
       , ZiskFv.AirsClean.Mem.componentWithDualMemBus
       , ZiskFv.AirsClean.SpecifiedRangesSlice.component
@@ -383,6 +385,7 @@ def addAddiSpinTables : List (Table FGL) :=
   , emptyComponentTable ZiskFv.AirsClean.MemAlignReadByte.component
   , emptyComponentTable ZiskFv.AirsClean.MemAlignByte.component
   , emptyComponentTable ZiskFv.AirsClean.MemAlign.component
+  , emptyComponentTable ZiskFv.AirsClean.MemAlignRangeSlice.component
   , emptyComponentTable ZiskFv.AirsClean.MemAlignRomSlice.component
   , emptyComponentTable ZiskFv.AirsClean.Mem.componentWithDualMemBus
   , emptyComponentTable ZiskFv.AirsClean.SpecifiedRangesSlice.component
@@ -403,7 +406,7 @@ def addAddiSpinWitness : EnsembleWitness addAddiSpinEnsemble where
       SoundEnsemble.addTable, SoundEnsemble.empty_tables, Ensemble.addTable]
   same_circuits := by
     intro i hi
-    have hi' : i < 13 := by
+    have hi' : i < 14 := by
       simpa [addAddiSpinTables] using hi
     interval_cases i <;>
       simp [addAddiSpinEnsemble, fullRv64imEnsemble, fullRv64imSoundEnsemble,
@@ -416,7 +419,7 @@ def addAddiSpinWitness : EnsembleWitness addAddiSpinEnsemble where
     simp [addAddiSpinTables, addAddiSpinBoundaryTable, registerBoundaryRowsTableOf,
       emptyComponentTable, addAddiSpinBinaryAddTable, binaryAddRowsTable,
       addAddiSpinMainTable, mainRowsTable] at h_table
-    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
       rfl
 
 theorem addAddiSpinWitness_tables :
@@ -428,11 +431,12 @@ theorem addAddiSpinWitness_table_constraints :
   intro table h_table
   rw [addAddiSpinWitness_tables] at h_table
   simp [addAddiSpinTables] at h_table
-  rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+  rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
   · exact addAddiSpinBoundaryTable_constraints
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlignReadByte.component
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlignByte.component
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlign.component
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlignRangeSlice.component
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlignRomSlice.component
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.Mem.componentWithDualMemBus
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.SpecifiedRangesSlice.component
@@ -632,7 +636,7 @@ theorem addAddiSpinWitness_transitions : addAddiSpinWitness.TransitionConstraint
     simp [EnsembleWitness.verifierTable]
   · rw [addAddiSpinWitness_tables] at h_table
     simp [addAddiSpinTables] at h_table
-    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
     · rw [Table.TransitionConstraints]
       intro index
       simp [addAddiSpinBoundaryTable, registerBoundaryRowsTableOf,
@@ -640,6 +644,7 @@ theorem addAddiSpinWitness_transitions : addAddiSpinWitness.TransitionConstraint
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignReadByte.component
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignByte.component
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlign.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignRangeSlice.component
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignRomSlice.component
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.Mem.componentWithDualMemBus
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.SpecifiedRangesSlice.component
@@ -665,7 +670,7 @@ theorem addAddiSpinWitness_cyclicSuccessorTransitions :
     simp [EnsembleWitness.verifierTable]
   · rw [addAddiSpinWitness_tables] at h_table
     simp [addAddiSpinTables] at h_table
-    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
     · rw [Table.CyclicSuccessorTransitionConstraints]
       intro index
       simp [addAddiSpinBoundaryTable, registerBoundaryRowsTableOf,
@@ -674,6 +679,8 @@ theorem addAddiSpinWitness_cyclicSuccessorTransitions :
         ZiskFv.AirsClean.MemAlignReadByte.component
     · exact emptyComponentTable_cyclicSuccessorTransitions ZiskFv.AirsClean.MemAlignByte.component
     · exact emptyComponentTable_cyclicSuccessorTransitions ZiskFv.AirsClean.MemAlign.component
+    · exact emptyComponentTable_cyclicSuccessorTransitions
+        ZiskFv.AirsClean.MemAlignRangeSlice.component
     · exact emptyComponentTable_cyclicSuccessorTransitions ZiskFv.AirsClean.MemAlignRomSlice.component
     · exact emptyComponentTable_cyclicSuccessorTransitions
         ZiskFv.AirsClean.Mem.componentWithDualMemBus
@@ -727,7 +734,9 @@ private theorem addAddiSpinWitness_main_component_cases
     exact not_addAddiSpin_main_component_of_width_ne (by decide) h_component
   · rw [addAddiSpinWitness_tables] at h_table
     simp [addAddiSpinTables] at h_table
-    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    · exfalso
+      exact not_addAddiSpin_main_component_of_name_ne (by decide) h_component
     · exfalso
       exact not_addAddiSpin_main_component_of_name_ne (by decide) h_component
     · exfalso
@@ -772,12 +781,13 @@ private theorem addAddiSpinWitness_mutable_mem_component_tables_empty
     exact absurd h_verifier_nil (by simp)
   · rw [addAddiSpinWitness_tables] at h_table
     simp [addAddiSpinTables] at h_table
-    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
     · exfalso
       exact not_addAddiSpin_mutable_mem_component_of_name_ne (by decide) h_component
     · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignReadByte.component
     · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignByte.component
     · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlign.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignRangeSlice.component
     · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignRomSlice.component
     · exact emptyComponentTable_table ZiskFv.AirsClean.Mem.componentWithDualMemBus
     · exact emptyComponentTable_table ZiskFv.AirsClean.SpecifiedRangesSlice.component
@@ -1372,15 +1382,15 @@ private theorem addAddiSpinMemBusInteractions_eq_tables :
   exact congrArg (fun tables => tables.flatMap (·.interactionsWith MemBusChannel.toRaw))
     addAddiSpinWitness_tables
 
-private theorem flatMap_thirteen_of_middle_nil
+private theorem flatMap_fourteen_of_middle_nil
     {α : Type u} {β : Type v} (f : α → List β)
-    (first e₀ e₁ e₂ e₃ e₄ e₅ e₆ e₇ e₈ e₉ last₀ last₁ : α)
+    (first e₀ e₁ e₂ e₃ e₄ e₅ e₆ e₇ e₈ e₉ e₁₀ last₀ last₁ : α)
     (h₀ : f e₀ = []) (h₁ : f e₁ = []) (h₂ : f e₂ = []) (h₃ : f e₃ = [])
     (h₄ : f e₄ = []) (h₅ : f e₅ = []) (h₆ : f e₆ = []) (h₇ : f e₇ = [])
-    (h₈ : f e₈ = []) (h₉ : f e₉ = []) :
-    [first, e₀, e₁, e₂, e₃, e₄, e₅, e₆, e₇, e₈, e₉, last₀, last₁].flatMap f =
+    (h₈ : f e₈ = []) (h₉ : f e₉ = []) (h₁₀ : f e₁₀ = []) :
+    [first, e₀, e₁, e₂, e₃, e₄, e₅, e₆, e₇, e₈, e₉, e₁₀, last₀, last₁].flatMap f =
       f first ++ f last₀ ++ f last₁ := by
-  simp [h₀, h₁, h₂, h₃, h₄, h₅, h₆, h₇, h₈, h₉]
+  simp [h₀, h₁, h₂, h₃, h₄, h₅, h₆, h₇, h₈, h₉, h₁₀]
 
 private theorem addAddiSpinTablesMemBusInteractions_eq_active :
     addAddiSpinTables.flatMap (·.interactionsWith MemBusChannel.toRaw) =
@@ -1388,20 +1398,21 @@ private theorem addAddiSpinTablesMemBusInteractions_eq_active :
         addAddiSpinBinaryAddTable.interactionsWith MemBusChannel.toRaw ++
         addAddiSpinMainTable.interactionsWith MemBusChannel.toRaw := by
   unfold addAddiSpinTables
-  exact flatMap_thirteen_of_middle_nil
+  exact flatMap_fourteen_of_middle_nil
     (α := Table FGL) (β := Interaction FGL)
     (f := fun table => table.interactionsWith MemBusChannel.toRaw)
     (first := addAddiSpinBoundaryTable)
     (e₀ := emptyComponentTable ZiskFv.AirsClean.MemAlignReadByte.component)
     (e₁ := emptyComponentTable ZiskFv.AirsClean.MemAlignByte.component)
     (e₂ := emptyComponentTable ZiskFv.AirsClean.MemAlign.component)
-    (e₃ := emptyComponentTable ZiskFv.AirsClean.MemAlignRomSlice.component)
-    (e₄ := emptyComponentTable ZiskFv.AirsClean.Mem.componentWithDualMemBus)
-    (e₅ := emptyComponentTable ZiskFv.AirsClean.SpecifiedRangesSlice.component)
-    (e₆ := emptyComponentTable ZiskFv.AirsClean.ArithDiv.component)
-    (e₇ := emptyComponentTable ZiskFv.AirsClean.ArithMul.componentWithArithTable)
-    (e₈ := emptyComponentTable ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (e₉ := emptyComponentTable ZiskFv.AirsClean.Binary.staticLookupComponent)
+    (e₃ := emptyComponentTable ZiskFv.AirsClean.MemAlignRangeSlice.component)
+    (e₄ := emptyComponentTable ZiskFv.AirsClean.MemAlignRomSlice.component)
+    (e₅ := emptyComponentTable ZiskFv.AirsClean.Mem.componentWithDualMemBus)
+    (e₆ := emptyComponentTable ZiskFv.AirsClean.SpecifiedRangesSlice.component)
+    (e₇ := emptyComponentTable ZiskFv.AirsClean.ArithDiv.component)
+    (e₈ := emptyComponentTable ZiskFv.AirsClean.ArithMul.componentWithArithTable)
+    (e₉ := emptyComponentTable ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
+    (e₁₀ := emptyComponentTable ZiskFv.AirsClean.Binary.staticLookupComponent)
     (last₀ := addAddiSpinBinaryAddTable) (last₁ := addAddiSpinMainTable)
     (h₀ := emptyComponentTable_interactionsWith
       ZiskFv.AirsClean.MemAlignReadByte.component MemBusChannel.toRaw)
@@ -1410,18 +1421,20 @@ private theorem addAddiSpinTablesMemBusInteractions_eq_active :
     (h₂ := emptyComponentTable_interactionsWith
       ZiskFv.AirsClean.MemAlign.component MemBusChannel.toRaw)
     (h₃ := emptyComponentTable_interactionsWith
-      ZiskFv.AirsClean.MemAlignRomSlice.component MemBusChannel.toRaw)
+      ZiskFv.AirsClean.MemAlignRangeSlice.component MemBusChannel.toRaw)
     (h₄ := emptyComponentTable_interactionsWith
-      ZiskFv.AirsClean.Mem.componentWithDualMemBus MemBusChannel.toRaw)
+      ZiskFv.AirsClean.MemAlignRomSlice.component MemBusChannel.toRaw)
     (h₅ := emptyComponentTable_interactionsWith
-      ZiskFv.AirsClean.SpecifiedRangesSlice.component MemBusChannel.toRaw)
+      ZiskFv.AirsClean.Mem.componentWithDualMemBus MemBusChannel.toRaw)
     (h₆ := emptyComponentTable_interactionsWith
-      ZiskFv.AirsClean.ArithDiv.component MemBusChannel.toRaw)
+      ZiskFv.AirsClean.SpecifiedRangesSlice.component MemBusChannel.toRaw)
     (h₇ := emptyComponentTable_interactionsWith
-      ZiskFv.AirsClean.ArithMul.componentWithArithTable MemBusChannel.toRaw)
+      ZiskFv.AirsClean.ArithDiv.component MemBusChannel.toRaw)
     (h₈ := emptyComponentTable_interactionsWith
-      ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent MemBusChannel.toRaw)
+      ZiskFv.AirsClean.ArithMul.componentWithArithTable MemBusChannel.toRaw)
     (h₉ := emptyComponentTable_interactionsWith
+      ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent MemBusChannel.toRaw)
+    (h₁₀ := emptyComponentTable_interactionsWith
       ZiskFv.AirsClean.Binary.staticLookupComponent MemBusChannel.toRaw)
 
 private theorem addAddiSpinBoundaryTableMemBusInteractions_eq_rows :
@@ -1550,6 +1563,60 @@ theorem addAddiSpinWitness_rangeChannel_balanced :
   · intro msg
     simp [balanceOf]
 
+private theorem addAddiSpinMemAlignRangeChannel_ne_memBus :
+    MemAlignRangeChannel.toRaw ≠ MemBusChannel.toRaw := by
+  intro h
+  have h_name := congrArg (fun raw : RawChannel FGL => raw.name) h
+  change "MemAlignRange107" = "MemoryBus" at h_name
+  simp at h_name
+
+private theorem addAddiSpinMemAlignRangeChannel_ne_opBus :
+    MemAlignRangeChannel.toRaw ≠ OpBusChannel.toRaw := by
+  intro h
+  have h_name := congrArg (fun raw : RawChannel FGL => raw.name) h
+  change "MemAlignRange107" = "OperationBus" at h_name
+  simp at h_name
+
+private theorem addAddiSpinBoundary_interactionsWith_memAlignRangeChannel_nil :
+    addAddiSpinBoundaryTable.interactionsWith MemAlignRangeChannel.toRaw = [] := by
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  change MemAlignRangeChannel.toRaw ∉ [MemBusChannel.toRaw]
+  simp only [List.mem_singleton]
+  exact addAddiSpinMemAlignRangeChannel_ne_memBus
+
+private theorem addAddiSpinBinaryAdd_interactionsWith_memAlignRangeChannel_nil :
+    addAddiSpinBinaryAddTable.interactionsWith MemAlignRangeChannel.toRaw = [] := by
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  change MemAlignRangeChannel.toRaw ∉ [OpBusChannel.toRaw]
+  simp only [List.mem_singleton]
+  exact addAddiSpinMemAlignRangeChannel_ne_opBus
+
+private theorem addAddiSpinMain_interactionsWith_memAlignRangeChannel_nil :
+    addAddiSpinMainTable.interactionsWith MemAlignRangeChannel.toRaw = [] := by
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  change MemAlignRangeChannel.toRaw ∉ [MemBusChannel.toRaw, OpBusChannel.toRaw]
+  intro h
+  simp only [List.mem_cons] at h
+  rcases h with h | h
+  · exact addAddiSpinMemAlignRangeChannel_ne_memBus h
+  · rcases h with h | h
+    · exact addAddiSpinMemAlignRangeChannel_ne_opBus h
+    · simp at h
+
+theorem addAddiSpinWitness_memAlignRangeChannel_balanced :
+    BalancedInteractions
+      (addAddiSpinWitness.tables.flatMap (·.interactionsWith MemAlignRangeChannel.toRaw)) := by
+  rw [addAddiSpinWitness_tables]
+  simp [addAddiSpinTables, addAddiSpinBoundary_interactionsWith_memAlignRangeChannel_nil,
+    addAddiSpinBinaryAdd_interactionsWith_memAlignRangeChannel_nil,
+    addAddiSpinMain_interactionsWith_memAlignRangeChannel_nil, emptyComponentTable_interactionsWith]
+  refine ⟨?_, ?_⟩
+  · left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+  · intro msg
+    simp [balanceOf]
+
 private theorem addAddiSpinBoundary_interactionsWith_memAlignRomChannel_nil :
     addAddiSpinBoundaryTable.interactionsWith MemAlignRomChannel.toRaw = [] := by
   apply Table.interactionsWith_nil_of_channel_not_mem
@@ -1608,7 +1675,8 @@ theorem addAddiSpinWitness_balancedChannels : addAddiSpinWitness.BalancedChannel
   simp [addAddiSpinEnsemble, fullRv64imEnsemble, fullRv64imSoundEnsemble,
     SoundEnsemble.toFormal, SoundEnsemble.addFinishedChannel_channels,
     SoundEnsemble.addTable_channels, SoundEnsemble.empty_channels] at h_channel
-  rcases h_channel with rfl | rfl | rfl | rfl
+  rcases h_channel with rfl | rfl | rfl | rfl | rfl
+  · exact addAddiSpinWitness_memAlignRangeChannel_balanced
   · change BalancedInteractions addAddiSpinMemBusInteractions
     exact addAddiSpinWitness_memBus_balanced
   · exact addAddiSpinWitness_opBus_balanced

--- a/ZiskFv/Compliance/AddSpinWitness.lean
+++ b/ZiskFv/Compliance/AddSpinWitness.lean
@@ -21,6 +21,7 @@ open ZiskFv.Channels.MemoryBus (MemBusChannel)
 open ZiskFv.Channels.OperationBus (OpBusChannel)
 open ZiskFv.Channels.SpecifiedRanges (SpecifiedRangesSliceChannel)
 open ZiskFv.Channels.MemAlignRom (MemAlignRomChannel)
+open ZiskFv.Channels.MemAlignRanges (MemAlignRangeChannel)
 open ZiskFv.Channels.ZiskRomBus (ZiskRomMessage)
 open ZiskFv.Compliance.Instantiation
 open ZiskFv.Compliance.RegisterMemBusBalance
@@ -491,6 +492,7 @@ def addSpinTables : List (Table FGL) :=
   , emptyComponentTable ZiskFv.AirsClean.MemAlignReadByte.component
   , emptyComponentTable ZiskFv.AirsClean.MemAlignByte.component
   , emptyComponentTable ZiskFv.AirsClean.MemAlign.component
+  , emptyComponentTable ZiskFv.AirsClean.MemAlignRangeSlice.component
   , emptyComponentTable ZiskFv.AirsClean.MemAlignRomSlice.component
   , emptyComponentTable ZiskFv.AirsClean.Mem.componentWithDualMemBus
   , emptyComponentTable ZiskFv.AirsClean.SpecifiedRangesSlice.component
@@ -506,6 +508,7 @@ def addSpinNonMainTables : List (Table FGL) :=
   , emptyComponentTable ZiskFv.AirsClean.MemAlignReadByte.component
   , emptyComponentTable ZiskFv.AirsClean.MemAlignByte.component
   , emptyComponentTable ZiskFv.AirsClean.MemAlign.component
+  , emptyComponentTable ZiskFv.AirsClean.MemAlignRangeSlice.component
   , emptyComponentTable ZiskFv.AirsClean.MemAlignRomSlice.component
   , emptyComponentTable ZiskFv.AirsClean.Mem.componentWithDualMemBus
   , emptyComponentTable ZiskFv.AirsClean.SpecifiedRangesSlice.component
@@ -532,7 +535,7 @@ def addSpinWitness : EnsembleWitness addSpinEnsemble where
       SoundEnsemble.empty_tables, Ensemble.addTable]
   same_circuits := by
     intro i hi
-    have hi' : i < 13 := by
+    have hi' : i < 14 := by
       simpa [addSpinTables] using hi
     interval_cases i <;>
       simp [addSpinEnsemble, fullRv64imEnsemble, fullRv64imSoundEnsemble, addSpinTables,
@@ -544,18 +547,19 @@ def addSpinWitness : EnsembleWitness addSpinEnsemble where
     intro table h_table
     simp [addSpinTables, registerBoundaryRowsTable, registerBoundaryRowsTableOf,
       emptyComponentTable, binaryAddRowsTable, addSpinMainTable, mainRowsTable] at h_table
-    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
       rfl
 
 theorem addSpinWitness_table_constraints :
     ∀ table ∈ addSpinWitness.tables, table.Constraints := by
   intro table h_table
   simp [addSpinWitness, addSpinTables] at h_table
-  rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+  rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
   · exact registerBoundaryRowsTable_constraints
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlignReadByte.component
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlignByte.component
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlign.component
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlignRangeSlice.component
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlignRomSlice.component
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.Mem.componentWithDualMemBus
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.SpecifiedRangesSlice.component
@@ -580,7 +584,7 @@ theorem addSpinWitness_transitions : addSpinWitness.TransitionConstraints := by
     intro index
     simp [EnsembleWitness.verifierTable]
   · simp [addSpinWitness, addSpinTables] at h_table
-    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
     · rw [Table.TransitionConstraints]
       intro index
       simp [registerBoundaryRowsTable, registerBoundaryRowsTableOf,
@@ -588,6 +592,7 @@ theorem addSpinWitness_transitions : addSpinWitness.TransitionConstraints := by
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignReadByte.component
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignByte.component
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlign.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignRangeSlice.component
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignRomSlice.component
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.Mem.componentWithDualMemBus
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.SpecifiedRangesSlice.component
@@ -611,7 +616,7 @@ theorem addSpinWitness_cyclicSuccessorTransitions :
     intro index
     simp [EnsembleWitness.verifierTable]
   · simp [addSpinWitness, addSpinTables] at h_table
-    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
     · rw [Table.CyclicSuccessorTransitionConstraints]
       intro index
       simp [registerBoundaryRowsTable, registerBoundaryRowsTableOf,
@@ -620,6 +625,8 @@ theorem addSpinWitness_cyclicSuccessorTransitions :
         ZiskFv.AirsClean.MemAlignReadByte.component
     · exact emptyComponentTable_cyclicSuccessorTransitions ZiskFv.AirsClean.MemAlignByte.component
     · exact emptyComponentTable_cyclicSuccessorTransitions ZiskFv.AirsClean.MemAlign.component
+    · exact emptyComponentTable_cyclicSuccessorTransitions
+        ZiskFv.AirsClean.MemAlignRangeSlice.component
     · exact emptyComponentTable_cyclicSuccessorTransitions ZiskFv.AirsClean.MemAlignRomSlice.component
     · exact emptyComponentTable_cyclicSuccessorTransitions
         ZiskFv.AirsClean.Mem.componentWithDualMemBus
@@ -675,7 +682,9 @@ private theorem addSpinWitness_main_component_cases
     exfalso
     exact not_addSpin_main_component_of_width_ne (by decide) h_component
   · simp [addSpinWitness, addSpinTables] at h_table
-    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    · exfalso
+      exact not_addSpin_main_component_of_name_ne (by decide) h_component
     · exfalso
       exact not_addSpin_main_component_of_name_ne (by decide) h_component
     · exfalso
@@ -718,12 +727,13 @@ private theorem addSpinWitness_mutable_mem_component_tables_empty (table : Table
       ZiskFv.AirsClean.Mem.componentWithDualMemBus_interactionsWith_memBus] at h_verifier_nil
     exact absurd h_verifier_nil (by simp)
   · simp [addSpinWitness, addSpinTables] at h_table
-    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
     · exfalso
       exact not_addSpin_mutable_mem_component_of_name_ne (by decide) h_component
     · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignReadByte.component
     · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignByte.component
     · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlign.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignRangeSlice.component
     · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignRomSlice.component
     · exact emptyComponentTable_table ZiskFv.AirsClean.Mem.componentWithDualMemBus
     · exact emptyComponentTable_table ZiskFv.AirsClean.SpecifiedRangesSlice.component
@@ -1180,6 +1190,20 @@ private theorem addSpinRangeChannel_ne_opBus :
   change "SpecifiedRangesSlice103" = "OperationBus" at h_name
   simp at h_name
 
+private theorem addSpinMemAlignRangeChannel_ne_memBus :
+    MemAlignRangeChannel.toRaw ≠ MemBusChannel.toRaw := by
+  intro h
+  have h_name := congrArg (fun raw : RawChannel FGL => raw.name) h
+  change "MemAlignRange107" = "MemoryBus" at h_name
+  simp at h_name
+
+private theorem addSpinMemAlignRangeChannel_ne_opBus :
+    MemAlignRangeChannel.toRaw ≠ OpBusChannel.toRaw := by
+  intro h
+  have h_name := congrArg (fun raw : RawChannel FGL => raw.name) h
+  change "MemAlignRange107" = "OperationBus" at h_name
+  simp at h_name
+
 private theorem addSpinRegisterBoundary_interactionsWith_rangeChannel_nil :
     registerBoundaryRowsTable.interactionsWith SpecifiedRangesSliceChannel.toRaw = [] := by
   apply Table.interactionsWith_nil_of_channel_not_mem
@@ -1214,6 +1238,46 @@ theorem addSpinWitness_rangeChannel_balanced :
   simp [addSpinTables, addSpinRegisterBoundary_interactionsWith_rangeChannel_nil,
     addSpinBinaryAdd_interactionsWith_rangeChannel_nil,
     addSpinMain_interactionsWith_rangeChannel_nil, emptyComponentTable_interactionsWith]
+  refine ⟨?_, ?_⟩
+  · left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+  · intro msg
+    simp [balanceOf]
+
+private theorem addSpinRegisterBoundary_interactionsWith_memAlignRangeChannel_nil :
+    registerBoundaryRowsTable.interactionsWith MemAlignRangeChannel.toRaw = [] := by
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  change MemAlignRangeChannel.toRaw ∉ [MemBusChannel.toRaw]
+  simp only [List.mem_singleton]
+  exact addSpinMemAlignRangeChannel_ne_memBus
+
+private theorem addSpinBinaryAdd_interactionsWith_memAlignRangeChannel_nil :
+    (binaryAddRowsTable [addX1BinaryAddRow]).interactionsWith MemAlignRangeChannel.toRaw = [] := by
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  change MemAlignRangeChannel.toRaw ∉ [OpBusChannel.toRaw]
+  simp only [List.mem_singleton]
+  exact addSpinMemAlignRangeChannel_ne_opBus
+
+private theorem addSpinMain_interactionsWith_memAlignRangeChannel_nil :
+    addSpinMainTable.interactionsWith MemAlignRangeChannel.toRaw = [] := by
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  change MemAlignRangeChannel.toRaw ∉ [MemBusChannel.toRaw, OpBusChannel.toRaw]
+  intro h
+  simp only [List.mem_cons] at h
+  rcases h with h | h
+  · exact addSpinMemAlignRangeChannel_ne_memBus h
+  · rcases h with h | h
+    · exact addSpinMemAlignRangeChannel_ne_opBus h
+    · simp at h
+
+theorem addSpinWitness_memAlignRangeChannel_balanced :
+    BalancedInteractions
+      (addSpinWitness.tables.flatMap (·.interactionsWith MemAlignRangeChannel.toRaw)) := by
+  rw [show addSpinWitness.tables = addSpinTables from rfl]
+  simp [addSpinTables, addSpinRegisterBoundary_interactionsWith_memAlignRangeChannel_nil,
+    addSpinBinaryAdd_interactionsWith_memAlignRangeChannel_nil,
+    addSpinMain_interactionsWith_memAlignRangeChannel_nil, emptyComponentTable_interactionsWith]
   refine ⟨?_, ?_⟩
   · left
     rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
@@ -1279,7 +1343,8 @@ theorem addSpinWitness_balancedChannels : addSpinWitness.BalancedChannels := by
   simp [addSpinEnsemble, fullRv64imEnsemble, fullRv64imSoundEnsemble,
     SoundEnsemble.toFormal, SoundEnsemble.addFinishedChannel_channels,
     SoundEnsemble.addTable_channels, SoundEnsemble.empty_channels] at h_channel
-  rcases h_channel with rfl | rfl | rfl | rfl
+  rcases h_channel with rfl | rfl | rfl | rfl | rfl
+  · exact addSpinWitness_memAlignRangeChannel_balanced
   · exact addSpinWitness_memBus_balanced
   · exact addSpinWitness_opBus_balanced
   · exact addSpinWitness_memAlignRomChannel_balanced

--- a/ZiskFv/Compliance/SingleAddWitness.lean
+++ b/ZiskFv/Compliance/SingleAddWitness.lean
@@ -22,6 +22,7 @@ open ZiskFv.Channels.MemoryBus (MemBusChannel)
 open ZiskFv.Channels.OperationBus (OpBusChannel)
 open ZiskFv.Channels.SpecifiedRanges (SpecifiedRangesSliceChannel)
 open ZiskFv.Channels.MemAlignRom (MemAlignRomChannel)
+open ZiskFv.Channels.MemAlignRanges (MemAlignRangeChannel)
 open ZiskFv.Compliance.Instantiation
 open ZiskFv.Compliance.RegisterMemBusBalance
 
@@ -82,6 +83,20 @@ private theorem rangeChannel_ne_opBus :
   intro h
   have h_name := congrArg (fun raw : RawChannel FGL => raw.name) h
   change "SpecifiedRangesSlice103" = "OperationBus" at h_name
+  simp at h_name
+
+private theorem memAlignRangeChannel_ne_memBus :
+    MemAlignRangeChannel.toRaw ≠ MemBusChannel.toRaw := by
+  intro h
+  have h_name := congrArg (fun raw : RawChannel FGL => raw.name) h
+  change "MemAlignRange107" = "MemoryBus" at h_name
+  simp at h_name
+
+private theorem memAlignRangeChannel_ne_opBus :
+    MemAlignRangeChannel.toRaw ≠ OpBusChannel.toRaw := by
+  intro h
+  have h_name := congrArg (fun raw : RawChannel FGL => raw.name) h
+  change "MemAlignRange107" = "OperationBus" at h_name
   simp at h_name
 
 def addX1BinaryAddRow : ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL :=
@@ -148,6 +163,7 @@ def singleAddTables : List (Table FGL) :=
   , emptyComponentTable ZiskFv.AirsClean.MemAlignReadByte.component
   , emptyComponentTable ZiskFv.AirsClean.MemAlignByte.component
   , emptyComponentTable ZiskFv.AirsClean.MemAlign.component
+  , emptyComponentTable ZiskFv.AirsClean.MemAlignRangeSlice.component
   , emptyComponentTable ZiskFv.AirsClean.MemAlignRomSlice.component
   , emptyComponentTable ZiskFv.AirsClean.Mem.componentWithDualMemBus
   , emptyComponentTable ZiskFv.AirsClean.SpecifiedRangesSlice.component
@@ -175,7 +191,7 @@ def singleAddWitness : EnsembleWitness singleAddEnsemble where
       SoundEnsemble.empty_tables, Ensemble.addTable]
   same_circuits := by
     intro i hi
-    have hi' : i < 13 := by
+    have hi' : i < 14 := by
       simpa [singleAddTables] using hi
     interval_cases i <;>
       simp [singleAddEnsemble, fullRv64imEnsemble, fullRv64imSoundEnsemble, singleAddTables,
@@ -187,18 +203,19 @@ def singleAddWitness : EnsembleWitness singleAddEnsemble where
     intro table h_table
     simp [singleAddTables, registerBoundaryRowsTable, registerBoundaryRowsTableOf,
       emptyComponentTable, binaryAddRowsTable, mainSingleRowTable] at h_table
-    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
       rfl
 
 theorem singleAddWitness_table_constraints :
     ∀ table ∈ singleAddWitness.tables, table.Constraints := by
   intro table h_table
   simp [singleAddWitness, singleAddTables] at h_table
-  rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+  rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
   · exact registerBoundaryRowsTable_constraints
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlignReadByte.component
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlignByte.component
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlign.component
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlignRangeSlice.component
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlignRomSlice.component
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.Mem.componentWithDualMemBus
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.SpecifiedRangesSlice.component
@@ -252,7 +269,7 @@ theorem singleAddWitness_transitions : singleAddWitness.TransitionConstraints :=
     intro index
     simp [EnsembleWitness.verifierTable]
   · simp [singleAddWitness, singleAddTables] at h_table
-    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
     · rw [Table.TransitionConstraints]
       intro index
       simp [registerBoundaryRowsTable, registerBoundaryRowsTableOf,
@@ -260,6 +277,7 @@ theorem singleAddWitness_transitions : singleAddWitness.TransitionConstraints :=
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignReadByte.component
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignByte.component
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlign.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignRangeSlice.component
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignRomSlice.component
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.Mem.componentWithDualMemBus
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.SpecifiedRangesSlice.component
@@ -283,7 +301,7 @@ theorem singleAddWitness_cyclicSuccessorTransitions :
     intro index
     simp [EnsembleWitness.verifierTable]
   · simp [singleAddWitness, singleAddTables] at h_table
-    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
     · rw [Table.CyclicSuccessorTransitionConstraints]
       intro index
       simp [registerBoundaryRowsTable, registerBoundaryRowsTableOf,
@@ -292,6 +310,8 @@ theorem singleAddWitness_cyclicSuccessorTransitions :
         ZiskFv.AirsClean.MemAlignReadByte.component
     · exact emptyComponentTable_cyclicSuccessorTransitions ZiskFv.AirsClean.MemAlignByte.component
     · exact emptyComponentTable_cyclicSuccessorTransitions ZiskFv.AirsClean.MemAlign.component
+    · exact emptyComponentTable_cyclicSuccessorTransitions
+        ZiskFv.AirsClean.MemAlignRangeSlice.component
     · exact emptyComponentTable_cyclicSuccessorTransitions ZiskFv.AirsClean.MemAlignRomSlice.component
     · exact emptyComponentTable_cyclicSuccessorTransitions
         ZiskFv.AirsClean.Mem.componentWithDualMemBus
@@ -347,7 +367,9 @@ private theorem singleAddWitness_main_component_cases
     exfalso
     exact not_main_component_of_width_ne (by decide) h_component
   · simp [singleAddWitness, singleAddTables] at h_table
-    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    · exfalso
+      exact not_main_component_of_name_ne (by decide) h_component
     · exfalso
       exact not_main_component_of_name_ne (by decide) h_component
     · exfalso
@@ -390,12 +412,13 @@ private theorem singleAddWitness_mutable_mem_component_tables_empty (table : Tab
       ZiskFv.AirsClean.Mem.componentWithDualMemBus_interactionsWith_memBus] at h_verifier_nil
     exact absurd h_verifier_nil (by simp)
   · simp [singleAddWitness, singleAddTables] at h_table
-    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
     · exfalso
       exact not_mutable_mem_component_of_name_ne (by decide) h_component
     · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignReadByte.component
     · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignByte.component
     · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlign.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignRangeSlice.component
     · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignRomSlice.component
     · exact emptyComponentTable_table ZiskFv.AirsClean.Mem.componentWithDualMemBus
     · exact emptyComponentTable_table ZiskFv.AirsClean.SpecifiedRangesSlice.component
@@ -562,6 +585,47 @@ theorem singleAddWitness_rangeChannel_balanced :
   · intro msg
     simp [balanceOf]
 
+private theorem registerBoundaryRowsTable_interactionsWith_memAlignRangeChannel_nil :
+    registerBoundaryRowsTable.interactionsWith MemAlignRangeChannel.toRaw = [] := by
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  change MemAlignRangeChannel.toRaw ∉ [MemBusChannel.toRaw]
+  simp only [List.mem_singleton]
+  exact memAlignRangeChannel_ne_memBus
+
+private theorem binaryAddRowsTable_interactionsWith_memAlignRangeChannel_nil :
+    (binaryAddRowsTable [addX1BinaryAddRow]).interactionsWith MemAlignRangeChannel.toRaw = [] := by
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  change MemAlignRangeChannel.toRaw ∉ [OpBusChannel.toRaw]
+  simp only [List.mem_singleton]
+  exact memAlignRangeChannel_ne_opBus
+
+private theorem mainSingleRowTable_interactionsWith_memAlignRangeChannel_nil :
+    (mainSingleRowTable 1 addX1Program addX1Row).interactionsWith MemAlignRangeChannel.toRaw = [] := by
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  change MemAlignRangeChannel.toRaw ∉ [MemBusChannel.toRaw, OpBusChannel.toRaw]
+  intro h
+  simp only [List.mem_cons] at h
+  rcases h with h | h
+  · exact memAlignRangeChannel_ne_memBus h
+  · rcases h with h | h
+    · exact memAlignRangeChannel_ne_opBus h
+    · simp at h
+
+theorem singleAddWitness_memAlignRangeChannel_balanced :
+    BalancedInteractions
+      (singleAddWitness.tables.flatMap (·.interactionsWith MemAlignRangeChannel.toRaw)) := by
+  rw [show singleAddWitness.tables = singleAddTables from rfl]
+  simp [singleAddTables, registerBoundaryRowsTable_interactionsWith_memAlignRangeChannel_nil,
+    binaryAddRowsTable_interactionsWith_memAlignRangeChannel_nil,
+    mainSingleRowTable_interactionsWith_memAlignRangeChannel_nil,
+    emptyComponentTable_interactionsWith]
+  refine ⟨?_, ?_⟩
+  · left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+  · intro msg
+    simp [balanceOf]
+
 private theorem registerBoundaryRowsTable_interactionsWith_memAlignRomChannel_nil :
     registerBoundaryRowsTable.interactionsWith MemAlignRomChannel.toRaw = [] := by
   apply Table.interactionsWith_nil_of_channel_not_mem
@@ -621,7 +685,8 @@ theorem singleAddWitness_balancedChannels : singleAddWitness.BalancedChannels :=
   simp [singleAddEnsemble, fullRv64imEnsemble, fullRv64imSoundEnsemble,
     SoundEnsemble.toFormal, SoundEnsemble.addFinishedChannel_channels,
     SoundEnsemble.addTable_channels, SoundEnsemble.empty_channels] at h_channel
-  rcases h_channel with rfl | rfl | rfl | rfl
+  rcases h_channel with rfl | rfl | rfl | rfl | rfl
+  · exact singleAddWitness_memAlignRangeChannel_balanced
   · exact singleAddWitness_memBus_balanced
   · exact singleAddWitness_opBus_balanced
   · exact singleAddWitness_memAlignRomChannel_balanced

--- a/trust/consistency/completeness_witness_memalign.lean
+++ b/trust/consistency/completeness_witness_memalign.lean
@@ -9,7 +9,7 @@ private def memAlignWitnessRow : MemAlignRow FGL :=
   memAlignRowOf .prove false false false
     true false false false false false false false
     1 2 3 4 5 6 7 8
-    16 0 4 9 0 123
+    16 0 4 9 0 123 0
 
 private theorem memAlignWitnessProverAssumptions
     (data : ProverData FGL) (hint : ProverHint FGL) :
@@ -17,7 +17,7 @@ private theorem memAlignWitnessProverAssumptions
   refine ⟨.prove, false, false, false,
     true, false, false, false, false, false, false, false,
     1, 2, 3, 4, 5, 6, 7, 8,
-    16, 0, 4, 9, 0, 123, ?_⟩
+    16, 0, 4, 9, 0, 123, 0, ?_⟩
   rfl
 
 theorem completeness_witness_memalign :

--- a/trust/consistency/completeness_witness_memalignbyte.lean
+++ b/trust/consistency/completeness_witness_memalignbyte.lean
@@ -12,7 +12,7 @@ private theorem memAlignByteWitnessProverAssumptions
     (data : ProverData FGL) (hint : ProverHint FGL) :
     circuit.ProverAssumptions memAlignByteWitnessRow data hint := by
   refine ⟨false, true, false, true, 42, 99, 1000, 2, 3, 4, 5,
-    by norm_num, by norm_num, ?_⟩
+    by norm_num, by norm_num, by norm_num, by norm_num, ?_⟩
   rfl
 
 theorem completeness_witness_memalignbyte :

--- a/trust/consistency/completeness_witness_memalignreadbyte.lean
+++ b/trust/consistency/completeness_witness_memalignreadbyte.lean
@@ -11,7 +11,8 @@ private def memAlignReadByteWitnessRow : MemAlignReadByteRow FGL :=
 private theorem memAlignReadByteWitnessProverAssumptions
     (data : ProverData FGL) (hint : ProverHint FGL) :
     circuit.ProverAssumptions memAlignReadByteWitnessRow data hint := by
-  refine ⟨false, true, false, 42, 1000, 2, 3, 4, 5, by norm_num, ?_⟩
+  refine ⟨false, true, false, 42, 1000, 2, 3, 4, 5,
+    by norm_num, by norm_num, by norm_num, ?_⟩
   rfl
 
 theorem completeness_witness_memalignreadbyte :

--- a/trust/consistency/root_soundness_instantiation_degenerate.lean
+++ b/trust/consistency/root_soundness_instantiation_degenerate.lean
@@ -126,6 +126,19 @@ private theorem wit_transitions : wit.TransitionConstraints := by
     change Fin 0 at index
     exact Fin.elim0 index
 
+private theorem wit_cyclicSuccessorTransitions : wit.CyclicSuccessorTransitionConstraints := by
+  intro table hmem
+  rw [Table.CyclicSuccessorTransitionConstraints]
+  intro index
+  rw [EnsembleWitness.allTables, List.mem_cons] at hmem
+  rcases hmem with h_verifier | h_table
+  · subst table
+    simp [EnsembleWitness.verifierTable]
+  · simp only [wit, EnsembleWitness.ofRows_tables, List.mem_ofFn] at h_table
+    obtain ⟨i, rfl⟩ := h_table
+    change Fin 0 at index
+    exact Fin.elim0 index
+
 /-- The degenerate accepted trace: empty program, all-empty witness, trivial
     channel balance, and vacuous transition / row-height obligations. -/
 private def trace : AcceptedZiskTrace 0 where
@@ -137,6 +150,7 @@ private def trace : AcceptedZiskTrace 0 where
   mem_replay_table := fun h => absurd h wit_not_mutableMemPresent
   mem_replay_source_covers := fun h => absurd h wit_not_mutableMemPresent
   transitions_hold := wit_transitions
+  cyclic_successor_transitions_hold := wit_cyclicSuccessorTransitions
   main_height := by intro table _ _ i; exact i.elim0
 
 private def sail : SailTrace 0 := nofun

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -288,6 +288,11 @@ and the direct-Mem branch exclusions `LoadBDirectMutableMemResidues.no_marb`,
 `no_mab`, and `no_memAlign`. Issue #242 owns replacing these exclusions/residues
 with a through-MemAlign derivation, gated on MemAlignRom extraction (#108) and a
 timeline argument from MemAlign provider rows back to the accepted Mem replay.
+The component-fidelity prerequisite is now intrinsic: generated c29 plus
+c1/c3/.../c15 are MemAlign's D1 predicate, and c0/c2/.../c14 plus h998 are its
+D3 predicate; the existing accepted-trace transition certificates check those
+component-owned relations. The remaining issue is their semantic consumption
+by the through-MemAlign timeline, not an omitted circuit constraint.
 
 ### Trace-coherence floor (`RowTraceCoherence`) — #76 Fold-B load reduction
 
@@ -713,6 +718,18 @@ Active conclusions:
   caller. The D3 premise is the separately documented verifier-checked
   accepted-trace certificate below; no soundness-side `ProverAssumptions` is
   used.
+- **MemAlign register-byte bus-107 route (#242).** This is the same cited
+  lookup/permutation protocol-soundness application, not a new trust kind.
+  `mem_align.pil:113-118` emits one Range Check for each `reg[i]`; the real
+  assumes hints #982/#984/#986/#988/#990/#992/#994/#996 are kernel-linked by
+  `link_MemAlign_38` and the cluster links `link_MemAlign_33` through
+  `link_MemAlign_36` (`constraint = template := by rfl`, at the corresponding
+  `std_sum.pil:590/599/656` occurrences). `MemAlign.component` emits those
+  exact eight negative one-slot bus-107 tuples. Finished balance selects only
+  `MemAlignRangeSlice`, whose static `rangeTable8` lookup supplies exact
+  membership. Consumer guarantees are `True`; no caller promise and no
+  soundness-side `ProverAssumptions` is used. The provider's identical
+  `ProverAssumptions` predicate is completeness-only.
 
 The active defect boundaries and retirement criteria are in
 [`defects.md`](defects.md).
@@ -761,8 +778,8 @@ trust surface even though they add no axiom.
 | Field (`Compliance/AcceptedZiskTrace.lean`) | PIL source | What it certifies |
 |---|---|---|
 | `main_height` (pre-existing) | — | the physical Main table has a row for every executed-step index; it may also carry padding rows |
-| `transitions_hold` (**#100**) | `main.pil:409-410` | the cross-row PC-handshake transition holds on every consecutive Main-row pair (a *polynomial* constraint the single-row per-row `Constraints` dropped) |
-| `cyclic_successor_transitions_hold` (**#242**) | `mem_align.pil:139-143` | the D3 cyclic successor relation holds on every effective MemAlign row, so h998's unmasked `DELTA_PC = pc' - pc` reads the actual successor PC, including the final-row-to-row-zero instance; its bus-133 ROM membership is then derived from finished-channel balance and the static provider |
+| `transitions_hold` (**#100**, extended for **#242**) | `main.pil:409-410`; `mem_align.pil:116-117,142` | component-owned D1 predecessor/current relations hold: Main's PC handshake and MemAlign's gated predecessor `delta_addr` plus eight `down_to_up` register continuities. These are verifier certificates, not caller assumptions. |
+| `cyclic_successor_transitions_hold` (**#242**) | `mem_align.pil:113-118,139-143` | MemAlign's D3 cyclic successor/current relations hold on every effective row: h998's unmasked `DELTA_PC = pc' - pc` and eight `up_to_down` register continuities, including final-row-to-row-zero. Its bus-133 ROM membership is derived from finished balance/static provider. |
 | `mem_replay_table` (**#115**, guarded by `MutableMemPresent witness`) | Full-ensemble table selection for the mutable Mem component | selects the concrete mutable-Mem table, proves witness membership and component identity, and proves the table is nonempty |
 | Derived `memReplaySegmentRanges` (not an `AcceptedZiskTrace` field) | Mem hints 884/886; `mem.pil:267-268` / `285-286`; linked c24–33 at `std_sum.pil:590/599/656/696`; generated `ValidatedLink` entries | derives selected-table `MemSegmentGeneratedRangeFacts` from `constraints_hold`, `channels_balanced`, and `transitions_hold`: the indexed source bridge identifies the canonical `ProverData` chunks, finished bus-103 balance finds the `SpecifiedRangesSlice` provider, and its static table supplies 16-bit membership. `ProverAssumptions` is completeness-only and is not used. |
 | `mem_replay_source_covers` (**#115**, guarded by `MutableMemPresent witness`) | Full-ensemble table/source correlation for the mutable Mem component | certifies that every mutable-Mem table in the accepted witness is the selected `mem_replay_table`; this is table identity only, not read-value agreement |
@@ -842,7 +859,7 @@ intrinsic cyclic current/successor transition surface. D1 remains inert to
 Clean's existing soundness theorem, so project-side accepted traces explicitly
 carry `transitions_hold`; D2 is consumed by canonical table materialization,
 constraints, interactions, transitions, and projections. D3 is consumed by
-the #242 MemAlign h998/bus-133 derivation: its cyclic relation is carried as
+the #242 MemAlign h998/register-continuity/bus-133 derivation: its cyclic relation is carried as
 the verifier-checked `cyclic_successor_transitions_hold` accepted-trace
 certificate, never by a caller assumption. The structural fixed-domain/no-wrap
 bound and cyclic successor indexing belong to `Air.Flat.Table`, not to a


### PR DESCRIPTION
Relates to #242.

## Scope

- Adds the source-exact MemAlign D1/D3 transition surface, including c0/c1/c29 and the gated register continuities.
- Finishes the eight bus-107 range pulls against the exact static provider and updates all concrete/degenerate witnesses for the 14-table ensemble.
- Completes the MemAlignByte and MemAlignReadByte consumer paths with their exact range lookups.

## Trust surface

The new transition obligations are component-owned and carried by the existing verifier-checked `transitions_hold` and `cyclic_successor_transitions_hold` certificates; no caller promise or soundness-side `ProverAssumptions` was added. Exact membership is derived from finished-channel balance.

## Verification

- `lake build ZiskFv`
- `trust/scripts/check-all.sh` (V1)
- `trust/scripts/check-all-semantic.sh` (V2; canonical binder and axiom-closure baselines unchanged)
- `nix run .#test`

## Timeline status

This deliberately stops before the final timeline/residue-deletion PR. The strengthened source model still does not establish the legacy required `value_1 = 0` high-half condition. `mem_align.pil:176-189` reconstructs `value[1]` from the upper selected register chunks. The exact extracted ROM row `[1, -1, 0, 0, 1, 1]` permits `reg_4 = 1` (other selected registers zero), hence `value_1 = 1`; bus 107 only proves byte range and the source transition-selector gates are zero for this row. No workaround or carve-out is introduced here.