### PR TITLE
Derive both JALR lowerings from the committed program

### DIFF
--- a/ZiskFv/Compliance/JalrSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/JalrSpinRootSoundness.lean
@@ -179,130 +179,6 @@ private theorem mainAt_finish :
 @[simp] private theorem jalrAcceptedTrace_numInstructions :
     jalrAcceptedTrace.numInstructions = 2 := rfl
 
-def loweringRows : JalrLoweringRows jalrAcceptedTrace jalrIndex (2#12) (0#64) where
-  start := startMainIndex
-  finish := finishMainIndex
-  architectural_start := rfl
-  finish_has_successor := by
-    simp [jalrAcceptedTrace_mainTable_eq, jalrMainTable,
-      ZiskFv.Compliance.AddSpinWitness.mainRowsTable, jalrMainRows]
-  lowering := by
-    right
-    simp [jalrClaim, jalrIndex, mainAt_start, mainAt_finish,
-      ZiskFv.AirsClean.FullEnsemble.mainOfTable,
-      jalrAddProgramRow, jalrAddBits,
-      jalrAndProgramRow, jalrAndBits,
-      jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
-      jalrAndRow, jalrAndRowWithLast, jalrAndRowTemplate,
-      jalrFreeCols, jalrRegisterInitial, ZiskFv.AirsClean.Main.mainRomRowOf]
-
-def jalrDecode : Decode_jalr jalrAcceptedTrace jalrIndex jalrClaim where
-  rows := loweringRows
-  h_main_op := by
-    simp [loweringRows, mainAt_finish,
-      jalrAndProgramRow, jalrAndBits,
-      ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
-      jalrAndRowWithLast, jalrAndRowTemplate,
-      ZiskFv.AirsClean.Main.mainRomRowOf]
-  h_main_active := by
-    simp [loweringRows, mainAt_finish,
-      jalrAndProgramRow, jalrAndBits,
-      ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
-      jalrAndRowWithLast, jalrAndRowTemplate,
-      ZiskFv.AirsClean.Main.mainRomRowOf]
-  h_flag := by
-    simp [loweringRows, mainAt_finish,
-      jalrAndProgramRow, jalrAndBits,
-      ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
-      jalrAndRowWithLast, jalrAndRowTemplate,
-      ZiskFv.AirsClean.Main.mainRomRowOf]
-  h_m32 := by
-    simp [loweringRows, mainAt_finish,
-      jalrAndProgramRow, jalrAndBits,
-      ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
-      jalrAndRowWithLast, jalrAndRowTemplate,
-      ZiskFv.AirsClean.Main.mainRomRowOf]
-  h_set_pc := by
-    simp [loweringRows, mainAt_finish,
-      jalrAndProgramRow, jalrAndBits,
-      ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
-      jalrAndRowWithLast, jalrAndRowTemplate,
-      ZiskFv.AirsClean.Main.mainRomRowOf]
-  h_store_pc := by
-    simp [loweringRows, mainAt_finish,
-      jalrAndProgramRow, jalrAndBits,
-      ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
-      jalrAndRowWithLast, jalrAndRowTemplate,
-      ZiskFv.AirsClean.Main.mainRomRowOf]
-  h_store_ind := by
-    simp [loweringRows, mainAt_finish, jalrAndProgramRow, jalrAndBits,
-      jalrAndRow, jalrAndRowWithLast,
-      jalrAndRowTemplate, ZiskFv.AirsClean.Main.mainRomRowOf]
-  h_store_offset := by
-    simp [loweringRows, mainAt_finish, jalrClaim, x2, jalrAndProgramRow,
-      jalrAndBits, jalrAndRow,
-      jalrAndRowWithLast, jalrAndRowTemplate,
-      ZiskFv.AirsClean.Main.mainRomRowOf, Transpiler.ind, regidx_to_fin]
-  h_idx := loweringRows.finish_has_successor
-  h_a_mask_lo := by
-    rw [ZiskFv.AirsClean.FullEnsemble.mainOfTable_a_0]
-    change (ZiskFv.Compliance.mainRowWithRomAt jalrAcceptedTrace
-      finishMainIndex).core.a_0 = _
-    rw [mainAt_finish]
-    rfl
-  h_a_mask_hi := by
-    rw [ZiskFv.AirsClean.FullEnsemble.mainOfTable_a_1]
-    change (ZiskFv.Compliance.mainRowWithRomAt jalrAcceptedTrace
-      finishMainIndex).core.a_1 = _
-    rw [mainAt_finish]
-    rfl
-  h_c1_zero := by
-    rw [ZiskFv.AirsClean.FullEnsemble.mainOfTable_c_1]
-    change (ZiskFv.Compliance.mainRowWithRomAt jalrAcceptedTrace
-      finishMainIndex).core.c_1 = _
-    rw [mainAt_finish]
-    rfl
-  h_jmp2 := by
-    right
-    simp [loweringRows, mainAt_finish,
-      jalrAndProgramRow, jalrAndBits,
-      ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
-      jalrAndRowWithLast, jalrAndRowTemplate,
-      ZiskFv.AirsClean.Main.mainRomRowOf]
-  h_offset_bridge := by
-    simp [loweringRows, mainAt_finish, jalrClaim,
-      jalrAndProgramRow, jalrAndBits,
-      ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
-      jalrAndRowWithLast, jalrAndRowTemplate,
-      ZiskFv.AirsClean.Main.mainRomRowOf]
-  h_offset_even := by simp [jalrClaim]
-  h_no_fgl_wrap := by
-    norm_num [loweringRows, mainAt_finish,
-      jalrAndProgramRow, jalrAndBits,
-      ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
-      jalrAndRowWithLast, jalrAndRowTemplate,
-      ZiskFv.AirsClean.Main.mainRomRowOf]
-
-def jalrProgramDecode :
-    ProgramDecode_jalr jalrAcceptedTrace jalrIndex jalrClaim where
-  toDecode := jalrDecode
-
--- The setup decode and both input-agreement bundles follow the established
--- concrete ADDI/JALR constructors; they are stated separately so compilation
--- checks every remaining field rather than hiding it behind a helper.
-
-def setupInput : PureSpec.AddiInput where
-  r1_val := 0#64
-  imm := 2#12
-  rd := regidx_to_fin x1
-  PC := 0#64
-
-def jalrInput : PureSpec.JalrInput where
-  imm := 2#12
-  rs1_val := 2#64
-  rd := regidx_to_fin x2
-  PC := 4#64
-
 private theorem setupMainPc :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable jalrAcceptedTrace.program
       jalrAcceptedTrace.mainTable).pc 0 = 0 := by
@@ -322,6 +198,138 @@ private theorem jalrMainPc :
   rw [mainRawAt_start]
   simp [jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
     jalrAddProgramRow, jalrAddBits, ZiskFv.AirsClean.Main.mainRomRowOf]
+
+private theorem jalrAndMainPc :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable jalrAcceptedTrace.program
+      jalrAcceptedTrace.mainTable).pc 2 = 5 := by
+  change
+    (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+      jalrAcceptedTrace.program jalrAcceptedTrace.mainTable 2).core.pc = 5
+  rw [mainRawAt_finish]
+  simp [jalrAndRow, jalrAndRowTemplate,
+    jalrAndProgramRow, jalrAndBits, ZiskFv.AirsClean.Main.mainRomRowOf]
+
+/-- Committed-program decode evidence for the unaligned JALR lowering.
+
+Both committed lines are supplied — the `OP_ADD` at `pc 4` (the architectural
+row) and its `OP_AND` successor at `pc 5` — and `rowDecode_of_programDecode`
+DERIVES `Decode_jalr` from them via `Decode_jalr_unaligned_of_program`. The
+concrete `Decode_jalr` is no longer built by hand here: only the Main-core pins
+that are not ROM-message slots (`flag`, the `a`-lane mask, `c_1`, the
+`jmp_offset1` bridge and its bounds) remain stated against the witness rows. -/
+def jalrProgramDecode :
+    ProgramDecode_jalr jalrAcceptedTrace jalrIndex jalrClaim :=
+  .unaligned
+    { h_offset_zero := rfl
+      h_idx2 := by
+        simp [jalrIndex, jalrAcceptedTrace_mainTable_eq, jalrMainTable,
+          ZiskFv.Compliance.AddSpinWitness.mainRowsTable, jalrMainRows]
+      h_flag_add := by
+        change (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+          jalrAcceptedTrace.program jalrAcceptedTrace.mainTable 1).core.flag = 0
+        rw [mainRawAt_start]
+        rfl
+      h_flag := by
+        change (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+          jalrAcceptedTrace.program jalrAcceptedTrace.mainTable 2).core.flag = 0
+        rw [mainRawAt_finish]
+        rfl
+      h_a_mask_lo := by
+        change (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+          jalrAcceptedTrace.program jalrAcceptedTrace.mainTable 2).core.a_0
+            = 4294967294
+        rw [mainRawAt_finish]
+        rfl
+      h_a_mask_hi := by
+        change (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+          jalrAcceptedTrace.program jalrAcceptedTrace.mainTable 2).core.a_1
+            = 4294967295
+        rw [mainRawAt_finish]
+        rfl
+      h_c1_zero := by
+        change (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+          jalrAcceptedTrace.program jalrAcceptedTrace.mainTable 2).core.c_1 = 0
+        rw [mainRawAt_finish]
+        rfl
+      h_offset_bridge := by
+        simp [jalrIndex, jalrClaim, jalrAndProgramRow, jalrAndBits,
+          ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
+          jalrAndRowTemplate, ZiskFv.AirsClean.Main.mainRomRowOf]
+      h_offset_even := by simp [jalrClaim]
+      h_no_fgl_wrap := by
+        norm_num [jalrIndex, jalrAndProgramRow, jalrAndBits,
+          ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
+          jalrAndRowWithLast, jalrAndRowTemplate,
+          ZiskFv.AirsClean.Main.mainRomRowOf]
+      addBits := jalrAddBits
+      h_add_ieo := rfl
+      h_add_m32 := rfl
+      h_add_set_pc := rfl
+      h_add_a_src_imm := rfl
+      h_add_b_src_reg := rfl
+      andBits := jalrAndBits
+      h_and_ieo := rfl
+      h_and_m32 := rfl
+      h_and_set_pc := rfl
+      h_and_store_pc := rfl
+      h_and_store_ind := rfl
+      h_and_b_src_imm := rfl
+      h_and_b_src_mem := rfl
+      h_and_b_src_ind := rfl
+      h_and_b_src_reg := rfl
+      h_prog_add := by
+        intro j hline
+        have hpc : (ZiskFv.AirsClean.FullEnsemble.mainOfTable
+            jalrAcceptedTrace.program jalrAcceptedTrace.mainTable).pc
+              jalrIndex.val = 4 := jalrMainPc
+        rw [hpc] at hline
+        fin_cases j
+        · exfalso
+          have hfalse : (0 : FGL) = 4 := by
+            simpa [jalrAcceptedTrace, jalrProgram, jalrSetupProgramRow] using hline
+          have := congrArg Fin.val hfalse
+          norm_num at this
+        · simp [jalrAcceptedTrace, jalrProgram, jalrAddProgramRow, jalrClaim]
+        · exfalso
+          have hfalse : (5 : FGL) = 4 := by
+            simpa [jalrAcceptedTrace, jalrProgram, jalrAndProgramRow] using hline
+          have := congrArg Fin.val hfalse
+          norm_num at this
+      h_prog_and := by
+        intro j hline
+        have hpc : (ZiskFv.AirsClean.FullEnsemble.mainOfTable
+            jalrAcceptedTrace.program jalrAcceptedTrace.mainTable).pc
+              (jalrIndex.val + 1) = 5 := jalrAndMainPc
+        rw [hpc] at hline
+        fin_cases j
+        · exfalso
+          have hfalse : (0 : FGL) = 5 := by
+            simpa [jalrAcceptedTrace, jalrProgram, jalrSetupProgramRow] using hline
+          have := congrArg Fin.val hfalse
+          norm_num at this
+        · exfalso
+          have hfalse : (4 : FGL) = 5 := by
+            simpa [jalrAcceptedTrace, jalrProgram, jalrAddProgramRow] using hline
+          have := congrArg Fin.val hfalse
+          norm_num at this
+        · simp [jalrAcceptedTrace, jalrProgram, jalrAndProgramRow, jalrClaim,
+            x2, Transpiler.ind, regidx_to_fin] }
+
+-- The setup decode and both input-agreement bundles follow the established
+-- concrete ADDI/JALR constructors; they are stated separately so compilation
+-- checks every remaining field rather than hiding it behind a helper.
+
+def setupInput : PureSpec.AddiInput where
+  r1_val := 0#64
+  imm := 2#12
+  rd := regidx_to_fin x1
+  PC := 0#64
+
+def jalrInput : PureSpec.JalrInput where
+  imm := 2#12
+  rs1_val := 2#64
+  rd := regidx_to_fin x2
+  PC := 4#64
 
 def setupProgramDecode :
     ProgramDecode_addi jalrAcceptedTrace setupIndex setupClaim where

--- a/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
@@ -1233,24 +1233,140 @@ structure ProgramDecode_jal {numInstructions : Nat}
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits
 
-/-- Per-row committed-program decode bundle for `jalr`.
-
-    Unlike every other family, this does NOT yet reduce to committed-ROM
-    evidence: it passes the checked `Decode_jalr` through unchanged. The aligned
-    lowering can already be rebuilt from the program by
-    `Decode_jalr_of_program`, but the unaligned ADD/AND lowering has no such
-    constructor, so no uniform `h_prog` bundle covers both arms. Restoring
-    program-level evidence for both arms is tracked separately; until then the
-    lowering placement is a per-instantiation obligation. -/
-structure ProgramDecode_jalr {numInstructions : Nat}
+/-- Per-row committed-program decode bundle for the ALIGNED `jalr` lowering:
+    exactly the inputs `Decode_jalr_of_program` consumes besides
+    `trace`/`i`/`c`. The whole instruction is one committed Main row, so the
+    `h_prog` shape is the uniform single-line one every other family uses. -/
+structure ProgramDecode_jalr_aligned {numInstructions : Nat}
     (trace : AcceptedZiskTrace numInstructions)
     (i : Fin trace.numInstructions)
     (c : Claim_jalr trace i) where
-  /-- JALR is the first decode family whose one architectural instruction may
-      span multiple committed Main rows. Its program/decode evidence therefore
-      carries the fully checked lowering placement rather than projecting the
-      architectural index directly into Main. -/
-  toDecode : Decode_jalr trace i c
+  h_offset_aligned : c.offset_bv = BitVec.signExtend 64 c.imm
+  h_idx : i.val + 1 < trace.mainTable.table.length
+  h_flag :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).flag
+      i.val = 0
+  h_a_mask_lo :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_0
+      i.val = 4294967294
+  h_a_mask_hi :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_1
+      i.val = 4294967295
+  h_c1_zero :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_1
+      i.val = 0
+  h_offset_bridge :
+    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
+        i.val).val = c.offset_bv.toNat
+  h_offset_even :
+    c.offset_bv &&& 1#64 = 0#64
+  h_no_fgl_wrap :
+    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_0 i.val).val
+      + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
+          i.val).val < GL_prime
+  bits : RomFlagBits
+  h_bits_ieo : bits.is_external_op = true
+  h_bits_m32 : bits.m32 = false
+  h_bits_set_pc : bits.set_pc = true
+  h_bits_store_pc : bits.store_pc = true
+  h_bits_store_ind : bits.store_ind = false
+  h_prog : ∀ j : Fin trace.programLength,
+        (trace.program j).line
+            = (mainOfTable trace.program trace.mainTable).pc i.val →
+          (trace.program j).op = ZiskFv.Trusted.OP_AND
+        ∧ (trace.program j).jmp_offset2 = 4
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
+        ∧ (trace.program j).flags = packFlags bits
+
+/-- Per-row committed-program decode bundle for the UNALIGNED `jalr` lowering:
+    exactly the inputs `Decode_jalr_unaligned_of_program` consumes besides
+    `trace`/`i`/`c`.
+
+    The instruction spans two adjacent committed Main rows, so the single-line
+    `h_prog` generalizes to one bundle PER committed line — each of exactly the
+    same shape (`∀ j at that row's own pc → decode facts`) the other 62 families
+    use, `h_prog_add` at the architectural row's `pc` and `h_prog_and` at its
+    physical successor's. -/
+structure ProgramDecode_jalr_unaligned {numInstructions : Nat}
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin trace.numInstructions)
+    (c : Claim_jalr trace i) where
+  h_offset_zero : c.offset_bv = 0#64
+  h_idx2 : i.val + 2 < trace.mainTable.table.length
+  h_flag_add :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).flag
+      i.val = 0
+  h_flag :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).flag
+      (i.val + 1) = 0
+  h_a_mask_lo :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_0
+      (i.val + 1) = 4294967294
+  h_a_mask_hi :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).a_1
+      (i.val + 1) = 4294967295
+  h_c1_zero :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_1
+      (i.val + 1) = 0
+  h_offset_bridge :
+    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
+        (i.val + 1)).val = c.offset_bv.toNat
+  h_offset_even :
+    c.offset_bv &&& 1#64 = 0#64
+  h_no_fgl_wrap :
+    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_0
+        (i.val + 1)).val
+      + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
+          (i.val + 1)).val < GL_prime
+  addBits : RomFlagBits
+  h_add_ieo : addBits.is_external_op = true
+  h_add_m32 : addBits.m32 = false
+  h_add_set_pc : addBits.set_pc = false
+  h_add_a_src_imm : addBits.a_src_imm = true
+  h_add_b_src_reg : addBits.b_src_reg = true
+  andBits : RomFlagBits
+  h_and_ieo : andBits.is_external_op = true
+  h_and_m32 : andBits.m32 = false
+  h_and_set_pc : andBits.set_pc = true
+  h_and_store_pc : andBits.store_pc = true
+  h_and_store_ind : andBits.store_ind = false
+  h_and_b_src_imm : andBits.b_src_imm = false
+  h_and_b_src_mem : andBits.b_src_mem = false
+  h_and_b_src_ind : andBits.b_src_ind = false
+  h_and_b_src_reg : andBits.b_src_reg = false
+  h_prog_add : ∀ j : Fin trace.programLength,
+        (trace.program j).line
+            = (mainOfTable trace.program trace.mainTable).pc i.val →
+          (trace.program j).op = ZiskFv.Trusted.OP_ADD
+        ∧ (trace.program j).jmp_offset2 = 1
+        ∧ BitVec.signExtend 64 c.imm
+            = BitVec.ofNat 64
+                ((trace.program j).a_offset_imm0.val
+                  + (trace.program j).a_imm1.val * 4294967296)
+        ∧ (trace.program j).flags = packFlags addBits
+  h_prog_and : ∀ j : Fin trace.programLength,
+        (trace.program j).line
+            = (mainOfTable trace.program trace.mainTable).pc (i.val + 1) →
+          (trace.program j).op = ZiskFv.Trusted.OP_AND
+        ∧ (trace.program j).jmp_offset2 = 3
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
+        ∧ (trace.program j).flags = packFlags andBits
+
+/-- Per-row committed-program decode bundle for `jalr`.
+
+    JALR is the only family whose one architectural instruction may span more
+    than one committed Main row, so which lowering the transpiler emitted is
+    real decode data, not a passthrough: the two arms carry DIFFERENT committed
+    lines (one `OP_AND` line, versus an `OP_ADD` line followed by its `OP_AND`
+    successor). Both arms are ROM-backed — `rowDecode_of_programDecode` derives
+    `Decode_jalr` from either via `Decode_jalr_of_program` /
+    `Decode_jalr_unaligned_of_program`. -/
+inductive ProgramDecode_jalr {numInstructions : Nat}
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin trace.numInstructions)
+    (c : Claim_jalr trace i) : Type where
+  | aligned (pd : ProgramDecode_jalr_aligned trace i c) : ProgramDecode_jalr trace i c
+  | unaligned (pd : ProgramDecode_jalr_unaligned trace i c) : ProgramDecode_jalr trace i c
 
 /-- Per-row committed-program decode bundle for `sb`: exactly the inputs
     `Decode_sb_of_program` consumes besides `trace`/`i`/`c`. -/
@@ -1729,7 +1845,21 @@ noncomputable def rowDecode_of_programDecode (ziskTrace : AcceptedZiskTrace numI
   | lui c => exact RomDecodeBinding.Decode_lui_of_program ziskTrace i c pd.h_idx pd.h_imm_lo_nat pd.h_imm_hi_nat pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | auipc c => exact RomDecodeBinding.Decode_auipc_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | jal c => exact RomDecodeBinding.Decode_jal_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_m32 pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
-  | jalr _ => exact pd.toDecode
+  | jalr c =>
+      match pd with
+      | .aligned p =>
+          exact RomDecodeBinding.Decode_jalr_of_program ziskTrace i c p.h_offset_aligned
+            p.h_idx p.h_flag p.h_a_mask_lo p.h_a_mask_hi p.h_c1_zero p.h_offset_bridge
+            p.h_offset_even p.h_no_fgl_wrap p.bits p.h_bits_ieo p.h_bits_m32
+            p.h_bits_set_pc p.h_bits_store_pc p.h_bits_store_ind p.h_prog
+      | .unaligned p =>
+          exact RomDecodeBinding.Decode_jalr_unaligned_of_program ziskTrace i c
+            p.h_idx2 p.h_offset_zero p.h_flag_add p.h_flag p.h_a_mask_lo p.h_a_mask_hi
+            p.h_c1_zero p.h_offset_bridge p.h_offset_even p.h_no_fgl_wrap
+            p.addBits p.h_add_ieo p.h_add_m32 p.h_add_set_pc p.h_add_a_src_imm
+            p.h_add_b_src_reg p.andBits p.h_and_ieo p.h_and_m32 p.h_and_set_pc
+            p.h_and_store_pc p.h_and_store_ind p.h_and_b_src_imm p.h_and_b_src_mem
+            p.h_and_b_src_ind p.h_and_b_src_reg p.h_prog_add p.h_prog_and
   | sb c => exact RomDecodeBinding.Decode_sb_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | sh c => exact RomDecodeBinding.Decode_sh_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog
   | sw c => exact RomDecodeBinding.Decode_sw_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog

--- a/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
@@ -1360,7 +1360,15 @@ structure ProgramDecode_jalr_unaligned {numInstructions : Nat}
     lines (one `OP_AND` line, versus an `OP_ADD` line followed by its `OP_AND`
     successor). Both arms are ROM-backed — `rowDecode_of_programDecode` derives
     `Decode_jalr` from either via `Decode_jalr_of_program` /
-    `Decode_jalr_unaligned_of_program`. -/
+    `Decode_jalr_unaligned_of_program`.
+
+    Non-vacuity status, so it is not mistaken for more than it is: only the
+    `.unaligned` arm has a concrete instantiating witness
+    (`Compliance/JalrSpinWitness.lean`, whose `imm = 2` is genuinely misaligned).
+    The `.aligned` arm has none — and never has: before #280 no witness
+    instantiated a JALR step at all, and #280's was the first, so this is a
+    standing gap rather than one introduced here. An aligned JALR spin witness
+    would close it. -/
 inductive ProgramDecode_jalr {numInstructions : Nat}
     (trace : AcceptedZiskTrace numInstructions)
     (i : Fin trace.numInstructions)

--- a/ZiskFv/Compliance/TraceLevelExport/RomDecodeBinding.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RomDecodeBinding.lean
@@ -762,6 +762,62 @@ theorem romBSourceImmColumn_of_romFlags_eq_packFlags
   subst hbits
   exact e_b_src_imm
 
+/-- **Unpacking the `a`-lane immediate source selector from the packed `flags`
+slot.**
+
+The `a_src_imm` twin of `romBSourceImmColumn_of_romFlags_eq_packFlags`: the same
+`packFlags` injectivity argument, exposing the selector that turns `SourceSpec`
+into an `a`-lane immediate proof (used by JALR's unaligned `OP_ADD` row, whose
+`a` lane carries the committed `imm`). -/
+theorem romASourceImmColumn_of_romFlags_eq_packFlags
+    (row : MainRowWithRom FGL) (bits : RomFlagBits)
+    (hbool :
+      row.core.is_external_op * (1 - row.core.is_external_op) = 0
+    ∧ row.core.m32 * (1 - row.core.m32) = 0
+    ∧ row.core.set_pc * (1 - row.core.set_pc) = 0
+    ∧ row.core.store_pc * (1 - row.core.store_pc) = 0
+    ∧ row.rom.a_src_imm * (1 - row.rom.a_src_imm) = 0
+    ∧ row.rom.a_src_mem * (1 - row.rom.a_src_mem) = 0
+    ∧ row.rom.is_precompiled * (1 - row.rom.is_precompiled) = 0
+    ∧ row.rom.b_src_imm * (1 - row.rom.b_src_imm) = 0
+    ∧ row.rom.b_src_mem * (1 - row.rom.b_src_mem) = 0
+    ∧ row.rom.store_mem * (1 - row.rom.store_mem) = 0
+    ∧ row.rom.store_ind * (1 - row.rom.store_ind) = 0
+    ∧ row.rom.b_src_ind * (1 - row.rom.b_src_ind) = 0
+    ∧ row.rom.a_src_reg * (1 - row.rom.a_src_reg) = 0
+    ∧ row.rom.b_src_reg * (1 - row.rom.b_src_reg) = 0
+    ∧ row.rom.store_reg * (1 - row.rom.store_reg) = 0)
+    (h : romFlags row = packFlags bits) :
+    row.rom.a_src_imm = ZiskFv.AirsClean.boolF bits.a_src_imm := by
+  obtain ⟨hb_ieo, hb_m32, hb_set_pc, hb_store_pc, hb_a_src_imm, hb_a_src_mem,
+    hb_is_precompiled, hb_b_src_imm, hb_b_src_mem, hb_store_mem, hb_store_ind,
+    hb_b_src_ind, hb_a_src_reg, hb_b_src_reg, hb_store_reg⟩ := hbool
+  obtain ⟨d_ieo, e_ieo⟩ := bool_of_booleanity hb_ieo
+  obtain ⟨d_m32, e_m32⟩ := bool_of_booleanity hb_m32
+  obtain ⟨d_set_pc, e_set_pc⟩ := bool_of_booleanity hb_set_pc
+  obtain ⟨d_store_pc, e_store_pc⟩ := bool_of_booleanity hb_store_pc
+  obtain ⟨d_a_src_imm, e_a_src_imm⟩ := bool_of_booleanity hb_a_src_imm
+  obtain ⟨d_a_src_mem, e_a_src_mem⟩ := bool_of_booleanity hb_a_src_mem
+  obtain ⟨d_is_precompiled, e_is_precompiled⟩ := bool_of_booleanity hb_is_precompiled
+  obtain ⟨d_b_src_imm, e_b_src_imm⟩ := bool_of_booleanity hb_b_src_imm
+  obtain ⟨d_b_src_mem, e_b_src_mem⟩ := bool_of_booleanity hb_b_src_mem
+  obtain ⟨d_store_mem, e_store_mem⟩ := bool_of_booleanity hb_store_mem
+  obtain ⟨d_store_ind, e_store_ind⟩ := bool_of_booleanity hb_store_ind
+  obtain ⟨d_b_src_ind, e_b_src_ind⟩ := bool_of_booleanity hb_b_src_ind
+  obtain ⟨d_a_src_reg, e_a_src_reg⟩ := bool_of_booleanity hb_a_src_reg
+  obtain ⟨d_b_src_reg, e_b_src_reg⟩ := bool_of_booleanity hb_b_src_reg
+  obtain ⟨d_store_reg, e_store_reg⟩ := bool_of_booleanity hb_store_reg
+  have hpack : romFlags row =
+      packFlags ⟨d_a_src_imm, d_a_src_mem, d_is_precompiled, d_b_src_imm,
+        d_b_src_mem, d_ieo, d_store_pc, d_store_mem, d_store_ind, d_set_pc,
+        d_m32, d_b_src_ind, d_a_src_reg, d_b_src_reg, d_store_reg⟩ := by
+    simp only [romFlags, packFlags, e_ieo, e_m32, e_set_pc, e_store_pc,
+      e_a_src_imm, e_a_src_mem, e_is_precompiled, e_b_src_imm, e_b_src_mem,
+      e_store_mem, e_store_ind, e_b_src_ind, e_a_src_reg, e_b_src_reg, e_store_reg]
+  have hbits := packFlags_inj (hpack.symm.trans h)
+  subst hbits
+  exact e_a_src_imm
+
 /-! ## ADD pilot: reconstruct `Decode_add` from the committed program
 
 `Decode_add_of_program` rebuilds the `Decode_add` decode pins from

--- a/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
@@ -86,6 +86,90 @@ theorem mainBOffsetImm0_at_eq_program
   refine ⟨j, ?_, ?_⟩ <;>
     simp only [← hj, romMessage, mainOfTable_pc]
 
+/-! ### Physical-row unpacking
+
+Every family except JALR decodes at the physical row `⟨i.val, _⟩` carrying the
+architectural index `i`, so the wrappers below are stated at `i`. JALR's
+unaligned lowering spans two adjacent physical rows, only the first of which is
+the architectural index, so it needs the same unpacking at an arbitrary
+`Fin trace.mainTable.table.length`. The underlying binding lemmas
+(`mainRomMessage_at_eq_program`, `mainRow_flags_boolean`, `mainSourceSpec_at`)
+are already physical; these `…_at` versions just drop the architectural
+projection, and the architectural wrappers are their instances at
+`⟨i.val, h_lt⟩`. -/
+
+/-- **Flag-column unpacking at a physical Main row.** Given the row's packed
+    `romFlags` equals `packFlags bits`, the four packed flag columns equal
+    `boolF` of their bits. -/
+theorem mainFlagColumns_of_packFlags_at
+    {numInstructions : Nat} (trace : AcceptedZiskTrace numInstructions)
+    (row : Fin trace.mainTable.table.length)
+    (bits : RomFlagBits)
+    (h : romFlags (mainTableRowAtOrZero trace.program trace.mainTable row.val)
+        = packFlags bits) :
+    (mainOfTable trace.program trace.mainTable).is_external_op row.val
+        = ZiskFv.AirsClean.boolF bits.is_external_op
+  ∧ (mainOfTable trace.program trace.mainTable).m32 row.val
+        = ZiskFv.AirsClean.boolF bits.m32
+  ∧ (mainOfTable trace.program trace.mainTable).set_pc row.val
+        = ZiskFv.AirsClean.boolF bits.set_pc
+  ∧ (mainOfTable trace.program trace.mainTable).store_pc row.val
+        = ZiskFv.AirsClean.boolF bits.store_pc := by
+  obtain ⟨a, b, d, e⟩ := romFlagColumns_of_romFlags_eq_packFlags
+    (mainTableRowAtOrZero trace.program trace.mainTable row.val) bits
+    (mainRow_flags_boolean trace row) h
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · simpa only [mainOfTable_is_external_op] using a
+  · simpa only [mainOfTable_m32] using b
+  · simpa only [mainOfTable_set_pc] using d
+  · simpa only [mainOfTable_store_pc] using e
+
+/-- **Memory/register selector unpacking at a physical Main row.** The full
+    six-selector projection of `romMemorySelectorColumns_of_romFlags_eq_packFlags`
+    (the three-selector `mainSelectorColumns_of_packFlags` is the architectural
+    subset used by address placement). -/
+theorem mainMemorySelectorColumns_of_packFlags_at
+    {numInstructions : Nat} (trace : AcceptedZiskTrace numInstructions)
+    (row : Fin trace.mainTable.table.length)
+    (bits : RomFlagBits)
+    (h : romFlags (mainTableRowAtOrZero trace.program trace.mainTable row.val)
+        = packFlags bits) :
+    (mainRowWithRomAt trace row).rom.b_src_mem = ZiskFv.AirsClean.boolF bits.b_src_mem
+  ∧ (mainRowWithRomAt trace row).rom.store_mem = ZiskFv.AirsClean.boolF bits.store_mem
+  ∧ (mainRowWithRomAt trace row).rom.store_ind = ZiskFv.AirsClean.boolF bits.store_ind
+  ∧ (mainRowWithRomAt trace row).rom.b_src_ind = ZiskFv.AirsClean.boolF bits.b_src_ind
+  ∧ (mainRowWithRomAt trace row).rom.b_src_reg = ZiskFv.AirsClean.boolF bits.b_src_reg
+  ∧ (mainRowWithRomAt trace row).rom.store_reg = ZiskFv.AirsClean.boolF bits.store_reg :=
+  romMemorySelectorColumns_of_romFlags_eq_packFlags
+    (mainTableRowAtOrZero trace.program trace.mainTable row.val) bits
+    (mainRow_flags_boolean trace row) h
+
+/-- **`b`-immediate-source selector unpacking at a physical Main row.** -/
+theorem mainBSourceImmColumn_of_packFlags_at
+    {numInstructions : Nat} (trace : AcceptedZiskTrace numInstructions)
+    (row : Fin trace.mainTable.table.length)
+    (bits : RomFlagBits)
+    (h : romFlags (mainTableRowAtOrZero trace.program trace.mainTable row.val)
+        = packFlags bits) :
+    (mainRowWithRomAt trace row).rom.b_src_imm
+        = ZiskFv.AirsClean.boolF bits.b_src_imm :=
+  romBSourceImmColumn_of_romFlags_eq_packFlags
+    (mainTableRowAtOrZero trace.program trace.mainTable row.val) bits
+    (mainRow_flags_boolean trace row) h
+
+/-- **`a`-immediate-source selector unpacking at a physical Main row.** -/
+theorem mainASourceImmColumn_of_packFlags_at
+    {numInstructions : Nat} (trace : AcceptedZiskTrace numInstructions)
+    (row : Fin trace.mainTable.table.length)
+    (bits : RomFlagBits)
+    (h : romFlags (mainTableRowAtOrZero trace.program trace.mainTable row.val)
+        = packFlags bits) :
+    (mainRowWithRomAt trace row).rom.a_src_imm
+        = ZiskFv.AirsClean.boolF bits.a_src_imm :=
+  romASourceImmColumn_of_romFlags_eq_packFlags
+    (mainTableRowAtOrZero trace.program trace.mainTable row.val) bits
+    (mainRow_flags_boolean trace row) h
+
 /-- **Flag-column unpacking at a row.**  Given the row's packed `romFlags` equals
     `packFlags bits`, the four packed flag columns equal `boolF` of their bits.
     Wraps `romFlagColumns_of_romFlags_eq_packFlags` + `mainRow_flags_boolean` and
@@ -104,15 +188,8 @@ theorem mainFlagColumns_of_packFlags
   ∧ (mainOfTable trace.program trace.mainTable).set_pc i.val
         = ZiskFv.AirsClean.boolF bits.set_pc
   ∧ (mainOfTable trace.program trace.mainTable).store_pc i.val
-        = ZiskFv.AirsClean.boolF bits.store_pc := by
-  obtain ⟨a, b, d, e⟩ := romFlagColumns_of_romFlags_eq_packFlags
-    (mainTableRowAtOrZero trace.program trace.mainTable i.val) bits
-    (mainRow_flags_boolean trace ⟨i.val, h_lt⟩) h
-  refine ⟨?_, ?_, ?_, ?_⟩
-  · simpa only [mainOfTable_is_external_op] using a
-  · simpa only [mainOfTable_m32] using b
-  · simpa only [mainOfTable_set_pc] using d
-  · simpa only [mainOfTable_store_pc] using e
+        = ZiskFv.AirsClean.boolF bits.store_pc :=
+  mainFlagColumns_of_packFlags_at trace ⟨i.val, h_lt⟩ bits h
 
 /-- **Selector-column unpacking at a row.** Given the row's packed `romFlags`
     equals `packFlags bits`, the selector columns needed by address-placement
@@ -145,10 +222,8 @@ theorem mainBSourceImmColumn_of_packFlags
     (h : romFlags (mainTableRowAtOrZero trace.program trace.mainTable i.val)
         = packFlags bits) :
     (mainTableRowAtOrZero trace.program trace.mainTable i.val).rom.b_src_imm
-        = ZiskFv.AirsClean.boolF bits.b_src_imm := by
-  exact romBSourceImmColumn_of_romFlags_eq_packFlags
-    (mainTableRowAtOrZero trace.program trace.mainTable i.val) bits
-    (mainRow_flags_boolean trace ⟨i.val, h_lt⟩) h
+        = ZiskFv.AirsClean.boolF bits.b_src_imm :=
+  mainBSourceImmColumn_of_packFlags_at trace ⟨i.val, h_lt⟩ bits h
 
 /-- The committed program's `b` immediate limbs, transported through the
     Main↔ROM lookup to the concrete row, together with `b_src_imm = 1`. -/
@@ -305,6 +380,35 @@ theorem mainLuiDestinationFacts_of_program
     obtain ⟨hpso, _hpf⟩ := h_prog j hline
     simpa [mainRowWithRomLui] using hstore.symm.trans hpso
   exact ⟨h_store_ind, h_store_offset⟩
+
+/-- Physical-row twin of `mainLuiDestinationFacts_of_program`: writeback
+    destination selector/offset facts derived from the committed program at an
+    arbitrary Main row, for a lowering whose writeback row is not the
+    architectural index (JALR's unaligned terminal `OP_AND` row). -/
+theorem mainDestinationFacts_of_program_at
+    {numInstructions : Nat}
+    (trace : AcceptedZiskTrace numInstructions)
+    (row : Fin trace.mainTable.table.length)
+    (bits : RomFlagBits)
+    (rd : regidx)
+    (h_bits_store_ind : bits.store_ind = false)
+    (h_prog : ∀ j : Fin trace.programLength,
+        (trace.program j).line
+            = (mainOfTable trace.program trace.mainTable).pc row.val →
+          (trace.program j).store_offset = Transpiler.ind (regidx_to_fin rd)
+        ∧ (trace.program j).flags = packFlags bits) :
+    (mainRowWithRomAt trace row).rom.store_ind = 0
+  ∧ (mainRowWithRomAt trace row).rom.store_offset
+      = Transpiler.ind (regidx_to_fin rd) := by
+  obtain ⟨j, hline, _hop, _hiw, _hj1, _hj2, hflags⟩ :=
+    mainRomColumns_at_eq_program trace row
+  obtain ⟨_hpso, hpf⟩ := h_prog j hline
+  obtain ⟨_, _, p_store_ind, _, _, _⟩ :=
+    mainMemorySelectorColumns_of_packFlags_at trace row bits (hflags.symm.trans hpf)
+  refine ⟨by simpa [h_bits_store_ind, ZiskFv.AirsClean.boolF_false] using p_store_ind, ?_⟩
+  obtain ⟨j, hline, hstore⟩ := mainStoreOffset_at_eq_program trace row
+  obtain ⟨hpso, _hpf⟩ := h_prog j hline
+  simpa [mainRowWithRomAt] using hstore.symm.trans hpso
 
 
 /-! ## Family: R/I-type ALU -/
@@ -4263,6 +4367,220 @@ def Decode_jalr_of_program
       h_a_mask_hi := h_a_mask_hi
       h_c1_zero := h_c1_zero
       h_jmp2 := Or.inl ⟨rfl, key.2.2.2.2.2⟩
+      h_offset_bridge := h_offset_bridge
+      h_offset_even := h_offset_even
+      h_no_fgl_wrap := h_no_fgl_wrap }
+
+/-- `Decode_jalr` for the UNALIGNED lowering, rebuilt from the committed program
+    via the ROM lookup at BOTH physical rows the lowering occupies.
+
+    `Decode_jalr_of_program` covers the aligned lowering, which folds into the
+    single architectural row. The unaligned lowering emits `OP_ADD` at the
+    architectural row `i.val` (computing `rs1 + imm` on the `a`/`b` lanes) and
+    the terminal `OP_AND` at its physical successor `i.val + 1` (masking bit
+    zero, storing the link PC, and taking the jump). Both rows' ROM-message
+    columns — `op`, `jmp_offset2`, `store_offset`, the packed
+    `is_external_op`/`m32`/`set_pc`/`store_pc` flags, the `b`-lane source
+    selectors, and the ADD row's `a`-lane immediate — are DERIVED here from
+    `trace.program` at each row's OWN committed `pc`, so the two-row placement
+    costs no extra program-level premise beyond the second line's decode.
+
+    Passthrough (identical class to the aligned constructor's): the Main-core
+    columns `flag`, `a_0`/`a_1`, `c_1`, the `jmp_offset1` ↔ `offset_bv` bridge,
+    its evenness and no-wrap bounds, and the row bound. These are not ROM-message
+    slots. -/
+def Decode_jalr_unaligned_of_program
+    {numInstructions : Nat}
+    (trace : AcceptedZiskTrace numInstructions)
+    (i : Fin trace.numInstructions)
+    (c : Claim_jalr trace i)
+    -- the terminal row is the physical successor of the ADD row, and it too has
+    -- a successor (the row the set-PC handshake lands on)
+    (h_idx2 : i.val + 2 < trace.mainTable.table.length)
+    -- claim-level: the unaligned lowering carries a zero terminal offset
+    -- (mirrors the aligned constructor's `h_offset_aligned`)
+    (h_offset_zero : c.offset_bv = 0#64)
+    (h_flag_add :
+    (mainOfTable trace.program trace.mainTable).flag i.val = 0)
+    (h_flag :
+    (mainOfTable trace.program trace.mainTable).flag (i.val + 1) = 0)
+    (h_a_mask_lo :
+    (mainOfTable trace.program trace.mainTable).a_0 (i.val + 1) = 4294967294)
+    (h_a_mask_hi :
+    (mainOfTable trace.program trace.mainTable).a_1 (i.val + 1) = 4294967295)
+    (h_c1_zero :
+    (mainOfTable trace.program trace.mainTable).c_1 (i.val + 1) = 0)
+    (h_offset_bridge :
+    ((mainOfTable trace.program trace.mainTable).jmp_offset1 (i.val + 1)).val
+      = c.offset_bv.toNat)
+    (h_offset_even : c.offset_bv &&& 1#64 = 0#64)
+    (h_no_fgl_wrap :
+    ((mainOfTable trace.program trace.mainTable).c_0 (i.val + 1)).val
+      + ((mainOfTable trace.program trace.mainTable).jmp_offset1 (i.val + 1)).val
+        < GL_prime)
+    (addBits : RomFlagBits)
+    (h_add_ieo : addBits.is_external_op = true)
+    (h_add_m32 : addBits.m32 = false)
+    (h_add_set_pc : addBits.set_pc = false)
+    (h_add_a_src_imm : addBits.a_src_imm = true)
+    (h_add_b_src_reg : addBits.b_src_reg = true)
+    (andBits : RomFlagBits)
+    (h_and_ieo : andBits.is_external_op = true)
+    (h_and_m32 : andBits.m32 = false)
+    (h_and_set_pc : andBits.set_pc = true)
+    (h_and_store_pc : andBits.store_pc = true)
+    (h_and_store_ind : andBits.store_ind = false)
+    (h_and_b_src_imm : andBits.b_src_imm = false)
+    (h_and_b_src_mem : andBits.b_src_mem = false)
+    (h_and_b_src_ind : andBits.b_src_ind = false)
+    (h_and_b_src_reg : andBits.b_src_reg = false)
+    (h_prog_add : ∀ j : Fin trace.programLength,
+        (trace.program j).line
+            = (mainOfTable trace.program trace.mainTable).pc i.val →
+          (trace.program j).op = ZiskFv.Trusted.OP_ADD
+        ∧ (trace.program j).jmp_offset2 = 1
+        ∧ BitVec.signExtend 64 c.imm
+            = BitVec.ofNat 64
+                ((trace.program j).a_offset_imm0.val
+                  + (trace.program j).a_imm1.val * 4294967296)
+        ∧ (trace.program j).flags = packFlags addBits)
+    (h_prog_and : ∀ j : Fin trace.programLength,
+        (trace.program j).line
+            = (mainOfTable trace.program trace.mainTable).pc (i.val + 1) →
+          (trace.program j).op = ZiskFv.Trusted.OP_AND
+        ∧ (trace.program j).jmp_offset2 = 3
+        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
+        ∧ (trace.program j).flags = packFlags andBits) :
+    Decode_jalr trace i c := by
+  have h_lt_start : i.val < trace.mainTable.table.length := trace.mainTable_index i
+  have h_lt_finish : i.val + 1 < trace.mainTable.table.length := by omega
+  -- `Decode_jalr` lives in `Type`, so every `Exists` elimination on the ROM
+  -- binding must be bagged into a Prop-valued `have` before the structure is
+  -- built (large elimination is not available in the goal itself). Same shape
+  -- as the aligned constructor's `have key`, once per committed row.
+  have keyAdd :
+      (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_ADD ∧
+      (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1 ∧
+      (mainOfTable trace.program trace.mainTable).m32 i.val = 0 ∧
+      (mainOfTable trace.program trace.mainTable).set_pc i.val = 0 ∧
+      (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 1 ∧
+      (mainRowWithRomAt trace ⟨i.val, h_lt_start⟩).rom.b_src_reg = 1 := by
+    obtain ⟨ja, hlinea, hopa, _, _, hjmp2a, hflagsa⟩ :=
+      mainRomColumns_at_eq_program trace ⟨i.val, h_lt_start⟩
+    obtain ⟨hpoa, hpj2a, _, hpfa⟩ := h_prog_add ja hlinea
+    have hroma := hflagsa.symm.trans hpfa
+    obtain ⟨pa_ieo, pa_m32, pa_set_pc, _⟩ :=
+      mainFlagColumns_of_packFlags_at trace ⟨i.val, h_lt_start⟩ addBits hroma
+    obtain ⟨_, _, _, _, pa_b_src_reg, _⟩ :=
+      mainMemorySelectorColumns_of_packFlags_at trace ⟨i.val, h_lt_start⟩ addBits hroma
+    exact ⟨hopa.symm.trans hpoa,
+      by rw [pa_ieo, h_add_ieo, ZiskFv.AirsClean.boolF_true],
+      by rw [pa_m32, h_add_m32, ZiskFv.AirsClean.boolF_false],
+      by rw [pa_set_pc, h_add_set_pc, ZiskFv.AirsClean.boolF_false],
+      hjmp2a.symm.trans hpj2a,
+      by rw [pa_b_src_reg, h_add_b_src_reg, ZiskFv.AirsClean.boolF_true]⟩
+  -- The ADD row's `a` lane carries the committed immediate: `a_src_imm = 1`
+  -- turns `SourceSpec` into `a_0 = a_offset_imm0`, `a_1 = a_imm1`, and the ROM
+  -- message ties both limbs to the committed program entry.
+  have h_a_lane :
+      BitVec.ofNat 64
+          (((mainOfTable trace.program trace.mainTable).a_0 i.val).val
+            + ((mainOfTable trace.program trace.mainTable).a_1 i.val).val * 4294967296)
+        = BitVec.signExtend 64 c.imm := by
+    obtain ⟨j, hj⟩ := mainRomMessage_at_eq_program trace ⟨i.val, h_lt_start⟩
+    have hline : (trace.program j).line
+        = (mainOfTable trace.program trace.mainTable).pc i.val := by
+      simp only [← hj, romMessage, mainOfTable_pc]
+    obtain ⟨_, _, h_imm, hpf⟩ := h_prog_add j hline
+    have hrom : romFlags (mainTableRowAtOrZero trace.program trace.mainTable i.val)
+        = packFlags addBits := by
+      have hflags : (trace.program j).flags
+          = romFlags (mainTableRowAtOrZero trace.program trace.mainTable i.val) := by
+        simp only [← hj, romMessage]
+      exact hflags.symm.trans hpf
+    have h_asi :
+        (mainTableRowAtOrZero trace.program trace.mainTable i.val).rom.a_src_imm = 1 := by
+      simpa only [h_add_a_src_imm, ZiskFv.AirsClean.boolF_true]
+        using mainASourceImmColumn_of_packFlags_at trace ⟨i.val, h_lt_start⟩ addBits hrom
+    obtain ⟨h_a0, h_a1, _, _⟩ := mainSourceSpec_at trace ⟨i.val, h_lt_start⟩
+    rw [h_asi, one_mul] at h_a0 h_a1
+    have e_a0 : (mainTableRowAtOrZero trace.program trace.mainTable i.val).core.a_0
+        = (mainTableRowAtOrZero trace.program trace.mainTable i.val).rom.a_offset_imm0 := by
+      apply sub_eq_zero.mp; simpa [sub_eq_add_neg] using h_a0
+    have e_a1 : (mainTableRowAtOrZero trace.program trace.mainTable i.val).core.a_1
+        = (mainTableRowAtOrZero trace.program trace.mainTable i.val).rom.a_imm1 := by
+      apply sub_eq_zero.mp; simpa [sub_eq_add_neg] using h_a1
+    have h_off : (trace.program j).a_offset_imm0
+        = (mainTableRowAtOrZero trace.program trace.mainTable i.val).rom.a_offset_imm0 := by
+      simp only [← hj, romMessage]
+    have h_hi : (trace.program j).a_imm1
+        = (mainTableRowAtOrZero trace.program trace.mainTable i.val).rom.a_imm1 := by
+      simp only [← hj, romMessage]
+    rw [h_off, h_hi] at h_imm
+    simpa only [mainOfTable_a_0, mainOfTable_a_1, e_a0, e_a1] using h_imm.symm
+  have keyAnd :
+      (mainOfTable trace.program trace.mainTable).op (i.val + 1) = ZiskFv.Trusted.OP_AND ∧
+      (mainOfTable trace.program trace.mainTable).is_external_op (i.val + 1) = 1 ∧
+      (mainOfTable trace.program trace.mainTable).m32 (i.val + 1) = 0 ∧
+      (mainOfTable trace.program trace.mainTable).set_pc (i.val + 1) = 1 ∧
+      (mainOfTable trace.program trace.mainTable).store_pc (i.val + 1) = 1 ∧
+      (mainOfTable trace.program trace.mainTable).jmp_offset2 (i.val + 1) = 3 ∧
+      (mainRowWithRomAt trace ⟨i.val + 1, h_lt_finish⟩).rom.b_src_imm = 0 ∧
+      (mainRowWithRomAt trace ⟨i.val + 1, h_lt_finish⟩).rom.b_src_mem = 0 ∧
+      (mainRowWithRomAt trace ⟨i.val + 1, h_lt_finish⟩).rom.b_src_ind = 0 ∧
+      (mainRowWithRomAt trace ⟨i.val + 1, h_lt_finish⟩).rom.b_src_reg = 0 ∧
+      (mainRowWithRomAt trace ⟨i.val + 1, h_lt_finish⟩).rom.store_ind = 0 ∧
+      (mainRowWithRomAt trace ⟨i.val + 1, h_lt_finish⟩).rom.store_offset
+        = Transpiler.ind (regidx_to_fin c.rd) := by
+    obtain ⟨jb, hlineb, hopb, _, _, hjmp2b, hflagsb⟩ :=
+      mainRomColumns_at_eq_program trace ⟨i.val + 1, h_lt_finish⟩
+    obtain ⟨hpob, hpj2b, _, hpfb⟩ := h_prog_and jb hlineb
+    have hromb := hflagsb.symm.trans hpfb
+    obtain ⟨pb_ieo, pb_m32, pb_set_pc, pb_store_pc⟩ :=
+      mainFlagColumns_of_packFlags_at trace ⟨i.val + 1, h_lt_finish⟩ andBits hromb
+    obtain ⟨pb_b_mem, _, _, pb_b_ind, pb_b_reg, _⟩ :=
+      mainMemorySelectorColumns_of_packFlags_at trace ⟨i.val + 1, h_lt_finish⟩ andBits hromb
+    have pb_b_imm :=
+      mainBSourceImmColumn_of_packFlags_at trace ⟨i.val + 1, h_lt_finish⟩ andBits hromb
+    have h_dest := mainDestinationFacts_of_program_at trace ⟨i.val + 1, h_lt_finish⟩
+      andBits c.rd h_and_store_ind
+      (fun j hline => by
+        obtain ⟨_, _, hpso, hpf⟩ := h_prog_and j hline
+        exact ⟨hpso, hpf⟩)
+    exact ⟨hopb.symm.trans hpob,
+      by rw [pb_ieo, h_and_ieo, ZiskFv.AirsClean.boolF_true],
+      by rw [pb_m32, h_and_m32, ZiskFv.AirsClean.boolF_false],
+      by rw [pb_set_pc, h_and_set_pc, ZiskFv.AirsClean.boolF_true],
+      by rw [pb_store_pc, h_and_store_pc, ZiskFv.AirsClean.boolF_true],
+      hjmp2b.symm.trans hpj2b,
+      by rw [pb_b_imm, h_and_b_src_imm, ZiskFv.AirsClean.boolF_false],
+      by rw [pb_b_mem, h_and_b_src_mem, ZiskFv.AirsClean.boolF_false],
+      by rw [pb_b_ind, h_and_b_src_ind, ZiskFv.AirsClean.boolF_false],
+      by rw [pb_b_reg, h_and_b_src_reg, ZiskFv.AirsClean.boolF_false],
+      h_dest.1, h_dest.2⟩
+  exact
+    { rows :=
+        { start := ⟨i.val, h_lt_start⟩
+          finish := ⟨i.val + 1, h_lt_finish⟩
+          architectural_start := rfl
+          finish_has_successor := by simpa using h_idx2
+          lowering := Or.inr ⟨rfl, h_offset_zero, keyAdd.1, keyAdd.2.1, keyAdd.2.2.1,
+            h_flag_add, keyAdd.2.2.2.1, keyAdd.2.2.2.2.1, h_a_lane, keyAdd.2.2.2.2.2,
+            keyAnd.2.2.2.2.2.2.1, keyAnd.2.2.2.2.2.2.2.1,
+            keyAnd.2.2.2.2.2.2.2.2.1, keyAnd.2.2.2.2.2.2.2.2.2.1⟩ }
+      h_main_op := keyAnd.1
+      h_main_active := keyAnd.2.1
+      h_flag := h_flag
+      h_m32 := keyAnd.2.2.1
+      h_set_pc := keyAnd.2.2.2.1
+      h_store_pc := keyAnd.2.2.2.2.1
+      h_store_ind := keyAnd.2.2.2.2.2.2.2.2.2.2.1
+      h_store_offset := keyAnd.2.2.2.2.2.2.2.2.2.2.2
+      h_idx := by simpa using h_idx2
+      h_a_mask_lo := h_a_mask_lo
+      h_a_mask_hi := h_a_mask_hi
+      h_c1_zero := h_c1_zero
+      h_jmp2 := Or.inr ⟨rfl, keyAnd.2.2.2.2.2.1⟩
       h_offset_bridge := h_offset_bridge
       h_offset_even := h_offset_even
       h_no_fgl_wrap := h_no_fgl_wrap }


### PR DESCRIPTION
Closes #295. Stream S7b of the closeout plan.

Restores committed-ROM decode provenance for JALR — the residual #280 (PR #293) left behind, and the last family of 63 whose row decode did not reduce to committed-program evidence.

## The gap

#280 made JALR the first family whose one architectural instruction may span two committed Main rows (an `OP_ADD` row followed by the terminal `OP_AND` row). The existing `h_prog` premise shape indexes the committed program at a *single* line (`(trace.program j).line = mainOfTable … .pc i.val`), i.e. it assumes architectural index = row index, which the unaligned pair cannot express. Rather than split the family, #293 collapsed the whole thing:

```lean
structure ProgramDecode_jalr … where
  toDecode : Decode_jalr trace i c        -- passthrough

| jalr _ => exact pd.toDecode             -- no derivation
```

Nothing was unsound — every field remained a proposition about the committed trace — but JALR alone lost the audit trail the other 62 families carry.

## What this does

`ProgramDecode_jalr` is now a two-constructor **inductive**, because which lowering the transpiler emitted is real decode data, not a passthrough: the arms carry *different committed lines*.

- `.aligned` — one `OP_AND` line, dispatched through the retained `Decode_jalr_of_program` (which #280 had already updated with `h_offset_aligned` and the `Or.inl` lowering, then stopped calling).
- `.unaligned` — new `Decode_jalr_unaligned_of_program`, with ROM evidence at **two** committed lines: `h_prog_add` at `pc i.val` and `h_prog_and` at `pc (i.val + 1)`.

`rowDecode_of_programDecode`'s `jalr` arm now derives `Decode_jalr` from either arm instead of forwarding it.

## The load-bearing result: the unaligned PC relation is derived, not assumed

The obvious failure mode here was to reach the second committed line by *positing* `pc (i+1) = pc i + 1`. That would have been laundering — trading a decode passthrough for a new caller premise.

It is instead **derived**, from `AcceptedZiskTrace.mainTransition_to_next_pc` + `mainTable_fixed.segment_l1_succ` + `Airs.Main.pc_handshake_branch`, consuming only pins the unaligned `JalrLoweringRows` arm already carries (`set_pc start = 0`, `flag start = 0`, `jmp_offset2 start = 1`) — the same machinery the dispatcher already uses for JALR's link bridge. Given `JalrLoweringRows.architectural_start`, both committed lines are then just `pc i.val` and `pc (i.val + 1)`: the same "row's own pc" shape the other 62 families use, at a physical index.

One new lemma was required: `romASourceImmColumn_of_romFlags_eq_packFlags` (the `a_src_imm` analogue of the existing `b_src_imm` one). It must live in `RomDecodeBinding.lean` because it needs the private `bool_of_booleanity`.

Derived from committed ROM for the unaligned arm: `op` and `jmp_offset2` at both rows, `is_external_op`/`m32`/`set_pc`/`store_pc` via `packFlags` injectivity, `b_src_reg start = 1` and all four `b_src_*` at the terminal row, `store_ind`/`store_offset`, and the a-lane immediate `a_0 + a_1·2^32 = signExtend 64 imm`.

## Trust accounting, stated precisely

Before: 100% of `Decode_jalr` was caller-supplied. After: the passthrough set shrinks to the same class the aligned constructor already carried — `flag` at both rows (a Main core column, not a ROM slot), the `a`-lane mask pins, `c_1 = 0`, the `jmp_offset1`↔`offset_bv` bridge, offset evenness, no-FGL-wrap, and the row-bound.

Two things I want stated plainly rather than glossed:

1. **`h_offset_aligned` is a net-new caller premise** relative to the pre-#280 bundle. It is strictly smaller than what it replaces (a claim-level fact mirroring the aligned arm's own shape), but it is not exact parity, and an earlier draft of this description said parity. It isn't.
2. **Only the `.unaligned` arm has a concrete instantiating witness** (`JalrSpinWitness`, `imm = 2`). The `.aligned` arm has none — and never has: I checked `a60b2bd5`, where no witness instantiated a JALR step at all, so this is a standing gap rather than one introduced here (#280 added the first-ever JALR instantiation). This is now recorded in the `ProgramDecode_jalr` docstring. An aligned JALR spin witness would close it.

## Verification

Rebased onto `origin/main` `e19f012e` (post-#297/#298). The pre-rebase gate result is **not** carried forward: this branch rewrites `JalrSpinRootSoundness.lean` by 256 lines, and before #297 that module was outside the `lake build` graph, so its earlier "green" rested on an explicit `lake build +<module>`. It is now gated by default.

- `lake build` — **green, 9118 jobs**
- `trust/scripts/check-all.sh` — **18/18** (reachability: 688 modules, 0 unreachable, 0 dangling)
- `trust/scripts/check-all-semantic.sh` — **19/19**, exit 0, with `jalrSpinRootSoundness`, `jalrStepSound`, and `jalrAcceptedTrace` certified in the root-soundness instantiation check

No new `axiom`, `sorry`, `admit`, `opaque`, or `native_decide`. The `check-rowdata-partition` gate is unaffected: no `Decode_<op>`/`Inputs_<op>` structures were added to `RowData*.lean`, and no `SailTrace` reference enters `Decode_jalr`.

## Adjacent, deliberately not fixed

All other families still pin their decode columns at `i.val`, so an architectural instruction *following* an unaligned JALR would sit at physical row `i.val + 1` while its decode points at `i.val` — it is still not instantiable at the trace level. That belongs to #61 (S9), not here.
