### PR TITLE
Instantiate root soundness for an SD/LD memory prefix

### DIFF
--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -180,6 +180,7 @@ import ZiskFv.Compliance.AddSpinWitness
 import ZiskFv.Compliance.AddSpinRootSoundness
 import ZiskFv.Compliance.AddAddiSpinWitness
 import ZiskFv.Compliance.AddAddiSpinRootSoundness
+import ZiskFv.Compliance.SdLdSpinRootSoundness
 import ZiskFv.Compliance.RangeWiringWitness
 -- In-build per-opcode static decode/row-mode pin discharge from the real
 -- Aeneas-extracted ZisK lowerer (eth-act/zisk-fv#111). Standalone; not yet

--- a/ZiskFv/Compliance/AddSpinWitness.lean
+++ b/ZiskFv/Compliance/AddSpinWitness.lean
@@ -890,8 +890,10 @@ theorem addSpinWitness_opBus_balanced :
       rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
       decide)
 
-private def addSpinMainMemBusInteractionsAt (env : Environment FGL) : List (Interaction FGL) :=
-  let rowVar := (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar
+def mainMemBusInteractionsAt
+    (length : ℕ) (program : Program length) (env : Environment FGL) :
+    List (Interaction FGL) :=
+  let rowVar := (componentWithRomMemAndOpBus length program).rowInputVar
   [ ((MemBusChannel.emitted rowVar.rom.a_src_reg (aRegPreMessageExpr rowVar)).toRaw).eval env
   , ((MemBusChannel.emitted (-(rowVar.rom.a_src_mem + rowVar.rom.a_src_reg))
       (aMemMessageExpr rowVar)).toRaw).eval env
@@ -904,12 +906,13 @@ private def addSpinMainMemBusInteractionsAt (env : Environment FGL) : List (Inte
       (-(rowVar.rom.store_mem + rowVar.rom.store_ind + rowVar.rom.store_reg))
       (cMemMessageExpr rowVar)).toRaw).eval env ]
 
-private theorem addSpinMainMemBusInteractionsAt_eq_valueLevel
-    (env : Environment FGL) (row : MainRowWithRom FGL)
-    (h_input : Eval.eval env (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar = row) :
-    addSpinMainMemBusInteractionsAt env = mainValueMemBusInteractions row := by
-  unfold addSpinMainMemBusInteractionsAt
-  let rowVar := (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar
+theorem mainMemBusInteractionsAt_eq_valueLevel
+    (length : ℕ) (program : Program length) (env : Environment FGL)
+    (row : MainRowWithRom FGL)
+    (h_input : Eval.eval env (componentWithRomMemAndOpBus length program).rowInputVar = row) :
+    mainMemBusInteractionsAt length program env = mainValueMemBusInteractions row := by
+  unfold mainMemBusInteractionsAt
+  let rowVar := (componentWithRomMemAndOpBus length program).rowInputVar
   have h_rom : eval env rowVar.rom = row.rom := by
     rw [mainRowWithRom_eval_rom]
     exact congrArg MainRowWithRom.rom h_input
@@ -1037,11 +1040,11 @@ private theorem addSpinMainMemBusInteractionsAt_eq_valueLevel
         mainBMemInteraction row, mainCRegPreInteraction row, mainCMemInteraction row]
   simp [h_aReg, h_aMem, h_bReg, h_bMem, h_cReg, h_cMem]
 
-private theorem addSpinMainMemBusInteractionsAt_eq_component
-    (env : Environment FGL) :
-    (componentWithRomMemAndOpBus 2 addSpinProgram).operations.interactionValuesWith
-        MemBusChannel.toRaw env = addSpinMainMemBusInteractionsAt env := by
-  simp [addSpinMainMemBusInteractionsAt, Operations.interactionValuesWith_eq_map,
+theorem mainMemBusInteractionsAt_eq_component
+    (length : ℕ) (program : Program length) (env : Environment FGL) :
+    (componentWithRomMemAndOpBus length program).operations.interactionValuesWith
+        MemBusChannel.toRaw env = mainMemBusInteractionsAt length program env := by
+  simp [mainMemBusInteractionsAt, Operations.interactionValuesWith_eq_map,
     componentWithRomMemAndOpBus_interactionsWith_memBus]
 
 theorem addSpinMainTable_interactionsWith_memBus :
@@ -1058,15 +1061,15 @@ theorem addSpinMainTable_interactionsWith_memBus :
             (mainFixedColumns.materialize 0 (mainRawRow addSpinAddRow))) =
         mainValueMemBusInteractions addSpinAddRow := by
     calc
-      _ = addSpinMainMemBusInteractionsAt
+      _ = mainMemBusInteractionsAt 2 addSpinProgram
           (Environment.fromArray
             (mainFixedColumns.materialize 0 (mainRawRow addSpinAddRow)) emptyData) := by
         simpa [addSpinMainTable, mainRowsTable] using
-          (addSpinMainMemBusInteractionsAt_eq_component
+          (mainMemBusInteractionsAt_eq_component 2 addSpinProgram
             (Environment.fromArray
               (mainFixedColumns.materialize 0 (mainRawRow addSpinAddRow)) emptyData))
       _ = mainValueMemBusInteractions addSpinAddRow :=
-        addSpinMainMemBusInteractionsAt_eq_valueLevel _ addSpinAddRow
+        mainMemBusInteractionsAt_eq_valueLevel 2 addSpinProgram _ addSpinAddRow
           (eval_mainRawRow_materialize 0 emptyData addSpinAddRow (by rfl) (by rfl))
   have h_one :
       addSpinMainTable.component.operations.interactionValuesWith
@@ -1075,15 +1078,15 @@ theorem addSpinMainTable_interactionsWith_memBus :
             (mainFixedColumns.materialize 1 (mainRawRow (addSpinJalRow 1)))) =
         mainValueMemBusInteractions (addSpinJalRow 1) := by
     calc
-      _ = addSpinMainMemBusInteractionsAt
+      _ = mainMemBusInteractionsAt 2 addSpinProgram
           (Environment.fromArray
             (mainFixedColumns.materialize 1 (mainRawRow (addSpinJalRow 1))) emptyData) := by
         simpa [addSpinMainTable, mainRowsTable] using
-          (addSpinMainMemBusInteractionsAt_eq_component
+          (mainMemBusInteractionsAt_eq_component 2 addSpinProgram
             (Environment.fromArray
               (mainFixedColumns.materialize 1 (mainRawRow (addSpinJalRow 1))) emptyData))
       _ = mainValueMemBusInteractions (addSpinJalRow 1) :=
-        addSpinMainMemBusInteractionsAt_eq_valueLevel _ (addSpinJalRow 1)
+        mainMemBusInteractionsAt_eq_valueLevel 2 addSpinProgram _ (addSpinJalRow 1)
           (eval_mainRawRow_materialize 1 emptyData (addSpinJalRow 1) (by rfl) (by rfl))
   have h_two :
       addSpinMainTable.component.operations.interactionValuesWith
@@ -1092,15 +1095,15 @@ theorem addSpinMainTable_interactionsWith_memBus :
             (mainFixedColumns.materialize 2 (mainRawRow (addSpinJalRow 2)))) =
         mainValueMemBusInteractions (addSpinJalRow 2) := by
     calc
-      _ = addSpinMainMemBusInteractionsAt
+      _ = mainMemBusInteractionsAt 2 addSpinProgram
           (Environment.fromArray
             (mainFixedColumns.materialize 2 (mainRawRow (addSpinJalRow 2))) emptyData) := by
         simpa [addSpinMainTable, mainRowsTable] using
-          (addSpinMainMemBusInteractionsAt_eq_component
+          (mainMemBusInteractionsAt_eq_component 2 addSpinProgram
             (Environment.fromArray
               (mainFixedColumns.materialize 2 (mainRawRow (addSpinJalRow 2))) emptyData))
       _ = mainValueMemBusInteractions (addSpinJalRow 2) :=
-        addSpinMainMemBusInteractionsAt_eq_valueLevel _ (addSpinJalRow 2)
+        mainMemBusInteractionsAt_eq_valueLevel 2 addSpinProgram _ (addSpinJalRow 2)
           (eval_mainRawRow_materialize 2 emptyData (addSpinJalRow 2) (by rfl) (by rfl))
   rw [h_zero, h_one, h_two]
   simpa only [List.append_assoc]

--- a/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
+++ b/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
@@ -2,6 +2,7 @@ import ZiskFv.AirsClean.Main.Circuit
 import ZiskFv.AirsClean.FullEnsemble.Balance.TableProjections
 import ZiskFv.AirsClean.Binary.Bridge
 import ZiskFv.AirsClean.BinaryAdd.Bridge
+import ZiskFv.AirsClean.BinaryExtension.StaticCircuit
 import ZiskFv.AirsClean.Mem.Bridge
 import ZiskFv.AirsClean.RegisterBoundary
 
@@ -812,6 +813,56 @@ theorem binaryAddRowsTable_constraints_of_proverAssumptions
       ZiskFv.AirsClean.BinaryAdd.component row h_localLength (h_assumptions row h_row)
   simpa [binaryAddRowsTable, binaryAddRowArray, Table.table, Environment.fromInput]
     using h_component
+
+def binaryExtensionRowArray
+    (row : ZiskFv.AirsClean.BinaryExtension.BinaryExtensionRow FGL) : Array FGL :=
+  (toElements row).toArray
+
+private theorem binaryExtensionShiftStatic_component_rawWidth :
+    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rawWidth =
+      size ZiskFv.AirsClean.BinaryExtension.BinaryExtensionRow := by
+  change ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupCircuit.size =
+    size ZiskFv.AirsClean.BinaryExtension.BinaryExtensionRow
+  rw [GeneralFormalCircuit.size_eq]
+  rfl
+
+def binaryExtensionShiftStaticRowsTable
+    (rows : List (ZiskFv.AirsClean.BinaryExtension.BinaryExtensionRow FGL)) : Table FGL where
+  component := ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+  rawRows := rows.map binaryExtensionRowArray
+  data := emptyData
+  raw_uniform_width := by
+    intro arr h_arr
+    rcases List.mem_map.mp h_arr with ⟨row, _, rfl⟩
+    rw [binaryExtensionShiftStatic_component_rawWidth]
+    simp [binaryExtensionRowArray]
+  fixed_domain := by
+    intro columns h_columns
+    simp [ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent] at h_columns
+
+theorem binaryExtensionShiftStaticRowsTable_constraints_of_proverAssumptions
+    (rows : List (ZiskFv.AirsClean.BinaryExtension.BinaryExtensionRow FGL))
+    (h_assumptions :
+      ∀ row ∈ rows,
+        ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.circuit.ProverAssumptions
+          row emptyData (ProverHint.empty FGL)) :
+    (binaryExtensionShiftStaticRowsTable rows).Constraints := by
+  have h_localLength :
+      ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.circuit.localLength
+        ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInputVar = 0 := by
+    rfl
+  rw [Table.Constraints]
+  intro arr h_arr
+  change arr ∈ rows.map binaryExtensionRowArray at h_arr
+  rcases List.mem_map.mp h_arr with ⟨row, h_row, rfl⟩
+  have h_component :
+      ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.operations.ConstraintsHold
+        (Environment.fromInput row emptyData) :=
+    component_constraintsHold_of_proverAssumptions
+      ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent row h_localLength
+      (h_assumptions row h_row)
+  simpa [binaryExtensionShiftStaticRowsTable, binaryExtensionRowArray, Table.table,
+    Environment.fromInput] using h_component
 
 def binaryRowArray (row : ZiskFv.AirsClean.Binary.BinaryRow FGL) : Array FGL :=
   (toElements row).toArray

--- a/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
+++ b/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
@@ -1482,17 +1482,17 @@ def registerBoundaryMemBusInteractions (row : RegisterBoundaryRow FGL) : List (I
   [registerBoundaryBootInteraction row, registerBoundaryReloadInteraction row]
 
 theorem registerBoundaryBootInteraction_eval_fromInput
-    (row : RegisterBoundaryRow FGL) :
+    (row : RegisterBoundaryRow FGL) (data : ProverData FGL := emptyData) :
     (((MemBusChannel.emitted (-1)
         (ZiskFv.AirsClean.RegisterBoundary.bootMessageExpr
           ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar)).toRaw).eval
-      (Environment.fromInput row emptyData)) =
+      (Environment.fromInput row data)) =
       registerBoundaryBootInteraction row := by
-  let env := Environment.fromInput row emptyData
+  let env := Environment.fromInput row data
   let rowVar := ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar
   have h_input : eval env rowVar = row := by
     dsimp [env, rowVar]
-    exact ProvableType.eval_fromInput_varFromOffset_zero row emptyData
+    exact ProvableType.eval_fromInput_varFromOffset_zero row data
   have h_msg_eval :
       eval env (ZiskFv.AirsClean.RegisterBoundary.bootMessageExpr rowVar) = bootMessage row := by
     rw [ZiskFv.AirsClean.RegisterBoundary.eval_bootMessageExpr, h_input]
@@ -1508,17 +1508,17 @@ theorem registerBoundaryBootInteraction_eval_fromInput
   · rfl
 
 theorem registerBoundaryReloadInteraction_eval_fromInput
-    (row : RegisterBoundaryRow FGL) :
+    (row : RegisterBoundaryRow FGL) (data : ProverData FGL := emptyData) :
     (((MemBusChannel.emitted 1
         (ZiskFv.AirsClean.RegisterBoundary.reloadMessageExpr
           ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar)).toRaw).eval
-      (Environment.fromInput row emptyData)) =
+      (Environment.fromInput row data)) =
       registerBoundaryReloadInteraction row := by
-  let env := Environment.fromInput row emptyData
+  let env := Environment.fromInput row data
   let rowVar := ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar
   have h_input : eval env rowVar = row := by
     dsimp [env, rowVar]
-    exact ProvableType.eval_fromInput_varFromOffset_zero row emptyData
+    exact ProvableType.eval_fromInput_varFromOffset_zero row data
   have h_msg_eval :
       eval env (ZiskFv.AirsClean.RegisterBoundary.reloadMessageExpr rowVar) =
         reloadMessage row := by

--- a/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
+++ b/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
@@ -171,7 +171,7 @@ private theorem component_constraintsHold_of_proverAssumptions_at
     (Component.constraintsHold_iff (component := component)
       (env := (proverEnv : Environment FGL))).mpr h_row
 
-private theorem component_constraintsHold_of_proverAssumptions_at_data
+theorem component_constraintsHold_of_proverAssumptions_at_data
     (component : Component FGL) (env : Environment FGL) (row : component.Input FGL)
     (data : ProverData FGL)
     (h_localLength : component.circuit.localLength component.rowInputVar = 0)

--- a/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
@@ -809,7 +809,43 @@ noncomputable def sdLdMemoryRowsOf : ℕ → List (Interaction.MemoryBusEntry FG
       (Pilot.execRowOf sdLdAcceptedTrace sdLdLdIndex)).e1]
   | _ => []
 
-set_option maxHeartbeats 0 in
+private theorem sdLdMemTable_activeReplayRows :
+    ZiskFv.AirsClean.FullEnsemble.activeMemReplayRowsOfTable sdLdMemTable =
+      sdLdAcceptedReplayRows := by
+  unfold ZiskFv.AirsClean.FullEnsemble.activeMemReplayRowsOfTable
+  rw [show sdLdMemTable.table =
+    [ZiskFv.AirsClean.Mem.memFixedColumns.materialize 0
+        (ZiskFv.AirsClean.Mem.memRawRowWithProverData sdLdMemData sdMemRow),
+      ZiskFv.AirsClean.Mem.memFixedColumns.materialize 1
+        (ZiskFv.AirsClean.Mem.memRawRowWithProverData sdLdMemData ldMemRow)] by rfl]
+  simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]
+  have hrow0 : Eval.eval
+      (sdLdMemTable.environment
+        (ZiskFv.AirsClean.Mem.memFixedColumns.materialize 0
+          (ZiskFv.AirsClean.Mem.memRawRowWithProverData sdLdMemData sdMemRow)))
+      ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar = sdMemRow := by
+    change Eval.eval
+      (Environment.fromArray
+        (ZiskFv.AirsClean.Mem.memFixedColumns.materialize 0
+          (ZiskFv.AirsClean.Mem.memRawRowWithProverData sdLdMemData sdMemRow)) sdLdMemData)
+      (varFromOffset (F := FGL) ZiskFv.AirsClean.Mem.MemRow 0) = sdMemRow
+    exact ZiskFv.AirsClean.Mem.eval_memRawRowWithProverData_materialize
+      0 sdLdMemData sdMemRow
+  have hrow1 : Eval.eval
+      (sdLdMemTable.environment
+        (ZiskFv.AirsClean.Mem.memFixedColumns.materialize 1
+          (ZiskFv.AirsClean.Mem.memRawRowWithProverData sdLdMemData ldMemRow)))
+      ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar = ldMemRow := by
+    change Eval.eval
+      (Environment.fromArray
+        (ZiskFv.AirsClean.Mem.memFixedColumns.materialize 1
+          (ZiskFv.AirsClean.Mem.memRawRowWithProverData sdLdMemData ldMemRow)) sdLdMemData)
+      (varFromOffset (F := FGL) ZiskFv.AirsClean.Mem.MemRow 0) = ldMemRow
+    exact ZiskFv.AirsClean.Mem.eval_memRawRowWithProverData_materialize
+      1 sdLdMemData ldMemRow
+  rw [hrow0, hrow1]
+  rfl
+
 noncomputable def sdLdBootSeed :
     BootSegmentMemorySeed sdLdAcceptedTrace sdLdSailTrace sdLdZiskStep where
   memInit := sdLdInitialMem
@@ -829,27 +865,31 @@ noncomputable def sdLdBootSeed :
         [(busSt sdLdAcceptedTrace sdLdSdIndex
           (Pilot.execRowOf sdLdAcceptedTrace sdLdSdIndex)).e2] by rfl]
       rw [sdLdStoreEntry_eq]
-      simp [sdLdSailTrace, sdLdState, replayMemoryAfterBusRows,
-        replayMemoryAfterBusRow, sdLdStoredMem, sdLdInitialMem,
-        sdLdSdIndex, sdMemRow, ZiskFv.AirsClean.Mem.memBusMessage,
-        ZiskFv.AirsClean.Mem.memRowOf, ZiskFv.AirsClean.Mem.memValueOf,
-        ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry, writeMemoryOfEntry,
-        ZiskFv.Channels.MemoryBusBytes.byteAt, sdLdAcceptedReplayRows]
+      change sdLdStoredMem =
+        replayMemoryAfterBusRows sdLdInitialMem
+          [ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+            (ZiskFv.AirsClean.Mem.memBusMessage sdMemRow) 1 2]
+      simp only [replayMemoryAfterBusRows, List.foldl_cons, List.foldl_nil,
+        replayMemoryAfterBusRow, if_true, replayStoreEvent_storeEventOfEntry]
+      rfl
     · rw [show (⟨5, by omega⟩ : Fin 7) = sdLdLdIndex by rfl]
       rw [show sdLdMemoryRowsOf 5 =
         [(busLd sdLdAcceptedTrace sdLdLdIndex
           (Pilot.execRowOf sdLdAcceptedTrace sdLdLdIndex)).e1] by rfl]
       rw [sdLdLoadEntry_eq]
-      simp [sdLdSailTrace, sdLdState, replayMemoryAfterBusRows,
-        replayMemoryAfterBusRow, sdLdStoredMem, sdLdLdIndex, ldMemRow,
-        ZiskFv.AirsClean.Mem.memBusMessage,
-        ZiskFv.AirsClean.Mem.memRowOf, ZiskFv.AirsClean.Mem.memValueOf,
-        ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry, writeMemoryOfEntry,
-        ZiskFv.Channels.MemoryBusBytes.byteAt, sdLdAcceptedReplayRows]
-      intro h_bad
-      norm_num at h_bad
+      change sdLdStoredMem =
+        replayMemoryAfterBusRows sdLdStoredMem
+          [ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+            (ZiskFv.AirsClean.Mem.memBusMessage ldMemRow) (-1) 2]
+      simp only [replayMemoryAfterBusRows, List.foldl_cons, List.foldl_nil]
+      exact (replayMemoryAfterBusRow_eq_self_of_read _ _ (by rfl) (by rfl)).symm
   readSoundInputs := by
     intro h_present
+    have h_replayRows :
+        sdLdAcceptedTrace.memReplayRows h_present = sdLdAcceptedReplayRows := by
+      change ZiskFv.AirsClean.FullEnsemble.activeMemReplayRowsOfTable sdLdMemTable =
+        sdLdAcceptedReplayRows
+      exact sdLdMemTable_activeReplayRows
     refine ⟨?_, ?_⟩
     · have h_first :
           (sdLdAcceptedTrace.memReplayBridge h_present).segment.is_first_segment = 1 := by
@@ -861,16 +901,11 @@ noncomputable def sdLdBootSeed :
       unfold ZiskFv.AirsClean.FullEnsemble.acceptedMemoryReplayEvidence_of_segmentSelector_memTableGeneratedRowsBridge
       rw [dif_pos h_first]
       unfold ZiskFv.AirsClean.FullEnsemble.acceptedMemoryReplayEvidence_of_firstSegment_memTableGeneratedRowsBridge
-      rw [← (sdLdAcceptedTrace.memReplayBridge h_present).rows_eq]
-      simp [sdLdInitialMem, AcceptedZiskTrace.memReplayBridge, sdLdAcceptedTrace,
-        ZiskFv.ZiskCircuit.MemTrace.zeroMemoryOfRows,
-        ZiskFv.ZiskCircuit.MemTrace.zeroMemoryOfEntry,
-        ZiskFv.ZiskCircuit.MemTrace.writeMemoryOfEntry,
-        ZiskFv.ZiskCircuit.MemTrace.zeroedMemoryEntryOfEntry,
-        sdLdTableWithData, sdLdMemTable, memRowsTable, sdLdMemRows,
-        sdMemRow, ldMemRow, ZiskFv.AirsClean.Mem.memRowOf,
-        ZiskFv.AirsClean.Mem.memReadSameAddrOf, ZiskFv.AirsClean.Mem.memValueOf,
-        sdLdAcceptedReplayRows]
+      change sdLdInitialMem =
+        ZiskFv.ZiskCircuit.MemTrace.zeroMemoryOfRows
+          (ZiskFv.AirsClean.FullEnsemble.activeMemReplayRowsOfTable sdLdMemTable)
+      rw [sdLdMemTable_activeReplayRows]
+      rfl
     · change MemoryBusRowsReplaySafePermutation _ _
       rw [ZiskFv.AirsClean.FullEnsemble.acceptedMemoryReplayEvidence_of_fullWitnessMemReplayBridge_rows]
       have h_execution :
@@ -882,12 +917,8 @@ noncomputable def sdLdBootSeed :
             (busLd sdLdAcceptedTrace sdLdLdIndex
               (Pilot.execRowOf sdLdAcceptedTrace sdLdLdIndex)).e1] =
             sdLdAcceptedTrace.memReplayRows h_present
-        rw [sdLdStoreEntry_eq, sdLdLoadEntry_eq]
-        simp [AcceptedZiskTrace.memReplayRows, AcceptedZiskTrace.memReplayTable,
-          AcceptedZiskTrace.memReplayBridge, sdLdAcceptedTrace, sdLdTableWithData,
-          sdLdMemTable, memRowsTable, sdLdMemRows, sdMemRow, ldMemRow,
-          ZiskFv.AirsClean.Mem.memRowOf, ZiskFv.AirsClean.Mem.memReadSameAddrOf,
-          ZiskFv.AirsClean.Mem.memValueOf]
+        rw [sdLdStoreEntry_eq, sdLdLoadEntry_eq, h_replayRows]
+        rfl
       rw [h_execution]
       exact MemoryBusRowsReplaySafePermutation.refl _
   memPresent_of_executionRows_nonempty := by
@@ -902,53 +933,53 @@ noncomputable def sdLdBootSeed :
         sdLdSdIndex, sdLdLdIndex]
     all_goals aesop
 
-private def sdLdSequentialOutsideDefectRegion
-    (i : Fin 7) (h_pc : sdLdMainPc i < GL_prime - 4) :
-    RowOutsideDefectRegion sdLdAcceptedTrace i (sdLdZiskStep i) := by
-  unfold RowOutsideDefectRegion sdLdZiskStep MainSequentialPcDomain mainPcVal
-  exact h_pc
-
 def sdLdAddiA0OutsideDefectRegion :
     RowOutsideDefectRegion sdLdAcceptedTrace sdLdAddiA0Index
-      (sdLdZiskStep sdLdAddiA0Index) :=
-  sdLdSequentialOutsideDefectRegion sdLdAddiA0Index (by
-    rw [sdLdMainPc]
-    norm_num [sdLdAddiA0Index])
+      (sdLdZiskStep sdLdAddiA0Index) := by
+  unfold RowOutsideDefectRegion sdLdZiskStep MainSequentialPcDomain mainPcVal
+  rw [sdLdMainPc]
+  change (0 : Nat) < GL_prime - 4
+  norm_num
 
 def sdLdSlliOutsideDefectRegion :
     RowOutsideDefectRegion sdLdAcceptedTrace sdLdSlliIndex
-      (sdLdZiskStep sdLdSlliIndex) :=
-  sdLdSequentialOutsideDefectRegion sdLdSlliIndex (by
-    rw [sdLdMainPc]
-    norm_num [sdLdSlliIndex])
+      (sdLdZiskStep sdLdSlliIndex) := by
+  unfold RowOutsideDefectRegion sdLdZiskStep MainSequentialPcDomain mainPcVal
+  rw [sdLdMainPc]
+  change (4 : Nat) < GL_prime - 4
+  norm_num
 
 def sdLdAddiEightOutsideDefectRegion :
     RowOutsideDefectRegion sdLdAcceptedTrace sdLdAddiEightIndex
-      (sdLdZiskStep sdLdAddiEightIndex) :=
-  sdLdSequentialOutsideDefectRegion sdLdAddiEightIndex (by
-    rw [sdLdMainPc]
-    norm_num [sdLdAddiEightIndex])
+      (sdLdZiskStep sdLdAddiEightIndex) := by
+  unfold RowOutsideDefectRegion sdLdZiskStep MainSequentialPcDomain mainPcVal
+  rw [sdLdMainPc]
+  change (8 : Nat) < GL_prime - 4
+  norm_num
 
 def sdLdAddiX2OutsideDefectRegion :
     RowOutsideDefectRegion sdLdAcceptedTrace sdLdAddiX2Index
-      (sdLdZiskStep sdLdAddiX2Index) :=
-  sdLdSequentialOutsideDefectRegion sdLdAddiX2Index (by
-    rw [sdLdMainPc]
-    norm_num [sdLdAddiX2Index])
+      (sdLdZiskStep sdLdAddiX2Index) := by
+  unfold RowOutsideDefectRegion sdLdZiskStep MainSequentialPcDomain mainPcVal
+  rw [sdLdMainPc]
+  change (12 : Nat) < GL_prime - 4
+  norm_num
 
 def sdLdSdOutsideDefectRegion :
     RowOutsideDefectRegion sdLdAcceptedTrace sdLdSdIndex
-      (sdLdZiskStep sdLdSdIndex) :=
-  sdLdSequentialOutsideDefectRegion sdLdSdIndex (by
-    rw [sdLdMainPc]
-    norm_num [sdLdSdIndex])
+      (sdLdZiskStep sdLdSdIndex) := by
+  unfold RowOutsideDefectRegion sdLdZiskStep MainSequentialPcDomain mainPcVal
+  rw [sdLdMainPc]
+  change (16 : Nat) < GL_prime - 4
+  norm_num
 
 def sdLdLdOutsideDefectRegion :
     RowOutsideDefectRegion sdLdAcceptedTrace sdLdLdIndex
-      (sdLdZiskStep sdLdLdIndex) :=
-  sdLdSequentialOutsideDefectRegion sdLdLdIndex (by
-    rw [sdLdMainPc]
-    norm_num [sdLdLdIndex])
+      (sdLdZiskStep sdLdLdIndex) := by
+  unfold RowOutsideDefectRegion sdLdZiskStep MainSequentialPcDomain mainPcVal
+  rw [sdLdMainPc]
+  change (20 : Nat) < GL_prime - 4
+  norm_num
 
 def sdLdJalOutsideDefectRegion :
     RowOutsideDefectRegion sdLdAcceptedTrace sdLdJalIndex
@@ -969,7 +1000,7 @@ def sdLdJalOutsideDefectRegion :
     rw [sdLdMainPc] at hpc
     rw [BitVec.toNat_add]
     rw [← hpc]
-    norm_num
+    norm_num [sdLdJalIndex]
 
 def sdLdOutsideDefectRegion :
     ∀ i : Fin 7, RowOutsideDefectRegion sdLdAcceptedTrace i (sdLdZiskStep i)

--- a/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
@@ -1,0 +1,130 @@
+import ZiskFv.Compliance.SdLdSpinWitness
+import ZiskFv.Soundness
+
+set_option maxRecDepth 10000
+
+/-!
+# Concrete `root_soundness` instantiation for the SD/LD spin trace (#221)
+
+The seven executed rows initialize x1 and x2, store 42 to `0xA0000008`,
+load it into x3, and finish at the self-looping JAL.
+-/
+
+open Goldilocks
+open ZiskFv.Compliance
+open ZiskFv.Compliance.AddSpinWitness
+open ZiskFv.Compliance.Instantiation
+open ZiskFv.Compliance.RegisterMemBusBalance
+open ZiskFv.Compliance.RomDecodeBinding
+open ZiskFv.Compliance.SdLdSpinWitness
+open ZiskFv.ZiskCircuit.MemTrace
+open ZiskFv.Trusted
+
+namespace ZiskFv.Compliance.SdLdSpinRootSoundness
+
+def x0 : regidx := regidx.Regidx (0#5)
+def x1 : regidx := regidx.Regidx (1#5)
+def x2 : regidx := regidx.Regidx (2#5)
+def x3 : regidx := regidx.Regidx (3#5)
+
+def sdLdAddiA0Index : Fin 7 := ⟨0, by decide⟩
+def sdLdSlliIndex : Fin 7 := ⟨1, by decide⟩
+def sdLdAddiEightIndex : Fin 7 := ⟨2, by decide⟩
+def sdLdAddiX2Index : Fin 7 := ⟨3, by decide⟩
+def sdLdSdIndex : Fin 7 := ⟨4, by decide⟩
+def sdLdLdIndex : Fin 7 := ⟨5, by decide⟩
+def sdLdJalIndex : Fin 7 := ⟨6, by decide⟩
+
+def sdLdAddiA0Claim : Claim_addi sdLdAcceptedTrace sdLdAddiA0Index where
+  r1 := x0
+  rd := x1
+  imm := 160#12
+
+def sdLdSlliClaim : Claim_slli sdLdAcceptedTrace sdLdSlliIndex where
+  r1 := x1
+  rd := x1
+  shamt := 24#6
+
+def sdLdAddiEightClaim : Claim_addi sdLdAcceptedTrace sdLdAddiEightIndex where
+  r1 := x1
+  rd := x1
+  imm := 8#12
+
+def sdLdAddiX2Claim : Claim_addi sdLdAcceptedTrace sdLdAddiX2Index where
+  r1 := x0
+  rd := x2
+  imm := 42#12
+
+def sdLdSdInput : PureSpec.SdInput where
+  r1 := 1#5
+  imm := 0#12
+  r2 := 2#5
+  r1_val := 2684354568#64
+  r2_val := 42#64
+  PC := 16#64
+
+def sdLdSdClaim : Claim_sd sdLdAcceptedTrace sdLdSdIndex where
+  sd_input := sdLdSdInput
+
+def sdLdLdInput : PureSpec.LdInput where
+  r1 := 1#5
+  imm := 0#12
+  rd := 3#5
+  r1_val := 2684354568#64
+  PC := 20#64
+  data0 := 42#8
+  data1 := 0#8
+  data2 := 0#8
+  data3 := 0#8
+  data4 := 0#8
+  data5 := 0#8
+  data6 := 0#8
+  data7 := 0#8
+
+def sdLdLdClaim : Claim_ld sdLdAcceptedTrace sdLdLdIndex where
+  ld_input := sdLdLdInput
+
+def sdLdJalClaim : Claim_jal sdLdAcceptedTrace sdLdJalIndex where
+  imm := 0#21
+  rd := x0
+
+def sdLdZiskStep : ∀ i : Fin 7, ZiskStep sdLdAcceptedTrace i
+  | ⟨0, _⟩ => .addi sdLdAddiA0Claim
+  | ⟨1, _⟩ => .slli sdLdSlliClaim
+  | ⟨2, _⟩ => .addi sdLdAddiEightClaim
+  | ⟨3, _⟩ => .addi sdLdAddiX2Claim
+  | ⟨4, _⟩ => .sd sdLdSdClaim
+  | ⟨5, _⟩ => .ld sdLdLdClaim
+  | ⟨6, _⟩ => .jal sdLdJalClaim
+
+def sdLdMisa : RegisterType Register.misa := 0#64
+
+def sdLdRegs (pc x1Value x2Value x3Value : BitVec 64) :
+    Std.ExtDHashMap Register RegisterType :=
+  let regs0 := (default : PreSail.SequentialState RegisterType Sail.trivialChoiceSource).regs
+  let regs1 := regs0.insert Register.PC pc
+  let regs2 := regs1.insert Register.misa sdLdMisa
+  let regs3 := regs2.insert (reg_of_fin (regidx_to_fin x1)) x1Value
+  let regs4 := regs3.insert (reg_of_fin (regidx_to_fin x2)) x2Value
+  regs4.insert (reg_of_fin (regidx_to_fin x3)) x3Value
+
+def sdLdStoredMem : Std.ExtHashMap Nat (BitVec 8) :=
+  ({} : Std.ExtHashMap Nat (BitVec 8)).insert 2684354568 (42#8)
+
+def sdLdState (pc x1Value x2Value x3Value : BitVec 64)
+    (mem : Std.ExtHashMap Nat (BitVec 8)) :
+    PreSail.SequentialState RegisterType Sail.trivialChoiceSource :=
+  { (default : PreSail.SequentialState RegisterType Sail.trivialChoiceSource) with
+    regs := sdLdRegs pc x1Value x2Value x3Value
+    mem := mem }
+
+def sdLdSailTrace : SailTrace 7
+  | ⟨0, _⟩ => sdLdState (0#64) (0#64) (0#64) (0#64) {}
+  | ⟨1, _⟩ => sdLdState (4#64) (160#64) (0#64) (0#64) {}
+  | ⟨2, _⟩ => sdLdState (8#64) (2684354560#64) (0#64) (0#64) {}
+  | ⟨3, _⟩ => sdLdState (12#64) (2684354568#64) (0#64) (0#64) {}
+  | ⟨4, _⟩ => sdLdState (16#64) (2684354568#64) (42#64) (0#64) {}
+  | ⟨5, _⟩ => sdLdState (20#64) (2684354568#64) (42#64) (0#64) sdLdStoredMem
+  | ⟨6, _⟩ => sdLdState (24#64) (2684354568#64) (42#64) (42#64) sdLdStoredMem
+
+end ZiskFv.Compliance.SdLdSpinRootSoundness

--- a/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
@@ -664,7 +664,16 @@ def sdLdLdInputs :
   h_opcode_assumptions := by
     unfold PureSpec.ld_state_assumptions
     simp [sdLdLdClaim, sdLdLdInput, sdLdSailTrace, sdLdLdIndex, sdLdState, sdLdRegs,
-      sdLdStoredMem, x1, x2, x3, regidx_to_fin, reg_of_fin,
+      sdLdStoredMem, sdLdInitialMem, sdLdAcceptedReplayRows, sdMemRow,
+      ZiskFv.AirsClean.Mem.memBusMessage, ZiskFv.AirsClean.Mem.memRowOf,
+      ZiskFv.AirsClean.Mem.memValueOf,
+      ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry,
+      ZiskFv.ZiskCircuit.MemTrace.writeMemoryOfEntry,
+      ZiskFv.ZiskCircuit.MemTrace.zeroMemoryOfRows,
+      ZiskFv.ZiskCircuit.MemTrace.zeroMemoryOfEntry,
+      ZiskFv.ZiskCircuit.MemTrace.zeroedMemoryEntryOfEntry,
+      ZiskFv.Channels.MemoryBusBytes.byteAt,
+      x1, x2, x3, regidx_to_fin, reg_of_fin,
       LeanRV64D.Functions.rX_bits, LeanRV64D.Functions.rX,
       Std.ExtDHashMap.get?_insert, Std.ExtDHashMap.get?_insert_self,
       Std.ExtHashMap.getElem_insert, Std.ExtHashMap.getElem_insert_self]
@@ -892,5 +901,124 @@ noncomputable def sdLdBootSeed :
       simp [MemoryOpPlacement, sdLdZiskStep, sdLdMemoryRowsOf,
         sdLdSdIndex, sdLdLdIndex]
     all_goals aesop
+
+private def sdLdSequentialOutsideDefectRegion
+    (i : Fin 7) (h_pc : sdLdMainPc i < GL_prime - 4) :
+    RowOutsideDefectRegion sdLdAcceptedTrace i (sdLdZiskStep i) := by
+  unfold RowOutsideDefectRegion sdLdZiskStep MainSequentialPcDomain mainPcVal
+  exact h_pc
+
+def sdLdAddiA0OutsideDefectRegion :
+    RowOutsideDefectRegion sdLdAcceptedTrace sdLdAddiA0Index
+      (sdLdZiskStep sdLdAddiA0Index) :=
+  sdLdSequentialOutsideDefectRegion sdLdAddiA0Index (by
+    rw [sdLdMainPc]
+    norm_num [sdLdAddiA0Index])
+
+def sdLdSlliOutsideDefectRegion :
+    RowOutsideDefectRegion sdLdAcceptedTrace sdLdSlliIndex
+      (sdLdZiskStep sdLdSlliIndex) :=
+  sdLdSequentialOutsideDefectRegion sdLdSlliIndex (by
+    rw [sdLdMainPc]
+    norm_num [sdLdSlliIndex])
+
+def sdLdAddiEightOutsideDefectRegion :
+    RowOutsideDefectRegion sdLdAcceptedTrace sdLdAddiEightIndex
+      (sdLdZiskStep sdLdAddiEightIndex) :=
+  sdLdSequentialOutsideDefectRegion sdLdAddiEightIndex (by
+    rw [sdLdMainPc]
+    norm_num [sdLdAddiEightIndex])
+
+def sdLdAddiX2OutsideDefectRegion :
+    RowOutsideDefectRegion sdLdAcceptedTrace sdLdAddiX2Index
+      (sdLdZiskStep sdLdAddiX2Index) :=
+  sdLdSequentialOutsideDefectRegion sdLdAddiX2Index (by
+    rw [sdLdMainPc]
+    norm_num [sdLdAddiX2Index])
+
+def sdLdSdOutsideDefectRegion :
+    RowOutsideDefectRegion sdLdAcceptedTrace sdLdSdIndex
+      (sdLdZiskStep sdLdSdIndex) :=
+  sdLdSequentialOutsideDefectRegion sdLdSdIndex (by
+    rw [sdLdMainPc]
+    norm_num [sdLdSdIndex])
+
+def sdLdLdOutsideDefectRegion :
+    RowOutsideDefectRegion sdLdAcceptedTrace sdLdLdIndex
+      (sdLdZiskStep sdLdLdIndex) :=
+  sdLdSequentialOutsideDefectRegion sdLdLdIndex (by
+    rw [sdLdMainPc]
+    norm_num [sdLdLdIndex])
+
+def sdLdJalOutsideDefectRegion :
+    RowOutsideDefectRegion sdLdAcceptedTrace sdLdJalIndex
+      (sdLdZiskStep sdLdJalIndex) where
+  h_no_fgl_wrap := by
+    unfold mainPcVal
+    rw [sdLdMainPc]
+    change 24 + (BitVec.signExtend 64 (0#21)).toNat < GL_prime
+    simp
+  h_pc_bound := by
+    unfold MainSequentialPcDomain mainPcVal
+    rw [sdLdMainPc]
+    change 24 < GL_prime - 4
+    norm_num
+  h_pc_offset_lt_2_32 := by
+    intro pc hpc
+    unfold mainPcVal at hpc
+    rw [sdLdMainPc] at hpc
+    rw [BitVec.toNat_add]
+    rw [← hpc]
+    norm_num
+
+def sdLdOutsideDefectRegion :
+    ∀ i : Fin 7, RowOutsideDefectRegion sdLdAcceptedTrace i (sdLdZiskStep i)
+  | ⟨0, _⟩ => sdLdAddiA0OutsideDefectRegion
+  | ⟨1, _⟩ => sdLdSlliOutsideDefectRegion
+  | ⟨2, _⟩ => sdLdAddiEightOutsideDefectRegion
+  | ⟨3, _⟩ => sdLdAddiX2OutsideDefectRegion
+  | ⟨4, _⟩ => sdLdSdOutsideDefectRegion
+  | ⟨5, _⟩ => sdLdLdOutsideDefectRegion
+  | ⟨6, _⟩ => sdLdJalOutsideDefectRegion
+
+theorem sdLdRootSoundness :
+    ∀ i : Fin 7, StepSound sdLdAcceptedTrace sdLdSailTrace i (sdLdZiskStep i) :=
+  root_soundness 7 sdLdAcceptedTrace sdLdSailTrace sdLdZiskStep
+    sdLdProgramDecodes sdLdInputsAgree sdLdBootSeed sdLdOutsideDefectRegion
+
+theorem sdLdAddiA0StepSound :
+    StepSound sdLdAcceptedTrace sdLdSailTrace sdLdAddiA0Index
+      (sdLdZiskStep sdLdAddiA0Index) :=
+  sdLdRootSoundness sdLdAddiA0Index
+
+theorem sdLdSlliStepSound :
+    StepSound sdLdAcceptedTrace sdLdSailTrace sdLdSlliIndex
+      (sdLdZiskStep sdLdSlliIndex) :=
+  sdLdRootSoundness sdLdSlliIndex
+
+theorem sdLdAddiEightStepSound :
+    StepSound sdLdAcceptedTrace sdLdSailTrace sdLdAddiEightIndex
+      (sdLdZiskStep sdLdAddiEightIndex) :=
+  sdLdRootSoundness sdLdAddiEightIndex
+
+theorem sdLdAddiX2StepSound :
+    StepSound sdLdAcceptedTrace sdLdSailTrace sdLdAddiX2Index
+      (sdLdZiskStep sdLdAddiX2Index) :=
+  sdLdRootSoundness sdLdAddiX2Index
+
+theorem sdLdSdStepSound :
+    StepSound sdLdAcceptedTrace sdLdSailTrace sdLdSdIndex
+      (sdLdZiskStep sdLdSdIndex) :=
+  sdLdRootSoundness sdLdSdIndex
+
+theorem sdLdLdStepSound :
+    StepSound sdLdAcceptedTrace sdLdSailTrace sdLdLdIndex
+      (sdLdZiskStep sdLdLdIndex) :=
+  sdLdRootSoundness sdLdLdIndex
+
+theorem sdLdJalStepSound :
+    StepSound sdLdAcceptedTrace sdLdSailTrace sdLdJalIndex
+      (sdLdZiskStep sdLdJalIndex) :=
+  sdLdRootSoundness sdLdJalIndex
 
 end ZiskFv.Compliance.SdLdSpinRootSoundness

--- a/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
@@ -175,4 +175,179 @@ private theorem sdLdMainPc (i : Fin 7) :
     sdLdAddiX1A0ProgramRow, sdLdSlliX1ProgramRow, sdLdAddiX1EightProgramRow,
     sdLdAddiX2ProgramRow, sdLdSdProgramRow, sdLdLdProgramRow, sdLdJalProgramRow]
 
+set_option maxHeartbeats 800000 in
+private theorem sdLdProgramIndex_eq (i j : Fin 7)
+    (hline : (sdLdProgram j).line =
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable sdLdAcceptedTrace.program
+        sdLdAcceptedTrace.mainTable).pc i.val) :
+    j = i := by
+  rw [sdLdMainPc] at hline
+  apply Fin.ext
+  have hval := congrArg (fun value : FGL => value.val) hline
+  fin_cases i <;> fin_cases j <;>
+    norm_num [sdLdProgram, sdLdAddiX1A0ProgramRow, sdLdSlliX1ProgramRow,
+      sdLdAddiX1EightProgramRow, sdLdAddiX2ProgramRow, sdLdSdProgramRow,
+      sdLdLdProgramRow, sdLdJalProgramRow] at hval <;> omega
+
+def sdLdAddiA0ProgramDecode :
+    ProgramDecode_addi sdLdAcceptedTrace sdLdAddiA0Index sdLdAddiA0Claim where
+  h_idx := by
+    rw [sdLdAcceptedTrace_mainTable_eq]
+    norm_num [sdLdAddiA0Index, sdLdTableWithData]
+  bits := addiX0Bits
+  h_bits_ieo := rfl
+  h_bits_m32 := rfl
+  h_bits_set_pc := rfl
+  h_bits_store_pc := rfl
+  h_bits_store_ind := rfl
+  h_bits_b_src_imm := rfl
+  h_prog := by
+    intro j hline
+    have hj : j = ⟨0, by decide⟩ := sdLdProgramIndex_eq sdLdAddiA0Index j hline
+    subst j
+    rw [sdLdAcceptedTrace_program]
+    norm_num [sdLdAcceptedTrace, sdLdProgram, sdLdAddiX1A0ProgramRow,
+      sdLdAddiA0Claim, x1, Transpiler.ind, regidx_to_fin, packFlags, addiX0Bits,
+      ZiskFv.AirsClean.boolF]
+    all_goals decide
+
+def sdLdSlliProgramDecode :
+    ProgramDecode_slli sdLdAcceptedTrace sdLdSlliIndex sdLdSlliClaim where
+  h_idx := by
+    rw [sdLdAcceptedTrace_mainTable_eq]
+    change 1 + 1 < (sdLdTableWithData sdLdMainTable).table.length
+    norm_num [sdLdTableWithData, sdLdMainTable, sdLdMainTableWithData,
+      sdLdMainTableEmptyData, AddSpinWitness.mainRowsTable, sdLdMainRows]
+  h_b_lo_t := by
+    rw [sdLdAcceptedTrace_mainTable_eq,
+      ZiskFv.AirsClean.FullEnsemble.mainOfTable_b_0]
+    change
+      (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero sdLdProgram
+        (sdLdTableWithData sdLdMainTable) sdLdSlliIndex.val).core.b_0 = _
+    rw [congrArg (fun row => row.core.b_0) (sdLdMainRowAt sdLdSlliIndex)]
+    norm_num [sdLdSlliIndex, sdLdMainRows, sdLdSlliClaim, sdLdSlliX1Row,
+      sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate, mainRomRowOf, shamt_b_lo]
+    decide
+  bits := addiX1Bits
+  h_bits_ieo := rfl
+  h_bits_m32 := rfl
+  h_bits_set_pc := rfl
+  h_bits_store_pc := rfl
+  h_bits_store_ind := rfl
+  h_prog := by
+    intro j hline
+    have hj : j = ⟨1, by decide⟩ := sdLdProgramIndex_eq sdLdSlliIndex j hline
+    subst j
+    rw [sdLdAcceptedTrace_program]
+    norm_num [sdLdAcceptedTrace, sdLdProgram, sdLdSlliX1ProgramRow,
+      sdLdSlliClaim, x1, Transpiler.ind, regidx_to_fin, packFlags, addiX1Bits,
+      ZiskFv.AirsClean.boolF]
+    all_goals decide
+
+def sdLdAddiEightProgramDecode :
+    ProgramDecode_addi sdLdAcceptedTrace sdLdAddiEightIndex sdLdAddiEightClaim where
+  h_idx := by
+    rw [sdLdAcceptedTrace_mainTable_eq]
+    norm_num [sdLdAddiEightIndex, sdLdTableWithData]
+  bits := addiX1Bits
+  h_bits_ieo := rfl
+  h_bits_m32 := rfl
+  h_bits_set_pc := rfl
+  h_bits_store_pc := rfl
+  h_bits_store_ind := rfl
+  h_bits_b_src_imm := rfl
+  h_prog := by
+    intro j hline
+    have hj : j = ⟨2, by decide⟩ := sdLdProgramIndex_eq sdLdAddiEightIndex j hline
+    subst j
+    rw [sdLdAcceptedTrace_program]
+    norm_num [sdLdAcceptedTrace, sdLdProgram, sdLdAddiX1EightProgramRow,
+      sdLdAddiEightClaim, x1, Transpiler.ind, regidx_to_fin, packFlags, addiX1Bits,
+      ZiskFv.AirsClean.boolF]
+    all_goals decide
+
+def sdLdAddiX2ProgramDecode :
+    ProgramDecode_addi sdLdAcceptedTrace sdLdAddiX2Index sdLdAddiX2Claim where
+  h_idx := by
+    rw [sdLdAcceptedTrace_mainTable_eq]
+    norm_num [sdLdAddiX2Index, sdLdTableWithData]
+  bits := addiX0Bits
+  h_bits_ieo := rfl
+  h_bits_m32 := rfl
+  h_bits_set_pc := rfl
+  h_bits_store_pc := rfl
+  h_bits_store_ind := rfl
+  h_bits_b_src_imm := rfl
+  h_prog := by
+    intro j hline
+    have hj : j = ⟨3, by decide⟩ := sdLdProgramIndex_eq sdLdAddiX2Index j hline
+    subst j
+    rw [sdLdAcceptedTrace_program]
+    norm_num [sdLdAcceptedTrace, sdLdProgram, sdLdAddiX2ProgramRow,
+      sdLdAddiX2Claim, x2, Transpiler.ind, regidx_to_fin, packFlags, addiX0Bits,
+      ZiskFv.AirsClean.boolF]
+    all_goals decide
+
+def sdLdSdProgramDecode :
+    ProgramDecode_sd sdLdAcceptedTrace sdLdSdIndex sdLdSdClaim where
+  h_idx := by
+    rw [sdLdAcceptedTrace_mainTable_eq]
+    norm_num [sdLdSdIndex, sdLdTableWithData]
+  bits := sdLdSdBits
+  h_bits_ieo := rfl
+  h_bits_set_pc := rfl
+  h_bits_store_pc := rfl
+  h_bits_store_ind := rfl
+  h_prog := by
+    intro j hline
+    have hj : j = ⟨4, by decide⟩ := sdLdProgramIndex_eq sdLdSdIndex j hline
+    subst j
+    rw [sdLdAcceptedTrace_program]
+    norm_num [sdLdAcceptedTrace, sdLdProgram, sdLdSdProgramRow, sdLdSdClaim,
+      sdLdSdInput, packFlags, sdLdSdBits, ZiskFv.AirsClean.boolF]
+    all_goals decide
+
+def sdLdLdProgramDecode :
+    ProgramDecode_ld sdLdAcceptedTrace sdLdLdIndex sdLdLdClaim where
+  h_idx := by
+    rw [sdLdAcceptedTrace_mainTable_eq]
+    norm_num [sdLdLdIndex, sdLdTableWithData]
+  bits := sdLdLdBits
+  h_bits_ieo := rfl
+  h_bits_set_pc := rfl
+  h_bits_store_pc := rfl
+  h_bits_store_ind := rfl
+  h_bits_store_reg := rfl
+  h_bits_b_src_ind := rfl
+  h_prog := by
+    intro j hline
+    have hj : j = ⟨5, by decide⟩ := sdLdProgramIndex_eq sdLdLdIndex j hline
+    subst j
+    rw [sdLdAcceptedTrace_program]
+    norm_num [sdLdAcceptedTrace, sdLdProgram, sdLdLdProgramRow, sdLdLdClaim,
+      sdLdLdInput, Transpiler.ind, Transpiler.regidxOfBitVec5, packFlags,
+      sdLdLdBits, ZiskFv.AirsClean.boolF]
+    all_goals decide
+
+def sdLdJalProgramDecode :
+    ProgramDecode_jal sdLdAcceptedTrace sdLdJalIndex sdLdJalClaim where
+  h_idx := by
+    rw [sdLdAcceptedTrace_mainTable_eq]
+    norm_num [sdLdJalIndex, sdLdTableWithData]
+  bits := AddSpinWitness.addSpinJalBits
+  h_bits_ieo := rfl
+  h_bits_m32 := rfl
+  h_bits_set_pc := rfl
+  h_bits_store_pc := rfl
+  h_bits_store_ind := rfl
+  h_prog := by
+    intro j hline
+    have hj : j = ⟨6, by decide⟩ := sdLdProgramIndex_eq sdLdJalIndex j hline
+    subst j
+    rw [sdLdAcceptedTrace_program]
+    norm_num [sdLdAcceptedTrace, sdLdProgram, sdLdJalProgramRow, sdLdJalClaim,
+      x0, Transpiler.ind, regidx_to_fin, packFlags, AddSpinWitness.addSpinJalBits,
+      ZiskFv.AirsClean.boolF]
+    all_goals decide
+
 end ZiskFv.Compliance.SdLdSpinRootSoundness

--- a/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
@@ -138,16 +138,19 @@ def sdLdRegs (pc x1Value x2Value x3Value : BitVec 64) :
   let regs9 := regs8.insert (reg_of_fin (regidx_to_fin x2)) x2Value
   regs9.insert (reg_of_fin (regidx_to_fin x3)) x3Value
 
+def sdLdAcceptedReplayRows : List (Interaction.MemoryBusEntry FGL) :=
+  [ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+      (ZiskFv.AirsClean.Mem.memBusMessage sdMemRow) 1 2,
+    ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+      (ZiskFv.AirsClean.Mem.memBusMessage ldMemRow) (-1) 2]
+
+def sdLdInitialMem : Std.ExtHashMap Nat (BitVec 8) :=
+  ZiskFv.ZiskCircuit.MemTrace.zeroMemoryOfRows sdLdAcceptedReplayRows
+
 def sdLdStoredMem : Std.ExtHashMap Nat (BitVec 8) :=
-  (((((((({} : Std.ExtHashMap Nat (BitVec 8))
-    |>.insert 2684354568 (42#8))
-    |>.insert 2684354569 (0#8))
-    |>.insert 2684354570 (0#8))
-    |>.insert 2684354571 (0#8))
-    |>.insert 2684354572 (0#8))
-    |>.insert 2684354573 (0#8))
-    |>.insert 2684354574 (0#8))
-    |>.insert 2684354575 (0#8)
+  ZiskFv.ZiskCircuit.MemTrace.writeMemoryOfEntry sdLdInitialMem
+    (ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+      (ZiskFv.AirsClean.Mem.memBusMessage sdMemRow) 1 2)
 
 def sdLdState (pc x1Value x2Value x3Value : BitVec 64)
     (mem : Std.ExtHashMap Nat (BitVec 8)) :
@@ -157,11 +160,11 @@ def sdLdState (pc x1Value x2Value x3Value : BitVec 64)
     mem := mem }
 
 def sdLdSailTrace : SailTrace 7
-  | ⟨0, _⟩ => sdLdState (0#64) (0#64) (0#64) (0#64) {}
-  | ⟨1, _⟩ => sdLdState (4#64) (160#64) (0#64) (0#64) {}
-  | ⟨2, _⟩ => sdLdState (8#64) (2684354560#64) (0#64) (0#64) {}
-  | ⟨3, _⟩ => sdLdState (12#64) (2684354568#64) (0#64) (0#64) {}
-  | ⟨4, _⟩ => sdLdState (16#64) (2684354568#64) (42#64) (0#64) {}
+  | ⟨0, _⟩ => sdLdState (0#64) (0#64) (0#64) (0#64) sdLdInitialMem
+  | ⟨1, _⟩ => sdLdState (4#64) (160#64) (0#64) (0#64) sdLdInitialMem
+  | ⟨2, _⟩ => sdLdState (8#64) (2684354560#64) (0#64) (0#64) sdLdInitialMem
+  | ⟨3, _⟩ => sdLdState (12#64) (2684354568#64) (0#64) (0#64) sdLdInitialMem
+  | ⟨4, _⟩ => sdLdState (16#64) (2684354568#64) (42#64) (0#64) sdLdInitialMem
   | ⟨5, _⟩ => sdLdState (20#64) (2684354568#64) (42#64) (0#64) sdLdStoredMem
   | ⟨6, _⟩ => sdLdState (24#64) (2684354568#64) (42#64) (42#64) sdLdStoredMem
 
@@ -767,5 +770,127 @@ def sdLdInputsAgree :
   | ⟨4, _⟩ => sdLdSdInputs
   | ⟨5, _⟩ => sdLdLdInputs
   | ⟨6, _⟩ => sdLdJalInputs
+
+private theorem sdLdStoreEntry_eq :
+    (busSt sdLdAcceptedTrace sdLdSdIndex
+      (Pilot.execRowOf sdLdAcceptedTrace sdLdSdIndex)).e2 =
+      ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+        (ZiskFv.AirsClean.Mem.memBusMessage sdMemRow) 1 2 := by
+  change ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+      (cMemMessage (mainRowWithRomSt sdLdAcceptedTrace sdLdSdIndex)) 1 2 = _
+  rw [show mainRowWithRomSt sdLdAcceptedTrace sdLdSdIndex = sdLdSdRow by
+    exact sdLdAcceptedMainRowAt sdLdSdIndex]
+  rw [sdLdStoreMessage_eq_mem]
+
+private theorem sdLdLoadEntry_eq :
+    (busLd sdLdAcceptedTrace sdLdLdIndex
+      (Pilot.execRowOf sdLdAcceptedTrace sdLdLdIndex)).e1 =
+      ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+        (ZiskFv.AirsClean.Mem.memBusMessage ldMemRow) (-1) 2 := by
+  change ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+      (bMemMessage (mainRowWithRomLd sdLdAcceptedTrace sdLdLdIndex)) (-1) 2 = _
+  rw [show mainRowWithRomLd sdLdAcceptedTrace sdLdLdIndex = sdLdLdRow by
+    exact sdLdAcceptedMainRowAt sdLdLdIndex]
+  rw [sdLdLoadMessage_eq_mem]
+
+noncomputable def sdLdMemoryRowsOf : ℕ → List (Interaction.MemoryBusEntry FGL)
+  | 4 => [(busSt sdLdAcceptedTrace sdLdSdIndex
+      (Pilot.execRowOf sdLdAcceptedTrace sdLdSdIndex)).e2]
+  | 5 => [(busLd sdLdAcceptedTrace sdLdLdIndex
+      (Pilot.execRowOf sdLdAcceptedTrace sdLdLdIndex)).e1]
+  | _ => []
+
+set_option maxHeartbeats 0 in
+noncomputable def sdLdBootSeed :
+    BootSegmentMemorySeed sdLdAcceptedTrace sdLdSailTrace sdLdZiskStep where
+  memInit := sdLdInitialMem
+  rowsOf := sdLdMemoryRowsOf
+  boot := by intro _; rfl
+  step := by
+    intro j h
+    change j + 1 < 7 at h
+    have hj : j = 0 ∨ j = 1 ∨ j = 2 ∨ j = 3 ∨ j = 4 ∨ j = 5 := by omega
+    rcases hj with rfl | rfl | rfl | rfl | rfl | rfl
+    · simp [sdLdSailTrace, sdLdState, sdLdMemoryRowsOf, replayMemoryAfterBusRows]
+    · simp [sdLdSailTrace, sdLdState, sdLdMemoryRowsOf, replayMemoryAfterBusRows]
+    · simp [sdLdSailTrace, sdLdState, sdLdMemoryRowsOf, replayMemoryAfterBusRows]
+    · simp [sdLdSailTrace, sdLdState, sdLdMemoryRowsOf, replayMemoryAfterBusRows]
+    · rw [show (⟨4, by omega⟩ : Fin 7) = sdLdSdIndex by rfl]
+      rw [show sdLdMemoryRowsOf 4 =
+        [(busSt sdLdAcceptedTrace sdLdSdIndex
+          (Pilot.execRowOf sdLdAcceptedTrace sdLdSdIndex)).e2] by rfl]
+      rw [sdLdStoreEntry_eq]
+      simp [sdLdSailTrace, sdLdState, replayMemoryAfterBusRows,
+        replayMemoryAfterBusRow, sdLdStoredMem, sdLdInitialMem,
+        sdLdSdIndex, sdMemRow, ZiskFv.AirsClean.Mem.memBusMessage,
+        ZiskFv.AirsClean.Mem.memRowOf, ZiskFv.AirsClean.Mem.memValueOf,
+        ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry, writeMemoryOfEntry,
+        ZiskFv.Channels.MemoryBusBytes.byteAt, sdLdAcceptedReplayRows]
+    · rw [show (⟨5, by omega⟩ : Fin 7) = sdLdLdIndex by rfl]
+      rw [show sdLdMemoryRowsOf 5 =
+        [(busLd sdLdAcceptedTrace sdLdLdIndex
+          (Pilot.execRowOf sdLdAcceptedTrace sdLdLdIndex)).e1] by rfl]
+      rw [sdLdLoadEntry_eq]
+      simp [sdLdSailTrace, sdLdState, replayMemoryAfterBusRows,
+        replayMemoryAfterBusRow, sdLdStoredMem, sdLdLdIndex, ldMemRow,
+        ZiskFv.AirsClean.Mem.memBusMessage,
+        ZiskFv.AirsClean.Mem.memRowOf, ZiskFv.AirsClean.Mem.memValueOf,
+        ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry, writeMemoryOfEntry,
+        ZiskFv.Channels.MemoryBusBytes.byteAt, sdLdAcceptedReplayRows]
+      intro h_bad
+      norm_num at h_bad
+  readSoundInputs := by
+    intro h_present
+    refine ⟨?_, ?_⟩
+    · have h_first :
+          (sdLdAcceptedTrace.memReplayBridge h_present).segment.is_first_segment = 1 := by
+        change ZiskFv.AirsClean.Mem.proverDataScalar sdLdMemData
+          ZiskFv.AirsClean.Mem.MemRawSidecarDataKey.Segment.isFirstSegment = 1
+        exact sdLdMemData_isFirstSegment
+      unfold ZiskFv.AirsClean.FullEnsemble.acceptedMemoryReplayEvidence_of_fullWitnessMemReplayBridge
+      unfold ZiskFv.AirsClean.FullEnsemble.acceptedMemoryReplayEvidence_of_memTableGeneratedRowsBridge_segmentRangeFacts
+      unfold ZiskFv.AirsClean.FullEnsemble.acceptedMemoryReplayEvidence_of_segmentSelector_memTableGeneratedRowsBridge
+      rw [dif_pos h_first]
+      unfold ZiskFv.AirsClean.FullEnsemble.acceptedMemoryReplayEvidence_of_firstSegment_memTableGeneratedRowsBridge
+      rw [← (sdLdAcceptedTrace.memReplayBridge h_present).rows_eq]
+      simp [sdLdInitialMem, AcceptedZiskTrace.memReplayBridge, sdLdAcceptedTrace,
+        ZiskFv.ZiskCircuit.MemTrace.zeroMemoryOfRows,
+        ZiskFv.ZiskCircuit.MemTrace.zeroMemoryOfEntry,
+        ZiskFv.ZiskCircuit.MemTrace.writeMemoryOfEntry,
+        ZiskFv.ZiskCircuit.MemTrace.zeroedMemoryEntryOfEntry,
+        sdLdTableWithData, sdLdMemTable, memRowsTable, sdLdMemRows,
+        sdMemRow, ldMemRow, ZiskFv.AirsClean.Mem.memRowOf,
+        ZiskFv.AirsClean.Mem.memReadSameAddrOf, ZiskFv.AirsClean.Mem.memValueOf,
+        sdLdAcceptedReplayRows]
+    · change MemoryBusRowsReplaySafePermutation _ _
+      rw [ZiskFv.AirsClean.FullEnsemble.acceptedMemoryReplayEvidence_of_fullWitnessMemReplayBridge_rows]
+      have h_execution :
+          (List.range sdLdAcceptedTrace.numInstructions).flatMap sdLdMemoryRowsOf =
+            sdLdAcceptedTrace.memReplayRows h_present := by
+        change
+          [(busSt sdLdAcceptedTrace sdLdSdIndex
+              (Pilot.execRowOf sdLdAcceptedTrace sdLdSdIndex)).e2,
+            (busLd sdLdAcceptedTrace sdLdLdIndex
+              (Pilot.execRowOf sdLdAcceptedTrace sdLdLdIndex)).e1] =
+            sdLdAcceptedTrace.memReplayRows h_present
+        rw [sdLdStoreEntry_eq, sdLdLoadEntry_eq]
+        simp [AcceptedZiskTrace.memReplayRows, AcceptedZiskTrace.memReplayTable,
+          AcceptedZiskTrace.memReplayBridge, sdLdAcceptedTrace, sdLdTableWithData,
+          sdLdMemTable, memRowsTable, sdLdMemRows, sdMemRow, ldMemRow,
+          ZiskFv.AirsClean.Mem.memRowOf, ZiskFv.AirsClean.Mem.memReadSameAddrOf,
+          ZiskFv.AirsClean.Mem.memValueOf]
+      rw [h_execution]
+      exact MemoryBusRowsReplaySafePermutation.refl _
+  memPresent_of_executionRows_nonempty := by
+    intro _
+    refine ⟨sdLdTableWithData sdLdMemTable, ?_, rfl, ?_⟩
+    · simp [sdLdAcceptedTrace, Air.Flat.EnsembleWitness.allTables, sdLdWitness, sdLdTables]
+    · norm_num [sdLdTableWithData, sdLdMemTable, memRowsTable, sdLdMemRows]
+  placement := by
+    intro i
+    fin_cases i <;>
+      simp [MemoryOpPlacement, sdLdZiskStep, sdLdMemoryRowsOf,
+        sdLdSdIndex, sdLdLdIndex]
+    all_goals aesop
 
 end ZiskFv.Compliance.SdLdSpinRootSoundness

--- a/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
@@ -17,6 +17,7 @@ open ZiskFv.Compliance.Instantiation
 open ZiskFv.Compliance.RegisterMemBusBalance
 open ZiskFv.Compliance.RomDecodeBinding
 open ZiskFv.Compliance.SdLdSpinWitness
+open ZiskFv.AirsClean.Main
 open ZiskFv.ZiskCircuit.MemTrace
 open ZiskFv.Trusted
 
@@ -109,7 +110,15 @@ def sdLdRegs (pc x1Value x2Value x3Value : BitVec 64) :
   regs4.insert (reg_of_fin (regidx_to_fin x3)) x3Value
 
 def sdLdStoredMem : Std.ExtHashMap Nat (BitVec 8) :=
-  ({} : Std.ExtHashMap Nat (BitVec 8)).insert 2684354568 (42#8)
+  (((((((({} : Std.ExtHashMap Nat (BitVec 8))
+    |>.insert 2684354568 (42#8))
+    |>.insert 2684354569 (0#8))
+    |>.insert 2684354570 (0#8))
+    |>.insert 2684354571 (0#8))
+    |>.insert 2684354572 (0#8))
+    |>.insert 2684354573 (0#8))
+    |>.insert 2684354574 (0#8))
+    |>.insert 2684354575 (0#8)
 
 def sdLdState (pc x1Value x2Value x3Value : BitVec 64)
     (mem : Std.ExtHashMap Nat (BitVec 8)) :
@@ -126,5 +135,44 @@ def sdLdSailTrace : SailTrace 7
   | ⟨4, _⟩ => sdLdState (16#64) (2684354568#64) (42#64) (0#64) {}
   | ⟨5, _⟩ => sdLdState (20#64) (2684354568#64) (42#64) (0#64) sdLdStoredMem
   | ⟨6, _⟩ => sdLdState (24#64) (2684354568#64) (42#64) (42#64) sdLdStoredMem
+
+private theorem sdLdAcceptedTrace_program :
+    sdLdAcceptedTrace.program = sdLdProgram := rfl
+
+private theorem sdLdMainRowAt (i : Fin 7) :
+    ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero sdLdProgram
+        (sdLdTableWithData sdLdMainTable) i.val =
+      sdLdMainRows[i.val]'(by
+        simpa [sdLdMainRows] using
+          Nat.lt_trans i.isLt (by decide : 7 < 8)) := by
+  unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+  rw [dif_pos (by change i.val < 8; omega)]
+  change Eval.eval (sdLdMainTable.environmentAt ⟨i.val, by
+      rw [sdLdMainTable_length]
+      omega⟩)
+      (componentWithRomMemAndOpBus 7 sdLdProgram).rowInputVar = _
+  simpa [sdLdMainRows] using sdLdMainTable_evalAt ⟨i.val, by
+    rw [sdLdMainTable_length]
+    omega⟩
+
+private theorem sdLdMainPc (i : Fin 7) :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable sdLdAcceptedTrace.program
+        sdLdAcceptedTrace.mainTable).pc i.val = (4 * i.val : Nat) := by
+  rw [sdLdAcceptedTrace_mainTable_eq]
+  change (ZiskFv.AirsClean.FullEnsemble.mainOfTable sdLdProgram
+      (sdLdTableWithData sdLdMainTable)).pc i.val = _
+  rw [ZiskFv.AirsClean.FullEnsemble.mainOfTable_pc]
+  change (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero sdLdProgram
+    (sdLdTableWithData sdLdMainTable) i.val).core.pc = _
+  rw [congrArg (fun row => row.core.pc) (sdLdMainRowAt i)]
+  fin_cases i <;>
+    simp [sdLdMainRows, sdLdAddiX1A0Row,
+    sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate, sdLdSlliX1Row,
+    sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate, sdLdAddiX1EightRow,
+    sdLdAddiX1EightRowWithLast, sdLdAddiX1EightRowTemplate, sdLdAddiX2Row,
+    sdLdAddiX2RowWithLast, sdLdAddiX2RowTemplate, sdLdSdRow, sdLdSdRowTemplate,
+    sdLdLdRow, sdLdLdRowTemplate, sdLdJalRow, mainRomRowOf,
+    sdLdAddiX1A0ProgramRow, sdLdSlliX1ProgramRow, sdLdAddiX1EightProgramRow,
+    sdLdAddiX2ProgramRow, sdLdSdProgramRow, sdLdLdProgramRow, sdLdJalProgramRow]
 
 end ZiskFv.Compliance.SdLdSpinRootSoundness

--- a/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
@@ -100,14 +100,43 @@ def sdLdZiskStep : ∀ i : Fin 7, ZiskStep sdLdAcceptedTrace i
 
 def sdLdMisa : RegisterType Register.misa := 0#64
 
+def sdLdPmaAttrs : PMA :=
+  { cacheable := false
+    coherent := false
+    executable := true
+    readable := true
+    writable := true
+    read_idempotent := true
+    write_idempotent := true
+    misaligned_fault := misaligned_fault.AlignmentFault
+    reservability := default
+    supports_cbo_zero := false }
+
+def sdLdPmaRegion : PMA_Region :=
+  { base := 0#64
+    size := BitVec.ofNat 64 (2 ^ 32)
+    attributes := sdLdPmaAttrs
+    include_in_device_tree := false }
+
+def sdLdModeRegs : ZiskFv.Compliance.ModeRegsFull :=
+  { mstatus := 0#64
+    pmaRegion := sdLdPmaRegion
+    misa := sdLdMisa
+    mseccfg := 0#64 }
+
 def sdLdRegs (pc x1Value x2Value x3Value : BitVec 64) :
     Std.ExtDHashMap Register RegisterType :=
   let regs0 := (default : PreSail.SequentialState RegisterType Sail.trivialChoiceSource).regs
   let regs1 := regs0.insert Register.PC pc
-  let regs2 := regs1.insert Register.misa sdLdMisa
-  let regs3 := regs2.insert (reg_of_fin (regidx_to_fin x1)) x1Value
-  let regs4 := regs3.insert (reg_of_fin (regidx_to_fin x2)) x2Value
-  regs4.insert (reg_of_fin (regidx_to_fin x3)) x3Value
+  let regs2 := regs1.insert Register.cur_privilege Privilege.Machine
+  let regs3 := regs2.insert Register.mstatus sdLdModeRegs.mstatus
+  let regs4 := regs3.insert Register.pma_regions [sdLdModeRegs.pmaRegion]
+  let regs5 := regs4.insert Register.htif_tohost_base (none : Option (BitVec 64))
+  let regs6 := regs5.insert Register.misa sdLdModeRegs.misa
+  let regs7 := regs6.insert Register.mseccfg sdLdModeRegs.mseccfg
+  let regs8 := regs7.insert (reg_of_fin (regidx_to_fin x1)) x1Value
+  let regs9 := regs8.insert (reg_of_fin (regidx_to_fin x2)) x2Value
+  regs9.insert (reg_of_fin (regidx_to_fin x3)) x3Value
 
 def sdLdStoredMem : Std.ExtHashMap Nat (BitVec 8) :=
   (((((((({} : Std.ExtHashMap Nat (BitVec 8))
@@ -349,5 +378,394 @@ def sdLdJalProgramDecode :
       x0, Transpiler.ind, regidx_to_fin, packFlags, AddSpinWitness.addSpinJalBits,
       ZiskFv.AirsClean.boolF]
     all_goals decide
+
+def sdLdAddiA0Input : PureSpec.AddiInput where
+  r1_val := 0#64
+  imm := 160#12
+  rd := regidx_to_fin x1
+  PC := 0#64
+
+private theorem sdLdReadX0 (i : Fin 7) :
+    read_xreg (regidx_to_fin x0) (sdLdSailTrace i) =
+      EStateM.Result.ok (0#64) (sdLdSailTrace i) := by
+  fin_cases i <;>
+    simp [sdLdSailTrace, sdLdState, sdLdRegs, x0, x1, x2, x3,
+      regidx_to_fin, read_xreg, reg_of_fin, sdLdStoredMem,
+      Std.ExtDHashMap.get?_insert]
+
+private theorem sdLdAcceptedMainRowAt (i : Fin 7) :
+    ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero sdLdAcceptedTrace.program
+        sdLdAcceptedTrace.mainTable i.val =
+      sdLdMainRows[i.val]'(by
+        simpa [sdLdMainRows] using Nat.lt_trans i.isLt (by decide : 7 < 8)) := by
+  rw [sdLdAcceptedTrace_program, sdLdAcceptedTrace_mainTable_eq]
+  exact sdLdMainRowAt i
+
+def sdLdAddiA0Inputs :
+    Inputs_addi sdLdAcceptedTrace sdLdSailTrace sdLdAddiA0Index
+      sdLdAddiA0Claim where
+  addi_input := sdLdAddiA0Input
+  h_input_r1 := by
+    simpa [sdLdAddiA0Input, sdLdAddiA0Claim] using sdLdReadX0 sdLdAddiA0Index
+  h_input_imm := rfl
+  h_input_pc := by
+    simp [sdLdAddiA0Input, sdLdSailTrace, sdLdAddiA0Index, sdLdState, sdLdRegs,
+      x1, x2, x3, regidx_to_fin, reg_of_fin, Std.ExtDHashMap.get?_insert]
+  h_input_rd := rfl
+  h_a_lo_t := by
+    rw [ZiskFv.AirsClean.FullEnsemble.mainOfTable_a_0]
+    change (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+      sdLdAcceptedTrace.program sdLdAcceptedTrace.mainTable
+      sdLdAddiA0Index.val).core.a_0 = _
+    rw [congrArg (fun row => row.core.a_0) (sdLdAcceptedMainRowAt sdLdAddiA0Index)]
+    simp only [sdLdAddiA0Claim]
+    rw [ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64_xreg_eq_of_read_xreg
+      (sdLdSailTrace sdLdAddiA0Index) (regidx_to_fin x0) (0#64)
+      (sdLdReadX0 sdLdAddiA0Index)]
+    norm_num [sdLdAddiA0Index, sdLdMainRows, sdLdAddiX1A0Row,
+      sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate, mainRomRowOf, lane_lo]
+  h_a_hi_t := by
+    rw [ZiskFv.AirsClean.FullEnsemble.mainOfTable_a_1]
+    change (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+      sdLdAcceptedTrace.program sdLdAcceptedTrace.mainTable
+      sdLdAddiA0Index.val).core.a_1 = _
+    rw [congrArg (fun row => row.core.a_1) (sdLdAcceptedMainRowAt sdLdAddiA0Index)]
+    simp only [sdLdAddiA0Claim]
+    rw [ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64_xreg_eq_of_read_xreg
+      (sdLdSailTrace sdLdAddiA0Index) (regidx_to_fin x0) (0#64)
+      (sdLdReadX0 sdLdAddiA0Index)]
+    norm_num [sdLdAddiA0Index, sdLdMainRows, sdLdAddiX1A0Row,
+      sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate, mainRomRowOf, lane_hi]
+  h_pc_bridge := by
+    rw [sdLdMainPc]
+    norm_num [sdLdAddiA0Index, sdLdAddiA0Input]
+
+private theorem sdLdReadX1 (i : Fin 7) :
+    read_xreg (regidx_to_fin x1) (sdLdSailTrace i) =
+      EStateM.Result.ok
+        ([0#64, 160#64, 2684354560#64, 2684354568#64,
+          2684354568#64, 2684354568#64, 2684354568#64][i.val]'(by
+            simpa using i.isLt))
+        (sdLdSailTrace i) := by
+  fin_cases i <;>
+    simp [sdLdSailTrace, sdLdState, sdLdRegs, x1, x2, x3, regidx_to_fin,
+      read_xreg, reg_of_fin, sdLdStoredMem, Std.ExtDHashMap.get?_insert]
+
+private theorem sdLdReadX2Sd :
+    read_xreg (regidx_to_fin x2) (sdLdSailTrace sdLdSdIndex) =
+      EStateM.Result.ok (42#64) (sdLdSailTrace sdLdSdIndex) := by
+  simp [sdLdSailTrace, sdLdSdIndex, sdLdState, sdLdRegs, x1, x2, x3,
+    regidx_to_fin, read_xreg, reg_of_fin, Std.ExtDHashMap.get?_insert]
+
+private theorem sdLdLaneLo
+    (i : Fin 7) (value : BitVec 64)
+    (hread : read_xreg (regidx_to_fin x1) (sdLdSailTrace i) =
+      EStateM.Result.ok value (sdLdSailTrace i))
+    (field : ZiskFv.Airs.Main.Valid_Main FGL FGL → Nat → FGL)
+    (hfield : field
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable sdLdAcceptedTrace.program
+        sdLdAcceptedTrace.mainTable) i.val = lane_lo value) :
+    field (ZiskFv.AirsClean.FullEnsemble.mainOfTable sdLdAcceptedTrace.program
+      sdLdAcceptedTrace.mainTable) i.val =
+      lane_lo ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64
+        (sdLdSailTrace i)).xreg (regidx_to_fin x1)) := by
+  rw [ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64_xreg_eq_of_read_xreg
+    (sdLdSailTrace i) (regidx_to_fin x1) value hread]
+  exact hfield
+
+private theorem sdLdLaneHi
+    (i : Fin 7) (value : BitVec 64)
+    (hread : read_xreg (regidx_to_fin x1) (sdLdSailTrace i) =
+      EStateM.Result.ok value (sdLdSailTrace i))
+    (field : ZiskFv.Airs.Main.Valid_Main FGL FGL → Nat → FGL)
+    (hfield : field
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable sdLdAcceptedTrace.program
+        sdLdAcceptedTrace.mainTable) i.val = lane_hi value) :
+    field (ZiskFv.AirsClean.FullEnsemble.mainOfTable sdLdAcceptedTrace.program
+      sdLdAcceptedTrace.mainTable) i.val =
+      lane_hi ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64
+        (sdLdSailTrace i)).xreg (regidx_to_fin x1)) := by
+  rw [ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64_xreg_eq_of_read_xreg
+    (sdLdSailTrace i) (regidx_to_fin x1) value hread]
+  exact hfield
+
+def sdLdSlliInput : PureSpec.SlliInput where
+  r1_val := 160#64
+  shamt := 24#6
+  rd := regidx_to_fin x1
+  PC := 4#64
+
+def sdLdSlliInputs :
+    Inputs_slli sdLdAcceptedTrace sdLdSailTrace sdLdSlliIndex sdLdSlliClaim where
+  slli_input := sdLdSlliInput
+  h_input_r1 := by
+    simpa [sdLdSlliInput, sdLdSlliIndex] using sdLdReadX1 sdLdSlliIndex
+  h_input_shamt := rfl
+  h_input_pc := by
+    simp [sdLdSlliInput, sdLdSailTrace, sdLdSlliIndex, sdLdState, sdLdRegs,
+      x1, x2, x3, regidx_to_fin, reg_of_fin, Std.ExtDHashMap.get?_insert]
+  h_input_rd := rfl
+  h_a_lo_t := by
+    apply sdLdLaneLo sdLdSlliIndex (160#64)
+      (by simpa [sdLdSlliIndex] using sdLdReadX1 sdLdSlliIndex)
+    rw [ZiskFv.AirsClean.FullEnsemble.mainOfTable_a_0]
+    change (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+      sdLdAcceptedTrace.program sdLdAcceptedTrace.mainTable
+      sdLdSlliIndex.val).core.a_0 = _
+    rw [congrArg (fun row => row.core.a_0) (sdLdAcceptedMainRowAt sdLdSlliIndex)]
+    norm_num [sdLdSlliIndex, sdLdMainRows, sdLdSlliX1Row,
+      sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate, mainRomRowOf, lane_lo]
+    decide
+  h_a_hi_t := by
+    apply sdLdLaneHi sdLdSlliIndex (160#64)
+      (by simpa [sdLdSlliIndex] using sdLdReadX1 sdLdSlliIndex)
+    rw [ZiskFv.AirsClean.FullEnsemble.mainOfTable_a_1]
+    change (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+      sdLdAcceptedTrace.program sdLdAcceptedTrace.mainTable
+      sdLdSlliIndex.val).core.a_1 = _
+    rw [congrArg (fun row => row.core.a_1) (sdLdAcceptedMainRowAt sdLdSlliIndex)]
+    norm_num [sdLdSlliIndex, sdLdMainRows, sdLdSlliX1Row,
+      sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate, mainRomRowOf, lane_hi]
+  h_pc_bridge := by rw [sdLdMainPc]; norm_num [sdLdSlliIndex, sdLdSlliInput]
+
+private def sdLdAddiInput
+    (value : BitVec 64) (imm : BitVec 12) (rd : regidx) (pc : BitVec 64) :
+    PureSpec.AddiInput where
+  r1_val := value
+  imm := imm
+  rd := regidx_to_fin rd
+  PC := pc
+
+def sdLdAddiEightInputs :
+    Inputs_addi sdLdAcceptedTrace sdLdSailTrace sdLdAddiEightIndex
+      sdLdAddiEightClaim where
+  addi_input := sdLdAddiInput (2684354560#64) (8#12) x1 (8#64)
+  h_input_r1 := by
+    simpa [sdLdAddiInput, sdLdAddiEightClaim, sdLdAddiEightIndex] using
+      sdLdReadX1 sdLdAddiEightIndex
+  h_input_imm := rfl
+  h_input_pc := by
+    simp [sdLdAddiInput, sdLdSailTrace, sdLdAddiEightIndex, sdLdState, sdLdRegs,
+      x1, x2, x3, regidx_to_fin, reg_of_fin, Std.ExtDHashMap.get?_insert]
+  h_input_rd := rfl
+  h_a_lo_t := by
+    apply sdLdLaneLo sdLdAddiEightIndex (2684354560#64)
+      (by simpa [sdLdAddiEightIndex] using sdLdReadX1 sdLdAddiEightIndex)
+    rw [ZiskFv.AirsClean.FullEnsemble.mainOfTable_a_0]
+    change (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+      sdLdAcceptedTrace.program sdLdAcceptedTrace.mainTable
+      sdLdAddiEightIndex.val).core.a_0 = _
+    rw [congrArg (fun row => row.core.a_0) (sdLdAcceptedMainRowAt sdLdAddiEightIndex)]
+    norm_num [sdLdAddiEightIndex, sdLdMainRows, sdLdAddiX1EightRow,
+      sdLdAddiX1EightRowWithLast, sdLdAddiX1EightRowTemplate, mainRomRowOf, lane_lo]
+    decide
+  h_a_hi_t := by
+    apply sdLdLaneHi sdLdAddiEightIndex (2684354560#64)
+      (by simpa [sdLdAddiEightIndex] using sdLdReadX1 sdLdAddiEightIndex)
+    rw [ZiskFv.AirsClean.FullEnsemble.mainOfTable_a_1]
+    change (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+      sdLdAcceptedTrace.program sdLdAcceptedTrace.mainTable
+      sdLdAddiEightIndex.val).core.a_1 = _
+    rw [congrArg (fun row => row.core.a_1) (sdLdAcceptedMainRowAt sdLdAddiEightIndex)]
+    norm_num [sdLdAddiEightIndex, sdLdMainRows, sdLdAddiX1EightRow,
+      sdLdAddiX1EightRowWithLast, sdLdAddiX1EightRowTemplate, mainRomRowOf, lane_hi]
+  h_pc_bridge := by rw [sdLdMainPc]; norm_num [sdLdAddiEightIndex, sdLdAddiInput]
+
+def sdLdAddiX2Inputs :
+    Inputs_addi sdLdAcceptedTrace sdLdSailTrace sdLdAddiX2Index sdLdAddiX2Claim where
+  addi_input := sdLdAddiInput (0#64) (42#12) x2 (12#64)
+  h_input_r1 := by simpa [sdLdAddiInput, sdLdAddiX2Claim] using sdLdReadX0 sdLdAddiX2Index
+  h_input_imm := rfl
+  h_input_pc := by
+    simp [sdLdAddiInput, sdLdSailTrace, sdLdAddiX2Index, sdLdState, sdLdRegs,
+      x1, x2, x3, regidx_to_fin, reg_of_fin, Std.ExtDHashMap.get?_insert]
+  h_input_rd := rfl
+  h_a_lo_t := by
+    rw [ZiskFv.AirsClean.FullEnsemble.mainOfTable_a_0]
+    change (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+      sdLdAcceptedTrace.program sdLdAcceptedTrace.mainTable
+      sdLdAddiX2Index.val).core.a_0 = _
+    rw [congrArg (fun row => row.core.a_0) (sdLdAcceptedMainRowAt sdLdAddiX2Index)]
+    simp only [sdLdAddiX2Claim]
+    rw [ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64_xreg_eq_of_read_xreg
+      (sdLdSailTrace sdLdAddiX2Index) (regidx_to_fin x0) (0#64)
+      (sdLdReadX0 sdLdAddiX2Index)]
+    norm_num [sdLdAddiX2Index, sdLdMainRows, sdLdAddiX2Row,
+      sdLdAddiX2RowWithLast, sdLdAddiX2RowTemplate, mainRomRowOf, lane_lo]
+  h_a_hi_t := by
+    rw [ZiskFv.AirsClean.FullEnsemble.mainOfTable_a_1]
+    change (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+      sdLdAcceptedTrace.program sdLdAcceptedTrace.mainTable
+      sdLdAddiX2Index.val).core.a_1 = _
+    rw [congrArg (fun row => row.core.a_1) (sdLdAcceptedMainRowAt sdLdAddiX2Index)]
+    simp only [sdLdAddiX2Claim]
+    rw [ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64_xreg_eq_of_read_xreg
+      (sdLdSailTrace sdLdAddiX2Index) (regidx_to_fin x0) (0#64)
+      (sdLdReadX0 sdLdAddiX2Index)]
+    norm_num [sdLdAddiX2Index, sdLdMainRows, sdLdAddiX2Row,
+      sdLdAddiX2RowWithLast, sdLdAddiX2RowTemplate, mainRomRowOf, lane_hi]
+  h_pc_bridge := by rw [sdLdMainPc]; norm_num [sdLdAddiX2Index, sdLdAddiInput]
+
+def sdLdSdInputs :
+    Inputs_sd sdLdAcceptedTrace sdLdSailTrace sdLdSdIndex sdLdSdClaim where
+  regs := sdLdModeRegs
+  h_opcode_assumptions := by
+    unfold PureSpec.sd_state_assumptions
+    simp [sdLdSdClaim, sdLdSdInput, sdLdSailTrace, sdLdSdIndex, sdLdState, sdLdRegs,
+      x1, x2, x3, regidx_to_fin, reg_of_fin, LeanRV64D.Functions.rX_bits,
+      LeanRV64D.Functions.rX, Std.ExtDHashMap.get?_insert,
+      Std.ExtDHashMap.get?_insert_self]
+  h_a0_value := by
+    rw [ZiskFv.AirsClean.FullEnsemble.mainOfTable_a_0]
+    change (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+      sdLdAcceptedTrace.program sdLdAcceptedTrace.mainTable sdLdSdIndex.val).core.a_0 = _
+    rw [congrArg (fun row => row.core.a_0) (sdLdAcceptedMainRowAt sdLdSdIndex)]
+    norm_num [sdLdSdIndex, sdLdSdClaim, sdLdSdInput, sdLdMainRows, sdLdSdRow,
+      sdLdSdRowTemplate, mainRomRowOf, lane_lo]
+    decide
+  h_a1_value := by
+    rw [ZiskFv.AirsClean.FullEnsemble.mainOfTable_a_1]
+    change (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+      sdLdAcceptedTrace.program sdLdAcceptedTrace.mainTable sdLdSdIndex.val).core.a_1 = _
+    rw [congrArg (fun row => row.core.a_1) (sdLdAcceptedMainRowAt sdLdSdIndex)]
+    norm_num [sdLdSdIndex, sdLdSdClaim, sdLdSdInput, sdLdMainRows, sdLdSdRow,
+      sdLdSdRowTemplate, mainRomRowOf, lane_hi]
+  h_b0_value := by
+    rw [ZiskFv.AirsClean.FullEnsemble.mainOfTable_b_0]
+    change (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+      sdLdAcceptedTrace.program sdLdAcceptedTrace.mainTable sdLdSdIndex.val).core.b_0 = _
+    rw [congrArg (fun row => row.core.b_0) (sdLdAcceptedMainRowAt sdLdSdIndex)]
+    norm_num [sdLdSdIndex, sdLdSdClaim, sdLdSdInput, sdLdMainRows, sdLdSdRow,
+      sdLdSdRowTemplate, mainRomRowOf, lane_lo]
+    decide
+  h_b1_value := by
+    rw [ZiskFv.AirsClean.FullEnsemble.mainOfTable_b_1]
+    change (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+      sdLdAcceptedTrace.program sdLdAcceptedTrace.mainTable sdLdSdIndex.val).core.b_1 = _
+    rw [congrArg (fun row => row.core.b_1) (sdLdAcceptedMainRowAt sdLdSdIndex)]
+    norm_num [sdLdSdIndex, sdLdSdClaim, sdLdSdInput, sdLdMainRows, sdLdSdRow,
+      sdLdSdRowTemplate, mainRomRowOf, lane_hi]
+  h_risc_v_assumptions := by
+    unfold RISC_V_assumptions
+    simp [sdLdSailTrace, sdLdSdIndex, sdLdState, sdLdRegs, sdLdModeRegs,
+      sdLdPmaRegion, sdLdPmaAttrs, x1, x2, x3, regidx_to_fin, reg_of_fin,
+      Sail.readReg, PreSail.readReg,
+      Std.ExtDHashMap.get?_insert, Std.ExtDHashMap.get?_insert_self]
+  h_pc_bridge := by rw [sdLdMainPc]; norm_num [sdLdSdIndex, sdLdSdClaim, sdLdSdInput]
+
+def sdLdLdInputs :
+    Inputs_ld sdLdAcceptedTrace sdLdSailTrace sdLdLdIndex sdLdLdClaim where
+  regs := sdLdModeRegs
+  mem := ZiskFv.AirsClean.FullEnsemble.memOfTableData sdLdMemTable
+  r_mem := 1
+  h_opcode_assumptions := by
+    unfold PureSpec.ld_state_assumptions
+    simp [sdLdLdClaim, sdLdLdInput, sdLdSailTrace, sdLdLdIndex, sdLdState, sdLdRegs,
+      sdLdStoredMem, x1, x2, x3, regidx_to_fin, reg_of_fin,
+      LeanRV64D.Functions.rX_bits, LeanRV64D.Functions.rX,
+      Std.ExtDHashMap.get?_insert, Std.ExtDHashMap.get?_insert_self,
+      Std.ExtHashMap.getElem_insert, Std.ExtHashMap.getElem_insert_self]
+  h_a0_value := by
+    rw [ZiskFv.AirsClean.FullEnsemble.mainOfTable_a_0]
+    change (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+      sdLdAcceptedTrace.program sdLdAcceptedTrace.mainTable sdLdLdIndex.val).core.a_0 = _
+    rw [congrArg (fun row => row.core.a_0) (sdLdAcceptedMainRowAt sdLdLdIndex)]
+    norm_num [sdLdLdIndex, sdLdLdClaim, sdLdLdInput, sdLdMainRows, sdLdLdRow,
+      sdLdLdRowTemplate, mainRomRowOf, lane_lo]
+    decide
+  h_risc_v_assumptions := by
+    unfold RISC_V_assumptions
+    simp [sdLdSailTrace, sdLdLdIndex, sdLdState, sdLdRegs, sdLdModeRegs,
+      sdLdPmaRegion, sdLdPmaAttrs, x1, x2, x3, regidx_to_fin, reg_of_fin,
+      Sail.readReg, PreSail.readReg,
+      Std.ExtDHashMap.get?_insert, Std.ExtDHashMap.get?_insert_self]
+  h_pc_bridge := by rw [sdLdMainPc]; norm_num [sdLdLdIndex, sdLdLdClaim, sdLdLdInput]
+  h_msg := by
+    have hmem :
+        ZiskFv.AirsClean.Mem.rowAt
+          (ZiskFv.AirsClean.FullEnsemble.memOfTableData sdLdMemTable) 1 = ldMemRow := by
+      rw [ZiskFv.AirsClean.FullEnsemble.rowAt_memOfTableData sdLdMemTable
+        ⟨1, by simp⟩]
+      exact sdLdMemTable_memRowAt_one
+    rw [hmem]
+    rw [show mainRowWithRomLd sdLdAcceptedTrace sdLdLdIndex = sdLdLdRow by
+      change ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+        sdLdAcceptedTrace.program sdLdAcceptedTrace.mainTable sdLdLdIndex.val = _
+      exact sdLdAcceptedMainRowAt sdLdLdIndex]
+    norm_num [loadMemMsg, loadMainMsg, ldMemRow, sdLdLdRow, sdLdLdRowTemplate,
+      sdLdLdProgramRow, sdLdLdBits, mainRomRowOf,
+      AbstractInteraction.eval, ChannelInteraction.toRaw,
+      Channel.emitted,
+      ZiskFv.AirsClean.Mem.memBusMessageExpr, bMemMessageExpr,
+      bMemOpExpr, memConstVar, mainConstVar, Expression.eval,
+      ZiskFv.AirsClean.Mem.memRowOf, ZiskFv.AirsClean.Mem.memReadSameAddrOf,
+      ZiskFv.AirsClean.Mem.memValueOf]
+    change Array.map (fun x => Expression.eval loadEvalEnv x)
+        (toElements (ZiskFv.AirsClean.Mem.memBusMessageExpr (memConstVar ldMemRow))).toArray =
+      Array.map (fun x => Expression.eval loadEvalEnv x)
+        (toElements (bMemMessageExpr (mainConstVar sdLdLdRow))).toArray
+    norm_num [memConstVar, mainConstVar, Expression.eval,
+      ZiskFv.AirsClean.Mem.memBusMessageExpr, bMemMessageExpr,
+      ldMemRow, sdLdLdRow, sdLdLdRowTemplate, sdLdLdProgramRow, sdLdLdBits,
+      bMemOpExpr, sdLdSdRow, sdLdSdRowTemplate, sdLdSdProgramRow, sdLdSdBits,
+      sdLdFreeCols, mainRomRowOf, mainRomFreeColsWithRegisterPrevious,
+      materializeMainRegisterRow, materializeMainRegisterAccesses,
+      withMainRegisterPrevious, ZiskFv.AirsClean.Mem.memRowOf,
+      ZiskFv.AirsClean.Mem.memReadSameAddrOf, ZiskFv.AirsClean.Mem.memValueOf]
+    simp [toElements, loadEvalEnv, ProvableStruct.componentsToElements,
+      ProvableStruct.components, ProvableStruct.toComponents]
+    decide
+  h_mem_sel := by
+    have hmem := ZiskFv.AirsClean.FullEnsemble.rowAt_memOfTableData
+      sdLdMemTable ⟨1, by simp⟩
+    have hrow := sdLdMemTable_memRowAt_one
+    exact congrArg ZiskFv.AirsClean.Mem.MemRow.sel (hmem.trans hrow)
+  h_mem_wr := by
+    have hmem := ZiskFv.AirsClean.FullEnsemble.rowAt_memOfTableData
+      sdLdMemTable ⟨1, by simp⟩
+    have hrow := sdLdMemTable_memRowAt_one
+    exact congrArg ZiskFv.AirsClean.Mem.MemRow.wr (hmem.trans hrow)
+
+def sdLdJalInput : PureSpec.JalInput where
+  imm := 0#21
+  rd := regidx_to_fin x0
+  PC := 24#64
+
+def sdLdJalInputs :
+    Inputs_jal sdLdAcceptedTrace sdLdSailTrace sdLdJalIndex sdLdJalClaim where
+  jal_input := sdLdJalInput
+  misa_val := sdLdMisa
+  h_pc_bridge := by rw [sdLdMainPc]; norm_num [sdLdJalIndex, sdLdJalInput]
+  h_input_rd := rfl
+  h_input_pc := by
+    simp [sdLdJalInput, sdLdSailTrace, sdLdJalIndex, sdLdState, sdLdRegs,
+      x1, x2, x3, regidx_to_fin, reg_of_fin, Std.ExtDHashMap.get?_insert]
+  h_input_misa := by
+    simp [sdLdSailTrace, sdLdJalIndex, sdLdState, sdLdRegs, sdLdModeRegs, sdLdMisa,
+      x1, x2, x3,
+      regidx_to_fin, reg_of_fin, Std.ExtDHashMap.get?_insert]
+  h_misa_c := by simp [sdLdMisa]
+  h_success := by simp [sdLdJalInput, PureSpec.execute_JAL_pure]
+  h_input_imm := rfl
+
+def sdLdProgramDecodes :
+    ∀ i : Fin 7, ProgramDecode sdLdAcceptedTrace i (sdLdZiskStep i)
+  | ⟨0, _⟩ => sdLdAddiA0ProgramDecode
+  | ⟨1, _⟩ => sdLdSlliProgramDecode
+  | ⟨2, _⟩ => sdLdAddiEightProgramDecode
+  | ⟨3, _⟩ => sdLdAddiX2ProgramDecode
+  | ⟨4, _⟩ => sdLdSdProgramDecode
+  | ⟨5, _⟩ => sdLdLdProgramDecode
+  | ⟨6, _⟩ => sdLdJalProgramDecode
+
+def sdLdInputsAgree :
+    ∀ i : Fin 7, InputsAgree sdLdAcceptedTrace sdLdSailTrace i (sdLdZiskStep i)
+  | ⟨0, _⟩ => sdLdAddiA0Inputs
+  | ⟨1, _⟩ => sdLdSlliInputs
+  | ⟨2, _⟩ => sdLdAddiEightInputs
+  | ⟨3, _⟩ => sdLdAddiX2Inputs
+  | ⟨4, _⟩ => sdLdSdInputs
+  | ⟨5, _⟩ => sdLdLdInputs
+  | ⟨6, _⟩ => sdLdJalInputs
 
 end ZiskFv.Compliance.SdLdSpinRootSoundness

--- a/ZiskFv/Compliance/SdLdSpinWitness.lean
+++ b/ZiskFv/Compliance/SdLdSpinWitness.lean
@@ -1,5 +1,6 @@
 import ZiskFv.Compliance.SdLdMemTable
 import ZiskFv.Compliance.AddAddiSpinWitness
+import ZiskFv.AirsClean.BinaryExtension.StaticCircuit
 
 /-!
 # Concrete SD/LD spin witness (#221)
@@ -644,6 +645,70 @@ theorem sdLdMainTable_cyclicSuccessorTransitions :
   intro index
   simp [sdLdMainTable, AddSpinWitness.mainRowsTable,
     ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus]
+
+def sdLdBinaryAddRows : List (ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL) :=
+  [ ZiskFv.AirsClean.BinaryAdd.binaryAddRowOf 0 160
+  , ZiskFv.AirsClean.BinaryAdd.binaryAddRowOf 2684354560 8
+  , ZiskFv.AirsClean.BinaryAdd.binaryAddRowOf 0 42 ]
+
+def sdLdBinaryAddTable : Table FGL :=
+  binaryAddRowsTable sdLdBinaryAddRows
+
+theorem sdLdBinaryAddTable_constraints : sdLdBinaryAddTable.Constraints := by
+  apply binaryAddRowsTable_constraints_of_proverAssumptions
+  intro row h_row
+  simp [sdLdBinaryAddRows] at h_row
+  rcases h_row with rfl | rfl | rfl
+  · exact ⟨0, 160, by decide, by decide, rfl⟩
+  · exact ⟨2684354560, 8, by decide, by decide, rfl⟩
+  · exact ⟨0, 42, by decide, by decide, rfl⟩
+
+private def sdLdSlliIndex (byteIndex byte : Nat)
+    (h_byteIndex : byteIndex < 8) (h_byte : byte < 256) :
+    ZiskFv.AirsClean.BinaryExtension.BinaryExtensionTableIndex :=
+  ⟨24 * 2048 + byteIndex * 256 + byte, by
+    norm_num [ZiskFv.AirsClean.BinaryExtensionTable.tableSize,
+      ZiskFv.AirsClean.BinaryExtensionTable.shiftBlockSize,
+      ZiskFv.AirsClean.BinaryExtensionTable.sextBlockSize]
+    omega⟩
+
+def sdLdSlliBinaryExtensionRow :
+    ZiskFv.AirsClean.BinaryExtension.BinaryExtensionRow FGL :=
+  ZiskFv.AirsClean.BinaryExtension.binaryExtensionStaticRowOf
+    (sdLdSlliIndex 0 160 (by decide) (by decide))
+    (sdLdSlliIndex 1 0 (by decide) (by decide))
+    (sdLdSlliIndex 2 0 (by decide) (by decide))
+    (sdLdSlliIndex 3 0 (by decide) (by decide))
+    (sdLdSlliIndex 4 0 (by decide) (by decide))
+    (sdLdSlliIndex 5 0 (by decide) (by decide))
+    (sdLdSlliIndex 6 0 (by decide) (by decide))
+    (sdLdSlliIndex 7 0 (by decide) (by decide)) 24 0
+
+theorem sdLdSlliBinaryExtension_proverAssumptions :
+    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupCircuit.ProverAssumptions
+      sdLdSlliBinaryExtensionRow emptyData (ProverHint.empty FGL) := by
+  refine ⟨(sdLdSlliIndex 0 160 (by decide) (by decide)),
+    (sdLdSlliIndex 1 0 (by decide) (by decide)),
+    (sdLdSlliIndex 2 0 (by decide) (by decide)),
+    (sdLdSlliIndex 3 0 (by decide) (by decide)),
+    (sdLdSlliIndex 4 0 (by decide) (by decide)),
+    (sdLdSlliIndex 5 0 (by decide) (by decide)),
+    (sdLdSlliIndex 6 0 (by decide) (by decide)),
+    (sdLdSlliIndex 7 0 (by decide) (by decide)), 24, 0, ?_⟩
+  repeat' apply And.intro
+  all_goals norm_num [sdLdSlliIndex,
+    ZiskFv.AirsClean.BinaryExtension.binaryExtensionTableRow,
+    ZiskFv.AirsClean.BinaryExtensionTable.rowOfIndex,
+    ZiskFv.AirsClean.BinaryExtensionTable.byteIndex,
+    ZiskFv.AirsClean.BinaryExtensionTable.shiftAmount,
+    ZiskFv.AirsClean.BinaryExtensionTable.opOfIndex,
+    ZiskFv.AirsClean.BinaryExtensionTable.blockOfIndex,
+    ZiskFv.AirsClean.BinaryExtensionTable.opOfBlock,
+    ZiskFv.AirsClean.BinaryExtensionTable.shiftBlockSize,
+    ZiskFv.AirsClean.BinaryExtensionTable.sextBlockSize,
+    ZiskFv.Airs.Tables.BinaryExtensionTable.OP_SLL,
+    ZiskFv.AirsClean.BinaryExtension.binaryExtensionStaticRowOf,
+    sdLdSlliBinaryExtensionRow]
 
 def sdLdX1Telescope :=
   registerTelescopingInteractions

--- a/ZiskFv/Compliance/SdLdSpinWitness.lean
+++ b/ZiskFv/Compliance/SdLdSpinWitness.lean
@@ -5,8 +5,8 @@ import ZiskFv.Compliance.AddAddiSpinWitness
 # Concrete SD/LD spin witness (#221)
 
 The Phase-2 witness follows the canonical dispatcher binding shapes: ADDI
-uses the `a` register source and `b` immediate source, and every program
-message is paired with its actual Main emitter row.
+uses the `b` immediate source, while an x0 `a` operand is immediate zero; every
+program message is paired with its actual Main emitter row.
 -/
 
 open Goldilocks
@@ -20,7 +20,7 @@ open ZiskFv.Compliance.RegisterMemBusBalance
 namespace ZiskFv.Compliance.SdLdSpinWitness
 
 def addiX0Bits : RomFlagBits where
-  a_src_imm := false
+  a_src_imm := true
   a_src_mem := false
   is_precompiled := false
   b_src_imm := true
@@ -32,7 +32,7 @@ def addiX0Bits : RomFlagBits where
   set_pc := false
   m32 := false
   b_src_ind := false
-  a_src_reg := true
+  a_src_reg := false
   b_src_reg := false
   store_reg := true
 
@@ -72,5 +72,20 @@ def sdLdAddiX2ProgramRow : ZiskRomMessage FGL :=
   { line := 12, a_offset_imm0 := 0, a_imm1 := 0, b_offset_imm0 := 42, b_imm1 := 0,
     ind_width := 8, op := ZiskFv.Trusted.OP_ADD, store_offset := 2, jmp_offset1 := 4,
     jmp_offset2 := 4, flags := packFlags addiX0Bits }
+
+/-- The x0 ADDI source form consumed by the ROM/Main binding has both
+immediate lanes fixed by its program message. -/
+def sdLdAddiX1A0FreeCols : MainRomFreeCols :=
+  mainRomFreeColsWithRegisterPrevious
+    { SingleAddWitness.addX1MainFreeCols with
+      a_0 := 0, a_1 := 0, b_0 := 160, b_1 := 0,
+      im_high_degree_2 := 0, segment_l1 := 0, main_step := 0 }
+    addX1RegisterInitial
+
+example : MainRomSourceGuard sdLdAddiX1A0ProgramRow addiX0Bits sdLdAddiX1A0FreeCols := by
+  norm_num [MainRomSourceGuard, sdLdAddiX1A0ProgramRow, addiX0Bits,
+    sdLdAddiX1A0FreeCols, mainRomFreeColsWithRegisterPrevious,
+    SingleAddWitness.addX1MainFreeCols, addX1RegisterInitial, boundaryRowIdle,
+    ZiskFv.AirsClean.RegisterBoundary.bootMessage]
 
 end ZiskFv.Compliance.SdLdSpinWitness

--- a/ZiskFv/Compliance/SdLdSpinWitness.lean
+++ b/ZiskFv/Compliance/SdLdSpinWitness.lean
@@ -2318,4 +2318,104 @@ theorem sdLdWitness_balancedChannels : sdLdWitness.BalancedChannels := by
   · exact sdLdWitness_memAlignRomChannel_balanced
   · exact sdLdWitness_rangeChannel_balanced
 
+private theorem not_sdLd_main_component_of_name_ne
+    {component : Component FGL}
+    (h_name : component.circuit.name ≠
+      (componentWithRomMemAndOpBus 7 sdLdProgram).circuit.name)
+    (h_component : component = componentWithRomMemAndOpBus 7 sdLdProgram) : False :=
+  h_name (congrArg (fun c : Component FGL => c.circuit.name) h_component)
+
+private theorem not_sdLd_main_component_of_width_ne
+    {component : Component FGL}
+    (h_width : component.width ≠ (componentWithRomMemAndOpBus 7 sdLdProgram).width)
+    (h_component : component = componentWithRomMemAndOpBus 7 sdLdProgram) : False :=
+  h_width (congrArg Component.width h_component)
+
+private theorem not_sdLd_mutable_mem_component_of_name_ne
+    {component : Component FGL}
+    (h_name : component.circuit.name ≠
+      ZiskFv.AirsClean.Mem.componentWithDualMemBus.circuit.name)
+    (h_component : component = ZiskFv.AirsClean.Mem.componentWithDualMemBus) : False :=
+  h_name (congrArg (fun c : Component FGL => c.circuit.name) h_component)
+
+private theorem sdLdWitness_main_component_cases
+    {table : Table FGL}
+    (h_table : table ∈ sdLdWitness.allTables)
+    (h_component : table.component = componentWithRomMemAndOpBus 7 sdLdProgram) :
+    table = sdLdTableWithData sdLdMainTable := by
+  rw [EnsembleWitness.allTables, List.mem_cons] at h_table
+  rcases h_table with h_verifier | h_table
+  · subst table
+    exfalso
+    exact not_sdLd_main_component_of_width_ne (by decide) h_component
+  · rw [sdLdWitness_tables] at h_table
+    simp [sdLdTables] at h_table
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl |
+      rfl | rfl | rfl | rfl
+    all_goals first
+      | rfl
+      | exfalso
+        exact not_sdLd_main_component_of_name_ne (by decide) h_component
+
+private theorem sdLdWitness_mem_component_cases
+    {table : Table FGL}
+    (h_table : table ∈ sdLdWitness.allTables)
+    (h_component : table.component = ZiskFv.AirsClean.Mem.componentWithDualMemBus) :
+    table = sdLdTableWithData sdLdMemTable := by
+  rw [EnsembleWitness.allTables, List.mem_cons] at h_table
+  rcases h_table with h_verifier | h_table
+  · subst table
+    exfalso
+    rw [EnsembleWitness.verifierTable_component] at h_component
+    have h_verifier_nil :=
+      ZiskFv.AirsClean.FullEnsemble.verifierTable_interactionsWith_memBus_nil
+        7 sdLdProgram
+    change Operations.interactionsWith MemBusChannel.toRaw
+      sdLdEnsemble.verifierTable.operations = [] at h_verifier_nil
+    rw [h_component,
+      ZiskFv.AirsClean.Mem.componentWithDualMemBus_interactionsWith_memBus] at h_verifier_nil
+    exact absurd h_verifier_nil (by simp)
+  · rw [sdLdWitness_tables] at h_table
+    simp [sdLdTables] at h_table
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl |
+      rfl | rfl | rfl | rfl
+    all_goals first
+      | rfl
+      | exfalso
+        exact not_sdLd_mutable_mem_component_of_name_ne (by decide) h_component
+
+theorem sdLdWitness_main_height :
+    ∀ table ∈ sdLdWitness.allTables,
+      table.component = componentWithRomMemAndOpBus 7 sdLdProgram →
+        ∀ i : Fin 7, i.val < table.table.length := by
+  intro table h_table h_component i
+  have h_main := sdLdWitness_main_component_cases h_table h_component
+  subst table
+  fin_cases i <;>
+    norm_num [sdLdTableWithData, sdLdMainTable, sdLdMainTableWithData,
+      sdLdMainTableEmptyData, AddSpinWitness.mainRowsTable, sdLdMainRows]
+
+def sdLdAcceptedTrace : AcceptedZiskTrace 7 where
+  programLength := 7
+  program := sdLdProgram
+  witness := sdLdWitness
+  constraints_hold := sdLdWitness_constraints
+  channels_balanced := sdLdWitness_balancedChannels
+  mem_replay_table := fun _ =>
+    ⟨sdLdTableWithData sdLdMemTable, by
+      simp [EnsembleWitness.allTables, sdLdWitness_tables, sdLdTables],
+      rfl,
+      by norm_num [sdLdTableWithData, sdLdMemTable, memRowsTable, sdLdMemRows]⟩
+  mem_replay_source_covers := fun _ table h_table h_component =>
+    sdLdWitness_mem_component_cases h_table h_component
+  transitions_hold := sdLdWitness_transitions
+  cyclic_successor_transitions_hold := sdLdWitness_cyclicSuccessorTransitions
+  main_height := sdLdWitness_main_height
+
+theorem sdLdAcceptedTrace_mainTable_eq :
+    sdLdAcceptedTrace.mainTable = sdLdTableWithData sdLdMainTable := by
+  exact sdLdWitness_main_component_cases
+    (by simpa [sdLdAcceptedTrace] using sdLdAcceptedTrace.mainTable_mem)
+    (by simpa [sdLdAcceptedTrace] using sdLdAcceptedTrace.mainTable_component)
+
 end ZiskFv.Compliance.SdLdSpinWitness

--- a/ZiskFv/Compliance/SdLdSpinWitness.lean
+++ b/ZiskFv/Compliance/SdLdSpinWitness.lean
@@ -1434,6 +1434,316 @@ theorem sdLdWitness_rangeChannel_balanced :
       rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
       decide
 
+private theorem sdLdBinaryAddOpBus_row
+    (row : ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL) :
+    ZiskFv.AirsClean.BinaryAdd.component.operations.interactionValuesWith
+        OpBusChannel.toRaw (Environment.fromInput row sdLdMemData) =
+      [binaryAddOpBusInteraction row] := by
+  have h_input :
+      Eval.eval (Environment.fromInput row sdLdMemData)
+        ZiskFv.AirsClean.BinaryAdd.component.rowInputVar = row :=
+    ProvableType.eval_fromInput_varFromOffset_zero row sdLdMemData
+  have h_msg_eval :
+      Eval.eval (Environment.fromInput row sdLdMemData)
+          (ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr
+            ZiskFv.AirsClean.BinaryAdd.component.rowInputVar) =
+        ZiskFv.AirsClean.BinaryAdd.opBusMessage row := by
+    rw [ZiskFv.AirsClean.BinaryAdd.eval_opBusMessageExpr, h_input]
+  have h_eval :
+      (((OpBusChannel.pushed
+        (ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr
+          ZiskFv.AirsClean.BinaryAdd.component.rowInputVar)).toRaw).eval
+        (Environment.fromInput row sdLdMemData)) =
+      binaryAddOpBusInteraction row := by
+    simp [binaryAddOpBusInteraction, AbstractInteraction.eval, ChannelInteraction.toRaw]
+    constructor
+    · rfl
+    constructor
+    · rw [toElements_eval_toArray]
+      change (toElements
+          (Eval.eval (Environment.fromInput row sdLdMemData)
+            (ZiskFv.AirsClean.BinaryAdd.opBusMessageExpr
+              ZiskFv.AirsClean.BinaryAdd.component.rowInputVar))).toArray =
+        (toElements (ZiskFv.AirsClean.BinaryAdd.opBusMessage row)).toArray
+      rw [h_msg_eval]
+    · rfl
+  rw [Operations.interactionValuesWith_eq_map,
+    ZiskFv.AirsClean.BinaryAdd.component_interactionsWith_opBus]
+  simp [h_eval]
+
+private theorem sdLdBinaryAddTable_opBusInteractions :
+    (sdLdTableWithData sdLdBinaryAddTable).interactionsWith OpBusChannel.toRaw =
+      sdLdBinaryAddRows.flatMap (fun row => [binaryAddOpBusInteraction row]) := by
+  rw [Table.interactionsWith]
+  change (sdLdBinaryAddRows.map binaryAddRowArray).flatMap (fun arr =>
+    ZiskFv.AirsClean.BinaryAdd.component.operations.interactionValuesWith
+      OpBusChannel.toRaw (Environment.fromArray arr sdLdMemData)) = _
+  simp_rw [List.flatMap_map]
+  simp [binaryAddRowArray, Environment.fromInput, sdLdBinaryAddOpBus_row]
+
+private theorem sdLdBinaryExtensionTable_opBusInteractions :
+    (sdLdTableWithData sdLdBinaryExtensionTable).interactionsWith OpBusChannel.toRaw =
+      [sdLdSlliBinaryExtensionOpBusInteraction] := by
+  rw [Table.interactionsWith]
+  change List.flatMap (fun arr =>
+    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.operations.interactionValuesWith
+      OpBusChannel.toRaw (Environment.fromArray arr sdLdMemData))
+    [binaryExtensionRowArray sdLdSlliBinaryExtensionRow] = _
+  simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]
+  change
+    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.operations.interactionValuesWith
+      OpBusChannel.toRaw
+      (Environment.fromInput sdLdSlliBinaryExtensionRow sdLdMemData) = _
+  have h_input :
+      Eval.eval (Environment.fromInput sdLdSlliBinaryExtensionRow sdLdMemData)
+        ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInputVar =
+      sdLdSlliBinaryExtensionRow :=
+    ProvableType.eval_fromInput_varFromOffset_zero sdLdSlliBinaryExtensionRow sdLdMemData
+  have h_msg_eval :
+      Eval.eval (Environment.fromInput sdLdSlliBinaryExtensionRow sdLdMemData)
+          (ZiskFv.AirsClean.BinaryExtension.opBusMessageExpr
+            ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInputVar) =
+        ZiskFv.AirsClean.BinaryExtension.opBusMessage sdLdSlliBinaryExtensionRow := by
+    rw [ZiskFv.AirsClean.BinaryExtension.eval_opBusMessageExpr, h_input]
+  rw [Operations.interactionValuesWith_eq_map,
+    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent_interactionsWith_opBus]
+  simp only [List.map_cons, List.map_nil]
+  congr 1
+  simp [sdLdSlliBinaryExtensionOpBusInteraction, AbstractInteraction.eval,
+    ChannelInteraction.toRaw]
+  constructor
+  · rfl
+  constructor
+  · rw [toElements_eval_toArray]
+    change (toElements
+        (Eval.eval (Environment.fromInput sdLdSlliBinaryExtensionRow sdLdMemData)
+          (ZiskFv.AirsClean.BinaryExtension.opBusMessageExpr
+            ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInputVar))).toArray =
+      (toElements
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
+          sdLdSlliBinaryExtensionRow)).toArray
+    rw [h_msg_eval]
+  · rfl
+
+private theorem sdLdMainOpBusInteractionsAt
+    (env : Environment FGL) (row : MainRowWithRom FGL)
+    (h_input :
+      Eval.eval env (componentWithRomMemAndOpBus 7 sdLdProgram).rowInputVar = row) :
+    (componentWithRomMemAndOpBus 7 sdLdProgram).operations.interactionValuesWith
+        OpBusChannel.toRaw env = [mainOpBusInteraction row] := by
+  let rowVar := (componentWithRomMemAndOpBus 7 sdLdProgram).rowInputVar
+  have h_core : Eval.eval env rowVar.core = row.core := by
+    rw [ZiskFv.AirsClean.FullEnsemble.mainRowWithRom_eval_core]
+    exact congrArg MainRowWithRom.core h_input
+  have h_field := ZiskFv.AirsClean.FullEnsemble.mainRow_eval_is_external_op env rowVar.core
+  rw [Operations.interactionValuesWith_eq_map,
+    componentWithRomMemAndOpBus_interactionsWith_opBus]
+  simp only [List.map_cons, List.map_nil]
+  congr 1
+  simp [mainOpBusInteraction, AbstractInteraction.eval, ChannelInteraction.toRaw]
+  constructor
+  · change Expression.eval env (-rowVar.core.is_external_op) = -row.core.is_external_op
+    simp [Expression.eval, h_field, h_core]
+  constructor
+  · have h_msg_eval :
+        Eval.eval env (opBusMessageExpr rowVar.core) = opBusMessage row.core := by
+      rw [eval_opBusMessageExpr, h_core]
+    rw [toElements_eval_toArray]
+    change (toElements (Eval.eval env (opBusMessageExpr rowVar.core))).toArray =
+      (toElements (opBusMessage row.core)).toArray
+    rw [h_msg_eval]
+  · rfl
+
+private theorem sdLdMainTable_opBusInteractions :
+    (sdLdTableWithData sdLdMainTable).interactionsWith OpBusChannel.toRaw =
+      sdLdMainRows.map mainOpBusInteraction := by
+  rw [Table.interactionsWith]
+  change List.flatMap (fun row =>
+    (componentWithRomMemAndOpBus 7 sdLdProgram).operations.interactionValuesWith
+      OpBusChannel.toRaw (Environment.fromArray row sdLdMemData))
+    (sdLdMainRows.map mainRawRow |>.mapIdx mainFixedColumns.materialize) = _
+  simp only [sdLdMainRows, List.map_cons, List.map_nil, List.mapIdx_cons,
+    List.mapIdx_nil, List.flatMap_cons, List.flatMap_nil, List.append_nil]
+  rw [sdLdMainOpBusInteractionsAt _ sdLdAddiX1A0Row
+      (eval_mainRawRow_materialize 0 sdLdMemData sdLdAddiX1A0Row
+        (by simp [sdLdAddiX1A0Row, sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate,
+          mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
+        (by simp [sdLdAddiX1A0Row, sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate,
+          mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])),
+    sdLdMainOpBusInteractionsAt _ sdLdSlliX1Row
+      (eval_mainRawRow_materialize 1 sdLdMemData sdLdSlliX1Row
+        (by simp [sdLdSlliX1Row, sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate,
+          mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
+        (by simp [sdLdSlliX1Row, sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate,
+          mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])),
+    sdLdMainOpBusInteractionsAt _ sdLdAddiX1EightRow
+      (eval_mainRawRow_materialize 2 sdLdMemData sdLdAddiX1EightRow
+        (by simp [sdLdAddiX1EightRow, sdLdAddiX1EightRowWithLast,
+          sdLdAddiX1EightRowTemplate, mainRomRowOf, sdLdFreeCols,
+          mainRomFreeColsWithRegisterPrevious])
+        (by simp [sdLdAddiX1EightRow, sdLdAddiX1EightRowWithLast,
+          sdLdAddiX1EightRowTemplate, mainRomRowOf, sdLdFreeCols,
+          mainRomFreeColsWithRegisterPrevious])),
+    sdLdMainOpBusInteractionsAt _ sdLdAddiX2Row
+      (eval_mainRawRow_materialize 3 sdLdMemData sdLdAddiX2Row
+        (by simp [sdLdAddiX2Row, sdLdAddiX2RowWithLast, sdLdAddiX2RowTemplate,
+          mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
+        (by simp [sdLdAddiX2Row, sdLdAddiX2RowWithLast, sdLdAddiX2RowTemplate,
+          mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])),
+    sdLdMainOpBusInteractionsAt _ sdLdSdRow
+      (eval_mainRawRow_materialize 4 sdLdMemData sdLdSdRow
+        (by simp [sdLdSdRow, sdLdSdRowTemplate, mainRomRowOf, sdLdFreeCols,
+          mainRomFreeColsWithRegisterPrevious])
+        (by simp [sdLdSdRow, sdLdSdRowTemplate, mainRomRowOf, sdLdFreeCols,
+          mainRomFreeColsWithRegisterPrevious])),
+    sdLdMainOpBusInteractionsAt _ sdLdLdRow
+      (eval_mainRawRow_materialize 5 sdLdMemData sdLdLdRow
+        (by simp [sdLdLdRow, sdLdLdRowTemplate, mainRomRowOf, sdLdFreeCols,
+          mainRomFreeColsWithRegisterPrevious])
+        (by simp [sdLdLdRow, sdLdLdRowTemplate, mainRomRowOf, sdLdFreeCols,
+          mainRomFreeColsWithRegisterPrevious])),
+    sdLdMainOpBusInteractionsAt _ (sdLdJalRow 6)
+      (eval_mainRawRow_materialize 6 sdLdMemData (sdLdJalRow 6)
+        (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
+          mainRomFreeColsWithRegisterPrevious])
+        (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
+          mainRomFreeColsWithRegisterPrevious])),
+    sdLdMainOpBusInteractionsAt _ (sdLdJalRow 7)
+      (eval_mainRawRow_materialize 7 sdLdMemData (sdLdJalRow 7)
+        (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
+          mainRomFreeColsWithRegisterPrevious])
+        (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
+          mainRomFreeColsWithRegisterPrevious]))]
+  rfl
+
+private theorem sdLdWitness_opBusInteractions :
+    sdLdWitness.tables.flatMap (·.interactionsWith OpBusChannel.toRaw) =
+      [ sdLdSlliBinaryExtensionOpBusInteraction
+      , binaryAddOpBusInteraction
+          (ZiskFv.AirsClean.BinaryAdd.binaryAddRowOf 0 160)
+      , binaryAddOpBusInteraction
+          (ZiskFv.AirsClean.BinaryAdd.binaryAddRowOf 2684354560 8)
+      , binaryAddOpBusInteraction
+          (ZiskFv.AirsClean.BinaryAdd.binaryAddRowOf 0 42)
+      , mainOpBusInteraction sdLdAddiX1A0Row
+      , mainOpBusInteraction sdLdSlliX1Row
+      , mainOpBusInteraction sdLdAddiX1EightRow
+      , mainOpBusInteraction sdLdAddiX2Row
+      , mainOpBusInteraction sdLdSdRow
+      , mainOpBusInteraction sdLdLdRow
+      , mainOpBusInteraction (sdLdJalRow 6)
+      , mainOpBusInteraction (sdLdJalRow 7) ] := by
+  have h_boundary :
+      (sdLdTableWithData sdLdBoundaryTable).interactionsWith OpBusChannel.toRaw = [] :=
+    ZiskFv.AirsClean.FullEnsemble.registerBoundary_table_interactionsWith_opBus_nil rfl
+  have h_mem :
+      (sdLdTableWithData sdLdMemTable).interactionsWith OpBusChannel.toRaw = [] :=
+    ZiskFv.AirsClean.FullEnsemble.mem_table_interactionsWith_opBus_nil rfl
+  have h_ranges :
+      sdLdSpecifiedRangesTable.interactionsWith OpBusChannel.toRaw = [] := by
+    apply Table.interactionsWith_nil_of_channel_not_mem
+    change OpBusChannel.toRaw ∉ [SpecifiedRangesSliceChannel.toRaw]
+    intro h
+    simp only [List.mem_singleton] at h
+    have h_name := congrArg (fun c : RawChannel FGL => c.name) h
+    simp [SpecifiedRangesSliceChannel, OpBusChannel, Channel.toRaw] at h_name
+  rw [sdLdWitness_tables]
+  simp [sdLdTables, h_boundary, h_mem, h_ranges,
+    sdLdBinaryExtensionTable_opBusInteractions, sdLdBinaryAddTable_opBusInteractions,
+    sdLdBinaryAddRows, sdLdMainTable_opBusInteractions, sdLdMainRows]
+
+theorem sdLdWitness_opBus_balanced :
+    BalancedInteractions
+      (sdLdWitness.tables.flatMap (·.interactionsWith OpBusChannel.toRaw)) := by
+  rw [sdLdWitness_opBusInteractions]
+  refine Air.Flat.balancedInteractions_of_present ?_
+    ([ sdLdSlliBinaryExtensionOpBusInteraction
+      , binaryAddOpBusInteraction
+          (ZiskFv.AirsClean.BinaryAdd.binaryAddRowOf 0 160)
+      , binaryAddOpBusInteraction
+          (ZiskFv.AirsClean.BinaryAdd.binaryAddRowOf 2684354560 8)
+      , binaryAddOpBusInteraction
+          (ZiskFv.AirsClean.BinaryAdd.binaryAddRowOf 0 42)
+      , mainOpBusInteraction sdLdAddiX1A0Row
+      , mainOpBusInteraction sdLdSlliX1Row
+      , mainOpBusInteraction sdLdAddiX1EightRow
+      , mainOpBusInteraction sdLdAddiX2Row
+      , mainOpBusInteraction sdLdSdRow
+      , mainOpBusInteraction sdLdLdRow
+      , mainOpBusInteraction (sdLdJalRow 6)
+      , mainOpBusInteraction (sdLdJalRow 7) ].map (·.msg)) ?_ ?_
+  · left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+  · intro interaction h_interaction
+    exact List.mem_map_of_mem h_interaction
+  · intro msg h_msg
+    simp only [List.mem_map] at h_msg
+    rcases h_msg with ⟨interaction, h_interaction, rfl⟩
+    simp at h_interaction
+    rcases h_interaction with
+      rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
+      decide
+
+private theorem sdLdBoundaryMemBus_row
+    (row : ZiskFv.AirsClean.RegisterBoundary.RegisterBoundaryRow FGL) :
+    ZiskFv.AirsClean.RegisterBoundary.component.operations.interactionValuesWith
+        MemBusChannel.toRaw (Environment.fromInput row sdLdMemData) =
+      registerBoundaryMemBusInteractions row := by
+  rw [Operations.interactionValuesWith_eq_map,
+    ZiskFv.AirsClean.RegisterBoundary.component_interactionsWith_memBus]
+  simp only [registerBoundaryMemBusInteractions, List.map_cons, List.map_nil]
+  exact congrArg₂ (fun boot reload => [boot, reload])
+    (registerBoundaryBootInteraction_eval_fromInput row sdLdMemData)
+    (registerBoundaryReloadInteraction_eval_fromInput row sdLdMemData)
+
+private theorem sdLdBoundaryTable_memBusInteractions :
+    (sdLdTableWithData sdLdBoundaryTable).interactionsWith MemBusChannel.toRaw =
+      sdLdBoundaryRows.flatMap registerBoundaryMemBusInteractions := by
+  rw [Table.interactionsWith]
+  change (sdLdBoundaryRows.map registerBoundaryRowArray).flatMap (fun arr =>
+    ZiskFv.AirsClean.RegisterBoundary.component.operations.interactionValuesWith
+      MemBusChannel.toRaw (Environment.fromArray arr sdLdMemData)) = _
+  simp_rw [List.flatMap_map]
+  simp [registerBoundaryRowArray, Environment.fromInput, sdLdBoundaryMemBus_row]
+
+private theorem sdLdMemTable_memBusInteractions :
+    (sdLdTableWithData sdLdMemTable).interactionsWith MemBusChannel.toRaw =
+      sdLdMemRows.flatMap (fun row => [memBusInteraction row, memBusDualInteraction row]) := by
+  simpa [sdLdTableWithData, sdLdMemTable] using
+    memRowsTable_interactionsWith_memBus sdLdMemData sdLdMemRows sdLdMemRows_capacity
+
+private theorem sdLdMainMemBus_row
+    (index : ℕ) (row : MainRowWithRom FGL)
+    (h_segment : row.core.segment_l1 = mainFixedColumns.fixedAt 0 index)
+    (h_step : row.rom.main_step = mainFixedColumns.fixedAt 1 index) :
+    (componentWithRomMemAndOpBus 7 sdLdProgram).operations.interactionValuesWith
+        MemBusChannel.toRaw
+        (Environment.fromArray (mainFixedColumns.materialize index (mainRawRow row)) sdLdMemData) =
+      AddSpinWitness.mainValueMemBusInteractions row := by
+  rw [AddSpinWitness.mainMemBusInteractionsAt_eq_component,
+    AddSpinWitness.mainMemBusInteractionsAt_eq_valueLevel]
+  exact eval_mainRawRow_materialize index sdLdMemData row h_segment h_step
+
+private theorem sdLdMainTable_memBusInteractions :
+    (sdLdTableWithData sdLdMainTable).interactionsWith MemBusChannel.toRaw =
+      sdLdMainRows.flatMap AddSpinWitness.mainValueMemBusInteractions := by
+  rw [Table.interactionsWith]
+  change List.flatMap (fun row =>
+    (componentWithRomMemAndOpBus 7 sdLdProgram).operations.interactionValuesWith
+      MemBusChannel.toRaw (Environment.fromArray row sdLdMemData))
+    (sdLdMainRows.map mainRawRow |>.mapIdx mainFixedColumns.materialize) = _
+  simp only [sdLdMainRows, List.map_cons, List.map_nil, List.mapIdx_cons,
+    List.mapIdx_nil, List.flatMap_cons, List.flatMap_nil, List.append_nil]
+  rw [sdLdMainMemBus_row 0 sdLdAddiX1A0Row (by decide) (by decide),
+    sdLdMainMemBus_row 1 sdLdSlliX1Row (by decide) (by decide),
+    sdLdMainMemBus_row 2 sdLdAddiX1EightRow (by decide) (by decide),
+    sdLdMainMemBus_row 3 sdLdAddiX2Row (by decide) (by decide),
+    sdLdMainMemBus_row 4 sdLdSdRow (by decide) (by decide),
+    sdLdMainMemBus_row 5 sdLdLdRow (by decide) (by decide),
+    sdLdMainMemBus_row 6 (sdLdJalRow 6) (by decide) (by decide),
+    sdLdMainMemBus_row 7 (sdLdJalRow 7) (by decide) (by decide)]
+
 theorem sdLdWitness_memAlignRangeChannel_balanced :
     BalancedInteractions
       (sdLdWitness.tables.flatMap

--- a/ZiskFv/Compliance/SdLdSpinWitness.lean
+++ b/ZiskFv/Compliance/SdLdSpinWitness.lean
@@ -73,6 +73,50 @@ def sdLdAddiX2ProgramRow : ZiskRomMessage FGL :=
     ind_width := 8, op := ZiskFv.Trusted.OP_ADD, store_offset := 2, jmp_offset1 := 4,
     jmp_offset2 := 4, flags := packFlags addiX0Bits }
 
+def sdLdSdBits : RomFlagBits where
+  a_src_imm := false
+  a_src_mem := false
+  is_precompiled := false
+  b_src_imm := false
+  b_src_mem := false
+  is_external_op := false
+  store_pc := false
+  store_mem := false
+  store_ind := true
+  set_pc := false
+  m32 := false
+  b_src_ind := false
+  a_src_reg := true
+  b_src_reg := true
+  store_reg := false
+
+def sdLdLdBits : RomFlagBits where
+  a_src_imm := false
+  a_src_mem := false
+  is_precompiled := false
+  b_src_imm := false
+  b_src_mem := false
+  is_external_op := false
+  store_pc := false
+  store_mem := false
+  store_ind := false
+  set_pc := false
+  m32 := false
+  b_src_ind := true
+  a_src_reg := true
+  b_src_reg := false
+  store_reg := true
+
+def sdLdSdProgramRow : ZiskRomMessage FGL :=
+  { line := 16, a_offset_imm0 := 1, a_imm1 := 0, b_offset_imm0 := 2, b_imm1 := 0,
+    ind_width := 8, op := ZiskFv.Trusted.OP_COPYB, store_offset := 0, jmp_offset1 := 4,
+    jmp_offset2 := 4, flags := packFlags sdLdSdBits }
+
+def sdLdLdProgramRow : ZiskRomMessage FGL :=
+  { line := 20, a_offset_imm0 := 1, a_imm1 := 0, b_offset_imm0 := 0, b_imm1 := 0,
+    ind_width := 8, op := ZiskFv.Trusted.OP_COPYB, store_offset := 3, jmp_offset1 := 4,
+    jmp_offset2 := 4, flags := packFlags sdLdLdBits }
+
 /-- The x0 ADDI source form consumed by the ROM/Main binding has both
 immediate lanes fixed by its program message. -/
 def sdLdAddiX1A0FreeCols : MainRomFreeCols :=

--- a/ZiskFv/Compliance/SdLdSpinWitness.lean
+++ b/ZiskFv/Compliance/SdLdSpinWitness.lean
@@ -305,15 +305,18 @@ def sdLdBoundaryRows :
 def sdLdBoundaryTable : Air.Flat.Table FGL :=
   registerBoundaryRowsTableOf sdLdBoundaryRows
 
-def sdLdMainTable : Air.Flat.Table FGL :=
+def sdLdMainTableEmptyData : Air.Flat.Table FGL :=
   AddSpinWitness.mainRowsTable 7 sdLdProgram sdLdMainRows sdLdMainRows_fixed_domain
 
 def sdLdMainTableWithData (data : ProverData FGL) : Air.Flat.Table FGL where
-  component := sdLdMainTable.component
-  rawRows := sdLdMainTable.rawRows
+  component := sdLdMainTableEmptyData.component
+  rawRows := sdLdMainTableEmptyData.rawRows
   data := data
-  raw_uniform_width := sdLdMainTable.raw_uniform_width
-  fixed_domain := sdLdMainTable.fixed_domain
+  raw_uniform_width := sdLdMainTableEmptyData.raw_uniform_width
+  fixed_domain := sdLdMainTableEmptyData.fixed_domain
+
+def sdLdMainTable : Air.Flat.Table FGL :=
+  sdLdMainTableWithData sdLdMemData
 
 theorem sdLdAddiX1A0Main_proverAssumptions :
     (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus 7 sdLdProgram).circuit.ProverAssumptions
@@ -618,21 +621,25 @@ theorem sdLdMainTableWithData_constraints (data : ProverData FGL)
       (h_assumptions (sdLdJalRow 7) (by simp [sdLdMainRows]))
 
 theorem sdLdMainTable_constraints : sdLdMainTable.Constraints := by
-  simpa [sdLdMainTableWithData] using
-    sdLdMainTableWithData_constraints emptyData (by
+  simpa [sdLdMainTable] using
+    sdLdMainTableWithData_constraints sdLdMemData (by
       intro row h_row
       simp [sdLdMainRows] at h_row
       rcases h_row with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
-      · exact sdLdAddiX1A0Main_proverAssumptions
-      · exact sdLdSlliX1Main_proverAssumptions
-      · exact sdLdAddiX1EightMain_proverAssumptions
-      · exact sdLdAddiX2Main_proverAssumptions
-      · exact sdLdSdMain_proverAssumptions
-      · exact sdLdLdMain_proverAssumptions
-      · exact sdLdJalMain_proverAssumptions 6
-      · exact sdLdJalMain_proverAssumptions 7)
+      · simpa using sdLdAddiX1A0Main_proverAssumptions
+      · simpa using sdLdSlliX1Main_proverAssumptions
+      · simpa using sdLdAddiX1EightMain_proverAssumptions
+      · simpa using sdLdAddiX2Main_proverAssumptions
+      · simpa using sdLdSdMain_proverAssumptions
+      · simpa using sdLdLdMain_proverAssumptions
+      · simpa using sdLdJalMain_proverAssumptions 6
+      · simpa using sdLdJalMain_proverAssumptions 7)
 
 @[simp] theorem sdLdMainTable_length : sdLdMainTable.length = 8 := by
+  rfl
+
+@[simp] theorem sdLdMainTableWithData_length (data : ProverData FGL) :
+    (sdLdMainTableWithData data).length = 8 := by
   rfl
 
 @[simp] theorem sdLdMainTable_evalAt (index : Fin sdLdMainTable.length) :
@@ -641,7 +648,7 @@ theorem sdLdMainTable_constraints : sdLdMainTable.Constraints := by
       sdLdMainRows[index.val]'(by simpa using index.isLt) := by
   fin_cases index <;>
     change Eval.eval
-      (Environment.fromArray (mainFixedColumns.materialize _ (mainRawRow _)) emptyData)
+      (Environment.fromArray (mainFixedColumns.materialize _ (mainRawRow _)) sdLdMemData)
       (varFromOffset MainRowWithRom 0) = _ <;>
     apply eval_mainRawRow_materialize <;>
     simp [sdLdAddiX1A0Row, sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate,
@@ -675,7 +682,8 @@ theorem sdLdMainTable_cyclicSuccessorTransitions :
     sdLdMainTable.CyclicSuccessorTransitionConstraints := by
   rw [Table.CyclicSuccessorTransitionConstraints]
   intro index
-  simp [sdLdMainTable, AddSpinWitness.mainRowsTable,
+  simp [sdLdMainTable, sdLdMainTableWithData, sdLdMainTableEmptyData,
+    AddSpinWitness.mainRowsTable,
     ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus]
 
 def sdLdBinaryAddRows : List (ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL) :=
@@ -870,7 +878,9 @@ def sdLdWitness : EnsembleWitness sdLdEnsemble where
   same_length := by
     simp [sdLdEnsemble, fullRv64imEnsemble, fullRv64imSoundEnsemble,
       sdLdTables, SoundEnsemble.toFormal, SoundEnsemble.addFinishedChannel_tables,
-      SoundEnsemble.addTable, SoundEnsemble.empty_tables, Ensemble.addTable]
+      SoundEnsemble.addTable, SoundEnsemble.empty_tables, Ensemble.addTable,
+      sdLdMainTable, sdLdMainTableWithData, sdLdMainTableEmptyData,
+      AddSpinWitness.mainRowsTable]
   same_circuits := by
     intro i hi
     have hi' : i < 14 := by
@@ -882,7 +892,8 @@ def sdLdWitness : EnsembleWitness sdLdEnsemble where
         sdLdTableWithData, sdLdBoundaryTable, registerBoundaryRowsTableOf, emptyComponentTable,
         sdLdMemTable, memRowsTable, sdLdBinaryExtensionTable,
         binaryExtensionShiftStaticRowsTable, sdLdBinaryAddTable, binaryAddRowsTable,
-        sdLdMainTable, AddSpinWitness.mainRowsTable]
+        sdLdMainTable, sdLdMainTableWithData, sdLdMainTableEmptyData,
+        AddSpinWitness.mainRowsTable]
   same_data := by
     intro table h_table
     simp [sdLdTables, sdLdTableWithData, sdLdBoundaryTable,
@@ -995,22 +1006,108 @@ theorem sdLdWitness_table_constraints :
   · exact sdLdBinaryExtensionTableWithData_constraints
   · exact sdLdEmptyTableWithData_constraints _
   · exact sdLdBinaryAddTableWithData_constraints
-  · simpa [sdLdTableWithData, sdLdMainTableWithData] using
-      sdLdMainTableWithData_constraints sdLdMemData (by
-        intro row h_row
-        simp [sdLdMainRows] at h_row
-        rcases h_row with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
-        · simpa using sdLdAddiX1A0Main_proverAssumptions
-        · simpa using sdLdSlliX1Main_proverAssumptions
-        · simpa using sdLdAddiX1EightMain_proverAssumptions
-        · simpa using sdLdAddiX2Main_proverAssumptions
-        · simpa using sdLdSdMain_proverAssumptions
-        · simpa using sdLdLdMain_proverAssumptions
-        · simpa using sdLdJalMain_proverAssumptions 6
-        · simpa using sdLdJalMain_proverAssumptions 7)
+  · simpa [sdLdTableWithData, sdLdMainTable] using sdLdMainTable_constraints
 
 theorem sdLdWitness_constraints : sdLdWitness.Constraints :=
   sdLdWitness.constraints_of_tables sdLdEnsemble_verifier sdLdWitness_table_constraints
+
+private theorem sdLdEmptyTableWithData_transitions (component : Component FGL) :
+    (sdLdTableWithData (emptyComponentTable component)).TransitionConstraints := by
+  rw [Table.TransitionConstraints]
+  intro index
+  have h_length :
+      (sdLdTableWithData (emptyComponentTable component)).length = 0 := by
+    simp [sdLdTableWithData, emptyComponentTable, Table.length, Table.table]
+  exact Fin.elim0 (Fin.cast h_length index)
+
+private theorem sdLdEmptyTableWithData_cyclicSuccessorTransitions (component : Component FGL) :
+    (sdLdTableWithData
+      (emptyComponentTable component)).CyclicSuccessorTransitionConstraints := by
+  rw [Table.CyclicSuccessorTransitionConstraints]
+  intro index
+  have h_length :
+      (sdLdTableWithData (emptyComponentTable component)).length = 0 := by
+    simp [sdLdTableWithData, emptyComponentTable, Table.length, Table.table]
+  exact Fin.elim0 (Fin.cast h_length index)
+
+theorem sdLdWitness_transitions : sdLdWitness.TransitionConstraints := by
+  intro table h_table
+  rw [EnsembleWitness.allTables, List.mem_cons] at h_table
+  rcases h_table with h_verifier | h_table
+  · subst table
+    rw [Table.TransitionConstraints]
+    intro index
+    simp [EnsembleWitness.verifierTable]
+  · rw [sdLdWitness_tables] at h_table
+    simp [sdLdTables] at h_table
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl |
+      rfl | rfl | rfl | rfl
+    · rw [Table.TransitionConstraints]
+      intro index
+      simp [sdLdTableWithData, sdLdBoundaryTable, registerBoundaryRowsTableOf,
+        ZiskFv.AirsClean.RegisterBoundary.component]
+    · exact sdLdEmptyTableWithData_transitions _
+    · exact sdLdEmptyTableWithData_transitions _
+    · exact sdLdEmptyTableWithData_transitions _
+    · exact sdLdEmptyTableWithData_transitions _
+    · exact sdLdEmptyTableWithData_transitions _
+    · simpa [sdLdTableWithData, sdLdMemTable, memRowsTable] using sdLdMemTable_transitions
+    · exact sdLdEmptyTableWithData_transitions _
+    · exact sdLdEmptyTableWithData_transitions _
+    · exact sdLdEmptyTableWithData_transitions _
+    · rw [Table.TransitionConstraints]
+      intro index
+      simp [sdLdTableWithData, sdLdBinaryExtensionTable,
+        binaryExtensionShiftStaticRowsTable,
+        ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent]
+    · exact sdLdEmptyTableWithData_transitions _
+    · rw [Table.TransitionConstraints]
+      intro index
+      simp [sdLdTableWithData, sdLdBinaryAddTable, binaryAddRowsTable,
+        ZiskFv.AirsClean.BinaryAdd.component]
+    · simpa [sdLdTableWithData, sdLdMainTable] using sdLdMainTable_transitions
+
+theorem sdLdWitness_cyclicSuccessorTransitions :
+    sdLdWitness.CyclicSuccessorTransitionConstraints := by
+  intro table h_table
+  rw [EnsembleWitness.allTables, List.mem_cons] at h_table
+  rcases h_table with h_verifier | h_table
+  · subst table
+    rw [Table.CyclicSuccessorTransitionConstraints]
+    intro index
+    simp [EnsembleWitness.verifierTable]
+  · rw [sdLdWitness_tables] at h_table
+    simp [sdLdTables] at h_table
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl |
+      rfl | rfl | rfl | rfl
+    · rw [Table.CyclicSuccessorTransitionConstraints]
+      intro index
+      simp [sdLdTableWithData, sdLdBoundaryTable, registerBoundaryRowsTableOf,
+        ZiskFv.AirsClean.RegisterBoundary.component]
+    · exact sdLdEmptyTableWithData_cyclicSuccessorTransitions _
+    · exact sdLdEmptyTableWithData_cyclicSuccessorTransitions _
+    · exact sdLdEmptyTableWithData_cyclicSuccessorTransitions _
+    · exact sdLdEmptyTableWithData_cyclicSuccessorTransitions _
+    · exact sdLdEmptyTableWithData_cyclicSuccessorTransitions _
+    · rw [Table.CyclicSuccessorTransitionConstraints]
+      intro index
+      simp [sdLdTableWithData, sdLdMemTable, memRowsTable,
+        ZiskFv.AirsClean.Mem.componentWithDualMemBus]
+    · exact sdLdEmptyTableWithData_cyclicSuccessorTransitions _
+    · exact sdLdEmptyTableWithData_cyclicSuccessorTransitions _
+    · exact sdLdEmptyTableWithData_cyclicSuccessorTransitions _
+    · rw [Table.CyclicSuccessorTransitionConstraints]
+      intro index
+      simp [sdLdTableWithData, sdLdBinaryExtensionTable,
+        binaryExtensionShiftStaticRowsTable,
+        ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent]
+    · exact sdLdEmptyTableWithData_cyclicSuccessorTransitions _
+    · rw [Table.CyclicSuccessorTransitionConstraints]
+      intro index
+      simp [sdLdTableWithData, sdLdBinaryAddTable, binaryAddRowsTable,
+        ZiskFv.AirsClean.BinaryAdd.component]
+    · simpa [sdLdTableWithData, sdLdMainTable] using
+        sdLdMainTable_cyclicSuccessorTransitions
 
 def sdLdX1Telescope :=
   registerTelescopingInteractions

--- a/ZiskFv/Compliance/SdLdSpinWitness.lean
+++ b/ZiskFv/Compliance/SdLdSpinWitness.lean
@@ -18,7 +18,12 @@ open Air.Flat
 open ZiskFv.AirsClean.FullEnsemble (fullRv64imEnsemble fullRv64imSoundEnsemble)
 open ZiskFv.AirsClean.Main
 open ZiskFv.AirsClean.ZiskInstructionRom (Program)
-open ZiskFv.Channels.MemoryBus (MemBusMessage)
+open ZiskFv.Channels.MemoryBus (MemBusChannel MemBusMessage)
+open ZiskFv.Channels.MemAlignRom (MemAlignRomChannel)
+open ZiskFv.Channels.MemAlignRanges (MemAlignRangeChannel)
+open ZiskFv.Channels.OperationBus (OpBusChannel)
+open ZiskFv.Channels.SpecifiedRanges
+  (SpecifiedRangeMessage SpecifiedRangesSliceChannel memDistanceMessage)
 open ZiskFv.Channels.ZiskRomBus (ZiskRomMessage)
 open ZiskFv.Compliance.Instantiation
 open ZiskFv.Compliance.RegisterMemBusBalance
@@ -855,6 +860,21 @@ def sdLdTableWithData (table : Table FGL) : Table FGL where
   raw_uniform_width := table.raw_uniform_width
   fixed_domain := table.fixed_domain
 
+def sdLdSpecifiedRangeValues : List FGL :=
+  [0, 0, 0, 0, 65534, 65534, 1023, 1023]
+
+def sdLdSpecifiedRangesTable : Table FGL where
+  component := ZiskFv.AirsClean.SpecifiedRangesSlice.component
+  rawRows := sdLdSpecifiedRangeValues.map (fun value => #[value])
+  data := sdLdMemData
+  raw_uniform_width := by
+    intro raw h_raw
+    rcases List.mem_map.mp h_raw with ⟨value, _h_value, rfl⟩
+    rfl
+  fixed_domain := by
+    intro columns h_columns
+    simp [ZiskFv.AirsClean.SpecifiedRangesSlice.component] at h_columns
+
 def sdLdTables : List (Table FGL) :=
   [ sdLdTableWithData sdLdBoundaryTable
   , sdLdTableWithData (emptyComponentTable ZiskFv.AirsClean.MemAlignReadByte.component)
@@ -863,7 +883,7 @@ def sdLdTables : List (Table FGL) :=
   , sdLdTableWithData (emptyComponentTable ZiskFv.AirsClean.MemAlignRangeSlice.component)
   , sdLdTableWithData (emptyComponentTable ZiskFv.AirsClean.MemAlignRomSlice.component)
   , sdLdTableWithData sdLdMemTable
-  , sdLdTableWithData (emptyComponentTable ZiskFv.AirsClean.SpecifiedRangesSlice.component)
+  , sdLdSpecifiedRangesTable
   , sdLdTableWithData (emptyComponentTable ZiskFv.AirsClean.ArithDiv.component)
   , sdLdTableWithData (emptyComponentTable ZiskFv.AirsClean.ArithMul.componentWithArithTable)
   , sdLdTableWithData sdLdBinaryExtensionTable
@@ -890,7 +910,7 @@ def sdLdWitness : EnsembleWitness sdLdEnsemble where
         sdLdTables, SoundEnsemble.toFormal, SoundEnsemble.addFinishedChannel_tables,
         SoundEnsemble.addTable, SoundEnsemble.empty_tables, Ensemble.addTable,
         sdLdTableWithData, sdLdBoundaryTable, registerBoundaryRowsTableOf, emptyComponentTable,
-        sdLdMemTable, memRowsTable, sdLdBinaryExtensionTable,
+        sdLdMemTable, memRowsTable, sdLdSpecifiedRangesTable, sdLdBinaryExtensionTable,
         binaryExtensionShiftStaticRowsTable, sdLdBinaryAddTable, binaryAddRowsTable,
         sdLdMainTable, sdLdMainTableWithData, sdLdMainTableEmptyData,
         AddSpinWitness.mainRowsTable]
@@ -898,7 +918,7 @@ def sdLdWitness : EnsembleWitness sdLdEnsemble where
     intro table h_table
     simp [sdLdTables, sdLdTableWithData, sdLdBoundaryTable,
       registerBoundaryRowsTableOf, emptyComponentTable,
-      sdLdMemTable, memRowsTable, sdLdBinaryExtensionTable,
+      sdLdMemTable, memRowsTable, sdLdSpecifiedRangesTable, sdLdBinaryExtensionTable,
       binaryExtensionShiftStaticRowsTable, sdLdBinaryAddTable, binaryAddRowsTable,
       sdLdMainTable, AddSpinWitness.mainRowsTable] at h_table
     rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl |
@@ -986,6 +1006,35 @@ private theorem sdLdBoundaryTableWithData_constraints :
   simpa [sdLdTableWithData, sdLdBoundaryTable, registerBoundaryRowsTableOf,
     registerBoundaryRowArray, Table.environment, Environment.fromInput] using h_component
 
+private theorem sdLdSpecifiedRangesTable_constraints :
+    sdLdSpecifiedRangesTable.Constraints := by
+  rw [Table.Constraints]
+  intro arr h_arr
+  change arr ∈ sdLdSpecifiedRangeValues.map (fun value => #[value]) at h_arr
+  rcases List.mem_map.mp h_arr with ⟨value, h_value, rfl⟩
+  have h_assumptions :
+      ZiskFv.AirsClean.SpecifiedRangesSlice.component.circuit.ProverAssumptions
+        value sdLdMemData (ProverHint.empty FGL) := by
+    simp [sdLdSpecifiedRangeValues] at h_value
+    rcases h_value with rfl | rfl | rfl
+    all_goals
+      change ((_: FGL).val < 2 ^ 16)
+      norm_num
+  have h_component :
+      ZiskFv.AirsClean.SpecifiedRangesSlice.component.operations.ConstraintsHold
+        (Environment.fromArray #[value] sdLdMemData) := by
+    apply ZiskFv.Compliance.Instantiation.component_constraintsHold_of_proverAssumptions_at_data
+      ZiskFv.AirsClean.SpecifiedRangesSlice.component
+      (Environment.fromArray #[value] sdLdMemData) value sdLdMemData
+    · rfl
+    · simpa [Environment.fromInput] using
+        (ProvableType.eval_fromInput_varFromOffset_zero (Input := field)
+          value sdLdMemData)
+    · rfl
+    · exact h_assumptions
+  simpa [sdLdSpecifiedRangesTable, Table.table, Table.environment,
+    Environment.fromInput] using h_component
+
 theorem sdLdWitness_table_constraints :
     ∀ table ∈ sdLdWitness.tables, table.Constraints := by
   intro table h_table
@@ -1000,7 +1049,7 @@ theorem sdLdWitness_table_constraints :
   · exact sdLdEmptyTableWithData_constraints _
   · exact sdLdEmptyTableWithData_constraints _
   · simpa [sdLdTableWithData, sdLdMemTable, memRowsTable] using sdLdMemTable_constraints
-  · exact sdLdEmptyTableWithData_constraints _
+  · exact sdLdSpecifiedRangesTable_constraints
   · exact sdLdEmptyTableWithData_constraints _
   · exact sdLdEmptyTableWithData_constraints _
   · exact sdLdBinaryExtensionTableWithData_constraints
@@ -1052,7 +1101,9 @@ theorem sdLdWitness_transitions : sdLdWitness.TransitionConstraints := by
     · exact sdLdEmptyTableWithData_transitions _
     · exact sdLdEmptyTableWithData_transitions _
     · simpa [sdLdTableWithData, sdLdMemTable, memRowsTable] using sdLdMemTable_transitions
-    · exact sdLdEmptyTableWithData_transitions _
+    · rw [Table.TransitionConstraints]
+      intro index
+      simp [sdLdSpecifiedRangesTable, ZiskFv.AirsClean.SpecifiedRangesSlice.component]
     · exact sdLdEmptyTableWithData_transitions _
     · exact sdLdEmptyTableWithData_transitions _
     · rw [Table.TransitionConstraints]
@@ -1093,7 +1144,9 @@ theorem sdLdWitness_cyclicSuccessorTransitions :
       intro index
       simp [sdLdTableWithData, sdLdMemTable, memRowsTable,
         ZiskFv.AirsClean.Mem.componentWithDualMemBus]
-    · exact sdLdEmptyTableWithData_cyclicSuccessorTransitions _
+    · rw [Table.CyclicSuccessorTransitionConstraints]
+      intro index
+      simp [sdLdSpecifiedRangesTable, ZiskFv.AirsClean.SpecifiedRangesSlice.component]
     · exact sdLdEmptyTableWithData_cyclicSuccessorTransitions _
     · exact sdLdEmptyTableWithData_cyclicSuccessorTransitions _
     · rw [Table.CyclicSuccessorTransitionConstraints]
@@ -1175,5 +1228,242 @@ theorem sdLdLoadMessage_eq_mem :
     ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle, ldMemRow,
     ZiskFv.AirsClean.Mem.memRowOf, ZiskFv.AirsClean.Mem.memReadSameAddrOf,
     ZiskFv.AirsClean.Mem.memValueOf]
+
+private def sdLdRangeConsumer (value : FGL) : Interaction FGL where
+  channel := SpecifiedRangesSliceChannel.toRaw
+  mult := -1
+  msg := (toElements (memDistanceMessage value)).toArray
+  same_size := by simp [Channel.toRaw]
+  assumeGuarantees := false
+
+private theorem sdLdEval_memDistanceMessage
+    (env : Environment FGL) (value : Expression FGL) :
+    Eval.eval env (memDistanceMessage value) =
+      memDistanceMessage (Expression.eval env value) := by
+  rw [SpecifiedRangeMessage.mk.injEq]
+  simp only [memDistanceMessage, ProvableStruct.eval_eq_eval, ProvableStruct.eval,
+    ProvableStruct.fromComponents, ProvableStruct.components,
+    ProvableStruct.toComponents, ProvableStruct.eval.go, ProvableType.eval_field,
+    Expression.eval]
+  repeat constructor
+
+private theorem sdLdMemTable_rangeInteractions :
+    (sdLdTableWithData sdLdMemTable).interactionsWith
+        SpecifiedRangesSliceChannel.toRaw =
+      [ sdLdRangeConsumer 0, sdLdRangeConsumer 0
+      , sdLdRangeConsumer 65534, sdLdRangeConsumer 1023
+      , sdLdRangeConsumer 0, sdLdRangeConsumer 0
+      , sdLdRangeConsumer 65534, sdLdRangeConsumer 1023 ] := by
+  rw [Table.interactionsWith]
+  change List.flatMap (fun row =>
+    ZiskFv.AirsClean.Mem.componentWithDualMemBus.operations.interactionValuesWith
+      SpecifiedRangesSliceChannel.toRaw (Environment.fromArray row sdLdMemData))
+    [ ZiskFv.AirsClean.Mem.memFixedColumns.materialize 0
+        (ZiskFv.AirsClean.Mem.memRawRowWithProverData sdLdMemData sdMemRow)
+    , ZiskFv.AirsClean.Mem.memFixedColumns.materialize 1
+        (ZiskFv.AirsClean.Mem.memRawRowWithProverData sdLdMemData ldMemRow) ] = _
+  simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]
+  simp_rw [Operations.interactionValuesWith_eq_map,
+    ZiskFv.AirsClean.Mem.componentWithDualMemBus_interactionsWith_rangeChannel]
+  simp only [List.map_cons, List.map_nil]
+  simp [sdLdRangeConsumer, AbstractInteraction.eval, ChannelInteraction.toRaw,
+    Channel.emitted, emitted]
+  simp_rw [← Vector.toArray_map, ← ProvableType.toElements_eval,
+    sdLdEval_memDistanceMessage]
+  norm_num [ZiskFv.AirsClean.Mem.eval_memDistanceBase0Expr_materialize,
+    ZiskFv.AirsClean.Mem.eval_memDistanceBase1Expr_materialize,
+    ZiskFv.AirsClean.Mem.eval_memDistanceEnd0Expr_materialize,
+    ZiskFv.AirsClean.Mem.eval_memDistanceEnd1Expr_materialize]
+  all_goals simp [Expression.eval]
+
+private theorem sdLdSpecifiedRange_evalRowInput (value : FGL) :
+    Expression.eval (Environment.fromArray #[value] sdLdMemData)
+        ZiskFv.AirsClean.SpecifiedRangesSlice.component.rowInputVar = value := by
+  change (Environment.fromArray #[value] sdLdMemData).get 0 = value
+  rfl
+
+private theorem sdLdSpecifiedRangesTable_rangeInteractions :
+    sdLdSpecifiedRangesTable.interactionsWith SpecifiedRangesSliceChannel.toRaw =
+      sdLdSpecifiedRangeValues.map
+        (fun value => SpecifiedRangesSliceChannel.pushedValue (memDistanceMessage value)) := by
+  rw [Table.interactionsWith]
+  change List.flatMap (fun row =>
+    ZiskFv.AirsClean.SpecifiedRangesSlice.component.operations.interactionValuesWith
+      SpecifiedRangesSliceChannel.toRaw (Environment.fromArray row sdLdMemData))
+    (sdLdSpecifiedRangeValues.map fun value => #[value]) = _
+  simp_rw [List.flatMap_map, Operations.interactionValuesWith_eq_map,
+    ZiskFv.AirsClean.SpecifiedRangesSlice.component_interactionsWith_rangeChannel]
+  simp [Channel.eval_pushed, sdLdEval_memDistanceMessage,
+    sdLdSpecifiedRange_evalRowInput, sdLdSpecifiedRangeValues]
+
+@[simp] private theorem sdLdEmptyTableWithData_interactions
+    (component : Component FGL) (channel : RawChannel FGL) :
+    (sdLdTableWithData
+      (emptyComponentTable component)).interactionsWith channel = [] := by
+  rw [Table.interactionsWith]
+  have h_empty :
+      (sdLdTableWithData (emptyComponentTable component)).table = [] := by
+    cases h_fixed : component.fixedColumns <;>
+      simp [sdLdTableWithData, emptyComponentTable, Table.table, h_fixed]
+  rw [h_empty]
+  rfl
+
+private theorem sdLdTables_interactionsWith_nil_of_ne_protocol
+    (channel : RawChannel FGL)
+    (h_mem : channel ≠ MemBusChannel.toRaw)
+    (h_op : channel ≠ OpBusChannel.toRaw)
+    (h_range : channel ≠ SpecifiedRangesSliceChannel.toRaw) :
+    sdLdWitness.tables.flatMap (·.interactionsWith channel) = [] := by
+  have h_boundary :
+      (sdLdTableWithData sdLdBoundaryTable).interactionsWith channel = [] := by
+    apply Table.interactionsWith_nil_of_channel_not_mem
+    change channel ∉ [MemBusChannel.toRaw]
+    simpa using h_mem
+  have h_memTable :
+      (sdLdTableWithData sdLdMemTable).interactionsWith channel = [] := by
+    apply Table.interactionsWith_nil_of_channel_not_mem
+    simp [circuit_norm, sdLdTableWithData, sdLdMemTable, memRowsTable,
+      ZiskFv.AirsClean.Mem.componentWithDualMemBus,
+      ZiskFv.AirsClean.Mem.circuitWithDualMemBus, h_mem, h_range]
+  have h_rangeTable :
+      sdLdSpecifiedRangesTable.interactionsWith channel = [] := by
+    apply Table.interactionsWith_nil_of_channel_not_mem
+    change channel ∉ [SpecifiedRangesSliceChannel.toRaw]
+    simpa using h_range
+  have h_extension :
+      (sdLdTableWithData sdLdBinaryExtensionTable).interactionsWith channel = [] := by
+    apply Table.interactionsWith_nil_of_channel_not_mem
+    change channel ∉ [OpBusChannel.toRaw]
+    simpa using h_op
+  have h_binaryAdd :
+      (sdLdTableWithData sdLdBinaryAddTable).interactionsWith channel = [] := by
+    apply Table.interactionsWith_nil_of_channel_not_mem
+    change channel ∉ [OpBusChannel.toRaw]
+    simpa using h_op
+  have h_main :
+      (sdLdTableWithData sdLdMainTable).interactionsWith channel = [] := by
+    apply Table.interactionsWith_nil_of_channel_not_mem
+    change channel ∉ [MemBusChannel.toRaw, OpBusChannel.toRaw]
+    simp only [List.mem_cons, List.not_mem_nil, or_false, not_or]
+    exact ⟨h_mem, h_op⟩
+  rw [sdLdWitness_tables]
+  simp [sdLdTables, h_boundary, h_memTable, h_rangeTable, h_extension, h_binaryAdd, h_main,
+    emptyComponentTable_interactionsWith]
+
+private theorem sdLdBalancedInteractions_nil :
+    BalancedInteractions ([] : List (Interaction FGL)) := by
+  refine ⟨?_, ?_⟩
+  · left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+  · intro msg
+    simp [balanceOf]
+
+private theorem sdLdWitness_rangeInteractions :
+    sdLdWitness.tables.flatMap
+        (·.interactionsWith SpecifiedRangesSliceChannel.toRaw) =
+      [ sdLdRangeConsumer 0, sdLdRangeConsumer 0
+      , sdLdRangeConsumer 65534, sdLdRangeConsumer 1023
+      , sdLdRangeConsumer 0, sdLdRangeConsumer 0
+      , sdLdRangeConsumer 65534, sdLdRangeConsumer 1023 ] ++
+        sdLdSpecifiedRangeValues.map
+          (fun value => SpecifiedRangesSliceChannel.pushedValue (memDistanceMessage value)) := by
+  have h_ne_mem : SpecifiedRangesSliceChannel.toRaw ≠ MemBusChannel.toRaw := by
+    intro h
+    have h_name := congrArg (fun c : RawChannel FGL => c.name) h
+    simp [SpecifiedRangesSliceChannel, MemBusChannel, Channel.toRaw] at h_name
+  have h_ne_op : SpecifiedRangesSliceChannel.toRaw ≠ OpBusChannel.toRaw := by
+    intro h
+    have h_name := congrArg (fun c : RawChannel FGL => c.name) h
+    simp [SpecifiedRangesSliceChannel, OpBusChannel, Channel.toRaw] at h_name
+  have h_boundary :
+      (sdLdTableWithData sdLdBoundaryTable).interactionsWith
+          SpecifiedRangesSliceChannel.toRaw = [] := by
+    apply Table.interactionsWith_nil_of_channel_not_mem
+    change SpecifiedRangesSliceChannel.toRaw ∉ [MemBusChannel.toRaw]
+    simpa using h_ne_mem
+  have h_extension :
+      (sdLdTableWithData sdLdBinaryExtensionTable).interactionsWith
+          SpecifiedRangesSliceChannel.toRaw = [] := by
+    apply Table.interactionsWith_nil_of_channel_not_mem
+    change SpecifiedRangesSliceChannel.toRaw ∉ [OpBusChannel.toRaw]
+    simpa using h_ne_op
+  have h_binaryAdd :
+      (sdLdTableWithData sdLdBinaryAddTable).interactionsWith
+          SpecifiedRangesSliceChannel.toRaw = [] := by
+    apply Table.interactionsWith_nil_of_channel_not_mem
+    change SpecifiedRangesSliceChannel.toRaw ∉ [OpBusChannel.toRaw]
+    simpa using h_ne_op
+  have h_main :
+      (sdLdTableWithData sdLdMainTable).interactionsWith
+          SpecifiedRangesSliceChannel.toRaw = [] := by
+    apply Table.interactionsWith_nil_of_channel_not_mem
+    change SpecifiedRangesSliceChannel.toRaw ∉
+      [MemBusChannel.toRaw, OpBusChannel.toRaw]
+    simp only [List.mem_cons, List.not_mem_nil, or_false, not_or]
+    exact ⟨h_ne_mem, h_ne_op⟩
+  rw [sdLdWitness_tables]
+  simp [sdLdTables, h_boundary, sdLdMemTable_rangeInteractions,
+    sdLdSpecifiedRangesTable_rangeInteractions, h_extension, h_binaryAdd, h_main]
+
+theorem sdLdWitness_rangeChannel_balanced :
+    BalancedInteractions
+      (sdLdWitness.tables.flatMap
+        (·.interactionsWith SpecifiedRangesSliceChannel.toRaw)) := by
+  rw [sdLdWitness_rangeInteractions]
+  refine Air.Flat.balancedInteractions_of_present ?_
+    (([ sdLdRangeConsumer 0, sdLdRangeConsumer 0
+      , sdLdRangeConsumer 65534, sdLdRangeConsumer 1023
+      , sdLdRangeConsumer 0, sdLdRangeConsumer 0
+      , sdLdRangeConsumer 65534, sdLdRangeConsumer 1023 ] ++
+        sdLdSpecifiedRangeValues.map
+          (fun value =>
+            SpecifiedRangesSliceChannel.pushedValue (memDistanceMessage value))).map
+      (·.msg)) ?_ ?_
+  · left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+  · intro interaction h_interaction
+    exact List.mem_map_of_mem h_interaction
+  · intro msg h_msg
+    simp only [List.mem_map] at h_msg
+    rcases h_msg with ⟨interaction, h_interaction, rfl⟩
+    simp [sdLdSpecifiedRangeValues] at h_interaction
+    rcases h_interaction with
+      rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl |
+      rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
+      decide
+
+theorem sdLdWitness_memAlignRangeChannel_balanced :
+    BalancedInteractions
+      (sdLdWitness.tables.flatMap
+        (·.interactionsWith MemAlignRangeChannel.toRaw)) := by
+  rw [sdLdTables_interactionsWith_nil_of_ne_protocol]
+  · exact sdLdBalancedInteractions_nil
+  · intro h
+    have h_name := congrArg (fun c : RawChannel FGL => c.name) h
+    simp [MemAlignRangeChannel, MemBusChannel, Channel.toRaw] at h_name
+  · intro h
+    have h_name := congrArg (fun c : RawChannel FGL => c.name) h
+    simp [MemAlignRangeChannel, OpBusChannel, Channel.toRaw] at h_name
+  · intro h
+    have h_name := congrArg (fun c : RawChannel FGL => c.name) h
+    simp [MemAlignRangeChannel, SpecifiedRangesSliceChannel, Channel.toRaw] at h_name
+
+theorem sdLdWitness_memAlignRomChannel_balanced :
+    BalancedInteractions
+      (sdLdWitness.tables.flatMap
+        (·.interactionsWith MemAlignRomChannel.toRaw)) := by
+  rw [sdLdTables_interactionsWith_nil_of_ne_protocol]
+  · exact sdLdBalancedInteractions_nil
+  · intro h
+    have h_name := congrArg (fun c : RawChannel FGL => c.name) h
+    simp [MemAlignRomChannel, MemBusChannel, Channel.toRaw] at h_name
+  · intro h
+    have h_name := congrArg (fun c : RawChannel FGL => c.name) h
+    simp [MemAlignRomChannel, OpBusChannel, Channel.toRaw] at h_name
+  · intro h
+    have h_name := congrArg (fun c : RawChannel FGL => c.name) h
+    simp [MemAlignRomChannel, SpecifiedRangesSliceChannel, Channel.toRaw] at h_name
 
 end ZiskFv.Compliance.SdLdSpinWitness

--- a/ZiskFv/Compliance/SdLdSpinWitness.lean
+++ b/ZiskFv/Compliance/SdLdSpinWitness.lean
@@ -209,6 +209,76 @@ def sdLdMainRows : List (MainRowWithRom FGL) :=
   [ sdLdAddiX1A0Row, sdLdSlliX1Row, sdLdAddiX1EightRow, sdLdAddiX2Row
   , sdLdSdRow, sdLdLdRow, sdLdJalRow 6, sdLdJalRow 7 ]
 
+theorem sdLdMain_pc_addi_slli :
+    pcHandshakeBetween sdLdAddiX1A0Row sdLdSlliX1Row := by
+  simp [pcHandshakeBetween, sdLdAddiX1A0Row, sdLdAddiX1A0RowWithLast,
+    sdLdAddiX1A0RowTemplate, sdLdSlliX1Row, sdLdSlliX1RowWithLast,
+    sdLdSlliX1RowTemplate, sdLdAddiX1A0ProgramRow, sdLdSlliX1ProgramRow,
+    addiX0Bits, addiX1Bits, mainRomRowOf, sdLdFreeCols,
+    mainRomFreeColsWithRegisterPrevious, materializeMainRegisterRow,
+    materializeMainRegisterAccesses, withMainRegisterPrevious,
+    ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
+
+theorem sdLdMain_pc_slli_addi :
+    pcHandshakeBetween sdLdSlliX1Row sdLdAddiX1EightRow := by
+  simp [pcHandshakeBetween, sdLdSlliX1Row, sdLdSlliX1RowWithLast,
+    sdLdSlliX1RowTemplate, sdLdAddiX1EightRow, sdLdAddiX1EightRowWithLast,
+    sdLdAddiX1EightRowTemplate, sdLdSlliX1ProgramRow, sdLdAddiX1EightProgramRow,
+    addiX1Bits, mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious,
+    materializeMainRegisterRow, materializeMainRegisterAccesses, withMainRegisterPrevious,
+    ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
+
+theorem sdLdMain_pc_addi_addi :
+    pcHandshakeBetween sdLdAddiX1EightRow sdLdAddiX2Row := by
+  simp [pcHandshakeBetween, sdLdAddiX1EightRow, sdLdAddiX1EightRowWithLast,
+    sdLdAddiX1EightRowTemplate, sdLdAddiX2Row, sdLdAddiX2RowWithLast,
+    sdLdAddiX2RowTemplate, sdLdAddiX1EightProgramRow, sdLdAddiX2ProgramRow,
+    addiX0Bits, addiX1Bits, mainRomRowOf, sdLdFreeCols,
+    mainRomFreeColsWithRegisterPrevious, materializeMainRegisterRow,
+    materializeMainRegisterAccesses, withMainRegisterPrevious,
+    ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
+
+theorem sdLdMain_pc_addi_sd :
+    pcHandshakeBetween sdLdAddiX2Row sdLdSdRow := by
+  simp [pcHandshakeBetween, sdLdAddiX2Row, sdLdAddiX2RowWithLast,
+    sdLdAddiX2RowTemplate, sdLdSdRow, sdLdSdRowTemplate, sdLdAddiX2ProgramRow,
+    sdLdSdProgramRow, addiX0Bits, sdLdSdBits, mainRomRowOf, sdLdFreeCols,
+    mainRomFreeColsWithRegisterPrevious, materializeMainRegisterRow,
+    materializeMainRegisterAccesses, withMainRegisterPrevious,
+    ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
+
+theorem sdLdMain_pc_sd_ld : pcHandshakeBetween sdLdSdRow sdLdLdRow := by
+  simp [pcHandshakeBetween, sdLdSdRow, sdLdSdRowTemplate, sdLdLdRow,
+    sdLdLdRowTemplate, sdLdSdProgramRow, sdLdLdProgramRow, sdLdSdBits, sdLdLdBits,
+    mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious,
+    materializeMainRegisterRow, materializeMainRegisterAccesses, withMainRegisterPrevious,
+    ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
+
+theorem sdLdMain_pc_ld_jal : pcHandshakeBetween sdLdLdRow (sdLdJalRow 6) := by
+  simp [pcHandshakeBetween, sdLdLdRow, sdLdLdRowTemplate, sdLdJalRow,
+    sdLdLdProgramRow, sdLdJalProgramRow, sdLdLdBits, AddSpinWitness.addSpinJalBits,
+    mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious,
+    materializeMainRegisterRow, materializeMainRegisterAccesses, withMainRegisterPrevious,
+    ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
+
+theorem sdLdMain_pc_jal_jal : pcHandshakeBetween (sdLdJalRow 6) (sdLdJalRow 7) := by
+  simp [pcHandshakeBetween, sdLdJalRow, sdLdJalProgramRow, AddSpinWitness.addSpinJalBits,
+    mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious,
+    ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
+  ring
+
+def sdLdProgram : Program 7
+  | ⟨0, _⟩ => sdLdAddiX1A0ProgramRow
+  | ⟨1, _⟩ => sdLdSlliX1ProgramRow
+  | ⟨2, _⟩ => sdLdAddiX1EightProgramRow
+  | ⟨3, _⟩ => sdLdAddiX2ProgramRow
+  | ⟨4, _⟩ => sdLdSdProgramRow
+  | ⟨5, _⟩ => sdLdLdProgramRow
+  | ⟨6, _⟩ => sdLdJalProgramRow
+
+theorem sdLdMainRows_fixed_domain : sdLdMainRows.length ≤ mainFixedCapacity := by
+  norm_num [sdLdMainRows, mainFixedCapacity]
+
 /-- The three non-idle register lanes close at their actual last Main access. -/
 def sdLdBoundaryRowX1 : ZiskFv.AirsClean.RegisterBoundary.RegisterBoundaryRow FGL :=
   registerBoundaryRowFromLast 1 (aMemMessage sdLdLdRow)
@@ -218,6 +288,17 @@ def sdLdBoundaryRowX2 : ZiskFv.AirsClean.RegisterBoundary.RegisterBoundaryRow FG
 
 def sdLdBoundaryRowX3 : ZiskFv.AirsClean.RegisterBoundary.RegisterBoundaryRow FGL :=
   registerBoundaryRowFromLast 3 (cMemMessage sdLdLdRow)
+
+def sdLdBoundaryRows :
+    List (ZiskFv.AirsClean.RegisterBoundary.RegisterBoundaryRow FGL) :=
+  [sdLdBoundaryRowX1, sdLdBoundaryRowX2, sdLdBoundaryRowX3] ++
+    (List.range 28).map (fun i => boundaryRowIdle ((i + 4 : Nat) : FGL))
+
+def sdLdBoundaryTable : Air.Flat.Table FGL :=
+  registerBoundaryRowsTableOf sdLdBoundaryRows
+
+def sdLdMainTable : Air.Flat.Table FGL :=
+  AddSpinWitness.mainRowsTable 7 sdLdProgram sdLdMainRows sdLdMainRows_fixed_domain
 
 def sdLdX1Telescope :=
   registerTelescopingInteractions

--- a/ZiskFv/Compliance/SdLdSpinWitness.lean
+++ b/ZiskFv/Compliance/SdLdSpinWitness.lean
@@ -4,9 +4,9 @@ import ZiskFv.Compliance.AddAddiSpinWitness
 /-!
 # Concrete SD/LD spin witness (#221)
 
-The Phase-2 witness starts from the pinned ZisK RV64IM lowering: x0 operands
-are immediate zero, immediate operands occupy the `b` source, and every
-program message is paired with its actual Main emitter row.
+The Phase-2 witness follows the canonical dispatcher binding shapes: ADDI
+uses the `a` register source and `b` immediate source, and every program
+message is paired with its actual Main emitter row.
 -/
 
 open Goldilocks
@@ -20,7 +20,7 @@ open ZiskFv.Compliance.RegisterMemBusBalance
 namespace ZiskFv.Compliance.SdLdSpinWitness
 
 def addiX0Bits : RomFlagBits where
-  a_src_imm := true
+  a_src_imm := false
   a_src_mem := false
   is_precompiled := false
   b_src_imm := true
@@ -32,7 +32,7 @@ def addiX0Bits : RomFlagBits where
   set_pc := false
   m32 := false
   b_src_ind := false
-  a_src_reg := false
+  a_src_reg := true
   b_src_reg := false
   store_reg := true
 

--- a/ZiskFv/Compliance/SdLdSpinWitness.lean
+++ b/ZiskFv/Compliance/SdLdSpinWitness.lean
@@ -685,7 +685,7 @@ def sdLdSlliBinaryExtensionRow :
     (sdLdSlliIndex 4 0 (by decide) (by decide))
     (sdLdSlliIndex 5 0 (by decide) (by decide))
     (sdLdSlliIndex 6 0 (by decide) (by decide))
-    (sdLdSlliIndex 7 0 (by decide) (by decide)) 24 0
+    (sdLdSlliIndex 7 0 (by decide) (by decide)) 0 0
 
 theorem sdLdSlliBinaryExtension_proverAssumptions :
     ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupCircuit.ProverAssumptions
@@ -697,7 +697,7 @@ theorem sdLdSlliBinaryExtension_proverAssumptions :
     (sdLdSlliIndex 4 0 (by decide) (by decide)),
     (sdLdSlliIndex 5 0 (by decide) (by decide)),
     (sdLdSlliIndex 6 0 (by decide) (by decide)),
-    (sdLdSlliIndex 7 0 (by decide) (by decide)), 24, 0, ?_⟩
+    (sdLdSlliIndex 7 0 (by decide) (by decide)), 0, 0, ?_⟩
   repeat' apply And.intro
   all_goals norm_num [sdLdSlliIndex,
     ZiskFv.AirsClean.BinaryExtension.binaryExtensionTableRow,
@@ -722,6 +722,88 @@ theorem sdLdBinaryExtensionTable_constraints : sdLdBinaryExtensionTable.Constrai
   simp only [List.mem_singleton] at h_row
   subst row
   exact sdLdSlliBinaryExtension_proverAssumptions
+
+theorem sdLdAddiX1A0_opBus_cancel :
+    BalancedInteractions
+      [ binaryAddOpBusInteraction (ZiskFv.AirsClean.BinaryAdd.binaryAddRowOf 0 160)
+      , mainOpBusInteraction sdLdAddiX1A0Row ] := by
+  refine Air.Flat.balancedInteractions_of_present ?_
+    ([ binaryAddOpBusInteraction (ZiskFv.AirsClean.BinaryAdd.binaryAddRowOf 0 160)
+     , mainOpBusInteraction sdLdAddiX1A0Row ].map (·.msg)) ?_ ?_
+  · left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+  · intro interaction h_interaction
+    exact List.mem_map_of_mem h_interaction
+  · intro msg h_msg
+    simp only [List.mem_map] at h_msg
+    rcases h_msg with ⟨interaction, h_interaction, rfl⟩
+    simp at h_interaction
+    rcases h_interaction with rfl | rfl <;> decide
+
+def sdLdSlliBinaryExtensionOpBusInteraction : Interaction FGL where
+  channel := ZiskFv.Channels.OperationBus.OpBusChannel.toRaw
+  mult := 1
+  msg := (toElements
+    (ZiskFv.AirsClean.BinaryExtension.opBusMessage sdLdSlliBinaryExtensionRow)).toArray
+  same_size := by simp [Channel.toRaw]
+  assumeGuarantees := false
+
+theorem sdLdSlliX1_opBus_cancel :
+    BalancedInteractions
+      [ sdLdSlliBinaryExtensionOpBusInteraction
+      , mainOpBusInteraction sdLdSlliX1Row ] := by
+  refine Air.Flat.balancedInteractions_of_present ?_
+    ([sdLdSlliBinaryExtensionOpBusInteraction,
+      mainOpBusInteraction sdLdSlliX1Row].map (·.msg)) ?_ ?_
+  · left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+  · intro interaction h_interaction
+    exact List.mem_map_of_mem h_interaction
+  · intro msg h_msg
+    simp only [List.mem_map] at h_msg
+    rcases h_msg with ⟨interaction, h_interaction, rfl⟩
+    simp at h_interaction
+    rcases h_interaction with rfl | rfl <;> decide
+
+theorem sdLdAddiX1Eight_opBus_cancel :
+    BalancedInteractions
+      [ binaryAddOpBusInteraction
+          (ZiskFv.AirsClean.BinaryAdd.binaryAddRowOf 2684354560 8)
+      , mainOpBusInteraction sdLdAddiX1EightRow ] := by
+  refine Air.Flat.balancedInteractions_of_present ?_
+    ([ binaryAddOpBusInteraction
+        (ZiskFv.AirsClean.BinaryAdd.binaryAddRowOf 2684354560 8)
+     , mainOpBusInteraction sdLdAddiX1EightRow ].map (·.msg)) ?_ ?_
+  · left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+  · intro interaction h_interaction
+    exact List.mem_map_of_mem h_interaction
+  · intro msg h_msg
+    simp only [List.mem_map] at h_msg
+    rcases h_msg with ⟨interaction, h_interaction, rfl⟩
+    simp at h_interaction
+    rcases h_interaction with rfl | rfl <;> decide
+
+theorem sdLdAddiX2_opBus_cancel :
+    BalancedInteractions
+      [ binaryAddOpBusInteraction (ZiskFv.AirsClean.BinaryAdd.binaryAddRowOf 0 42)
+      , mainOpBusInteraction sdLdAddiX2Row ] := by
+  refine Air.Flat.balancedInteractions_of_present ?_
+    ([ binaryAddOpBusInteraction (ZiskFv.AirsClean.BinaryAdd.binaryAddRowOf 0 42)
+     , mainOpBusInteraction sdLdAddiX2Row ].map (·.msg)) ?_ ?_
+  · left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+  · intro interaction h_interaction
+    exact List.mem_map_of_mem h_interaction
+  · intro msg h_msg
+    simp only [List.mem_map] at h_msg
+    rcases h_msg with ⟨interaction, h_interaction, rfl⟩
+    simp at h_interaction
+    rcases h_interaction with rfl | rfl <;> decide
 
 def sdLdX1Telescope :=
   registerTelescopingInteractions

--- a/ZiskFv/Compliance/SdLdSpinWitness.lean
+++ b/ZiskFv/Compliance/SdLdSpinWitness.lean
@@ -126,10 +126,87 @@ def sdLdAddiX1A0FreeCols : MainRomFreeCols :=
       im_high_degree_2 := 0, segment_l1 := 0, main_step := 0 }
     addX1RegisterInitial
 
-example : MainRomSourceGuard sdLdAddiX1A0ProgramRow addiX0Bits sdLdAddiX1A0FreeCols := by
+theorem sdLdAddiX1A0_sourceGuard :
+    MainRomSourceGuard sdLdAddiX1A0ProgramRow addiX0Bits sdLdAddiX1A0FreeCols := by
   norm_num [MainRomSourceGuard, sdLdAddiX1A0ProgramRow, addiX0Bits,
     sdLdAddiX1A0FreeCols, mainRomFreeColsWithRegisterPrevious,
     SingleAddWitness.addX1MainFreeCols, addX1RegisterInitial, boundaryRowIdle,
     ZiskFv.AirsClean.RegisterBoundary.bootMessage]
+
+/-! The register histories are kept separately: x1 is written then read twice,
+x2 is written then read by SD, and x3 is written by LD.  x0 is immediate-zero
+in the two ADDI rows and deliberately has no boundary lane. -/
+
+@[reducible] def sdLdFreeCols (step a0 a1 b0 b1 : FGL) : MainRomFreeCols :=
+  mainRomFreeColsWithRegisterPrevious
+    { SingleAddWitness.addX1MainFreeCols with
+      a_0 := a0, a_1 := a1, b_0 := b0, b_1 := b1,
+      im_high_degree_2 := 0, segment_l1 := 0, main_step := step }
+    addX1RegisterInitial
+
+@[reducible] def sdLdAddiX1A0RowTemplate : MainRowWithRom FGL :=
+  mainRomRowOf sdLdAddiX1A0ProgramRow addiX0Bits
+    (MainRomExecKind.external false 160 0) (sdLdFreeCols 0 0 0 160 0)
+
+@[reducible] def sdLdAddiX1A0RowWithLast : MemBusMessage FGL × MainRowWithRom FGL :=
+  materializeMainRegisterRow addX1RegisterInitial sdLdAddiX1A0RowTemplate [.store]
+
+def sdLdAddiX1A0Row : MainRowWithRom FGL := sdLdAddiX1A0RowWithLast.2
+
+@[reducible] def sdLdSlliX1RowTemplate : MainRowWithRom FGL :=
+  mainRomRowOf sdLdSlliX1ProgramRow addiX1Bits
+    (MainRomExecKind.external false 2684354560 0) (sdLdFreeCols 1 160 0 24 0)
+
+@[reducible] def sdLdSlliX1RowWithLast : MemBusMessage FGL × MainRowWithRom FGL :=
+  materializeMainRegisterRow sdLdAddiX1A0RowWithLast.1 sdLdSlliX1RowTemplate [.a, .store]
+
+def sdLdSlliX1Row : MainRowWithRom FGL := sdLdSlliX1RowWithLast.2
+
+@[reducible] def sdLdAddiX1EightRowTemplate : MainRowWithRom FGL :=
+  mainRomRowOf sdLdAddiX1EightProgramRow addiX1Bits
+    (MainRomExecKind.external false 2684354568 0) (sdLdFreeCols 2 2684354560 0 8 0)
+
+@[reducible] def sdLdAddiX1EightRowWithLast : MemBusMessage FGL × MainRowWithRom FGL :=
+  materializeMainRegisterRow sdLdSlliX1RowWithLast.1 sdLdAddiX1EightRowTemplate [.a, .store]
+
+def sdLdAddiX1EightRow : MainRowWithRom FGL := sdLdAddiX1EightRowWithLast.2
+
+@[reducible] def sdLdAddiX2RowTemplate : MainRowWithRom FGL :=
+  mainRomRowOf sdLdAddiX2ProgramRow addiX0Bits
+    (MainRomExecKind.external false 42 0) (sdLdFreeCols 3 0 0 42 0)
+
+@[reducible] def sdLdAddiX2RowWithLast : MemBusMessage FGL × MainRowWithRom FGL :=
+  materializeMainRegisterRow addX1RegisterInitial sdLdAddiX2RowTemplate [.store]
+
+def sdLdAddiX2Row : MainRowWithRom FGL := sdLdAddiX2RowWithLast.2
+
+@[reducible] def sdLdSdRowTemplate : MainRowWithRom FGL :=
+  mainRomRowOf sdLdSdProgramRow sdLdSdBits MainRomExecKind.internalCopyB
+    (sdLdFreeCols 4 2684354568 0 42 0)
+
+def sdLdSdRow : MainRowWithRom FGL :=
+  withMainRegisterPrevious .b sdLdAddiX2RowWithLast.1 <|
+    withMainRegisterPrevious .a sdLdAddiX1EightRowWithLast.1 sdLdSdRowTemplate
+
+@[reducible] def sdLdLdRowTemplate : MainRowWithRom FGL :=
+  mainRomRowOf sdLdLdProgramRow sdLdLdBits MainRomExecKind.internalCopyB
+    (sdLdFreeCols 5 2684354568 0 42 0)
+
+def sdLdLdRow : MainRowWithRom FGL :=
+  withMainRegisterPrevious .store addX1RegisterInitial <|
+    withMainRegisterPrevious .a (aMemMessage sdLdSdRow) sdLdLdRowTemplate
+
+def sdLdJalProgramRow : ZiskRomMessage FGL :=
+  { line := 24, a_offset_imm0 := 0, a_imm1 := 0, b_offset_imm0 := 0, b_imm1 := 0,
+    ind_width := 8, op := ZiskFv.Trusted.OP_FLAG, store_offset := 0, jmp_offset1 := 0,
+    jmp_offset2 := 4, flags := packFlags AddSpinWitness.addSpinJalBits }
+
+def sdLdJalRow (step : FGL) : MainRowWithRom FGL :=
+  mainRomRowOf sdLdJalProgramRow AddSpinWitness.addSpinJalBits MainRomExecKind.internalFlag
+    (sdLdFreeCols step 0 0 0 0)
+
+def sdLdMainRows : List (MainRowWithRom FGL) :=
+  [ sdLdAddiX1A0Row, sdLdSlliX1Row, sdLdAddiX1EightRow, sdLdAddiX2Row
+  , sdLdSdRow, sdLdLdRow, sdLdJalRow 6, sdLdJalRow 7 ]
 
 end ZiskFv.Compliance.SdLdSpinWitness

--- a/ZiskFv/Compliance/SdLdSpinWitness.lean
+++ b/ZiskFv/Compliance/SdLdSpinWitness.lean
@@ -15,12 +15,14 @@ program message is paired with its actual Main emitter row.
 
 open Goldilocks
 open Air.Flat
+open ZiskFv.AirsClean.FullEnsemble (fullRv64imEnsemble fullRv64imSoundEnsemble)
 open ZiskFv.AirsClean.Main
 open ZiskFv.AirsClean.ZiskInstructionRom (Program)
 open ZiskFv.Channels.MemoryBus (MemBusMessage)
 open ZiskFv.Channels.ZiskRomBus (ZiskRomMessage)
 open ZiskFv.Compliance.Instantiation
 open ZiskFv.Compliance.RegisterMemBusBalance
+open ZiskFv.Compliance.SingleAddWitness
 
 namespace ZiskFv.Compliance.SdLdSpinWitness
 
@@ -804,6 +806,67 @@ theorem sdLdAddiX2_opBus_cancel :
     rcases h_msg with ⟨interaction, h_interaction, rfl⟩
     simp at h_interaction
     rcases h_interaction with rfl | rfl <;> decide
+
+def sdLdEnsemble : Ensemble FGL unit :=
+  (fullRv64imEnsemble 7 sdLdProgram).ensemble
+
+theorem sdLdEnsemble_verifier : sdLdEnsemble.verifier = .empty FGL unit :=
+  (fullRv64imSoundEnsemble 7 sdLdProgram).verifier_empty
+
+def sdLdTableWithData (table : Table FGL) : Table FGL where
+  component := table.component
+  rawRows := table.rawRows
+  data := sdLdMemData
+  raw_uniform_width := table.raw_uniform_width
+  fixed_domain := table.fixed_domain
+
+def sdLdTables : List (Table FGL) :=
+  [ sdLdTableWithData sdLdBoundaryTable
+  , sdLdTableWithData (emptyComponentTable ZiskFv.AirsClean.MemAlignReadByte.component)
+  , sdLdTableWithData (emptyComponentTable ZiskFv.AirsClean.MemAlignByte.component)
+  , sdLdTableWithData (emptyComponentTable ZiskFv.AirsClean.MemAlign.component)
+  , sdLdTableWithData (emptyComponentTable ZiskFv.AirsClean.MemAlignRangeSlice.component)
+  , sdLdTableWithData (emptyComponentTable ZiskFv.AirsClean.MemAlignRomSlice.component)
+  , sdLdTableWithData sdLdMemTable
+  , sdLdTableWithData (emptyComponentTable ZiskFv.AirsClean.SpecifiedRangesSlice.component)
+  , sdLdTableWithData (emptyComponentTable ZiskFv.AirsClean.ArithDiv.component)
+  , sdLdTableWithData (emptyComponentTable ZiskFv.AirsClean.ArithMul.componentWithArithTable)
+  , sdLdTableWithData sdLdBinaryExtensionTable
+  , sdLdTableWithData (emptyComponentTable ZiskFv.AirsClean.Binary.staticLookupComponent)
+  , sdLdTableWithData sdLdBinaryAddTable
+  , sdLdTableWithData sdLdMainTable ]
+
+def sdLdWitness : EnsembleWitness sdLdEnsemble where
+  tables := sdLdTables
+  data := sdLdMemData
+  publicInput := ()
+  same_length := by
+    simp [sdLdEnsemble, fullRv64imEnsemble, fullRv64imSoundEnsemble,
+      sdLdTables, SoundEnsemble.toFormal, SoundEnsemble.addFinishedChannel_tables,
+      SoundEnsemble.addTable, SoundEnsemble.empty_tables, Ensemble.addTable]
+  same_circuits := by
+    intro i hi
+    have hi' : i < 14 := by
+      simpa [sdLdTables] using hi
+    interval_cases i <;>
+      simp [sdLdEnsemble, fullRv64imEnsemble, fullRv64imSoundEnsemble,
+        sdLdTables, SoundEnsemble.toFormal, SoundEnsemble.addFinishedChannel_tables,
+        SoundEnsemble.addTable, SoundEnsemble.empty_tables, Ensemble.addTable,
+        sdLdTableWithData, sdLdBoundaryTable, registerBoundaryRowsTableOf, emptyComponentTable,
+        sdLdMemTable, memRowsTable, sdLdBinaryExtensionTable,
+        binaryExtensionShiftStaticRowsTable, sdLdBinaryAddTable, binaryAddRowsTable,
+        sdLdMainTable, AddSpinWitness.mainRowsTable]
+  same_data := by
+    intro table h_table
+    simp [sdLdTables, sdLdTableWithData, sdLdBoundaryTable,
+      registerBoundaryRowsTableOf, emptyComponentTable,
+      sdLdMemTable, memRowsTable, sdLdBinaryExtensionTable,
+      binaryExtensionShiftStaticRowsTable, sdLdBinaryAddTable, binaryAddRowsTable,
+      sdLdMainTable, AddSpinWitness.mainRowsTable] at h_table
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl |
+      rfl | rfl | rfl | rfl <;> rfl
+
+theorem sdLdWitness_tables : sdLdWitness.tables = sdLdTables := rfl
 
 def sdLdX1Telescope :=
   registerTelescopingInteractions

--- a/ZiskFv/Compliance/SdLdSpinWitness.lean
+++ b/ZiskFv/Compliance/SdLdSpinWitness.lean
@@ -209,4 +209,81 @@ def sdLdMainRows : List (MainRowWithRom FGL) :=
   [ sdLdAddiX1A0Row, sdLdSlliX1Row, sdLdAddiX1EightRow, sdLdAddiX2Row
   , sdLdSdRow, sdLdLdRow, sdLdJalRow 6, sdLdJalRow 7 ]
 
+/-- The three non-idle register lanes close at their actual last Main access. -/
+def sdLdBoundaryRowX1 : ZiskFv.AirsClean.RegisterBoundary.RegisterBoundaryRow FGL :=
+  registerBoundaryRowFromLast 1 (aMemMessage sdLdLdRow)
+
+def sdLdBoundaryRowX2 : ZiskFv.AirsClean.RegisterBoundary.RegisterBoundaryRow FGL :=
+  registerBoundaryRowFromLast 2 (bMemMessage sdLdSdRow)
+
+def sdLdBoundaryRowX3 : ZiskFv.AirsClean.RegisterBoundary.RegisterBoundaryRow FGL :=
+  registerBoundaryRowFromLast 3 (cMemMessage sdLdLdRow)
+
+def sdLdX1Telescope :=
+  registerTelescopingInteractions
+    (ZiskFv.AirsClean.RegisterBoundary.bootMessage sdLdBoundaryRowX1)
+    [ cMemMessage sdLdAddiX1A0Row
+    , aMemMessage sdLdSlliX1Row, cMemMessage sdLdSlliX1Row
+    , aMemMessage sdLdAddiX1EightRow, cMemMessage sdLdAddiX1EightRow
+    , aMemMessage sdLdSdRow, aMemMessage sdLdLdRow ]
+
+def sdLdX2Telescope :=
+  registerTelescopingInteractions
+    (ZiskFv.AirsClean.RegisterBoundary.bootMessage sdLdBoundaryRowX2)
+    [cMemMessage sdLdAddiX2Row, bMemMessage sdLdSdRow]
+
+def sdLdX3Telescope :=
+  registerTelescopingInteractions
+    (ZiskFv.AirsClean.RegisterBoundary.bootMessage sdLdBoundaryRowX3)
+    [cMemMessage sdLdLdRow]
+
+theorem sdLdX1Telescope_balanced : BalancedInteractions sdLdX1Telescope := by
+  apply registerTelescopingInteractions_balanced
+  left
+  rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+  decide
+
+theorem sdLdX2Telescope_balanced : BalancedInteractions sdLdX2Telescope := by
+  apply registerTelescopingInteractions_balanced
+  left
+  rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+  decide
+
+theorem sdLdX3Telescope_balanced : BalancedInteractions sdLdX3Telescope := by
+  apply registerTelescopingInteractions_balanced
+  left
+  rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+  decide
+
+/-- The store's c-slot is exactly Mem's primary provider tuple at timestamp 19. -/
+theorem sdLdStoreMessage_eq_mem :
+    cMemMessage sdLdSdRow = ZiskFv.AirsClean.Mem.memBusMessage sdMemRow := by
+  norm_num [cMemMessage, ZiskFv.AirsClean.Mem.memBusMessage, sdLdSdRow,
+    sdLdSdRowTemplate, sdLdSdProgramRow, sdLdSdBits, sdLdFreeCols,
+    sdLdAddiX1EightRowWithLast, sdLdAddiX1EightRowTemplate,
+    sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate, sdLdAddiX1A0RowWithLast,
+    sdLdAddiX1A0RowTemplate, sdLdAddiX1A0ProgramRow, sdLdSlliX1ProgramRow,
+    sdLdAddiX1EightProgramRow, addiX0Bits, addiX1Bits, mainRomRowOf,
+    mainRomFreeColsWithRegisterPrevious, materializeMainRegisterRow,
+    materializeMainRegisterAccesses, withMainRegisterPrevious,
+    ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle, sdMemRow,
+    ZiskFv.AirsClean.Mem.memRowOf, ZiskFv.AirsClean.Mem.memReadSameAddrOf,
+    ZiskFv.AirsClean.Mem.memValueOf]
+
+/-- The load's b-slot is exactly Mem's primary provider tuple at timestamp 22. -/
+theorem sdLdLoadMessage_eq_mem :
+    bMemMessage sdLdLdRow = ZiskFv.AirsClean.Mem.memBusMessage ldMemRow := by
+  norm_num [bMemMessage, ZiskFv.AirsClean.Mem.memBusMessage, sdLdLdRow,
+    sdLdLdRowTemplate, sdLdLdProgramRow, sdLdLdBits, sdLdFreeCols,
+    sdLdSdRow, sdLdSdRowTemplate, sdLdSdProgramRow, sdLdSdBits,
+    sdLdAddiX1EightRowWithLast, sdLdAddiX1EightRowTemplate,
+    sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate, sdLdAddiX1A0RowWithLast,
+    sdLdAddiX1A0RowTemplate, sdLdAddiX1A0ProgramRow, sdLdSlliX1ProgramRow,
+    sdLdAddiX1EightProgramRow, addiX0Bits, addiX1Bits, mainRomRowOf,
+    mainRomFreeColsWithRegisterPrevious, materializeMainRegisterRow,
+    materializeMainRegisterAccesses, withMainRegisterPrevious,
+    ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle, ldMemRow,
+    ZiskFv.AirsClean.Mem.memRowOf, ZiskFv.AirsClean.Mem.memReadSameAddrOf,
+    ZiskFv.AirsClean.Mem.memValueOf]
+
 end ZiskFv.Compliance.SdLdSpinWitness

--- a/ZiskFv/Compliance/SdLdSpinWitness.lean
+++ b/ZiskFv/Compliance/SdLdSpinWitness.lean
@@ -300,6 +300,109 @@ def sdLdBoundaryTable : Air.Flat.Table FGL :=
 def sdLdMainTable : Air.Flat.Table FGL :=
   AddSpinWitness.mainRowsTable 7 sdLdProgram sdLdMainRows sdLdMainRows_fixed_domain
 
+theorem sdLdAddiX1A0Main_proverAssumptions :
+    (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus 7 sdLdProgram).circuit.ProverAssumptions
+      sdLdAddiX1A0Row emptyData (ProverHint.empty FGL) := by
+  refine ⟨⟨0, by decide⟩, addiX0Bits, MainRomExecKind.external false 160 0,
+    sdLdAddiX1A0FreeCols, ?_, ?_, ?_, ?_, ?_⟩
+  · decide
+  · simp [MainRomExecKind.Coherent, addiX0Bits]
+  · exact sdLdAddiX1A0_sourceGuard
+  · simp [MainRomAddressGuard, addiX0Bits]
+  · rfl
+
+theorem sdLdSlliX1Main_proverAssumptions :
+    (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus 7 sdLdProgram).circuit.ProverAssumptions
+      sdLdSlliX1Row emptyData (ProverHint.empty FGL) := by
+  refine ⟨⟨1, by decide⟩, addiX1Bits, MainRomExecKind.external false 2684354560 0,
+    mainRomFreeColsOfRow sdLdSlliX1Row, ?_, ?_, ?_, ?_, ?_⟩
+  · decide
+  · simp [MainRomExecKind.Coherent, addiX1Bits]
+  · norm_num [MainRomSourceGuard, sdLdProgram, sdLdSlliX1Row, sdLdSlliX1RowWithLast,
+      sdLdSlliX1RowTemplate, sdLdSlliX1ProgramRow, addiX1Bits, sdLdFreeCols,
+      mainRomRowOf, mainRomFreeColsOfRow, mainRomFreeColsWithRegisterPrevious,
+      materializeMainRegisterRow, materializeMainRegisterAccesses, withMainRegisterPrevious,
+      ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
+  · simp [MainRomAddressGuard, addiX1Bits]
+  · rfl
+
+theorem sdLdAddiX1EightMain_proverAssumptions :
+    (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus 7 sdLdProgram).circuit.ProverAssumptions
+      sdLdAddiX1EightRow emptyData (ProverHint.empty FGL) := by
+  refine ⟨⟨2, by decide⟩, addiX1Bits, MainRomExecKind.external false 2684354568 0,
+    mainRomFreeColsOfRow sdLdAddiX1EightRow, ?_, ?_, ?_, ?_, ?_⟩
+  · decide
+  · simp [MainRomExecKind.Coherent, addiX1Bits]
+  · norm_num [MainRomSourceGuard, sdLdProgram, sdLdAddiX1EightRow,
+      sdLdAddiX1EightRowWithLast, sdLdAddiX1EightRowTemplate,
+      sdLdAddiX1EightProgramRow, addiX1Bits, sdLdFreeCols, mainRomRowOf,
+      mainRomFreeColsOfRow, mainRomFreeColsWithRegisterPrevious,
+      materializeMainRegisterRow, materializeMainRegisterAccesses, withMainRegisterPrevious,
+      sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate, sdLdSlliX1ProgramRow,
+      sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate, sdLdAddiX1A0ProgramRow,
+      addiX0Bits, ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
+  · simp [MainRomAddressGuard, addiX1Bits]
+  · rfl
+
+theorem sdLdAddiX2Main_proverAssumptions :
+    (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus 7 sdLdProgram).circuit.ProverAssumptions
+      sdLdAddiX2Row emptyData (ProverHint.empty FGL) := by
+  refine ⟨⟨3, by decide⟩, addiX0Bits, MainRomExecKind.external false 42 0,
+    mainRomFreeColsOfRow sdLdAddiX2Row, ?_, ?_, ?_, ?_, ?_⟩
+  · decide
+  · simp [MainRomExecKind.Coherent, addiX0Bits]
+  · norm_num [MainRomSourceGuard, sdLdProgram, sdLdAddiX2Row, sdLdAddiX2RowWithLast,
+      sdLdAddiX2RowTemplate, sdLdAddiX2ProgramRow, addiX0Bits, sdLdFreeCols, mainRomRowOf,
+      mainRomFreeColsOfRow, mainRomFreeColsWithRegisterPrevious,
+      materializeMainRegisterRow, materializeMainRegisterAccesses, withMainRegisterPrevious,
+      ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
+  · simp [MainRomAddressGuard, addiX0Bits]
+  · rfl
+
+theorem sdLdSdMain_proverAssumptions :
+    (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus 7 sdLdProgram).circuit.ProverAssumptions
+      sdLdSdRow emptyData (ProverHint.empty FGL) := by
+  refine ⟨⟨4, by decide⟩, sdLdSdBits, MainRomExecKind.internalCopyB,
+    mainRomFreeColsOfRow sdLdSdRow, ?_, ?_, ?_, ?_, ?_⟩
+  · decide
+  · simp [MainRomExecKind.Coherent, sdLdProgram, sdLdSdBits, sdLdSdProgramRow]
+  · simp [MainRomSourceGuard, sdLdSdBits]
+  · norm_num [MainRomAddressGuard, sdLdSdBits, sdLdSdRow, sdLdSdRowTemplate,
+      sdLdFreeCols, mainRomFreeColsOfRow, mainRomRowOf, withMainRegisterPrevious,
+      sdLdAddiX1EightRowWithLast, sdLdAddiX1EightRowTemplate,
+      sdLdAddiX2RowWithLast, sdLdAddiX2RowTemplate, materializeMainRegisterRow,
+      materializeMainRegisterAccesses, ZiskFv.AirsClean.RegisterBoundary.bootMessage,
+      boundaryRowIdle]
+  · rfl
+
+theorem sdLdLdMain_proverAssumptions :
+    (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus 7 sdLdProgram).circuit.ProverAssumptions
+      sdLdLdRow emptyData (ProverHint.empty FGL) := by
+  refine ⟨⟨5, by decide⟩, sdLdLdBits, MainRomExecKind.internalCopyB,
+    mainRomFreeColsOfRow sdLdLdRow, ?_, ?_, ?_, ?_, ?_⟩
+  · decide
+  · simp [MainRomExecKind.Coherent, sdLdProgram, sdLdLdBits, sdLdLdProgramRow]
+  · simp [MainRomSourceGuard, sdLdLdBits]
+  · norm_num [MainRomAddressGuard, sdLdLdBits, sdLdLdRow, sdLdLdRowTemplate,
+      sdLdFreeCols, mainRomFreeColsOfRow, mainRomRowOf, withMainRegisterPrevious,
+      sdLdSdRow, sdLdSdRowTemplate, sdLdAddiX1EightRowWithLast,
+      sdLdAddiX1EightRowTemplate, sdLdAddiX2RowWithLast, sdLdAddiX2RowTemplate,
+      materializeMainRegisterRow, materializeMainRegisterAccesses,
+      ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
+  · rfl
+
+theorem sdLdJalMain_proverAssumptions (step : FGL) :
+    (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus 7 sdLdProgram).circuit.ProverAssumptions
+      (sdLdJalRow step) emptyData (ProverHint.empty FGL) := by
+  refine ⟨⟨6, by decide⟩, AddSpinWitness.addSpinJalBits, MainRomExecKind.internalFlag,
+    sdLdFreeCols step 0 0 0 0, ?_, ?_, ?_, ?_, ?_⟩
+  · decide
+  · norm_num [MainRomExecKind.Coherent, sdLdProgram, sdLdJalProgramRow,
+      AddSpinWitness.addSpinJalBits, ZiskFv.Trusted.OP_FLAG]
+  · simp [MainRomSourceGuard, AddSpinWitness.addSpinJalBits]
+  · simp [MainRomAddressGuard, AddSpinWitness.addSpinJalBits]
+  · rfl
+
 def sdLdX1Telescope :=
   registerTelescopingInteractions
     (ZiskFv.AirsClean.RegisterBoundary.bootMessage sdLdBoundaryRowX1)

--- a/ZiskFv/Compliance/SdLdSpinWitness.lean
+++ b/ZiskFv/Compliance/SdLdSpinWitness.lean
@@ -2,6 +2,9 @@ import ZiskFv.Compliance.SdLdMemTable
 import ZiskFv.Compliance.AddAddiSpinWitness
 import ZiskFv.AirsClean.BinaryExtension.StaticCircuit
 
+set_option maxRecDepth 10000
+set_option maxHeartbeats 800000
+
 /-!
 # Concrete SD/LD spin witness (#221)
 
@@ -709,6 +712,16 @@ theorem sdLdSlliBinaryExtension_proverAssumptions :
     ZiskFv.Airs.Tables.BinaryExtensionTable.OP_SLL,
     ZiskFv.AirsClean.BinaryExtension.binaryExtensionStaticRowOf,
     sdLdSlliBinaryExtensionRow]
+
+def sdLdBinaryExtensionTable : Table FGL :=
+  binaryExtensionShiftStaticRowsTable [sdLdSlliBinaryExtensionRow]
+
+theorem sdLdBinaryExtensionTable_constraints : sdLdBinaryExtensionTable.Constraints := by
+  apply binaryExtensionShiftStaticRowsTable_constraints_of_proverAssumptions
+  intro row h_row
+  simp only [List.mem_singleton] at h_row
+  subst row
+  exact sdLdSlliBinaryExtension_proverAssumptions
 
 def sdLdX1Telescope :=
   registerTelescopingInteractions

--- a/ZiskFv/Compliance/SdLdSpinWitness.lean
+++ b/ZiskFv/Compliance/SdLdSpinWitness.lean
@@ -308,6 +308,13 @@ def sdLdBoundaryTable : Air.Flat.Table FGL :=
 def sdLdMainTable : Air.Flat.Table FGL :=
   AddSpinWitness.mainRowsTable 7 sdLdProgram sdLdMainRows sdLdMainRows_fixed_domain
 
+def sdLdMainTableWithData (data : ProverData FGL) : Air.Flat.Table FGL where
+  component := sdLdMainTable.component
+  rawRows := sdLdMainTable.rawRows
+  data := data
+  raw_uniform_width := sdLdMainTable.raw_uniform_width
+  fixed_domain := sdLdMainTable.fixed_domain
+
 theorem sdLdAddiX1A0Main_proverAssumptions :
     (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus 7 sdLdProgram).circuit.ProverAssumptions
       sdLdAddiX1A0Row emptyData (ProverHint.empty FGL) := by
@@ -482,15 +489,15 @@ private theorem sdLdUsesLocalWitnesses_of_localLength_zero
       · exact ih (offset := s.localLength + offset) h_ops
 
 private theorem sdLdMain_constraintsHold_materialize
-    (index : Nat) (row : MainRowWithRom FGL)
+    (data : ProverData FGL) (index : Nat) (row : MainRowWithRom FGL)
     (h_segment_l1 : row.core.segment_l1 = mainFixedColumns.fixedAt 0 index)
     (h_main_step : row.rom.main_step = mainFixedColumns.fixedAt 1 index)
     (h_assumptions :
       (componentWithRomMemAndOpBus 7 sdLdProgram).circuit.ProverAssumptions
-        row emptyData (ProverHint.empty FGL)) :
+        row data (ProverHint.empty FGL)) :
     (componentWithRomMemAndOpBus 7 sdLdProgram).operations.ConstraintsHold
-      (Environment.fromArray (mainFixedColumns.materialize index (mainRawRow row)) emptyData) := by
-  let env := Environment.fromArray (mainFixedColumns.materialize index (mainRawRow row)) emptyData
+      (Environment.fromArray (mainFixedColumns.materialize index (mainRawRow row)) data) := by
+  let env := Environment.fromArray (mainFixedColumns.materialize index (mainRawRow row)) data
   let proverEnv := sdLdProverEnvFromEnvironment env
   have h_localLength :
       (componentWithRomMemAndOpBus 7 sdLdProgram).circuit.localLength
@@ -510,7 +517,7 @@ private theorem sdLdMain_constraintsHold_materialize
   have h_input_verifier : Eval.eval env
       (componentWithRomMemAndOpBus 7 sdLdProgram).rowInputVar = row := by
     dsimp [env]
-    exact eval_mainRawRow_materialize index emptyData row h_segment_l1 h_main_step
+    exact eval_mainRawRow_materialize index data row h_segment_l1 h_main_step
   have h_input : Eval.eval proverEnv
       (componentWithRomMemAndOpBus 7 sdLdProgram).rowInputVar = row := by
     rw [ProvableType.eval_varFromOffset_prover]
@@ -539,7 +546,12 @@ attribute [local simp] mainFixedColumns_segment_l1_first
   mainFixedColumns_segment_l1_nonfirst mainFixedColumns_main_step_eq_index
   mainFixedCapacity
 
-theorem sdLdMainTable_constraints : sdLdMainTable.Constraints := by
+theorem sdLdMainTableWithData_constraints (data : ProverData FGL)
+    (h_assumptions :
+      ∀ row ∈ sdLdMainRows,
+        (componentWithRomMemAndOpBus 7 sdLdProgram).circuit.ProverAssumptions
+          row data (ProverHint.empty FGL)) :
+    (sdLdMainTableWithData data).Constraints := by
   change ∀ arr ∈
       [ mainFixedColumns.materialize 0 (mainRawRow sdLdAddiX1A0Row)
       , mainFixedColumns.materialize 1 (mainRawRow sdLdSlliX1Row)
@@ -550,60 +562,75 @@ theorem sdLdMainTable_constraints : sdLdMainTable.Constraints := by
       , mainFixedColumns.materialize 6 (mainRawRow (sdLdJalRow 6))
       , mainFixedColumns.materialize 7 (mainRawRow (sdLdJalRow 7)) ],
       (componentWithRomMemAndOpBus 7 sdLdProgram).operations.ConstraintsHold
-        (Environment.fromArray arr emptyData)
+        (Environment.fromArray arr data)
   intro arr h_arr
   simp only [List.mem_cons, List.not_mem_nil, or_false] at h_arr
   rcases h_arr with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
-  · exact sdLdMain_constraintsHold_materialize 0 sdLdAddiX1A0Row
+  · exact sdLdMain_constraintsHold_materialize data 0 sdLdAddiX1A0Row
       (by simp [sdLdAddiX1A0Row, sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate,
         mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
       (by simp [sdLdAddiX1A0Row, sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate,
         mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
-      sdLdAddiX1A0Main_proverAssumptions
-  · exact sdLdMain_constraintsHold_materialize 1 sdLdSlliX1Row
+      (h_assumptions sdLdAddiX1A0Row (by simp [sdLdMainRows]))
+  · exact sdLdMain_constraintsHold_materialize data 1 sdLdSlliX1Row
       (by simp [sdLdSlliX1Row, sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate,
         mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
       (by simp [sdLdSlliX1Row, sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate,
         mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
-      sdLdSlliX1Main_proverAssumptions
-  · exact sdLdMain_constraintsHold_materialize 2 sdLdAddiX1EightRow
+      (h_assumptions sdLdSlliX1Row (by simp [sdLdMainRows]))
+  · exact sdLdMain_constraintsHold_materialize data 2 sdLdAddiX1EightRow
       (by simp [sdLdAddiX1EightRow, sdLdAddiX1EightRowWithLast,
         sdLdAddiX1EightRowTemplate, mainRomRowOf, sdLdFreeCols,
         mainRomFreeColsWithRegisterPrevious])
       (by simp [sdLdAddiX1EightRow, sdLdAddiX1EightRowWithLast,
         sdLdAddiX1EightRowTemplate, mainRomRowOf, sdLdFreeCols,
         mainRomFreeColsWithRegisterPrevious])
-      sdLdAddiX1EightMain_proverAssumptions
-  · exact sdLdMain_constraintsHold_materialize 3 sdLdAddiX2Row
+      (h_assumptions sdLdAddiX1EightRow (by simp [sdLdMainRows]))
+  · exact sdLdMain_constraintsHold_materialize data 3 sdLdAddiX2Row
       (by simp [sdLdAddiX2Row, sdLdAddiX2RowWithLast, sdLdAddiX2RowTemplate,
         mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
       (by simp [sdLdAddiX2Row, sdLdAddiX2RowWithLast, sdLdAddiX2RowTemplate,
         mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
-      sdLdAddiX2Main_proverAssumptions
-  · exact sdLdMain_constraintsHold_materialize 4 sdLdSdRow
+      (h_assumptions sdLdAddiX2Row (by simp [sdLdMainRows]))
+  · exact sdLdMain_constraintsHold_materialize data 4 sdLdSdRow
       (by simp [sdLdSdRow, sdLdSdRowTemplate, mainRomRowOf, sdLdFreeCols,
         mainRomFreeColsWithRegisterPrevious])
       (by simp [sdLdSdRow, sdLdSdRowTemplate, mainRomRowOf, sdLdFreeCols,
         mainRomFreeColsWithRegisterPrevious])
-      sdLdSdMain_proverAssumptions
-  · exact sdLdMain_constraintsHold_materialize 5 sdLdLdRow
+      (h_assumptions sdLdSdRow (by simp [sdLdMainRows]))
+  · exact sdLdMain_constraintsHold_materialize data 5 sdLdLdRow
       (by simp [sdLdLdRow, sdLdLdRowTemplate, mainRomRowOf, sdLdFreeCols,
         mainRomFreeColsWithRegisterPrevious])
       (by simp [sdLdLdRow, sdLdLdRowTemplate, mainRomRowOf, sdLdFreeCols,
         mainRomFreeColsWithRegisterPrevious])
-      sdLdLdMain_proverAssumptions
-  · exact sdLdMain_constraintsHold_materialize 6 (sdLdJalRow 6)
+      (h_assumptions sdLdLdRow (by simp [sdLdMainRows]))
+  · exact sdLdMain_constraintsHold_materialize data 6 (sdLdJalRow 6)
       (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
         mainRomFreeColsWithRegisterPrevious])
       (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
         mainRomFreeColsWithRegisterPrevious])
-      (sdLdJalMain_proverAssumptions 6)
-  · exact sdLdMain_constraintsHold_materialize 7 (sdLdJalRow 7)
+      (h_assumptions (sdLdJalRow 6) (by simp [sdLdMainRows]))
+  · exact sdLdMain_constraintsHold_materialize data 7 (sdLdJalRow 7)
       (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
         mainRomFreeColsWithRegisterPrevious])
       (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
         mainRomFreeColsWithRegisterPrevious])
-      (sdLdJalMain_proverAssumptions 7)
+      (h_assumptions (sdLdJalRow 7) (by simp [sdLdMainRows]))
+
+theorem sdLdMainTable_constraints : sdLdMainTable.Constraints := by
+  simpa [sdLdMainTableWithData] using
+    sdLdMainTableWithData_constraints emptyData (by
+      intro row h_row
+      simp [sdLdMainRows] at h_row
+      rcases h_row with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+      · exact sdLdAddiX1A0Main_proverAssumptions
+      · exact sdLdSlliX1Main_proverAssumptions
+      · exact sdLdAddiX1EightMain_proverAssumptions
+      · exact sdLdAddiX2Main_proverAssumptions
+      · exact sdLdSdMain_proverAssumptions
+      · exact sdLdLdMain_proverAssumptions
+      · exact sdLdJalMain_proverAssumptions 6
+      · exact sdLdJalMain_proverAssumptions 7)
 
 @[simp] theorem sdLdMainTable_length : sdLdMainTable.length = 8 := by
   rfl
@@ -867,6 +894,123 @@ def sdLdWitness : EnsembleWitness sdLdEnsemble where
       rfl | rfl | rfl | rfl <;> rfl
 
 theorem sdLdWitness_tables : sdLdWitness.tables = sdLdTables := rfl
+
+private theorem sdLdBinaryAddTableWithData_constraints :
+    (sdLdTableWithData sdLdBinaryAddTable).Constraints := by
+  rw [Table.Constraints]
+  intro arr h_arr
+  change arr ∈ sdLdBinaryAddRows.map binaryAddRowArray at h_arr
+  rcases List.mem_map.mp h_arr with ⟨row, h_row, rfl⟩
+  have h_assumptions :
+      ZiskFv.AirsClean.BinaryAdd.component.circuit.ProverAssumptions
+        row sdLdMemData (ProverHint.empty FGL) := by
+    simp [sdLdBinaryAddRows] at h_row
+    rcases h_row with rfl | rfl | rfl
+    · exact ⟨0, 160, by decide, by decide, rfl⟩
+    · exact ⟨2684354560, 8, by decide, by decide, rfl⟩
+    · exact ⟨0, 42, by decide, by decide, rfl⟩
+  have h_component :
+      ZiskFv.AirsClean.BinaryAdd.component.operations.ConstraintsHold
+        (Environment.fromInput row sdLdMemData) := by
+    apply ZiskFv.Compliance.Instantiation.component_constraintsHold_of_proverAssumptions_at_data
+      ZiskFv.AirsClean.BinaryAdd.component (Environment.fromInput row sdLdMemData)
+      row sdLdMemData
+    · rfl
+    · exact ProvableType.eval_fromInput_varFromOffset_zero row sdLdMemData
+    · rfl
+    · exact h_assumptions
+  simpa [sdLdTableWithData, sdLdBinaryAddTable, binaryAddRowsTable,
+    binaryAddRowArray, Table.table, Environment.fromInput] using h_component
+
+private theorem sdLdBinaryExtensionTableWithData_constraints :
+    (sdLdTableWithData sdLdBinaryExtensionTable).Constraints := by
+  rw [Table.Constraints]
+  intro arr h_arr
+  change arr ∈ [sdLdSlliBinaryExtensionRow].map binaryExtensionRowArray at h_arr
+  rcases List.mem_map.mp h_arr with ⟨row, h_row, rfl⟩
+  simp only [List.mem_singleton] at h_row
+  subst row
+  have h_assumptions :
+      ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.circuit.ProverAssumptions
+        sdLdSlliBinaryExtensionRow sdLdMemData (ProverHint.empty FGL) := by
+    simpa using sdLdSlliBinaryExtension_proverAssumptions
+  have h_component :
+      ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.operations.ConstraintsHold
+        (Environment.fromInput sdLdSlliBinaryExtensionRow sdLdMemData) := by
+    apply ZiskFv.Compliance.Instantiation.component_constraintsHold_of_proverAssumptions_at_data
+      ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+      (Environment.fromInput sdLdSlliBinaryExtensionRow sdLdMemData)
+      sdLdSlliBinaryExtensionRow sdLdMemData
+    · rfl
+    · exact ProvableType.eval_fromInput_varFromOffset_zero sdLdSlliBinaryExtensionRow sdLdMemData
+    · rfl
+    · exact h_assumptions
+  simpa [sdLdTableWithData, sdLdBinaryExtensionTable,
+    binaryExtensionShiftStaticRowsTable, binaryExtensionRowArray, Table.table,
+    Environment.fromInput] using h_component
+
+private theorem sdLdEmptyTableWithData_constraints (component : Component FGL) :
+    (sdLdTableWithData (emptyComponentTable component)).Constraints := by
+  rw [Table.Constraints]
+  intro row h_row
+  cases h_fixed : component.fixedColumns <;>
+    simp [sdLdTableWithData, emptyComponentTable, Table.table, h_fixed] at h_row
+
+private theorem sdLdBoundaryTableWithData_constraints :
+    (sdLdTableWithData sdLdBoundaryTable).Constraints := by
+  rw [Table.Constraints]
+  intro arr h_arr
+  change arr ∈ sdLdBoundaryRows.map registerBoundaryRowArray at h_arr
+  rcases List.mem_map.mp h_arr with ⟨row, _h_row, rfl⟩
+  have h_component :
+      ZiskFv.AirsClean.RegisterBoundary.component.operations.ConstraintsHold
+        (Environment.fromInput row sdLdMemData) := by
+    apply ZiskFv.Compliance.Instantiation.component_constraintsHold_of_proverAssumptions_at_data
+      ZiskFv.AirsClean.RegisterBoundary.component (Environment.fromInput row sdLdMemData)
+      row sdLdMemData
+    · rfl
+    · exact ProvableType.eval_fromInput_varFromOffset_zero row sdLdMemData
+    · rfl
+    · trivial
+  simpa [sdLdTableWithData, sdLdBoundaryTable, registerBoundaryRowsTableOf,
+    registerBoundaryRowArray, Table.environment, Environment.fromInput] using h_component
+
+theorem sdLdWitness_table_constraints :
+    ∀ table ∈ sdLdWitness.tables, table.Constraints := by
+  intro table h_table
+  rw [sdLdWitness_tables] at h_table
+  simp [sdLdTables] at h_table
+  rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl |
+    rfl | rfl | rfl | rfl
+  · exact sdLdBoundaryTableWithData_constraints
+  · exact sdLdEmptyTableWithData_constraints _
+  · exact sdLdEmptyTableWithData_constraints _
+  · exact sdLdEmptyTableWithData_constraints _
+  · exact sdLdEmptyTableWithData_constraints _
+  · exact sdLdEmptyTableWithData_constraints _
+  · simpa [sdLdTableWithData, sdLdMemTable, memRowsTable] using sdLdMemTable_constraints
+  · exact sdLdEmptyTableWithData_constraints _
+  · exact sdLdEmptyTableWithData_constraints _
+  · exact sdLdEmptyTableWithData_constraints _
+  · exact sdLdBinaryExtensionTableWithData_constraints
+  · exact sdLdEmptyTableWithData_constraints _
+  · exact sdLdBinaryAddTableWithData_constraints
+  · simpa [sdLdTableWithData, sdLdMainTableWithData] using
+      sdLdMainTableWithData_constraints sdLdMemData (by
+        intro row h_row
+        simp [sdLdMainRows] at h_row
+        rcases h_row with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+        · simpa using sdLdAddiX1A0Main_proverAssumptions
+        · simpa using sdLdSlliX1Main_proverAssumptions
+        · simpa using sdLdAddiX1EightMain_proverAssumptions
+        · simpa using sdLdAddiX2Main_proverAssumptions
+        · simpa using sdLdSdMain_proverAssumptions
+        · simpa using sdLdLdMain_proverAssumptions
+        · simpa using sdLdJalMain_proverAssumptions 6
+        · simpa using sdLdJalMain_proverAssumptions 7)
+
+theorem sdLdWitness_constraints : sdLdWitness.Constraints :=
+  sdLdWitness.constraints_of_tables sdLdEnsemble_verifier sdLdWitness_table_constraints
 
 def sdLdX1Telescope :=
   registerTelescopingInteractions

--- a/ZiskFv/Compliance/SdLdSpinWitness.lean
+++ b/ZiskFv/Compliance/SdLdSpinWitness.lean
@@ -1705,7 +1705,7 @@ private theorem sdLdBoundaryTable_memBusInteractions :
     ZiskFv.AirsClean.RegisterBoundary.component.operations.interactionValuesWith
       MemBusChannel.toRaw (Environment.fromArray arr sdLdMemData)) = _
   simp_rw [List.flatMap_map]
-  simp [registerBoundaryRowArray, Environment.fromInput, sdLdBoundaryMemBus_row]
+  simp [registerBoundaryRowArray, sdLdBoundaryMemBus_row]
 
 private theorem sdLdMemTable_memBusInteractions :
     (sdLdTableWithData sdLdMemTable).interactionsWith MemBusChannel.toRaw =
@@ -1744,6 +1744,535 @@ private theorem sdLdMainTable_memBusInteractions :
     sdLdMainMemBus_row 6 (sdLdJalRow 6) (by decide) (by decide),
     sdLdMainMemBus_row 7 (sdLdJalRow 7) (by decide) (by decide)]
 
+private def sdLdMemBusInteractions : List (Interaction FGL) :=
+  sdLdBoundaryRows.flatMap registerBoundaryMemBusInteractions ++
+    sdLdMemRows.flatMap (fun row => [memBusInteraction row, memBusDualInteraction row]) ++
+    sdLdMainRows.flatMap AddSpinWitness.mainValueMemBusInteractions
+
+private theorem sdLdWitness_memBusInteractions :
+    sdLdWitness.tables.flatMap (·.interactionsWith MemBusChannel.toRaw) =
+      sdLdMemBusInteractions := by
+  have h_ranges :
+      sdLdSpecifiedRangesTable.interactionsWith MemBusChannel.toRaw = [] :=
+    ZiskFv.AirsClean.FullEnsemble.specifiedRangesSlice_table_interactionsWith_memBus_nil rfl
+  have h_extension :
+      (sdLdTableWithData sdLdBinaryExtensionTable).interactionsWith MemBusChannel.toRaw = [] :=
+    ZiskFv.AirsClean.FullEnsemble.staticBinaryExtension_table_interactionsWith_memBus_nil rfl
+  have h_add :
+      (sdLdTableWithData sdLdBinaryAddTable).interactionsWith MemBusChannel.toRaw = [] :=
+    ZiskFv.AirsClean.FullEnsemble.binaryAdd_table_interactionsWith_memBus_nil rfl
+  rw [sdLdWitness_tables]
+  simp [sdLdTables, sdLdBoundaryTable_memBusInteractions,
+    sdLdMemTable_memBusInteractions, sdLdMainTable_memBusInteractions, h_ranges,
+    h_extension, h_add, sdLdMemBusInteractions]
+
+private def sdLdStoreMemBusPair : List (Interaction FGL) :=
+  [RegisterMemBusBalance.emittedPulledValue (cMemMessage sdLdSdRow),
+    memBusInteraction sdMemRow]
+
+private def sdLdLoadMemBusPair : List (Interaction FGL) :=
+  [RegisterMemBusBalance.emittedPulledValue (bMemMessage sdLdLdRow),
+    memBusInteraction ldMemRow]
+
+private def sdLdIdleBoundaryMessages : List (MemBusMessage FGL) :=
+  (List.range 28).map fun i =>
+    ZiskFv.AirsClean.RegisterBoundary.bootMessage
+      (boundaryRowIdle ((i + 4 : Nat) : FGL))
+
+private def sdLdIdleBoundaryInteractions : List (Interaction FGL) :=
+  (List.range 28).flatMap fun i =>
+    registerBoundaryMemBusInteractions
+      (boundaryRowIdle ((i + 4 : Nat) : FGL))
+
+private theorem sdLdIdleBoundaryInteractions_eq_paired :
+    sdLdIdleBoundaryInteractions =
+      RegisterMemBusBalance.pairedInteractions sdLdIdleBoundaryMessages := by
+  unfold sdLdIdleBoundaryInteractions sdLdIdleBoundaryMessages
+  generalize List.range 28 = indices
+  induction indices with
+  | nil => rfl
+  | cons i rest ih =>
+      simp only [List.map_cons, List.flatMap_cons,
+        RegisterMemBusBalance.pairedInteractions]
+      have h_head :
+          registerBoundaryMemBusInteractions
+              (boundaryRowIdle ((i + 4 : Nat) : FGL)) =
+            RegisterMemBusBalance.pairedInteraction
+              (ZiskFv.AirsClean.RegisterBoundary.bootMessage
+                (boundaryRowIdle ((i + 4 : Nat) : FGL))) := by
+        simp [registerBoundaryMemBusInteractions, registerBoundaryBootInteraction,
+          registerBoundaryReloadInteraction, RegisterMemBusBalance.pairedInteraction,
+          boundaryRowIdle, RegisterMemBusBalance.emittedPulledValue, Channel.pushedValue]
+      rw [h_head]
+      exact congrArg
+        (RegisterMemBusBalance.pairedInteraction
+          (ZiskFv.AirsClean.RegisterBoundary.bootMessage
+            (boundaryRowIdle ((i + 4 : Nat) : FGL))) ++ ·)
+        ih
+
+private theorem sdLdIdleBoundaryInteractions_balanced :
+    BalancedInteractions sdLdIdleBoundaryInteractions := by
+  rw [sdLdIdleBoundaryInteractions_eq_paired]
+  apply RegisterMemBusBalance.pairedInteractions_balanced
+  left
+  rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+  decide
+
+private def sdLdMemBusCore : List (Interaction FGL) :=
+  sdLdX1Telescope ++ sdLdX2Telescope ++ sdLdX3Telescope ++
+    sdLdIdleBoundaryInteractions ++ sdLdStoreMemBusPair ++ sdLdLoadMemBusPair
+
+private def sdLdMemBusZeroResidual : List (Interaction FGL) :=
+  sdLdMemBusInteractions.filter (·.mult = 0)
+
+private theorem sdLdStoreMemBusPair_balanced :
+    BalancedInteractions sdLdStoreMemBusPair := by
+  rw [sdLdStoreMemBusPair, sdLdStoreMessage_eq_mem]
+  exact RegisterMemBusBalance.pairedInteraction_balanced
+    (ZiskFv.AirsClean.Mem.memBusMessage sdMemRow)
+
+private theorem sdLdLoadMemBusPair_balanced :
+    BalancedInteractions sdLdLoadMemBusPair := by
+  rw [sdLdLoadMemBusPair, sdLdLoadMessage_eq_mem]
+  exact RegisterMemBusBalance.pairedInteraction_balanced
+    (ZiskFv.AirsClean.Mem.memBusMessage ldMemRow)
+
+private theorem sdLdMemBusZeroResidual_balanced :
+    BalancedInteractions sdLdMemBusZeroResidual := by
+  apply RegisterMemBusBalance.zeroInteractions_balanced
+  · intro interaction h_interaction
+    exact of_decide_eq_true (List.mem_filter.mp h_interaction |>.2)
+  · left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+
+private theorem sdLdMemBusCore_balanced : BalancedInteractions sdLdMemBusCore := by
+  unfold sdLdMemBusCore
+  have h12 := RegisterMemBusBalance.balancedInteractions_append_of_balanced
+    sdLdX1Telescope_balanced sdLdX2Telescope_balanced (by
+      left
+      rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+      decide)
+  have h123 := RegisterMemBusBalance.balancedInteractions_append_of_balanced
+    h12 sdLdX3Telescope_balanced (by
+      left
+      rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+      decide)
+  have h123i := RegisterMemBusBalance.balancedInteractions_append_of_balanced
+    h123 sdLdIdleBoundaryInteractions_balanced (by
+      left
+      rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+      decide)
+  have h123is := RegisterMemBusBalance.balancedInteractions_append_of_balanced
+    h123i sdLdStoreMemBusPair_balanced (by
+      left
+      rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+      decide)
+  exact RegisterMemBusBalance.balancedInteractions_append_of_balanced
+    h123is sdLdLoadMemBusPair_balanced (by
+      left
+      rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+      decide)
+
+private theorem perm_filter_ne_zero_append_filter_eq_zero
+    (interactions : List (Interaction FGL)) :
+    List.Perm interactions
+      (interactions.filter (·.mult ≠ 0) ++ interactions.filter (·.mult = 0)) := by
+  induction interactions with
+  | nil => simp
+  | cons interaction rest ih =>
+      by_cases h_zero : interaction.mult = 0
+      · have h_swap : List.Perm
+            ([interaction] ++ rest.filter (·.mult ≠ 0))
+            (rest.filter (·.mult ≠ 0) ++ [interaction]) :=
+          List.perm_append_comm
+        have h_reorder := List.Perm.append h_swap
+          (List.Perm.refl (rest.filter (·.mult = 0)))
+        exact (List.Perm.cons interaction ih).trans <| by
+          simpa [h_zero, List.append_assoc] using h_reorder
+      · simpa [h_zero] using List.Perm.cons interaction ih
+
+private theorem sdLdPermMiddle₄ {α : Type} (a : α)
+    (first second third fourth rest : List α) :
+    List.Perm (first ++ (second ++ (third ++ (fourth ++ a :: rest))))
+      (a :: first ++ (second ++ (third ++ (fourth ++ rest)))) := by
+  simpa only [List.append_assoc] using
+    (List.perm_middle (a := a) (l₁ := first ++ second ++ third ++ fourth) (l₂ := rest))
+
+private theorem sdLdMemBusStructuralPerm {α : Type} (idle : List α)
+    (a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 : α)
+    (a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 : α) :
+    List.Perm
+      ([a1, a2, a3, a4, a5, a6] ++ idle ++
+        [a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18,
+          a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30])
+      ([a1, a2, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18,
+          a21, a22, a26, a27, a3, a4, a19, a20, a23, a24, a5, a6, a29, a30] ++
+        idle ++ [a25, a7, a28, a8]) := by
+  simp only [List.append_assoc]
+  refine (List.perm_middle (l₁ := [])
+    (l₂ := [a2, a3, a4, a5, a6] ++ idle ++
+      [a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18,
+        a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30])).trans
+    (List.Perm.cons a1 ?_)
+  refine (List.perm_middle (l₁ := [])
+    (l₂ := [a3, a4, a5, a6] ++ idle ++
+      [a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18,
+        a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30])).trans
+    (List.Perm.cons a2 ?_)
+  refine (sdLdPermMiddle₄ a9 [] [a3, a4, a5, a6] idle [a7, a8]
+    [a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20,
+      a21, a22, a23, a24, a25, a26, a27, a28, a29, a30]).trans
+    (List.Perm.cons a9 ?_)
+  refine (sdLdPermMiddle₄ a10 [] [a3, a4, a5, a6] idle [a7, a8]
+    [a11, a12, a13, a14, a15, a16, a17, a18, a19, a20,
+      a21, a22, a23, a24, a25, a26, a27, a28, a29, a30]).trans
+    (List.Perm.cons a10 ?_)
+  refine (sdLdPermMiddle₄ a11 [] [a3, a4, a5, a6] idle [a7, a8]
+    [a12, a13, a14, a15, a16, a17, a18, a19, a20, a21,
+      a22, a23, a24, a25, a26, a27, a28, a29, a30]).trans
+    (List.Perm.cons a11 ?_)
+  refine (sdLdPermMiddle₄ a12 [] [a3, a4, a5, a6] idle [a7, a8]
+    [a13, a14, a15, a16, a17, a18, a19, a20, a21, a22,
+      a23, a24, a25, a26, a27, a28, a29, a30]).trans
+    (List.Perm.cons a12 ?_)
+  refine (sdLdPermMiddle₄ a13 [] [a3, a4, a5, a6] idle [a7, a8]
+    [a14, a15, a16, a17, a18, a19, a20, a21, a22, a23,
+      a24, a25, a26, a27, a28, a29, a30]).trans
+    (List.Perm.cons a13 ?_)
+  refine (sdLdPermMiddle₄ a14 [] [a3, a4, a5, a6] idle [a7, a8]
+    [a15, a16, a17, a18, a19, a20, a21, a22, a23, a24,
+      a25, a26, a27, a28, a29, a30]).trans
+    (List.Perm.cons a14 ?_)
+  refine (sdLdPermMiddle₄ a15 [] [a3, a4, a5, a6] idle [a7, a8]
+    [a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+      a26, a27, a28, a29, a30]).trans
+    (List.Perm.cons a15 ?_)
+  refine (sdLdPermMiddle₄ a16 [] [a3, a4, a5, a6] idle [a7, a8]
+    [a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
+      a27, a28, a29, a30]).trans
+    (List.Perm.cons a16 ?_)
+  refine (sdLdPermMiddle₄ a17 [] [a3, a4, a5, a6] idle [a7, a8]
+    [a18, a19, a20, a21, a22, a23, a24, a25, a26, a27,
+      a28, a29, a30]).trans
+    (List.Perm.cons a17 ?_)
+  refine (sdLdPermMiddle₄ a18 [] [a3, a4, a5, a6] idle [a7, a8]
+    [a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30]).trans
+    (List.Perm.cons a18 ?_)
+  refine (sdLdPermMiddle₄ a21 [] [a3, a4, a5, a6] idle [a7, a8, a19, a20]
+    [a22, a23, a24, a25, a26, a27, a28, a29, a30]).trans
+    (List.Perm.cons a21 ?_)
+  refine (sdLdPermMiddle₄ a22 [] [a3, a4, a5, a6] idle [a7, a8, a19, a20]
+    [a23, a24, a25, a26, a27, a28, a29, a30]).trans
+    (List.Perm.cons a22 ?_)
+  refine (sdLdPermMiddle₄ a26 [] [a3, a4, a5, a6] idle
+    [a7, a8, a19, a20, a23, a24, a25] [a27, a28, a29, a30]).trans
+    (List.Perm.cons a26 ?_)
+  refine (sdLdPermMiddle₄ a27 [] [a3, a4, a5, a6] idle
+    [a7, a8, a19, a20, a23, a24, a25] [a28, a29, a30]).trans
+    (List.Perm.cons a27 ?_)
+  refine (List.perm_middle (l₁ := [])
+    (l₂ := [a4, a5, a6] ++ idle ++
+      [a7, a8, a19, a20, a23, a24, a25, a28, a29, a30])).trans
+    (List.Perm.cons a3 ?_)
+  refine (List.perm_middle (l₁ := [])
+    (l₂ := [a5, a6] ++ idle ++
+      [a7, a8, a19, a20, a23, a24, a25, a28, a29, a30])).trans
+    (List.Perm.cons a4 ?_)
+  refine (sdLdPermMiddle₄ a19 [] [a5, a6] idle [a7, a8]
+    [a20, a23, a24, a25, a28, a29, a30]).trans
+    (List.Perm.cons a19 ?_)
+  refine (sdLdPermMiddle₄ a20 [] [a5, a6] idle [a7, a8]
+    [a23, a24, a25, a28, a29, a30]).trans
+    (List.Perm.cons a20 ?_)
+  refine (sdLdPermMiddle₄ a23 [] [a5, a6] idle [a7, a8]
+    [a24, a25, a28, a29, a30]).trans
+    (List.Perm.cons a23 ?_)
+  refine (sdLdPermMiddle₄ a24 [] [a5, a6] idle [a7, a8]
+    [a25, a28, a29, a30]).trans
+    (List.Perm.cons a24 ?_)
+  refine (List.perm_middle (l₁ := [])
+    (l₂ := [a6] ++ idle ++ [a7, a8, a25, a28, a29, a30])).trans
+    (List.Perm.cons a5 ?_)
+  refine (List.perm_middle (l₁ := [])
+    (l₂ := idle ++ [a7, a8, a25, a28, a29, a30])).trans
+    (List.Perm.cons a6 ?_)
+  refine (sdLdPermMiddle₄ a29 [] [] idle [a7, a8, a25, a28] [a30]).trans
+    (List.Perm.cons a29 ?_)
+  refine (sdLdPermMiddle₄ a30 [] [] idle [a7, a8, a25, a28] []).trans
+    (List.Perm.cons a30 ?_)
+  simpa only [List.nil_append] using List.Perm.append (List.Perm.refl idle) <|
+    (List.perm_middle (l₁ := [a7, a8]) (l₂ := [a28])).trans <|
+      List.Perm.cons a25 <| List.Perm.cons a7 <|
+        List.perm_middle (a := a28) (l₁ := [a8]) (l₂ := [])
+
+private def sdLdMemBusNonzeroChronological : List (Interaction FGL) :=
+  [ registerBoundaryBootInteraction sdLdBoundaryRowX1
+  , registerBoundaryReloadInteraction sdLdBoundaryRowX1
+  , registerBoundaryBootInteraction sdLdBoundaryRowX2
+  , registerBoundaryReloadInteraction sdLdBoundaryRowX2
+  , registerBoundaryBootInteraction sdLdBoundaryRowX3
+  , registerBoundaryReloadInteraction sdLdBoundaryRowX3 ] ++
+  sdLdIdleBoundaryInteractions ++
+  [ memBusInteraction sdMemRow
+  , memBusInteraction ldMemRow
+  , mainCRegPreInteraction sdLdAddiX1A0Row
+  , mainCMemInteraction sdLdAddiX1A0Row
+  , mainARegPreInteraction sdLdSlliX1Row
+  , mainAMemInteraction sdLdSlliX1Row
+  , mainCRegPreInteraction sdLdSlliX1Row
+  , mainCMemInteraction sdLdSlliX1Row
+  , mainARegPreInteraction sdLdAddiX1EightRow
+  , mainAMemInteraction sdLdAddiX1EightRow
+  , mainCRegPreInteraction sdLdAddiX1EightRow
+  , mainCMemInteraction sdLdAddiX1EightRow
+  , mainCRegPreInteraction sdLdAddiX2Row
+  , mainCMemInteraction sdLdAddiX2Row
+  , mainARegPreInteraction sdLdSdRow
+  , mainAMemInteraction sdLdSdRow
+  , mainBRegPreInteraction sdLdSdRow
+  , mainBMemInteraction sdLdSdRow
+  , mainCMemInteraction sdLdSdRow
+  , mainARegPreInteraction sdLdLdRow
+  , mainAMemInteraction sdLdLdRow
+  , mainBMemInteraction sdLdLdRow
+  , mainCRegPreInteraction sdLdLdRow
+  , mainCMemInteraction sdLdLdRow ]
+
+private theorem sdLdMemBusNonzero_filter :
+    sdLdMemBusInteractions.filter (·.mult ≠ 0) = sdLdMemBusNonzeroChronological := by
+  have h_idle :
+      sdLdIdleBoundaryInteractions.filter (fun interaction => !decide (interaction.mult = 0)) =
+        sdLdIdleBoundaryInteractions := by
+    unfold sdLdIdleBoundaryInteractions
+    generalize List.range 28 = indices
+    induction indices with
+    | nil => rfl
+    | cons i rest ih =>
+        simp only [List.flatMap_cons, List.filter_append]
+        rw [ih]
+        simp [registerBoundaryMemBusInteractions, registerBoundaryBootInteraction,
+          registerBoundaryReloadInteraction, RegisterMemBusBalance.emittedPulledValue,
+          Channel.pushedValue]
+  have h_boundary :
+      (sdLdBoundaryRows.flatMap registerBoundaryMemBusInteractions).filter
+          (fun interaction => !decide (interaction.mult = 0)) =
+        [ registerBoundaryBootInteraction sdLdBoundaryRowX1
+        , registerBoundaryReloadInteraction sdLdBoundaryRowX1
+        , registerBoundaryBootInteraction sdLdBoundaryRowX2
+        , registerBoundaryReloadInteraction sdLdBoundaryRowX2
+        , registerBoundaryBootInteraction sdLdBoundaryRowX3
+        , registerBoundaryReloadInteraction sdLdBoundaryRowX3 ] ++
+          sdLdIdleBoundaryInteractions := by
+    simp only [sdLdBoundaryRows, List.flatMap_append, List.flatMap_cons,
+      List.flatMap_nil, List.append_nil, List.filter_append]
+    rw [show
+      List.flatMap registerBoundaryMemBusInteractions
+          (List.map (fun i => boundaryRowIdle ((i + 4 : Nat) : FGL)) (List.range 28)) =
+        sdLdIdleBoundaryInteractions by
+          simp only [sdLdIdleBoundaryInteractions, List.flatMap_map]]
+    rw [h_idle]
+    simp [registerBoundaryMemBusInteractions, registerBoundaryBootInteraction,
+      registerBoundaryReloadInteraction]
+  have h_mem :
+      (sdLdMemRows.flatMap
+          (fun row => [memBusInteraction row, memBusDualInteraction row])).filter
+          (fun interaction => !decide (interaction.mult = 0)) =
+        [memBusInteraction sdMemRow, memBusInteraction ldMemRow] := by
+    simp [sdLdMemRows, memBusInteraction, memBusDualInteraction, sdMemRow, ldMemRow,
+      ZiskFv.AirsClean.Mem.memRowOf]
+  have h_addi_a0 :
+      (AddSpinWitness.mainValueMemBusInteractions sdLdAddiX1A0Row).filter
+          (fun interaction => !decide (interaction.mult = 0)) =
+        [mainCRegPreInteraction sdLdAddiX1A0Row,
+          mainCMemInteraction sdLdAddiX1A0Row] := by
+    simp [AddSpinWitness.mainValueMemBusInteractions, sdLdAddiX1A0Row,
+      sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate, mainRomRowOf,
+      addiX0Bits, mainARegPreInteraction, mainAMemInteraction,
+      mainBRegPreInteraction, mainBMemInteraction, mainCRegPreInteraction,
+      mainCMemInteraction]
+  have h_slli :
+      (AddSpinWitness.mainValueMemBusInteractions sdLdSlliX1Row).filter
+          (fun interaction => !decide (interaction.mult = 0)) =
+        [ mainARegPreInteraction sdLdSlliX1Row
+        , mainAMemInteraction sdLdSlliX1Row
+        , mainCRegPreInteraction sdLdSlliX1Row
+        , mainCMemInteraction sdLdSlliX1Row ] := by
+    simp [AddSpinWitness.mainValueMemBusInteractions, sdLdSlliX1Row,
+      sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate, mainRomRowOf, addiX1Bits,
+      mainARegPreInteraction, mainAMemInteraction, mainBRegPreInteraction,
+      mainBMemInteraction, mainCRegPreInteraction, mainCMemInteraction]
+  have h_addi_eight :
+      (AddSpinWitness.mainValueMemBusInteractions sdLdAddiX1EightRow).filter
+          (fun interaction => !decide (interaction.mult = 0)) =
+        [ mainARegPreInteraction sdLdAddiX1EightRow
+        , mainAMemInteraction sdLdAddiX1EightRow
+        , mainCRegPreInteraction sdLdAddiX1EightRow
+        , mainCMemInteraction sdLdAddiX1EightRow ] := by
+    simp [AddSpinWitness.mainValueMemBusInteractions, sdLdAddiX1EightRow,
+      sdLdAddiX1EightRowWithLast, sdLdAddiX1EightRowTemplate, mainRomRowOf,
+      addiX1Bits, mainARegPreInteraction, mainAMemInteraction,
+      mainBRegPreInteraction, mainBMemInteraction, mainCRegPreInteraction,
+      mainCMemInteraction]
+  have h_addi_x2 :
+      (AddSpinWitness.mainValueMemBusInteractions sdLdAddiX2Row).filter
+          (fun interaction => !decide (interaction.mult = 0)) =
+        [mainCRegPreInteraction sdLdAddiX2Row, mainCMemInteraction sdLdAddiX2Row] := by
+    simp [AddSpinWitness.mainValueMemBusInteractions, sdLdAddiX2Row,
+      sdLdAddiX2RowWithLast, sdLdAddiX2RowTemplate, mainRomRowOf, addiX0Bits,
+      mainARegPreInteraction, mainAMemInteraction, mainBRegPreInteraction,
+      mainBMemInteraction, mainCRegPreInteraction, mainCMemInteraction]
+  have h_sd :
+      (AddSpinWitness.mainValueMemBusInteractions sdLdSdRow).filter
+          (fun interaction => !decide (interaction.mult = 0)) =
+        [ mainARegPreInteraction sdLdSdRow
+        , mainAMemInteraction sdLdSdRow
+        , mainBRegPreInteraction sdLdSdRow
+        , mainBMemInteraction sdLdSdRow
+        , mainCMemInteraction sdLdSdRow ] := by
+    simp [AddSpinWitness.mainValueMemBusInteractions, sdLdSdRow,
+      sdLdSdRowTemplate, mainRomRowOf, sdLdSdBits, mainARegPreInteraction,
+      mainAMemInteraction, mainBRegPreInteraction, mainBMemInteraction,
+      mainCRegPreInteraction, mainCMemInteraction]
+  have h_ld :
+      (AddSpinWitness.mainValueMemBusInteractions sdLdLdRow).filter
+          (fun interaction => !decide (interaction.mult = 0)) =
+        [ mainARegPreInteraction sdLdLdRow
+        , mainAMemInteraction sdLdLdRow
+        , mainBMemInteraction sdLdLdRow
+        , mainCRegPreInteraction sdLdLdRow
+        , mainCMemInteraction sdLdLdRow ] := by
+    simp [AddSpinWitness.mainValueMemBusInteractions, sdLdLdRow,
+      sdLdLdRowTemplate, mainRomRowOf, sdLdLdBits, mainARegPreInteraction,
+      mainAMemInteraction, mainBRegPreInteraction, mainBMemInteraction,
+      mainCRegPreInteraction, mainCMemInteraction]
+  have h_jal (step : FGL) :
+      (AddSpinWitness.mainValueMemBusInteractions (sdLdJalRow step)).filter
+          (fun interaction => !decide (interaction.mult = 0)) = [] := by
+    simp [AddSpinWitness.mainValueMemBusInteractions, sdLdJalRow, mainRomRowOf,
+      AddSpinWitness.addSpinJalBits, mainARegPreInteraction, mainAMemInteraction,
+      mainBRegPreInteraction, mainBMemInteraction, mainCRegPreInteraction,
+      mainCMemInteraction]
+  simp only [sdLdMemBusInteractions, List.filter_append, h_boundary, h_mem,
+    sdLdMainRows, List.flatMap_cons, List.flatMap_nil, List.append_nil,
+    h_addi_a0, h_slli, h_addi_eight, h_addi_x2, h_sd, h_ld, h_jal]
+  rfl
+
+private theorem sdLdMemBusNonzeroChronological_perm_core :
+    List.Perm sdLdMemBusNonzeroChronological sdLdMemBusCore := by
+  change List.Perm
+    ([ registerBoundaryBootInteraction sdLdBoundaryRowX1
+     , registerBoundaryReloadInteraction sdLdBoundaryRowX1
+     , registerBoundaryBootInteraction sdLdBoundaryRowX2
+     , registerBoundaryReloadInteraction sdLdBoundaryRowX2
+     , registerBoundaryBootInteraction sdLdBoundaryRowX3
+     , registerBoundaryReloadInteraction sdLdBoundaryRowX3 ] ++
+      sdLdIdleBoundaryInteractions ++
+      [ memBusInteraction sdMemRow
+      , memBusInteraction ldMemRow
+      , mainCRegPreInteraction sdLdAddiX1A0Row
+      , mainCMemInteraction sdLdAddiX1A0Row
+      , mainARegPreInteraction sdLdSlliX1Row
+      , mainAMemInteraction sdLdSlliX1Row
+      , mainCRegPreInteraction sdLdSlliX1Row
+      , mainCMemInteraction sdLdSlliX1Row
+      , mainARegPreInteraction sdLdAddiX1EightRow
+      , mainAMemInteraction sdLdAddiX1EightRow
+      , mainCRegPreInteraction sdLdAddiX1EightRow
+      , mainCMemInteraction sdLdAddiX1EightRow
+      , mainCRegPreInteraction sdLdAddiX2Row
+      , mainCMemInteraction sdLdAddiX2Row
+      , mainARegPreInteraction sdLdSdRow
+      , mainAMemInteraction sdLdSdRow
+      , mainBRegPreInteraction sdLdSdRow
+      , mainBMemInteraction sdLdSdRow
+      , mainCMemInteraction sdLdSdRow
+      , mainARegPreInteraction sdLdLdRow
+      , mainAMemInteraction sdLdLdRow
+      , mainBMemInteraction sdLdLdRow
+      , mainCRegPreInteraction sdLdLdRow
+      , mainCMemInteraction sdLdLdRow ])
+    ([ registerBoundaryBootInteraction sdLdBoundaryRowX1
+     , registerBoundaryReloadInteraction sdLdBoundaryRowX1
+     , mainCRegPreInteraction sdLdAddiX1A0Row
+     , mainCMemInteraction sdLdAddiX1A0Row
+     , mainARegPreInteraction sdLdSlliX1Row
+     , mainAMemInteraction sdLdSlliX1Row
+     , mainCRegPreInteraction sdLdSlliX1Row
+     , mainCMemInteraction sdLdSlliX1Row
+     , mainARegPreInteraction sdLdAddiX1EightRow
+     , mainAMemInteraction sdLdAddiX1EightRow
+     , mainCRegPreInteraction sdLdAddiX1EightRow
+     , mainCMemInteraction sdLdAddiX1EightRow
+     , mainARegPreInteraction sdLdSdRow
+     , mainAMemInteraction sdLdSdRow
+     , mainARegPreInteraction sdLdLdRow
+     , mainAMemInteraction sdLdLdRow
+     , registerBoundaryBootInteraction sdLdBoundaryRowX2
+     , registerBoundaryReloadInteraction sdLdBoundaryRowX2
+     , mainCRegPreInteraction sdLdAddiX2Row
+     , mainCMemInteraction sdLdAddiX2Row
+     , mainBRegPreInteraction sdLdSdRow
+     , mainBMemInteraction sdLdSdRow
+     , registerBoundaryBootInteraction sdLdBoundaryRowX3
+     , registerBoundaryReloadInteraction sdLdBoundaryRowX3
+     , mainCRegPreInteraction sdLdLdRow
+     , mainCMemInteraction sdLdLdRow ] ++
+      sdLdIdleBoundaryInteractions ++
+      [ mainCMemInteraction sdLdSdRow
+      , memBusInteraction sdMemRow
+      , mainBMemInteraction sdLdLdRow
+      , memBusInteraction ldMemRow ])
+  exact sdLdMemBusStructuralPerm sdLdIdleBoundaryInteractions
+      (registerBoundaryBootInteraction sdLdBoundaryRowX1)
+      (registerBoundaryReloadInteraction sdLdBoundaryRowX1)
+      (registerBoundaryBootInteraction sdLdBoundaryRowX2)
+      (registerBoundaryReloadInteraction sdLdBoundaryRowX2)
+      (registerBoundaryBootInteraction sdLdBoundaryRowX3)
+      (registerBoundaryReloadInteraction sdLdBoundaryRowX3)
+      (memBusInteraction sdMemRow)
+      (memBusInteraction ldMemRow)
+      (mainCRegPreInteraction sdLdAddiX1A0Row)
+      (mainCMemInteraction sdLdAddiX1A0Row)
+      (mainARegPreInteraction sdLdSlliX1Row)
+      (mainAMemInteraction sdLdSlliX1Row)
+      (mainCRegPreInteraction sdLdSlliX1Row)
+      (mainCMemInteraction sdLdSlliX1Row)
+      (mainARegPreInteraction sdLdAddiX1EightRow)
+      (mainAMemInteraction sdLdAddiX1EightRow)
+      (mainCRegPreInteraction sdLdAddiX1EightRow)
+      (mainCMemInteraction sdLdAddiX1EightRow)
+      (mainCRegPreInteraction sdLdAddiX2Row)
+      (mainCMemInteraction sdLdAddiX2Row)
+      (mainARegPreInteraction sdLdSdRow)
+      (mainAMemInteraction sdLdSdRow)
+      (mainBRegPreInteraction sdLdSdRow)
+      (mainBMemInteraction sdLdSdRow)
+      (mainCMemInteraction sdLdSdRow)
+      (mainARegPreInteraction sdLdLdRow)
+      (mainAMemInteraction sdLdLdRow)
+      (mainBMemInteraction sdLdLdRow)
+      (mainCRegPreInteraction sdLdLdRow)
+      (mainCMemInteraction sdLdLdRow)
+
+private theorem sdLdMemBusNonzero_perm_core :
+    List.Perm (sdLdMemBusInteractions.filter (·.mult ≠ 0)) sdLdMemBusCore := by
+  rw [sdLdMemBusNonzero_filter]
+  exact sdLdMemBusNonzeroChronological_perm_core
+
+theorem sdLdWitness_memBusChannel_balanced :
+    BalancedInteractions
+      (sdLdWitness.tables.flatMap (·.interactionsWith MemBusChannel.toRaw)) := by
+  rw [sdLdWitness_memBusInteractions]
+  apply balancedInteractions_of_perm
+    (RegisterMemBusBalance.balancedInteractions_append_of_balanced
+      sdLdMemBusCore_balanced sdLdMemBusZeroResidual_balanced (by
+        left
+        rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+        decide))
+  exact ((perm_filter_ne_zero_append_filter_eq_zero sdLdMemBusInteractions).trans <|
+    List.Perm.append sdLdMemBusNonzero_perm_core List.Perm.rfl).symm
+
 theorem sdLdWitness_memAlignRangeChannel_balanced :
     BalancedInteractions
       (sdLdWitness.tables.flatMap
@@ -1775,5 +2304,18 @@ theorem sdLdWitness_memAlignRomChannel_balanced :
   · intro h
     have h_name := congrArg (fun c : RawChannel FGL => c.name) h
     simp [MemAlignRomChannel, SpecifiedRangesSliceChannel, Channel.toRaw] at h_name
+
+theorem sdLdWitness_balancedChannels : sdLdWitness.BalancedChannels := by
+  refine sdLdWitness.balancedChannels_of_tables sdLdEnsemble_verifier ?_
+  intro channel h_channel
+  simp [sdLdEnsemble, fullRv64imEnsemble, fullRv64imSoundEnsemble,
+    SoundEnsemble.toFormal, SoundEnsemble.addFinishedChannel_channels,
+    SoundEnsemble.addTable_channels, SoundEnsemble.empty_channels] at h_channel
+  rcases h_channel with rfl | rfl | rfl | rfl | rfl
+  · exact sdLdWitness_memAlignRangeChannel_balanced
+  · exact sdLdWitness_memBusChannel_balanced
+  · exact sdLdWitness_opBus_balanced
+  · exact sdLdWitness_memAlignRomChannel_balanced
+  · exact sdLdWitness_rangeChannel_balanced
 
 end ZiskFv.Compliance.SdLdSpinWitness

--- a/ZiskFv/Compliance/SdLdSpinWitness.lean
+++ b/ZiskFv/Compliance/SdLdSpinWitness.lean
@@ -1,0 +1,76 @@
+import ZiskFv.Compliance.SdLdMemTable
+import ZiskFv.Compliance.AddAddiSpinWitness
+
+/-!
+# Concrete SD/LD spin witness (#221)
+
+The Phase-2 witness starts from the pinned ZisK RV64IM lowering: x0 operands
+are immediate zero, immediate operands occupy the `b` source, and every
+program message is paired with its actual Main emitter row.
+-/
+
+open Goldilocks
+open ZiskFv.AirsClean.Main
+open ZiskFv.AirsClean.ZiskInstructionRom (Program)
+open ZiskFv.Channels.MemoryBus (MemBusMessage)
+open ZiskFv.Channels.ZiskRomBus (ZiskRomMessage)
+open ZiskFv.Compliance.Instantiation
+open ZiskFv.Compliance.RegisterMemBusBalance
+
+namespace ZiskFv.Compliance.SdLdSpinWitness
+
+def addiX0Bits : RomFlagBits where
+  a_src_imm := true
+  a_src_mem := false
+  is_precompiled := false
+  b_src_imm := true
+  b_src_mem := false
+  is_external_op := true
+  store_pc := false
+  store_mem := false
+  store_ind := false
+  set_pc := false
+  m32 := false
+  b_src_ind := false
+  a_src_reg := false
+  b_src_reg := false
+  store_reg := true
+
+def addiX1Bits : RomFlagBits where
+  a_src_imm := false
+  a_src_mem := false
+  is_precompiled := false
+  b_src_imm := true
+  b_src_mem := false
+  is_external_op := true
+  store_pc := false
+  store_mem := false
+  store_ind := false
+  set_pc := false
+  m32 := false
+  b_src_ind := false
+  a_src_reg := true
+  b_src_reg := false
+  store_reg := true
+
+def sdLdAddiX1A0ProgramRow : ZiskRomMessage FGL :=
+  { line := 0, a_offset_imm0 := 0, a_imm1 := 0, b_offset_imm0 := 160, b_imm1 := 0,
+    ind_width := 8, op := ZiskFv.Trusted.OP_ADD, store_offset := 1, jmp_offset1 := 4,
+    jmp_offset2 := 4, flags := packFlags addiX0Bits }
+
+def sdLdSlliX1ProgramRow : ZiskRomMessage FGL :=
+  { line := 4, a_offset_imm0 := 1, a_imm1 := 0, b_offset_imm0 := 24, b_imm1 := 0,
+    ind_width := 8, op := ZiskFv.Trusted.OP_SLL, store_offset := 1, jmp_offset1 := 4,
+    jmp_offset2 := 4, flags := packFlags addiX1Bits }
+
+def sdLdAddiX1EightProgramRow : ZiskRomMessage FGL :=
+  { line := 8, a_offset_imm0 := 1, a_imm1 := 0, b_offset_imm0 := 8, b_imm1 := 0,
+    ind_width := 8, op := ZiskFv.Trusted.OP_ADD, store_offset := 1, jmp_offset1 := 4,
+    jmp_offset2 := 4, flags := packFlags addiX1Bits }
+
+def sdLdAddiX2ProgramRow : ZiskRomMessage FGL :=
+  { line := 12, a_offset_imm0 := 0, a_imm1 := 0, b_offset_imm0 := 42, b_imm1 := 0,
+    ind_width := 8, op := ZiskFv.Trusted.OP_ADD, store_offset := 2, jmp_offset1 := 4,
+    jmp_offset2 := 4, flags := packFlags addiX0Bits }
+
+end ZiskFv.Compliance.SdLdSpinWitness

--- a/ZiskFv/Compliance/SdLdSpinWitness.lean
+++ b/ZiskFv/Compliance/SdLdSpinWitness.lean
@@ -10,6 +10,7 @@ program message is paired with its actual Main emitter row.
 -/
 
 open Goldilocks
+open Air.Flat
 open ZiskFv.AirsClean.Main
 open ZiskFv.AirsClean.ZiskInstructionRom (Program)
 open ZiskFv.Channels.MemoryBus (MemBusMessage)
@@ -123,7 +124,7 @@ def sdLdAddiX1A0FreeCols : MainRomFreeCols :=
   mainRomFreeColsWithRegisterPrevious
     { SingleAddWitness.addX1MainFreeCols with
       a_0 := 0, a_1 := 0, b_0 := 160, b_1 := 0,
-      im_high_degree_2 := 0, segment_l1 := 0, main_step := 0 }
+      im_high_degree_2 := 0, segment_l1 := 1, main_step := 0 }
     addX1RegisterInitial
 
 theorem sdLdAddiX1A0_sourceGuard :
@@ -146,7 +147,8 @@ in the two ADDI rows and deliberately has no boundary lane. -/
 
 @[reducible] def sdLdAddiX1A0RowTemplate : MainRowWithRom FGL :=
   mainRomRowOf sdLdAddiX1A0ProgramRow addiX0Bits
-    (MainRomExecKind.external false 160 0) (sdLdFreeCols 0 0 0 160 0)
+    (MainRomExecKind.external false 160 0)
+    { sdLdFreeCols 0 0 0 160 0 with segment_l1 := 1 }
 
 @[reducible] def sdLdAddiX1A0RowWithLast : MemBusMessage FGL × MainRowWithRom FGL :=
   materializeMainRegisterRow addX1RegisterInitial sdLdAddiX1A0RowTemplate [.store]
@@ -402,6 +404,246 @@ theorem sdLdJalMain_proverAssumptions (step : FGL) :
   · simp [MainRomSourceGuard, AddSpinWitness.addSpinJalBits]
   · simp [MainRomAddressGuard, AddSpinWitness.addSpinJalBits]
   · rfl
+
+private def sdLdProverEnvFromEnvironment (env : Environment FGL) :
+    ProverEnvironment FGL where
+  get := env.get
+  data := env.data
+  hint := ProverHint.empty FGL
+
+private theorem sdLdFlatForAllWitness_of_localLength_zero
+    {env : ProverEnvironment FGL} {offset : Nat} {ops : List (FlatOperation FGL)}
+    (h_len : FlatOperation.localLength ops = 0) :
+    FlatOperation.forAll offset
+      { witness := fun offset _ compute => env.ExtendsVector (compute env) offset }
+      ops := by
+  induction ops generalizing offset with
+  | nil => trivial
+  | cons op ops ih =>
+      cases op with
+      | witness m compute =>
+          simp [FlatOperation.localLength] at h_len
+          have h_m : m = 0 := by omega
+          have h_ops : FlatOperation.localLength ops = 0 := by omega
+          subst m
+          constructor
+          · intro i
+            exact Fin.elim0 i
+          · simpa [Nat.zero_add] using ih (offset := offset) h_ops
+      | assert e =>
+          simp [FlatOperation.localLength] at h_len
+          simpa [FlatOperation.forAll] using ih (offset := offset) h_len
+      | lookup l =>
+          simp [FlatOperation.localLength] at h_len
+          simpa [FlatOperation.forAll] using ih (offset := offset) h_len
+      | interact i =>
+          simp [FlatOperation.localLength] at h_len
+          simpa [FlatOperation.forAll] using ih (offset := offset) h_len
+
+private theorem sdLdUsesLocalWitnesses_of_localLength_zero
+    {env : ProverEnvironment FGL} {offset : Nat} {ops : Operations FGL}
+    (h_len : ops.localLength = 0) :
+    env.UsesLocalWitnesses offset ops := by
+  rw [ProverEnvironment.UsesLocalWitnesses, Operations.forAllFlat]
+  induction ops using Operations.induct generalizing offset with
+  | empty => trivial
+  | witness m compute ops ih =>
+      simp [Operations.localLength] at h_len
+      have h_m : m = 0 := by omega
+      have h_ops : ops.localLength = 0 := by omega
+      subst m
+      constructor
+      · intro i
+        exact Fin.elim0 i
+      · simpa [Nat.zero_add] using ih (offset := offset) h_ops
+  | assert e ops ih =>
+      simp [Operations.localLength] at h_len
+      simpa [Operations.forAll] using ih (offset := offset) h_len
+  | lookup l ops ih =>
+      simp [Operations.localLength] at h_len
+      simpa [Operations.forAll] using ih (offset := offset) h_len
+  | interact i ops ih =>
+      simp [Operations.localLength] at h_len
+      simpa [Operations.forAll] using ih (offset := offset) h_len
+  | subcircuit s ops ih =>
+      simp [Operations.localLength] at h_len
+      have h_s : s.localLength = 0 := by omega
+      have h_ops : ops.localLength = 0 := by omega
+      constructor
+      · apply sdLdFlatForAllWitness_of_localLength_zero
+        rw [← s.localLength_eq]
+        exact h_s
+      · exact ih (offset := s.localLength + offset) h_ops
+
+private theorem sdLdMain_constraintsHold_materialize
+    (index : Nat) (row : MainRowWithRom FGL)
+    (h_segment_l1 : row.core.segment_l1 = mainFixedColumns.fixedAt 0 index)
+    (h_main_step : row.rom.main_step = mainFixedColumns.fixedAt 1 index)
+    (h_assumptions :
+      (componentWithRomMemAndOpBus 7 sdLdProgram).circuit.ProverAssumptions
+        row emptyData (ProverHint.empty FGL)) :
+    (componentWithRomMemAndOpBus 7 sdLdProgram).operations.ConstraintsHold
+      (Environment.fromArray (mainFixedColumns.materialize index (mainRawRow row)) emptyData) := by
+  let env := Environment.fromArray (mainFixedColumns.materialize index (mainRawRow row)) emptyData
+  let proverEnv := sdLdProverEnvFromEnvironment env
+  have h_localLength :
+      (componentWithRomMemAndOpBus 7 sdLdProgram).circuit.localLength
+        (componentWithRomMemAndOpBus 7 sdLdProgram).rowInputVar = 0 := by
+    change (mainWithRomMemAndOpBusElaborated 7 sdLdProgram).localLength
+        (componentWithRomMemAndOpBus 7 sdLdProgram).rowInputVar = 0
+    rfl
+  have h_env : proverEnv.UsesLocalWitnesses
+      (componentWithRomMemAndOpBus 7 sdLdProgram).rowOffset
+      (componentWithRomMemAndOpBus 7 sdLdProgram).rowOperations := by
+    apply sdLdUsesLocalWitnesses_of_localLength_zero
+    change ((componentWithRomMemAndOpBus 7 sdLdProgram).circuit.main
+      (componentWithRomMemAndOpBus 7 sdLdProgram).rowInputVar).localLength
+        (componentWithRomMemAndOpBus 7 sdLdProgram).rowOffset = 0
+    rw [(componentWithRomMemAndOpBus 7 sdLdProgram).circuit.localLength_eq]
+    exact h_localLength
+  have h_input_verifier : Eval.eval env
+      (componentWithRomMemAndOpBus 7 sdLdProgram).rowInputVar = row := by
+    dsimp [env]
+    exact eval_mainRawRow_materialize index emptyData row h_segment_l1 h_main_step
+  have h_input : Eval.eval proverEnv
+      (componentWithRomMemAndOpBus 7 sdLdProgram).rowInputVar = row := by
+    rw [ProvableType.eval_varFromOffset_prover]
+    rw [← h_input_verifier]
+    rw [ProvableType.eval_varFromOffset]
+    congr
+  have h_assumptions' :
+      (componentWithRomMemAndOpBus 7 sdLdProgram).circuit.ProverAssumptions
+        (Eval.eval proverEnv (componentWithRomMemAndOpBus 7 sdLdProgram).rowInputVar)
+        proverEnv.data proverEnv.hint := by
+    rw [h_input]
+    simpa [proverEnv, sdLdProverEnvFromEnvironment, env] using h_assumptions
+  have h_full :=
+    (componentWithRomMemAndOpBus 7 sdLdProgram).circuit.original_full_completeness
+      (componentWithRomMemAndOpBus 7 sdLdProgram).rowOffset proverEnv
+      (componentWithRomMemAndOpBus 7 sdLdProgram).rowInputVar h_env h_assumptions'
+  have h_row :
+      (componentWithRomMemAndOpBus 7 sdLdProgram).rowOperations.ConstraintsHold
+        (proverEnv : Environment FGL) := by
+    simpa [Component.rowOperations, Component.rowInputVar, Component.rowOffset] using h_full.1
+  simpa [proverEnv, sdLdProverEnvFromEnvironment, env] using
+    (Component.constraintsHold_iff (component := componentWithRomMemAndOpBus 7 sdLdProgram)
+      (env := (proverEnv : Environment FGL))).mpr h_row
+
+attribute [local simp] mainFixedColumns_segment_l1_first
+  mainFixedColumns_segment_l1_nonfirst mainFixedColumns_main_step_eq_index
+  mainFixedCapacity
+
+theorem sdLdMainTable_constraints : sdLdMainTable.Constraints := by
+  change ∀ arr ∈
+      [ mainFixedColumns.materialize 0 (mainRawRow sdLdAddiX1A0Row)
+      , mainFixedColumns.materialize 1 (mainRawRow sdLdSlliX1Row)
+      , mainFixedColumns.materialize 2 (mainRawRow sdLdAddiX1EightRow)
+      , mainFixedColumns.materialize 3 (mainRawRow sdLdAddiX2Row)
+      , mainFixedColumns.materialize 4 (mainRawRow sdLdSdRow)
+      , mainFixedColumns.materialize 5 (mainRawRow sdLdLdRow)
+      , mainFixedColumns.materialize 6 (mainRawRow (sdLdJalRow 6))
+      , mainFixedColumns.materialize 7 (mainRawRow (sdLdJalRow 7)) ],
+      (componentWithRomMemAndOpBus 7 sdLdProgram).operations.ConstraintsHold
+        (Environment.fromArray arr emptyData)
+  intro arr h_arr
+  simp only [List.mem_cons, List.not_mem_nil, or_false] at h_arr
+  rcases h_arr with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+  · exact sdLdMain_constraintsHold_materialize 0 sdLdAddiX1A0Row
+      (by simp [sdLdAddiX1A0Row, sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate,
+        mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
+      (by simp [sdLdAddiX1A0Row, sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate,
+        mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
+      sdLdAddiX1A0Main_proverAssumptions
+  · exact sdLdMain_constraintsHold_materialize 1 sdLdSlliX1Row
+      (by simp [sdLdSlliX1Row, sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate,
+        mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
+      (by simp [sdLdSlliX1Row, sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate,
+        mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
+      sdLdSlliX1Main_proverAssumptions
+  · exact sdLdMain_constraintsHold_materialize 2 sdLdAddiX1EightRow
+      (by simp [sdLdAddiX1EightRow, sdLdAddiX1EightRowWithLast,
+        sdLdAddiX1EightRowTemplate, mainRomRowOf, sdLdFreeCols,
+        mainRomFreeColsWithRegisterPrevious])
+      (by simp [sdLdAddiX1EightRow, sdLdAddiX1EightRowWithLast,
+        sdLdAddiX1EightRowTemplate, mainRomRowOf, sdLdFreeCols,
+        mainRomFreeColsWithRegisterPrevious])
+      sdLdAddiX1EightMain_proverAssumptions
+  · exact sdLdMain_constraintsHold_materialize 3 sdLdAddiX2Row
+      (by simp [sdLdAddiX2Row, sdLdAddiX2RowWithLast, sdLdAddiX2RowTemplate,
+        mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
+      (by simp [sdLdAddiX2Row, sdLdAddiX2RowWithLast, sdLdAddiX2RowTemplate,
+        mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
+      sdLdAddiX2Main_proverAssumptions
+  · exact sdLdMain_constraintsHold_materialize 4 sdLdSdRow
+      (by simp [sdLdSdRow, sdLdSdRowTemplate, mainRomRowOf, sdLdFreeCols,
+        mainRomFreeColsWithRegisterPrevious])
+      (by simp [sdLdSdRow, sdLdSdRowTemplate, mainRomRowOf, sdLdFreeCols,
+        mainRomFreeColsWithRegisterPrevious])
+      sdLdSdMain_proverAssumptions
+  · exact sdLdMain_constraintsHold_materialize 5 sdLdLdRow
+      (by simp [sdLdLdRow, sdLdLdRowTemplate, mainRomRowOf, sdLdFreeCols,
+        mainRomFreeColsWithRegisterPrevious])
+      (by simp [sdLdLdRow, sdLdLdRowTemplate, mainRomRowOf, sdLdFreeCols,
+        mainRomFreeColsWithRegisterPrevious])
+      sdLdLdMain_proverAssumptions
+  · exact sdLdMain_constraintsHold_materialize 6 (sdLdJalRow 6)
+      (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
+        mainRomFreeColsWithRegisterPrevious])
+      (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
+        mainRomFreeColsWithRegisterPrevious])
+      (sdLdJalMain_proverAssumptions 6)
+  · exact sdLdMain_constraintsHold_materialize 7 (sdLdJalRow 7)
+      (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
+        mainRomFreeColsWithRegisterPrevious])
+      (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
+        mainRomFreeColsWithRegisterPrevious])
+      (sdLdJalMain_proverAssumptions 7)
+
+@[simp] theorem sdLdMainTable_length : sdLdMainTable.length = 8 := by
+  rfl
+
+@[simp] theorem sdLdMainTable_evalAt (index : Fin sdLdMainTable.length) :
+    Eval.eval (sdLdMainTable.environmentAt index)
+        (componentWithRomMemAndOpBus 7 sdLdProgram).rowInputVar =
+      sdLdMainRows[index.val]'(by simpa using index.isLt) := by
+  fin_cases index <;>
+    change Eval.eval
+      (Environment.fromArray (mainFixedColumns.materialize _ (mainRawRow _)) emptyData)
+      (varFromOffset MainRowWithRom 0) = _ <;>
+    apply eval_mainRawRow_materialize <;>
+    simp [sdLdAddiX1A0Row, sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate,
+      sdLdSlliX1Row, sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate,
+      sdLdAddiX1EightRow, sdLdAddiX1EightRowWithLast, sdLdAddiX1EightRowTemplate,
+      sdLdAddiX2Row, sdLdAddiX2RowWithLast, sdLdAddiX2RowTemplate,
+      sdLdSdRow, sdLdSdRowTemplate, sdLdLdRow, sdLdLdRowTemplate, sdLdJalRow,
+      mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious]
+
+theorem sdLdMainTable_transitions : sdLdMainTable.TransitionConstraints := by
+  rw [Table.TransitionConstraints]
+  intro index
+  change pcHandshakeBetween
+    (Eval.eval (sdLdMainTable.previousEnvironment index)
+      (componentWithRomMemAndOpBus 7 sdLdProgram).rowInputVar)
+    (Eval.eval (sdLdMainTable.environmentAt index)
+      (componentWithRomMemAndOpBus 7 sdLdProgram).rowInputVar)
+  fin_cases index
+  · simp [Table.previousEnvironment, sdLdMainRows, pcHandshakeBetween, sdLdAddiX1A0Row,
+      sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate, mainRomRowOf,
+      sdLdFreeCols, mainRomFreeColsWithRegisterPrevious]
+  · simpa [Table.previousEnvironment, sdLdMainRows] using sdLdMain_pc_addi_slli
+  · simpa [Table.previousEnvironment, sdLdMainRows] using sdLdMain_pc_slli_addi
+  · simpa [Table.previousEnvironment, sdLdMainRows] using sdLdMain_pc_addi_addi
+  · simpa [Table.previousEnvironment, sdLdMainRows] using sdLdMain_pc_addi_sd
+  · simpa [Table.previousEnvironment, sdLdMainRows] using sdLdMain_pc_sd_ld
+  · simpa [Table.previousEnvironment, sdLdMainRows] using sdLdMain_pc_ld_jal
+  · simpa [Table.previousEnvironment, sdLdMainRows] using sdLdMain_pc_jal_jal
+
+theorem sdLdMainTable_cyclicSuccessorTransitions :
+    sdLdMainTable.CyclicSuccessorTransitionConstraints := by
+  rw [Table.CyclicSuccessorTransitionConstraints]
+  intro index
+  simp [sdLdMainTable, AddSpinWitness.mainRowsTable,
+    ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus]
 
 def sdLdX1Telescope :=
   registerTelescopingInteractions

--- a/trust/consistency/root_soundness_instantiation_sd_ld_spin.lean
+++ b/trust/consistency/root_soundness_instantiation_sd_ld_spin.lean
@@ -1,0 +1,7 @@
+import ZiskFv.Compliance.SdLdSpinRootSoundness
+
+#print axioms ZiskFv.Compliance.SdLdSpinRootSoundness.sdLdRootSoundness
+#print axioms ZiskFv.Compliance.SdLdSpinWitness.sdLdAcceptedTrace
+#print axioms ZiskFv.Compliance.SdLdSpinWitness.sdLdWitness_balancedChannels
+#print axioms ZiskFv.Compliance.SdLdSpinRootSoundness.sdLdSdStepSound
+#print axioms ZiskFv.Compliance.SdLdSpinRootSoundness.sdLdLdStepSound


### PR DESCRIPTION
## Summary

Phase 2 of #221, stacked on Phase 1 PR #290. Instantiates the current-surface
`ZiskFv.Compliance.root_soundness` on a concrete seven-instruction trace whose Mem table is the
non-degenerate two-row store→load timeline built in #290.

- assemble the full fourteen-table `EnsembleWitness` (Boundary, Mem, SpecifiedRanges,
  BinaryExtension, BinaryAdd, Main real; MemAlign/Arith legitimately empty for aligned
  doubleword access) and prove all five channels balanced
- build the `AcceptedZiskTrace`: table constraints, transitions, cyclic-successor transitions,
  main height, and the `mem_replay_table` / `mem_replay_source_covers` certificates
- supply the first memory-carrying `BootSegmentMemorySeed` with real `boot` / `step` /
  `placement` / `readSoundInputs` and a reflexive replay-order certificate
- discharge all four `root_soundness` binders concretely — `ZiskStep`, `ProgramDecode`,
  `InputsAgree`, `RowOutsideDefectRegion` — and export `sdLdRootSoundness` plus seven per-step
  `StepSound` corollaries
- add the V2 gate hook `trust/consistency/root_soundness_instantiation_sd_ld_spin.lean`,
  mirroring the AddAddiSpin wiring, and import the root module from `ZiskFv.lean`

## Program

Zero-booted registers force an in-program preamble: RegisterBoundary boot pulls are definitionally
zero-valued (`bootMessage`, faithful to `mem.pil:507-508`), so nonzero `x1`/`x2` cannot be
boot-seeded. LUI is avoided for RV64 sign-extension reasons.

```
0:  addi x1, x0, 160        ; x1 = 160
4:  slli x1, x1, 24         ; x1 = 0xA0000000
8:  addi x1, x1, 8          ; x1 = 0xA0000008
12: addi x2, x0, 42         ; x2 = 42
16: sd   x2, 0(x1)          ; store 42
20: ld   x3, 0(x1)          ; x3 = 42
24: jal  x0, 0              ; spin
```

The SD/LD word address is `0xA0000008 / 8 = 0x14000001`, matching #290's Mem rows; their Main
MemBus timestamps are the c-slot `3 + 4*4 = 19` and the b-slot `2 + 4*5 = 22`. The Sail trace
carries the zeroed memory image through step 4 and the written image from step 5, so `x3 = 42` at
step 6 comes from the store — the load is not reading a pre-seeded value.

## Trust surface

No axiom, `sorry`, `native_decide`, or new caller assumption. `#print axioms` for
`sdLdRootSoundness` is byte-identical to the existing `add_spin` baseline (`cancel_reservation`,
four Sail platform externs, the `riscv_f*` float externs, and kernel axioms);
`sdLdAcceptedTrace` and `sdLdWitness_balancedChannels` are kernel-axioms-only. No protected
interface, validator, trust policy file, or defect ledger is touched.

## Verification

- `lake build` (9074 jobs)
- `trust/scripts/check-all.sh` — 17/17
- `trust/scripts/check-all-semantic.sh` — 18/18
- `nix run .#test` — 8/8

Closes #221.
