### PR TITLE
Construct the SD/LD Mem provider table

### DIFF
--- a/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean
@@ -1789,6 +1789,7 @@ def MemAlignLoadProviderRowMatchSpec
               ZiskFv.AirsClean.MemAlign.component.rowInputVar))
           0 entry
 
+set_option maxHeartbeats 1000000 in
 /-- A structural MemAlignReadByte load-provider row supplies the corresponding
     branch of the legacy subdoubleword provider witness, once the Main row's
     load width is pinned to one byte.
@@ -1796,7 +1797,6 @@ def MemAlignLoadProviderRowMatchSpec
 The selected row's byte range comes directly from the Clean component `Spec`:
 that is the source-faithful static-lookup conclusion carried by the accepted
 table, not a whole-table validator premise. -/
-set_option maxHeartbeats 1000000 in
 theorem exists_subdoublewordLoadProviderWitness_of_memAlignReadByteLoadProviderRowMatchSpec
     {length : ℕ} {program : Program length}
     {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
@@ -1816,7 +1816,8 @@ theorem exists_subdoublewordLoadProviderWitness_of_memAlignReadByteLoadProviderR
       (eval (providerTable.environment providerRow)
         ZiskFv.AirsClean.MemAlignReadByte.component.rowInputVar) := by
     rw [h_component] at h_spec
-    simpa only [ZiskFv.AirsClean.MemAlignReadByte.component_spec] using h_spec
+    rw [ZiskFv.AirsClean.MemAlignReadByte.component_spec] at h_spec
+    simpa only [Air.Flat.Component.rowInput, eval_varFromOffset_valueFromOffset] using h_spec
   refine ⟨
     ZiskFv.AirsClean.MemAlignReadByte.validOfRow
       (eval (providerTable.environment providerRow)
@@ -1825,13 +1826,13 @@ theorem exists_subdoublewordLoadProviderWitness_of_memAlignReadByteLoadProviderR
   exact
     { provider := Or.inr (Or.inl ⟨0, h_match, h_width, h_row_spec.2⟩) }
 
+set_option maxHeartbeats 1000000 in
 /-- A structural MemAlignByte load-provider row supplies the corresponding
     branch of the legacy subdoubleword provider witness, once the Main row's
     load width is pinned to one byte.
 
 As above, the selected row's range is derived from the table's in-circuit
 static lookup through its Clean component `Spec`. -/
-set_option maxHeartbeats 1000000 in
 theorem exists_subdoublewordLoadProviderWitness_of_memAlignByteLoadProviderRowMatchSpec
     {length : ℕ} {program : Program length}
     {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
@@ -1851,7 +1852,8 @@ theorem exists_subdoublewordLoadProviderWitness_of_memAlignByteLoadProviderRowMa
       (eval (providerTable.environment providerRow)
         ZiskFv.AirsClean.MemAlignByte.component.rowInputVar) := by
     rw [h_component] at h_spec
-    simpa only [ZiskFv.AirsClean.MemAlignByte.component_spec] using h_spec
+    rw [ZiskFv.AirsClean.MemAlignByte.component_spec] at h_spec
+    simpa only [Air.Flat.Component.rowInput, eval_varFromOffset_valueFromOffset] using h_spec
   refine ⟨
     ZiskFv.AirsClean.MemAlignByte.validOfRow
       (eval (providerTable.environment providerRow)

--- a/ZiskFv/AirsClean/Mem/GeneratedTransition.lean
+++ b/ZiskFv/AirsClean/Mem/GeneratedTransition.lean
@@ -184,6 +184,25 @@ theorem eval_memRawRow_materialize
     simp [IndexedFixedColumns.materialize, memFixedColumns, memFixedLayout, memRawRow,
       ProvableType.size]
 
+/-- Materializing a Mem row with its canonical prover-data range cells still
+    decodes the thirteen witness fields as the original row. -/
+theorem eval_memRawRowWithProverData_materialize
+    (index : Nat) (data : ProverData FGL) (row : MemRow FGL) :
+    Eval.eval
+      (Environment.fromArray (memFixedColumns.materialize index
+        (memRawRowWithProverData data row)) data)
+      (varFromOffset (F := FGL) MemRow 0) = row := by
+  rw [ProvableStruct.eval_eq_eval, ProvableStruct.varFromOffset_eq_varFromOffset]
+  unfold ProvableStruct.eval ProvableStruct.varFromOffset
+  simp only [instProvableStructMemRow, ProvableStruct.eval.go,
+    ProvableStruct.varFromOffset.go, ProvableType.eval_field,
+    ProvableType.varFromOffset_field, Expression.eval, Nat.zero_add]
+  cases row with
+  | mk addr step sel addr_changes step_dual sel_dual value_0 value_1 wr previous_step
+      increment_0 increment_1 read_same_addr =>
+    simp [IndexedFixedColumns.materialize, memFixedColumns, memFixedLayout,
+      memRawRowWithProverData, ProvableType.size]
+
 /-- Decode the 13 raw Mem witness cells from an effective transition environment. -/
 @[reducible]
 def memRowFromEnvironment (env : Environment FGL) : MemRow FGL :=

--- a/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
+++ b/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
@@ -170,6 +170,40 @@ private theorem component_constraintsHold_of_proverAssumptions_at
     (Component.constraintsHold_iff (component := component)
       (env := (proverEnv : Environment FGL))).mpr h_row
 
+private theorem component_constraintsHold_of_proverAssumptions_at_data
+    (component : Component FGL) (env : Environment FGL) (row : component.Input FGL)
+    (data : ProverData FGL)
+    (h_localLength : component.circuit.localLength component.rowInputVar = 0)
+    (h_input : Eval.eval env component.rowInputVar = row)
+    (h_data : env.data = data)
+    (h_assumptions :
+      component.circuit.ProverAssumptions row data (ProverHint.empty FGL)) :
+    component.operations.ConstraintsHold env := by
+  let proverEnv := proverEnvFromEnvironment env
+  have h_env : proverEnv.UsesLocalWitnesses component.rowOffset component.rowOperations := by
+    apply usesLocalWitnesses_of_localLength_zero
+    change ((component.circuit.main component.rowInputVar).localLength component.rowOffset) = 0
+    rw [component.circuit.localLength_eq]
+    exact h_localLength
+  have h_input' : Eval.eval proverEnv component.rowInputVar = row := by
+    rw [ProvableType.eval_varFromOffset_prover]
+    rw [← h_input]
+    rw [ProvableType.eval_varFromOffset]
+    congr
+  have h_assumptions' :
+      component.circuit.ProverAssumptions (Eval.eval proverEnv component.rowInputVar)
+        proverEnv.data proverEnv.hint := by
+    rw [h_input']
+    simpa [proverEnv, proverEnvFromEnvironment, h_data] using h_assumptions
+  have h_full :=
+    component.circuit.original_full_completeness component.rowOffset proverEnv component.rowInputVar
+      h_env h_assumptions'
+  have h_row : component.rowOperations.ConstraintsHold (proverEnv : Environment FGL) := by
+    simpa [Component.rowOperations, Component.rowInputVar, Component.rowOffset] using h_full.1
+  simpa [proverEnv, proverEnvFromEnvironment] using
+    (Component.constraintsHold_iff (component := component)
+      (env := (proverEnv : Environment FGL))).mpr h_row
+
 @[reducible] def mainRowArray (row : MainRowWithRom FGL) : Array FGL :=
   mainRawRow row
 
@@ -962,6 +996,83 @@ def memSingleRowTable (row : ZiskFv.AirsClean.Mem.MemRow FGL) : Table FGL where
     subst columns
     norm_num [ZiskFv.AirsClean.Mem.memFixedColumns, ZiskFv.AirsClean.Mem.memFixedCapacity]
 
+/-- A bounded sequence of concrete Mem rows with the component's canonical
+    prover-data-backed range cells materialized into every raw row. -/
+def memRowsTable
+    (data : ProverData FGL) (rows : List (ZiskFv.AirsClean.Mem.MemRow FGL))
+    (h_capacity : rows.length ≤ ZiskFv.AirsClean.Mem.memFixedCapacity) : Table FGL where
+  component := ZiskFv.AirsClean.Mem.componentWithDualMemBus
+  rawRows := rows.map (ZiskFv.AirsClean.Mem.memRawRowWithProverData data)
+  data := data
+  raw_uniform_width := by
+    intro raw h_raw
+    simp only [List.mem_map] at h_raw
+    obtain ⟨row, _, rfl⟩ := h_raw
+    simp [ZiskFv.AirsClean.Mem.componentWithDualMemBus,
+      ZiskFv.AirsClean.Mem.memRawRowWithProverData]
+  fixed_domain := by
+    intro columns h_columns
+    have h_columns' : columns = ZiskFv.AirsClean.Mem.memFixedColumns := by
+      simpa [ZiskFv.AirsClean.Mem.componentWithDualMemBus] using h_columns.symm
+    subst columns
+    change (rows.map (ZiskFv.AirsClean.Mem.memRawRowWithProverData data)).length ≤
+      ZiskFv.AirsClean.Mem.memFixedCapacity
+    simpa using h_capacity
+
+/-- The named Mem input decoded from a prover-data-materialized raw row is its
+    original thirteen-field witness row. -/
+theorem memRowsTable_rowInput
+    (index : Nat) (data : ProverData FGL) (row : ZiskFv.AirsClean.Mem.MemRow FGL) :
+    ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInput
+      (Environment.fromArray
+        (ZiskFv.AirsClean.Mem.memFixedColumns.materialize index
+          (ZiskFv.AirsClean.Mem.memRawRowWithProverData data row)) data) = row := by
+  simpa only [Air.Flat.Component.rowInput, eval_varFromOffset_valueFromOffset] using
+    ZiskFv.AirsClean.Mem.eval_memRawRowWithProverData_materialize index data row
+
+/-- Row-local Mem constraints for a bounded concrete table follow from each
+    row's honest completeness witness, using the same shared prover data as
+    the table's source-linked range cells. -/
+theorem memRowsTable_constraints_of_proverAssumptions
+    (data : ProverData FGL) (rows : List (ZiskFv.AirsClean.Mem.MemRow FGL))
+    (h_capacity : rows.length ≤ ZiskFv.AirsClean.Mem.memFixedCapacity)
+    (h_assumptions : ∀ index : Fin rows.length,
+      ZiskFv.AirsClean.Mem.componentWithDualMemBus.circuit.ProverAssumptions
+        (rows.get index) data (ProverHint.empty FGL)) :
+    (memRowsTable data rows h_capacity).Constraints := by
+  have h_localLength :
+      ZiskFv.AirsClean.Mem.componentWithDualMemBus.circuit.localLength
+        ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar = 0 := by
+    change ZiskFv.AirsClean.Mem.memWithDualMemBusElaborated.localLength
+      ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar = 0
+    rfl
+  rw [Table.Constraints]
+  change ∀ arr ∈ List.mapIdx (fun index raw =>
+      ZiskFv.AirsClean.Mem.memFixedColumns.materialize index raw)
+      (rows.map (ZiskFv.AirsClean.Mem.memRawRowWithProverData data)),
+    ZiskFv.AirsClean.Mem.componentWithDualMemBus.operations.ConstraintsHold
+      (Environment.fromArray arr data)
+  intro arr h_arr
+  obtain ⟨index, h_arr⟩ := List.mem_iff_get.mp h_arr
+  let rowsIndex : Fin rows.length := ⟨index.val, by simpa using index.isLt⟩
+  have h_effective :
+      (List.mapIdx (fun index raw =>
+        ZiskFv.AirsClean.Mem.memFixedColumns.materialize index raw)
+        (rows.map (ZiskFv.AirsClean.Mem.memRawRowWithProverData data))).get index =
+        ZiskFv.AirsClean.Mem.memFixedColumns.materialize rowsIndex.val
+          (ZiskFv.AirsClean.Mem.memRawRowWithProverData data (rows.get rowsIndex)) := by
+    simpa [List.mapIdx_eq_ofFn, rowsIndex]
+  rw [h_effective] at h_arr
+  subst arr
+  exact component_constraintsHold_of_proverAssumptions_at_data
+    ZiskFv.AirsClean.Mem.componentWithDualMemBus
+    (Environment.fromArray
+      (ZiskFv.AirsClean.Mem.memFixedColumns.materialize rowsIndex.val
+        (ZiskFv.AirsClean.Mem.memRawRowWithProverData data (rows.get rowsIndex))) data)
+    (rows.get rowsIndex) data h_localLength
+    (ZiskFv.AirsClean.Mem.eval_memRawRowWithProverData_materialize rowsIndex.val data
+      (rows.get rowsIndex)) rfl (h_assumptions rowsIndex)
+
 private theorem memSingleRowTable_effectiveRows
     (row : ZiskFv.AirsClean.Mem.MemRow FGL) :
     (memSingleRowTable row).table =
@@ -1000,6 +1111,132 @@ def memBusDualInteraction (row : ZiskFv.AirsClean.Mem.MemRow FGL) : Interaction 
   msg := (toElements (ZiskFv.AirsClean.Mem.memBusDualMessage row)).toArray
   same_size := by simp [Channel.toRaw]
   assumeGuarantees := false
+
+private theorem memComponentMemBusInteraction_eval_at
+    (index : Nat) (data : ProverData FGL) (row : ZiskFv.AirsClean.Mem.MemRow FGL) :
+    (((MemBusChannel.emitted
+        ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar.sel
+        (ZiskFv.AirsClean.Mem.memBusMessageExpr
+          ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar)).toRaw).eval
+      (Environment.fromArray
+        (ZiskFv.AirsClean.Mem.memFixedColumns.materialize index
+          (ZiskFv.AirsClean.Mem.memRawRowWithProverData data row)) data)) =
+      memBusInteraction row := by
+  let env := Environment.fromArray
+    (ZiskFv.AirsClean.Mem.memFixedColumns.materialize index
+      (ZiskFv.AirsClean.Mem.memRawRowWithProverData data row)) data
+  let rowVar := ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar
+  have h_input : eval env rowVar = row := by
+    dsimp [env, rowVar]
+    exact ZiskFv.AirsClean.Mem.eval_memRawRowWithProverData_materialize index data row
+  have h_field := memRow_eval_sel env rowVar
+  have h_msg_eval :
+      eval env (ZiskFv.AirsClean.Mem.memBusMessageExpr rowVar) =
+        ZiskFv.AirsClean.Mem.memBusMessage row := by
+    rw [ZiskFv.AirsClean.Mem.eval_memBusMessageExpr]
+    rw [h_input]
+  simp [memBusInteraction, AbstractInteraction.eval, ChannelInteraction.toRaw]
+  constructor
+  · change Expression.eval env rowVar.sel = row.sel
+    rw [h_field, h_input]
+  constructor
+  · rw [toElements_eval_toArray]
+    change (toElements
+        (eval env (ZiskFv.AirsClean.Mem.memBusMessageExpr rowVar))).toArray =
+      (toElements (ZiskFv.AirsClean.Mem.memBusMessage row)).toArray
+    rw [h_msg_eval]
+  · rfl
+
+private theorem memComponentMemBusDualInteraction_eval_at
+    (index : Nat) (data : ProverData FGL) (row : ZiskFv.AirsClean.Mem.MemRow FGL) :
+    (((MemBusChannel.emitted
+        ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar.sel_dual
+        (ZiskFv.AirsClean.Mem.memBusDualMessageExpr
+          ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar)).toRaw).eval
+      (Environment.fromArray
+        (ZiskFv.AirsClean.Mem.memFixedColumns.materialize index
+          (ZiskFv.AirsClean.Mem.memRawRowWithProverData data row)) data)) =
+      memBusDualInteraction row := by
+  let env := Environment.fromArray
+    (ZiskFv.AirsClean.Mem.memFixedColumns.materialize index
+      (ZiskFv.AirsClean.Mem.memRawRowWithProverData data row)) data
+  let rowVar := ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar
+  have h_input : eval env rowVar = row := by
+    dsimp [env, rowVar]
+    exact ZiskFv.AirsClean.Mem.eval_memRawRowWithProverData_materialize index data row
+  have h_field := memRow_eval_sel_dual env rowVar
+  have h_msg_eval :
+      eval env (ZiskFv.AirsClean.Mem.memBusDualMessageExpr rowVar) =
+        ZiskFv.AirsClean.Mem.memBusDualMessage row := by
+    rw [ZiskFv.AirsClean.Mem.eval_memBusDualMessageExpr]
+    rw [h_input]
+  simp [memBusDualInteraction, AbstractInteraction.eval, ChannelInteraction.toRaw]
+  constructor
+  · change Expression.eval env rowVar.sel_dual = row.sel_dual
+    rw [h_field, h_input]
+  constructor
+  · rw [toElements_eval_toArray]
+    change (toElements
+        (eval env (ZiskFv.AirsClean.Mem.memBusDualMessageExpr rowVar))).toArray =
+      (toElements (ZiskFv.AirsClean.Mem.memBusDualMessage row)).toArray
+    rw [h_msg_eval]
+  · rfl
+
+private theorem memRowsTable_memBus_row
+    (index : Nat) (data : ProverData FGL) (row : ZiskFv.AirsClean.Mem.MemRow FGL) :
+    ZiskFv.AirsClean.Mem.componentWithDualMemBus.operations.interactionValuesWith
+        MemBusChannel.toRaw
+        (Environment.fromArray
+          (ZiskFv.AirsClean.Mem.memFixedColumns.materialize index
+            (ZiskFv.AirsClean.Mem.memRawRowWithProverData data row)) data) =
+      [memBusInteraction row, memBusDualInteraction row] := by
+  rw [Operations.interactionValuesWith_eq_map,
+    ZiskFv.AirsClean.Mem.componentWithDualMemBus_interactionsWith_memBus]
+  simp only [List.map_cons, List.map_nil]
+  exact congrArg₂ (fun primary dual => [primary, dual])
+    (memComponentMemBusInteraction_eval_at index data row)
+    (memComponentMemBusDualInteraction_eval_at index data row)
+
+private theorem memRowsTable_interactionsWith_memBus_go
+    (data : ProverData FGL) :
+    ∀ (offset : Nat) (rows : List (ZiskFv.AirsClean.Mem.MemRow FGL)),
+      (List.mapIdx (fun index raw =>
+        ZiskFv.AirsClean.Mem.memFixedColumns.materialize (offset + index) raw)
+        (rows.map (ZiskFv.AirsClean.Mem.memRawRowWithProverData data))).flatMap (fun arr =>
+          ZiskFv.AirsClean.Mem.componentWithDualMemBus.operations.interactionValuesWith
+            MemBusChannel.toRaw (Environment.fromArray arr data)) =
+        rows.flatMap fun row => [memBusInteraction row, memBusDualInteraction row] := by
+  intro offset rows
+  induction rows generalizing offset with
+  | nil => rfl
+  | cons row rows ih =>
+      simp only [List.map_cons, List.mapIdx_cons, List.flatMap_cons]
+      rw [memRowsTable_memBus_row]
+      have h_indexed :
+          (fun index raw => ZiskFv.AirsClean.Mem.memFixedColumns.materialize
+              (offset + (index + 1)) raw) =
+            (fun index raw => ZiskFv.AirsClean.Mem.memFixedColumns.materialize
+              ((offset + 1) + index) raw) := by
+        funext index raw
+        congr 1
+        omega
+      rw [h_indexed]
+      exact congrArg (fun tail => [memBusInteraction row, memBusDualInteraction row] ++ tail)
+        (ih (offset := offset + 1))
+
+theorem memRowsTable_interactionsWith_memBus
+    (data : ProverData FGL) (rows : List (ZiskFv.AirsClean.Mem.MemRow FGL))
+    (h_capacity : rows.length ≤ ZiskFv.AirsClean.Mem.memFixedCapacity) :
+    (memRowsTable data rows h_capacity).interactionsWith MemBusChannel.toRaw =
+      rows.flatMap fun row => [memBusInteraction row, memBusDualInteraction row] := by
+  change
+    (List.mapIdx (fun index raw =>
+      ZiskFv.AirsClean.Mem.memFixedColumns.materialize index raw)
+      (rows.map (ZiskFv.AirsClean.Mem.memRawRowWithProverData data))).flatMap (fun arr =>
+        ZiskFv.AirsClean.Mem.componentWithDualMemBus.operations.interactionValuesWith
+          MemBusChannel.toRaw (Environment.fromArray arr data)) =
+      rows.flatMap fun row => [memBusInteraction row, memBusDualInteraction row]
+  simpa using memRowsTable_interactionsWith_memBus_go data 0 rows
 
 theorem memComponentMemBusInteraction_eval
     (row : ZiskFv.AirsClean.Mem.MemRow FGL) :

--- a/ZiskFv/Compliance/SdLdMemTable.lean
+++ b/ZiskFv/Compliance/SdLdMemTable.lean
@@ -1,0 +1,463 @@
+import ZiskFv.Compliance.Instantiation.ConcreteRowReductions
+import ZiskFv.AirsClean.FullEnsemble.Balance.TableProjections
+
+/-!
+# Concrete SD/LD Mem provider table
+
+The #221 constructibility phase fixes the first non-empty mutable-Mem table
+used by an accepted trace: an SD of the non-zero doubleword `42`, followed by
+an LD of the same word.  The table has the physical Mem fixed schema, so its
+first row is the actual segment boundary rather than a synthetic prefix.
+
+Regenerate the sidecar literals with the arithmetic recorded in
+`docs/ai/plan/PLAN_MEM_PREFIX_221.md`; they solve `mem.pil`'s generated
+segment and permutation equations for `std_alpha = 0`, `std_gamma = 1`.
+-/
+
+namespace ZiskFv.Compliance
+
+open Goldilocks
+open Air.Flat
+open ZiskFv.AirsClean
+open ZiskFv.AirsClean.Mem
+open ZiskFv.AirsClean.FullEnsemble
+open ZiskFv.Compliance.Instantiation
+open ZiskFv.Channels.MemoryBus (MemBusChannel)
+
+/-- Store `42` at Mem word address `0x14000001` on step 3. -/
+def sdMemRow : MemRow FGL :=
+  memRowOf true false true true 335544321 3 0 0 0 0 42 0
+
+/-- Load the stored word from the same Mem address on step 6. -/
+def ldMemRow : MemRow FGL :=
+  memRowOf true false false false 335544321 6 0 3 3 0 42 0
+
+/-- The first non-degenerate mutable-Mem timeline: a write followed by a
+same-address read of its non-zero value. -/
+def sdLdMemRows : List (MemRow FGL) := [sdMemRow, ldMemRow]
+
+/-- A one-column prover-data entry with one scalar at each provided row. -/
+private def memPrefixColumn (values : Array FGL) (width : Nat) : Array (Vector FGL width) :=
+  values.map fun value => Vector.ofFn fun _ : Fin width => value
+
+/-- Canonical generated Mem sidecars for the concrete two-row timeline.
+
+`SEGMENT_L1` and `__L1__` are deliberately absent: they are component-owned
+physical fixed columns (`[1, 0, ...]`), not prover-controlled data. -/
+def sdLdMemData : ProverData FGL := fun key width =>
+  memPrefixColumn
+    (if key = MemRawSidecarDataKey.gsum then #[13400303369572487623, 8353862669730390925]
+    else if key = MemRawSidecarDataKey.im0 then #[10110234730352224099, 10110234730352224099]
+    else if key = MemRawSidecarDataKey.im1 then #[8384883667915720146, 8384883667915720146]
+    else if key = MemRawSidecarDataKey.Segment.segmentId then #[0]
+    else if key = MemRawSidecarDataKey.Segment.isFirstSegment then #[1]
+    else if key = MemRawSidecarDataKey.Segment.isLastSegment then #[1]
+    else if key = MemRawSidecarDataKey.Segment.previousSegmentValue0 then #[0]
+    else if key = MemRawSidecarDataKey.Segment.previousSegmentValue1 then #[0]
+    else if key = MemRawSidecarDataKey.Segment.previousSegmentStep then #[0]
+    else if key = MemRawSidecarDataKey.Segment.previousSegmentAddr then #[335544320]
+    else if key = MemRawSidecarDataKey.Segment.segmentLastValue0 then #[42]
+    else if key = MemRawSidecarDataKey.Segment.segmentLastValue1 then #[0]
+    else if key = MemRawSidecarDataKey.Segment.segmentLastStep then #[6]
+    else if key = MemRawSidecarDataKey.Segment.segmentLastAddr then #[335544321]
+    else if key = MemRawSidecarDataKey.Segment.distanceBase0 then #[0]
+    else if key = MemRawSidecarDataKey.Segment.distanceBase1 then #[0]
+    else if key = MemRawSidecarDataKey.Segment.distanceEnd0 then #[65534]
+    else if key = MemRawSidecarDataKey.Segment.distanceEnd1 then #[1023]
+    else if key = MemRawSidecarDataKey.Permutation.stdAlpha then #[0]
+    else if key = MemRawSidecarDataKey.Permutation.stdGamma then #[1]
+    else if key = MemRawSidecarDataKey.Permutation.imDirect0 then #[1537228672451215360]
+    else if key = MemRawSidecarDataKey.Permutation.imDirect1 then #[0]
+    else if key = MemRawSidecarDataKey.Permutation.imDirect2 then #[10110234730352224099]
+    else if key = MemRawSidecarDataKey.Permutation.imDirect3 then #[10110234730352224099]
+    else if key = MemRawSidecarDataKey.Permutation.imDirect4 then #[10110234730352224099]
+    else if key = MemRawSidecarDataKey.Permutation.imDirect5 then #[10110234730352224099]
+    else #[]) width
+
+theorem sdLdMemRows_capacity : sdLdMemRows.length ≤ memFixedCapacity := by
+  norm_num [sdLdMemRows, memFixedCapacity]
+
+/-- The concrete two-row provider table, backed by the canonical generated
+sidecar keys and the physical 2^22-row Mem fixed schema. -/
+def sdLdMemTable : Table FGL :=
+  memRowsTable sdLdMemData sdLdMemRows sdLdMemRows_capacity
+
+theorem sdMemRow_rangeFacts : dualMemRowRangeFacts sdMemRow := by
+  norm_num [dualMemRowRangeFacts, sdMemRow, memRowOf, memReadSameAddrOf, memValueOf]
+
+theorem ldMemRow_rangeFacts : dualMemRowRangeFacts ldMemRow := by
+  norm_num [dualMemRowRangeFacts, ldMemRow, memRowOf, memReadSameAddrOf, memValueOf]
+
+theorem sdMemRow_proverAssumptions :
+    componentWithDualMemBus.circuit.ProverAssumptions sdMemRow sdLdMemData
+      (ProverHint.empty FGL) := by
+  refine ⟨true, false, true, true, 335544321, 3, 0, 0, 0, 0, 42, 0,
+    (by intro _; rfl), (by intro _; rfl), sdMemRow_rangeFacts, ?_⟩
+  rfl
+
+theorem ldMemRow_proverAssumptions :
+    componentWithDualMemBus.circuit.ProverAssumptions ldMemRow sdLdMemData
+      (ProverHint.empty FGL) := by
+  refine ⟨true, false, false, false, 335544321, 6, 0, 3, 3, 0, 42, 0,
+    (by intro _; rfl), (by intro _; rfl), ldMemRow_rangeFacts, ?_⟩
+  rfl
+
+theorem sdLdMemRows_proverAssumptions (index : Fin sdLdMemRows.length) :
+    componentWithDualMemBus.circuit.ProverAssumptions (sdLdMemRows.get index)
+      sdLdMemData (ProverHint.empty FGL) := by
+  have h_index : index.val < 2 := by
+    simpa [sdLdMemRows] using index.isLt
+  interval_cases h : index.val
+  · have h_eq : index = ⟨0, by simp [sdLdMemRows]⟩ := Fin.ext (by omega)
+    subst index
+    simpa [sdLdMemRows] using sdMemRow_proverAssumptions
+  · have h_eq : index = ⟨1, by simp [sdLdMemRows]⟩ := Fin.ext (by omega)
+    subst index
+    simpa [sdLdMemRows] using ldMemRow_proverAssumptions
+
+theorem sdLdMemTable_constraints : sdLdMemTable.Constraints := by
+  exact memRowsTable_constraints_of_proverAssumptions sdLdMemData sdLdMemRows
+    sdLdMemRows_capacity sdLdMemRows_proverAssumptions
+
+theorem sdLdMemTable_memBusInteractions :
+    sdLdMemTable.interactionsWith MemBusChannel.toRaw =
+      [memBusInteraction sdMemRow, memBusDualInteraction sdMemRow,
+        memBusInteraction ldMemRow, memBusDualInteraction ldMemRow] := by
+  rw [sdLdMemTable, memRowsTable_interactionsWith_memBus]
+  rfl
+
+@[simp] theorem sdLdMemTable_length : sdLdMemTable.length = 2 := by
+  rfl
+
+@[simp] theorem sdLdMemData_isFirstSegment :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Segment.isFirstSegment = 1 := by
+  have h_gsum : MemRawSidecarDataKey.Segment.isFirstSegment ≠ MemRawSidecarDataKey.gsum :=
+    by decide
+  have h_im0 : MemRawSidecarDataKey.Segment.isFirstSegment ≠ MemRawSidecarDataKey.im0 :=
+    by decide
+  have h_im1 : MemRawSidecarDataKey.Segment.isFirstSegment ≠ MemRawSidecarDataKey.im1 :=
+    by decide
+  have h_segmentId :
+      MemRawSidecarDataKey.Segment.isFirstSegment ≠ MemRawSidecarDataKey.Segment.segmentId :=
+    by decide
+  simp [proverDataScalar, proverDataColumn, sdLdMemData, memPrefixColumn,
+    h_gsum, h_im0, h_im1, h_segmentId]
+
+@[simp] theorem sdLdMemData_gsum_zero :
+    memSidecarGsumOfProverData sdLdMemData 0 = 13400303369572487623 := by
+  norm_num [memSidecarGsumOfProverData, proverDataColumn, sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_gsum_one :
+    memSidecarGsumOfProverData sdLdMemData 1 = 8353862669730390925 := by
+  simp (config := { decide := true }) [memSidecarGsumOfProverData,
+    proverDataColumn, sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_im0_zero :
+    memSidecarIm0OfProverData sdLdMemData 0 = 10110234730352224099 := by
+  simp (config := { decide := true }) [memSidecarIm0OfProverData,
+    proverDataColumn, sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_im0_one :
+    memSidecarIm0OfProverData sdLdMemData 1 = 10110234730352224099 := by
+  simp (config := { decide := true }) [memSidecarIm0OfProverData,
+    proverDataColumn, sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_im1_zero :
+    memSidecarIm1OfProverData sdLdMemData 0 = 8384883667915720146 := by
+  simp (config := { decide := true }) [memSidecarIm1OfProverData,
+    proverDataColumn, sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_im1_one :
+    memSidecarIm1OfProverData sdLdMemData 1 = 8384883667915720146 := by
+  simp (config := { decide := true }) [memSidecarIm1OfProverData,
+    proverDataColumn, sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_segmentId :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Segment.segmentId = 0 := by
+  simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
+    sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_isLastSegment :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Segment.isLastSegment = 1 := by
+  simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
+    sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_previousSegmentValue0 :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Segment.previousSegmentValue0 = 0 := by
+  simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
+    sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_previousSegmentValue1 :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Segment.previousSegmentValue1 = 0 := by
+  simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
+    sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_previousSegmentStep :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Segment.previousSegmentStep = 0 := by
+  simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
+    sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_previousSegmentAddr :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Segment.previousSegmentAddr = 335544320 := by
+  simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
+    sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_segmentLastValue0 :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Segment.segmentLastValue0 = 42 := by
+  simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
+    sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_segmentLastValue1 :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Segment.segmentLastValue1 = 0 := by
+  simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
+    sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_segmentLastStep :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Segment.segmentLastStep = 6 := by
+  simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
+    sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_segmentLastAddr :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Segment.segmentLastAddr = 335544321 := by
+  simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
+    sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_distanceBase0 :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Segment.distanceBase0 = 0 := by
+  simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
+    sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_distanceBase1 :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Segment.distanceBase1 = 0 := by
+  simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
+    sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_distanceEnd0 :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Segment.distanceEnd0 = 65534 := by
+  simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
+    sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_distanceEnd1 :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Segment.distanceEnd1 = 1023 := by
+  simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
+    sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_stdAlpha :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Permutation.stdAlpha = 0 := by
+  simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
+    sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_stdGamma :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Permutation.stdGamma = 1 := by
+  simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
+    sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_imDirect0 :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Permutation.imDirect0 = 1537228672451215360 := by
+  simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
+    sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_imDirect1 :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Permutation.imDirect1 = 0 := by
+  simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
+    sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_imDirect2 :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Permutation.imDirect2 = 10110234730352224099 := by
+  simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
+    sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_imDirect3 :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Permutation.imDirect3 = 10110234730352224099 := by
+  simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
+    sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_imDirect4 :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Permutation.imDirect4 = 10110234730352224099 := by
+  simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
+    sdLdMemData, memPrefixColumn]
+
+@[simp] theorem sdLdMemData_imDirect5 :
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Permutation.imDirect5 = 10110234730352224099 := by
+  simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
+    sdLdMemData, memPrefixColumn]
+
+private def sdLdMemSegmentColumns : ZiskFv.Airs.Mem.SegmentColumns FGL where
+  segment_id := 0
+  is_first_segment := 1
+  is_last_segment := 1
+  previous_segment_value_0 := 0
+  previous_segment_value_1 := 0
+  previous_segment_step := 0
+  previous_segment_addr := 335544320
+  segment_last_value_0 := 42
+  segment_last_value_1 := 0
+  segment_last_step := 6
+  segment_last_addr := 335544321
+  distance_base_0 := 0
+  distance_base_1 := 0
+  distance_end_0 := 65534
+  distance_end_1 := 1023
+  segment_l1 := fun row => memFixedColumns.fixedAt MemFixedColumn.segmentL1 row
+
+private def sdLdMemPermutationColumns : ZiskFv.Airs.Mem.PermutationColumns FGL where
+  std_alpha := 0
+  std_gamma := 1
+  l1 := fun row => memFixedColumns.fixedAt MemFixedColumn.l1 row
+  im_direct_0 := 1537228672451215360
+  im_direct_1 := 0
+  im_direct_2 := 10110234730352224099
+  im_direct_3 := 10110234730352224099
+  im_direct_4 := 10110234730352224099
+  im_direct_5 := 10110234730352224099
+
+private theorem sdLdMemSegmentColumns_source :
+    memSegmentColumnsOfProverDataAndFixed sdLdMemData
+      (fun row => memFixedColumns.fixedAt MemFixedColumn.segmentL1 row) =
+      sdLdMemSegmentColumns := by
+  simp [sdLdMemSegmentColumns]
+
+private theorem sdLdMemPermutationColumns_source :
+    memPermutationColumnsOfProverDataAndFixed sdLdMemData
+      (fun row => memFixedColumns.fixedAt MemFixedColumn.l1 row) =
+      sdLdMemPermutationColumns := by
+  simp [sdLdMemPermutationColumns]
+
+@[simp] theorem sdLdMemTable_memRowAt_zero :
+    memRowFromEnvironment (sdLdMemTable.environmentAt ⟨0, by simp⟩) = sdMemRow := by
+  change Eval.eval
+      (Environment.fromArray
+        (memFixedColumns.materialize 0 (memRawRowWithProverData sdLdMemData sdMemRow))
+        sdLdMemData)
+      (varFromOffset (F := FGL) MemRow 0) = sdMemRow
+  exact eval_memRawRowWithProverData_materialize 0 sdLdMemData sdMemRow
+
+@[simp] theorem sdLdMemTable_memRowAt_one :
+    memRowFromEnvironment (sdLdMemTable.environmentAt ⟨1, by simp⟩) = ldMemRow := by
+  change Eval.eval
+      (Environment.fromArray
+        (memFixedColumns.materialize 1 (memRawRowWithProverData sdLdMemData ldMemRow))
+        sdLdMemData)
+      (varFromOffset (F := FGL) MemRow 0) = ldMemRow
+  exact eval_memRawRowWithProverData_materialize 1 sdLdMemData ldMemRow
+
+private theorem sdLdMemTable_rangeBridge_zero :
+    memRangeSidecarBridge (sdLdMemTable.environmentAt ⟨0, by simp⟩) := by
+  exact ⟨eval_memDistanceBase0Expr_materialize 0 sdLdMemData sdMemRow,
+    eval_memDistanceBase1Expr_materialize 0 sdLdMemData sdMemRow,
+    eval_memDistanceEnd0Expr_materialize 0 sdLdMemData sdMemRow,
+    eval_memDistanceEnd1Expr_materialize 0 sdLdMemData sdMemRow⟩
+
+private theorem sdLdMemTable_rangeBridge_one :
+    memRangeSidecarBridge (sdLdMemTable.environmentAt ⟨1, by simp⟩) := by
+  exact ⟨eval_memDistanceBase0Expr_materialize 1 sdLdMemData ldMemRow,
+    eval_memDistanceBase1Expr_materialize 1 sdLdMemData ldMemRow,
+    eval_memDistanceEnd0Expr_materialize 1 sdLdMemData ldMemRow,
+    eval_memDistanceEnd1Expr_materialize 1 sdLdMemData ldMemRow⟩
+
+@[simp] theorem sdLdMemFixed_segmentL1_zero :
+    memFixedColumns.fixedAt MemFixedColumn.segmentL1 0 = 1 := by rfl
+
+@[simp] theorem sdLdMemFixed_segmentL1_one :
+    memFixedColumns.fixedAt MemFixedColumn.segmentL1 1 = 0 := by rfl
+
+@[simp] theorem sdLdMemFixed_segmentL1_two :
+    memFixedColumns.fixedAt MemFixedColumn.segmentL1 2 = 0 := by rfl
+
+@[simp] theorem sdLdMemFixed_l1_zero :
+    memFixedColumns.fixedAt MemFixedColumn.l1 0 = 1 := by rfl
+
+@[simp] theorem sdLdMemFixed_l1_one :
+    memFixedColumns.fixedAt MemFixedColumn.l1 1 = 0 := by rfl
+
+@[simp] theorem sdLdMemFixed_l1_two :
+    memFixedColumns.fixedAt MemFixedColumn.l1 2 = 0 := by rfl
+
+/-- The two real Mem rows satisfy every generated continuity, range-source,
+and permutation equation. Row zero uses the component's saturated
+predecessor; row one uses the preceding store row. -/
+theorem sdLdMemTable_transitions : sdLdMemTable.TransitionConstraints := by
+  rw [Table.TransitionConstraints]
+  intro index
+  have h_index_lt : index.val < 2 := by
+    simpa only [sdLdMemTable_length] using index.isLt
+  interval_cases h : index.val
+  · have h_eq : index = ⟨0, by simp⟩ := Fin.ext (by omega)
+    subst index
+    let previous := sdLdMemTable.previousEnvironment ⟨0, by simp⟩
+    let current := sdLdMemTable.environmentAt ⟨0, by simp⟩
+    have h_current : memRowFromEnvironment current = sdMemRow := by
+      exact sdLdMemTable_memRowAt_zero
+    have h_previous :
+        memRowFromEnvironment previous = sdMemRow := by
+      dsimp [previous]
+      simpa only [Table.previousEnvironment, Nat.zero_sub] using h_current
+    have h_data : current.data = sdLdMemData := by rfl
+    have h_range : memRangeSidecarBridge current := by
+      exact sdLdMemTable_rangeBridge_zero
+    change generatedTransition memFixedColumns 0 previous current
+    simp only [generatedTransition, h_data, sdLdMemSegmentColumns_source,
+      sdLdMemPermutationColumns_source]
+    refine ⟨?_, ?_, h_range⟩
+    · norm_num [ZiskFv.Airs.Mem.segmentResidualEveryRow, memWindow, h_current,
+        h_previous, sdLdMemSegmentColumns, ZiskFv.Airs.Mem.previous_row_step,
+        ZiskFv.Airs.Mem.delta_addr, ZiskFv.Airs.Mem.segment_previous_addr,
+        ZiskFv.Airs.Mem.delta_step, ZiskFv.Airs.Mem.segment_previous_value_0,
+        ZiskFv.Airs.Mem.segment_previous_value_1, sdMemRow, memRowOf,
+        memReadSameAddrOf, memValueOf]
+    · norm_num [ZiskFv.Airs.Mem.permutation_every_row, memWindow, h_current,
+        h_previous, h_data, sdLdMemPermutationColumns, ZiskFv.Airs.Mem.gsum_increment_1,
+        ZiskFv.Airs.Mem.gsum_dual_step, ZiskFv.Airs.Mem.gsum_increment_0,
+        ZiskFv.Airs.Mem.gsum_primary_mem, ZiskFv.Airs.Mem.gsum_dual_mem,
+        sdLdMemSegmentColumns, ZiskFv.Airs.Mem.direct_gsum_0, ZiskFv.Airs.Mem.direct_gsum_1,
+        ZiskFv.Airs.Mem.direct_gsum_distance_base_0,
+        ZiskFv.Airs.Mem.direct_gsum_distance_base_1,
+        ZiskFv.Airs.Mem.direct_gsum_distance_end_0,
+        ZiskFv.Airs.Mem.direct_gsum_distance_end_1,
+        ZiskFv.Airs.Mem.gsum_accumulator_delta, sdMemRow, memRowOf,
+        memReadSameAddrOf, memValueOf] <;> decide
+  · have h_eq : index = ⟨1, by simp⟩ := Fin.ext (by omega)
+    subst index
+    let previous := sdLdMemTable.previousEnvironment ⟨1, by simp⟩
+    let current := sdLdMemTable.environmentAt ⟨1, by simp⟩
+    have h_current : memRowFromEnvironment current = ldMemRow := by
+      exact sdLdMemTable_memRowAt_one
+    have h_previous :
+        memRowFromEnvironment previous = sdMemRow := by
+      dsimp [previous]
+      simpa only [Table.previousEnvironment] using sdLdMemTable_memRowAt_zero
+    have h_data : current.data = sdLdMemData := by rfl
+    have h_range : memRangeSidecarBridge current := by
+      exact sdLdMemTable_rangeBridge_one
+    change generatedTransition memFixedColumns 1 previous current
+    simp only [generatedTransition, h_data, sdLdMemSegmentColumns_source,
+      sdLdMemPermutationColumns_source]
+    refine ⟨?_, ?_, h_range⟩
+    · norm_num [ZiskFv.Airs.Mem.segmentResidualEveryRow, memWindow, h_current,
+        h_previous, sdLdMemSegmentColumns, ZiskFv.Airs.Mem.previous_row_step,
+        ZiskFv.Airs.Mem.delta_addr, ZiskFv.Airs.Mem.segment_previous_addr,
+        ZiskFv.Airs.Mem.delta_step, ZiskFv.Airs.Mem.segment_previous_value_0,
+        ZiskFv.Airs.Mem.segment_previous_value_1, sdMemRow, ldMemRow, memRowOf,
+        memReadSameAddrOf, memValueOf]
+    · norm_num [ZiskFv.Airs.Mem.permutation_every_row, memWindow, h_current,
+        h_previous, h_data, sdLdMemPermutationColumns, ZiskFv.Airs.Mem.gsum_increment_1,
+        ZiskFv.Airs.Mem.gsum_dual_step, ZiskFv.Airs.Mem.gsum_increment_0,
+        ZiskFv.Airs.Mem.gsum_primary_mem, ZiskFv.Airs.Mem.gsum_dual_mem,
+        sdLdMemSegmentColumns, ZiskFv.Airs.Mem.direct_gsum_0, ZiskFv.Airs.Mem.direct_gsum_1,
+        ZiskFv.Airs.Mem.direct_gsum_distance_base_0,
+        ZiskFv.Airs.Mem.direct_gsum_distance_base_1,
+        ZiskFv.Airs.Mem.direct_gsum_distance_end_0,
+        ZiskFv.Airs.Mem.direct_gsum_distance_end_1,
+        ZiskFv.Airs.Mem.gsum_accumulator_delta, sdMemRow, ldMemRow, memRowOf,
+        memReadSameAddrOf, memValueOf] <;> decide
+
+/-- The full `mem.pil` generated surface (segment 0--23 and permutation
+24--33) is available from this table's ordinary constraints and indexed
+transition certificate; it is not a separate accepted-trace premise. -/
+theorem sdLdMemTable_generatedConstraintFacts :
+    MemTableGeneratedConstraintFacts sdLdMemTable (memOfTableData sdLdMemTable)
+      (memSegmentOfTableData sdLdMemTable) (memPermutationOfTableData sdLdMemTable) := by
+  exact memTableGeneratedConstraintFacts_of_component_constraints_transitions
+    sdLdMemTable rfl sdLdMemTable_constraints sdLdMemTable_transitions
+
+end ZiskFv.Compliance

--- a/ZiskFv/Compliance/SdLdMemTable.lean
+++ b/ZiskFv/Compliance/SdLdMemTable.lean
@@ -24,13 +24,13 @@ open ZiskFv.AirsClean.FullEnsemble
 open ZiskFv.Compliance.Instantiation
 open ZiskFv.Channels.MemoryBus (MemBusChannel)
 
-/-- Store `42` at Mem word address `0x14000001` on Main step 4. -/
+/-- Store `42` at Mem word address `0x14000001` at its c-slot timestamp 19. -/
 def sdMemRow : MemRow FGL :=
-  memRowOf true false true true 335544321 4 0 0 0 0 42 0
+  memRowOf true false true true 335544321 19 0 0 0 0 42 0
 
-/-- Load the stored word from the same Mem address on Main step 5. -/
+/-- Load the stored word from the same Mem address at its b-slot timestamp 22. -/
 def ldMemRow : MemRow FGL :=
-  memRowOf true false false false 335544321 5 0 4 1 0 42 0
+  memRowOf true false false false 335544321 22 0 19 3 0 42 0
 
 /-- The first non-degenerate mutable-Mem timeline: a write followed by a
 same-address read of its non-zero value. -/
@@ -58,7 +58,7 @@ def sdLdMemData : ProverData FGL := fun key width =>
     else if key = MemRawSidecarDataKey.Segment.previousSegmentAddr then #[335544320]
     else if key = MemRawSidecarDataKey.Segment.segmentLastValue0 then #[42]
     else if key = MemRawSidecarDataKey.Segment.segmentLastValue1 then #[0]
-    else if key = MemRawSidecarDataKey.Segment.segmentLastStep then #[5]
+    else if key = MemRawSidecarDataKey.Segment.segmentLastStep then #[22]
     else if key = MemRawSidecarDataKey.Segment.segmentLastAddr then #[335544321]
     else if key = MemRawSidecarDataKey.Segment.distanceBase0 then #[0]
     else if key = MemRawSidecarDataKey.Segment.distanceBase1 then #[0]
@@ -91,14 +91,14 @@ theorem ldMemRow_rangeFacts : dualMemRowRangeFacts ldMemRow := by
 theorem sdMemRow_proverAssumptions :
     componentWithDualMemBus.circuit.ProverAssumptions sdMemRow sdLdMemData
       (ProverHint.empty FGL) := by
-  refine ⟨true, false, true, true, 335544321, 4, 0, 0, 0, 0, 42, 0,
+  refine ⟨true, false, true, true, 335544321, 19, 0, 0, 0, 0, 42, 0,
     (by intro _; rfl), (by intro _; rfl), sdMemRow_rangeFacts, ?_⟩
   rfl
 
 theorem ldMemRow_proverAssumptions :
     componentWithDualMemBus.circuit.ProverAssumptions ldMemRow sdLdMemData
       (ProverHint.empty FGL) := by
-  refine ⟨true, false, false, false, 335544321, 5, 0, 4, 1, 0, 42, 0,
+  refine ⟨true, false, false, false, 335544321, 22, 0, 19, 3, 0, 42, 0,
     (by intro _; rfl), (by intro _; rfl), ldMemRow_rangeFacts, ?_⟩
   rfl
 
@@ -213,7 +213,7 @@ theorem sdLdMemTable_memBusInteractions :
     sdLdMemData, memPrefixColumn]
 
 @[simp] theorem sdLdMemData_segmentLastStep :
-    proverDataScalar sdLdMemData MemRawSidecarDataKey.Segment.segmentLastStep = 5 := by
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Segment.segmentLastStep = 22 := by
   simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
     sdLdMemData, memPrefixColumn]
 
@@ -292,7 +292,7 @@ private def sdLdMemSegmentColumns : ZiskFv.Airs.Mem.SegmentColumns FGL where
   previous_segment_addr := 335544320
   segment_last_value_0 := 42
   segment_last_value_1 := 0
-  segment_last_step := 5
+  segment_last_step := 22
   segment_last_addr := 335544321
   distance_base_0 := 0
   distance_base_1 := 0

--- a/ZiskFv/Compliance/SdLdMemTable.lean
+++ b/ZiskFv/Compliance/SdLdMemTable.lean
@@ -24,13 +24,13 @@ open ZiskFv.AirsClean.FullEnsemble
 open ZiskFv.Compliance.Instantiation
 open ZiskFv.Channels.MemoryBus (MemBusChannel)
 
-/-- Store `42` at Mem word address `0x14000001` on step 3. -/
+/-- Store `42` at Mem word address `0x14000001` on Main step 4. -/
 def sdMemRow : MemRow FGL :=
-  memRowOf true false true true 335544321 3 0 0 0 0 42 0
+  memRowOf true false true true 335544321 4 0 0 0 0 42 0
 
-/-- Load the stored word from the same Mem address on step 6. -/
+/-- Load the stored word from the same Mem address on Main step 5. -/
 def ldMemRow : MemRow FGL :=
-  memRowOf true false false false 335544321 6 0 3 3 0 42 0
+  memRowOf true false false false 335544321 5 0 4 1 0 42 0
 
 /-- The first non-degenerate mutable-Mem timeline: a write followed by a
 same-address read of its non-zero value. -/
@@ -58,7 +58,7 @@ def sdLdMemData : ProverData FGL := fun key width =>
     else if key = MemRawSidecarDataKey.Segment.previousSegmentAddr then #[335544320]
     else if key = MemRawSidecarDataKey.Segment.segmentLastValue0 then #[42]
     else if key = MemRawSidecarDataKey.Segment.segmentLastValue1 then #[0]
-    else if key = MemRawSidecarDataKey.Segment.segmentLastStep then #[6]
+    else if key = MemRawSidecarDataKey.Segment.segmentLastStep then #[5]
     else if key = MemRawSidecarDataKey.Segment.segmentLastAddr then #[335544321]
     else if key = MemRawSidecarDataKey.Segment.distanceBase0 then #[0]
     else if key = MemRawSidecarDataKey.Segment.distanceBase1 then #[0]
@@ -91,14 +91,14 @@ theorem ldMemRow_rangeFacts : dualMemRowRangeFacts ldMemRow := by
 theorem sdMemRow_proverAssumptions :
     componentWithDualMemBus.circuit.ProverAssumptions sdMemRow sdLdMemData
       (ProverHint.empty FGL) := by
-  refine ⟨true, false, true, true, 335544321, 3, 0, 0, 0, 0, 42, 0,
+  refine ⟨true, false, true, true, 335544321, 4, 0, 0, 0, 0, 42, 0,
     (by intro _; rfl), (by intro _; rfl), sdMemRow_rangeFacts, ?_⟩
   rfl
 
 theorem ldMemRow_proverAssumptions :
     componentWithDualMemBus.circuit.ProverAssumptions ldMemRow sdLdMemData
       (ProverHint.empty FGL) := by
-  refine ⟨true, false, false, false, 335544321, 6, 0, 3, 3, 0, 42, 0,
+  refine ⟨true, false, false, false, 335544321, 5, 0, 4, 1, 0, 42, 0,
     (by intro _; rfl), (by intro _; rfl), ldMemRow_rangeFacts, ?_⟩
   rfl
 
@@ -213,7 +213,7 @@ theorem sdLdMemTable_memBusInteractions :
     sdLdMemData, memPrefixColumn]
 
 @[simp] theorem sdLdMemData_segmentLastStep :
-    proverDataScalar sdLdMemData MemRawSidecarDataKey.Segment.segmentLastStep = 6 := by
+    proverDataScalar sdLdMemData MemRawSidecarDataKey.Segment.segmentLastStep = 5 := by
   simp (config := { decide := true }) [proverDataScalar, proverDataColumn,
     sdLdMemData, memPrefixColumn]
 
@@ -292,7 +292,7 @@ private def sdLdMemSegmentColumns : ZiskFv.Airs.Mem.SegmentColumns FGL where
   previous_segment_addr := 335544320
   segment_last_value_0 := 42
   segment_last_value_1 := 0
-  segment_last_step := 6
+  segment_last_step := 5
   segment_last_addr := 335544321
   distance_base_0 := 0
   distance_base_1 := 0

--- a/ZiskFv/Compliance/TraceLevelExport/BootSegmentMemorySeed.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/BootSegmentMemorySeed.lean
@@ -618,11 +618,14 @@ theorem exists_subdoublewordLoadProviderWitness_of_not_memAlignNarrowLoadLaneFor
     h_providerTable h_providerRow h_spec h_component h_match
   have h_width : ma.width 0 = main.ind_width r_main := h_fits.1.trans h_main_width.symm
   have h_value_1_zero : ma.value_1 0 = 0 := (h_fits.2.1 rfl).1
-  have h_value_0_lt_1 : (ma.value_0 0).val < 256 := (h_fits.2.1 rfl).2
+  have h_value_0_lt_1 : ma.width 0 = 1 → (ma.value_0 0).val < 256 := by
+    intro _
+    exact (h_fits.2.1 rfl).2
   have h_value_0_lt_2 : ma.width 0 = 2 → (ma.value_0 0).val < 65536 := by
     intro h_width_2
     have h_one_eq_two : (1 : FGL) = 2 := h_fits.1.symm.trans h_width_2
-    norm_num at h_one_eq_two
+    have h_one_eq_two_nat : (1 : ℕ) = 2 := congrArg Fin.val h_one_eq_two
+    norm_num at h_one_eq_two_nat
   refine ⟨ma, ?_⟩
   exact { provider := Or.inr (Or.inr
     ⟨0, h_match, h_width, h_value_1_zero, h_value_0_lt_1, h_value_0_lt_2⟩) }

--- a/trust/consistency/memory_prefix_sd_ld_mem_table.lean
+++ b/trust/consistency/memory_prefix_sd_ld_mem_table.lean
@@ -1,0 +1,29 @@
+import ZiskFv.Compliance.SdLdMemTable
+
+/-!
+# SD/LD non-degenerate Mem-prefix constructibility
+
+The #221 constructibility check establishes the first real mutable-Mem prefix used by an
+accepted trace: an SD of `42` and an LD of that same word at RAM word address
+`0x14000001`.  This hook keeps the full local and generated Mem surfaces in
+the semantic trust gate before the root-soundness assembly consumes the table.
+-/
+
+namespace ZiskFv.TrustConsistency
+
+open Goldilocks
+open ZiskFv.Compliance
+
+theorem sd_ld_mem_table_constructible :
+    sdLdMemTable.Constraints ∧ sdLdMemTable.TransitionConstraints ∧
+      ZiskFv.AirsClean.FullEnsemble.MemTableGeneratedConstraintFacts
+        sdLdMemTable
+        (ZiskFv.AirsClean.FullEnsemble.memOfTableData sdLdMemTable)
+        (ZiskFv.AirsClean.FullEnsemble.memSegmentOfTableData sdLdMemTable)
+        (ZiskFv.AirsClean.FullEnsemble.memPermutationOfTableData sdLdMemTable) :=
+  ⟨sdLdMemTable_constraints, sdLdMemTable_transitions,
+    sdLdMemTable_generatedConstraintFacts⟩
+
+#print axioms sd_ld_mem_table_constructible
+
+end ZiskFv.TrustConsistency

--- a/trust/scripts/check-all-semantic.sh
+++ b/trust/scripts/check-all-semantic.sh
@@ -72,29 +72,31 @@ run_register_mem_bus_witnesses() {
   return $ok
 }
 
-run "1/17 axiom-deps baseline (V2)"        "$dir/check-axiom-deps.sh"
-run "2/17 forbidden types (V2)"            "$dir/check-no-output-eq-v2.sh"
-run "3/17 closure vs baseline-axioms (V2)" "$dir/check-closure-vs-baseline.sh"
-run "4/17 global theorem binders (V2)"     "$dir/check-global-theorem-binders.sh"
-run "5/17 strong-export axiom closure (V2)" "$dir/check-strong-export-closure.sh"
-run "6/17 strong-export binders + forbidden types (V2)" "$dir/check-strong-export-binders.sh"
-run "7/17 consistency false probe rejected" reject_false_probe
-run "8/17 MemAlign narrow-load lane constraint repro" \
+run "1/18 axiom-deps baseline (V2)"        "$dir/check-axiom-deps.sh"
+run "2/18 forbidden types (V2)"            "$dir/check-no-output-eq-v2.sh"
+run "3/18 closure vs baseline-axioms (V2)" "$dir/check-closure-vs-baseline.sh"
+run "4/18 global theorem binders (V2)"     "$dir/check-global-theorem-binders.sh"
+run "5/18 strong-export axiom closure (V2)" "$dir/check-strong-export-closure.sh"
+run "6/18 strong-export binders + forbidden types (V2)" "$dir/check-strong-export-binders.sh"
+run "7/18 consistency false probe rejected" reject_false_probe
+run "8/18 MemAlign narrow-load lane constraint repro" \
   run_lean_no_sorry trust/consistency/memalign_narrow_load_lane_defect.lean
-run "9/17 Sail memory timeline witness" \
+run "9/18 Sail memory timeline witness" \
   run_lean_no_sorry trust/consistency/load_byte_agreement_witness.lean
-run "10/17 memory timeline construction witness" \
+run "10/18 memory timeline construction witness" \
   run_lean_no_sorry trust/consistency/memory_timeline_construction_witness.lean
-run "11/17 memory prefix alignment witness" \
+run "11/18 memory prefix alignment witness" \
   run_lean_no_sorry trust/consistency/memory_prefix_alignment_witness.lean
-run "12/17 global ADD theorem instantiation" \
+run "12/18 SD/LD Mem-prefix constructibility" \
+  run_lean_no_sorry trust/consistency/memory_prefix_sd_ld_mem_table.lean
+run "13/18 global ADD theorem instantiation" \
   run_lean_no_sorry trust/consistency/global_theorem_instantiation_add.lean
-run "13/17 global LD theorem instantiation" \
+run "14/18 global LD theorem instantiation" \
   run_lean_no_sorry trust/consistency/global_theorem_instantiation_ld.lean
-run "14/17 root_soundness instantiation witnesses" run_root_soundness_instantiations
-run "15/17 Clean completeness witnesses" run_witnesses
-run "16/17 register MemBus balance witnesses" run_register_mem_bus_witnesses
-run "17/17 Aeneas extraction-pin raw axiom closure (V2)" \
+run "15/18 root_soundness instantiation witnesses" run_root_soundness_instantiations
+run "16/18 Clean completeness witnesses" run_witnesses
+run "17/18 register MemBus balance witnesses" run_register_mem_bus_witnesses
+run "18/18 Aeneas extraction-pin raw axiom closure (V2)" \
   "$dir/check-extraction-closure.sh"
 
 if [ $overall -eq 0 ]; then


### PR DESCRIPTION
## Summary

- construct the first non-empty mutable-Mem table: an SD of 42 then an LD of the same RAM-window word at `0x14000001`
- prove the full row, segment (0–23), permutation (24–33), range-source, and logUp generated Mem surface from ordinary table constraints and transitions
- add reusable bounded Mem-row table materialization and exact MemBus interaction projections
- include two narrowly-scoped `origin/main` source-build corrections revealed by the required root build

This is Phase 1 of #221. The root-soundness SD/LD/JAL instantiation follows in the stacked main PR.

## Preamble and timestamp corrections (2026-07-23)

The zero-register-boot preamble places SD and LD at Main indices 4 and 5. Their actual Main MemBus timestamps are tuple slots plus four times the index: SD c-slot `3 + 4*4 = 19`; LD b-slot `2 + 4*5 = 22`. Superseding commit `a0ead1ca` sets the Mem rows to `(step, previous_step, increment) = (19, 0, 0)` and `(22, 19, 3)`, with `segment_last_step = 22`; it deliberately does not amend the prior pushed correction.

At `std_alpha = 0`, the generated permutation/logUp fold is timestamp-blind. This is expected: exact tuple equality in `BalancedInteractions` independently binds the full MemBus message, including timestamp, between Main and Mem; no pairing freedom is introduced.

## Trust surface

The generated constraint facts are derived from `constraints_hold` and indexed transitions; no accepted-trace certificate field, caller assumption, axiom, `sorry`, or new `native_decide` was added.

## Verification

Initial Phase-1 tree:

- `trust/scripts/check-all.sh`
- `lake build ZiskFv`
- `trust/scripts/check-all-semantic.sh` (18 checks)
- `nix run .#test`

After the timestamp correction:

- `lake build ZiskFv.Compliance.SdLdMemTable`
- `trust/scripts/check-all.sh`

`#print axioms sd_ld_mem_table_constructible` reports only standard kernel inheritance (`propext`, `Classical.choice`, `Quot.sound`).