### PR TITLE
Build and gate the JALR and DIV root-soundness witnesses

### DIFF
--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -181,6 +181,8 @@ import ZiskFv.Compliance.AddSpinRootSoundness
 import ZiskFv.Compliance.AddAddiSpinWitness
 import ZiskFv.Compliance.AddAddiSpinRootSoundness
 import ZiskFv.Compliance.SdLdSpinRootSoundness
+import ZiskFv.Compliance.JalrSpinRootSoundness
+import ZiskFv.Compliance.DivSpinRootSoundness
 import ZiskFv.Compliance.RangeWiringWitness
 -- In-build per-opcode static decode/row-mode pin discharge from the real
 -- Aeneas-extracted ZisK lowerer (eth-act/zisk-fv#111). Standalone; not yet

--- a/ZiskFv/Compliance/DivSpinRootSoundness/Final.lean
+++ b/ZiskFv/Compliance/DivSpinRootSoundness/Final.lean
@@ -7,29 +7,38 @@ namespace ZiskFv.Compliance.DivSpinRootSoundness
 
 theorem divSpinRootSoundness :
     ∀ i : Fin 4,
-      StepSound divSpinAcceptedTrace divSpinSailTrace i (divSpinZiskStep i) :=
+      StepSound divSpinAcceptedTrace divSpinSailTrace i (divSpinZiskStep i)
+        (rowDecode_of_programDecode divSpinAcceptedTrace i (divSpinProgramDecodes i)) :=
   root_soundness 4 divSpinAcceptedTrace divSpinSailTrace divSpinZiskStep
     divSpinProgramDecodes divSpinInputsAgree divSpinBootSeed
     divSpinOutsideDefectRegion
 
 theorem divSpinAddiX1StepSound :
     StepSound divSpinAcceptedTrace divSpinSailTrace divSpinAddiX1Index
-      (divSpinZiskStep divSpinAddiX1Index) :=
+      (divSpinZiskStep divSpinAddiX1Index)
+      (rowDecode_of_programDecode divSpinAcceptedTrace divSpinAddiX1Index
+        (divSpinProgramDecodes divSpinAddiX1Index)) :=
   divSpinRootSoundness divSpinAddiX1Index
 
 theorem divSpinAddiX2StepSound :
     StepSound divSpinAcceptedTrace divSpinSailTrace divSpinAddiX2Index
-      (divSpinZiskStep divSpinAddiX2Index) :=
+      (divSpinZiskStep divSpinAddiX2Index)
+      (rowDecode_of_programDecode divSpinAcceptedTrace divSpinAddiX2Index
+        (divSpinProgramDecodes divSpinAddiX2Index)) :=
   divSpinRootSoundness divSpinAddiX2Index
 
 theorem divSpinDivStepSound :
     StepSound divSpinAcceptedTrace divSpinSailTrace divSpinDivIndex
-      (divSpinZiskStep divSpinDivIndex) :=
+      (divSpinZiskStep divSpinDivIndex)
+      (rowDecode_of_programDecode divSpinAcceptedTrace divSpinDivIndex
+        (divSpinProgramDecodes divSpinDivIndex)) :=
   divSpinRootSoundness divSpinDivIndex
 
 theorem divSpinJalStepSound :
     StepSound divSpinAcceptedTrace divSpinSailTrace divSpinJalIndex
-      (divSpinZiskStep divSpinJalIndex) :=
+      (divSpinZiskStep divSpinJalIndex)
+      (rowDecode_of_programDecode divSpinAcceptedTrace divSpinJalIndex
+        (divSpinProgramDecodes divSpinJalIndex)) :=
   divSpinRootSoundness divSpinJalIndex
 
 end ZiskFv.Compliance.DivSpinRootSoundness

--- a/ZiskFv/Compliance/DivSpinWitness/Constraints.lean
+++ b/ZiskFv/Compliance/DivSpinWitness/Constraints.lean
@@ -27,8 +27,9 @@ attribute [local simp] mainFixedColumns_segment_l1_first
   mainFixedCapacity
 
 theorem divSpinMain_pcHandshake_addi_x1_x2 :
-    pcHandshakeBetween divSpinAddiX1Row divSpinAddiX2Row := by
-  simp [pcHandshakeBetween, divSpinAddiX1Row, divSpinAddiX2Row,
+    transitionBetween divSpinAddiX1Row divSpinAddiX2Row := by
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween,
+    divSpinAddiX1Row, divSpinAddiX2Row,
     divSpinAddiX1RowWithLast, divSpinAddiX2RowWithLast,
     divSpinAddiX1RowTemplate, divSpinAddiX2RowTemplate,
     divSpinAddiX1ProgramRow, divSpinAddiX2ProgramRow, divSpinAddiBits,
@@ -39,8 +40,9 @@ theorem divSpinMain_pcHandshake_addi_x1_x2 :
     ZiskFv.Compliance.RegisterMemBusBalance.withMainRegisterPrevious]
 
 theorem divSpinMain_pcHandshake_addi_x2_div :
-    pcHandshakeBetween divSpinAddiX2Row divSpinDivRow := by
-  simp [pcHandshakeBetween, divSpinAddiX2Row, divSpinAddiX2RowWithLast,
+    transitionBetween divSpinAddiX2Row divSpinDivRow := by
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween,
+    divSpinAddiX2Row, divSpinAddiX2RowWithLast,
     divSpinAddiX2RowTemplate, divSpinDivRow, divSpinDivRowTemplate,
     divSpinAddiX2ProgramRow, divSpinDivProgramRow, divSpinAddiBits,
     divSpinDivBits, divSpinAddiFree, divSpinAddiBits,
@@ -50,16 +52,18 @@ theorem divSpinMain_pcHandshake_addi_x2_div :
     ZiskFv.Compliance.RegisterMemBusBalance.withMainRegisterPrevious]
 
 theorem divSpinMain_pcHandshake_div_jal :
-    pcHandshakeBetween divSpinDivRow (divSpinJalRow 3) := by
-  simp [pcHandshakeBetween, divSpinDivRow, divSpinJalRow,
+    transitionBetween divSpinDivRow (divSpinJalRow 3) := by
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween,
+    divSpinDivRow, divSpinJalRow,
     divSpinJalProgramRow, divSpinDivProgramRow, divSpinDivBits,
     ZiskFv.Compliance.AddSpinWitness.addSpinJalRow,
     ZiskFv.Compliance.AddSpinWitness.addSpinJalProgramRow,
     ZiskFv.Compliance.AddSpinWitness.addSpinJalBits, mainRomRowOf]
 
 theorem divSpinMain_pcHandshake_jal_jal :
-    pcHandshakeBetween (divSpinJalRow 3) (divSpinJalRow 4) := by
-  simp [pcHandshakeBetween, divSpinJalRow, divSpinJalProgramRow,
+    transitionBetween (divSpinJalRow 3) (divSpinJalRow 4) := by
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween,
+    divSpinJalRow, divSpinJalProgramRow,
     ZiskFv.Compliance.AddSpinWitness.addSpinJalProgramRow,
     ZiskFv.Compliance.AddSpinWitness.addSpinJalBits,
     ZiskFv.Compliance.AddSpinWitness.addSpinJalFreeCols, mainRomRowOf]
@@ -132,7 +136,8 @@ theorem divSpinJalMain_proverAssumptions (step : FGL) :
       (divSpinJalRow step) emptyData (ProverHint.empty FGL) := by
   refine ⟨⟨3, by decide⟩, ZiskFv.Compliance.AddSpinWitness.addSpinJalBits,
     MainRomExecKind.internalFlag,
-    ZiskFv.Compliance.AddSpinWitness.addSpinJalFreeCols step,
+    { ZiskFv.Compliance.AddSpinWitness.addSpinJalFreeCols step with
+      b_0 := if step = 3 then 3 else 0 },
     ?_, ?_, ?_, ?_, ?_⟩
   · decide
   · norm_num [MainRomExecKind.Coherent, divSpinProgram, divSpinJalProgramRow,
@@ -215,7 +220,7 @@ theorem divSpinMainTable_transitions : divSpinMainTable.TransitionConstraints :=
   rw [Table.TransitionConstraints]
   intro index
   fin_cases index
-  · change pcHandshakeBetween _
+  · change transitionBetween _
       (Eval.eval
         (Environment.fromArray
           (mainFixedColumns.materialize 0 (mainRawRow divSpinAddiX1Row)) emptyData)
@@ -226,11 +231,11 @@ theorem divSpinMainTable_transitions : divSpinMainTable.TransitionConstraints :=
       (by simp [divSpinAddiX1Row, divSpinAddiX1RowTemplate, mainRomRowOf,
         divSpinAddiFree])]
     simp [Table.previousEnvironment, divSpinMainTable, mainRowsTable,
-      divSpinMainRows, pcHandshakeBetween,
+      divSpinMainRows, transitionBetween, sourceCCopyBetween, pcHandshakeBetween,
       divSpinAddiX1Row, divSpinAddiX1RowWithLast, divSpinAddiX1RowTemplate,
       divSpinAddiBits, ZiskFv.Compliance.SdLdSpinWitness.addiX0Bits,
       mainRomRowOf, divSpinAddiFree, divSpinRegisterInitial]
-  · change pcHandshakeBetween
+  · change transitionBetween
       (Eval.eval
         (Environment.fromArray
           (mainFixedColumns.materialize 0 (mainRawRow divSpinAddiX1Row)) emptyData)
@@ -250,7 +255,7 @@ theorem divSpinMainTable_transitions : divSpinMainTable.TransitionConstraints :=
         (by simp [divSpinAddiX2Row, divSpinAddiX2RowTemplate, mainRomRowOf,
           divSpinAddiFree])]
     exact divSpinMain_pcHandshake_addi_x1_x2
-  · change pcHandshakeBetween
+  · change transitionBetween
       (Eval.eval
         (Environment.fromArray
           (mainFixedColumns.materialize 1 (mainRawRow divSpinAddiX2Row)) emptyData)
@@ -268,7 +273,7 @@ theorem divSpinMainTable_transitions : divSpinMainTable.TransitionConstraints :=
         (by simp [divSpinDivRow, divSpinDivRowTemplate, mainRomRowOf])
         (by simp [divSpinDivRow, divSpinDivRowTemplate, mainRomRowOf])]
     exact divSpinMain_pcHandshake_addi_x2_div
-  · change pcHandshakeBetween
+  · change transitionBetween
       (Eval.eval
         (Environment.fromArray
           (mainFixedColumns.materialize 2 (mainRawRow divSpinDivRow)) emptyData)
@@ -284,7 +289,7 @@ theorem divSpinMainTable_transitions : divSpinMainTable.TransitionConstraints :=
         (by simp [divSpinJalRow, mainRomRowOf])
         (by simp [divSpinJalRow, mainRomRowOf])]
     exact divSpinMain_pcHandshake_div_jal
-  · change pcHandshakeBetween
+  · change transitionBetween
       (Eval.eval
         (Environment.fromArray
           (mainFixedColumns.materialize 3 (mainRawRow (divSpinJalRow 3))) emptyData)

--- a/ZiskFv/Compliance/DivSpinWitness/Definitions.lean
+++ b/ZiskFv/Compliance/DivSpinWitness/Definitions.lean
@@ -282,10 +282,17 @@ def divSpinDivRow : MainRowWithRom FGL :=
 def divSpinJalProgramRow : ZiskRomMessage FGL :=
   { ZiskFv.Compliance.AddSpinWitness.addSpinJalProgramRow with line := 12 }
 
+/-- The spin JAL row. It sets none of `b_src_mem/imm/ind/reg`, so Main's source-C
+copy (`main.pil:386`, carried on `Component.transition` since #280) forces its
+`b` lanes to equal the PREDECESSOR row's `c` lanes. At `step = 3` the
+predecessor is the DIV row, whose `c` is the quotient `6 / 2 = 3`; every later
+spin row follows a JAL, whose own `c` is `0`. Same shape as
+`SdLdSpinWitness.sdLdJalRow`, which copies its predecessor LD's result. -/
 def divSpinJalRow (step : FGL) : MainRowWithRom FGL :=
   mainRomRowOf divSpinJalProgramRow
     ZiskFv.Compliance.AddSpinWitness.addSpinJalBits MainRomExecKind.internalFlag
-    (ZiskFv.Compliance.AddSpinWitness.addSpinJalFreeCols step)
+    { ZiskFv.Compliance.AddSpinWitness.addSpinJalFreeCols step with
+      b_0 := if step = 3 then 3 else 0 }
 
 def divSpinProgram : Program 4
   | ⟨0, _⟩ => divSpinAddiX1ProgramRow

--- a/ZiskFv/Compliance/JalrSpinWitness.lean
+++ b/ZiskFv/Compliance/JalrSpinWitness.lean
@@ -529,7 +529,7 @@ def jalrTables : List (Table FGL) :=
   , emptyComponentTable ZiskFv.AirsClean.Mem.componentWithDualMemBus
   , emptyComponentTable ZiskFv.AirsClean.SpecifiedRangesSlice.component
   , emptyComponentTable ZiskFv.AirsClean.ArithDiv.component
-  , emptyComponentTable ZiskFv.AirsClean.ArithMul.componentWithArithTable
+  , emptyComponentTable ZiskFv.AirsClean.ArithMul.componentComplete
   , emptyComponentTable ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
   , jalrBinaryAndTable
   , jalrBinaryAddTable
@@ -587,7 +587,7 @@ theorem jalrWitness_table_constraints :
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.Mem.componentWithDualMemBus
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.SpecifiedRangesSlice.component
   · exact emptyComponentTable_constraints ZiskFv.AirsClean.ArithDiv.component
-  · exact emptyComponentTable_constraints ZiskFv.AirsClean.ArithMul.componentWithArithTable
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.ArithMul.componentComplete
   · exact emptyComponentTable_constraints
       ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
   · exact jalrBinaryAndTable_constraints
@@ -622,7 +622,7 @@ theorem jalrWitness_transitions : jalrWitness.TransitionConstraints := by
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.Mem.componentWithDualMemBus
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.SpecifiedRangesSlice.component
     · exact emptyComponentTable_transitions ZiskFv.AirsClean.ArithDiv.component
-    · exact emptyComponentTable_transitions ZiskFv.AirsClean.ArithMul.componentWithArithTable
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.ArithMul.componentComplete
     · exact emptyComponentTable_transitions
         ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
     · rw [Table.TransitionConstraints]
@@ -667,7 +667,7 @@ theorem jalrWitness_cyclicSuccessorTransitions :
         ZiskFv.AirsClean.SpecifiedRangesSlice.component
     · exact emptyComponentTable_cyclicSuccessorTransitions ZiskFv.AirsClean.ArithDiv.component
     · exact emptyComponentTable_cyclicSuccessorTransitions
-        ZiskFv.AirsClean.ArithMul.componentWithArithTable
+        ZiskFv.AirsClean.ArithMul.componentComplete
     · exact emptyComponentTable_cyclicSuccessorTransitions
         ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
     · rw [Table.CyclicSuccessorTransitionConstraints]
@@ -1332,7 +1332,7 @@ private theorem jalrWitness_mutable_mem_component_tables_empty
     · exact emptyComponentTable_table ZiskFv.AirsClean.Mem.componentWithDualMemBus
     · exact emptyComponentTable_table ZiskFv.AirsClean.SpecifiedRangesSlice.component
     · exact emptyComponentTable_table ZiskFv.AirsClean.ArithDiv.component
-    · exact emptyComponentTable_table ZiskFv.AirsClean.ArithMul.componentWithArithTable
+    · exact emptyComponentTable_table ZiskFv.AirsClean.ArithMul.componentComplete
     · exact emptyComponentTable_table
         ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
     · exfalso


### PR DESCRIPTION
Repairs `origin/main` after #293 and #294 landed back-to-back. Both PRs were individually green, but their concrete witnesses were never built against each other, and a Lake packaging gap hid it.

## The packaging gap

`ZiskFv` is a root-based Lake library (`roots = ["ZiskFv"]`, no globs), so a module reaches the build graph only by being imported from `ZiskFv.lean`. Neither #293's `JalrSpinRootSoundness` nor #294's `DivSpinRootSoundness` was imported there — `git show fac67c2f --stat` shows #293 never touched `ZiskFv.lean` at all.

So `lake build` never compiled either witness. Their oleans existed only where an author had run an explicit `lake build +<module>` (exactly the command in #293's PR body), which is what made `check-all-semantic.sh` check 15 pass on each branch. **From a clean build it fails** — and it did, on merged `main`:

```
trust/consistency/root_soundness_instantiation_jalr_spin.lean:1:0: error: object file
'…/ZiskFv/Compliance/JalrSpinRootSoundness.olean' of module
ZiskFv.Compliance.JalrSpinRootSoundness does not exist
```

This PR adds the two imports next to the other spin roots, as the convention already does for Add/AddAddi/SdLd.

## What that exposed

Putting them in the graph surfaced four real breakages — one per direction of the merge. Each witness was written against the other PR's pre-merge shapes:

**1. `DivSpinWitness/Constraints.lean` — stale transition shape.** It discharged Main's transition with `change pcHandshakeBetween …`, but #280 extended `Component.transition` to `transitionBetween` = PC handshake **∧** non-segment source-C copy. The four `divSpinMain_pcHandshake_*` lemmas are restated over `transitionBetween` with `sourceCCopyBetween` added to their simp sets, matching how `AddSpinWitness` was updated in #293.

**2. `DivSpinWitness/Definitions.lean` — the witness genuinely violated the new constraint.** The spin JAL row reused AddSpin's free columns with `b_0 = 0` while setting none of `b_src_mem/imm/ind/reg`. With the source-C copy (`main.pil:386`) now live on the transition, that forces its `b` lanes to equal the predecessor row's `c` lanes — and the predecessor is the DIV row, whose `c` is the quotient `6 / 2 = 3`. The goal reduced to `⊢ False`. Fixed by carrying `b_0 = if step = 3 then 3 else 0`: the row after DIV copies the quotient, later spin rows follow a JAL whose own `c` is `0`. This is the same shape `SdLdSpinWitness.sdLdJalRow` already uses to copy its predecessor LD's result. `divSpinJalMain_proverAssumptions` threads the same free columns.

**3. `DivSpinRootSoundness/Final.lean` — stale `root_soundness` conclusion.** All five theorems were stated over the pre-#280 `StepSound`, which is now indexed by the checked row decode (`rowDecode_of_programDecode …`). This is #294's headline deliverable — the concrete ADDI/ADDI/DIV/JAL trace instantiating all eight binders — so it could not have compiled against merged `main` in any form.

**4. `JalrSpinWitness.lean` — stale ensemble component.** It still named `ArithMul.componentWithArithTable` at ensemble slot 9, which #279 swapped to `componentComplete`. This is the identical mechanical rename #279 applied to the four witnesses that existed on its branch; the JALR one did not exist there yet. The JALR trace has no Arith operation, so the table is empty either way.

## Anti-laundering

No obligation is weakened, renamed, or relocated. Every change updates a concrete witness to satisfy a constraint that legitimately got stronger — which is what a concrete witness is for. Item 2 is the only semantic change to a witness row, and it makes the row *more* constrained, not less. No new `axiom`, `sorry`, `admit`, `opaque`, or `native_decide`; no allowlist or ledger edits.

## Gates

- `lake build` — **green, 9114 jobs** (was 9076; the extra jobs are the two witness modules now actually being compiled)
- `trust/scripts/check-all.sh` — **17/17**
- `trust/scripts/check-all-semantic.sh` — **18/18**, exit 0, with both `ZiskFv.Compliance.JalrSpinRootSoundness.jalrSpinRootSoundness` and `ZiskFv.Compliance.DivSpinRootSoundness.divSpinRootSoundness` now certified in check 15

## Note on process

`proofs.yml` is push-only, so neither PR was ever gated as a PR, and the post-merge run on `main` is the first real signal. The deeper issue is that check 15 was passing on developer machines for modules `lake build` does not build — so "V2 18/18" on those branches was resting on leftover explicit builds rather than on a reproducible graph. After this PR, **these two witnesses** are in the default build graph and check 15 means what it says for them.

**Confirmed by CI.** The post-merge `proofs` run on `main` (30367646088) fails on *both* probes — a clean runner has no leftover explicit builds, so it reports `DivSpinRootSoundness.olean … does not exist` as well as the JALR one. That independently confirms this was latent in both PRs rather than caused by the rebase.

**Scope, explicitly:** this PR fixes 2 of the 6 modules currently outside the build graph. Still unreachable from `ZiskFv.lean`, and therefore still never compiled by `lake build`: `ZiskFv/Regression/SignedDivOrdinaryCounterexample.lean`, `ZiskFv/Compliance/DivSpinWitness/OpBusInteractions.lean`, `ZiskFv/Compliance/DivSpinWitness/MemBusCoreBalance.lean`, plus the pre-existing `ZiskFv/ZiskCircuit/MulH.lean`, `MulHSU.lean`, and `ZiskFv/Compliance/AcceptedZiskTrace/MemAlignRom.lean`. Those, and a gate to prevent recurrence, are handled in the stacked follow-on.

