### PR TITLE
Derive JALR source-C transitions from Main

### DIFF
--- a/ZiskFv/AirsClean/Main/Circuit.lean
+++ b/ZiskFv/AirsClean/Main/Circuit.lean
@@ -712,6 +712,28 @@ def pcHandshakeBetween (prev curr : MainRowWithRom FGL) : Prop :=
         + (1 - prev.core.set_pc) * (prev.core.pc + prev.core.jmp_offset2)
         + prev.core.flag * (prev.core.jmp_offset1 - prev.core.jmp_offset2))) = 0
 
+/-- The non-segment specialization of Main's two source-C copy equations
+    (`main.pil:386`, extracted as `constraint_4_every_row` and
+    `constraint_10_every_row`).  The physical constraint selects a public
+    segment input at a segment boundary; Clean's transition interface has no
+    public-input surface, so the intrinsic transition states exactly the
+    within-segment equation and gates it by `SEGMENT_L1`. -/
+def sourceCCopyBetween (prev curr : MainRowWithRom FGL) : Prop :=
+  (1 - curr.core.segment_l1) *
+      (1 - curr.rom.b_src_mem - curr.rom.b_src_imm -
+        curr.rom.b_src_ind - curr.rom.b_src_reg) *
+      (curr.core.b_0 - prev.core.c_0) = 0
+  ∧
+  (1 - curr.core.segment_l1) *
+      (1 - curr.rom.b_src_mem - curr.rom.b_src_imm -
+        curr.rom.b_src_ind - curr.rom.b_src_reg) *
+      (curr.core.b_1 - prev.core.c_1) = 0
+
+/-- Main's intrinsic two-row constraints currently represented by the Clean
+    component: the PC handshake and the non-segment source-C copy. -/
+def transitionBetween (prev curr : MainRowWithRom FGL) : Prop :=
+  pcHandshakeBetween prev curr ∧ sourceCCopyBetween prev curr
+
 /-- ZisK instantiates both the Main witness and fixed traces over this physical
     domain (`zisk/pil/src/pil_helpers/traces.rs:273-282`). -/
 def mainFixedCapacity : Nat := 4194304
@@ -918,7 +940,7 @@ theorem eval_mainRawRow_materialize
     zero Clean saturates the predecessor to the current row, and the materialized
     `SEGMENT_L1 = 1` gate makes the equation vacuous as in the PIL. -/
 def pcHandshakeTransition (_index : Nat) (prev curr : Environment FGL) : Prop :=
-  pcHandshakeBetween
+  transitionBetween
     (Eval.eval prev (varFromOffset (F := FGL) MainRowWithRom 0))
     (Eval.eval curr (varFromOffset (F := FGL) MainRowWithRom 0))
 

--- a/ZiskFv/Compliance/AddAddiSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/AddAddiSpinRootSoundness.lean
@@ -485,24 +485,33 @@ def addAddiSpinOutsideDefectRegion :
 
 theorem addAddiSpinRootSoundness :
     ∀ i : Fin 3,
-      StepSound addAddiSpinAcceptedTrace addAddiSpinSailTrace i (addAddiSpinZiskStep i) :=
+      StepSound addAddiSpinAcceptedTrace addAddiSpinSailTrace i
+        (addAddiSpinZiskStep i)
+        (rowDecode_of_programDecode addAddiSpinAcceptedTrace i
+          (addAddiSpinProgramDecodes i)) :=
   root_soundness 3 addAddiSpinAcceptedTrace addAddiSpinSailTrace addAddiSpinZiskStep
     addAddiSpinProgramDecodes addAddiSpinInputsAgree addAddiSpinBootSeed
     addAddiSpinOutsideDefectRegion
 
 theorem addAddiSpinAddStepSound :
     StepSound addAddiSpinAcceptedTrace addAddiSpinSailTrace addAddiSpinAddIndex
-      (addAddiSpinZiskStep addAddiSpinAddIndex) :=
+      (addAddiSpinZiskStep addAddiSpinAddIndex)
+      (rowDecode_of_programDecode addAddiSpinAcceptedTrace addAddiSpinAddIndex
+        (addAddiSpinProgramDecodes addAddiSpinAddIndex)) :=
   addAddiSpinRootSoundness addAddiSpinAddIndex
 
 theorem addAddiSpinAddiStepSound :
     StepSound addAddiSpinAcceptedTrace addAddiSpinSailTrace addAddiSpinAddiIndex
-      (addAddiSpinZiskStep addAddiSpinAddiIndex) :=
+      (addAddiSpinZiskStep addAddiSpinAddiIndex)
+      (rowDecode_of_programDecode addAddiSpinAcceptedTrace addAddiSpinAddiIndex
+        (addAddiSpinProgramDecodes addAddiSpinAddiIndex)) :=
   addAddiSpinRootSoundness addAddiSpinAddiIndex
 
 theorem addAddiSpinJalStepSound :
     StepSound addAddiSpinAcceptedTrace addAddiSpinSailTrace addAddiSpinJalIndex
-      (addAddiSpinZiskStep addAddiSpinJalIndex) :=
+      (addAddiSpinZiskStep addAddiSpinJalIndex)
+      (rowDecode_of_programDecode addAddiSpinAcceptedTrace addAddiSpinJalIndex
+        (addAddiSpinProgramDecodes addAddiSpinJalIndex)) :=
   addAddiSpinRootSoundness addAddiSpinJalIndex
 
 end ZiskFv.Compliance.AddAddiSpinRootSoundness

--- a/ZiskFv/Compliance/AddAddiSpinWitness.lean
+++ b/ZiskFv/Compliance/AddAddiSpinWitness.lean
@@ -454,20 +454,19 @@ theorem addAddiSpinWitness_constraints : addAddiSpinWitness.Constraints :=
 
 private theorem addAddiSpinMain_pcHandshake_add_addi :
     transitionBetween addAddiSpinAddRow addAddiSpinAddiRow := by
-  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, addAddiSpinAddRow, addAddiSpinAddiRow,
-    addAddiSpinAddiProgramRow, addAddiSpinAddiBits, addX1Row,
-    mainRomRowOf]
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, addAddiSpinAddRow,
+    addAddiSpinAddiRow, addAddiSpinAddiProgramRow, addAddiSpinAddiBits, addX1Row, mainRomRowOf]
 
 private theorem addAddiSpinMain_pcHandshake_addi_jal :
     transitionBetween addAddiSpinAddiRow (addAddiSpinJalRow 2) := by
-  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, addAddiSpinAddiRow, addAddiSpinAddiProgramRow,
-    addAddiSpinAddiBits, addAddiSpinJalRow,
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, addAddiSpinAddiRow,
+    addAddiSpinAddiProgramRow, addAddiSpinAddiBits, addAddiSpinJalRow,
     addSpinJalRow, addSpinJalProgramRow, addSpinJalBits, mainRomRowOf]
 
 private theorem addAddiSpinMain_pcHandshake_jal_jal :
     transitionBetween (addAddiSpinJalRow 2) (addAddiSpinJalRow 3) := by
-  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, addAddiSpinJalRow, addSpinJalRow, addSpinJalProgramRow,
-    addSpinJalBits, mainRomRowOf]
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, addAddiSpinJalRow,
+    addSpinJalRow, addSpinJalProgramRow, addSpinJalBits, mainRomRowOf]
   ring
 
 @[simp] theorem addAddiSpinMainTable_eval_rowInputVar_zero

--- a/ZiskFv/Compliance/AddAddiSpinWitness.lean
+++ b/ZiskFv/Compliance/AddAddiSpinWitness.lean
@@ -453,20 +453,20 @@ theorem addAddiSpinWitness_constraints : addAddiSpinWitness.Constraints :=
     addAddiSpinWitness_table_constraints
 
 private theorem addAddiSpinMain_pcHandshake_add_addi :
-    pcHandshakeBetween addAddiSpinAddRow addAddiSpinAddiRow := by
-  simp [pcHandshakeBetween, addAddiSpinAddRow, addAddiSpinAddiRow,
+    transitionBetween addAddiSpinAddRow addAddiSpinAddiRow := by
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, addAddiSpinAddRow, addAddiSpinAddiRow,
     addAddiSpinAddiProgramRow, addAddiSpinAddiBits, addX1Row,
     mainRomRowOf]
 
 private theorem addAddiSpinMain_pcHandshake_addi_jal :
-    pcHandshakeBetween addAddiSpinAddiRow (addAddiSpinJalRow 2) := by
-  simp [pcHandshakeBetween, addAddiSpinAddiRow, addAddiSpinAddiProgramRow,
+    transitionBetween addAddiSpinAddiRow (addAddiSpinJalRow 2) := by
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, addAddiSpinAddiRow, addAddiSpinAddiProgramRow,
     addAddiSpinAddiBits, addAddiSpinJalRow,
     addSpinJalRow, addSpinJalProgramRow, addSpinJalBits, mainRomRowOf]
 
 private theorem addAddiSpinMain_pcHandshake_jal_jal :
-    pcHandshakeBetween (addAddiSpinJalRow 2) (addAddiSpinJalRow 3) := by
-  simp [pcHandshakeBetween, addAddiSpinJalRow, addSpinJalRow, addSpinJalProgramRow,
+    transitionBetween (addAddiSpinJalRow 2) (addAddiSpinJalRow 3) := by
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, addAddiSpinJalRow, addSpinJalRow, addSpinJalProgramRow,
     addSpinJalBits, mainRomRowOf]
   ring
 
@@ -565,7 +565,7 @@ theorem addAddiSpinMainTable_transitions : addAddiSpinMainTable.TransitionConstr
         simp⟩ :=
       Fin.ext (by omega)
     subst index
-    change pcHandshakeBetween
+    change transitionBetween
       (Eval.eval
         (addAddiSpinMainTable.previousEnvironment
           ⟨0, by simp⟩)
@@ -576,12 +576,12 @@ theorem addAddiSpinMainTable_transitions : addAddiSpinMainTable.TransitionConstr
         (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar)
     simp only [Table.previousEnvironment]
     rw [addAddiSpinMainTable_evalAt_zero]
-    simp [pcHandshakeBetween, addAddiSpinAddRow, addX1Row]
+    simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, addAddiSpinAddRow, addX1Row]
   · have h_index : index = ⟨1, by
         simp⟩ :=
       Fin.ext (by omega)
     subst index
-    change pcHandshakeBetween
+    change transitionBetween
       (Eval.eval
         (addAddiSpinMainTable.previousEnvironment
           ⟨1, by simp⟩)
@@ -597,7 +597,7 @@ theorem addAddiSpinMainTable_transitions : addAddiSpinMainTable.TransitionConstr
         simp⟩ :=
       Fin.ext (by omega)
     subst index
-    change pcHandshakeBetween
+    change transitionBetween
       (Eval.eval
         (addAddiSpinMainTable.previousEnvironment
           ⟨2, by simp⟩)
@@ -613,7 +613,7 @@ theorem addAddiSpinMainTable_transitions : addAddiSpinMainTable.TransitionConstr
         simp⟩ :=
       Fin.ext (by omega)
     subst index
-    change pcHandshakeBetween
+    change transitionBetween
       (Eval.eval
         (addAddiSpinMainTable.previousEnvironment
           ⟨3, by simp⟩)

--- a/ZiskFv/Compliance/AddSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/AddSpinRootSoundness.lean
@@ -362,13 +362,17 @@ def addSpinOutsideDefectRegion :
   | ⟨1, _⟩ => addSpinJalOutsideDefectRegion
 
 theorem addSpinRootSoundness :
-    ∀ i : Fin 2, StepSound addSpinAcceptedTrace addSpinSailTrace i (addSpinZiskStep i) :=
+    ∀ i : Fin 2, StepSound addSpinAcceptedTrace addSpinSailTrace i
+      (addSpinZiskStep i)
+      (rowDecode_of_programDecode addSpinAcceptedTrace i (addSpinProgramDecodes i)) :=
   root_soundness 2 addSpinAcceptedTrace addSpinSailTrace addSpinZiskStep
     addSpinProgramDecodes addSpinInputsAgree addSpinBootSeed addSpinOutsideDefectRegion
 
 theorem addSpinAddStepSound :
     StepSound addSpinAcceptedTrace addSpinSailTrace addSpinAddIndex
-      (addSpinZiskStep addSpinAddIndex) :=
+      (addSpinZiskStep addSpinAddIndex)
+      (rowDecode_of_programDecode addSpinAcceptedTrace addSpinAddIndex
+        (addSpinProgramDecodes addSpinAddIndex)) :=
   addSpinRootSoundness addSpinAddIndex
 
 def addPaddedAddIndex : Fin 1 := ⟨0, by decide⟩
@@ -585,13 +589,17 @@ def addPaddedOutsideDefectRegion :
   | ⟨0, _⟩ => addPaddedAddOutsideDefectRegion
 
 theorem addPaddedRootSoundness :
-    ∀ i : Fin 1, StepSound addPaddedAcceptedTrace addPaddedSailTrace i (addPaddedZiskStep i) :=
+    ∀ i : Fin 1, StepSound addPaddedAcceptedTrace addPaddedSailTrace i
+      (addPaddedZiskStep i)
+      (rowDecode_of_programDecode addPaddedAcceptedTrace i (addPaddedProgramDecodes i)) :=
   root_soundness 1 addPaddedAcceptedTrace addPaddedSailTrace addPaddedZiskStep
     addPaddedProgramDecodes addPaddedInputsAgree addPaddedBootSeed addPaddedOutsideDefectRegion
 
 theorem addPaddedAddStepSound :
     StepSound addPaddedAcceptedTrace addPaddedSailTrace addPaddedAddIndex
-      (addPaddedZiskStep addPaddedAddIndex) :=
+      (addPaddedZiskStep addPaddedAddIndex)
+      (rowDecode_of_programDecode addPaddedAcceptedTrace addPaddedAddIndex
+        (addPaddedProgramDecodes addPaddedAddIndex)) :=
   addPaddedRootSoundness addPaddedAddIndex
 
 end ZiskFv.Compliance.AddSpinRootSoundness

--- a/ZiskFv/Compliance/AddSpinWitness.lean
+++ b/ZiskFv/Compliance/AddSpinWitness.lean
@@ -310,13 +310,13 @@ private theorem addSpinMain_constraintsHold_materialize
       (env := (proverEnv : Environment FGL))).mpr h_row
 
 theorem addSpinMain_pcHandshake_add_jal :
-    pcHandshakeBetween addSpinAddRow (addSpinJalRow 1) := by
-  simp [pcHandshakeBetween, addSpinAddRow, addSpinJalRow, addSpinJalProgramRow, addSpinJalBits,
+    transitionBetween addSpinAddRow (addSpinJalRow 1) := by
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, addSpinAddRow, addSpinJalRow, addSpinJalProgramRow, addSpinJalBits,
     addX1Row, mainRomRowOf]
 
 theorem addSpinMain_pcHandshake_jal_jal :
-    pcHandshakeBetween (addSpinJalRow 1) (addSpinJalRow 2) := by
-  simp [pcHandshakeBetween, addSpinJalRow, addSpinJalProgramRow, addSpinJalBits, mainRomRowOf]
+    transitionBetween (addSpinJalRow 1) (addSpinJalRow 2) := by
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, addSpinJalRow, addSpinJalProgramRow, addSpinJalBits, mainRomRowOf]
   ring
 
 @[simp] theorem addSpinMainTable_eval_rowInputVar_zero
@@ -444,7 +444,7 @@ theorem addSpinMainTable_transitions : addSpinMainTable.TransitionConstraints :=
   · have h_index : index = ⟨0, by
         simp⟩ := Fin.ext (by omega)
     subst index
-    change pcHandshakeBetween
+    change transitionBetween
       (Eval.eval
         (addSpinMainTable.previousEnvironment
           ⟨0, by simp⟩)
@@ -455,11 +455,11 @@ theorem addSpinMainTable_transitions : addSpinMainTable.TransitionConstraints :=
         (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar)
     simp only [Table.previousEnvironment]
     rw [addSpinMainTable_evalAt_zero]
-    simp [pcHandshakeBetween, addSpinAddRow, addX1Row]
+    simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, addSpinAddRow, addX1Row]
   · have h_index : index = ⟨1, by
         simp⟩ := Fin.ext (by omega)
     subst index
-    change pcHandshakeBetween
+    change transitionBetween
       (Eval.eval
         (addSpinMainTable.previousEnvironment
           ⟨1, by simp⟩)
@@ -474,7 +474,7 @@ theorem addSpinMainTable_transitions : addSpinMainTable.TransitionConstraints :=
   · have h_index : index = ⟨2, by
         simp⟩ := Fin.ext (by omega)
     subst index
-    change pcHandshakeBetween
+    change transitionBetween
       (Eval.eval
         (addSpinMainTable.previousEnvironment
           ⟨2, by simp⟩)

--- a/ZiskFv/Compliance/AddSpinWitness.lean
+++ b/ZiskFv/Compliance/AddSpinWitness.lean
@@ -311,12 +311,13 @@ private theorem addSpinMain_constraintsHold_materialize
 
 theorem addSpinMain_pcHandshake_add_jal :
     transitionBetween addSpinAddRow (addSpinJalRow 1) := by
-  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, addSpinAddRow, addSpinJalRow, addSpinJalProgramRow, addSpinJalBits,
-    addX1Row, mainRomRowOf]
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, addSpinAddRow,
+    addSpinJalRow, addSpinJalProgramRow, addSpinJalBits, addX1Row, mainRomRowOf]
 
 theorem addSpinMain_pcHandshake_jal_jal :
     transitionBetween (addSpinJalRow 1) (addSpinJalRow 2) := by
-  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, addSpinJalRow, addSpinJalProgramRow, addSpinJalBits, mainRomRowOf]
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, addSpinJalRow,
+    addSpinJalProgramRow, addSpinJalBits, mainRomRowOf]
   ring
 
 @[simp] theorem addSpinMainTable_eval_rowInputVar_zero

--- a/ZiskFv/Compliance/ConstructionAdd.lean
+++ b/ZiskFv/Compliance/ConstructionAdd.lean
@@ -79,7 +79,215 @@ open ZiskFv.Airs.Main
 open ZiskFv.Airs.OperationBus
 open ZiskFv.EquivCore.Promises
 
-set_option maxHeartbeats 2000000
+set_option maxHeartbeats 32000000
+set_option maxRecDepth 2048
+
+private lemma byte_ranges_of_static_match
+    {op_val : ℕ} {a b c : FGL}
+    (h : ZiskFv.Airs.Binary.consumer_byte_match_wf op_val a b c) :
+    a.val < 256 ∧ b.val < 256 ∧ c.val < 256 := by
+  obtain ⟨e, h_wf, _, h_a, h_b, h_c⟩ := h
+  rcases h_wf.1 with ⟨ha, hb, hc, _⟩
+  exact ⟨by simpa [h_a] using ha, by simpa [h_b] using hb,
+    by simpa [h_c] using hc⟩
+
+/-- A static Binary ADD row computes the packed 64-bit sum. -/
+private lemma static_binary_add_packed
+    (row : ZiskFv.AirsClean.Binary.BinaryRow FGL)
+    (out : ZiskFv.EquivCore.Bridge.Binary.BinaryChainStaticOut64
+      (ZiskFv.AirsClean.Binary.validOfRow row) 0
+      ZiskFv.Airs.Tables.BinaryTable.OP_ADD) :
+    BitVec.ofNat 64
+        (row.aBytes.free_in_a_0.val + row.aBytes.free_in_a_1.val * 256
+          + row.aBytes.free_in_a_2.val * 65536 + row.aBytes.free_in_a_3.val * 16777216
+          + row.aBytes.free_in_a_4.val * 4294967296
+          + row.aBytes.free_in_a_5.val * 1099511627776
+          + row.aBytes.free_in_a_6.val * 281474976710656
+          + row.aBytes.free_in_a_7.val * 72057594037927936)
+      +
+      BitVec.ofNat 64
+        (row.bBytes.free_in_b_0.val + row.bBytes.free_in_b_1.val * 256
+          + row.bBytes.free_in_b_2.val * 65536 + row.bBytes.free_in_b_3.val * 16777216
+          + row.bBytes.free_in_b_4.val * 4294967296
+          + row.bBytes.free_in_b_5.val * 1099511627776
+          + row.bBytes.free_in_b_6.val * 281474976710656
+          + row.bBytes.free_in_b_7.val * 72057594037927936)
+      =
+      BitVec.ofNat 64
+        (row.cBytes.free_in_c_0.val + row.cBytes.free_in_c_1.val * 256
+          + row.cBytes.free_in_c_2.val * 65536 + row.cBytes.free_in_c_3.val * 16777216
+          + row.cBytes.free_in_c_4.val * 4294967296
+          + row.cBytes.free_in_c_5.val * 1099511627776
+          + row.cBytes.free_in_c_6.val * 281474976710656
+          + row.cBytes.free_in_c_7.val * 72057594037927936) := by
+  have h_matches := allByteMatchesOfStaticOut64_local out
+  rcases h_matches with ⟨h0, h1, h2, h3, h4, h5, h6, h7⟩
+  obtain ⟨ha0, hb0, hc0⟩ := byte_ranges_of_static_match h0
+  obtain ⟨ha1, hb1, hc1⟩ := byte_ranges_of_static_match h1
+  obtain ⟨ha2, hb2, hc2⟩ := byte_ranges_of_static_match h2
+  obtain ⟨ha3, hb3, hc3⟩ := byte_ranges_of_static_match h3
+  obtain ⟨ha4, hb4, hc4⟩ := byte_ranges_of_static_match h4
+  obtain ⟨ha5, hb5, hc5⟩ := byte_ranges_of_static_match h5
+  obtain ⟨ha6, hb6, hc6⟩ := byte_ranges_of_static_match h6
+  obtain ⟨ha7, hb7, hc7⟩ := byte_ranges_of_static_match h7
+  exact ZiskFv.Airs.Binary.binary_add_chunks_eq_bv_add_of_wf
+    row.aBytes.free_in_a_0 row.aBytes.free_in_a_1 row.aBytes.free_in_a_2 row.aBytes.free_in_a_3
+    row.aBytes.free_in_a_4 row.aBytes.free_in_a_5 row.aBytes.free_in_a_6 row.aBytes.free_in_a_7
+    row.bBytes.free_in_b_0 row.bBytes.free_in_b_1 row.bBytes.free_in_b_2 row.bBytes.free_in_b_3
+    row.bBytes.free_in_b_4 row.bBytes.free_in_b_5 row.bBytes.free_in_b_6 row.bBytes.free_in_b_7
+    row.cBytes.free_in_c_0 row.cBytes.free_in_c_1 row.cBytes.free_in_c_2 row.cBytes.free_in_c_3
+    row.cBytes.free_in_c_4 row.cBytes.free_in_c_5 row.cBytes.free_in_c_6 row.cBytes.free_in_c_7
+    0 row.chain.carry_0 row.chain.carry_1 row.chain.carry_2
+    row.chain.carry_3 row.chain.carry_4 row.chain.carry_5 row.chain.carry_6
+    (ZiskFv.AirsClean.Binary.lookupFlags012Row row row.chain.carry_0)
+    (ZiskFv.AirsClean.Binary.lookupFlags012Row row row.chain.carry_1)
+    (ZiskFv.AirsClean.Binary.lookupFlags012Row row row.chain.carry_2)
+    (ZiskFv.AirsClean.Binary.lookupFlags3456Row row row.chain.carry_3)
+    (ZiskFv.AirsClean.Binary.lookupFlags3456Row row row.chain.carry_4)
+    (ZiskFv.AirsClean.Binary.lookupFlags3456Row row row.chain.carry_5)
+    (ZiskFv.AirsClean.Binary.lookupFlags3456Row row row.chain.carry_6)
+    (ZiskFv.AirsClean.Binary.lookupFlags7Row row)
+    (2 * row.mode.use_first_byte) 0 0 row.mode.mode32 0 0 0 (1 - row.mode.mode32)
+    out.chain_0 out.chain_1 out.chain_2 out.chain_3
+    out.chain_4 out.chain_5 out.chain_6 out.chain_7
+    ha0 ha1 ha2 ha3 ha4 ha5 ha6 ha7 hb0 hb1 hb2 hb3 hb4 hb5 hb6 hb7
+    hc0 hc1 hc2 hc3 hc4 hc5 hc6 hc7
+    out.cin0_eq out.cin1_eq out.cin2_eq out.cin3_eq
+    out.cin4_eq out.cin5_eq out.cin6_eq out.cin7_eq
+    out.pi0_ne out.pi1_ne out.pi2_ne out.pi3_ne
+    out.pi4_ne out.pi5_ne out.pi6_ne out.pi7_eq
+
+/-- Circuit-only ADD semantics from the static Binary provider shape. -/
+theorem main_add_packed_result_of_static_provider
+    (m : Valid_Main FGL FGL)
+    (i : Nat)
+    (row : ZiskFv.AirsClean.Binary.BinaryRow FGL)
+    (h_op : m.op i = OP_ADD)
+    (h_m32 : m.m32 i = 0)
+    (h_core : ZiskFv.Airs.Binary.core_every_row
+      (ZiskFv.AirsClean.Binary.validOfRow row) 0)
+    (h_facts : ZiskFv.AirsClean.Binary.StaticBinaryTableWfFacts row)
+    (h_spec : ZiskFv.AirsClean.Binary.StaticBinaryTableSpecFacts row)
+    (h_match : matches_entry
+      (opBus_row_Main m i)
+      (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+        (ZiskFv.AirsClean.Binary.opBusMessage row) 1)) :
+    BitVec.ofNat 64
+        ((m.c_0 i).val + (m.c_1 i).val * 4294967296)
+      =
+      BitVec.ofNat 64
+        ((m.a_0 i).val + (m.a_1 i).val * 4294967296)
+      +
+      BitVec.ofNat 64
+        ((m.b_0 i).val + (m.b_1 i).val * 4294967296) := by
+  have h_emit : row.chain.b_op + 16 * row.mode.mode32 =
+      (ZiskFv.Airs.Tables.BinaryTable.OP_ADD : FGL) := by
+    have hm := h_match
+    simp only [matches_entry, opBus_row_Main] at hm
+    rw [← hm.2.1]
+    simpa [ZiskFv.Airs.Tables.BinaryTable.OP_ADD, OP_ADD] using h_op
+  obtain ⟨h_row_m32, h_bop, _⟩ :=
+    ZiskFv.EquivCore.Bridge.Binary.logic_row_mode_pins_of_emit_op_lt_16_of_static_spec
+      row h_spec ZiskFv.Airs.Tables.BinaryTable.OP_ADD
+      (by simp [ZiskFv.Airs.Tables.BinaryTable.OP_ADD]) h_core h_emit
+  have out :=
+    ZiskFv.EquivCore.Bridge.Binary.byte_chain_discharge_64_of_static_row
+      row h_facts ZiskFv.Airs.Tables.BinaryTable.OP_ADD h_core h_row_m32 h_bop
+  have h_carry_bool :
+      row.chain.carry_7 * (1 - row.chain.carry_7) = 0 := by
+    simpa [ZiskFv.AirsClean.Binary.validOfRow] using h_core.2.1
+  have h_matches := allByteMatchesOfStaticOut64_local out
+  have ha := ZiskFv.EquivCore.Bridge.Binary.main_a_packing_of_match
+    m row i h_matches h_m32 h_match
+  have hb := ZiskFv.EquivCore.Bridge.Binary.main_b_packing_of_match
+    m row i h_matches h_m32 h_match
+  have hcarry : row.chain.carry_7 = 0 := by
+    exact ZiskFv.EquivCore.Bridge.Binary.carry_7_zero_ADD_of_static_chain
+      (ZiskFv.AirsClean.Binary.validOfRow row) 0 out h_core h_carry_bool
+  have hflag : m.flag i = 0 := by
+    have hm := h_match
+    simp only [matches_entry, opBus_row_Main,
+      ZiskFv.AirsClean.Binary.opBusMessage,
+      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry] at hm
+    exact hm.2.2.2.2.2.2.2.2.1.trans hcarry
+  obtain ⟨hc0, hc1⟩ :=
+    ZiskFv.EquivCore.Bridge.Binary.main_c_lanes_carryfree_of_match
+      m row i h_match hflag
+  rcases h_matches with ⟨hm0, hm1, hm2, hm3, hm4, hm5, hm6, hm7⟩
+  obtain ⟨_, _, hc0_lt⟩ := byte_ranges_of_static_match hm0
+  obtain ⟨_, _, hc1_lt⟩ := byte_ranges_of_static_match hm1
+  obtain ⟨_, _, hc2_lt⟩ := byte_ranges_of_static_match hm2
+  obtain ⟨_, _, hc3_lt⟩ := byte_ranges_of_static_match hm3
+  obtain ⟨_, _, hc4_lt⟩ := byte_ranges_of_static_match hm4
+  obtain ⟨_, _, hc5_lt⟩ := byte_ranges_of_static_match hm5
+  obtain ⟨_, _, hc6_lt⟩ := byte_ranges_of_static_match hm6
+  obtain ⟨_, _, hc7_lt⟩ := byte_ranges_of_static_match hm7
+  have hc_lo_lt :
+      row.cBytes.free_in_c_0.val + row.cBytes.free_in_c_1.val * 256
+        + row.cBytes.free_in_c_2.val * 65536
+        + row.cBytes.free_in_c_3.val * 16777216 < GL_prime := by omega
+  have hc_hi_lt :
+      row.cBytes.free_in_c_4.val + row.cBytes.free_in_c_5.val * 256
+        + row.cBytes.free_in_c_6.val * 65536
+        + row.cBytes.free_in_c_7.val * 16777216 < GL_prime := by omega
+  rw [hc0, hc1, ha, hb]
+  simp only [Fin.val_add, Fin.val_mul]
+  norm_num at ⊢
+  rw [Nat.mod_eq_of_lt hc_lo_lt, Nat.mod_eq_of_lt hc_hi_lt]
+  simpa [Nat.add_assoc, Nat.mul_assoc, Nat.mul_add, Nat.add_mul] using
+    (static_binary_add_packed row out).symm
+
+/-- Circuit-only ADD semantics from the dedicated BinaryAdd provider shape. -/
+theorem main_add_packed_result_of_binaryadd_provider
+    (m : Valid_Main FGL FGL)
+    (i : Nat)
+    (row : ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL)
+    (h_m32 : m.m32 i = 0)
+    (h_facts : ZiskFv.AirsClean.BinaryAdd.ComponentSpecFacts row)
+    (h_match : matches_entry
+      (opBus_row_Main m i)
+      (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+        (ZiskFv.AirsClean.BinaryAdd.opBusMessage row) 1)) :
+    BitVec.ofNat 64
+        ((m.c_0 i).val + (m.c_1 i).val * 4294967296)
+      =
+      BitVec.ofNat 64
+        ((m.a_0 i).val + (m.a_1 i).val * 4294967296)
+      +
+      BitVec.ofNat 64
+        ((m.b_0 i).val + (m.b_1 i).val * 4294967296) := by
+  have hadd :=
+    ZiskFv.AirsClean.BinaryAdd.binary_add_chunks_eq_bv_add_via_component
+      (ZiskFv.AirsClean.BinaryAdd.validOfRow row) 0
+      (ZiskFv.AirsClean.BinaryAdd.core_every_row_of_component_spec_facts row h_facts)
+      (ZiskFv.AirsClean.BinaryAdd.a_chunks_in_range_of_component_spec_facts row h_facts)
+      (ZiskFv.AirsClean.BinaryAdd.b_chunks_in_range_of_component_spec_facts row h_facts)
+      (ZiskFv.AirsClean.BinaryAdd.c_chunks_in_range_of_component_spec_facts row h_facts)
+  have hm := h_match
+  simp only [matches_entry, opBus_row_Main,
+    ZiskFv.AirsClean.BinaryAdd.opBusMessage,
+    ZiskFv.Channels.OperationBus.OpBusMessage.toEntry] at hm
+  obtain ⟨_, _, ha0, ha1, hb0, hb1, hc0, hc1, _, _, _, _⟩ := hm
+  obtain ⟨_, _, _, _, hc0_lt, hc1_lt, hc2_lt, hc3_lt⟩ := h_facts.2.2
+  have hc_lo_lt :
+      row.c_chunks_1.val * 65536 + row.c_chunks_0.val < GL_prime := by omega
+  have hc_hi_lt :
+      row.c_chunks_3.val * 65536 + row.c_chunks_2.val < GL_prime := by omega
+  rw [h_m32] at ha1 hb1
+  simp only [one_sub_zero_mul] at ha1 hb1
+  rw [hc0, hc1, ha0, ha1, hb0, hb1]
+  simp only [Fin.val_add, Fin.val_mul]
+  norm_num at ⊢
+  rw [Nat.mod_eq_of_lt hc_lo_lt, Nat.mod_eq_of_lt hc_hi_lt]
+  have hc_pack :
+      row.c_chunks_1.val * 65536 + row.c_chunks_0.val
+          + (row.c_chunks_3.val * 65536 + row.c_chunks_2.val) * 4294967296
+        =
+      row.c_chunks_0.val + row.c_chunks_1.val * 65536
+          + row.c_chunks_2.val * 4294967296
+          + row.c_chunks_3.val * 281474976710656 := by omega
+  rw [hc_pack]
+  simpa [ZiskFv.AirsClean.BinaryAdd.validOfRow] using hadd.symm
 
 /-- Sound ADD construction (PR4, approach (a): two-arm provider case-split).
 

--- a/ZiskFv/Compliance/ConstructionAdd.lean
+++ b/ZiskFv/Compliance/ConstructionAdd.lean
@@ -79,8 +79,7 @@ open ZiskFv.Airs.Main
 open ZiskFv.Airs.OperationBus
 open ZiskFv.EquivCore.Promises
 
-set_option maxHeartbeats 32000000
-set_option maxRecDepth 2048
+set_option maxHeartbeats 2000000
 
 private lemma byte_ranges_of_static_match
     {op_val : ℕ} {a b c : FGL}

--- a/ZiskFv/Compliance/ConstructionLui.lean
+++ b/ZiskFv/Compliance/ConstructionLui.lean
@@ -61,6 +61,15 @@ open Interaction
 
 set_option maxHeartbeats 2000000
 
+/-- The honest unified Main+ROM row at a physical Main-table index. -/
+@[reducible]
+noncomputable def mainRowWithRomAt
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin trace.mainTable.table.length) :
+    ZiskFv.AirsClean.Main.MainRowWithRom FGL :=
+  ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+    trace.program trace.mainTable i.val
+
 /-- The honest unified Main+ROM row at trace index `i`, drawn from the real Main
     table.  Its `.core` equals `rowAt (mainOfTable …) i`. -/
 @[reducible]
@@ -69,6 +78,15 @@ noncomputable def mainRowWithRomLui
     ZiskFv.AirsClean.Main.MainRowWithRom FGL :=
   ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
     trace.program trace.mainTable i.val
+
+/-- The Main `c` memory-bus emission at a physical Main-table index. -/
+@[reducible]
+noncomputable def eRdAt
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin trace.mainTable.table.length) :
+    Interaction.MemoryBusEntry FGL :=
+  ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
+    (ZiskFv.AirsClean.Main.cMemMessage (mainRowWithRomAt trace i)) 1 1
 
 /-- Construction-chosen rd-write entry: the real Clean Main `c` memory-bus
     emission (rd write) of the honest unified row.  The `StorePcMemoryWitness`
@@ -79,6 +97,26 @@ noncomputable def eRdLui
     Interaction.MemoryBusEntry FGL :=
   ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry
     (ZiskFv.AirsClean.Main.cMemMessage (mainRowWithRomLui trace i)) 1 1
+
+/-- The Main per-row `Spec` at a physical Main-table index. -/
+theorem mainSpec_at_physical
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin trace.mainTable.table.length) :
+    ZiskFv.AirsClean.Main.Spec
+      (ZiskFv.AirsClean.Main.rowAt
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
+        i.val) := by
+  let mainRow := trace.mainTable.table.get i
+  have h_mainRow_mem : mainRow ∈ trace.mainTable.table := by simp [mainRow]
+  have h_main_component_spec :
+      trace.mainTable.component.Spec
+        (trace.mainTable.environment (trace.mainTable.table.get i)) := by
+    simpa [mainRow] using
+      trace.spec_holds trace.mainTable trace.mainTable_mem mainRow h_mainRow_mem
+  exact
+    ZiskFv.AirsClean.FullEnsemble.mainSpec_rowAt_mainOfTable_of_component_spec
+      trace.program trace.mainTable i trace.mainTable_component
+      h_main_component_spec
 
 /-- The Main per-row `Spec` at trace index `i`, derived from `trace.spec_holds`.
     (Standalone version of the in-wrapper `h_main_spec` derivation.) -/

--- a/ZiskFv/Compliance/JalrSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/JalrSpinRootSoundness.lean
@@ -1,0 +1,498 @@
+import ZiskFv.Compliance.JalrSpinWitness
+import ZiskFv.Soundness
+
+set_option maxRecDepth 10000
+
+/-!
+# Concrete `root_soundness` instantiation for unaligned JALR lowering
+
+The architectural trace executes `ADDI x1,x0,2`, then `JALR x2,2(x1)`.
+The JALR is represented by adjacent physical Main rows `ADD; AND`; the
+terminal AND jumps back to the physical successor at architectural PC 4.
+-/
+
+open Goldilocks
+open ZiskFv.Compliance
+open ZiskFv.Compliance.AddSpinWitness
+open ZiskFv.Compliance.Instantiation
+open ZiskFv.Compliance.JalrSpinWitness
+open ZiskFv.Compliance.RomDecodeBinding
+open ZiskFv.ZiskCircuit.MemTrace
+open ZiskFv.Trusted
+
+namespace ZiskFv.Compliance.JalrSpinRootSoundness
+
+def x0 : regidx := regidx.Regidx (0#5)
+def x1 : regidx := regidx.Regidx (1#5)
+def x2 : regidx := regidx.Regidx (2#5)
+
+def setupIndex : Fin 2 := ⟨0, by decide⟩
+def jalrIndex : Fin 2 := ⟨1, by decide⟩
+
+def setupClaim : Claim_addi jalrAcceptedTrace setupIndex where
+  r1 := x0
+  rd := x1
+  imm := 2#12
+
+def jalrClaim : Claim_jalr jalrAcceptedTrace jalrIndex where
+  imm := 2#12
+  rs1 := x1
+  rd := x2
+  offset_bv := 0#64
+
+def jalrSpinZiskStep : ∀ i : Fin 2, ZiskStep jalrAcceptedTrace i
+  | ⟨0, _⟩ => .addi setupClaim
+  | ⟨1, _⟩ => .jalr jalrClaim
+
+def misa : RegisterType Register.misa := 0#64
+def mseccfg : RegisterType Register.mseccfg := 0#64
+
+def regs (pc x1Value x2Value : BitVec 64) :
+    Std.ExtDHashMap Register RegisterType :=
+  let regs0 :=
+    (default : PreSail.SequentialState RegisterType Sail.trivialChoiceSource).regs
+  let regs1 := regs0.insert Register.PC pc
+  let regs2 := regs1.insert Register.cur_privilege Privilege.Machine
+  let regs3 := regs2.insert Register.misa misa
+  let regs4 := regs3.insert Register.mseccfg mseccfg
+  let regs5 := regs4.insert (reg_of_fin (regidx_to_fin x1)) x1Value
+  regs5.insert (reg_of_fin (regidx_to_fin x2)) x2Value
+
+def state (pc x1Value x2Value : BitVec 64) :
+    PreSail.SequentialState RegisterType Sail.trivialChoiceSource :=
+  { (default : PreSail.SequentialState RegisterType Sail.trivialChoiceSource) with
+    regs := regs pc x1Value x2Value
+    mem := {} }
+
+def sailTrace : SailTrace 2
+  | ⟨0, _⟩ => state (0#64) (0#64) (0#64)
+  | ⟨1, _⟩ => state (4#64) (2#64) (0#64)
+
+def bootSeed :
+    BootSegmentMemorySeed jalrAcceptedTrace sailTrace jalrSpinZiskStep where
+  memInit := {}
+  rowsOf := fun _ => []
+  boot := by
+    intro h
+    rfl
+  step := by
+    intro j h
+    change j + 1 < 2 at h
+    have : j = 0 := by omega
+    subst j
+    simp [sailTrace, state, replayMemoryAfterBusRows]
+  readSoundInputs := fun h => absurd h jalrWitness_not_mutableMemPresent
+  memPresent_of_executionRows_nonempty := by
+    intro h_nonempty
+    exact absurd (by simp [AcceptedZiskTrace.numInstructions]) h_nonempty
+  placement := by
+    intro i
+    fin_cases i <;> simp [MemoryOpPlacement, jalrSpinZiskStep]
+
+def setupMainIndex : Fin jalrAcceptedTrace.mainTable.table.length :=
+  Fin.cast
+    (congrArg (fun table : Air.Flat.Table FGL => table.table.length)
+      jalrAcceptedTrace_mainTable_eq).symm
+    (⟨0, by decide⟩ : Fin jalrMainTable.table.length)
+
+def startMainIndex : Fin jalrAcceptedTrace.mainTable.table.length :=
+  Fin.cast
+    (congrArg (fun table : Air.Flat.Table FGL => table.table.length)
+      jalrAcceptedTrace_mainTable_eq).symm
+    (⟨1, by decide⟩ : Fin jalrMainTable.table.length)
+
+def finishMainIndex : Fin jalrAcceptedTrace.mainTable.table.length :=
+  Fin.cast
+    (congrArg (fun table : Air.Flat.Table FGL => table.table.length)
+      jalrAcceptedTrace_mainTable_eq).symm
+    (⟨2, by decide⟩ : Fin jalrMainTable.table.length)
+
+@[simp] theorem setupMainIndex_val : setupMainIndex.val = 0 := by
+  simp [setupMainIndex]
+
+@[simp] theorem startMainIndex_val : startMainIndex.val = 1 := by
+  simp [startMainIndex]
+
+@[simp] theorem finishMainIndex_val : finishMainIndex.val = 2 := by
+  simp [finishMainIndex]
+
+private theorem setupMainGet :
+    jalrAcceptedTrace.mainTable.table.get setupMainIndex =
+      jalrMainTable.table.get (⟨0, by decide⟩ : Fin jalrMainTable.table.length) := by
+  simp [setupMainIndex, jalrAcceptedTrace_mainTable_eq]
+
+private theorem startMainGet :
+    jalrAcceptedTrace.mainTable.table.get startMainIndex =
+      jalrMainTable.table.get (⟨1, by decide⟩ : Fin jalrMainTable.table.length) := by
+  simp [startMainIndex, jalrAcceptedTrace_mainTable_eq]
+
+private theorem finishMainGet :
+    jalrAcceptedTrace.mainTable.table.get finishMainIndex =
+      jalrMainTable.table.get (⟨2, by decide⟩ : Fin jalrMainTable.table.length) := by
+  simp [finishMainIndex, jalrAcceptedTrace_mainTable_eq]
+
+private theorem mainAt_setup :
+    ZiskFv.Compliance.mainRowWithRomAt jalrAcceptedTrace setupMainIndex =
+      jalrSetupRow := by
+  unfold ZiskFv.Compliance.mainRowWithRomAt
+  rw [ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get]
+  rw [setupMainGet]
+  rw [jalrAcceptedTrace_mainTable_eq]
+  convert jalrMainTable_evalAt (⟨0, by decide⟩ : Fin jalrMainTable.length) using 1 <;>
+    simp [jalrMainRows]
+
+private theorem mainAt_start :
+    ZiskFv.Compliance.mainRowWithRomAt jalrAcceptedTrace startMainIndex =
+      jalrAddRow := by
+  unfold ZiskFv.Compliance.mainRowWithRomAt
+  rw [ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get]
+  rw [startMainGet]
+  rw [jalrAcceptedTrace_mainTable_eq]
+  convert jalrMainTable_evalAt (⟨1, by decide⟩ : Fin jalrMainTable.length) using 1 <;>
+    simp [jalrMainRows]
+
+private theorem mainAt_finish :
+    ZiskFv.Compliance.mainRowWithRomAt jalrAcceptedTrace finishMainIndex =
+      jalrAndRow := by
+  unfold ZiskFv.Compliance.mainRowWithRomAt
+  rw [ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get]
+  rw [finishMainGet]
+  rw [jalrAcceptedTrace_mainTable_eq]
+  convert jalrMainTable_evalAt (⟨2, by decide⟩ : Fin jalrMainTable.length) using 1 <;>
+    simp [jalrMainRows]
+
+@[simp] private theorem mainRawAt_setup :
+    ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+      jalrAcceptedTrace.program jalrAcceptedTrace.mainTable 0 = jalrSetupRow := by
+  simpa [ZiskFv.Compliance.mainRowWithRomAt, setupMainIndex] using mainAt_setup
+
+@[simp] private theorem mainRawAt_start :
+    ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+      jalrAcceptedTrace.program jalrAcceptedTrace.mainTable 1 = jalrAddRow := by
+  simpa [ZiskFv.Compliance.mainRowWithRomAt, startMainIndex] using mainAt_start
+
+@[simp] private theorem mainRawAt_finish :
+    ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+      jalrAcceptedTrace.program jalrAcceptedTrace.mainTable 2 = jalrAndRow := by
+  simpa [ZiskFv.Compliance.mainRowWithRomAt, finishMainIndex] using mainAt_finish
+
+@[simp] private theorem jalrAcceptedTrace_numInstructions :
+    jalrAcceptedTrace.numInstructions = 2 := rfl
+
+def loweringRows : JalrLoweringRows jalrAcceptedTrace jalrIndex (2#12) (0#64) where
+  start := startMainIndex
+  finish := finishMainIndex
+  architectural_start := rfl
+  finish_has_successor := by
+    simp [jalrAcceptedTrace_mainTable_eq, jalrMainTable,
+      ZiskFv.Compliance.AddSpinWitness.mainRowsTable, jalrMainRows]
+  lowering := by
+    right
+    simp [jalrClaim, jalrIndex, mainAt_start, mainAt_finish,
+      ZiskFv.AirsClean.FullEnsemble.mainOfTable,
+      jalrAddProgramRow, jalrAddBits,
+      jalrAndProgramRow, jalrAndBits,
+      jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
+      jalrAndRow, jalrAndRowWithLast, jalrAndRowTemplate,
+      jalrFreeCols, jalrRegisterInitial, ZiskFv.AirsClean.Main.mainRomRowOf]
+
+def jalrDecode : Decode_jalr jalrAcceptedTrace jalrIndex jalrClaim where
+  rows := loweringRows
+  h_main_op := by
+    simp [loweringRows, mainAt_finish,
+      jalrAndProgramRow, jalrAndBits,
+      ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
+      jalrAndRowWithLast, jalrAndRowTemplate,
+      ZiskFv.AirsClean.Main.mainRomRowOf]
+  h_main_active := by
+    simp [loweringRows, mainAt_finish,
+      jalrAndProgramRow, jalrAndBits,
+      ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
+      jalrAndRowWithLast, jalrAndRowTemplate,
+      ZiskFv.AirsClean.Main.mainRomRowOf]
+  h_flag := by
+    simp [loweringRows, mainAt_finish,
+      jalrAndProgramRow, jalrAndBits,
+      ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
+      jalrAndRowWithLast, jalrAndRowTemplate,
+      ZiskFv.AirsClean.Main.mainRomRowOf]
+  h_m32 := by
+    simp [loweringRows, mainAt_finish,
+      jalrAndProgramRow, jalrAndBits,
+      ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
+      jalrAndRowWithLast, jalrAndRowTemplate,
+      ZiskFv.AirsClean.Main.mainRomRowOf]
+  h_set_pc := by
+    simp [loweringRows, mainAt_finish,
+      jalrAndProgramRow, jalrAndBits,
+      ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
+      jalrAndRowWithLast, jalrAndRowTemplate,
+      ZiskFv.AirsClean.Main.mainRomRowOf]
+  h_store_pc := by
+    simp [loweringRows, mainAt_finish,
+      jalrAndProgramRow, jalrAndBits,
+      ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
+      jalrAndRowWithLast, jalrAndRowTemplate,
+      ZiskFv.AirsClean.Main.mainRomRowOf]
+  h_store_ind := by
+    simp [loweringRows, mainAt_finish, jalrAndProgramRow, jalrAndBits,
+      jalrAndRow, jalrAndRowWithLast,
+      jalrAndRowTemplate, ZiskFv.AirsClean.Main.mainRomRowOf]
+  h_store_offset := by
+    simp [loweringRows, mainAt_finish, jalrClaim, x2, jalrAndProgramRow,
+      jalrAndBits, jalrAndRow,
+      jalrAndRowWithLast, jalrAndRowTemplate,
+      ZiskFv.AirsClean.Main.mainRomRowOf, Transpiler.ind, regidx_to_fin]
+  h_idx := loweringRows.finish_has_successor
+  h_a_mask_lo := by
+    rw [ZiskFv.AirsClean.FullEnsemble.mainOfTable_a_0]
+    change (ZiskFv.Compliance.mainRowWithRomAt jalrAcceptedTrace
+      finishMainIndex).core.a_0 = _
+    rw [mainAt_finish]
+    rfl
+  h_a_mask_hi := by
+    rw [ZiskFv.AirsClean.FullEnsemble.mainOfTable_a_1]
+    change (ZiskFv.Compliance.mainRowWithRomAt jalrAcceptedTrace
+      finishMainIndex).core.a_1 = _
+    rw [mainAt_finish]
+    rfl
+  h_c1_zero := by
+    rw [ZiskFv.AirsClean.FullEnsemble.mainOfTable_c_1]
+    change (ZiskFv.Compliance.mainRowWithRomAt jalrAcceptedTrace
+      finishMainIndex).core.c_1 = _
+    rw [mainAt_finish]
+    rfl
+  h_jmp2 := by
+    right
+    simp [loweringRows, mainAt_finish,
+      jalrAndProgramRow, jalrAndBits,
+      ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
+      jalrAndRowWithLast, jalrAndRowTemplate,
+      ZiskFv.AirsClean.Main.mainRomRowOf]
+  h_offset_bridge := by
+    simp [loweringRows, mainAt_finish, jalrClaim,
+      jalrAndProgramRow, jalrAndBits,
+      ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
+      jalrAndRowWithLast, jalrAndRowTemplate,
+      ZiskFv.AirsClean.Main.mainRomRowOf]
+  h_offset_even := by simp [jalrClaim]
+  h_no_fgl_wrap := by
+    norm_num [loweringRows, mainAt_finish,
+      jalrAndProgramRow, jalrAndBits,
+      ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
+      jalrAndRowWithLast, jalrAndRowTemplate,
+      ZiskFv.AirsClean.Main.mainRomRowOf]
+
+def jalrProgramDecode :
+    ProgramDecode_jalr jalrAcceptedTrace jalrIndex jalrClaim where
+  toDecode := jalrDecode
+
+-- The setup decode and both input-agreement bundles follow the established
+-- concrete ADDI/JALR constructors; they are stated separately so compilation
+-- checks every remaining field rather than hiding it behind a helper.
+
+def setupInput : PureSpec.AddiInput where
+  r1_val := 0#64
+  imm := 2#12
+  rd := regidx_to_fin x1
+  PC := 0#64
+
+def jalrInput : PureSpec.JalrInput where
+  imm := 2#12
+  rs1_val := 2#64
+  rd := regidx_to_fin x2
+  PC := 4#64
+
+private theorem setupMainPc :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable jalrAcceptedTrace.program
+      jalrAcceptedTrace.mainTable).pc 0 = 0 := by
+  change
+    (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+      jalrAcceptedTrace.program jalrAcceptedTrace.mainTable 0).core.pc = 0
+  rw [mainRawAt_setup]
+  simp [jalrSetupRow, jalrSetupRowWithLast, jalrSetupRowTemplate,
+    jalrSetupProgramRow, jalrSetupBits, ZiskFv.AirsClean.Main.mainRomRowOf]
+
+private theorem jalrMainPc :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable jalrAcceptedTrace.program
+      jalrAcceptedTrace.mainTable).pc 1 = 4 := by
+  change
+    (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+      jalrAcceptedTrace.program jalrAcceptedTrace.mainTable 1).core.pc = 4
+  rw [mainRawAt_start]
+  simp [jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
+    jalrAddProgramRow, jalrAddBits, ZiskFv.AirsClean.Main.mainRomRowOf]
+
+def setupProgramDecode :
+    ProgramDecode_addi jalrAcceptedTrace setupIndex setupClaim where
+  h_idx := by
+    rw [jalrAcceptedTrace_mainTable_eq]
+    simp [setupIndex, jalrMainTable,
+      ZiskFv.Compliance.AddSpinWitness.mainRowsTable, jalrMainRows]
+  bits := jalrSetupBits
+  h_bits_ieo := rfl
+  h_bits_m32 := rfl
+  h_bits_set_pc := rfl
+  h_bits_store_pc := rfl
+  h_bits_store_ind := rfl
+  h_bits_b_src_imm := rfl
+  h_prog := by
+    intro j hline
+    fin_cases j
+    · simp [jalrAcceptedTrace, jalrProgram, jalrSetupProgramRow, setupClaim,
+        x0, x1, Transpiler.ind, regidx_to_fin,
+        ZiskFv.AirsClean.Main.packFlags, jalrSetupBits,
+        ZiskFv.AirsClean.boolF]
+    · change (jalrAcceptedTrace.program
+          (⟨1, by norm_num [jalrAcceptedTrace]⟩ :
+            Fin jalrAcceptedTrace.programLength)).line =
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable jalrAcceptedTrace.program
+          jalrAcceptedTrace.mainTable).pc 0 at hline
+      rw [setupMainPc] at hline
+      exfalso
+      have hfalse : (4 : FGL) = 0 := by
+        simpa [jalrAcceptedTrace, jalrProgram, jalrAddProgramRow] using hline
+      have := congrArg Fin.val hfalse
+      norm_num at this
+    · change (jalrAcceptedTrace.program
+          (⟨2, by norm_num [jalrAcceptedTrace]⟩ :
+            Fin jalrAcceptedTrace.programLength)).line =
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable jalrAcceptedTrace.program
+          jalrAcceptedTrace.mainTable).pc 0 at hline
+      rw [setupMainPc] at hline
+      exfalso
+      have hfalse : (5 : FGL) = 0 := by
+        simpa [jalrAcceptedTrace, jalrProgram, jalrAndProgramRow] using hline
+      have := congrArg Fin.val hfalse
+      norm_num at this
+
+private theorem readX0_setup :
+    read_xreg (regidx_to_fin x0) (sailTrace setupIndex) =
+      EStateM.Result.ok (0#64) (sailTrace setupIndex) := by
+  simp [sailTrace, setupIndex, state, regs, x0, regidx_to_fin, read_xreg,
+    reg_of_fin]
+
+private theorem readX1_jalr :
+    read_xreg (regidx_to_fin x1) (sailTrace jalrIndex) =
+      EStateM.Result.ok (2#64) (sailTrace jalrIndex) := by
+  simp [sailTrace, jalrIndex, state, regs, x1, x2, regidx_to_fin, read_xreg,
+    reg_of_fin, Sail.readReg, Std.ExtDHashMap.get?_insert]
+
+def setupInputs :
+    Inputs_addi jalrAcceptedTrace sailTrace setupIndex setupClaim where
+  addi_input := setupInput
+  h_input_r1 := by simpa [setupInput, setupClaim] using readX0_setup
+  h_input_imm := rfl
+  h_input_pc := by
+    simp [setupInput, sailTrace, setupIndex, state, regs, x1, x2,
+      regidx_to_fin, reg_of_fin, Std.ExtDHashMap.get?_insert]
+  h_input_rd := rfl
+  h_a_lo_t := by
+    simp only [setupClaim]
+    rw [ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64_xreg_eq_of_read_xreg
+      (sailTrace setupIndex) (regidx_to_fin x0) (0#64) readX0_setup]
+    simp [setupIndex, setupInput, ZiskFv.AirsClean.FullEnsemble.mainOfTable,
+      mainAt_setup, jalrMainRows, jalrSetupRow, jalrSetupRowWithLast,
+      jalrSetupRowTemplate, jalrSetupProgramRow, jalrSetupBits,
+      ZiskFv.AirsClean.Main.mainRomRowOf, sailTrace, state, regs, x0, x1, x2,
+      regidx_to_fin, reg_of_fin, Sail.readReg, Std.ExtDHashMap.get?_insert,
+      lane_lo]
+  h_a_hi_t := by
+    simp only [setupClaim]
+    rw [ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64_xreg_eq_of_read_xreg
+      (sailTrace setupIndex) (regidx_to_fin x0) (0#64) readX0_setup]
+    simp [setupIndex, setupInput, ZiskFv.AirsClean.FullEnsemble.mainOfTable,
+      mainAt_setup, jalrMainRows, jalrSetupRow, jalrSetupRowWithLast,
+      jalrSetupRowTemplate, jalrSetupProgramRow, jalrSetupBits,
+      ZiskFv.AirsClean.Main.mainRomRowOf, sailTrace, state, regs, x0, x1, x2,
+      regidx_to_fin, reg_of_fin, Sail.readReg, Std.ExtDHashMap.get?_insert,
+      lane_hi]
+  h_pc_bridge := by
+    norm_num [setupIndex, setupMainPc, setupInput]
+
+def jalrInputs :
+    Inputs_jalr jalrAcceptedTrace sailTrace jalrIndex jalrClaim where
+  jalr_input := jalrInput
+  misa_val := misa
+  mseccfg := mseccfg
+  h_rs1_start := by
+    norm_num [jalrIndex, jalrInput,
+      ZiskFv.AirsClean.FullEnsemble.mainOfTable, mainAt_start,
+      jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate, jalrAddProgramRow,
+      jalrAddBits, ZiskFv.AirsClean.Main.mainRomRowOf]
+  h_input_rd := rfl
+  h_input_pc := by
+    simp [jalrInput, sailTrace, jalrIndex, state, regs, x1, x2,
+      regidx_to_fin, reg_of_fin, Std.ExtDHashMap.get?_insert]
+  h_pc_bridge := by
+    norm_num [jalrIndex, jalrMainPc, jalrInput]
+  h_input_misa := by
+    simp [sailTrace, jalrIndex, state, regs, x1, x2,
+      regidx_to_fin, reg_of_fin, misa, Std.ExtDHashMap.get?_insert]
+  h_misa_c := by simp [misa]
+  h_success := by simp [jalrInput, PureSpec.execute_JALR_pure]
+  h_input_imm := rfl
+  h_input_rs1 := by simpa [jalrInput, jalrClaim] using readX1_jalr
+  h_cur_privilege := by
+    simp [sailTrace, jalrIndex, state, regs, x1, x2,
+      regidx_to_fin, reg_of_fin, Sail.readReg, Std.ExtDHashMap.get?_insert]
+  h_mseccfg := by
+    simp [sailTrace, jalrIndex, state, regs, x1, x2, mseccfg,
+      regidx_to_fin, reg_of_fin, Sail.readReg, Std.ExtDHashMap.get?_insert]
+
+def programDecodes :
+    ∀ i : Fin 2, ProgramDecode jalrAcceptedTrace i (jalrSpinZiskStep i)
+  | ⟨0, _⟩ => setupProgramDecode
+  | ⟨1, _⟩ => jalrProgramDecode
+
+def inputsAgree :
+    ∀ i : Fin 2, InputsAgree jalrAcceptedTrace sailTrace i
+      (jalrSpinZiskStep i)
+  | ⟨0, _⟩ => setupInputs
+  | ⟨1, _⟩ => jalrInputs
+
+def setupOutsideDefectRegion :
+    RowOutsideDefectRegion jalrAcceptedTrace setupIndex
+      (jalrSpinZiskStep setupIndex) := by
+  simp [RowOutsideDefectRegion, jalrSpinZiskStep, setupIndex,
+    MainSequentialPcDomain, mainPcVal, setupMainPc]
+
+def jalrOutsideDefectRegion :
+    RowOutsideDefectRegion jalrAcceptedTrace jalrIndex
+      (jalrSpinZiskStep jalrIndex) where
+  h_pc_bound := by
+    unfold MainSequentialPcDomain mainPcVal
+    norm_num [jalrIndex, jalrMainPc, ZiskFv.AirsClean.FullEnsemble.mainOfTable,
+      mainAt_start, jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
+      jalrAddProgramRow, jalrAddBits, ZiskFv.AirsClean.Main.mainRomRowOf]
+  h_pc_offset_lt_2_32 := by
+    intro pc hpc
+    unfold mainPcVal at hpc
+    norm_num [jalrIndex, jalrMainPc, ZiskFv.AirsClean.FullEnsemble.mainOfTable,
+      mainAt_start, jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
+      jalrAddProgramRow, jalrAddBits, ZiskFv.AirsClean.Main.mainRomRowOf] at hpc
+    have hpc_eq : pc = 4#64 := BitVec.eq_of_toNat_eq hpc.symm
+    subst pc
+    norm_num
+
+def outsideDefectRegion :
+    ∀ i : Fin 2, RowOutsideDefectRegion jalrAcceptedTrace i
+      (jalrSpinZiskStep i)
+  | ⟨0, _⟩ => setupOutsideDefectRegion
+  | ⟨1, _⟩ => jalrOutsideDefectRegion
+
+theorem jalrSpinRootSoundness :
+    ∀ i : Fin 2,
+      StepSound jalrAcceptedTrace sailTrace i (jalrSpinZiskStep i)
+        (rowDecode_of_programDecode jalrAcceptedTrace i (programDecodes i)) :=
+  root_soundness 2 jalrAcceptedTrace sailTrace jalrSpinZiskStep
+    programDecodes inputsAgree bootSeed outsideDefectRegion
+
+theorem jalrStepSound :
+    StepSound jalrAcceptedTrace sailTrace jalrIndex
+      (jalrSpinZiskStep jalrIndex)
+      (rowDecode_of_programDecode jalrAcceptedTrace jalrIndex
+        (programDecodes jalrIndex)) :=
+  jalrSpinRootSoundness jalrIndex
+
+end ZiskFv.Compliance.JalrSpinRootSoundness

--- a/ZiskFv/Compliance/JalrSpinWitness.lean
+++ b/ZiskFv/Compliance/JalrSpinWitness.lean
@@ -1,0 +1,1382 @@
+import ZiskFv.Compliance.AddSpinWitness
+import ZiskFv.AirsClean.Binary.Circuit
+
+/-!
+# Concrete unaligned JALR lowering witness
+
+An architectural `ADDI x1,x0,2` establishes a four-byte-aligned JALR target,
+then `JALR x2, 2(x1)` lowers to adjacent physical Main rows `[ADD, AND]`.
+The ADD produces `4`; Main's intrinsic source-C
+transition copies that result into the terminal AND row, which clears bit zero,
+stores link PC `8` in x2, and jumps to the physical successor at PC `4`.
+-/
+
+set_option maxRecDepth 10000
+
+open Goldilocks
+open Air.Flat
+open ZiskFv.AirsClean.FullEnsemble (fullRv64imEnsemble fullRv64imSoundEnsemble)
+open ZiskFv.AirsClean.Main
+open ZiskFv.AirsClean.ZiskInstructionRom (Program)
+open ZiskFv.Channels.MemoryBus (MemBusChannel MemBusMessage)
+open ZiskFv.Channels.OperationBus (OpBusChannel)
+open ZiskFv.Channels.SpecifiedRanges (SpecifiedRangesSliceChannel)
+open ZiskFv.Channels.MemAlignRom (MemAlignRomChannel)
+open ZiskFv.Channels.MemAlignRanges (MemAlignRangeChannel)
+open ZiskFv.Channels.ZiskRomBus (ZiskRomMessage)
+open ZiskFv.Compliance.Instantiation
+open ZiskFv.Compliance.AddSpinWitness
+open ZiskFv.Compliance.SingleAddWitness
+open ZiskFv.Compliance.RegisterMemBusBalance
+
+namespace ZiskFv.Compliance.JalrSpinWitness
+
+def jalrSetupBits : RomFlagBits :=
+  { a_src_imm := true
+    a_src_mem := false
+    is_precompiled := false
+    b_src_imm := true
+    b_src_mem := false
+    is_external_op := true
+    store_pc := false
+    store_mem := false
+    store_ind := false
+    set_pc := false
+    m32 := false
+    b_src_ind := false
+    a_src_reg := false
+    b_src_reg := false
+    store_reg := true }
+
+def jalrAddBits : RomFlagBits where
+  a_src_imm := true
+  a_src_mem := false
+  is_precompiled := false
+  b_src_imm := false
+  b_src_mem := false
+  is_external_op := true
+  store_pc := false
+  store_mem := false
+  store_ind := false
+  set_pc := false
+  m32 := false
+  b_src_ind := false
+  a_src_reg := false
+  b_src_reg := true
+  store_reg := false
+
+def jalrAndBits : RomFlagBits where
+  a_src_imm := true
+  a_src_mem := false
+  is_precompiled := false
+  b_src_imm := false
+  b_src_mem := false
+  is_external_op := true
+  store_pc := true
+  store_mem := false
+  store_ind := false
+  set_pc := true
+  m32 := false
+  b_src_ind := false
+  a_src_reg := false
+  b_src_reg := false
+  store_reg := true
+
+def jalrSetupProgramRow : ZiskRomMessage FGL :=
+  { line := 0
+    a_offset_imm0 := 0
+    a_imm1 := 0
+    b_offset_imm0 := 2
+    b_imm1 := 0
+    ind_width := 8
+    op := ZiskFv.Trusted.OP_ADD
+    store_offset := 1
+    jmp_offset1 := 4
+    jmp_offset2 := 4
+    flags := packFlags jalrSetupBits }
+
+def jalrAddProgramRow : ZiskRomMessage FGL :=
+  { line := 4
+    a_offset_imm0 := 2
+    a_imm1 := 0
+    b_offset_imm0 := 1
+    b_imm1 := 0
+    ind_width := 8
+    op := ZiskFv.Trusted.OP_ADD
+    store_offset := 0
+    jmp_offset1 := 0
+    jmp_offset2 := 1
+    flags := packFlags jalrAddBits }
+
+def jalrAndProgramRow : ZiskRomMessage FGL :=
+  { line := 5
+    a_offset_imm0 := 4294967294
+    a_imm1 := 4294967295
+    b_offset_imm0 := 0
+    b_imm1 := 0
+    ind_width := 8
+    op := ZiskFv.Trusted.OP_AND
+    store_offset := 2
+    jmp_offset1 := 0
+    jmp_offset2 := 3
+    flags := packFlags jalrAndBits }
+
+def jalrProgram : Program 3
+  | ⟨0, _⟩ => jalrSetupProgramRow
+  | ⟨1, _⟩ => jalrAddProgramRow
+  | ⟨2, _⟩ => jalrAndProgramRow
+
+@[reducible] def jalrRegisterInitial (reg : FGL) : MemBusMessage FGL :=
+  ZiskFv.AirsClean.RegisterBoundary.bootMessage (boundaryRowIdle reg)
+
+@[reducible] def jalrFreeCols
+    (step a0 a1 b0 b1 : FGL) (previous : MemBusMessage FGL) :
+    MainRomFreeCols :=
+  mainRomFreeColsWithRegisterPrevious
+    { ZiskFv.Compliance.SingleAddWitness.addX1MainFreeCols with
+      a_0 := a0
+      a_1 := a1
+      b_0 := b0
+      b_1 := b1
+      im_high_degree_2 := 0
+      segment_l1 := 0
+      main_step := step }
+    previous
+
+@[reducible] def jalrSetupRowTemplate : MainRowWithRom FGL :=
+  mainRomRowOf jalrSetupProgramRow jalrSetupBits
+    (MainRomExecKind.external false 2 0)
+    { jalrFreeCols 0 0 0 2 0 (jalrRegisterInitial 1) with segment_l1 := 1 }
+
+@[reducible] def jalrSetupRowWithLast : MemBusMessage FGL × MainRowWithRom FGL :=
+  materializeMainRegisterRow (jalrRegisterInitial 1) jalrSetupRowTemplate [.store]
+
+def jalrSetupRow : MainRowWithRom FGL := jalrSetupRowWithLast.2
+
+@[reducible] def jalrAddRowTemplate : MainRowWithRom FGL :=
+  mainRomRowOf jalrAddProgramRow jalrAddBits
+    (MainRomExecKind.external false 4 0)
+    (jalrFreeCols 1 2 0 2 0 jalrSetupRowWithLast.1)
+
+@[reducible] def jalrAddRowWithLast : MemBusMessage FGL × MainRowWithRom FGL :=
+  materializeMainRegisterRow jalrSetupRowWithLast.1 jalrAddRowTemplate [.b]
+
+def jalrAddRow : MainRowWithRom FGL := jalrAddRowWithLast.2
+
+@[reducible] def jalrAndRowTemplate : MainRowWithRom FGL :=
+  mainRomRowOf jalrAndProgramRow jalrAndBits
+    (MainRomExecKind.external false 4 0)
+    (jalrFreeCols 2 4294967294 4294967295 4 0 (jalrRegisterInitial 2))
+
+@[reducible] def jalrAndRowWithLast : MemBusMessage FGL × MainRowWithRom FGL :=
+  materializeMainRegisterRow (jalrRegisterInitial 2) jalrAndRowTemplate [.store]
+
+def jalrAndRow : MainRowWithRom FGL := jalrAndRowWithLast.2
+
+@[reducible] def jalrSuccessorRowTemplate : MainRowWithRom FGL :=
+  mainRomRowOf jalrAddProgramRow jalrAddBits
+    (MainRomExecKind.external false 4 0)
+    (jalrFreeCols 3 2 0 2 0 jalrAddRowWithLast.1)
+
+@[reducible] def jalrSuccessorRowWithLast : MemBusMessage FGL × MainRowWithRom FGL :=
+  materializeMainRegisterRow jalrAddRowWithLast.1 jalrSuccessorRowTemplate [.b]
+
+def jalrSuccessorRow : MainRowWithRom FGL := jalrSuccessorRowWithLast.2
+
+def jalrMainRows : List (MainRowWithRom FGL) :=
+  [jalrSetupRow, jalrAddRow, jalrAndRow, jalrSuccessorRow]
+
+theorem jalrMainRows_fixed_domain :
+    jalrMainRows.length ≤ mainFixedCapacity := by
+  norm_num [jalrMainRows, mainFixedCapacity]
+
+def jalrMainTable : Table FGL :=
+  ZiskFv.Compliance.AddSpinWitness.mainRowsTable
+    3 jalrProgram jalrMainRows jalrMainRows_fixed_domain
+
+private theorem jalrMainTable_effectiveRows :
+    jalrMainTable.table =
+      [ mainFixedColumns.materialize 0 (mainRawRow jalrSetupRow)
+      , mainFixedColumns.materialize 1 (mainRawRow jalrAddRow)
+      , mainFixedColumns.materialize 2 (mainRawRow jalrAndRow)
+      , mainFixedColumns.materialize 3 (mainRawRow jalrSuccessorRow) ] := by
+  simp [jalrMainTable, ZiskFv.Compliance.AddSpinWitness.mainRowsTable,
+    Table.table, componentWithRomMemAndOpBus, jalrMainRows]
+
+theorem jalrTransition_add_and :
+    transitionBetween jalrAddRow jalrAndRow := by
+  simp [transitionBetween, pcHandshakeBetween, sourceCCopyBetween,
+    jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
+    jalrAndRow, jalrAndRowWithLast, jalrAndRowTemplate,
+    jalrAddProgramRow, jalrAndProgramRow, jalrAddBits, jalrAndBits,
+    jalrFreeCols, jalrRegisterInitial, mainRomRowOf,
+    materializeMainRegisterRow, materializeMainRegisterAccesses,
+    withMainRegisterPrevious, boundaryRowIdle,
+    ZiskFv.AirsClean.RegisterBoundary.bootMessage]
+
+theorem jalrTransition_setup_add :
+    transitionBetween jalrSetupRow jalrAddRow := by
+  simp [transitionBetween, pcHandshakeBetween, sourceCCopyBetween,
+    jalrSetupRow, jalrSetupRowWithLast, jalrSetupRowTemplate,
+    jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
+    jalrSetupProgramRow, jalrAddProgramRow, jalrSetupBits, jalrAddBits,
+    jalrFreeCols, jalrRegisterInitial, mainRomRowOf,
+    materializeMainRegisterRow, materializeMainRegisterAccesses,
+    withMainRegisterPrevious, boundaryRowIdle,
+    ZiskFv.AirsClean.RegisterBoundary.bootMessage]
+
+theorem jalrTransition_and_successor :
+    transitionBetween jalrAndRow jalrSuccessorRow := by
+  simp [transitionBetween, pcHandshakeBetween, sourceCCopyBetween,
+    jalrAndRow, jalrAndRowWithLast, jalrAndRowTemplate,
+    jalrSuccessorRow, jalrSuccessorRowWithLast, jalrSuccessorRowTemplate,
+    jalrAndProgramRow, jalrAddProgramRow, jalrAndBits, jalrAddBits,
+    jalrFreeCols, jalrRegisterInitial, mainRomRowOf,
+    materializeMainRegisterRow, materializeMainRegisterAccesses,
+    withMainRegisterPrevious, boundaryRowIdle,
+    ZiskFv.AirsClean.RegisterBoundary.bootMessage]
+
+def jalrBoundaryRowX1 :
+  ZiskFv.AirsClean.RegisterBoundary.RegisterBoundaryRow FGL :=
+  registerBoundaryRowFromLast 1 (bMemMessage jalrSuccessorRow)
+
+def jalrBoundaryRowX2 :
+    ZiskFv.AirsClean.RegisterBoundary.RegisterBoundaryRow FGL :=
+  registerBoundaryRowFromLast 2 (cMemMessage jalrAndRow)
+
+private theorem jalrBoundaryRowX1_reload :
+    ZiskFv.AirsClean.RegisterBoundary.reloadMessage jalrBoundaryRowX1 =
+      bMemMessage jalrSuccessorRow := by
+  rfl
+
+private theorem jalrBoundaryRowX2_reload :
+    ZiskFv.AirsClean.RegisterBoundary.reloadMessage jalrBoundaryRowX2 =
+      cMemMessage jalrAndRow := by
+  rfl
+
+def jalrBoundaryRows :
+    List (ZiskFv.AirsClean.RegisterBoundary.RegisterBoundaryRow FGL) :=
+  [jalrBoundaryRowX1, jalrBoundaryRowX2] ++
+    (List.range 29).map (fun i => boundaryRowIdle ((i + 3 : Nat) : FGL))
+
+def jalrBoundaryTable : Table FGL :=
+  registerBoundaryRowsTableOf jalrBoundaryRows
+
+def jalrSetupBinaryAddRow : ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL :=
+  ZiskFv.AirsClean.BinaryAdd.binaryAddRowOf 0 2
+
+def jalrLoweringBinaryAddRow : ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL :=
+  ZiskFv.AirsClean.BinaryAdd.binaryAddRowOf 2 2
+
+def jalrBinaryAddTable : Table FGL :=
+  binaryAddRowsTable
+    [jalrSetupBinaryAddRow, jalrLoweringBinaryAddRow, jalrLoweringBinaryAddRow]
+
+private def jalrAndByte0Index : ZiskFv.AirsClean.Binary.BinaryTableIndex :=
+  ⟨ZiskFv.AirsClean.BinaryTable.block14 + 1278, by
+    norm_num [ZiskFv.AirsClean.BinaryTable.block14,
+      ZiskFv.AirsClean.BinaryTable.block13, ZiskFv.AirsClean.BinaryTable.block12,
+      ZiskFv.AirsClean.BinaryTable.block11, ZiskFv.AirsClean.BinaryTable.block10,
+      ZiskFv.AirsClean.BinaryTable.block9, ZiskFv.AirsClean.BinaryTable.block8,
+      ZiskFv.AirsClean.BinaryTable.block7, ZiskFv.AirsClean.BinaryTable.block6,
+      ZiskFv.AirsClean.BinaryTable.block5, ZiskFv.AirsClean.BinaryTable.block4,
+      ZiskFv.AirsClean.BinaryTable.block3, ZiskFv.AirsClean.BinaryTable.block2,
+      ZiskFv.AirsClean.BinaryTable.block1,
+      ZiskFv.AirsClean.BinaryTable.minMaxBlockSize,
+      ZiskFv.AirsClean.BinaryTable.absBlockSize,
+      ZiskFv.AirsClean.BinaryTable.fullBlockSize,
+      ZiskFv.AirsClean.BinaryTable.tableSize]⟩
+
+private def jalrAndMiddleIndex : ZiskFv.AirsClean.Binary.BinaryTableIndex :=
+  ⟨ZiskFv.AirsClean.BinaryTable.block14 + 255, by
+    norm_num [ZiskFv.AirsClean.BinaryTable.block14,
+      ZiskFv.AirsClean.BinaryTable.block13, ZiskFv.AirsClean.BinaryTable.block12,
+      ZiskFv.AirsClean.BinaryTable.block11, ZiskFv.AirsClean.BinaryTable.block10,
+      ZiskFv.AirsClean.BinaryTable.block9, ZiskFv.AirsClean.BinaryTable.block8,
+      ZiskFv.AirsClean.BinaryTable.block7, ZiskFv.AirsClean.BinaryTable.block6,
+      ZiskFv.AirsClean.BinaryTable.block5, ZiskFv.AirsClean.BinaryTable.block4,
+      ZiskFv.AirsClean.BinaryTable.block3, ZiskFv.AirsClean.BinaryTable.block2,
+      ZiskFv.AirsClean.BinaryTable.block1,
+      ZiskFv.AirsClean.BinaryTable.minMaxBlockSize,
+      ZiskFv.AirsClean.BinaryTable.absBlockSize,
+      ZiskFv.AirsClean.BinaryTable.fullBlockSize,
+      ZiskFv.AirsClean.BinaryTable.tableSize]⟩
+
+private def jalrAndLastIndex : ZiskFv.AirsClean.Binary.BinaryTableIndex :=
+  ⟨ZiskFv.AirsClean.BinaryTable.block14 + 65791, by
+    norm_num [ZiskFv.AirsClean.BinaryTable.block14,
+      ZiskFv.AirsClean.BinaryTable.block13, ZiskFv.AirsClean.BinaryTable.block12,
+      ZiskFv.AirsClean.BinaryTable.block11, ZiskFv.AirsClean.BinaryTable.block10,
+      ZiskFv.AirsClean.BinaryTable.block9, ZiskFv.AirsClean.BinaryTable.block8,
+      ZiskFv.AirsClean.BinaryTable.block7, ZiskFv.AirsClean.BinaryTable.block6,
+      ZiskFv.AirsClean.BinaryTable.block5, ZiskFv.AirsClean.BinaryTable.block4,
+      ZiskFv.AirsClean.BinaryTable.block3, ZiskFv.AirsClean.BinaryTable.block2,
+      ZiskFv.AirsClean.BinaryTable.block1,
+      ZiskFv.AirsClean.BinaryTable.minMaxBlockSize,
+      ZiskFv.AirsClean.BinaryTable.absBlockSize,
+      ZiskFv.AirsClean.BinaryTable.fullBlockSize,
+      ZiskFv.AirsClean.BinaryTable.tableSize]⟩
+
+def jalrBinaryAndRow : ZiskFv.AirsClean.Binary.BinaryRow FGL :=
+  ZiskFv.AirsClean.Binary.binaryStaticRowOf false false false false false
+    jalrAndByte0Index
+    jalrAndMiddleIndex jalrAndMiddleIndex jalrAndMiddleIndex
+    jalrAndMiddleIndex jalrAndMiddleIndex jalrAndMiddleIndex
+    jalrAndLastIndex
+
+def jalrBinaryAndTable : Table FGL :=
+  binarySingleRowTable jalrBinaryAndRow
+
+theorem jalrSetupMain_proverAssumptions :
+    (componentWithRomMemAndOpBus 3 jalrProgram).circuit.ProverAssumptions
+      jalrSetupRow emptyData (ProverHint.empty FGL) := by
+  refine ⟨⟨0, by decide⟩, jalrSetupBits, MainRomExecKind.external false 2 0,
+    { jalrFreeCols 0 0 0 2 0 (jalrRegisterInitial 1) with segment_l1 := 1 },
+    ?_, ?_, ?_, ?_, ?_⟩
+  · decide
+  · simp [MainRomExecKind.Coherent, jalrSetupBits]
+  · simp [MainRomSourceGuard, jalrProgram, jalrSetupProgramRow, jalrSetupBits]
+  · simp [MainRomAddressGuard, jalrSetupBits]
+  · simp [jalrSetupRow, jalrSetupRowWithLast, jalrSetupRowTemplate,
+      jalrProgram, jalrSetupProgramRow, jalrSetupBits, mainRomRowOf,
+      jalrFreeCols, jalrRegisterInitial,
+      materializeMainRegisterRow, materializeMainRegisterAccesses,
+      withMainRegisterPrevious]
+
+theorem jalrAddMain_proverAssumptions :
+    (componentWithRomMemAndOpBus 3 jalrProgram).circuit.ProverAssumptions
+      jalrAddRow emptyData (ProverHint.empty FGL) := by
+  refine ⟨⟨1, by decide⟩, jalrAddBits, MainRomExecKind.external false 4 0,
+    jalrFreeCols 1 2 0 2 0 jalrSetupRowWithLast.1,
+    ?_, ?_, ?_, ?_, ?_⟩
+  · decide
+  · simp [MainRomExecKind.Coherent, jalrAddBits]
+  · simp [MainRomSourceGuard, jalrProgram, jalrAddProgramRow, jalrAddBits]
+  · simp [MainRomAddressGuard, jalrAddBits]
+  · simp [jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
+      jalrProgram, jalrAddProgramRow, jalrAddBits, mainRomRowOf,
+      jalrFreeCols, jalrRegisterInitial,
+      materializeMainRegisterRow, materializeMainRegisterAccesses,
+      withMainRegisterPrevious]
+
+theorem jalrAndMain_proverAssumptions :
+    (componentWithRomMemAndOpBus 3 jalrProgram).circuit.ProverAssumptions
+      jalrAndRow emptyData (ProverHint.empty FGL) := by
+  refine ⟨⟨2, by decide⟩, jalrAndBits, MainRomExecKind.external false 4 0,
+    jalrFreeCols 2 4294967294 4294967295 4 0 (jalrRegisterInitial 2),
+    ?_, ?_, ?_, ?_, ?_⟩
+  · decide
+  · simp [MainRomExecKind.Coherent, jalrAndBits]
+  · simp [MainRomSourceGuard, jalrProgram, jalrAndProgramRow, jalrAndBits]
+  · simp [MainRomAddressGuard, jalrAndBits]
+  · simp [jalrAndRow, jalrAndRowWithLast, jalrAndRowTemplate,
+      jalrProgram, jalrAndProgramRow, jalrAndBits, mainRomRowOf,
+      jalrFreeCols, jalrRegisterInitial,
+      materializeMainRegisterRow, materializeMainRegisterAccesses,
+      withMainRegisterPrevious]
+
+theorem jalrSuccessorMain_proverAssumptions :
+    (componentWithRomMemAndOpBus 3 jalrProgram).circuit.ProverAssumptions
+      jalrSuccessorRow emptyData (ProverHint.empty FGL) := by
+  refine ⟨⟨1, by decide⟩, jalrAddBits, MainRomExecKind.external false 4 0,
+    jalrFreeCols 3 2 0 2 0 jalrAddRowWithLast.1, ?_, ?_, ?_, ?_, ?_⟩
+  · decide
+  · simp [MainRomExecKind.Coherent, jalrAddBits]
+  · simp [MainRomSourceGuard, jalrProgram, jalrAddProgramRow, jalrAddBits]
+  · simp [MainRomAddressGuard, jalrAddBits]
+  · simp [jalrSuccessorRow, jalrSuccessorRowWithLast, jalrSuccessorRowTemplate,
+      jalrProgram, jalrAddProgramRow, jalrAddBits, mainRomRowOf,
+      jalrFreeCols, jalrRegisterInitial,
+      materializeMainRegisterRow, materializeMainRegisterAccesses,
+      withMainRegisterPrevious]
+
+private theorem jalrMain_constraintsHold_materialize
+    (index : Nat) (row : MainRowWithRom FGL)
+    (h_segment_l1 : row.core.segment_l1 = mainFixedColumns.fixedAt 0 index)
+    (h_main_step : row.rom.main_step = mainFixedColumns.fixedAt 1 index)
+    (h_assumptions :
+      (componentWithRomMemAndOpBus 3 jalrProgram).circuit.ProverAssumptions
+        row emptyData (ProverHint.empty FGL)) :
+    (componentWithRomMemAndOpBus 3 jalrProgram).operations.ConstraintsHold
+      (Environment.fromArray
+        (mainFixedColumns.materialize index (mainRawRow row)) emptyData) := by
+  apply component_constraintsHold_of_proverAssumptions_at_data
+    (componentWithRomMemAndOpBus 3 jalrProgram)
+    (Environment.fromArray
+      (mainFixedColumns.materialize index (mainRawRow row)) emptyData)
+    row emptyData
+  · change (mainWithRomMemAndOpBusElaborated 3 jalrProgram).localLength
+      (componentWithRomMemAndOpBus 3 jalrProgram).rowInputVar = 0
+    rfl
+  · exact eval_mainRawRow_materialize
+      index emptyData row h_segment_l1 h_main_step
+  · rfl
+  · exact h_assumptions
+
+theorem jalrMainTable_constraints : jalrMainTable.Constraints := by
+  change ∀ arr ∈
+      [ mainFixedColumns.materialize 0 (mainRawRow jalrSetupRow)
+      , mainFixedColumns.materialize 1 (mainRawRow jalrAddRow)
+      , mainFixedColumns.materialize 2 (mainRawRow jalrAndRow)
+      , mainFixedColumns.materialize 3 (mainRawRow jalrSuccessorRow) ],
+      (componentWithRomMemAndOpBus 3 jalrProgram).operations.ConstraintsHold
+        (Environment.fromArray arr emptyData)
+  intro arr h_arr
+  simp only [List.mem_cons, List.not_mem_nil, or_false] at h_arr
+  rcases h_arr with rfl | rfl | rfl | rfl
+  · exact jalrMain_constraintsHold_materialize 0 jalrSetupRow
+      (by rfl) (by rfl) jalrSetupMain_proverAssumptions
+  · exact jalrMain_constraintsHold_materialize 1 jalrAddRow
+      (by rfl) (by rfl) jalrAddMain_proverAssumptions
+  · exact jalrMain_constraintsHold_materialize 2 jalrAndRow
+      (by rfl) (by rfl) jalrAndMain_proverAssumptions
+  · exact jalrMain_constraintsHold_materialize 3 jalrSuccessorRow
+      (by rfl) (by rfl) jalrSuccessorMain_proverAssumptions
+
+theorem jalrBinaryAddTable_constraints : jalrBinaryAddTable.Constraints := by
+  apply binaryAddRowsTable_constraints_of_proverAssumptions
+  intro row h_row
+  simp [jalrSetupBinaryAddRow, jalrLoweringBinaryAddRow] at h_row
+  rcases h_row with rfl | rfl
+  · exact ⟨0, 2, by decide, by decide, rfl⟩
+  · exact ⟨2, 2, by decide, by decide, rfl⟩
+
+theorem jalrBinaryAndTable_constraints : jalrBinaryAndTable.Constraints := by
+  apply binarySingleRowTable_constraints_of_proverAssumptions
+  refine ⟨false, false, false, false, false,
+    jalrAndByte0Index,
+    jalrAndMiddleIndex, jalrAndMiddleIndex, jalrAndMiddleIndex,
+    jalrAndMiddleIndex, jalrAndMiddleIndex, jalrAndMiddleIndex,
+    jalrAndLastIndex, ?_⟩
+  norm_num [jalrBinaryAndRow, jalrAndByte0Index, jalrAndMiddleIndex,
+    jalrAndLastIndex, ZiskFv.AirsClean.Binary.binaryTableRow,
+    ZiskFv.AirsClean.BinaryTable.rowOfIndex,
+    ZiskFv.AirsClean.BinaryTable.blockOfIndex,
+    ZiskFv.AirsClean.BinaryTable.relativeIndex,
+    ZiskFv.AirsClean.BinaryTable.coutOfIndex,
+    ZiskFv.AirsClean.BinaryTable.resultIsAOfIndex,
+    ZiskFv.AirsClean.BinaryTable.cIsSignedOfIndex,
+    ZiskFv.AirsClean.BinaryTable.opOfIndex,
+    ZiskFv.AirsClean.BinaryTable.opOfBlock,
+    ZiskFv.AirsClean.Binary.binaryMode32AndCIsSignedOf,
+    ZiskFv.AirsClean.Binary.binaryBOpOrSextOf,
+    ZiskFv.AirsClean.BinaryTable.block14,
+    ZiskFv.AirsClean.BinaryTable.block13, ZiskFv.AirsClean.BinaryTable.block12,
+    ZiskFv.AirsClean.BinaryTable.block11, ZiskFv.AirsClean.BinaryTable.block10,
+    ZiskFv.AirsClean.BinaryTable.block9, ZiskFv.AirsClean.BinaryTable.block8,
+    ZiskFv.AirsClean.BinaryTable.block7, ZiskFv.AirsClean.BinaryTable.block6,
+    ZiskFv.AirsClean.BinaryTable.block5, ZiskFv.AirsClean.BinaryTable.block4,
+    ZiskFv.AirsClean.BinaryTable.block3, ZiskFv.AirsClean.BinaryTable.block2,
+    ZiskFv.AirsClean.BinaryTable.block1,
+    ZiskFv.AirsClean.BinaryTable.minMaxBlockSize,
+    ZiskFv.AirsClean.BinaryTable.absBlockSize,
+    ZiskFv.AirsClean.BinaryTable.fullBlockSize]
+
+theorem jalrBoundaryTable_constraints : jalrBoundaryTable.Constraints :=
+  registerBoundaryRowsTableOf_constraints jalrBoundaryRows
+
+@[simp] theorem jalrMainTable_length : jalrMainTable.length = 4 := rfl
+
+@[simp] theorem jalrMainTable_evalAt (index : Fin jalrMainTable.length) :
+    Eval.eval (jalrMainTable.environmentAt index)
+        (componentWithRomMemAndOpBus 3 jalrProgram).rowInputVar =
+      jalrMainRows[index.val]'(by
+        change index.val < 4
+        exact (Fin.cast jalrMainTable_length index).isLt) := by
+  fin_cases index <;>
+    change Eval.eval
+      (Environment.fromArray (mainFixedColumns.materialize _ (mainRawRow _)) emptyData)
+      (varFromOffset MainRowWithRom 0) = _ <;>
+    apply eval_mainRawRow_materialize <;>
+    simp [jalrMainRows, jalrSetupRow, jalrSetupRowWithLast, jalrSetupRowTemplate,
+      jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
+      jalrAndRow, jalrAndRowWithLast, jalrAndRowTemplate, jalrSuccessorRow,
+      jalrSuccessorRowWithLast, jalrSuccessorRowTemplate,
+      mainRomRowOf, jalrFreeCols, jalrRegisterInitial] <;> rfl
+
+theorem jalrMainTable_transitions : jalrMainTable.TransitionConstraints := by
+  rw [Table.TransitionConstraints]
+  intro index
+  change transitionBetween
+    (Eval.eval (jalrMainTable.previousEnvironment index)
+      (componentWithRomMemAndOpBus 3 jalrProgram).rowInputVar)
+    (Eval.eval (jalrMainTable.environmentAt index)
+      (componentWithRomMemAndOpBus 3 jalrProgram).rowInputVar)
+  fin_cases index
+  · simp [Table.previousEnvironment, jalrMainRows, transitionBetween,
+      pcHandshakeBetween, sourceCCopyBetween, jalrSetupRow,
+      jalrSetupRowWithLast, jalrSetupRowTemplate, mainRomRowOf,
+      jalrFreeCols, jalrRegisterInitial]
+  · simpa [Table.previousEnvironment, jalrMainRows] using jalrTransition_setup_add
+  · simpa [Table.previousEnvironment, jalrMainRows] using jalrTransition_add_and
+  · simpa [Table.previousEnvironment, jalrMainRows] using
+      jalrTransition_and_successor
+
+theorem jalrMainTable_cyclicSuccessorTransitions :
+    jalrMainTable.CyclicSuccessorTransitionConstraints := by
+  rw [Table.CyclicSuccessorTransitionConstraints]
+  intro index
+  simp [jalrMainTable, ZiskFv.Compliance.AddSpinWitness.mainRowsTable,
+    componentWithRomMemAndOpBus]
+
+def jalrTables : List (Table FGL) :=
+  [ jalrBoundaryTable
+  , emptyComponentTable ZiskFv.AirsClean.MemAlignReadByte.component
+  , emptyComponentTable ZiskFv.AirsClean.MemAlignByte.component
+  , emptyComponentTable ZiskFv.AirsClean.MemAlign.component
+  , emptyComponentTable ZiskFv.AirsClean.MemAlignRangeSlice.component
+  , emptyComponentTable ZiskFv.AirsClean.MemAlignRomSlice.component
+  , emptyComponentTable ZiskFv.AirsClean.Mem.componentWithDualMemBus
+  , emptyComponentTable ZiskFv.AirsClean.SpecifiedRangesSlice.component
+  , emptyComponentTable ZiskFv.AirsClean.ArithDiv.component
+  , emptyComponentTable ZiskFv.AirsClean.ArithMul.componentWithArithTable
+  , emptyComponentTable ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+  , jalrBinaryAndTable
+  , jalrBinaryAddTable
+  , jalrMainTable ]
+
+def jalrEnsemble : Ensemble FGL unit :=
+  (fullRv64imEnsemble 3 jalrProgram).ensemble
+
+theorem jalrEnsemble_verifier :
+    jalrEnsemble.verifier = .empty FGL unit :=
+  (fullRv64imSoundEnsemble 3 jalrProgram).verifier_empty
+
+def jalrWitness : EnsembleWitness jalrEnsemble where
+  tables := jalrTables
+  data := emptyData
+  publicInput := ()
+  same_length := by
+    simp [jalrEnsemble, fullRv64imEnsemble, fullRv64imSoundEnsemble,
+      jalrTables, SoundEnsemble.toFormal, SoundEnsemble.addFinishedChannel_tables,
+      SoundEnsemble.addTable, SoundEnsemble.empty_tables, Ensemble.addTable]
+  same_circuits := by
+    intro i hi
+    have hi' : i < 14 := by simpa [jalrTables] using hi
+    interval_cases i <;>
+      simp [jalrEnsemble, fullRv64imEnsemble, fullRv64imSoundEnsemble,
+        jalrTables, SoundEnsemble.toFormal, SoundEnsemble.addFinishedChannel_tables,
+        SoundEnsemble.addTable, SoundEnsemble.empty_tables, Ensemble.addTable,
+        jalrBoundaryTable, registerBoundaryRowsTableOf, emptyComponentTable,
+        jalrBinaryAndTable, binarySingleRowTable, jalrBinaryAddTable,
+        binaryAddRowsTable, jalrMainTable,
+        ZiskFv.Compliance.AddSpinWitness.mainRowsTable]
+  same_data := by
+    intro table h_table
+    simp [jalrTables, jalrBoundaryTable, registerBoundaryRowsTableOf,
+      emptyComponentTable, jalrBinaryAndTable, binarySingleRowTable,
+      jalrBinaryAddTable, binaryAddRowsTable, jalrMainTable,
+      ZiskFv.Compliance.AddSpinWitness.mainRowsTable] at h_table
+    rcases h_table with
+      rfl | rfl | rfl | rfl | rfl | rfl | rfl |
+      rfl | rfl | rfl | rfl | rfl | rfl | rfl <;> rfl
+
+theorem jalrWitness_table_constraints :
+    ∀ table ∈ jalrWitness.tables, table.Constraints := by
+  intro table h_table
+  simp [jalrWitness, jalrTables] at h_table
+  rcases h_table with
+    rfl | rfl | rfl | rfl | rfl | rfl | rfl |
+    rfl | rfl | rfl | rfl | rfl | rfl | rfl
+  · exact jalrBoundaryTable_constraints
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlignReadByte.component
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlignByte.component
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlign.component
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlignRangeSlice.component
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlignRomSlice.component
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.Mem.componentWithDualMemBus
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.SpecifiedRangesSlice.component
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.ArithDiv.component
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.ArithMul.componentWithArithTable
+  · exact emptyComponentTable_constraints
+      ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+  · exact jalrBinaryAndTable_constraints
+  · exact jalrBinaryAddTable_constraints
+  · exact jalrMainTable_constraints
+
+theorem jalrWitness_constraints : jalrWitness.Constraints :=
+  jalrWitness.constraints_of_tables jalrEnsemble_verifier
+    jalrWitness_table_constraints
+
+theorem jalrWitness_transitions : jalrWitness.TransitionConstraints := by
+  intro table h_table
+  rw [EnsembleWitness.allTables, List.mem_cons] at h_table
+  rcases h_table with h_verifier | h_table
+  · subst table
+    rw [Table.TransitionConstraints]
+    intro index
+    simp [EnsembleWitness.verifierTable]
+  · simp [jalrWitness, jalrTables] at h_table
+    rcases h_table with
+      rfl | rfl | rfl | rfl | rfl | rfl | rfl |
+      rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    · rw [Table.TransitionConstraints]
+      intro index
+      simp [jalrBoundaryTable, registerBoundaryRowsTableOf,
+        ZiskFv.AirsClean.RegisterBoundary.component]
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignReadByte.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignByte.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlign.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignRangeSlice.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignRomSlice.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.Mem.componentWithDualMemBus
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.SpecifiedRangesSlice.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.ArithDiv.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.ArithMul.componentWithArithTable
+    · exact emptyComponentTable_transitions
+        ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+    · rw [Table.TransitionConstraints]
+      intro index
+      simp [jalrBinaryAndTable, binarySingleRowTable,
+        ZiskFv.AirsClean.Binary.staticLookupComponent]
+    · rw [Table.TransitionConstraints]
+      intro index
+      simp [jalrBinaryAddTable, binaryAddRowsTable,
+        ZiskFv.AirsClean.BinaryAdd.component]
+    · exact jalrMainTable_transitions
+
+theorem jalrWitness_cyclicSuccessorTransitions :
+    jalrWitness.CyclicSuccessorTransitionConstraints := by
+  intro table h_table
+  rw [EnsembleWitness.allTables, List.mem_cons] at h_table
+  rcases h_table with h_verifier | h_table
+  · subst table
+    rw [Table.CyclicSuccessorTransitionConstraints]
+    intro index
+    simp [EnsembleWitness.verifierTable]
+  · simp [jalrWitness, jalrTables] at h_table
+    rcases h_table with
+      rfl | rfl | rfl | rfl | rfl | rfl | rfl |
+      rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    · rw [Table.CyclicSuccessorTransitionConstraints]
+      intro index
+      simp [jalrBoundaryTable, registerBoundaryRowsTableOf,
+        ZiskFv.AirsClean.RegisterBoundary.component]
+    · exact emptyComponentTable_cyclicSuccessorTransitions
+        ZiskFv.AirsClean.MemAlignReadByte.component
+    · exact emptyComponentTable_cyclicSuccessorTransitions
+        ZiskFv.AirsClean.MemAlignByte.component
+    · exact emptyComponentTable_cyclicSuccessorTransitions ZiskFv.AirsClean.MemAlign.component
+    · exact emptyComponentTable_cyclicSuccessorTransitions
+        ZiskFv.AirsClean.MemAlignRangeSlice.component
+    · exact emptyComponentTable_cyclicSuccessorTransitions
+        ZiskFv.AirsClean.MemAlignRomSlice.component
+    · exact emptyComponentTable_cyclicSuccessorTransitions
+        ZiskFv.AirsClean.Mem.componentWithDualMemBus
+    · exact emptyComponentTable_cyclicSuccessorTransitions
+        ZiskFv.AirsClean.SpecifiedRangesSlice.component
+    · exact emptyComponentTable_cyclicSuccessorTransitions ZiskFv.AirsClean.ArithDiv.component
+    · exact emptyComponentTable_cyclicSuccessorTransitions
+        ZiskFv.AirsClean.ArithMul.componentWithArithTable
+    · exact emptyComponentTable_cyclicSuccessorTransitions
+        ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+    · rw [Table.CyclicSuccessorTransitionConstraints]
+      intro index
+      simp [jalrBinaryAndTable, binarySingleRowTable,
+        ZiskFv.AirsClean.Binary.staticLookupComponent]
+    · rw [Table.CyclicSuccessorTransitionConstraints]
+      intro index
+      simp [jalrBinaryAddTable, binaryAddRowsTable,
+        ZiskFv.AirsClean.BinaryAdd.component]
+    · exact jalrMainTable_cyclicSuccessorTransitions
+
+private theorem jalrMainOpBusInteraction_eval_at
+    (env : Environment FGL) (row : MainRowWithRom FGL)
+    (h_input :
+      Eval.eval env (componentWithRomMemAndOpBus 3 jalrProgram).rowInputVar = row) :
+    (((OpBusChannel.emitted
+        (-(componentWithRomMemAndOpBus 3 jalrProgram).rowInputVar.core.is_external_op)
+        (opBusMessageExpr
+          (componentWithRomMemAndOpBus 3 jalrProgram).rowInputVar.core)).toRaw).eval env) =
+      mainOpBusInteraction row := by
+  let rowVar := (componentWithRomMemAndOpBus 3 jalrProgram).rowInputVar
+  have h_core : Eval.eval env rowVar.core = row.core := by
+    rw [ZiskFv.AirsClean.FullEnsemble.mainRowWithRom_eval_core]
+    exact congrArg MainRowWithRom.core h_input
+  have h_field :=
+    ZiskFv.AirsClean.FullEnsemble.mainRow_eval_is_external_op env rowVar.core
+  simp [mainOpBusInteraction, AbstractInteraction.eval, ChannelInteraction.toRaw]
+  constructor
+  · change Expression.eval env (-rowVar.core.is_external_op) =
+      -row.core.is_external_op
+    simp [Expression.eval, h_field, h_core]
+  constructor
+  · have h_msg_eval :
+        Eval.eval env (opBusMessageExpr rowVar.core) = opBusMessage row.core := by
+      rw [eval_opBusMessageExpr, h_core]
+    rw [toElements_eval_toArray]
+    change (toElements (Eval.eval env (opBusMessageExpr rowVar.core))).toArray =
+      (toElements (opBusMessage row.core)).toArray
+    rw [h_msg_eval]
+  · rfl
+
+private theorem jalrMainOpBusInteractionsAt
+    (env : Environment FGL) (row : MainRowWithRom FGL)
+    (h_input :
+      Eval.eval env (componentWithRomMemAndOpBus 3 jalrProgram).rowInputVar = row) :
+    (componentWithRomMemAndOpBus 3 jalrProgram).operations.interactionValuesWith
+        OpBusChannel.toRaw env = [mainOpBusInteraction row] := by
+  simp [Operations.interactionValuesWith_eq_map,
+    componentWithRomMemAndOpBus_interactionsWith_opBus]
+  exact jalrMainOpBusInteraction_eval_at env row h_input
+
+theorem jalrMainTable_interactionsWith_opBus :
+    jalrMainTable.interactionsWith OpBusChannel.toRaw =
+      [ mainOpBusInteraction jalrSetupRow
+      , mainOpBusInteraction jalrAddRow
+      , mainOpBusInteraction jalrAndRow
+      , mainOpBusInteraction jalrSuccessorRow ] := by
+  rw [Table.interactionsWith, jalrMainTable_effectiveRows]
+  simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]
+  have h_at (index : Nat) (row : MainRowWithRom FGL)
+      (h_segment : row.core.segment_l1 = mainFixedColumns.fixedAt 0 index)
+      (h_step : row.rom.main_step = mainFixedColumns.fixedAt 1 index) :
+      jalrMainTable.component.operations.interactionValuesWith OpBusChannel.toRaw
+          (jalrMainTable.environment
+            (mainFixedColumns.materialize index (mainRawRow row))) =
+        [mainOpBusInteraction row] := by
+    simpa [jalrMainTable, ZiskFv.Compliance.AddSpinWitness.mainRowsTable] using
+      (jalrMainOpBusInteractionsAt
+        (Environment.fromArray
+          (mainFixedColumns.materialize index (mainRawRow row)) emptyData)
+        row (eval_mainRawRow_materialize index emptyData row h_segment h_step))
+  rw [h_at 0 jalrSetupRow (by rfl) (by rfl),
+    h_at 1 jalrAddRow (by rfl) (by rfl),
+    h_at 2 jalrAndRow (by rfl) (by rfl),
+    h_at 3 jalrSuccessorRow (by rfl) (by rfl)]
+  rfl
+
+theorem jalrMainTable_interactionsWith_memBus :
+    jalrMainTable.interactionsWith MemBusChannel.toRaw =
+      mainValueMemBusInteractions jalrSetupRow ++
+      mainValueMemBusInteractions jalrAddRow ++
+      mainValueMemBusInteractions jalrAndRow ++
+      mainValueMemBusInteractions jalrSuccessorRow := by
+  rw [Table.interactionsWith, jalrMainTable_effectiveRows]
+  simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]
+  have h_at (index : Nat) (row : MainRowWithRom FGL)
+      (h_segment : row.core.segment_l1 = mainFixedColumns.fixedAt 0 index)
+      (h_step : row.rom.main_step = mainFixedColumns.fixedAt 1 index) :
+      jalrMainTable.component.operations.interactionValuesWith MemBusChannel.toRaw
+          (jalrMainTable.environment
+            (mainFixedColumns.materialize index (mainRawRow row))) =
+        mainValueMemBusInteractions row := by
+    calc
+      _ = mainMemBusInteractionsAt 3 jalrProgram
+          (Environment.fromArray
+            (mainFixedColumns.materialize index (mainRawRow row)) emptyData) := by
+        simpa [jalrMainTable, ZiskFv.Compliance.AddSpinWitness.mainRowsTable] using
+          mainMemBusInteractionsAt_eq_component 3 jalrProgram
+            (Environment.fromArray
+              (mainFixedColumns.materialize index (mainRawRow row)) emptyData)
+      _ = mainValueMemBusInteractions row :=
+        mainMemBusInteractionsAt_eq_valueLevel 3 jalrProgram _ row
+          (eval_mainRawRow_materialize index emptyData row h_segment h_step)
+  rw [h_at 0 jalrSetupRow (by rfl) (by rfl),
+    h_at 1 jalrAddRow (by rfl) (by rfl),
+    h_at 2 jalrAndRow (by rfl) (by rfl),
+    h_at 3 jalrSuccessorRow (by rfl) (by rfl)]
+  rfl
+
+theorem jalrOpBus_interactions :
+    jalrWitness.tables.flatMap (·.interactionsWith OpBusChannel.toRaw) =
+      [ binaryOpBusInteraction jalrBinaryAndRow
+      , binaryAddOpBusInteraction jalrSetupBinaryAddRow
+      , binaryAddOpBusInteraction jalrLoweringBinaryAddRow
+      , binaryAddOpBusInteraction jalrLoweringBinaryAddRow
+      , mainOpBusInteraction jalrSetupRow
+      , mainOpBusInteraction jalrAddRow
+      , mainOpBusInteraction jalrAndRow
+      , mainOpBusInteraction jalrSuccessorRow ] := by
+  have h_boundary :
+      jalrBoundaryTable.interactionsWith OpBusChannel.toRaw = [] := by
+    exact
+      ZiskFv.AirsClean.FullEnsemble.registerBoundary_table_interactionsWith_opBus_nil
+        (table := jalrBoundaryTable) rfl
+  rw [show jalrWitness.tables = jalrTables from rfl]
+  simp [jalrTables, h_boundary, emptyComponentTable_interactionsWith,
+    jalrBinaryAndTable, binarySingleRowTable_interactionsWith_opBus,
+    jalrBinaryAddTable, binaryAddRowsTable_interactionsWith_opBus,
+    jalrMainTable_interactionsWith_opBus]
+
+theorem jalrWitness_opBus_balanced :
+    BalancedInteractions
+      (jalrWitness.tables.flatMap (·.interactionsWith OpBusChannel.toRaw)) := by
+  rw [jalrOpBus_interactions]
+  refine Air.Flat.balancedInteractions_of_present ?_
+    ([ binaryOpBusInteraction jalrBinaryAndRow
+     , binaryAddOpBusInteraction jalrSetupBinaryAddRow
+     , binaryAddOpBusInteraction jalrLoweringBinaryAddRow
+     , binaryAddOpBusInteraction jalrLoweringBinaryAddRow
+     , mainOpBusInteraction jalrSetupRow
+     , mainOpBusInteraction jalrAddRow
+     , mainOpBusInteraction jalrAndRow
+     , mainOpBusInteraction jalrSuccessorRow ].map (·.msg)) ?_ ?_
+  · left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+  · intro interaction h_interaction
+    exact List.mem_map_of_mem h_interaction
+  · intro msg h_msg
+    simp only [List.mem_map] at h_msg
+    rcases h_msg with ⟨interaction, h_interaction, rfl⟩
+    simp at h_interaction
+    rcases h_interaction with
+      rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
+      decide
+
+def jalrMemBusInteractions : List (Interaction FGL) :=
+  jalrBoundaryRows.flatMap registerBoundaryMemBusInteractions ++
+    mainValueMemBusInteractions jalrSetupRow ++
+    mainValueMemBusInteractions jalrAddRow ++
+    mainValueMemBusInteractions jalrAndRow ++
+    mainValueMemBusInteractions jalrSuccessorRow
+
+theorem jalrWitness_memBus_interactions :
+    jalrWitness.tables.flatMap (·.interactionsWith MemBusChannel.toRaw) =
+      jalrMemBusInteractions := by
+  have h_boundary :
+      jalrBoundaryTable.interactionsWith MemBusChannel.toRaw =
+        jalrBoundaryRows.flatMap registerBoundaryMemBusInteractions := by
+    simpa [jalrBoundaryTable] using
+      registerBoundaryRowsTableOf_interactionsWith_memBus jalrBoundaryRows
+  have h_binary :
+      jalrBinaryAndTable.interactionsWith MemBusChannel.toRaw = [] := by
+    exact
+      ZiskFv.AirsClean.FullEnsemble.staticBinary_table_interactionsWith_memBus_nil
+        (table := jalrBinaryAndTable) rfl
+  have h_binaryAdd :
+      jalrBinaryAddTable.interactionsWith MemBusChannel.toRaw = [] := by
+    exact
+      ZiskFv.AirsClean.FullEnsemble.binaryAdd_table_interactionsWith_memBus_nil
+        (table := jalrBinaryAddTable) rfl
+  rw [show jalrWitness.tables = jalrTables from rfl]
+  simp [jalrTables, jalrMemBusInteractions, h_boundary, h_binary, h_binaryAdd,
+    emptyComponentTable_interactionsWith, jalrMainTable_interactionsWith_memBus]
+
+private def jalrX1Interactions : List (Interaction FGL) :=
+  boundaryInteractions jalrBoundaryRowX1 ++
+    mainValueMemBusInteractions jalrSetupRow ++
+    mainValueMemBusInteractions jalrAddRow ++
+    mainValueMemBusInteractions jalrSuccessorRow
+
+private def jalrX1Telescope : List (Interaction FGL) :=
+  registerTelescopingInteractions
+    (ZiskFv.AirsClean.RegisterBoundary.bootMessage jalrBoundaryRowX1)
+    [cMemMessage jalrSetupRow, bMemMessage jalrAddRow, bMemMessage jalrSuccessorRow]
+
+private def jalrX1ZeroInteractions : List (Interaction FGL) :=
+  [ mainCRegPreInteraction jalrSuccessorRow, mainCMemInteraction jalrSuccessorRow
+  , mainARegPreInteraction jalrSetupRow, mainAMemInteraction jalrSetupRow
+  , mainBRegPreInteraction jalrSetupRow, mainBMemInteraction jalrSetupRow
+  , mainARegPreInteraction jalrAddRow, mainAMemInteraction jalrAddRow
+  , mainCRegPreInteraction jalrAddRow, mainCMemInteraction jalrAddRow
+  , mainARegPreInteraction jalrSuccessorRow, mainAMemInteraction jalrSuccessorRow
+  ]
+
+private theorem perm_extract_three
+    {α : Type} (pre zero₁ selected₁ zero₂ selected₂ zero₃ selected₃ zero₄ : List α) :
+    List.Perm
+      (pre ++ zero₁ ++ selected₁ ++ zero₂ ++ selected₂ ++ zero₃ ++ selected₃ ++ zero₄)
+      (pre ++ selected₁ ++ selected₂ ++ selected₃ ++ zero₄ ++ zero₁ ++ zero₂ ++ zero₃) := by
+  have h_tail : List.Perm
+      (zero₁ ++ selected₁ ++ zero₂ ++ selected₂ ++ zero₃ ++ selected₃ ++ zero₄)
+      (selected₁ ++ selected₂ ++ selected₃ ++ zero₄ ++ zero₁ ++ zero₂ ++ zero₃) := by
+    have h₁ : List.Perm
+        (zero₁ ++ selected₁ ++ zero₂ ++ selected₂ ++ zero₃ ++ selected₃ ++ zero₄)
+        ((selected₁ ++ zero₂ ++ selected₂ ++ zero₃ ++ selected₃ ++ zero₄) ++ zero₁) := by
+      have h_swap : List.Perm
+          (zero₁ ++ (selected₁ ++ zero₂ ++ selected₂ ++ zero₃ ++ selected₃ ++ zero₄))
+          ((selected₁ ++ zero₂ ++ selected₂ ++ zero₃ ++ selected₃ ++ zero₄) ++ zero₁) :=
+        List.perm_append_comm
+      simpa [List.append_assoc] using
+        h_swap
+    have h₂ : List.Perm
+        ((selected₁ ++ zero₂ ++ selected₂ ++ zero₃ ++ selected₃ ++ zero₄) ++ zero₁)
+        (selected₁ ++ ((selected₂ ++ zero₃ ++ selected₃ ++ zero₄ ++ zero₁) ++ zero₂)) := by
+      have h_swap : List.Perm
+          (zero₂ ++ (selected₂ ++ zero₃ ++ selected₃ ++ zero₄ ++ zero₁))
+          ((selected₂ ++ zero₃ ++ selected₃ ++ zero₄ ++ zero₁) ++ zero₂) :=
+        List.perm_append_comm
+      simpa [List.append_assoc] using
+        List.Perm.append (List.Perm.refl selected₁) h_swap
+    have h₃ : List.Perm
+        (selected₁ ++ ((selected₂ ++ zero₃ ++ selected₃ ++ zero₄ ++ zero₁) ++ zero₂))
+        (selected₁ ++ selected₂ ++
+          ((selected₃ ++ zero₄ ++ zero₁ ++ zero₂) ++ zero₃)) := by
+      have h_swap : List.Perm
+          (zero₃ ++ (selected₃ ++ zero₄ ++ zero₁ ++ zero₂))
+          ((selected₃ ++ zero₄ ++ zero₁ ++ zero₂) ++ zero₃) :=
+        List.perm_append_comm
+      simpa [List.append_assoc] using
+        List.Perm.append (List.Perm.refl (selected₁ ++ selected₂)) h_swap
+    simpa [List.append_assoc] using h₁.trans (h₂.trans h₃)
+  simpa [List.append_assoc] using List.Perm.append (List.Perm.refl pre) h_tail
+
+private theorem jalrX1Interactions_perm :
+    List.Perm jalrX1Interactions (jalrX1Telescope ++ jalrX1ZeroInteractions) := by
+  rw [jalrX1Interactions]
+  rw [boundaryInteractions_eq_messages, jalrBoundaryRowX1_reload]
+  let pre := [emittedPulledValue
+    (ZiskFv.AirsClean.RegisterBoundary.bootMessage jalrBoundaryRowX1),
+    MemBusChannel.pushedValue (bMemMessage jalrSuccessorRow)]
+  let z₁ := [mainARegPreInteraction jalrSetupRow, mainAMemInteraction jalrSetupRow,
+    mainBRegPreInteraction jalrSetupRow, mainBMemInteraction jalrSetupRow]
+  let t₁ := [mainCRegPreInteraction jalrSetupRow, mainCMemInteraction jalrSetupRow]
+  let z₂ := [mainARegPreInteraction jalrAddRow, mainAMemInteraction jalrAddRow]
+  let t₂ := [mainBRegPreInteraction jalrAddRow, mainBMemInteraction jalrAddRow]
+  let z₃ := [mainCRegPreInteraction jalrAddRow, mainCMemInteraction jalrAddRow,
+    mainARegPreInteraction jalrSuccessorRow, mainAMemInteraction jalrSuccessorRow]
+  let t₃ := [mainBRegPreInteraction jalrSuccessorRow, mainBMemInteraction jalrSuccessorRow]
+  let z₄ := [mainCRegPreInteraction jalrSuccessorRow, mainCMemInteraction jalrSuccessorRow]
+  simpa only [pre, z₁, t₁, z₂, t₂, z₃, t₃, z₄,
+    jalrX1Telescope, jalrX1ZeroInteractions,
+    boundaryInteractions, registerBoundaryMemBusInteractions,
+    registerBoundaryBootInteraction, registerBoundaryReloadInteraction,
+    registerTelescopingInteractions, pairedInteraction,
+    mainValueMemBusInteractions, jalrBoundaryRowX1, registerBoundaryRowFromLast,
+    jalrSetupRow, jalrSetupRowWithLast, jalrSetupRowTemplate,
+    jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
+    jalrSuccessorRow, jalrSuccessorRowWithLast, jalrSuccessorRowTemplate,
+    jalrSetupProgramRow, jalrAddProgramRow, jalrSetupBits, jalrAddBits,
+    jalrFreeCols, jalrRegisterInitial, mainRomRowOf,
+    materializeMainRegisterRow, materializeMainRegisterAccesses,
+    withMainRegisterPrevious, boundaryRowIdle,
+    ZiskFv.AirsClean.RegisterBoundary.bootMessage,
+    mainARegPreInteraction, mainAMemInteraction, mainBRegPreInteraction,
+    mainBMemInteraction, mainCRegPreInteraction, mainCMemInteraction,
+    emittedPulledValue, Channel.pushedValue] using
+    (perm_extract_three pre z₁ t₁ z₂ t₂ z₃ t₃ z₄)
+
+private theorem jalrX1Interactions_balanced :
+    BalancedInteractions jalrX1Interactions := by
+  have h_telescope : BalancedInteractions jalrX1Telescope := by
+    apply registerTelescopingInteractions_balanced
+    left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+  have h_zero : BalancedInteractions jalrX1ZeroInteractions := by
+    apply zeroInteractions_balanced
+    · intro interaction h_interaction
+      simp [jalrX1ZeroInteractions] at h_interaction
+      rcases h_interaction with
+        rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
+        decide
+    · left
+      rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+      decide
+  exact balancedInteractions_of_perm
+    (balancedInteractions_append_of_balanced h_telescope h_zero (by
+      left
+      rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+      decide))
+    jalrX1Interactions_perm.symm
+
+private def jalrX2Interactions : List (Interaction FGL) :=
+  boundaryInteractions jalrBoundaryRowX2 ++ mainValueMemBusInteractions jalrAndRow
+
+private def jalrX2Telescope : List (Interaction FGL) :=
+  registerTelescopingInteractions
+    (ZiskFv.AirsClean.RegisterBoundary.bootMessage jalrBoundaryRowX2)
+    [cMemMessage jalrAndRow]
+
+private def jalrX2ZeroInteractions : List (Interaction FGL) :=
+  [ mainARegPreInteraction jalrAndRow, mainAMemInteraction jalrAndRow
+  , mainBRegPreInteraction jalrAndRow, mainBMemInteraction jalrAndRow ]
+
+private theorem jalrX2Interactions_perm :
+    List.Perm jalrX2Interactions (jalrX2Telescope ++ jalrX2ZeroInteractions) := by
+  rw [jalrX2Interactions]
+  rw [boundaryInteractions_eq_messages, jalrBoundaryRowX2_reload]
+  let pre := [emittedPulledValue
+    (ZiskFv.AirsClean.RegisterBoundary.bootMessage jalrBoundaryRowX2),
+    MemBusChannel.pushedValue (cMemMessage jalrAndRow)]
+  let zeros := [mainARegPreInteraction jalrAndRow, mainAMemInteraction jalrAndRow,
+    mainBRegPreInteraction jalrAndRow, mainBMemInteraction jalrAndRow]
+  let selected := [mainCRegPreInteraction jalrAndRow, mainCMemInteraction jalrAndRow]
+  simpa only [pre, zeros, selected, jalrX2Telescope, jalrX2ZeroInteractions,
+    boundaryInteractions, registerBoundaryMemBusInteractions,
+    registerBoundaryBootInteraction, registerBoundaryReloadInteraction,
+    registerTelescopingInteractions, pairedInteraction,
+    mainValueMemBusInteractions, jalrBoundaryRowX2, registerBoundaryRowFromLast,
+    jalrAndRow, jalrAndRowWithLast, jalrAndRowTemplate,
+    jalrAndProgramRow, jalrAndBits, jalrFreeCols, jalrRegisterInitial, mainRomRowOf,
+    materializeMainRegisterRow, materializeMainRegisterAccesses,
+    withMainRegisterPrevious, boundaryRowIdle,
+    ZiskFv.AirsClean.RegisterBoundary.bootMessage,
+    mainARegPreInteraction, mainAMemInteraction, mainBRegPreInteraction,
+    mainBMemInteraction, mainCRegPreInteraction, mainCMemInteraction,
+    emittedPulledValue, Channel.pushedValue] using
+    (List.Perm.append (List.Perm.refl pre)
+      (show List.Perm (zeros ++ selected) (selected ++ zeros) from List.perm_append_comm))
+
+private theorem jalrX2Interactions_balanced :
+    BalancedInteractions jalrX2Interactions := by
+  have h_telescope : BalancedInteractions jalrX2Telescope := by
+    apply registerTelescopingInteractions_balanced
+    left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+  have h_zero : BalancedInteractions jalrX2ZeroInteractions := by
+    apply zeroInteractions_balanced
+    · intro interaction h_interaction
+      simp [jalrX2ZeroInteractions] at h_interaction
+      rcases h_interaction with rfl | rfl | rfl | rfl <;> decide
+    · left
+      rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+      decide
+  exact balancedInteractions_of_perm
+    (balancedInteractions_append_of_balanced h_telescope h_zero (by
+      left
+      rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+      decide))
+    jalrX2Interactions_perm.symm
+
+private def jalrIdleBoundaryInteractions : List (Interaction FGL) :=
+  (List.range 29).flatMap fun i =>
+    boundaryInteractions (boundaryRowIdle ((i + 3 : Nat) : FGL))
+
+private def jalrIdleBoundaryMessages : List (MemBusMessage FGL) :=
+  (List.range 29).map fun i =>
+    ZiskFv.AirsClean.RegisterBoundary.bootMessage
+      (boundaryRowIdle ((i + 3 : Nat) : FGL))
+
+private theorem jalrIdleBoundaryInteractions_eq_paired :
+    jalrIdleBoundaryInteractions = pairedInteractions jalrIdleBoundaryMessages := by
+  unfold jalrIdleBoundaryInteractions jalrIdleBoundaryMessages
+  generalize List.range 29 = indices
+  induction indices with
+  | nil => rfl
+  | cons i rest ih =>
+      simp only [List.map_cons, List.flatMap_cons, pairedInteractions]
+      have h_head : boundaryInteractions (boundaryRowIdle ((i + 3 : Nat) : FGL)) =
+          pairedInteraction
+            (ZiskFv.AirsClean.RegisterBoundary.bootMessage
+              (boundaryRowIdle ((i + 3 : Nat) : FGL))) := by
+        simp [boundaryInteractions, registerBoundaryMemBusInteractions,
+          registerBoundaryBootInteraction, registerBoundaryReloadInteraction,
+          pairedInteraction, boundaryRowIdle, emittedPulledValue, Channel.pushedValue]
+      rw [h_head, ih]
+      rfl
+
+private theorem jalrIdleBoundaryInteractions_balanced :
+    BalancedInteractions jalrIdleBoundaryInteractions := by
+  rw [jalrIdleBoundaryInteractions_eq_paired]
+  apply pairedInteractions_balanced
+  left
+  rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+  decide
+
+theorem jalrWitness_memBus_balanced :
+    BalancedInteractions
+      (jalrWitness.tables.flatMap (·.interactionsWith MemBusChannel.toRaw)) := by
+  rw [jalrWitness_memBus_interactions]
+  have h_boundary :
+      jalrBoundaryRows.flatMap registerBoundaryMemBusInteractions =
+        boundaryInteractions jalrBoundaryRowX1 ++
+          boundaryInteractions jalrBoundaryRowX2 ++ jalrIdleBoundaryInteractions := by
+    simp [jalrBoundaryRows, jalrIdleBoundaryInteractions, boundaryInteractions]
+    generalize List.range 29 = indices
+    induction indices with
+    | nil => rfl
+    | cons i rest ih => simp [ih]
+  rw [jalrMemBusInteractions, h_boundary]
+  let bx1 := boundaryInteractions jalrBoundaryRowX1
+  let bx2 := boundaryInteractions jalrBoundaryRowX2
+  let idle := jalrIdleBoundaryInteractions
+  let setup := mainValueMemBusInteractions jalrSetupRow
+  let add := mainValueMemBusInteractions jalrAddRow
+  let andRow := mainValueMemBusInteractions jalrAndRow
+  let successor := mainValueMemBusInteractions jalrSuccessorRow
+  have h_swap_front : List.Perm
+      (bx1 ++ bx2 ++ idle ++ setup ++ add ++ andRow ++ successor)
+      (bx1 ++ setup ++ add ++ andRow ++ successor ++ bx2 ++ idle) := by
+    have h_swap : List.Perm
+        ((bx2 ++ idle) ++ (setup ++ add ++ andRow ++ successor))
+        ((setup ++ add ++ andRow ++ successor) ++ (bx2 ++ idle)) :=
+      List.perm_append_comm
+    simpa [List.append_assoc] using List.Perm.append (List.Perm.refl bx1) h_swap
+  have h_swap_and : List.Perm
+      (bx1 ++ setup ++ add ++ andRow ++ successor ++ bx2 ++ idle)
+      (bx1 ++ setup ++ add ++ successor ++ bx2 ++ andRow ++ idle) := by
+    have h_swap : List.Perm
+        (andRow ++ (successor ++ bx2)) ((successor ++ bx2) ++ andRow) :=
+      List.perm_append_comm
+    have h_middle := List.Perm.append (List.Perm.refl (bx1 ++ setup ++ add)) h_swap
+    simpa [List.append_assoc] using List.Perm.append h_middle (List.Perm.refl idle)
+  have h_perm : List.Perm
+      (bx1 ++ bx2 ++ idle ++ setup ++ add ++ andRow ++ successor)
+      (jalrX1Interactions ++ jalrX2Interactions ++ jalrIdleBoundaryInteractions) := by
+    simpa [bx1, bx2, idle, setup, add, andRow, successor,
+      jalrX1Interactions, jalrX2Interactions, List.append_assoc] using
+      h_swap_front.trans h_swap_and
+  have h_combined :
+      BalancedInteractions
+        (jalrX1Interactions ++ jalrX2Interactions ++ jalrIdleBoundaryInteractions) :=
+    balancedInteractions_append_of_balanced
+      (balancedInteractions_append_of_balanced
+        jalrX1Interactions_balanced jalrX2Interactions_balanced (by
+          left
+          rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+          decide))
+      jalrIdleBoundaryInteractions_balanced (by
+        left
+        rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+        decide)
+  apply balancedInteractions_of_perm h_combined
+  simpa [bx1, bx2, idle, setup, add, andRow, successor, List.append_assoc] using h_perm.symm
+
+private theorem jalrChannel_ne
+    (channel : RawChannel FGL) (expectedName : String)
+    (h_name : channel.name = expectedName)
+    (other : RawChannel FGL) (otherName : String)
+    (h_other_name : other.name = otherName)
+    (h_names : expectedName ≠ otherName) :
+    channel ≠ other := by
+  intro h
+  apply h_names
+  calc
+    expectedName = channel.name := h_name.symm
+    _ = other.name := congrArg (fun raw : RawChannel FGL => raw.name) h
+    _ = otherName := h_other_name
+
+private theorem jalrWitness_otherChannel_balanced
+    (channel : RawChannel FGL)
+    (hne_mem : channel ≠ MemBusChannel.toRaw)
+    (hne_op : channel ≠ OpBusChannel.toRaw) :
+    BalancedInteractions
+      (jalrWitness.tables.flatMap (·.interactionsWith channel)) := by
+  have h_boundary : jalrBoundaryTable.interactionsWith channel = [] := by
+    apply Table.interactionsWith_nil_of_channel_not_mem
+    change channel ∉ [MemBusChannel.toRaw]
+    simpa only [List.mem_singleton] using hne_mem
+  have h_binary : jalrBinaryAndTable.interactionsWith channel = [] := by
+    apply Table.interactionsWith_nil_of_channel_not_mem
+    change channel ∉ [OpBusChannel.toRaw]
+    simpa only [List.mem_singleton] using hne_op
+  have h_binaryAdd : jalrBinaryAddTable.interactionsWith channel = [] := by
+    apply Table.interactionsWith_nil_of_channel_not_mem
+    change channel ∉ [OpBusChannel.toRaw]
+    simpa only [List.mem_singleton] using hne_op
+  have h_main : jalrMainTable.interactionsWith channel = [] := by
+    apply Table.interactionsWith_nil_of_channel_not_mem
+    change channel ∉ [MemBusChannel.toRaw, OpBusChannel.toRaw]
+    simpa only [List.mem_cons, List.not_mem_nil, or_false] using
+      (by
+        simp only [not_or]
+        exact ⟨hne_mem, hne_op⟩)
+  rw [show jalrWitness.tables = jalrTables from rfl]
+  simp [jalrTables, h_boundary, h_binary, h_binaryAdd, h_main,
+    emptyComponentTable_interactionsWith]
+  refine ⟨?_, ?_⟩
+  · left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+  · intro msg
+    simp [balanceOf]
+
+private theorem jalrRangeChannel_ne_memBus :
+    SpecifiedRangesSliceChannel.toRaw ≠ MemBusChannel.toRaw := by
+  exact jalrChannel_ne _ _ rfl _ _ rfl (by decide)
+
+private theorem jalrRangeChannel_ne_opBus :
+    SpecifiedRangesSliceChannel.toRaw ≠ OpBusChannel.toRaw := by
+  exact jalrChannel_ne _ _ rfl _ _ rfl (by decide)
+
+private theorem jalrMemAlignRangeChannel_ne_memBus :
+    MemAlignRangeChannel.toRaw ≠ MemBusChannel.toRaw := by
+  exact jalrChannel_ne _ _ rfl _ _ rfl (by decide)
+
+private theorem jalrMemAlignRangeChannel_ne_opBus :
+    MemAlignRangeChannel.toRaw ≠ OpBusChannel.toRaw := by
+  exact jalrChannel_ne _ _ rfl _ _ rfl (by decide)
+
+private theorem jalrMemAlignRomChannel_ne_memBus :
+    MemAlignRomChannel.toRaw ≠ MemBusChannel.toRaw := by
+  exact jalrChannel_ne _ _ rfl _ _ rfl (by decide)
+
+private theorem jalrMemAlignRomChannel_ne_opBus :
+    MemAlignRomChannel.toRaw ≠ OpBusChannel.toRaw := by
+  exact jalrChannel_ne _ _ rfl _ _ rfl (by decide)
+
+theorem jalrWitness_rangeChannel_balanced :
+    BalancedInteractions
+      (jalrWitness.tables.flatMap
+        (·.interactionsWith SpecifiedRangesSliceChannel.toRaw)) :=
+  jalrWitness_otherChannel_balanced _ jalrRangeChannel_ne_memBus
+    jalrRangeChannel_ne_opBus
+
+theorem jalrWitness_memAlignRangeChannel_balanced :
+    BalancedInteractions
+      (jalrWitness.tables.flatMap (·.interactionsWith MemAlignRangeChannel.toRaw)) :=
+  jalrWitness_otherChannel_balanced _ jalrMemAlignRangeChannel_ne_memBus
+    jalrMemAlignRangeChannel_ne_opBus
+
+theorem jalrWitness_memAlignRomChannel_balanced :
+    BalancedInteractions
+      (jalrWitness.tables.flatMap (·.interactionsWith MemAlignRomChannel.toRaw)) :=
+  jalrWitness_otherChannel_balanced _ jalrMemAlignRomChannel_ne_memBus
+    jalrMemAlignRomChannel_ne_opBus
+
+theorem jalrWitness_balancedChannels : jalrWitness.BalancedChannels := by
+  refine jalrWitness.balancedChannels_of_tables jalrEnsemble_verifier ?_
+  intro channel h_channel
+  simp [jalrEnsemble, fullRv64imEnsemble, fullRv64imSoundEnsemble,
+    SoundEnsemble.toFormal, SoundEnsemble.addFinishedChannel_channels,
+    SoundEnsemble.addTable_channels, SoundEnsemble.empty_channels] at h_channel
+  rcases h_channel with rfl | rfl | rfl | rfl | rfl
+  · exact jalrWitness_memAlignRangeChannel_balanced
+  · exact jalrWitness_memBus_balanced
+  · exact jalrWitness_opBus_balanced
+  · exact jalrWitness_memAlignRomChannel_balanced
+  · exact jalrWitness_rangeChannel_balanced
+
+private theorem not_jalr_main_component_of_name_ne
+    {component : Component FGL}
+    (h_name :
+      component.circuit.name ≠
+        (componentWithRomMemAndOpBus 3 jalrProgram).circuit.name)
+    (h_component : component = componentWithRomMemAndOpBus 3 jalrProgram) :
+    False :=
+  h_name (congrArg (fun c : Component FGL => c.circuit.name) h_component)
+
+private theorem not_jalr_main_component_of_width_ne
+    {component : Component FGL}
+    (h_width :
+      component.width ≠ (componentWithRomMemAndOpBus 3 jalrProgram).width)
+    (h_component : component = componentWithRomMemAndOpBus 3 jalrProgram) :
+    False :=
+  h_width (congrArg Component.width h_component)
+
+private theorem not_jalr_mutable_mem_component_of_name_ne
+    {component : Component FGL}
+    (h_name :
+      component.circuit.name ≠
+        ZiskFv.AirsClean.Mem.componentWithDualMemBus.circuit.name)
+    (h_component :
+      component = ZiskFv.AirsClean.Mem.componentWithDualMemBus) :
+    False :=
+  h_name (congrArg (fun c : Component FGL => c.circuit.name) h_component)
+
+private theorem jalrWitness_main_component_cases
+    {table : Table FGL}
+    (h_table : table ∈ jalrWitness.allTables)
+    (h_component :
+      table.component = componentWithRomMemAndOpBus 3 jalrProgram) :
+    table = jalrMainTable := by
+  rw [EnsembleWitness.allTables, List.mem_cons] at h_table
+  rcases h_table with h_verifier | h_table
+  · subst table
+    exfalso
+    exact not_jalr_main_component_of_width_ne (by decide) h_component
+  · simp [jalrWitness, jalrTables] at h_table
+    rcases h_table with
+      rfl | rfl | rfl | rfl | rfl | rfl | rfl |
+      rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    · exfalso
+      exact not_jalr_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_jalr_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_jalr_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_jalr_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_jalr_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_jalr_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_jalr_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_jalr_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_jalr_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_jalr_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_jalr_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_jalr_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_jalr_main_component_of_name_ne (by decide) h_component
+    · rfl
+
+private theorem jalrWitness_mutable_mem_component_tables_empty
+    (table : Table FGL) (h_table : table ∈ jalrWitness.allTables)
+    (h_component :
+      table.component = ZiskFv.AirsClean.Mem.componentWithDualMemBus) :
+    table.table = [] := by
+  rw [EnsembleWitness.allTables, List.mem_cons] at h_table
+  rcases h_table with h_verifier | h_table
+  · exfalso
+    rw [h_verifier, EnsembleWitness.verifierTable_component] at h_component
+    have h_verifier_nil :=
+      ZiskFv.AirsClean.FullEnsemble.verifierTable_interactionsWith_memBus_nil
+        3 jalrProgram
+    change Operations.interactionsWith MemBusChannel.toRaw
+      jalrEnsemble.verifierTable.operations = [] at h_verifier_nil
+    rw [h_component,
+      ZiskFv.AirsClean.Mem.componentWithDualMemBus_interactionsWith_memBus] at h_verifier_nil
+    exact absurd h_verifier_nil (by simp)
+  · simp [jalrWitness, jalrTables] at h_table
+    rcases h_table with
+      rfl | rfl | rfl | rfl | rfl | rfl | rfl |
+      rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    · exfalso
+      exact not_jalr_mutable_mem_component_of_name_ne (by decide) h_component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignReadByte.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignByte.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlign.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignRangeSlice.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignRomSlice.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.Mem.componentWithDualMemBus
+    · exact emptyComponentTable_table ZiskFv.AirsClean.SpecifiedRangesSlice.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.ArithDiv.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.ArithMul.componentWithArithTable
+    · exact emptyComponentTable_table
+        ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+    · exfalso
+      exact not_jalr_mutable_mem_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_jalr_mutable_mem_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_jalr_mutable_mem_component_of_name_ne (by decide) h_component
+
+theorem jalrWitness_not_mutableMemPresent :
+    ¬ MutableMemPresent jalrWitness := by
+  intro h_present
+  obtain ⟨table, h_table, h_component, h_length⟩ := h_present
+  have h_empty :=
+    jalrWitness_mutable_mem_component_tables_empty table h_table h_component
+  exact absurd h_length (by simp [h_empty])
+
+theorem jalrWitness_main_height :
+    ∀ table ∈ jalrWitness.allTables,
+      table.component = componentWithRomMemAndOpBus 3 jalrProgram →
+        ∀ i : Fin 2, i.val < table.table.length := by
+  intro table h_table h_component i
+  have h_main := jalrWitness_main_component_cases h_table h_component
+  subst table
+  fin_cases i <;>
+    norm_num [jalrMainTable, ZiskFv.Compliance.AddSpinWitness.mainRowsTable,
+      jalrMainRows]
+
+def jalrAcceptedTrace : AcceptedZiskTrace 2 where
+  programLength := 3
+  program := jalrProgram
+  witness := jalrWitness
+  constraints_hold := jalrWitness_constraints
+  channels_balanced := jalrWitness_balancedChannels
+  mem_replay_table := fun h => absurd h jalrWitness_not_mutableMemPresent
+  mem_replay_source_covers := fun h => absurd h jalrWitness_not_mutableMemPresent
+  transitions_hold := jalrWitness_transitions
+  cyclic_successor_transitions_hold := jalrWitness_cyclicSuccessorTransitions
+  main_height := jalrWitness_main_height
+
+theorem jalrAcceptedTrace_mainTable_eq :
+    jalrAcceptedTrace.mainTable = jalrMainTable := by
+  exact jalrWitness_main_component_cases
+    (by simpa [jalrAcceptedTrace] using jalrAcceptedTrace.mainTable_mem)
+    (by simpa [jalrAcceptedTrace] using jalrAcceptedTrace.mainTable_component)
+
+end ZiskFv.Compliance.JalrSpinWitness

--- a/ZiskFv/Compliance/MainTransition.lean
+++ b/ZiskFv/Compliance/MainTransition.lean
@@ -101,6 +101,7 @@ theorem AcceptedZiskTrace.mainTransition_to_next_pc
   change ZiskFv.AirsClean.Main.pcHandshakeTransition transitionIndex.val
     (trace.mainTable.previousEnvironment transitionIndex)
     (trace.mainTable.environmentAt transitionIndex) at h_trans
+  have h_trans_pc := h_trans.1
   have h_transition : ZiskFv.AirsClean.Main.pcHandshakeBetween
       ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
           trace.programLength trace.program).rowInput
@@ -109,7 +110,7 @@ theorem AcceptedZiskTrace.mainTransition_to_next_pc
           trace.programLength trace.program).rowInput
         (trace.mainTable.environmentAt transitionIndex)) := by
     simpa only [ZiskFv.AirsClean.Main.pcHandshakeTransition, Air.Flat.Component.rowInput,
-      Air.Flat.Component.rowInputVar, eval_varFromOffset_valueFromOffset] using h_trans
+      Air.Flat.Component.rowInputVar, eval_varFromOffset_valueFromOffset] using h_trans_pc
   have h_previous := rowInputPrevious_eq_mainTableRowAtOrZero trace.program trace.mainTable
     transitionIndex (by simp [transitionIndex])
   have h_current := rowInputAt_eq_mainTableRowAtOrZero trace.program trace.mainTable

--- a/ZiskFv/Compliance/MainTransition.lean
+++ b/ZiskFv/Compliance/MainTransition.lean
@@ -45,7 +45,7 @@ theorem rowInput_eq_mainTableRowAtOrZero
     eval_varFromOffset_valueFromOffset]
 
 /-- The indexed effective-row environment projects to the corresponding Main row. -/
-private theorem rowInputAt_eq_mainTableRowAtOrZero
+theorem rowInputAt_eq_mainTableRowAtOrZero
     {length : ℕ} (program : Program length) (table : Table FGL)
     (index : Fin table.length) :
     (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program).rowInput
@@ -59,7 +59,7 @@ private theorem rowInputAt_eq_mainTableRowAtOrZero
   exact rowInput_eq_mainTableRowAtOrZero program table index.val h_index
 
 /-- The saturated predecessor environment projects to the preceding effective Main row. -/
-private theorem rowInputPrevious_eq_mainTableRowAtOrZero
+theorem rowInputPrevious_eq_mainTableRowAtOrZero
     {length : ℕ} (program : Program length) (table : Table FGL)
     (index : Fin table.length) (h_positive : 0 < index.val) :
     (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program).rowInput

--- a/ZiskFv/Compliance/OpBusProviderMatch.lean
+++ b/ZiskFv/Compliance/OpBusProviderMatch.lean
@@ -19,9 +19,9 @@ namespace ZiskFv.Compliance
 
 open ZiskFv.AirsClean.FullEnsemble
 
-theorem main_request_logic_provided
+theorem main_request_logic_provided_at
     (trace : AcceptedZiskTrace numInstructions)
-    (i : Fin numInstructions)
+    (i : Fin trace.mainTable.table.length)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
@@ -48,10 +48,7 @@ theorem main_request_logic_provided
               (ZiskFv.AirsClean.Binary.opBusMessage
                 (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
                   (providerTable.environment providerRow))) 1) := by
-  have h_mainIdx_lt : i.val < trace.mainTable.table.length :=
-    trace.mainTable_index i
-  let mainIdx : Fin trace.mainTable.table.length :=
-    ⟨i.val, h_mainIdx_lt⟩
+  let mainIdx : Fin trace.mainTable.table.length := i
   let mainRow := trace.mainTable.table.get mainIdx
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
@@ -109,6 +106,38 @@ theorem main_request_logic_provided
         trace.mainTable_mem trace.mainTable_component h_mainRow_mem
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
+
+theorem main_request_logic_provided
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin numInstructions)
+    (h_main_active :
+      ZiskFv.Airs.Main.Valid_Main.is_external_op
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
+        i.val = 1)
+    (h_main_op :
+      ZiskFv.Airs.Main.Valid_Main.op
+          (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
+          i.val = ZiskFv.Trusted.OP_AND
+        ∨ ZiskFv.Airs.Main.Valid_Main.op
+          (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
+          i.val = ZiskFv.Trusted.OP_OR
+        ∨ ZiskFv.Airs.Main.Valid_Main.op
+          (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
+          i.val = ZiskFv.Trusted.OP_XOR) :
+    ∃ providerTable ∈ trace.witness.allTables,
+      ∃ providerRow ∈ providerTable.table,
+        providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent
+          ∧ providerTable.Spec
+          ∧ ZiskFv.Airs.OperationBus.matches_entry
+            (ZiskFv.Airs.OperationBus.opBus_row_Main
+              (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
+              i.val)
+            (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+              (ZiskFv.AirsClean.Binary.opBusMessage
+                (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
+                  (providerTable.environment providerRow))) 1) :=
+  main_request_logic_provided_at trace
+    ⟨i.val, trace.mainTable_index i⟩ h_main_active h_main_op
 
 theorem main_request_sub_provided
     (trace : AcceptedZiskTrace numInstructions)

--- a/ZiskFv/Compliance/OpBusProviderMatch.lean
+++ b/ZiskFv/Compliance/OpBusProviderMatch.lean
@@ -195,9 +195,9 @@ theorem main_request_sub_provided
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op
 
-theorem main_request_add_provided
+theorem main_request_add_provided_at
     (trace : AcceptedZiskTrace numInstructions)
-    (i : Fin numInstructions)
+    (i : Fin trace.mainTable.table.length)
     (h_main_active :
       ZiskFv.Airs.Main.Valid_Main.is_external_op
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
@@ -235,10 +235,7 @@ theorem main_request_add_provided
                 (ZiskFv.AirsClean.BinaryAdd.opBusMessage
                   (ZiskFv.AirsClean.BinaryAdd.component.rowInput
                     (providerTable.environment providerRow))) 1))) := by
-  have h_mainIdx_lt : i.val < trace.mainTable.table.length :=
-    trace.mainTable_index i
-  let mainIdx : Fin trace.mainTable.table.length :=
-    ⟨i.val, h_mainIdx_lt⟩
+  let mainIdx : Fin trace.mainTable.table.length := i
   let mainRow := trace.mainTable.table.get mainIdx
   let mainInteraction :=
     ((ZiskFv.Channels.OperationBus.OpBusChannel.emitted
@@ -317,6 +314,49 @@ theorem main_request_add_provided
         trace.mainTable_mem trace.mainTable_component h_mainRow_mem
         h_main_row h_main_active h_mainInteraction_mem
         h_mainInteraction_eval h_active h_main_op⟩
+
+theorem main_request_add_provided
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin numInstructions)
+    (h_main_active :
+      ZiskFv.Airs.Main.Valid_Main.is_external_op
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
+        i.val = 1)
+    (h_main_op :
+      ZiskFv.Airs.Main.Valid_Main.op
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
+        i.val = ZiskFv.Trusted.OP_ADD) :
+    ZiskFv.Airs.Main.add_subset_holds
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
+      i.val
+    ∧
+      ((∃ providerTable ∈ trace.witness.allTables,
+        ∃ providerRow ∈ providerTable.table,
+          providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent
+            ∧ providerTable.Spec
+            ∧ ZiskFv.Airs.OperationBus.matches_entry
+              (ZiskFv.Airs.OperationBus.opBus_row_Main
+                (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
+                i.val)
+              (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+                (ZiskFv.AirsClean.Binary.opBusMessage
+                  (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
+                    (providerTable.environment providerRow))) 1))
+      ∨
+      (∃ providerTable ∈ trace.witness.allTables,
+        ∃ providerRow ∈ providerTable.table,
+          providerTable.component = ZiskFv.AirsClean.BinaryAdd.component
+            ∧ providerTable.Spec
+            ∧ ZiskFv.Airs.OperationBus.matches_entry
+              (ZiskFv.Airs.OperationBus.opBus_row_Main
+                (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
+                i.val)
+              (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
+                (ZiskFv.AirsClean.BinaryAdd.opBusMessage
+                  (ZiskFv.AirsClean.BinaryAdd.component.rowInput
+                    (providerTable.environment providerRow))) 1))) :=
+  main_request_add_provided_at trace
+    ⟨i.val, trace.mainTable_index i⟩ h_main_active h_main_op
 
 theorem main_request_compare_provided
     (trace : AcceptedZiskTrace numInstructions)

--- a/ZiskFv/Compliance/Pilot/JalrNextPC.lean
+++ b/ZiskFv/Compliance/Pilot/JalrNextPC.lean
@@ -180,7 +180,7 @@ theorem jalr_c0_val_eq_masked_operand
     scope pin (`h_c1_zero`, `h_no_fgl_wrap`), or decode/ROM pin. -/
 theorem jalr_setpc_nextPC_discharged
     (trace : AcceptedZiskTrace numInstructions)
-    (i : Fin trace.numInstructions)
+    (i : Fin trace.mainTable.table.length)
     (row : ZiskFv.AirsClean.Binary.BinaryRow FGL)
     (operand offset_bv : BitVec 64)
     (h_idx : i.val + 1 < trace.mainTable.table.length)
@@ -212,14 +212,14 @@ theorem jalr_setpc_nextPC_discharged
       ((mainOfTable trace.program trace.mainTable).c_0 i.val).val
         + ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val).val < GL_prime) :
     (register_type_pc_equiv ▸
-        (BitVec.ofNat 64 ((execRowOf trace i)[1]!.pc).val))
+        (BitVec.ofNat 64 ((execRowAt trace i)[1]!.pc).val))
       = 0xFFFFFFFFFFFFFFFE#64 &&& (operand + offset_bv) := by
   have h_c0 :
       ((mainOfTable trace.program trace.mainTable).c_0 i.val).val
         = (0xFFFFFFFFFFFFFFFE#64 &&& operand).toNat :=
     jalr_c0_val_eq_masked_operand row _ _ operand h_matches h_match_clo h_match_chi
       h_a_mask h_b_operand hc0 hc1 hc2 hc3 hc4 hc5 hc6 hc7 h_c1_zero
-  rw [setpc_path_nextPC_discharged trace i h_idx h_set_pc h_flag,
+  rw [setpc_path_nextPC_discharged_at trace i h_idx h_set_pc h_flag,
       ofNat_fgl_pc_plus_offset_eq _ _ (0xFFFFFFFFFFFFFFFE#64 &&& operand) offset_bv
         h_c0 h_offset_bridge h_no_fgl_wrap,
       masked_add_offset_even operand offset_bv h_offset_even]

--- a/ZiskFv/Compliance/Pilot/SubNextPC.lean
+++ b/ZiskFv/Compliance/Pilot/SubNextPC.lean
@@ -56,6 +56,18 @@ open ZiskFv.Airs.Main (pc_handshake_with_next_pc pc_handshake_branch pc_handshak
   pc_handshake_setpc)
 open Interaction
 
+/-- Execution-bus row at a physical Main-table index whose successor exists. -/
+@[reducible] noncomputable def execRowAt
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin trace.mainTable.table.length) :
+    List (Interaction.ExecutionBusEntry FGL) :=
+  [ { multiplicity := -1
+    , pc := (mainOfTable trace.program trace.mainTable).pc i.val
+    , timestamp := 1 }
+  , { multiplicity := 1
+    , pc := (mainOfTable trace.program trace.mainTable).pc (i.val + 1)
+    , timestamp := 1 } ]
+
 /-- **Trace-derived execution-bus row.** The two committed execution-bus entries
     for the Main row at trace index `i`: the read entry (`multiplicity = -1`) whose
     `pc` is the *current* committed Main `pc` column `pc i`, and the write/next-PC
@@ -282,6 +294,36 @@ theorem setpc_path_nextPC_discharged
     pc_handshake_setpc (mainOfTable trace.program trace.mainTable) i.val
       ((mainOfTable trace.program trace.mainTable).pc (i.val + 1)) h_set_pc h_flag h_hand
   -- (4) Substitute; the `register_type_pc_equiv ▸ …` cast is defeq-identity.
+  rw [h_pc1, h_step]
+
+/-- Physical-row form of `setpc_path_nextPC_discharged`, used when one
+    architectural instruction occupies multiple Main rows. -/
+theorem setpc_path_nextPC_discharged_at
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin trace.mainTable.table.length)
+    (h_idx : i.val + 1 < trace.mainTable.table.length)
+    (h_set_pc :
+      (mainOfTable trace.program trace.mainTable).set_pc i.val = 1)
+    (h_flag :
+      (mainOfTable trace.program trace.mainTable).flag i.val = 0) :
+    (register_type_pc_equiv ▸
+        (BitVec.ofNat 64
+          ((execRowAt trace i)[1]!.pc).val))
+      = BitVec.ofNat 64
+          (((mainOfTable trace.program trace.mainTable).c_0 i.val
+            + (mainOfTable trace.program trace.mainTable).jmp_offset1 i.val).val) := by
+  have h_pc1 :
+      (execRowAt trace i)[1]!.pc
+        = (mainOfTable trace.program trace.mainTable).pc (i.val + 1) := rfl
+  have h_seg := trace.mainTable_fixed.segment_l1_succ i.val h_idx
+  have h_hand :=
+    ZiskFv.Compliance.AcceptedZiskTrace.mainTransition_to_next_pc trace i.val h_idx h_seg
+  have h_step :
+      (mainOfTable trace.program trace.mainTable).pc (i.val + 1)
+        = (mainOfTable trace.program trace.mainTable).c_0 i.val
+          + (mainOfTable trace.program trace.mainTable).jmp_offset1 i.val :=
+    pc_handshake_setpc (mainOfTable trace.program trace.mainTable) i.val
+      ((mainOfTable trace.program trace.mainTable).pc (i.val + 1)) h_set_pc h_flag h_hand
   rw [h_pc1, h_step]
 
 /-- **Pilot SUB next-PC discharge.** From the accepted trace's transition

--- a/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
@@ -1013,43 +1013,59 @@ def sdLdOutsideDefectRegion :
   | ⟨6, _⟩ => sdLdJalOutsideDefectRegion
 
 theorem sdLdRootSoundness :
-    ∀ i : Fin 7, StepSound sdLdAcceptedTrace sdLdSailTrace i (sdLdZiskStep i) :=
+    ∀ i : Fin 7, StepSound sdLdAcceptedTrace sdLdSailTrace i
+      (sdLdZiskStep i)
+      (rowDecode_of_programDecode sdLdAcceptedTrace i (sdLdProgramDecodes i)) :=
   root_soundness 7 sdLdAcceptedTrace sdLdSailTrace sdLdZiskStep
     sdLdProgramDecodes sdLdInputsAgree sdLdBootSeed sdLdOutsideDefectRegion
 
 theorem sdLdAddiA0StepSound :
     StepSound sdLdAcceptedTrace sdLdSailTrace sdLdAddiA0Index
-      (sdLdZiskStep sdLdAddiA0Index) :=
+      (sdLdZiskStep sdLdAddiA0Index)
+      (rowDecode_of_programDecode sdLdAcceptedTrace sdLdAddiA0Index
+        (sdLdProgramDecodes sdLdAddiA0Index)) :=
   sdLdRootSoundness sdLdAddiA0Index
 
 theorem sdLdSlliStepSound :
     StepSound sdLdAcceptedTrace sdLdSailTrace sdLdSlliIndex
-      (sdLdZiskStep sdLdSlliIndex) :=
+      (sdLdZiskStep sdLdSlliIndex)
+      (rowDecode_of_programDecode sdLdAcceptedTrace sdLdSlliIndex
+        (sdLdProgramDecodes sdLdSlliIndex)) :=
   sdLdRootSoundness sdLdSlliIndex
 
 theorem sdLdAddiEightStepSound :
     StepSound sdLdAcceptedTrace sdLdSailTrace sdLdAddiEightIndex
-      (sdLdZiskStep sdLdAddiEightIndex) :=
+      (sdLdZiskStep sdLdAddiEightIndex)
+      (rowDecode_of_programDecode sdLdAcceptedTrace sdLdAddiEightIndex
+        (sdLdProgramDecodes sdLdAddiEightIndex)) :=
   sdLdRootSoundness sdLdAddiEightIndex
 
 theorem sdLdAddiX2StepSound :
     StepSound sdLdAcceptedTrace sdLdSailTrace sdLdAddiX2Index
-      (sdLdZiskStep sdLdAddiX2Index) :=
+      (sdLdZiskStep sdLdAddiX2Index)
+      (rowDecode_of_programDecode sdLdAcceptedTrace sdLdAddiX2Index
+        (sdLdProgramDecodes sdLdAddiX2Index)) :=
   sdLdRootSoundness sdLdAddiX2Index
 
 theorem sdLdSdStepSound :
     StepSound sdLdAcceptedTrace sdLdSailTrace sdLdSdIndex
-      (sdLdZiskStep sdLdSdIndex) :=
+      (sdLdZiskStep sdLdSdIndex)
+      (rowDecode_of_programDecode sdLdAcceptedTrace sdLdSdIndex
+        (sdLdProgramDecodes sdLdSdIndex)) :=
   sdLdRootSoundness sdLdSdIndex
 
 theorem sdLdLdStepSound :
     StepSound sdLdAcceptedTrace sdLdSailTrace sdLdLdIndex
-      (sdLdZiskStep sdLdLdIndex) :=
+      (sdLdZiskStep sdLdLdIndex)
+      (rowDecode_of_programDecode sdLdAcceptedTrace sdLdLdIndex
+        (sdLdProgramDecodes sdLdLdIndex)) :=
   sdLdRootSoundness sdLdLdIndex
 
 theorem sdLdJalStepSound :
     StepSound sdLdAcceptedTrace sdLdSailTrace sdLdJalIndex
-      (sdLdZiskStep sdLdJalIndex) :=
+      (sdLdZiskStep sdLdJalIndex)
+      (rowDecode_of_programDecode sdLdAcceptedTrace sdLdJalIndex
+        (sdLdProgramDecodes sdLdJalIndex)) :=
   sdLdRootSoundness sdLdJalIndex
 
 end ZiskFv.Compliance.SdLdSpinRootSoundness

--- a/ZiskFv/Compliance/SdLdSpinWitness.lean
+++ b/ZiskFv/Compliance/SdLdSpinWitness.lean
@@ -216,15 +216,15 @@ def sdLdJalProgramRow : ZiskRomMessage FGL :=
 
 def sdLdJalRow (step : FGL) : MainRowWithRom FGL :=
   mainRomRowOf sdLdJalProgramRow AddSpinWitness.addSpinJalBits MainRomExecKind.internalFlag
-    (sdLdFreeCols step 0 0 0 0)
+    (sdLdFreeCols step 0 0 (if step = 6 then 42 else 0) 0)
 
 def sdLdMainRows : List (MainRowWithRom FGL) :=
   [ sdLdAddiX1A0Row, sdLdSlliX1Row, sdLdAddiX1EightRow, sdLdAddiX2Row
   , sdLdSdRow, sdLdLdRow, sdLdJalRow 6, sdLdJalRow 7 ]
 
 theorem sdLdMain_pc_addi_slli :
-    pcHandshakeBetween sdLdAddiX1A0Row sdLdSlliX1Row := by
-  simp [pcHandshakeBetween, sdLdAddiX1A0Row, sdLdAddiX1A0RowWithLast,
+    transitionBetween sdLdAddiX1A0Row sdLdSlliX1Row := by
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdAddiX1A0Row, sdLdAddiX1A0RowWithLast,
     sdLdAddiX1A0RowTemplate, sdLdSlliX1Row, sdLdSlliX1RowWithLast,
     sdLdSlliX1RowTemplate, sdLdAddiX1A0ProgramRow, sdLdSlliX1ProgramRow,
     addiX0Bits, addiX1Bits, mainRomRowOf, sdLdFreeCols,
@@ -233,8 +233,8 @@ theorem sdLdMain_pc_addi_slli :
     ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
 
 theorem sdLdMain_pc_slli_addi :
-    pcHandshakeBetween sdLdSlliX1Row sdLdAddiX1EightRow := by
-  simp [pcHandshakeBetween, sdLdSlliX1Row, sdLdSlliX1RowWithLast,
+    transitionBetween sdLdSlliX1Row sdLdAddiX1EightRow := by
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdSlliX1Row, sdLdSlliX1RowWithLast,
     sdLdSlliX1RowTemplate, sdLdAddiX1EightRow, sdLdAddiX1EightRowWithLast,
     sdLdAddiX1EightRowTemplate, sdLdSlliX1ProgramRow, sdLdAddiX1EightProgramRow,
     addiX1Bits, mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious,
@@ -242,8 +242,8 @@ theorem sdLdMain_pc_slli_addi :
     ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
 
 theorem sdLdMain_pc_addi_addi :
-    pcHandshakeBetween sdLdAddiX1EightRow sdLdAddiX2Row := by
-  simp [pcHandshakeBetween, sdLdAddiX1EightRow, sdLdAddiX1EightRowWithLast,
+    transitionBetween sdLdAddiX1EightRow sdLdAddiX2Row := by
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdAddiX1EightRow, sdLdAddiX1EightRowWithLast,
     sdLdAddiX1EightRowTemplate, sdLdAddiX2Row, sdLdAddiX2RowWithLast,
     sdLdAddiX2RowTemplate, sdLdAddiX1EightProgramRow, sdLdAddiX2ProgramRow,
     addiX0Bits, addiX1Bits, mainRomRowOf, sdLdFreeCols,
@@ -252,30 +252,30 @@ theorem sdLdMain_pc_addi_addi :
     ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
 
 theorem sdLdMain_pc_addi_sd :
-    pcHandshakeBetween sdLdAddiX2Row sdLdSdRow := by
-  simp [pcHandshakeBetween, sdLdAddiX2Row, sdLdAddiX2RowWithLast,
+    transitionBetween sdLdAddiX2Row sdLdSdRow := by
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdAddiX2Row, sdLdAddiX2RowWithLast,
     sdLdAddiX2RowTemplate, sdLdSdRow, sdLdSdRowTemplate, sdLdAddiX2ProgramRow,
     sdLdSdProgramRow, addiX0Bits, sdLdSdBits, mainRomRowOf, sdLdFreeCols,
     mainRomFreeColsWithRegisterPrevious, materializeMainRegisterRow,
     materializeMainRegisterAccesses, withMainRegisterPrevious,
     ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
 
-theorem sdLdMain_pc_sd_ld : pcHandshakeBetween sdLdSdRow sdLdLdRow := by
-  simp [pcHandshakeBetween, sdLdSdRow, sdLdSdRowTemplate, sdLdLdRow,
+theorem sdLdMain_pc_sd_ld : transitionBetween sdLdSdRow sdLdLdRow := by
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdSdRow, sdLdSdRowTemplate, sdLdLdRow,
     sdLdLdRowTemplate, sdLdSdProgramRow, sdLdLdProgramRow, sdLdSdBits, sdLdLdBits,
     mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious,
     materializeMainRegisterRow, materializeMainRegisterAccesses, withMainRegisterPrevious,
     ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
 
-theorem sdLdMain_pc_ld_jal : pcHandshakeBetween sdLdLdRow (sdLdJalRow 6) := by
-  simp [pcHandshakeBetween, sdLdLdRow, sdLdLdRowTemplate, sdLdJalRow,
+theorem sdLdMain_pc_ld_jal : transitionBetween sdLdLdRow (sdLdJalRow 6) := by
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdLdRow, sdLdLdRowTemplate, sdLdJalRow,
     sdLdLdProgramRow, sdLdJalProgramRow, sdLdLdBits, AddSpinWitness.addSpinJalBits,
     mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious,
     materializeMainRegisterRow, materializeMainRegisterAccesses, withMainRegisterPrevious,
     ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
 
-theorem sdLdMain_pc_jal_jal : pcHandshakeBetween (sdLdJalRow 6) (sdLdJalRow 7) := by
-  simp [pcHandshakeBetween, sdLdJalRow, sdLdJalProgramRow, AddSpinWitness.addSpinJalBits,
+theorem sdLdMain_pc_jal_jal : transitionBetween (sdLdJalRow 6) (sdLdJalRow 7) := by
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdJalRow, sdLdJalProgramRow, AddSpinWitness.addSpinJalBits,
     mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious,
     ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
   ring
@@ -418,7 +418,7 @@ theorem sdLdJalMain_proverAssumptions (step : FGL) :
     (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus 7 sdLdProgram).circuit.ProverAssumptions
       (sdLdJalRow step) emptyData (ProverHint.empty FGL) := by
   refine ⟨⟨6, by decide⟩, AddSpinWitness.addSpinJalBits, MainRomExecKind.internalFlag,
-    sdLdFreeCols step 0 0 0 0, ?_, ?_, ?_, ?_, ?_⟩
+    sdLdFreeCols step 0 0 (if step = 6 then 42 else 0) 0, ?_, ?_, ?_, ?_, ?_⟩
   · decide
   · norm_num [MainRomExecKind.Coherent, sdLdProgram, sdLdJalProgramRow,
       AddSpinWitness.addSpinJalBits, ZiskFv.Trusted.OP_FLAG]
@@ -666,13 +666,14 @@ theorem sdLdMainTable_constraints : sdLdMainTable.Constraints := by
 theorem sdLdMainTable_transitions : sdLdMainTable.TransitionConstraints := by
   rw [Table.TransitionConstraints]
   intro index
-  change pcHandshakeBetween
+  change transitionBetween
     (Eval.eval (sdLdMainTable.previousEnvironment index)
       (componentWithRomMemAndOpBus 7 sdLdProgram).rowInputVar)
     (Eval.eval (sdLdMainTable.environmentAt index)
       (componentWithRomMemAndOpBus 7 sdLdProgram).rowInputVar)
   fin_cases index
-  · simp [Table.previousEnvironment, sdLdMainRows, pcHandshakeBetween, sdLdAddiX1A0Row,
+  · simp [Table.previousEnvironment, sdLdMainRows, transitionBetween, sourceCCopyBetween,
+      pcHandshakeBetween, sdLdAddiX1A0Row,
       sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate, mainRomRowOf,
       sdLdFreeCols, mainRomFreeColsWithRegisterPrevious]
   · simpa [Table.previousEnvironment, sdLdMainRows] using sdLdMain_pc_addi_slli

--- a/ZiskFv/Compliance/SdLdSpinWitness.lean
+++ b/ZiskFv/Compliance/SdLdSpinWitness.lean
@@ -224,7 +224,8 @@ def sdLdMainRows : List (MainRowWithRom FGL) :=
 
 theorem sdLdMain_pc_addi_slli :
     transitionBetween sdLdAddiX1A0Row sdLdSlliX1Row := by
-  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdAddiX1A0Row, sdLdAddiX1A0RowWithLast,
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdAddiX1A0Row,
+    sdLdAddiX1A0RowWithLast,
     sdLdAddiX1A0RowTemplate, sdLdSlliX1Row, sdLdSlliX1RowWithLast,
     sdLdSlliX1RowTemplate, sdLdAddiX1A0ProgramRow, sdLdSlliX1ProgramRow,
     addiX0Bits, addiX1Bits, mainRomRowOf, sdLdFreeCols,
@@ -234,7 +235,8 @@ theorem sdLdMain_pc_addi_slli :
 
 theorem sdLdMain_pc_slli_addi :
     transitionBetween sdLdSlliX1Row sdLdAddiX1EightRow := by
-  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdSlliX1Row, sdLdSlliX1RowWithLast,
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdSlliX1Row,
+    sdLdSlliX1RowWithLast,
     sdLdSlliX1RowTemplate, sdLdAddiX1EightRow, sdLdAddiX1EightRowWithLast,
     sdLdAddiX1EightRowTemplate, sdLdSlliX1ProgramRow, sdLdAddiX1EightProgramRow,
     addiX1Bits, mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious,
@@ -243,7 +245,8 @@ theorem sdLdMain_pc_slli_addi :
 
 theorem sdLdMain_pc_addi_addi :
     transitionBetween sdLdAddiX1EightRow sdLdAddiX2Row := by
-  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdAddiX1EightRow, sdLdAddiX1EightRowWithLast,
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdAddiX1EightRow,
+    sdLdAddiX1EightRowWithLast,
     sdLdAddiX1EightRowTemplate, sdLdAddiX2Row, sdLdAddiX2RowWithLast,
     sdLdAddiX2RowTemplate, sdLdAddiX1EightProgramRow, sdLdAddiX2ProgramRow,
     addiX0Bits, addiX1Bits, mainRomRowOf, sdLdFreeCols,
@@ -253,7 +256,8 @@ theorem sdLdMain_pc_addi_addi :
 
 theorem sdLdMain_pc_addi_sd :
     transitionBetween sdLdAddiX2Row sdLdSdRow := by
-  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdAddiX2Row, sdLdAddiX2RowWithLast,
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdAddiX2Row,
+    sdLdAddiX2RowWithLast,
     sdLdAddiX2RowTemplate, sdLdSdRow, sdLdSdRowTemplate, sdLdAddiX2ProgramRow,
     sdLdSdProgramRow, addiX0Bits, sdLdSdBits, mainRomRowOf, sdLdFreeCols,
     mainRomFreeColsWithRegisterPrevious, materializeMainRegisterRow,
@@ -261,21 +265,24 @@ theorem sdLdMain_pc_addi_sd :
     ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
 
 theorem sdLdMain_pc_sd_ld : transitionBetween sdLdSdRow sdLdLdRow := by
-  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdSdRow, sdLdSdRowTemplate, sdLdLdRow,
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdSdRow,
+    sdLdSdRowTemplate, sdLdLdRow,
     sdLdLdRowTemplate, sdLdSdProgramRow, sdLdLdProgramRow, sdLdSdBits, sdLdLdBits,
     mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious,
     materializeMainRegisterRow, materializeMainRegisterAccesses, withMainRegisterPrevious,
     ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
 
 theorem sdLdMain_pc_ld_jal : transitionBetween sdLdLdRow (sdLdJalRow 6) := by
-  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdLdRow, sdLdLdRowTemplate, sdLdJalRow,
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdLdRow,
+    sdLdLdRowTemplate, sdLdJalRow,
     sdLdLdProgramRow, sdLdJalProgramRow, sdLdLdBits, AddSpinWitness.addSpinJalBits,
     mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious,
     materializeMainRegisterRow, materializeMainRegisterAccesses, withMainRegisterPrevious,
     ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
 
 theorem sdLdMain_pc_jal_jal : transitionBetween (sdLdJalRow 6) (sdLdJalRow 7) := by
-  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdJalRow, sdLdJalProgramRow, AddSpinWitness.addSpinJalBits,
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdJalRow,
+    sdLdJalProgramRow, AddSpinWitness.addSpinJalBits,
     mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious,
     ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
   ring

--- a/ZiskFv/Compliance/SingleAddWitness.lean
+++ b/ZiskFv/Compliance/SingleAddWitness.lean
@@ -254,7 +254,7 @@ private theorem mainSingleRowTable_transitions
   have h_segment_l1_one : row.core.segment_l1 = 1 := by
     rw [h_segment_l1]
     rfl
-  simp [pcHandshakeBetween, h_segment_l1_one]
+  simp [transitionBetween, pcHandshakeBetween, sourceCCopyBetween, h_segment_l1_one]
 
 private theorem addX1MainTable_transitions :
     (mainSingleRowTable 1 addX1Program addX1Row).TransitionConstraints :=

--- a/ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean
@@ -41,6 +41,7 @@ open ZiskFv.Channels.MemoryBusBytes (byteAt)
 open ZiskFv.AirsClean.FullEnsemble (mainOfTable)
 open ZiskFv.Tactics.ALUITypeArchetype (itype_imm_subset_holds_main)
 open Interaction
+open Air.Flat
 
 -- The M-extension row-computing defs are reducible/semireducible; structure-field
 -- elaboration would otherwise whnf-reduce the full per-row ArithMul/ArithDiv
@@ -698,7 +699,7 @@ theorem no_memAlignSkippableProveForge_of_lw_rowOutside
       (busLd ziskTrace i (Pilot.execRowOf ziskTrace i)).e1 :=
   h_outside.2.2
 
-def StepSound
+private def StepSoundWithoutDecode
     (ziskTrace : AcceptedZiskTrace numInstructions) (sailTrace : SailTrace ziskTrace.numInstructions) (i : Fin ziskTrace.numInstructions) :
     ZiskStep ziskTrace i → Prop
   | .sub c =>
@@ -1089,11 +1090,13 @@ def StepSound
       = ZiskFv.Channels.state_effect_via_channels
           ⟨Pilot.execRowOf ziskTrace i, [eRdLui ziskTrace i]⟩ (sailTrace i)
   | .jalr c =>
-      (do
-        Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
-        LeanRV64D.Functions.execute (instruction.JALR (c.imm, c.rs1, c.rd))) (sailTrace i)
-      = ZiskFv.Channels.state_effect_via_channels
-          ⟨Pilot.execRowOf ziskTrace i, [eRdLui ziskTrace i]⟩ (sailTrace i)
+      ∃ decode : Decode_jalr ziskTrace i c,
+        (do
+          Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
+          LeanRV64D.Functions.execute (instruction.JALR (c.imm, c.rs1, c.rd))) (sailTrace i)
+        = ZiskFv.Channels.state_effect_via_channels
+            ⟨Pilot.execRowAt ziskTrace decode.rows.finish,
+              [eRdAt ziskTrace decode.rows.finish]⟩ (sailTrace i)
   | .sb c =>
       execute_instruction (instruction.STORE
           (c.sb_input.imm, regidx.Regidx c.sb_input.r2, regidx.Regidx c.sb_input.r1, 1))
@@ -1186,6 +1189,28 @@ def StepSound
       execute_instruction (instruction.FENCE (c.fm, c.fenceP, c.fenceS, c.rs, c.rd)) (sailTrace i)
       = ZiskFv.Channels.state_effect_via_channels ⟨Pilot.execRowOf ziskTrace i, []⟩ (sailTrace i)
 
+/-- Per-step soundness indexed by the checked row decode. JALR needs this
+    index because one architectural instruction may occupy an aligned singleton
+    Main row or an unaligned ADD/AND pair. Other families retain their existing
+    identity-row effects until the decode-driven export migration. -/
+def StepSound
+    (ziskTrace : AcceptedZiskTrace numInstructions)
+    (sailTrace : SailTrace ziskTrace.numInstructions)
+    (i : Fin ziskTrace.numInstructions)
+    (zs : ZiskStep ziskTrace i)
+    (rd : RowDecode ziskTrace i zs) : Prop :=
+  match zs, rd with
+  | .jalr c, decode =>
+      (do
+        Sail.writeReg Register.nextPC
+          (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
+        LeanRV64D.Functions.execute
+          (instruction.JALR (c.imm, c.rs1, c.rd))) (sailTrace i)
+      = ZiskFv.Channels.state_effect_via_channels
+          ⟨Pilot.execRowAt ziskTrace decode.rows.finish,
+            [eRdAt ziskTrace decode.rows.finish]⟩ (sailTrace i)
+  | other, _ => StepSoundWithoutDecode ziskTrace sailTrace i other
+
 /-- Per-row dispatch to the matching strengthened step theorem.
 
     The `hAvoidKnownBugs` parameter carries the per-row defect-exclusion obligation
@@ -1204,7 +1229,7 @@ theorem stepSound_of_evidence (ziskTrace : AcceptedZiskTrace numInstructions) (s
     (rd : RowDecode ziskTrace i zs) (ia : InputsAgree ziskTrace sailTrace i zs)
     (memEv : MemoryOpEvidenceFor ziskTrace sailTrace i zs)
     (hAvoidKnownBugs : RowOutsideDefectRegion ziskTrace i zs) :
-    StepSound ziskTrace sailTrace i zs := by
+    StepSound ziskTrace sailTrace i zs rd := by
   cases zs with
   | sub c =>
       exact stepStrong_sub ziskTrace sailTrace i (toRowData_sub c rd ia)
@@ -1359,11 +1384,343 @@ theorem stepSound_of_evidence (ziskTrace : AcceptedZiskTrace numInstructions) (s
       exact stepStrong_auipc ziskTrace sailTrace i (toRowData_auipc c rd ia)
         (auipcRangeDomain_of_main ia.h_input_imm ia.h_pc_bridge hAvoidKnownBugs)
   | jal c =>
-      exact stepStrong_jal ziskTrace sailTrace i (toRowData_jal c rd ia)
-        (jalRangeDomain_of_main ia.h_input_imm ia.h_pc_bridge hAvoidKnownBugs)
+      let h_domain :=
+        jalRangeDomain_of_main ia.h_input_imm ia.h_pc_bridge hAvoidKnownBugs
+      let nextPC_val : BitVec 64 :=
+        ia.jal_input.PC + BitVec.signExtend 64 ia.jal_input.imm
+      have h_nextPC_option :
+          (PureSpec.execute_JAL_pure ia.jal_input).nextPC = .some nextPC_val :=
+        PureSpec.execute_JAL_pure_succ_nextPC ia.jal_input ia.h_success
+      have h_offset_bridge :
+          ((mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset1 i.val).val =
+            (BitVec.signExtend 64 ia.jal_input.imm).toNat := by
+        simpa [ia.h_input_imm] using rd.h_jmp_offset1_imm
+      have h_no_wrap_fgl :
+          ((mainOfTable ziskTrace.program ziskTrace.mainTable).pc i.val).val
+            + ((mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset1 i.val).val
+              < GL_prime := by
+        rw [ia.h_pc_bridge, h_offset_bridge]
+        exact h_domain.h_no_fgl_wrap
+      have h_spec := mainSpec_at ziskTrace sailTrace i
+      have h_subset := ZiskFv.AirsClean.Main.add_subset_holds_of_spec_rowAt
+        (mainOfTable ziskTrace.program ziskTrace.mainTable) i.val h_spec
+      have h_flag :
+          (mainOfTable ziskTrace.program ziskTrace.mainTable).flag i.val = 1 :=
+        ZiskFv.Airs.Main.flag_eq_one_of_internal_op_zero
+          (mainOfTable ziskTrace.program ziskTrace.mainTable) i.val rd.h_main_active
+          (by simpa [ZiskFv.Trusted.OP_FLAG] using rd.h_main_op)
+          h_subset.2.2.2.2.1
+      have h_nextPC_matches :
+          (register_type_pc_equiv ▸
+              (BitVec.ofNat 64 ((Pilot.execRowOf ziskTrace i)[1]!.pc).val))
+            = nextPC_val := by
+        simpa [nextPC_val] using jal_nextPC_matches_of_physical ziskTrace i
+          ia.jal_input.PC ia.jal_input.imm rd.h_idx rd.h_set_pc h_flag
+          ia.h_pc_bridge h_offset_bridge h_no_wrap_fgl
+      have h_not_throws :
+          (PureSpec.execute_JAL_pure ia.jal_input).throws = false :=
+        PureSpec.execute_JAL_pure_succ_throws ia.jal_input ia.h_success
+      have h_rd_idx :
+          ia.jal_input.rd =
+            Transpiler.wrap_to_regidx (eRdLui ziskTrace i).ptr :=
+        ia.h_input_rd.trans
+          (eRdLui_rd_idx_of_decode (trace := ziskTrace) (i := i)
+            (rd := c.rd) rd.h_store_ind rd.h_store_offset)
+      exact construction_jal_sound_claimed_dead ziskTrace sailTrace i
+        ia.jal_input c.imm c.rd ia.misa_val nextPC_val
+        rd.h_main_op rd.h_main_active rd.h_m32 rd.h_set_pc rd.h_store_pc
+        rd.h_jmp2 ia.h_pc_bridge (Pilot.execRowOf ziskTrace i)
+        (by rfl) (by rfl) (by rfl) h_nextPC_matches
+        ia.h_input_rd ia.h_input_pc ia.h_input_misa ia.h_misa_c ia.h_success
+        h_nextPC_option h_rd_idx
+        ia.h_input_imm h_not_throws h_domain.h_pc_bound
+        h_domain.h_pc_offset_lt_2_32
   | jalr c =>
-      exact stepStrong_jalr ziskTrace sailTrace i (toRowData_jalr c rd ia)
-        (jalrRangeDomain_of_main ia.h_pc_bridge hAvoidKnownBugs)
+      let h_domain :=
+        jalrRangeDomain_of_main ia.h_pc_bridge hAvoidKnownBugs
+      set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable with hm
+      set state := sailTrace i with hstate
+      let finish := rd.rows.finish
+      let r := finish.val
+      let e_rd := eRdAt ziskTrace finish
+      -- (a) Main per-row Spec ⇒ the JALR Main constraint subset.
+      have h_spec := mainSpec_at_physical ziskTrace finish
+      have h_add_subset : ZiskFv.Airs.Main.add_subset_holds m r :=
+        ZiskFv.AirsClean.Main.add_subset_holds_of_spec_rowAt m r h_spec
+      obtain ⟨_h_c0, _h_b0, _h_c1, _h_b1, _h_set_flag, _h_clear_flag, h_disjoint,
+          h_flag_bool, h_ext_bool⟩ := h_add_subset
+      -- (a) the handshake is definitional: pick `next_pc` as its RHS.
+      let next_pc : FGL :=
+        m.set_pc r * (m.c_0 r + m.jmp_offset1 r)
+          + (1 - m.set_pc r) * (m.pc r + m.jmp_offset2 r)
+          + m.flag r * (m.jmp_offset1 r - m.jmp_offset2 r)
+      have h_handshake :
+          ZiskFv.Airs.Main.pc_handshake_with_next_pc m r next_pc := rfl
+      have h_jalr_subset :
+          ZiskFv.Airs.Main.flag_boolean m r
+          ∧ ZiskFv.Airs.Main.is_external_op_boolean m r
+          ∧ ZiskFv.Airs.Main.flag_set_pc_disjoint m r
+          ∧ ZiskFv.Airs.Main.pc_handshake_with_next_pc m r next_pc :=
+        ⟨h_flag_bool, h_ext_bool, h_disjoint, h_handshake⟩
+      -- (a) `StorePcMemoryWitness` from the real Clean Main `c` message row.
+      have h_row_core :
+          (mainRowWithRomAt ziskTrace finish).core =
+            ZiskFv.AirsClean.Main.rowAt m r := by
+        have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
+          ziskTrace.program ziskTrace.mainTable finish
+        simpa [mainRowWithRomAt, m, r, finish,
+          ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := finish)] using this.symm
+      let store_pc_mem : ZiskFv.Compliance.StorePcMemoryWitness m r e_rd :=
+        { row := mainRowWithRomAt ziskTrace finish
+          row_eq := h_row_core
+          rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
+      let pins : ZiskFv.Compliance.MainRowPins m r 1 OP_AND :=
+        ⟨rd.h_main_active, rd.h_main_op⟩
+      -- (b) Binary `OP_AND` provider witnesses for the JALR row (mirrors
+      --     `stepStrong_and`): the static Binary table row backing the masked-AND.
+      obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
+          h_component, h_table_spec, h_match⟩ :=
+        main_request_logic_provided_at
+          ziskTrace finish rd.h_main_active (Or.inl rd.h_main_op)
+      let providerInput :=
+        ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
+          (providerTable.environment providerRow)
+      obtain ⟨h_core, h_facts⟩ :=
+        ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
+          h_component h_table_spec h_provider_row
+      have h_static :
+          ZiskFv.AirsClean.Binary.StaticBinaryTableSpecFacts providerInput :=
+        ZiskFv.AirsClean.BinaryFamily.staticBinary_spec_facts_of_table_spec
+          h_component h_table_spec h_provider_row
+      have h_m32_zero : m.m32 r = 0 := rd.h_m32
+      have h_emit :
+          providerInput.chain.b_op + 16 * providerInput.mode.mode32 =
+            (ZiskFv.Airs.Tables.BinaryTable.OP_AND : FGL) := by
+        have h_match_op := h_match
+        simp only [ZiskFv.Airs.OperationBus.matches_entry,
+          ZiskFv.Airs.OperationBus.opBus_row_Main] at h_match_op
+        have h_op_match :
+            m.op r = providerInput.chain.b_op + 16 * providerInput.mode.mode32 :=
+          h_match_op.2.1
+        rw [← h_op_match]
+        simpa [ZiskFv.Airs.Tables.BinaryTable.OP_AND, ZiskFv.Trusted.OP_AND] using
+          rd.h_main_op
+      obtain ⟨h_row_m32, h_bop, _⟩ :=
+        ZiskFv.EquivCore.Bridge.Binary.logic_row_mode_pins_of_emit_op_lt_16_of_static_spec
+          providerInput h_static ZiskFv.Airs.Tables.BinaryTable.OP_AND (by
+            simp [ZiskFv.Airs.Tables.BinaryTable.OP_AND])
+          h_core h_emit
+      have h_out :=
+        ZiskFv.EquivCore.Bridge.Binary.byte_chain_discharge_64_of_static_row
+          providerInput h_facts
+          ZiskFv.Airs.Tables.BinaryTable.OP_AND h_core h_row_m32 h_bop
+      have h_matches :
+          ZiskFv.EquivCore.Bridge.Binary.all_byte_matches_wf_at_row
+            providerInput ZiskFv.Airs.Tables.BinaryTable.OP_AND :=
+        allByteMatchesOfStaticOut64_local h_out
+      -- (c) lane projections: `a = mask`, `b = operand` (committed `b`-lane packing),
+      --     and the carry-free `c` lanes (from `flag = 0`).
+      have h_a_mask :
+          ZiskFv.EquivCore.Add.binaryRowA64 providerInput = 0xFFFFFFFFFFFFFFFE#64 := by
+        have h_a_pack : ZiskFv.EquivCore.Add.binaryRowA64 providerInput
+            = BitVec.ofNat 64 ((m.a_0 r).val + (m.a_1 r).val * 4294967296) := by
+          simpa [ZiskFv.EquivCore.Add.binaryRowA64] using
+            (ZiskFv.EquivCore.Bridge.Binary.main_a_packing_of_match
+              m providerInput r h_matches h_m32_zero h_match).symm
+        rw [h_a_pack, rd.h_a_mask_lo, rd.h_a_mask_hi]
+        decide
+      have h_b_operand :
+          ZiskFv.EquivCore.Add.binaryRowB64 providerInput
+            = BitVec.ofNat 64 ((m.b_0 r).val + (m.b_1 r).val * 4294967296) := by
+        simpa [ZiskFv.EquivCore.Add.binaryRowB64] using
+          (ZiskFv.EquivCore.Bridge.Binary.main_b_packing_of_match
+            m providerInput r h_matches h_m32_zero h_match).symm
+      obtain ⟨h_match_clo, h_match_chi⟩ :=
+        ZiskFv.EquivCore.Bridge.Binary.main_c_lanes_carryfree_of_match
+          m providerInput r h_match rd.h_flag
+      obtain ⟨hc0, hc1, hc2, hc3, hc4, hc5, hc6, hc7⟩ :=
+        ZiskFv.EquivCore.Bridge.Binary.cByte_ranges_of_all_byte_matches_row
+          providerInput h_matches
+      let nextPC_val : BitVec 64 :=
+        0xFFFFFFFFFFFFFFFE &&&
+          (ia.jalr_input.rs1_val + BitVec.signExtend 64 ia.jalr_input.imm)
+      have h_nextPC_option :
+          (PureSpec.execute_JALR_pure ia.jalr_input).nextPC = .some nextPC_val :=
+        PureSpec.execute_JALR_pure_succ_nextPC ia.jalr_input ia.h_success
+      have h_nextPC_disch :
+          (register_type_pc_equiv ▸
+              (BitVec.ofNat 64 ((Pilot.execRowAt ziskTrace finish)[1]!.pc).val))
+            = nextPC_val := by
+        have hoo :
+            BitVec.ofNat 64 ((m.b_0 r).val + (m.b_1 r).val * 4294967296)
+                + c.offset_bv
+              = ia.jalr_input.rs1_val
+                + BitVec.signExtend 64 ia.jalr_input.imm := by
+          rcases rd.rows.lowering with h_aligned | h_unaligned
+          · obtain ⟨h_start_finish, h_offset⟩ := h_aligned
+            have h_rs1 := ia.h_rs1_start
+            rw [← rd.rows.architectural_start, h_start_finish] at h_rs1
+            rw [h_offset, ia.h_input_imm, h_rs1]
+          · obtain ⟨h_adj, h_offset, h_add_op, h_add_active, h_add_m32,
+                _h_start_flag, _h_start_set_pc, _h_start_jmp2, h_start_a,
+                _h_start_b_reg, h_finish_b_imm, h_finish_b_mem,
+                h_finish_b_ind, h_finish_b_reg⟩ := h_unaligned
+            have h_add := main_add_packed_result_at ziskTrace rd.rows.start
+              h_add_active h_add_op h_add_m32
+            let transitionIndex : Fin ziskTrace.mainTable.length :=
+              ⟨finish.val, by simpa only [Table.length, Table.table_length]
+                using finish.isLt⟩
+            have h_trans := ziskTrace.transitions_hold ziskTrace.mainTable
+              ziskTrace.mainTable_mem transitionIndex
+            rw [ziskTrace.mainTable_component] at h_trans
+            have h_transition :
+                ZiskFv.AirsClean.Main.transitionBetween
+                  ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+                      ziskTrace.programLength ziskTrace.program).rowInput
+                    (ziskTrace.mainTable.previousEnvironment transitionIndex))
+                  ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+                      ziskTrace.programLength ziskTrace.program).rowInput
+                    (ziskTrace.mainTable.environmentAt transitionIndex)) :=
+              transitionBetween_of_pcHandshakeTransition
+                ziskTrace.programLength ziskTrace.program transitionIndex.val
+                (ziskTrace.mainTable.previousEnvironment transitionIndex)
+                (ziskTrace.mainTable.environmentAt transitionIndex) h_trans
+            have h_positive : 0 < transitionIndex.val := by
+              dsimp [transitionIndex]
+              omega
+            have h_prev_idx :
+                transitionIndex.val - 1 = rd.rows.start.val := by
+              dsimp [transitionIndex]
+              omega
+            have h_previous :=
+              rowInputPrevious_eq_mainTableRowAtOrZero
+                ziskTrace.program ziskTrace.mainTable transitionIndex h_positive
+            have h_current :=
+              rowInputAt_eq_mainTableRowAtOrZero
+                ziskTrace.program ziskTrace.mainTable transitionIndex
+            rw [h_previous, h_current] at h_transition
+            rw [h_prev_idx] at h_transition
+            have h_between :
+                ZiskFv.AirsClean.Main.transitionBetween
+                  (mainRowWithRomAt ziskTrace rd.rows.start)
+                  (mainRowWithRomAt ziskTrace finish) := by
+              exact h_transition
+            have h_copy := source_c_copy_lanes_of_between
+              (mainRowWithRomAt ziskTrace rd.rows.start)
+              (mainRowWithRomAt ziskTrace finish) h_between
+              (by
+                have h_seg :=
+                  ziskTrace.mainTable_fixed.segment_l1_succ rd.rows.start.val
+                    (by simpa [h_adj] using finish.isLt)
+                rw [h_adj] at h_seg
+                exact h_seg)
+              h_finish_b_imm h_finish_b_mem h_finish_b_ind h_finish_b_reg
+            exact jalr_unaligned_operand_target m i.val rd.rows.start.val r
+              c.offset_bv c.imm ia.jalr_input.imm ia.jalr_input.rs1_val
+              h_offset h_add h_copy h_start_a rd.rows.architectural_start
+              ia.h_rs1_start ia.h_input_imm
+        have h_exec :=
+          ZiskFv.Compliance.Pilot.jalr_setpc_nextPC_discharged
+            ziskTrace finish providerInput
+            (BitVec.ofNat 64 ((m.b_0 r).val + (m.b_1 r).val * 4294967296))
+            c.offset_bv
+            rd.h_idx rd.h_set_pc rd.h_flag
+            h_matches h_match_clo h_match_chi h_a_mask h_b_operand
+            hc0 hc1 hc2 hc3 hc4 hc5 hc6 hc7
+            rd.h_c1_zero rd.h_offset_bridge
+            rd.h_offset_even rd.h_no_fgl_wrap
+        exact jalr_nextPC_matches_of_target
+          (register_type_pc_equiv ▸
+            BitVec.ofNat 64 ((Pilot.execRowAt ziskTrace finish)[1]!.pc).val)
+          (BitVec.ofNat 64 ((m.b_0 r).val + (m.b_1 r).val * 4294967296))
+          c.offset_bv
+          (ia.jalr_input.rs1_val
+            + BitVec.signExtend 64 ia.jalr_input.imm)
+          h_exec hoo
+      let promises : ZiskFv.EquivCore.Promises.JumpPromises
+          state ia.jalr_input.PC ia.jalr_input.rd ia.misa_val
+          (PureSpec.execute_JALR_pure ia.jalr_input).success
+          (PureSpec.execute_JALR_pure ia.jalr_input).nextPC
+          c.rd (Pilot.execRowAt ziskTrace finish) e_rd nextPC_val :=
+        { input_rd_eq := ia.h_input_rd
+          input_pc_eq := ia.h_input_pc
+          input_misa_eq := ia.h_input_misa
+          misa_c_zero := ia.h_misa_c
+          -- exec artifacts: now `rfl` (`Pilot.execRowOf` is a concrete two-entry list).
+          exec_len := by rfl
+          e0_mult := by rfl
+          e1_mult := by rfl
+          nextPC_matches := h_nextPC_disch
+          rd_mult := by rfl
+          rd_as := by rfl
+          success := ia.h_success
+          nextPC_option := h_nextPC_option
+          rd_idx := ia.h_input_rd.trans
+            (eRdAt_rd_idx_of_decode (trace := ziskTrace) (i := finish)
+              (rd := c.rd) rd.h_store_ind rd.h_store_offset) }
+      have h_link_bridge :
+          (m.pc finish.val + m.jmp_offset2 finish.val).val =
+            (ia.jalr_input.PC + 4#64).toNat := by
+        dsimp only [finish]
+        rcases rd.rows.lowering with h_aligned | h_unaligned
+        · obtain ⟨h_start_finish, _⟩ := h_aligned
+          have hsf : rd.rows.start.val = finish.val :=
+            congrArg Fin.val h_start_finish
+          have h_finish_jmp2 : m.jmp_offset2 finish.val = 4 := by
+            rcases rd.h_jmp2 with h | h
+            · exact h.2
+            · rw [hsf] at h
+              omega
+          have h_pc : (m.pc finish.val).val =
+              ia.jalr_input.PC.toNat := by
+            rw [← hsf, rd.rows.architectural_start]
+            simpa [m] using ia.h_pc_bridge
+          exact jalr_link_bridge_scalar (m.pc finish.val)
+            (m.pc finish.val) (m.jmp_offset2 finish.val) ia.jalr_input.PC
+            (by rw [h_finish_jmp2]) h_pc h_domain.h_pc_bound
+        · have h_adj := h_unaligned.1
+          have h_start_flag := h_unaligned.2.2.2.2.2.1
+          have h_start_set_pc := h_unaligned.2.2.2.2.2.2.1
+          have h_start_jmp2 := h_unaligned.2.2.2.2.2.2.2.1
+          have h_finish_jmp2 : m.jmp_offset2 finish.val = 3 := by
+            rcases rd.h_jmp2 with h | h
+            · rw [h.1] at h_adj
+              omega
+            · exact h.2
+          have h_start_pc : (m.pc rd.rows.start.val).val =
+              ia.jalr_input.PC.toNat := by
+            rw [rd.rows.architectural_start]
+            simpa [m] using ia.h_pc_bridge
+          have h_seg := ziskTrace.mainTable_fixed.segment_l1_succ
+            rd.rows.start.val (by simpa [h_adj] using finish.isLt)
+          have h_hand := ziskTrace.mainTransition_to_next_pc rd.rows.start.val
+            (by simpa [h_adj] using finish.isLt) h_seg
+          have h_pc_step := ZiskFv.Airs.Main.pc_handshake_branch m
+            rd.rows.start.val (m.pc (rd.rows.start.val + 1))
+            h_start_set_pc h_hand
+          rw [h_start_flag, h_start_jmp2] at h_pc_step
+          simp only [zero_mul, add_zero] at h_pc_step
+          have h_total :
+              m.pc finish.val + m.jmp_offset2 finish.val =
+                m.pc rd.rows.start.val + 4 := by
+            rw [h_finish_jmp2]
+            have h_finish_pc :
+                m.pc finish.val = m.pc rd.rows.start.val + 1 := by
+              simpa [h_adj] using h_pc_step
+            rw [h_finish_pc]
+            ring
+          exact jalr_link_bridge_scalar (m.pc rd.rows.start.val)
+            (m.pc finish.val) (m.jmp_offset2 finish.val) ia.jalr_input.PC
+            h_total h_start_pc h_domain.h_pc_bound
+      exact ZiskFv.Compliance.equiv_JALR
+        state ia.jalr_input c.imm c.rs1 c.rd
+        ia.misa_val ia.mseccfg (Pilot.execRowAt ziskTrace finish)
+        e_rd nextPC_val m r next_pc store_pc_mem pins rd.h_flag
+        rd.h_m32 rd.h_set_pc rd.h_store_pc h_jalr_subset
+        promises ia.h_input_imm ia.h_input_rs1
+        ia.h_cur_privilege ia.h_mseccfg h_link_bridge
+        h_domain.h_pc_bound h_domain.h_pc_offset_lt_2_32
+
   | sb c => exact stepStrong_sb ziskTrace sailTrace i (toRowData_sb c rd ia) memEv hAvoidKnownBugs
   | sh c => exact stepStrong_sh ziskTrace sailTrace i (toRowData_sh c rd ia) memEv hAvoidKnownBugs
   | sw c => exact stepStrong_sw ziskTrace sailTrace i (toRowData_sw c rd ia) memEv hAvoidKnownBugs

--- a/ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean
@@ -1089,6 +1089,10 @@ private def StepSoundWithoutDecode
       execute_instruction (instruction.JAL (c.imm, c.rd)) (sailTrace i)
       = ZiskFv.Channels.state_effect_via_channels
           ⟨Pilot.execRowOf ziskTrace i, [eRdLui ziskTrace i]⟩ (sailTrace i)
+  -- UNREACHABLE, and kept only so this match stays exhaustive: the public
+  -- `StepSound` matches `.jalr` against its own decode-indexed arm before ever
+  -- falling through to here. That arm supersedes this weaker existential form
+  -- (it fixes the lowering row from the caller's decode instead of positing one).
   | .jalr c =>
       ∃ decode : Decode_jalr ziskTrace i c,
         (do

--- a/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
@@ -1233,8 +1233,15 @@ structure ProgramDecode_jal {numInstructions : Nat}
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits
 
-/-- Per-row committed-program decode bundle for `jalr`: exactly the inputs
-    `Decode_jalr_of_program` consumes besides `trace`/`i`/`c`. -/
+/-- Per-row committed-program decode bundle for `jalr`.
+
+    Unlike every other family, this does NOT yet reduce to committed-ROM
+    evidence: it passes the checked `Decode_jalr` through unchanged. The aligned
+    lowering can already be rebuilt from the program by
+    `Decode_jalr_of_program`, but the unaligned ADD/AND lowering has no such
+    constructor, so no uniform `h_prog` bundle covers both arms. Restoring
+    program-level evidence for both arms is tracked separately; until then the
+    lowering placement is a per-instantiation obligation. -/
 structure ProgramDecode_jalr {numInstructions : Nat}
     (trace : AcceptedZiskTrace numInstructions)
     (i : Fin trace.numInstructions)

--- a/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
@@ -1239,41 +1239,11 @@ structure ProgramDecode_jalr {numInstructions : Nat}
     (trace : AcceptedZiskTrace numInstructions)
     (i : Fin trace.numInstructions)
     (c : Claim_jalr trace i) where
-  h_idx : i.val + 1 < trace.mainTable.table.length
-  h_flag :
-    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).flag
-      i.val = 0
-  h_a_mask_lo :
-    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_0
-      i.val = 4294967294
-  h_a_mask_hi :
-    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_1
-      i.val = 4294967295
-  h_c1_zero :
-    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_1
-      i.val = 0
-  h_offset_bridge :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-        i.val).val = c.offset_bv.toNat
-  h_offset_even :
-    c.offset_bv &&& 1#64 = 0#64
-  h_no_fgl_wrap :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_0 i.val).val
-      + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-          i.val).val < GL_prime
-  bits : RomFlagBits
-  h_bits_ieo : bits.is_external_op = true
-  h_bits_m32 : bits.m32 = false
-  h_bits_set_pc : bits.set_pc = true
-  h_bits_store_pc : bits.store_pc = true
-  h_bits_store_ind : bits.store_ind = false
-  h_prog : ∀ j : Fin trace.programLength,
-        (trace.program j).line
-            = (mainOfTable trace.program trace.mainTable).pc i.val →
-          (trace.program j).op = ZiskFv.Trusted.OP_AND
-        ∧ (trace.program j).jmp_offset2 = 4
-        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
-        ∧ (trace.program j).flags = packFlags bits
+  /-- JALR is the first decode family whose one architectural instruction may
+      span multiple committed Main rows. Its program/decode evidence therefore
+      carries the fully checked lowering placement rather than projecting the
+      architectural index directly into Main. -/
+  toDecode : Decode_jalr trace i c
 
 /-- Per-row committed-program decode bundle for `sb`: exactly the inputs
     `Decode_sb_of_program` consumes besides `trace`/`i`/`c`. -/
@@ -1752,7 +1722,7 @@ noncomputable def rowDecode_of_programDecode (ziskTrace : AcceptedZiskTrace numI
   | lui c => exact RomDecodeBinding.Decode_lui_of_program ziskTrace i c pd.h_idx pd.h_imm_lo_nat pd.h_imm_hi_nat pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | auipc c => exact RomDecodeBinding.Decode_auipc_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | jal c => exact RomDecodeBinding.Decode_jal_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
-  | jalr c => exact RomDecodeBinding.Decode_jalr_of_program ziskTrace i c pd.h_idx pd.h_flag pd.h_a_mask_lo pd.h_a_mask_hi pd.h_c1_zero pd.h_offset_bridge pd.h_offset_even pd.h_no_fgl_wrap pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
+  | jalr _ => exact pd.toDecode
   | sb c => exact RomDecodeBinding.Decode_sb_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | sh c => exact RomDecodeBinding.Decode_sh_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | sw c => exact RomDecodeBinding.Decode_sw_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog

--- a/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
@@ -4186,6 +4186,7 @@ def Decode_jalr_of_program
     (trace : AcceptedZiskTrace numInstructions)
     (i : Fin trace.numInstructions)
     (c : Claim_jalr trace i)
+    (h_offset_aligned : c.offset_bv = BitVec.signExtend 64 c.imm)
     (h_idx : i.val + 1 < trace.mainTable.table.length)
     (h_flag :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).flag
@@ -4223,6 +4224,13 @@ def Decode_jalr_of_program
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_jalr trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
+  let physical : Fin trace.mainTable.table.length := ⟨i.val, h_lt⟩
+  let rows : JalrLoweringRows trace i c.imm c.offset_bv :=
+    { start := physical
+      finish := physical
+      architectural_start := rfl
+      finish_has_successor := h_idx
+      lowering := Or.inl ⟨rfl, h_offset_aligned⟩ }
   have h_dest := mainLuiDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
     (fun j hline => by
       obtain ⟨_hpo, _hpj2, hpso, hpf⟩ := h_prog j hline
@@ -4241,7 +4249,8 @@ def Decode_jalr_of_program
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_true], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_true], hjmp2.symm.trans hpj2⟩
   exact
-    { h_main_op := key.1
+    { rows := rows
+      h_main_op := key.1
       h_main_active := key.2.1
       h_m32 := key.2.2.1
       h_set_pc := key.2.2.2.1
@@ -4253,7 +4262,7 @@ def Decode_jalr_of_program
       h_a_mask_lo := h_a_mask_lo
       h_a_mask_hi := h_a_mask_hi
       h_c1_zero := h_c1_zero
-      h_jmp2 := key.2.2.2.2.2
+      h_jmp2 := Or.inl ⟨rfl, key.2.2.2.2.2⟩
       h_offset_bridge := h_offset_bridge
       h_offset_even := h_offset_even
       h_no_fgl_wrap := h_no_fgl_wrap }

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
@@ -677,6 +677,43 @@ def toRowData_jal {trace : AcceptedZiskTrace numInstructions} {binding : SailTra
   toDecode := dec
   toInputs := ia
 
+/-- Physical Main-row placement for one architectural JALR.
+
+The aligned lowering occupies one Main row. The unaligned lowering occupies an
+`OP_ADD` row followed immediately by the terminal `OP_AND` row. These indices
+are decode/placement evidence about committed rows; they are not an
+accepted-trace certificate or an architectural-to-physical map. -/
+structure JalrLoweringRows
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin trace.numInstructions)
+    (imm : BitVec 12)
+    (offset_bv : BitVec 64) where
+  start : Fin trace.mainTable.table.length
+  finish : Fin trace.mainTable.table.length
+  architectural_start : start.val = i.val
+  finish_has_successor : finish.val + 1 < trace.mainTable.table.length
+  lowering :
+    (start = finish
+      ∧ offset_bv = BitVec.signExtend 64 imm)
+    ∨
+    (start.val + 1 = finish.val
+      ∧ offset_bv = 0#64
+      ∧ (mainOfTable trace.program trace.mainTable).op start.val = ZiskFv.Trusted.OP_ADD
+      ∧ (mainOfTable trace.program trace.mainTable).is_external_op start.val = 1
+      ∧ (mainOfTable trace.program trace.mainTable).m32 start.val = 0
+      ∧ (mainOfTable trace.program trace.mainTable).flag start.val = 0
+      ∧ (mainOfTable trace.program trace.mainTable).set_pc start.val = 0
+      ∧ (mainOfTable trace.program trace.mainTable).jmp_offset2 start.val = 1
+      ∧ BitVec.ofNat 64
+          (((mainOfTable trace.program trace.mainTable).a_0 start.val).val
+            + ((mainOfTable trace.program trace.mainTable).a_1 start.val).val * 4294967296)
+          = BitVec.signExtend 64 imm
+      ∧ (mainRowWithRomAt trace start).rom.b_src_reg = 1
+      ∧ (mainRowWithRomAt trace finish).rom.b_src_imm = 0
+      ∧ (mainRowWithRomAt trace finish).rom.b_src_mem = 0
+      ∧ (mainRowWithRomAt trace finish).rom.b_src_ind = 0
+      ∧ (mainRowWithRomAt trace finish).rom.b_src_reg = 0)
+
 structure Claim_jalr (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   imm : BitVec 12
   rs1 : regidx
@@ -687,84 +724,88 @@ structure Claim_jalr (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.
 
 structure Decode_jalr (trace : AcceptedZiskTrace numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_jalr trace i) : Type where
+  rows : JalrLoweringRows trace i c.imm c.offset_bv
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
-      i.val = ZiskFv.Trusted.OP_AND
+      rows.finish.val = ZiskFv.Trusted.OP_AND
   h_main_active :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).is_external_op
-      i.val = 1
+      rows.finish.val = 1
   h_flag :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).flag
-      i.val = 0
+      rows.finish.val = 0
   h_m32 :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).m32
-      i.val = 0
+      rows.finish.val = 0
   h_set_pc :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).set_pc
-      i.val = 1
+      rows.finish.val = 1
   h_store_pc :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).store_pc
-      i.val = 1
+      rows.finish.val = 1
   h_store_ind :
-    (mainRowWithRomLui trace i).rom.store_ind = 0
+    (mainRowWithRomAt trace rows.finish).rom.store_ind = 0
   h_store_offset :
-    (mainRowWithRomLui trace i).rom.store_offset =
+    (mainRowWithRomAt trace rows.finish).rom.store_offset =
       Transpiler.ind (regidx_to_fin c.rd)
   -- #100 next-PC transition inputs (replace the exec artifacts; the next-PC
   -- residual is now DERIVED via `jalr_setpc_nextPC_discharged`). All are
   -- same-world circuit / decode / ROM pins (no Sail-binding dependency).
   --   * `h_idx`: the next Main row exists (cross-row boundary marker).
-  h_idx : i.val + 1 < trace.mainTable.table.length
+  h_idx : rows.finish.val + 1 < trace.mainTable.table.length
   --   * mask `a`-lane pins (`JALR_MASK = 0xFFFFFFFFFFFFFFFE` loaded into `a`,
   --     `riscv2zisk_context.rs::jalr` `src_a("imm", JALR_MASK)`):
   --     `a_0 = 0xFFFFFFFE`, `a_1 = 0xFFFFFFFF`.
   h_a_mask_lo :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_0
-      i.val = 4294967294
+      rows.finish.val = 4294967294
   h_a_mask_hi :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_1
-      i.val = 4294967295
+      rows.finish.val = 4294967295
   --   * the 32-bit-PC scope pin `c_1 = 0` (JALR analogue of JAL/AUIPC's
   --     `h_pc_offset_lt_2_32`: the AND result's hi lane is dropped by the
   --     set-PC handshake, so the jump must stay inside ZisK's 32-bit PC space).
   h_c1_zero :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_1
-      i.val = 0
+      rows.finish.val = 0
   h_jmp2 :
-    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
-      i.val = 4
+    (rows.start = rows.finish
+      ∧ (mainOfTable trace.program trace.mainTable).jmp_offset2 rows.finish.val = 4)
+    ∨
+    (rows.start.val + 1 = rows.finish.val
+      ∧ (mainOfTable trace.program trace.mainTable).jmp_offset2 rows.finish.val = 3)
   --   * the `jmp_offset1` field ↔ `offset_bv` bridge (unsigned-equal offset
   --     contract, same shape AUIPC/JAL use) + the evenness ROM guard
   --     (aligned `imm % 4 == 0` ⇒ `offset_bv` even; trivial for unaligned
   --     `offset_bv = 0`) + the field-level no-FGL-wrap bound.
   h_offset_bridge :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-        i.val).val = c.offset_bv.toNat
+        rows.finish.val).val = c.offset_bv.toNat
   h_offset_even : c.offset_bv &&& 1#64 = 0#64
   h_no_fgl_wrap :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_0 i.val).val
+    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_0
+        rows.finish.val).val
       + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-          i.val).val < GL_prime
+          rows.finish.val).val < GL_prime
 
 structure Inputs_jalr (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_jalr trace i) : Type where
   jalr_input : PureSpec.JalrInput
   misa_val : RegisterType Register.misa
   mseccfg : RegisterType Register.mseccfg
-  -- #100: the per-lowering operand identity replacing the cross-world
-  -- `h_nextPC_matches`. The committed Main `b`-lane (`b_0 + b_1 · 2^32`) plus
-  -- `offset_bv` equals Sail's pre-mask target `rs1_val + signExtend 64 imm`:
-  --   * aligned   (`b = rs1`,        `offset_bv = signExtend imm`);
-  --   * unaligned (`b = rs1 + imm`,  `offset_bv = 0`).
-  -- A TRUE, satisfiable fact for a real JALR row in BOTH lowerings (the masking
-  -- itself is handled downstream by `jalr_setpc_nextPC_discharged`).
-  h_operand_offset :
+  /-- Genuine cross-world input agreement at the lowering's source row.
+
+  This says only that the committed register-sourced `b` operand equals Sail's
+  `rs1` value. For an unaligned lowering, the ADD result, source-C copy into the
+  terminal AND row, and zero terminal offset are derived from live circuit,
+  provider, transition, and decode evidence. -/
+  h_rs1_start :
     BitVec.ofNat 64
-        (((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).b_0 i.val).val
+        (((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).b_0
+            i.val).val
           + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).b_1
               i.val).val * 4294967296)
-      + c.offset_bv
-      = jalr_input.rs1_val + BitVec.signExtend 64 jalr_input.imm
+      = jalr_input.rs1_val
   h_input_rd : jalr_input.rd = regidx_to_fin c.rd
   h_input_pc : (binding i).regs.get? Register.PC = .some jalr_input.PC
   h_pc_bridge :

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
@@ -642,7 +642,8 @@ structure Decode_jal (trace : AcceptedZiskTrace numInstructions)
   -- carries h_set_pc above): the next row exists. The taken-offset pin is
   -- committed-program decode (`h_jmp_offset1_imm`); the target no-wrap bound
   -- still lives in Inputs because it references `jal_input.PC`. `flag = 1` is DERIVED in
-  -- `stepStrong_jal` from the OP_FLAG decode pins + `internal_op0_sets_flag`.
+  -- the dispatcher's `jal` arm from the OP_FLAG decode pins via
+  -- `flag_eq_one_of_internal_op_zero`.
   h_idx : i.val + 1 < trace.mainTable.table.length
 
 structure Inputs_jal (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
@@ -661,21 +662,9 @@ structure Inputs_jal (trace : AcceptedZiskTrace numInstructions) (binding : Sail
   h_success : (PureSpec.execute_JAL_pure jal_input).success = true
   h_input_imm : jal_input.imm = c.imm
 
-/-- Per-op residual bundle for the `jal` archetype: the 3-way `Claim`/`Decode`/`Inputs`
-    split is the single declaration site for every field; `RowData_jal` bundles them. -/
-structure RowData_jal
-    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
-  toClaim : Claim_jal trace i
-  toDecode : Decode_jal trace i toClaim
-  toInputs : Inputs_jal trace binding i toClaim
-
-def toRowData_jal {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
-    {i : Fin trace.numInstructions}
-    (c : Claim_jal trace i) (dec : Decode_jal trace i c)
-    (ia : Inputs_jal trace binding i c) : RowData_jal trace binding i where
-  toClaim := c
-  toDecode := dec
-  toInputs := ia
+-- `jal` and `jalr` have no `RowData_<op>` bundle: their dispatch arms consume
+-- the `Claim`/`Decode`/`Inputs` triple directly (the `jalr` conclusion is stated
+-- at the decode-selected lowering row, which a `RowData` bundle cannot index).
 
 /-- Physical Main-row placement for one architectural JALR.
 
@@ -824,21 +813,6 @@ structure Inputs_jalr (trace : AcceptedZiskTrace numInstructions) (binding : Sai
   -- #100: JALR link-PC range/domain facts live in `RowOutsideDefectRegion`
   -- as `JalrRangeDomain`.
 
-/-- Per-op residual bundle for the `jalr` archetype: the 3-way `Claim`/`Decode`/`Inputs`
-    split is the single declaration site for every field; `RowData_jalr` bundles them. -/
-structure RowData_jalr
-    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions) where
-  toClaim : Claim_jalr trace i
-  toDecode : Decode_jalr trace i toClaim
-  toInputs : Inputs_jalr trace binding i toClaim
-
-def toRowData_jalr {trace : AcceptedZiskTrace numInstructions} {binding : SailTrace trace.numInstructions}
-    {i : Fin trace.numInstructions}
-    (c : Claim_jalr trace i) (dec : Decode_jalr trace i c)
-    (ia : Inputs_jalr trace binding i c) : RowData_jalr trace binding i where
-  toClaim := c
-  toDecode := dec
-  toInputs := ia
 
 structure Claim_fence (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.numInstructions) where
   fm : BitVec 4

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
@@ -70,6 +70,25 @@ theorem eRdLui_rd_idx_of_decode
   rw [h_addr2, h_store_offset, h_store_ind]
   simp [Transpiler.wrap_to_regidx_ind]
 
+/-- Physical-row counterpart of `eRdLui_rd_idx_of_decode`. -/
+theorem eRdAt_rd_idx_of_decode
+    {numInstructions : Nat}
+    {trace : AcceptedZiskTrace numInstructions}
+    {i : Fin trace.mainTable.table.length}
+    {rd : regidx}
+    (h_store_ind : (mainRowWithRomAt trace i).rom.store_ind = 0)
+    (h_store_offset :
+      (mainRowWithRomAt trace i).rom.store_offset =
+        Transpiler.ind (regidx_to_fin rd)) :
+    regidx_to_fin rd =
+      Transpiler.wrap_to_regidx (eRdAt trace i).ptr := by
+  have h_spec := RomDecodeBinding.mainAddressSpec_at trace i
+  have h_addr2 := h_spec.2.2.1
+  rw [eRdAt, ZiskFv.AirsClean.Main.cMemMessage,
+    ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry]
+  rw [h_addr2, h_store_offset, h_store_ind]
+  simp [Transpiler.wrap_to_regidx_ind]
+
 private theorem lane_lo_eq_natCast_of_toNat_lt_2_32
     {r1_val : BitVec 64}
     (h_r1_lt32 : r1_val.toNat < 4294967296) :
@@ -287,6 +306,220 @@ theorem jalr_link_bridge_of_decode
     Nat.lt_trans (Fin.isLt _) h_gl_lt64
   rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt h_val_lt64] at h_toNat
   exact h_toNat
+
+/-- JALR link-value bridge for the unaligned physical ADD/AND lowering. -/
+theorem jalr_link_bridge_unaligned
+    {numInstructions : Nat}
+    {trace : AcceptedZiskTrace numInstructions}
+    (start finish : Fin trace.mainTable.table.length)
+    {pc : BitVec 64}
+    (h_adj : start.val + 1 = finish.val)
+    (h_start_flag :
+      (mainOfTable trace.program trace.mainTable).flag start.val = 0)
+    (h_start_set_pc :
+      (mainOfTable trace.program trace.mainTable).set_pc start.val = 0)
+    (h_start_jmp2 :
+      (mainOfTable trace.program trace.mainTable).jmp_offset2 start.val = 1)
+    (h_finish_jmp2 :
+      (mainOfTable trace.program trace.mainTable).jmp_offset2 finish.val = 3)
+    (h_pc_bridge :
+      ((mainOfTable trace.program trace.mainTable).pc start.val).val = pc.toNat)
+    (h_pc_bound : pc.toNat < GL_prime - 4) :
+    ((mainOfTable trace.program trace.mainTable).pc finish.val
+        + (mainOfTable trace.program trace.mainTable).jmp_offset2 finish.val).val
+      = (pc + 4#64).toNat := by
+  have h_seg := trace.mainTable_fixed.segment_l1_succ
+    start.val (by simpa [h_adj] using finish.isLt)
+  have h_hand := trace.mainTransition_to_next_pc start.val
+    (by simpa [h_adj] using finish.isLt) h_seg
+  have h_pc_step := ZiskFv.Airs.Main.pc_handshake_branch
+    (mainOfTable trace.program trace.mainTable) start.val
+    ((mainOfTable trace.program trace.mainTable).pc (start.val + 1))
+    h_start_set_pc h_hand
+  rw [h_start_flag, h_start_jmp2] at h_pc_step
+  simp only [zero_mul, add_zero] at h_pc_step
+  have h_finish_pc :
+      (mainOfTable trace.program trace.mainTable).pc finish.val =
+        (mainOfTable trace.program trace.mainTable).pc start.val + 1 := by
+    simpa [h_adj] using h_pc_step
+  rw [h_finish_jmp2, h_finish_pc]
+  have h_bv_eq := Pilot.ofNat_fgl_pc_plus_4_eq
+    ((mainOfTable trace.program trace.mainTable).pc start.val)
+    pc h_pc_bridge h_pc_bound
+  have h_toNat := congrArg BitVec.toNat h_bv_eq
+  have h_gl_lt64 : GL_prime < 2 ^ 64 :=
+    ZiskFv.PackedBitVec.WidePCNoWrap.GL_prime_lt_pow_64
+  have h_field :
+      (mainOfTable trace.program trace.mainTable).pc start.val + 1 + 3 =
+        (mainOfTable trace.program trace.mainTable).pc start.val + 4 := by ring
+  rw [h_field]
+  have h_val_lt64 :
+      ((((mainOfTable trace.program trace.mainTable).pc start.val
+        + 4 : FGL)).val) < 2 ^ 64 :=
+    Nat.lt_trans (Fin.isLt _) h_gl_lt64
+  rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt h_val_lt64] at h_toNat
+  exact h_toNat
+
+theorem jalr_link_bridge_scalar
+    (base finishPC finishOffset : FGL) (pc : BitVec 64)
+    (h_total : finishPC + finishOffset = base + 4)
+    (h_pc : base.val = pc.toNat)
+    (h_pc_bound : pc.toNat < GL_prime - 4) :
+    (finishPC + finishOffset).val = (pc + 4#64).toNat := by
+  rw [h_total]
+  have h_bv_eq :=
+    Pilot.ofNat_fgl_pc_plus_4_eq base pc h_pc h_pc_bound
+  have h_toNat := congrArg BitVec.toNat h_bv_eq
+  have h_gl_lt64 : GL_prime < 2 ^ 64 :=
+    ZiskFv.PackedBitVec.WidePCNoWrap.GL_prime_lt_pow_64
+  have h_val_lt64 : ((base + 4 : FGL).val) < 2 ^ 64 :=
+    Nat.lt_trans (Fin.isLt _) h_gl_lt64
+  rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt h_val_lt64] at h_toNat
+  exact h_toNat
+
+/-- Packed ADD result at a physical Main row, resolving either live provider
+    arm without exposing the dependent provider disjunction in the theorem
+    signature. -/
+theorem main_add_packed_result_at
+    {numInstructions : Nat}
+    (trace : AcceptedZiskTrace numInstructions)
+    (start : Fin trace.mainTable.table.length)
+    (h_active : (mainOfTable trace.program trace.mainTable).is_external_op
+      start.val = 1)
+    (h_op : (mainOfTable trace.program trace.mainTable).op start.val = OP_ADD)
+    (h_m32 : (mainOfTable trace.program trace.mainTable).m32 start.val = 0) :
+    BitVec.ofNat 64
+        (((mainOfTable trace.program trace.mainTable).c_0 start.val).val
+          + ((mainOfTable trace.program trace.mainTable).c_1 start.val).val
+            * 4294967296)
+      =
+      BitVec.ofNat 64
+          (((mainOfTable trace.program trace.mainTable).a_0 start.val).val
+            + ((mainOfTable trace.program trace.mainTable).a_1 start.val).val
+              * 4294967296)
+        +
+        BitVec.ofNat 64
+          (((mainOfTable trace.program trace.mainTable).b_0 start.val).val
+            + ((mainOfTable trace.program trace.mainTable).b_1 start.val).val
+              * 4294967296) := by
+  obtain ⟨_, h_provider⟩ :=
+    main_request_add_provided_at trace start h_active h_op
+  rcases h_provider with h_static | h_binaryadd
+  · obtain ⟨table, _, row, hrow, hcomponent, hspec, hmatch⟩ := h_static
+    let providerInput :=
+      ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
+        (table.environment row)
+    obtain ⟨hcore, hfacts⟩ :=
+      ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
+        hcomponent hspec hrow
+    have hstatic :
+        ZiskFv.AirsClean.Binary.StaticBinaryTableSpecFacts providerInput :=
+      ZiskFv.AirsClean.BinaryFamily.staticBinary_spec_facts_of_table_spec
+        hcomponent hspec hrow
+    exact main_add_packed_result_of_static_provider
+      (mainOfTable trace.program trace.mainTable) start.val providerInput
+      h_op h_m32 hcore hfacts hstatic hmatch
+  · obtain ⟨table, _, row, hrow, hcomponent, hspec, hmatch⟩ := h_binaryadd
+    let providerInput :=
+      ZiskFv.AirsClean.BinaryAdd.component.rowInput (table.environment row)
+    have hfacts :
+        ZiskFv.AirsClean.BinaryAdd.ComponentSpecFacts providerInput := by
+      have hs : ZiskFv.AirsClean.BinaryAdd.component.Spec
+          (table.environment row) := by
+        simpa [hcomponent] using hspec row hrow
+      simpa [providerInput, ZiskFv.AirsClean.BinaryAdd.component_spec] using hs
+    exact main_add_packed_result_of_binaryadd_provider
+      (mainOfTable trace.program trace.mainTable) start.val providerInput
+      h_m32 hfacts hmatch
+
+/-- Pure row algebra for Main's non-segment source-C copy constraint. -/
+theorem source_c_copy_lanes_of_between
+    (previous current : ZiskFv.AirsClean.Main.MainRowWithRom FGL)
+    (h_transition : ZiskFv.AirsClean.Main.transitionBetween previous current)
+    (h_segment : current.core.segment_l1 = 0)
+    (h_b_imm : current.rom.b_src_imm = 0)
+    (h_b_mem : current.rom.b_src_mem = 0)
+    (h_b_ind : current.rom.b_src_ind = 0)
+    (h_b_reg : current.rom.b_src_reg = 0) :
+    current.core.b_0 = previous.core.c_0
+      ∧ current.core.b_1 = previous.core.c_1 := by
+  simpa [ZiskFv.AirsClean.Main.sourceCCopyBetween, h_segment,
+    h_b_imm, h_b_mem, h_b_ind, h_b_reg, sub_eq_zero] using h_transition.2
+
+theorem jalr_unaligned_operand_target
+    (m : Valid_Main FGL FGL)
+    (architectural start finish : Nat)
+    (claimOffset : BitVec 64) (claimImm inputImm : BitVec 12)
+    (rs1 : BitVec 64)
+    (h_offset : claimOffset = 0#64)
+    (h_add :
+      BitVec.ofNat 64 ((m.c_0 start).val + (m.c_1 start).val * 4294967296)
+        =
+      BitVec.ofNat 64 ((m.a_0 start).val + (m.a_1 start).val * 4294967296)
+        + BitVec.ofNat 64
+          ((m.b_0 start).val + (m.b_1 start).val * 4294967296))
+    (h_copy :
+      m.b_0 finish = m.c_0 start ∧ m.b_1 finish = m.c_1 start)
+    (h_start_a :
+      BitVec.ofNat 64 ((m.a_0 start).val + (m.a_1 start).val * 4294967296)
+        = BitVec.signExtend 64 claimImm)
+    (h_architectural : start = architectural)
+    (h_rs1 :
+      BitVec.ofNat 64
+          ((m.b_0 architectural).val + (m.b_1 architectural).val * 4294967296)
+        = rs1)
+    (h_imm : inputImm = claimImm) :
+    BitVec.ofNat 64 ((m.b_0 finish).val + (m.b_1 finish).val * 4294967296)
+        + claimOffset
+      = rs1 + BitVec.signExtend 64 inputImm := by
+  rw [h_offset, BitVec.add_zero, h_copy.1, h_copy.2, h_add,
+    h_start_a, h_architectural, h_rs1, h_imm]
+  exact BitVec.add_comm _ _
+
+theorem transitionBetween_of_pcHandshakeTransition
+    (programLength : Nat)
+    (program : ZiskFv.AirsClean.ZiskInstructionRom.Program programLength)
+    (idx : Nat) (previous current : Environment FGL)
+    (h : ZiskFv.AirsClean.Main.pcHandshakeTransition idx previous current) :
+    ZiskFv.AirsClean.Main.transitionBetween
+      ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          programLength program).rowInput previous)
+      ((ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          programLength program).rowInput current) := by
+  simpa only [ZiskFv.AirsClean.Main.pcHandshakeTransition,
+    Air.Flat.Component.rowInput, Air.Flat.Component.rowInputVar,
+    eval_varFromOffset_valueFromOffset] using h
+
+theorem jalr_nextPC_matches_of_target
+    (execPC operand offset target : BitVec 64)
+    (h_exec :
+      execPC = 0xFFFFFFFFFFFFFFFE#64 &&& (operand + offset))
+    (h_target : operand + offset = target) :
+    execPC = 0xFFFFFFFFFFFFFFFE#64 &&& target := by
+  rw [h_exec, h_target]
+
+theorem jal_nextPC_matches_of_physical
+    {numInstructions : Nat}
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin trace.numInstructions)
+    (pc : BitVec 64) (imm : BitVec 21)
+    (h_idx : i.val + 1 < trace.mainTable.table.length)
+    (h_set_pc : (mainOfTable trace.program trace.mainTable).set_pc i.val = 0)
+    (h_flag : (mainOfTable trace.program trace.mainTable).flag i.val = 1)
+    (h_pc_bridge :
+      ((mainOfTable trace.program trace.mainTable).pc i.val).val = pc.toNat)
+    (h_offset_bridge :
+      ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val).val =
+        (BitVec.signExtend 64 imm).toNat)
+    (h_no_wrap :
+      ((mainOfTable trace.program trace.mainTable).pc i.val).val
+        + ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val).val < GL_prime) :
+    (register_type_pc_equiv ▸
+        (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
+      = pc + BitVec.signExtend 64 imm := by
+  rw [Pilot.flag_path_nextPC_discharged trace i h_idx h_set_pc h_flag]
+  exact Pilot.ofNat_fgl_pc_plus_offset_eq _ _ pc (BitVec.signExtend 64 imm)
+    h_pc_bridge h_offset_bridge h_no_wrap
 
 /-! ## Strengthened control-flow + U-type arms (branches, JAL/JALR, LUI/AUIPC)
 
@@ -1212,314 +1445,6 @@ theorem stepStrong_auipc
   have h_known : Defects.NoKnownDefect env :=
     noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
   exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.1
-
-/-- Strengthened `jal` step (channel-balance form), via the OpEnvelope route:
-    CONSTRUCT `OpEnvelope.jal` from the trace's `RowData_jal` and invoke
-    `zisk_riscv_compliant_program_bus`, projecting the `exec_eq_remaining`
-    conjunct.
-
-    Same PATH-1 provenance construction as `stepStrong_lui`/`stepStrong_auipc`:
-    the JAL `provenance`/`row_mode` are BUILT from the five mode pins
-    (`mainRowProvenance_of_pins`).  `aeneasBridgeTrust` is the JAL tuple
-    `⟨⟨provenance⟩, row_mode, h_jmp2, h_pc_bridge⟩`; `NoKnownDefect` from the
-    locally-assembled `NoKnownDefect` (non-defect). -/
-theorem stepStrong_jal
-    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_jal trace binding i)
-    (h_domain : JalRangeDomain d.toInputs.jal_input) :
-    execute_instruction (instruction.JAL (d.toClaim.imm, d.toClaim.rd)) (binding i)
-      = ZiskFv.Channels.state_effect_via_channels
-          ⟨Pilot.execRowOf trace i, [eRdLui trace i]⟩ (binding i) := by
-  set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
-  set state := binding i with hstate
-  let e_rd := eRdLui trace i
-  -- (a) Main per-row Spec ⇒ the JAL Main constraint subset.
-  have h_spec := mainSpec_at trace binding i
-  have h_add_subset : ZiskFv.Airs.Main.add_subset_holds m i.val :=
-    ZiskFv.AirsClean.Main.add_subset_holds_of_spec_rowAt m i.val h_spec
-  obtain ⟨h_c0, _h_b0, h_c1, _h_b1, h_set_flag, _h_clear_flag, h_disjoint,
-      h_flag_bool, h_ext_bool⟩ := h_add_subset
-  -- #100: `flag = 1` is DERIVED (not pinned) from the OP_FLAG decode pins
-  -- and the Main `internal_op0_sets_flag` constraint (`h_set_flag`).
-  have h_flag : m.flag i.val = 1 :=
-    ZiskFv.Airs.Main.flag_eq_one_of_internal_op_zero m i.val d.toDecode.h_main_active
-      (by simpa [ZiskFv.Trusted.OP_FLAG] using d.toDecode.h_main_op) h_set_flag
-  let nextPC_val : BitVec 64 :=
-    d.toInputs.jal_input.PC + BitVec.signExtend 64 d.toInputs.jal_input.imm
-  have h_nextPC_option :
-      (PureSpec.execute_JAL_pure d.toInputs.jal_input).nextPC = .some nextPC_val :=
-    PureSpec.execute_JAL_pure_succ_nextPC d.toInputs.jal_input d.toInputs.h_success
-  -- #100: the field-level no-wrap bound (`pc.val + jmp_offset1.val < GL_prime`),
-  -- in column form for `ofNat_fgl_pc_plus_offset_eq`, from the input-facing
-  -- target bound via the PC / offset row-shape bridges.
-  have h_offset_bridge :
-      (m.jmp_offset1 i.val).val =
-        (BitVec.signExtend 64 d.toInputs.jal_input.imm).toNat := by
-    simpa [hm, d.toInputs.h_input_imm] using d.toDecode.h_jmp_offset1_imm
-  have h_no_wrap_fgl :
-      ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
-        + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-            i.val).val
-        < GL_prime := by
-    rw [d.toInputs.h_pc_bridge, h_offset_bridge]
-    exact h_domain.h_no_fgl_wrap
-  let next_pc : FGL :=
-    m.set_pc i.val * (m.c_0 i.val + m.jmp_offset1 i.val)
-      + (1 - m.set_pc i.val) * (m.pc i.val + m.jmp_offset2 i.val)
-      + m.flag i.val * (m.jmp_offset1 i.val - m.jmp_offset2 i.val)
-  have h_handshake :
-      ZiskFv.Airs.Main.pc_handshake_with_next_pc m i.val next_pc := rfl
-  have h_jal_subset :
-      ZiskFv.Airs.Main.jump_subset_holds m i.val next_pc :=
-    ⟨h_flag_bool, h_ext_bool, h_disjoint, h_c0, h_c1, h_set_flag, h_handshake⟩
-  -- (b1) provenance + row_mode built from the five decode pins.
-  let provenance : ZiskFv.Compliance.MainRowProvenance m i.val :=
-    mainRowProvenance_of_pins m i.val ZiskFv.Compliance.ExtractedConst.opFlag
-      false false false true
-      (by simpa [ZiskFv.Trusted.OP_FLAG, ZiskFv.Compliance.natF,
-        ZiskFv.Compliance.ExtractedConst.opFlag] using d.toDecode.h_main_op)
-      (by simpa [ZiskFv.Compliance.boolF] using d.toDecode.h_main_active)
-      (by simpa [ZiskFv.Compliance.boolF] using d.toDecode.h_m32)
-      (by simpa [ZiskFv.Compliance.boolF] using d.toDecode.h_set_pc)
-      (by simpa [ZiskFv.Compliance.boolF] using d.toDecode.h_store_pc)
-  let row_mode : ZiskFv.Compliance.MainRowProvenance.JalRowMode provenance :=
-    { op_eq := rfl, internal_eq := rfl, m32_eq := rfl, set_pc_eq := rfl, store_pc_eq := rfl }
-  have h_row_core :
-      (mainRowWithRomLui trace i).core =
-        ZiskFv.AirsClean.Main.rowAt m i.val := by
-    have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-      trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-    simpa [mainRowWithRomLui, m,
-      ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-  let store_pc_mem : ZiskFv.Compliance.StorePcMemoryWitness m i.val e_rd :=
-    { row := mainRowWithRomLui trace i
-      row_eq := h_row_core
-      rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
-  let promises : ZiskFv.EquivCore.Promises.JumpPromises
-      state d.toInputs.jal_input.PC d.toInputs.jal_input.rd d.toInputs.misa_val
-      (PureSpec.execute_JAL_pure d.toInputs.jal_input).success
-      (PureSpec.execute_JAL_pure d.toInputs.jal_input).nextPC
-      d.toClaim.rd (Pilot.execRowOf trace i) e_rd nextPC_val :=
-    { input_rd_eq := d.toInputs.h_input_rd
-      input_pc_eq := d.toInputs.h_input_pc
-      input_misa_eq := d.toInputs.h_input_misa
-      misa_c_zero := d.toInputs.h_misa_c
-      exec_len := by rfl
-      e0_mult := by rfl
-      e1_mult := by rfl
-      -- #100: next-PC residual DISCHARGED from the in-circuit transition
-      -- certificate via the FLAG-PATH lemma (set_pc=0, flag=1 ⇒ pc + jmp_offset1),
-      -- then the signed-offset wide-PC cast (`jmp_offset1 = signExtend imm` +
-      -- target no-wrap) gives JAL's taken target `PC + signExtend 64 imm`,
-      -- with `nextPC_val` chosen as that computed target.
-      nextPC_matches := by
-        have hstep := Pilot.flag_path_nextPC_discharged trace i
-          d.toDecode.h_idx d.toDecode.h_set_pc h_flag
-        rw [hstep]
-        simpa [nextPC_val] using (Pilot.ofNat_fgl_pc_plus_offset_eq _ _
-          d.toInputs.jal_input.PC (BitVec.signExtend 64 d.toInputs.jal_input.imm)
-          d.toInputs.h_pc_bridge h_offset_bridge h_no_wrap_fgl)
-      rd_mult := by rfl
-      rd_as := by rfl
-      success := d.toInputs.h_success
-      nextPC_option := h_nextPC_option
-      rd_idx := d.toInputs.h_input_rd.trans
-        (eRdLui_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset) }
-  have h_not_throws : (PureSpec.execute_JAL_pure d.toInputs.jal_input).throws = false :=
-    PureSpec.execute_JAL_pure_succ_throws
-      d.toInputs.jal_input d.toInputs.h_success
-  let env : OpEnvelope state m i.val :=
-    OpEnvelope.jal d.toInputs.jal_input d.toClaim.imm d.toClaim.rd d.toInputs.misa_val next_pc (Pilot.execRowOf trace i) e_rd
-      nextPC_val store_pc_mem provenance row_mode h_jal_subset d.toDecode.h_jmp2 d.toInputs.h_pc_bridge
-      promises d.toInputs.h_input_imm h_not_throws h_domain.h_pc_bound
-      h_domain.h_pc_offset_lt_2_32
-  have h_bridge : env.aeneasBridgeTrust :=
-    ⟨⟨provenance⟩, row_mode, d.toDecode.h_jmp2, d.toInputs.h_pc_bridge⟩
-  have h_mem : env.memoryTimelineConstructionEvidence := by trivial
-  have h_known : Defects.NoKnownDefect env :=
-    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
-  exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
-
-/-- Strengthened `jalr` step (channel-balance form), via the OpEnvelope route:
-    CONSTRUCT `OpEnvelope.jalr` from the trace's `RowData_jalr` (mirroring
-    `construction_jalr_sound`'s internal `next_pc` / `e_rd` / `store_pc_mem` /
-    `pins` / `h_jalr_subset` / `promises` derivations) and invoke
-    `zisk_riscv_compliant_program_bus`, projecting the `exec_eq_remaining`
-    conjunct.  The non-defect arm carries no defect obligation (`True`);
-    `NoKnownDefect` is assembled locally via `noKnownDefect_of_shapes`.  JALR's
-    `aeneasBridgeTrust` is flat decode pins already in
-    `RowData_jalr` (no `MainRowProvenance`). -/
-theorem stepStrong_jalr
-    (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions) (i : Fin trace.numInstructions)
-    (d : RowData_jalr trace binding i)
-    (h_domain : JalrRangeDomain d.toInputs.jalr_input) :
-    (do
-      Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
-      LeanRV64D.Functions.execute (instruction.JALR (d.toClaim.imm, d.toClaim.rs1, d.toClaim.rd))) (binding i)
-      = ZiskFv.Channels.state_effect_via_channels
-          ⟨Pilot.execRowOf trace i, [eRdLui trace i]⟩ (binding i) := by
-  set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
-  set state := binding i with hstate
-  let e_rd := eRdLui trace i
-  -- (a) Main per-row Spec ⇒ the JALR Main constraint subset.
-  have h_spec := mainSpec_at trace binding i
-  have h_add_subset : ZiskFv.Airs.Main.add_subset_holds m i.val :=
-    ZiskFv.AirsClean.Main.add_subset_holds_of_spec_rowAt m i.val h_spec
-  obtain ⟨_h_c0, _h_b0, _h_c1, _h_b1, _h_set_flag, _h_clear_flag, h_disjoint,
-      h_flag_bool, h_ext_bool⟩ := h_add_subset
-  -- (a) the handshake is definitional: pick `next_pc` as its RHS.
-  let next_pc : FGL :=
-    m.set_pc i.val * (m.c_0 i.val + m.jmp_offset1 i.val)
-      + (1 - m.set_pc i.val) * (m.pc i.val + m.jmp_offset2 i.val)
-      + m.flag i.val * (m.jmp_offset1 i.val - m.jmp_offset2 i.val)
-  have h_handshake :
-      ZiskFv.Airs.Main.pc_handshake_with_next_pc m i.val next_pc := rfl
-  have h_jalr_subset :
-      ZiskFv.Airs.Main.flag_boolean m i.val
-      ∧ ZiskFv.Airs.Main.is_external_op_boolean m i.val
-      ∧ ZiskFv.Airs.Main.flag_set_pc_disjoint m i.val
-      ∧ ZiskFv.Airs.Main.pc_handshake_with_next_pc m i.val next_pc :=
-    ⟨h_flag_bool, h_ext_bool, h_disjoint, h_handshake⟩
-  -- (a) `StorePcMemoryWitness` from the real Clean Main `c` message row.
-  have h_row_core :
-      (mainRowWithRomLui trace i).core =
-        ZiskFv.AirsClean.Main.rowAt m i.val := by
-    have := ZiskFv.AirsClean.FullEnsemble.rowAt_mainOfTable
-      trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-    simpa [mainRowWithRomLui, m,
-      ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get (idx := ⟨i.val, trace.mainTable_index i⟩)] using this.symm
-  let store_pc_mem : ZiskFv.Compliance.StorePcMemoryWitness m i.val e_rd :=
-    { row := mainRowWithRomLui trace i
-      row_eq := h_row_core
-      rd_write_match := ZiskFv.Airs.MemoryBus.matches_memory_entry_refl _ }
-  let pins : ZiskFv.Compliance.MainRowPins m i.val 1 OP_AND :=
-    ⟨d.toDecode.h_main_active, d.toDecode.h_main_op⟩
-  -- (b) Binary `OP_AND` provider witnesses for the JALR row (mirrors
-  --     `stepStrong_and`): the static Binary table row backing the masked-AND.
-  obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
-      h_component, h_table_spec, h_match⟩ :=
-    main_request_logic_provided
-      trace i d.toDecode.h_main_active (Or.inl d.toDecode.h_main_op)
-  let providerInput :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_static :
-      ZiskFv.AirsClean.Binary.StaticBinaryTableSpecFacts providerInput :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_spec_facts_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_m32_zero : m.m32 i.val = 0 := d.toDecode.h_m32
-  have h_emit :
-      providerInput.chain.b_op + 16 * providerInput.mode.mode32 =
-        (ZiskFv.Airs.Tables.BinaryTable.OP_AND : FGL) := by
-    have h_match_op := h_match
-    simp only [ZiskFv.Airs.OperationBus.matches_entry,
-      ZiskFv.Airs.OperationBus.opBus_row_Main] at h_match_op
-    have h_op_match :
-        m.op i.val = providerInput.chain.b_op + 16 * providerInput.mode.mode32 :=
-      h_match_op.2.1
-    rw [← h_op_match]
-    simpa [ZiskFv.Airs.Tables.BinaryTable.OP_AND, ZiskFv.Trusted.OP_AND] using
-      d.toDecode.h_main_op
-  obtain ⟨h_row_m32, h_bop, _⟩ :=
-    ZiskFv.EquivCore.Bridge.Binary.logic_row_mode_pins_of_emit_op_lt_16_of_static_spec
-      providerInput h_static ZiskFv.Airs.Tables.BinaryTable.OP_AND (by
-        simp [ZiskFv.Airs.Tables.BinaryTable.OP_AND])
-      h_core h_emit
-  have h_out :=
-    ZiskFv.EquivCore.Bridge.Binary.byte_chain_discharge_64_of_static_row
-      providerInput h_facts
-      ZiskFv.Airs.Tables.BinaryTable.OP_AND h_core h_row_m32 h_bop
-  have h_matches :
-      ZiskFv.EquivCore.Bridge.Binary.all_byte_matches_wf_at_row
-        providerInput ZiskFv.Airs.Tables.BinaryTable.OP_AND :=
-    allByteMatchesOfStaticOut64_local h_out
-  -- (c) lane projections: `a = mask`, `b = operand` (committed `b`-lane packing),
-  --     and the carry-free `c` lanes (from `flag = 0`).
-  have h_a_mask :
-      ZiskFv.EquivCore.Add.binaryRowA64 providerInput = 0xFFFFFFFFFFFFFFFE#64 := by
-    have h_a_pack : ZiskFv.EquivCore.Add.binaryRowA64 providerInput
-        = BitVec.ofNat 64 ((m.a_0 i.val).val + (m.a_1 i.val).val * 4294967296) := by
-      simpa [ZiskFv.EquivCore.Add.binaryRowA64] using
-        (ZiskFv.EquivCore.Bridge.Binary.main_a_packing_of_match
-          m providerInput i.val h_matches h_m32_zero h_match).symm
-    rw [h_a_pack, d.toDecode.h_a_mask_lo, d.toDecode.h_a_mask_hi]
-    decide
-  have h_b_operand :
-      ZiskFv.EquivCore.Add.binaryRowB64 providerInput
-        = BitVec.ofNat 64 ((m.b_0 i.val).val + (m.b_1 i.val).val * 4294967296) := by
-    simpa [ZiskFv.EquivCore.Add.binaryRowB64] using
-      (ZiskFv.EquivCore.Bridge.Binary.main_b_packing_of_match
-        m providerInput i.val h_matches h_m32_zero h_match).symm
-  obtain ⟨h_match_clo, h_match_chi⟩ :=
-    ZiskFv.EquivCore.Bridge.Binary.main_c_lanes_carryfree_of_match
-      m providerInput i.val h_match d.toDecode.h_flag
-  obtain ⟨hc0, hc1, hc2, hc3, hc4, hc5, hc6, hc7⟩ :=
-    ZiskFv.EquivCore.Bridge.Binary.cByte_ranges_of_all_byte_matches_row
-      providerInput h_matches
-  let nextPC_val : BitVec 64 :=
-    0xFFFFFFFFFFFFFFFE &&&
-      (d.toInputs.jalr_input.rs1_val + BitVec.signExtend 64 d.toInputs.jalr_input.imm)
-  have h_nextPC_option :
-      (PureSpec.execute_JALR_pure d.toInputs.jalr_input).nextPC = .some nextPC_val :=
-    PureSpec.execute_JALR_pure_succ_nextPC d.toInputs.jalr_input d.toInputs.h_success
-  -- (e) #100: the cross-world next-PC residual is DISCHARGED from the accepted
-  --     trace's in-circuit set-PC handshake composed with the masked-AND
-  --     target-value derivation (`jalr_setpc_nextPC_discharged`), then bridged to
-  --     Sail's `mask &&& (rs1 + signExtend imm)` via the per-lowering operand
-  --     identity (`h_operand_offset`) and the success-branch target (`h_target`).
-  have h_nextPC_disch :
-      (register_type_pc_equiv ▸
-          (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
-        = nextPC_val := by
-    have hoo := d.toInputs.h_operand_offset
-    rw [← hm] at hoo
-    rw [ZiskFv.Compliance.Pilot.jalr_setpc_nextPC_discharged
-          trace i providerInput
-          (BitVec.ofNat 64 ((m.b_0 i.val).val + (m.b_1 i.val).val * 4294967296))
-          d.toClaim.offset_bv
-          d.toDecode.h_idx d.toDecode.h_set_pc d.toDecode.h_flag
-          h_matches h_match_clo h_match_chi h_a_mask h_b_operand
-          hc0 hc1 hc2 hc3 hc4 hc5 hc6 hc7
-          d.toDecode.h_c1_zero d.toDecode.h_offset_bridge
-          d.toDecode.h_offset_even d.toDecode.h_no_fgl_wrap,
-        hoo]
-    simp [nextPC_val]
-  let promises : ZiskFv.EquivCore.Promises.JumpPromises
-      state d.toInputs.jalr_input.PC d.toInputs.jalr_input.rd d.toInputs.misa_val
-      (PureSpec.execute_JALR_pure d.toInputs.jalr_input).success
-      (PureSpec.execute_JALR_pure d.toInputs.jalr_input).nextPC
-      d.toClaim.rd (Pilot.execRowOf trace i) e_rd nextPC_val :=
-    { input_rd_eq := d.toInputs.h_input_rd
-      input_pc_eq := d.toInputs.h_input_pc
-      input_misa_eq := d.toInputs.h_input_misa
-      misa_c_zero := d.toInputs.h_misa_c
-      -- exec artifacts: now `rfl` (`Pilot.execRowOf` is a concrete two-entry list).
-      exec_len := by rfl
-      e0_mult := by rfl
-      e1_mult := by rfl
-      nextPC_matches := h_nextPC_disch
-      rd_mult := by rfl
-      rd_as := by rfl
-      success := d.toInputs.h_success
-      nextPC_option := h_nextPC_option
-      rd_idx := d.toInputs.h_input_rd.trans
-        (eRdLui_rd_idx_of_decode d.toDecode.h_store_ind d.toDecode.h_store_offset) }
-  have h_link_bridge :=
-    jalr_link_bridge_of_decode d.toInputs.h_pc_bridge d.toDecode.h_jmp2 h_domain.h_pc_bound
-  let env : OpEnvelope state m i.val :=
-    OpEnvelope.jalr d.toInputs.jalr_input d.toClaim.imm d.toClaim.rs1 d.toClaim.rd d.toInputs.misa_val d.toInputs.mseccfg (Pilot.execRowOf trace i) e_rd
-      nextPC_val next_pc store_pc_mem pins d.toDecode.h_flag d.toDecode.h_m32 d.toDecode.h_set_pc d.toDecode.h_store_pc
-      h_jalr_subset promises d.toInputs.h_input_imm d.toInputs.h_input_rs1 d.toInputs.h_cur_privilege d.toInputs.h_mseccfg
-      h_link_bridge h_domain.h_pc_bound h_domain.h_pc_offset_lt_2_32
-  have h_bridge : env.aeneasBridgeTrust :=
-    ⟨d.toDecode.h_flag, d.toDecode.h_m32, d.toDecode.h_set_pc, d.toDecode.h_store_pc, h_link_bridge⟩
-  have h_mem : env.memoryTimelineConstructionEvidence := by trivial
-  have h_known : Defects.NoKnownDefect env :=
-    noKnownDefect_of_shapes env (fun h => h) (fun h => h) trivial
-  exact (zisk_riscv_compliant_program_bus env h_bridge h_mem h_known).2.2.2.2.2.2.2.2.2.2.2
 
 /-! ## Strengthened store arms (SB/SH/SW/SD, channel-balance form) — OpEnvelope route
 

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
@@ -307,59 +307,6 @@ theorem jalr_link_bridge_of_decode
   rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt h_val_lt64] at h_toNat
   exact h_toNat
 
-/-- JALR link-value bridge for the unaligned physical ADD/AND lowering. -/
-theorem jalr_link_bridge_unaligned
-    {numInstructions : Nat}
-    {trace : AcceptedZiskTrace numInstructions}
-    (start finish : Fin trace.mainTable.table.length)
-    {pc : BitVec 64}
-    (h_adj : start.val + 1 = finish.val)
-    (h_start_flag :
-      (mainOfTable trace.program trace.mainTable).flag start.val = 0)
-    (h_start_set_pc :
-      (mainOfTable trace.program trace.mainTable).set_pc start.val = 0)
-    (h_start_jmp2 :
-      (mainOfTable trace.program trace.mainTable).jmp_offset2 start.val = 1)
-    (h_finish_jmp2 :
-      (mainOfTable trace.program trace.mainTable).jmp_offset2 finish.val = 3)
-    (h_pc_bridge :
-      ((mainOfTable trace.program trace.mainTable).pc start.val).val = pc.toNat)
-    (h_pc_bound : pc.toNat < GL_prime - 4) :
-    ((mainOfTable trace.program trace.mainTable).pc finish.val
-        + (mainOfTable trace.program trace.mainTable).jmp_offset2 finish.val).val
-      = (pc + 4#64).toNat := by
-  have h_seg := trace.mainTable_fixed.segment_l1_succ
-    start.val (by simpa [h_adj] using finish.isLt)
-  have h_hand := trace.mainTransition_to_next_pc start.val
-    (by simpa [h_adj] using finish.isLt) h_seg
-  have h_pc_step := ZiskFv.Airs.Main.pc_handshake_branch
-    (mainOfTable trace.program trace.mainTable) start.val
-    ((mainOfTable trace.program trace.mainTable).pc (start.val + 1))
-    h_start_set_pc h_hand
-  rw [h_start_flag, h_start_jmp2] at h_pc_step
-  simp only [zero_mul, add_zero] at h_pc_step
-  have h_finish_pc :
-      (mainOfTable trace.program trace.mainTable).pc finish.val =
-        (mainOfTable trace.program trace.mainTable).pc start.val + 1 := by
-    simpa [h_adj] using h_pc_step
-  rw [h_finish_jmp2, h_finish_pc]
-  have h_bv_eq := Pilot.ofNat_fgl_pc_plus_4_eq
-    ((mainOfTable trace.program trace.mainTable).pc start.val)
-    pc h_pc_bridge h_pc_bound
-  have h_toNat := congrArg BitVec.toNat h_bv_eq
-  have h_gl_lt64 : GL_prime < 2 ^ 64 :=
-    ZiskFv.PackedBitVec.WidePCNoWrap.GL_prime_lt_pow_64
-  have h_field :
-      (mainOfTable trace.program trace.mainTable).pc start.val + 1 + 3 =
-        (mainOfTable trace.program trace.mainTable).pc start.val + 4 := by ring
-  rw [h_field]
-  have h_val_lt64 :
-      ((((mainOfTable trace.program trace.mainTable).pc start.val
-        + 4 : FGL)).val) < 2 ^ 64 :=
-    Nat.lt_trans (Fin.isLt _) h_gl_lt64
-  rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt h_val_lt64] at h_toNat
-  exact h_toNat
-
 theorem jalr_link_bridge_scalar
     (base finishPC finishOffset : FGL) (pc : BitVec 64)
     (h_total : finishPC + finishOffset = base + 4)

--- a/ZiskFv/Soundness.lean
+++ b/ZiskFv/Soundness.lean
@@ -61,7 +61,9 @@ theorem root_soundness
     (bootSeed : BootSegmentMemorySeed ziskTrace sailTrace ziskStep)
     (hAvoidKnownBugs : ∀ i : Fin numInstructions,
       RowOutsideDefectRegion ziskTrace i (ziskStep i)) :
-    ∀ i : Fin numInstructions, StepSound ziskTrace sailTrace i (ziskStep i) :=
+    ∀ i : Fin numInstructions,
+      StepSound ziskTrace sailTrace i (ziskStep i)
+        (rowDecode_of_programDecode ziskTrace i (programDecodes i)) :=
   fun i =>
     stepSound_of_evidence ziskTrace sailTrace i (ziskStep i)
       (rowDecode_of_programDecode ziskTrace i (programDecodes i)) (inputsAgree i)

--- a/trust/consistency/root_soundness_instantiation_degenerate.lean
+++ b/trust/consistency/root_soundness_instantiation_degenerate.lean
@@ -156,6 +156,7 @@ private def trace : AcceptedZiskTrace 0 where
 private def sail : SailTrace 0 := nofun
 
 private def step : ∀ i : Fin 0, ZiskStep trace i := nofun
+private def decode : ∀ i : Fin 0, ProgramDecode trace i (step i) := nofun
 
 /-- The degenerate boot / cross-segment memory seed: empty boot memory, no rows,
     and every per-instruction obligation vacuous over `Fin 0`.  With the concrete
@@ -177,8 +178,10 @@ private def seed : BootSegmentMemorySeed trace sail step where
     and feeds it through the headline theorem — witnessing that the object
     `root_soundness` quantifies over is inhabited and accepted. -/
 theorem root_soundness_instantiation_degenerate :
-    ∀ i : Fin 0, StepSound trace sail i (step i) :=
-  root_soundness 0 trace sail step nofun nofun seed nofun
+    ∀ i : Fin 0,
+      StepSound trace sail i (step i)
+        (rowDecode_of_programDecode trace i (decode i)) :=
+  root_soundness 0 trace sail step decode nofun seed nofun
 
 #print axioms root_soundness_instantiation_degenerate
 

--- a/trust/consistency/root_soundness_instantiation_jalr_spin.lean
+++ b/trust/consistency/root_soundness_instantiation_jalr_spin.lean
@@ -1,0 +1,6 @@
+import ZiskFv.Compliance.JalrSpinRootSoundness
+
+#print axioms ZiskFv.Compliance.JalrSpinRootSoundness.jalrSpinRootSoundness
+#print axioms ZiskFv.Compliance.JalrSpinRootSoundness.jalrStepSound
+#print axioms ZiskFv.Compliance.JalrSpinWitness.jalrAcceptedTrace
+#print axioms ZiskFv.Compliance.JalrSpinWitness.jalrWitness_balancedChannels

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -799,7 +799,7 @@ trust surface even though they add no axiom.
 | Field (`Compliance/AcceptedZiskTrace.lean`) | PIL source | What it certifies |
 |---|---|---|
 | `main_height` (pre-existing) | — | the physical Main table has a row for every executed-step index; it may also carry padding rows |
-| `transitions_hold` (**#100**, extended for **#242**) | `main.pil:409-410`; `mem_align.pil:116-117,142` | component-owned D1 predecessor/current relations hold: Main's PC handshake and MemAlign's gated predecessor `delta_addr` plus eight `down_to_up` register continuities. These are verifier certificates, not caller assumptions. |
+| `transitions_hold` (**#100**, extended for **#242** and **#280**) | `main.pil:409-410`, `main.pil:386`; `mem_align.pil:116-117,142` | component-owned D1 predecessor/current relations hold: Main's PC handshake, Main's non-segment source-C copy (a row that sets none of `b_src_mem/imm/ind/reg` reads its `b[0]`/`b[1]` lanes from the predecessor row's `c[0]`/`c[1]`), and MemAlign's gated predecessor `delta_addr` plus eight `down_to_up` register continuities. These are verifier certificates, not caller assumptions. |
 | `cyclic_successor_transitions_hold` (**#242**) | `mem_align.pil:113-118,139-143` | MemAlign's D3 cyclic successor/current relations hold on every effective row: h998's unmasked `DELTA_PC = pc' - pc` and eight `up_to_down` register continuities, including final-row-to-row-zero. Its bus-133 ROM membership is derived from finished balance/static provider. |
 | `mem_replay_table` (**#115**, guarded by `MutableMemPresent witness`) | Full-ensemble table selection for the mutable Mem component | selects the concrete mutable-Mem table, proves witness membership and component identity, and proves the table is nonempty |
 | Derived `memReplaySegmentRanges` (not an `AcceptedZiskTrace` field) | Mem hints 884/886; `mem.pil:267-268` / `285-286`; linked c24–33 at `std_sum.pil:590/599/656/696`; generated `ValidatedLink` entries | derives selected-table `MemSegmentGeneratedRangeFacts` from `constraints_hold`, `channels_balanced`, and `transitions_hold`: the indexed source bridge identifies the canonical `ProverData` chunks, finished bus-103 balance finds the `SpecifiedRangesSlice` provider, and its static table supplies 16-bit membership. `ProverAssumptions` is completeness-only and is not used. |
@@ -850,6 +850,37 @@ per-op flag/target/cast content **proven** (0 new `ZiskFv.*` axioms). The Clean
 consumes it — see `docs/clean-fork-divergences.md` D1); the obligation lives
 entirely at the `AcceptedZiskTrace` layer, which is why it is in `main_height`'s
 class rather than `constraints_hold`'s.
+
+**#280 extension of the same certificate (JALR source-C) — a REDUCTION.**
+`transitions_hold` now also carries Main's non-segment source-C copy
+(`main.pil:386`, extracted as `constraint_4_every_row` /
+`constraint_10_every_row`): `Main.transitionBetween` is
+`pcHandshakeBetween ∧ sourceCCopyBetween`, and `sourceCCopyBetween` states
+exactly the `(1 - SEGMENT_L1)`-gated *within-segment* equation. Clean's
+transition interface has no public-input surface, so the segment-boundary case
+(`SEGMENT_L1 = 1`, where the PIL selects the public `segment_previous_c` input)
+is deliberately **not** modeled, and neither is the a-lane copy
+(`main.pil:385`). The modeled relation is therefore *implied by* the PIL
+constraint and never stronger than it.
+
+This extension **reduces** caller trust rather than shifting it. The unaligned
+JALR lowering (an `OP_ADD` row followed by the terminal `OP_AND` row) now reads
+its ADD result out of the predecessor row through this certificate, which
+retires the per-op premise `Inputs_jalr.h_operand_offset` — the cross-world sum
+identity `b + offset_bv = rs1_val + signExtend imm`, which in the unaligned case
+silently assumed the whole ADD computation — in favour of the narrower register
+agreement `h_rs1_start : b = rs1_val`, the same input-agreement class every other
+opcode already carries. The remaining lowering facts (`OP_ADD` pins, the
+adjacency `start + 1 = finish`, the terminal row's `b_src_*` selectors) are
+sailTrace-free decode/placement evidence in `JalrLoweringRows`, not new
+cross-world promises.
+
+Consequently `root_soundness`'s conclusion is now indexed by the checked decode
+(`StepSound … zs (rowDecode_of_programDecode …)`): for JALR the state effect is
+stated at the lowering's terminal row `decode.rows.finish` instead of at the
+architectural index `i`. No binder is added — `programDecodes` was already a
+`root_soundness` binder — and `JalrLoweringRows.architectural_start` pins
+`start.val = i.val`; every other family still reads its effect at `i`.
 
 **Within-segment boundary (explicit).** `mainTransition_to_next_pc`
 (`Compliance/MainTransition.lean`) requires `i + 1 < mainTable.table.length` — a


### PR DESCRIPTION
Closes #280 when merged.

This derives the former JALR operand-offset premise from the physical AIR:

- model Main's non-segment source-C copy as an intrinsic transition constraint;
- re-discharge all concrete transition witnesses;
- delete `Inputs_jalr.h_operand_offset`;
- decode unaligned JALR through its physical ADD/AND lowering rows;
- derive the target from the live ADD provider, source-C transition, and terminal AND row;
- add a concrete ADDI/JALR accepted trace and instantiate the public eight-binder `root_soundness` theorem;
- register the JALR root witness in the semantic trust gate.

The surviving `h_rs1_start` is the narrower, genuine Main/Sail register agreement. `Compliance/Defects.lean` is byte-unchanged.

Local gates at `a0204359`:

- `lake build +ZiskFv.Compliance.ConstructionAdd`
- `lake build +ZiskFv.Compliance.JalrSpinRootSoundness`
- `lake build` (9,074 jobs)
- `trust/scripts/check-all.sh` (17/17)
- `trust/scripts/check-all-semantic.sh` (18/18, including JALR)
- `nix run .#test` (8/8)

All pass at the restored 2M `ConstructionAdd` heartbeat limit. Zero project axioms, zero non-generated `sorry`, and no new `native_decide`.
