### PR TITLE
Prove the ZisK lowerer succeeds for all 63 RV64IM opcodes (#61 S1)

### DIFF
--- a/ZiskFv/Compliance/AeneasBridgeTrust/Extraction.lean
+++ b/ZiskFv/Compliance/AeneasBridgeTrust/Extraction.lean
@@ -63,3 +63,4 @@ import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.LoadStore
 import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.Precompiled
 import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.Dispatch
 import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.DynamicFields
+import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.Totality

--- a/ZiskFv/Compliance/AeneasBridgeTrust/Extraction/Totality.lean
+++ b/ZiskFv/Compliance/AeneasBridgeTrust/Extraction/Totality.lean
@@ -1,0 +1,1868 @@
+/-
+ZiskFv/Compliance/AeneasBridgeTrust/Extraction/Totality.lean  (eth-act/zisk-fv#61 / #111)
+
+Symbolic-register LOWERING-TOTALITY for the REAL Aeneas-extracted ZisK lowerer
+(`trust/aeneas/ProductionM2.lean`, the `ProductionM2` lean_lib).
+
+Every theorem in `Extraction/Dispatch.lean` (#111's 63-opcode static and row-mode
+decode pins) is stated in the shape
+
+    (h : lower_rv64im_single_row_input self ri <Opcode> hni = ok ctx) → <pins>
+
+i.e. it PRESUPPOSES that the lowerer succeeded, and leaves that presupposition to
+the caller.  Nothing in the tree discharged it, so the pins were conditional on an
+unproved fact and could in principle have been vacuous.  This module removes that
+presupposition: §11 proves
+
+    ∃ ctx, lower_rv64im_single_row_input self ri <Opcode> hni = ok ctx
+
+for all 63 RV64IM opcodes, from the in-range register fields alone, and §12
+re-states each `<op>_dispatch_static_pins` with the `= ok ctx` hypothesis GONE.
+
+Kernel-sound: NO native_decide / bv_decide / ofReduceBool / trustCompiler /
+`sorry`, and no new assumption of any kind (see §12's note on what is and is not
+closed).
+
+Key facts:
+  * The decoder's register fields are 5-bit masks, hence `< 32`
+    (`decode_r_bounds`), so the lowerer's `reg * 8` overflow branches are
+    UNREACHABLE (contradictory, discharged by `scalar_tac` against the
+    numBits-split `REGS_IN_MAIN_{FROM,TO}` cast values) and every taken branch
+    returns `ok` — so `create_register_op_typed` is TOTAL with NO `≠ 0`
+    side-condition (those are dispatcher-routing conditions for ADD/OR only).
+  * `decode_extract_from_decoded` and `ZiskInstExtract.from_inst` are total
+    (every opcode/format arm returns `ok`; `from_inst` copies the row fields).
+  * `ind_width` is total exactly on the four legal access widths, and the
+    dispatcher's load/store arms pass only those (§9) — so the `hw` premise of
+    the §6 load/store lemmas is DERIVED, never assumed.
+-/
+import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.Helpers
+import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.Dispatch
+import ZiskFv.Compliance.AeneasBridgeTrust.Decode.Leaves
+
+open Aeneas Aeneas.Std Result zisk_core
+open aeneas_extract.rv64im_decode
+open ZiskFv.Compliance.Decode (toU32)
+
+namespace ZiskFv.Compliance.Extraction
+
+set_option maxHeartbeats 4000000
+set_option linter.unusedSimpArgs false
+
+/-! ## 1. Decoder register-field bounds (the 5-bit masks land `< 32`). -/
+
+/-- A masked, right-shifted 32-bit field is bounded by `mask >>> k`. -/
+theorem and_ushr_toNat_lt (x : Std.U32) (mbv : BitVec 32) (k : Nat) (bnd : Nat)
+    (h : mbv.toNat >>> k < bnd) :
+    ((x &&& ⟨mbv⟩ : Std.U32).bv.ushiftRight k).toNat < bnd := by
+  rw [show ((x &&& (⟨mbv⟩ : Std.U32)).bv.ushiftRight k) = (x.bv &&& mbv) >>> k from rfl,
+     BitVec.toNat_ushiftRight, BitVec.toNat_and]
+  have hle : (x.bv.toNat &&& mbv.toNat) ≤ mbv.toNat := Nat.and_le_right
+  rw [Nat.shiftRight_eq_div_pow] at h ⊢
+  exact lt_of_le_of_lt (Nat.div_le_div_right hle) h
+
+/-- `decode_r` is total and its `rd`/`rs1`/`rs2` fields are `< 32`. -/
+theorem decode_r_bounds (raw : Std.U32) (op : RiscvOpcode) :
+    ∃ d, decode_r raw op = ok d ∧ d.opcode = op
+      ∧ d.rd.val < 32 ∧ d.rs1.val < 32 ∧ d.rs2.val < 32 := by
+  refine ⟨_, rfl, rfl, ?_, ?_, ?_⟩ <;> simp only [UScalar.val]
+  · exact and_ushr_toNat_lt raw 3968#32 (7#i32).toNat 32 (by decide)
+  · exact and_ushr_toNat_lt raw 1015808#32 (15#i32).toNat 32 (by decide)
+  · exact and_ushr_toNat_lt raw 32505856#32 (20#i32).toNat 32 (by decide)
+
+/-! ## 2. numBits-split cast values for the register-bound comparisons. -/
+
+theorem cast_one_u64 : (UScalar.cast UScalarTy.U64 1#usize).val = 1 := by
+  simp only [Aeneas.Std.UScalar.cast]
+  rcases System.Platform.numBits_eq with h | h <;> simp_all <;> decide
+theorem cast_31_u64 : (UScalar.cast UScalarTy.U64 31#usize).val = 31 := by
+  simp only [Aeneas.Std.UScalar.cast]
+  rcases System.Platform.numBits_eq with h | h <;> simp_all <;> decide
+theorem cast_one_i64 : (UScalar.hcast IScalarTy.I64 1#usize).val = 1 := by
+  simp only [Aeneas.Std.UScalar.hcast]
+  rcases System.Platform.numBits_eq with h | h <;> simp_all <;> decide
+theorem cast_31_i64 : (UScalar.hcast IScalarTy.I64 31#usize).val = 31 := by
+  simp only [Aeneas.Std.UScalar.hcast]
+  rcases System.Platform.numBits_eq with h | h <;> simp_all <;> decide
+
+theorem cast_u32_u64_val (x : Std.U32) : (UScalar.cast UScalarTy.U64 x).val = x.val := by
+  simp only [Aeneas.Std.UScalar.cast, UScalar.val, BitVec.toNat_setWidth]
+  rw [show UScalarTy.U64.numBits = 64 from rfl,
+     Nat.mod_eq_of_lt (lt_of_lt_of_le x.bv.isLt (by norm_num))]
+
+theorem hcast_u32_i64_val (x : Std.U32) : (UScalar.hcast IScalarTy.I64 x : Std.I64).val = x.val := by
+  have hlt : x.bv.toNat < 2 ^ 64 := lt_of_lt_of_le x.bv.isLt (by norm_num)
+  simp only [Aeneas.Std.UScalar.hcast, IScalar.val, UScalar.val]
+  rw [BitVec.toInt_eq_toNat_of_lt (by
+        rw [BitVec.toNat_setWidth, show IScalarTy.I64.numBits = 64 from rfl, Nat.mod_eq_of_lt hlt]
+        have := x.bv.isLt; omega),
+     BitVec.toNat_setWidth, show IScalarTy.I64.numBits = 64 from rfl, Nat.mod_eq_of_lt hlt]
+
+/-! ## 3. Builder totality (every register-class branch returns `ok`). -/
+
+theorem src_a_reg_ok (self : zisk_inst_builder.ZiskInstBuilder) (reg : Std.U64) (usp : Bool)
+    (hb : reg.val < 32) : ∃ z, zisk_inst_builder.ZiskInstBuilder.src_a_reg self reg usp = ok z := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.src_a_reg, zisk_inst_builder.ZiskInstBuilder.src_a_imm,
+    zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO, zisk_registers.REG_FIRST,
+    mem.SYS_ADDR, mem.RAM_ADDR, lift, Bind.bind, bind_ok]
+  have e1 := cast_one_u64; have e31 := cast_31_u64
+  split_ifs <;> first | exact ⟨_, rfl⟩ | (exfalso; scalar_tac)
+
+theorem src_b_reg_ok (self : zisk_inst_builder.ZiskInstBuilder) (reg : Std.U64) (usp : Bool)
+    (hb : reg.val < 32) : ∃ z, zisk_inst_builder.ZiskInstBuilder.src_b_reg self reg usp = ok z := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.src_b_reg, zisk_inst_builder.ZiskInstBuilder.src_b_imm,
+    zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO, zisk_registers.REG_FIRST,
+    mem.SYS_ADDR, mem.RAM_ADDR, lift, Bind.bind, bind_ok]
+  have e1 := cast_one_u64; have e31 := cast_31_u64
+  split_ifs <;> first | exact ⟨_, rfl⟩ | (exfalso; scalar_tac)
+
+theorem store_reg_ok (self : zisk_inst_builder.ZiskInstBuilder) (off : Std.I64) (usp spc : Bool)
+    (hlo : 0 ≤ off.val) (hhi : off.val < 32) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.store_reg self off usp spc = ok z := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.store_reg,
+    zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO, zisk_registers.REG_FIRST,
+    mem.SYS_ADDR, mem.RAM_ADDR, lift, Bind.bind, bind_ok]
+  have e1 := cast_one_i64; have e31 := cast_31_i64
+  split_ifs <;> first | exact ⟨_, rfl⟩ | (exfalso; scalar_tac)
+
+theorem src_b_imm_ok (self : zisk_inst_builder.ZiskInstBuilder) (v : Std.U64) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.src_b_imm self v = ok z := ⟨_, rfl⟩
+
+theorem op_zisk_ok (self : zisk_inst_builder.ZiskInstBuilder) (op : zisk_ops.ZiskOp) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.op_zisk self op = ok z := by
+  cases op <;> exact ⟨_, rfl⟩
+
+theorem new_ok (i : riscv2zisk_single_row.Rv64imLoweringInput) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.new_for_rv64im_lowering i = ok z := ⟨_, rfl⟩
+
+theorem new_raw_ok (rom : Std.U64) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.new rom = ok z := ⟨_, rfl⟩
+
+theorem j_ok (self : zisk_inst_builder.ZiskInstBuilder) (j1 j2 : Std.I64) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.j self j1 j2 = ok z := ⟨_, rfl⟩
+
+theorem build_ok (self : zisk_inst_builder.ZiskInstBuilder) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.build self = ok z := ⟨_, rfl⟩
+
+theorem insert_inst_ok (self : riscv2zisk_context.Riscv2ZiskContext) (rom : Std.U64)
+    (zib : zisk_inst_builder.ZiskInstBuilder) :
+    ∃ z, riscv2zisk_context.Riscv2ZiskContext.insert_inst self rom zib = ok z := ⟨_, rfl⟩
+
+/-! ## 4. Entry-point + helper totality used by the transpile bridge. -/
+
+/-- `create_register_op_typed` is total for in-range register fields (no `≠ 0`). -/
+theorem create_register_op_typed_ok
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp) (inst_size : Std.U64)
+    (h1 : i.rs1.val < 32) (h2 : i.rs2.val < 32) (h3 : i.rd.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.create_register_op_typed self i op inst_size = ok ctx := by
+  obtain ⟨z0, hz0⟩ := new_ok i
+  obtain ⟨z1, hz1⟩ := src_a_reg_ok z0 (UScalar.cast UScalarTy.U64 i.rs1) false (by rw [cast_u32_u64_val]; exact h1)
+  obtain ⟨z2, hz2⟩ := src_b_reg_ok z1 (UScalar.cast UScalarTy.U64 i.rs2) false (by rw [cast_u32_u64_val]; exact h2)
+  obtain ⟨z3, hz3⟩ := op_zisk_ok z2 op
+  obtain ⟨z4, hz4⟩ := store_reg_ok z3 (UScalar.hcast IScalarTy.I64 i.rd) false false
+    (by rw [hcast_u32_i64_val]; exact_mod_cast Nat.zero_le _)
+    (by rw [hcast_u32_i64_val]; exact_mod_cast h3)
+  obtain ⟨z5, hz5⟩ := j_ok z4 (UScalar.hcast IScalarTy.I64 inst_size) (UScalar.hcast IScalarTy.I64 inst_size)
+  obtain ⟨z6, hz6⟩ := build_ok z5
+  obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z6
+  refine ⟨{ s1 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.create_register_op_typed]
+  simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hz5, hz6, hs1]
+
+/-- `from_inst` is total and copies the row's decode/row-mode fields (incl.
+`ind_width`, which the load/store bridge reads). -/
+theorem from_inst_ok (zi : zisk_inst.ZiskInst) :
+    ∃ e, aeneas_extract.ZiskInstExtract.from_inst zi = ok e
+      ∧ e.op = zi.op ∧ e.is_external_op = zi.is_external_op ∧ e.m32 = zi.m32
+      ∧ e.set_pc = zi.set_pc ∧ e.store_pc = zi.store_pc
+      ∧ e.jmp_offset1 = zi.jmp_offset1 ∧ e.jmp_offset2 = zi.jmp_offset2
+      ∧ e.ind_width = zi.ind_width := by
+  refine ⟨_, rfl, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;> rfl
+
+/-- `decode_extract_from_decoded` is total (every opcode/format arm returns `ok`). -/
+theorem decode_extract_ok (d : aeneas_extract.rv64im_decode.DecodedRv64im) :
+    ∃ e, aeneas_extract.decode_extract_from_decoded d = ok e := by
+  obtain ⟨b, hb⟩ : ∃ b, aeneas_extract.rv64im_decode.DecodedRv64im.is_supported_rv64im d = ok b := by
+    rw [aeneas_extract.rv64im_decode.DecodedRv64im.is_supported_rv64im]; cases d.opcode <;> exact ⟨_, rfl⟩
+  obtain ⟨i, hi⟩ : ∃ i, aeneas_extract.opcode_id d.opcode = ok i := by
+    rw [aeneas_extract.opcode_id.eq_def]; cases d.opcode <;> exact ⟨_, rfl⟩
+  obtain ⟨i1, hi1⟩ : ∃ i, aeneas_extract.format_id d.format = ok i := by
+    rw [aeneas_extract.format_id.eq_def]; cases d.format <;> exact ⟨_, rfl⟩
+  simp only [aeneas_extract.decode_extract_from_decoded, Bind.bind, bind_ok, hb, hi, hi1]
+  exact ⟨_, rfl⟩
+
+/-! ## 5. Immediate-ALU lowering totality (block 3, immediate/shift families).
+
+`immediate_op_typed` is the canonical builder for the plain immediates
+(SLLI/SRLI/SRAI, SLTI/SLTIU, ANDI, ADDIW, SLLIW/SRLIW/SRAIW).  Unlike the
+register builder it uses `src_b_imm` (unconditionally total) for the second
+operand, so its only register-bound branches are `src_a_reg` (on `rs1`) and
+`store_reg` (on `rd`).  Hence totality needs only `rs1 < 32 ∧ rd < 32` (no rs2,
+no `≠ 0`). -/
+
+attribute [local step] ZiskFv.Compliance.Decode.signext_spec
+
+-- `decode_i` is total and its `rd`/`rs1` fields are `< 32` (the 5-bit masks land
+-- `< 32`; the `imm` field's `signext` is discharged via `signext_spec`).  The
+-- `shift_level` flag only affects `imm`, so the bounds hold for either value.
+set_option maxHeartbeats 1000000 in
+theorem decode_i_bounds (raw : Std.U32) (op : RiscvOpcode) (sh : Bool) :
+    ∃ d, decode_i raw op sh = ok d ∧ d.opcode = op ∧ d.rd.val < 32 ∧ d.rs1.val < 32
+      ∧ d.rd.bv = (raw &&& 3968#u32).bv >>> 7 := by
+  have spec : decode_i raw op sh
+      ⦃ d => d.opcode = op ∧ d.rd.val < 32 ∧ d.rs1.val < 32 ∧ d.rd.bv = (raw &&& 3968#u32).bv >>> 7 ⦄ := by
+    rcases sh with _ | _
+    · rw [decode_i]
+      simp only [aeneas_extract.rv64im_decode.DecodedRv64im.new, lift, bind_ok,
+        Bool.false_eq_true, if_false, reduceIte]
+      step*
+      · -- signext precondition: i7 (a 12-bit slice) ≤ 2147483647
+        rw [i7_post1, Nat.shiftRight_eq_div_pow]
+        have h : (↑(raw &&& 4293918720#u32) : Nat) < 2 ^ 32 := by
+          have := (raw &&& 4293918720#u32).bv.isLt; simpa only [UScalar.val] using this
+        omega
+      · refine ⟨?_, ?_, i3_post2⟩
+        · rw [i3_post1, Nat.shiftRight_eq_div_pow]
+          have h : (↑(raw &&& 3968#u32) : Nat) ≤ 3968 := by
+            simp only [UScalar.val, BitVec.toNat_and]; exact le_trans Nat.and_le_right (by decide)
+          omega
+        · rw [i5_post1, Nat.shiftRight_eq_div_pow]
+          have h : (↑(raw &&& 1015808#u32) : Nat) ≤ 1015808 := by
+            simp only [UScalar.val, BitVec.toNat_and]; exact le_trans Nat.and_le_right (by decide)
+          omega
+    · rw [decode_i]
+      simp only [aeneas_extract.rv64im_decode.DecodedRv64im.new, lift, bind_ok,
+        if_true, reduceIte]
+      step*
+      · rw [i7_post1, Nat.shiftRight_eq_div_pow]
+        have h : (↑(raw &&& 4293918720#u32) : Nat) < 2 ^ 32 := by
+          have := (raw &&& 4293918720#u32).bv.isLt; simpa only [UScalar.val] using this
+        omega
+      · refine ⟨?_, ?_, i3_post2⟩
+        · rw [i3_post1, Nat.shiftRight_eq_div_pow]
+          have h : (↑(raw &&& 3968#u32) : Nat) ≤ 3968 := by
+            simp only [UScalar.val, BitVec.toNat_and]; exact le_trans Nat.and_le_right (by decide)
+          omega
+        · rw [i5_post1, Nat.shiftRight_eq_div_pow]
+          have h : (↑(raw &&& 1015808#u32) : Nat) ≤ 1015808 := by
+            simp only [UScalar.val, BitVec.toNat_and]; exact le_trans Nat.and_le_right (by decide)
+          omega
+  obtain ⟨d, hd, hpost⟩ := WP.spec_imp_exists spec
+  exact ⟨d, hd, hpost⟩
+
+/-- `immediate_op_typed` is total for in-range register fields (`rs1 < 32`,
+`rd < 32`).  The second operand is `src_b_imm` (unconditionally total), so the
+only register-bound branches are `src_a_reg` (on `rs1`) and `store_reg` (on `rd`),
+discharged by the same numBits-split technique as the register builder — NO `≠ 0`
+and NO `rs2` side-condition. -/
+theorem immediate_op_typed_ok
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp) (inst_size : Std.U64)
+    (h1 : i.rs1.val < 32) (h3 : i.rd.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.immediate_op_typed self i op inst_size = ok ctx := by
+  obtain ⟨z0, hz0⟩ := new_ok i
+  obtain ⟨z1, hz1⟩ := src_a_reg_ok z0 (UScalar.cast UScalarTy.U64 i.rs1) false (by rw [cast_u32_u64_val]; exact h1)
+  obtain ⟨z2, hz2⟩ := src_b_imm_ok z1 (IScalar.hcast UScalarTy.U64 i.imm)
+  obtain ⟨z3, hz3⟩ := op_zisk_ok z2 op
+  obtain ⟨z4, hz4⟩ := store_reg_ok z3 (UScalar.hcast IScalarTy.I64 i.rd) false false
+    (by rw [hcast_u32_i64_val]; exact_mod_cast Nat.zero_le _)
+    (by rw [hcast_u32_i64_val]; exact_mod_cast h3)
+  obtain ⟨z5, hz5⟩ := j_ok z4 (UScalar.hcast IScalarTy.I64 inst_size) (UScalar.hcast IScalarTy.I64 inst_size)
+  obtain ⟨z6, hz6⟩ := build_ok z5
+  obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z6
+  refine ⟨{ s1 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.immediate_op_typed]
+  simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hz5, hz6, hs1]
+
+/-! ## 6. Load / store lowering totality (block 3, load & store families).
+
+`load_op_typed` / `store_op_typed` are the canonical builders for the memory
+ops.  Both go through a `_with_reg_offset` helper with a literal `0` register
+offset (loads `0#i64`, stores `0#u64`), so totality additionally needs (a) that
+the `ind_width` builder accepts the per-op access-width literal (the `hw`
+hypothesis, discharged `⟨_, rfl⟩` for `w ∈ {1,2,4,8}`), and (b) that the `+ 0`
+offset addition is total and value-preserving (`iscalar_add_zero_ok` /
+`uscalar_add_zero_ok`).  Loads need `rs1 < 32 ∧ rd < 32` (`src_a_reg` on rs1,
+`store_reg` on rd); stores need `rs1 < 32 ∧ rs2 < 32` (`src_a_reg` on rs1,
+`src_b_reg` on rs2 — no rd: the store target is indirect, via `store_ind`). -/
+
+/-- `src_b_ind` is unconditionally total (both `use_sp` branches return `ok`). -/
+theorem src_b_ind_ok (self : zisk_inst_builder.ZiskInstBuilder) (off : Std.U64) (usp : Bool) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.src_b_ind self off usp = ok z := by
+  cases usp <;> exact ⟨_, rfl⟩
+
+/-- `store_ind` is unconditionally total. -/
+theorem store_ind_ok (self : zisk_inst_builder.ZiskInstBuilder) (off : Std.I64) (usp : Bool) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.store_ind self off usp = ok z := ⟨_, rfl⟩
+
+/-- Adding the literal `0#i64` offset is total and value-preserving (the register
+offset is `0` in `load_op_typed`'s `_with_reg_offset` call). -/
+theorem iscalar_add_zero_ok (x : Std.I64) : ∃ z, x + 0#i64 = ok z ∧ z.val = x.val := by
+  obtain ⟨z, hz, hv⟩ :=
+    WP.spec_imp_exists (IScalar.add_spec (x := x) (y := 0#i64) (by scalar_tac) (by scalar_tac))
+  exact ⟨z, hz, by simpa using hv⟩
+
+/-- Adding the literal `0#u64` offset is total and value-preserving (the register
+offset is `0` in `store_op_typed`'s `_with_reg_offset` call). -/
+theorem uscalar_add_zero_ok (x : Std.U64) : ∃ z, x + 0#u64 = ok z ∧ z.val = x.val := by
+  obtain ⟨z, hz, hv⟩ :=
+    WP.spec_imp_exists (UScalar.add_spec (x := x) (y := 0#u64) (by scalar_tac))
+  exact ⟨z, hz, by simpa using hv⟩
+
+set_option maxHeartbeats 1000000 in
+/-- `decode_s` is total and its `rs1`/`rs2` fields are `< 32` (the 5-bit masks
+land `< 32`; the `imm` field's `signext` is discharged exactly as in
+`decode_s_spec`). -/
+theorem decode_s_bounds (raw : Std.U32) (op : RiscvOpcode) :
+    ∃ d, decode_s raw op = ok d ∧ d.opcode = op ∧ d.rs1.val < 32 ∧ d.rs2.val < 32 := by
+  have spec : decode_s raw op
+      ⦃ d => d.opcode = op ∧ d.rs1.val < 32 ∧ d.rs2.val < 32 ⦄ := by
+    rw [decode_s]
+    simp only [aeneas_extract.rv64im_decode.DecodedRv64im.new, lift, bind_ok]
+    step*
+    · -- signext precondition: i9 = (i8 ||| imm4_0) ≤ 2147483647 (verbatim `decode_s_spec`)
+      have hi8 : (i8 : Std.U32).val < 2 ^ 31 := by
+        have h11 : imm11_5.val < 2 ^ 7 := by
+          rw [imm11_5_post1, Nat.shiftRight_eq_div_pow]
+          have h : (raw &&& 4261412864#u32).val < 2 ^ 32 := (raw &&& 4261412864#u32).bv.isLt
+          simp only [UScalar.val] at h ⊢; omega
+        rw [i8_post1, Nat.shiftLeft_eq]
+        have hle := Nat.mod_le (↑imm11_5 * 2 ^ 5) U32.size
+        simp only [UScalar.val] at h11 hle ⊢; omega
+      have hi40 : (imm4_0 : Std.U32).val < 2 ^ 31 := by
+        rw [imm4_0_post1]; exact ZiskFv.Compliance.Decode.shr_field_lt raw _ 7 (by norm_num)
+      have : (i8 ||| imm4_0).val < 2 ^ 31 := by
+        simp only [UScalar.val, BitVec.toNat_or] at hi8 hi40 ⊢; exact Nat.or_lt_two_pow hi8 hi40
+      simp only [UScalar.val] at this ⊢; omega
+    · refine ⟨?_, ?_⟩
+      · rw [i4_post1, Nat.shiftRight_eq_div_pow]
+        have h : (↑(raw &&& 1015808#u32) : Nat) ≤ 1015808 := by
+          simp only [UScalar.val, BitVec.toNat_and]; exact le_trans Nat.and_le_right (by decide)
+        omega
+      · rw [i6_post1, Nat.shiftRight_eq_div_pow]
+        have h : (↑(raw &&& 32505856#u32) : Nat) ≤ 32505856 := by
+          simp only [UScalar.val, BitVec.toNat_and]; exact le_trans Nat.and_le_right (by decide)
+        omega
+  obtain ⟨d, hd, hpost⟩ := WP.spec_imp_exists spec
+  exact ⟨d, hd, hpost⟩
+
+/-- `load_op_with_reg_offset` (the `0#i64`-offset specialization used by
+`load_op_typed`) is total for in-range register fields. -/
+theorem load_op_with_reg_offset_ok
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp) (w inst_size : Std.U64)
+    (hw : ∀ s : zisk_inst_builder.ZiskInstBuilder,
+            ∃ z, zisk_inst_builder.ZiskInstBuilder.ind_width s w = ok z)
+    (h1 : i.rs1.val < 32) (h3 : i.rd.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.load_op_with_reg_offset self i op w inst_size 0#i64
+      = ok ctx := by
+  obtain ⟨z0, hz0⟩ := new_ok i
+  obtain ⟨z1, hz1⟩ := src_a_reg_ok z0 (UScalar.cast UScalarTy.U64 i.rs1) false
+    (by rw [cast_u32_u64_val]; exact h1)
+  obtain ⟨z2, hz2⟩ := hw z1
+  obtain ⟨z3, hz3⟩ := src_b_ind_ok z2 (IScalar.hcast UScalarTy.U64 i.imm) false
+  obtain ⟨z4, hz4⟩ := op_zisk_ok z3 op
+  obtain ⟨i4, hi4, hi4v⟩ := iscalar_add_zero_ok (UScalar.hcast IScalarTy.I64 i.rd)
+  obtain ⟨z5, hz5⟩ := store_reg_ok z4 i4 false false
+    (by rw [hi4v, hcast_u32_i64_val]; exact_mod_cast Nat.zero_le _)
+    (by rw [hi4v, hcast_u32_i64_val]; exact_mod_cast h3)
+  obtain ⟨z6, hz6⟩ := j_ok z5 (UScalar.hcast IScalarTy.I64 inst_size) (UScalar.hcast IScalarTy.I64 inst_size)
+  obtain ⟨z7, hz7⟩ := build_ok z6
+  obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z7
+  refine ⟨{ s1 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.load_op_with_reg_offset]
+  simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hi4, hz5, hz6, hz7, hs1]
+
+/-- `load_op_typed` is total for in-range register fields (`rs1 < 32`, `rd < 32`)
+and a legal access-width literal (`hw`). -/
+theorem load_op_typed_ok
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp) (w inst_size : Std.U64)
+    (hw : ∀ s : zisk_inst_builder.ZiskInstBuilder,
+            ∃ z, zisk_inst_builder.ZiskInstBuilder.ind_width s w = ok z)
+    (h1 : i.rs1.val < 32) (h3 : i.rd.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.load_op_typed self i op w inst_size = ok ctx := by
+  obtain ⟨ctx0, hctx0⟩ :=
+    load_op_with_reg_offset_ok { self with extract_marker := () } i op w inst_size hw h1 h3
+  refine ⟨{ ctx0 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.load_op_typed]
+  simp only [Bind.bind, bind_ok, hctx0]
+
+/-- `store_op_with_reg_offset` (the `0#u64`-offset specialization used by
+`store_op_typed`) is total for in-range register fields (`rs1 < 32`, `rs2 < 32`;
+no rd — the store target is indirect). -/
+theorem store_op_with_reg_offset_ok
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp) (w inst_size : Std.U64)
+    (hw : ∀ s : zisk_inst_builder.ZiskInstBuilder,
+            ∃ z, zisk_inst_builder.ZiskInstBuilder.ind_width s w = ok z)
+    (h1 : i.rs1.val < 32) (h2 : i.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.store_op_with_reg_offset self i op w inst_size 0#u64
+      = ok ctx := by
+  obtain ⟨z0, hz0⟩ := new_ok i
+  obtain ⟨z1, hz1⟩ := src_a_reg_ok z0 (UScalar.cast UScalarTy.U64 i.rs1) false
+    (by rw [cast_u32_u64_val]; exact h1)
+  obtain ⟨i3, hi3, hi3v⟩ := uscalar_add_zero_ok (UScalar.cast UScalarTy.U64 i.rs2)
+  obtain ⟨z2, hz2⟩ := src_b_reg_ok z1 i3 false (by rw [hi3v, cast_u32_u64_val]; exact h2)
+  obtain ⟨z3, hz3⟩ := op_zisk_ok z2 op
+  obtain ⟨z4, hz4⟩ := hw z3
+  obtain ⟨z5, hz5⟩ := store_ind_ok z4 (IScalar.cast IScalarTy.I64 i.imm) false
+  obtain ⟨z6, hz6⟩ := j_ok z5 (UScalar.hcast IScalarTy.I64 inst_size) (UScalar.hcast IScalarTy.I64 inst_size)
+  obtain ⟨z7, hz7⟩ := build_ok z6
+  obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z7
+  refine ⟨{ s1 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.store_op_with_reg_offset]
+  simp only [lift, Bind.bind, bind_ok, hz0, hz1, hi3, hz2, hz3, hz4, hz5, hz6, hz7, hs1]
+
+/-- `store_op_typed` is total for in-range register fields (`rs1 < 32`, `rs2 < 32`)
+and a legal access-width literal (`hw`). -/
+theorem store_op_typed_ok
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp) (w inst_size : Std.U64)
+    (hw : ∀ s : zisk_inst_builder.ZiskInstBuilder,
+            ∃ z, zisk_inst_builder.ZiskInstBuilder.ind_width s w = ok z)
+    (h1 : i.rs1.val < 32) (h2 : i.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.store_op_typed self i op w inst_size = ok ctx := by
+  obtain ⟨ctx0, hctx0⟩ :=
+    store_op_with_reg_offset_ok { self with extract_marker := () } i op w inst_size hw h1 h2
+  refine ⟨{ ctx0 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.store_op_typed]
+  simp only [Bind.bind, bind_ok, hctx0]
+
+/-! ## 7. Branch lowering totality (block 3, branch family).
+
+`create_branch_op_typed` mirrors `create_register_op_typed` but writes NO `rd`
+(no `store_reg`) and chooses the two `j` offset arguments by the `neg` flag.  Its
+only register-bound branches are `src_a_reg` (on `rs1`) and `src_b_reg` (on `rs2`),
+so totality needs only `rs1 < 32 ∧ rs2 < 32` (no rd, no `≠ 0`).  The `if neg`
+chooses which constant slot is `inst_size`; both arms are `j_ok` (unconditional). -/
+
+set_option maxHeartbeats 1000000 in
+/-- `decode_b` is total and its `rs1`/`rs2` fields are `< 32` (the 5-bit masks land
+`< 32`; the `imm` field's `signext` is discharged exactly as in `decode_b_spec`). -/
+theorem decode_b_bounds (raw : Std.U32) (op : RiscvOpcode) :
+    ∃ d, decode_b raw op = ok d ∧ d.opcode = op ∧ d.rs1.val < 32 ∧ d.rs2.val < 32 := by
+  have spec : decode_b raw op
+      ⦃ d => d.opcode = op ∧ d.rs1.val < 32 ∧ d.rs2.val < 32 ⦄ := by
+    rw [decode_b]
+    simp only [aeneas_extract.rv64im_decode.DecodedRv64im.new, lift, bind_ok]
+    step*
+    · -- signext precondition: ↑(i10 ||| i11 ||| i13 ||| i15) ≤ 2147483647 (verbatim `decode_b_spec`)
+      have hi10 : (i10 : Std.U32).val < 2 ^ 31 := by
+        have hf : imm12.val < 2 ^ 1 := by
+          rw [imm12_post1, Nat.shiftRight_eq_div_pow]
+          have h : (raw &&& 2147483648#u32).val < 2 ^ 32 := (raw &&& 2147483648#u32).bv.isLt
+          simp only [UScalar.val] at h ⊢; omega
+        rw [i10_post1, Nat.shiftLeft_eq]
+        have hle := Nat.mod_le (↑imm12 * 2 ^ 12) U32.size
+        simp only [UScalar.val] at hf hle ⊢; omega
+      have hi11 : (i11 : Std.U32).val < 2 ^ 31 := by
+        have hf : imm11.val < 2 ^ 1 := by
+          rw [imm11_post1, Nat.shiftRight_eq_div_pow]
+          have h : (raw &&& 128#u32).val ≤ 128 := by
+            have hand : (raw &&& 128#u32).val ≤ (128#u32).val := by
+              simp only [UScalar.val, BitVec.toNat_and]; exact Nat.and_le_right
+            have hmval : (128#u32).val = 128 := by decide
+            omega
+          simp only [UScalar.val] at h ⊢; omega
+        rw [i11_post1, Nat.shiftLeft_eq]
+        have hle := Nat.mod_le (↑imm11 * 2 ^ 11) U32.size
+        simp only [UScalar.val] at hf hle ⊢; omega
+      have hi13 : (i13 : Std.U32).val < 2 ^ 31 := by
+        have hf : imm10_5.val < 2 ^ 7 := by
+          rw [imm10_5_post1, Nat.shiftRight_eq_div_pow]
+          have h : (raw &&& 2113929216#u32).val < 2 ^ 32 := (raw &&& 2113929216#u32).bv.isLt
+          simp only [UScalar.val] at h ⊢; omega
+        rw [i13_post1, Nat.shiftLeft_eq]
+        have hle := Nat.mod_le (↑imm10_5 * 2 ^ 5) U32.size
+        simp only [UScalar.val] at hf hle ⊢; omega
+      have hi15 : (i15 : Std.U32).val < 2 ^ 31 := by
+        have hf : imm4_1.val < 2 ^ 24 := by
+          rw [imm4_1_post1, Nat.shiftRight_eq_div_pow]
+          have h : (raw &&& 3840#u32).val < 2 ^ 32 := (raw &&& 3840#u32).bv.isLt
+          simp only [UScalar.val] at h ⊢; omega
+        rw [i15_post1, Nat.shiftLeft_eq]
+        have hle := Nat.mod_le (↑imm4_1 * 2 ^ 1) U32.size
+        simp only [UScalar.val] at hf hle ⊢; omega
+      have : (i10 ||| i11 ||| i13 ||| i15).val < 2 ^ 31 := by
+        simp only [UScalar.val, BitVec.toNat_or] at hi10 hi11 hi13 hi15 ⊢
+        exact Nat.or_lt_two_pow (Nat.or_lt_two_pow (Nat.or_lt_two_pow hi10 hi11) hi13) hi15
+      simp only [UScalar.val] at this ⊢; omega
+    · refine ⟨?_, ?_⟩
+      · rw [i5_post1, Nat.shiftRight_eq_div_pow]
+        have h : (↑(raw &&& 1015808#u32) : Nat) ≤ 1015808 := by
+          simp only [UScalar.val, BitVec.toNat_and]; exact le_trans Nat.and_le_right (by decide)
+        omega
+      · rw [i7_post1, Nat.shiftRight_eq_div_pow]
+        have h : (↑(raw &&& 32505856#u32) : Nat) ≤ 32505856 := by
+          simp only [UScalar.val, BitVec.toNat_and]; exact le_trans Nat.and_le_right (by decide)
+        omega
+  obtain ⟨d, hd, hpost⟩ := WP.spec_imp_exists spec
+  exact ⟨d, hd, hpost⟩
+
+/-- `create_branch_op_typed` is total for in-range register fields (`rs1 < 32`,
+`rs2 < 32`).  No `rd`, no `≠ 0` side-condition. -/
+theorem create_branch_op_typed_ok
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp)
+    (neg : Bool) (inst_size : Std.U64)
+    (h1 : i.rs1.val < 32) (h2 : i.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.create_branch_op_typed self i op neg inst_size
+      = ok ctx := by
+  obtain ⟨z0, hz0⟩ := new_ok i
+  obtain ⟨z1, hz1⟩ := src_a_reg_ok z0 (UScalar.cast UScalarTy.U64 i.rs1) false
+    (by rw [cast_u32_u64_val]; exact h1)
+  obtain ⟨z2, hz2⟩ := src_b_reg_ok z1 (UScalar.cast UScalarTy.U64 i.rs2) false
+    (by rw [cast_u32_u64_val]; exact h2)
+  obtain ⟨z3, hz3⟩ := op_zisk_ok z2 op
+  cases neg
+  · obtain ⟨z4, hz4⟩ := j_ok z3 (IScalar.cast IScalarTy.I64 i.imm) (UScalar.hcast IScalarTy.I64 inst_size)
+    obtain ⟨z5, hz5⟩ := build_ok z4
+    obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z5
+    refine ⟨{ s1 with extract_marker := () }, ?_⟩
+    rw [riscv2zisk_context.Riscv2ZiskContext.create_branch_op_typed]
+    simp only [Bool.false_eq_true, if_false, reduceIte, lift, Bind.bind, bind_ok,
+      hz0, hz1, hz2, hz3, hz4, hz5, hs1]
+  · obtain ⟨z4, hz4⟩ := j_ok z3 (UScalar.hcast IScalarTy.I64 inst_size) (IScalar.cast IScalarTy.I64 i.imm)
+    obtain ⟨z5, hz5⟩ := build_ok z4
+    obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z5
+    refine ⟨{ s1 with extract_marker := () }, ?_⟩
+    rw [riscv2zisk_context.Riscv2ZiskContext.create_branch_op_typed]
+    simp only [if_true, reduceIte, lift, Bind.bind, bind_ok,
+      hz0, hz1, hz2, hz3, hz4, hz5, hs1]
+
+/-! ## 8. Control lowering totality (block 3, LUI / AUIPC / JAL / JALR / FENCE).
+
+The U-type / J-type decoders give the `rd` field (`< 32`); the control builders
+use `src_a_imm` / `src_b_imm` (unconditional), `store_reg` / `store_pc_reg` (on
+`rd`), `src_b_reg` (on `rs1`, JALR only), and `j` (unconditional).  JALR's
+`i.imm % 4` TWO-ROW split is handled by casing on the remainder; its second-row
+`rom_address + 1` / `inst_size - 1` arithmetic is total at the transpile call
+site (`rom_address = 0`, `inst_size = 4`). -/
+
+/-- `decode_u` is total (no `signext` on the path); `rd` is `< 32` and its bitvec
+recovers the `[7,11]` field (for the symbolic `rd ≠ 0` derivation). -/
+theorem decode_u_bounds (raw : Std.U32) (op : RiscvOpcode) :
+    ∃ d, decode_u raw op = ok d ∧ d.opcode = op ∧ d.rd.val < 32
+      ∧ d.rd.bv = (raw &&& 3968#u32).bv >>> 7 := by
+  refine ⟨_, rfl, rfl, ?_, rfl⟩
+  simp only [UScalar.val]
+  exact and_ushr_toNat_lt raw 3968#32 (7#i32).toNat 32 (by decide)
+
+set_option maxHeartbeats 1000000 in
+/-- `decode_j` is total and its `rd` field is `< 32` (the `imm` field's `signext`
+is discharged exactly as in `decode_j_spec`). -/
+theorem decode_j_bounds (raw : Std.U32) (op : RiscvOpcode) :
+    ∃ d, decode_j raw op = ok d ∧ d.opcode = op ∧ d.rd.val < 32
+      ∧ d.rd.bv = (raw &&& 3968#u32).bv >>> 7 := by
+  have spec : decode_j raw op
+      ⦃ d => d.opcode = op ∧ d.rd.val < 32 ∧ d.rd.bv = (raw &&& 3968#u32).bv >>> 7 ⦄ := by
+    rw [decode_j]
+    simp only [aeneas_extract.rv64im_decode.DecodedRv64im.new, lift, bind_ok]
+    step*
+    · -- signext precondition: ↑(i6 ||| i7 ||| i9 ||| i11) ≤ 2147483647 (verbatim `decode_j_spec`)
+      have hi6 : (i6 : Std.U32).val < 2 ^ 31 := by
+        have hf : imm20.val < 2 ^ 1 := by
+          rw [imm20_post1, Nat.shiftRight_eq_div_pow]
+          have h : (raw &&& 2147483648#u32).val < 2 ^ 32 := (raw &&& 2147483648#u32).bv.isLt
+          simp only [UScalar.val] at h ⊢; omega
+        rw [i6_post1, Nat.shiftLeft_eq]
+        have hle := Nat.mod_le (↑imm20 * 2 ^ 20) U32.size
+        simp only [UScalar.val] at hf hle ⊢; omega
+      have hi7 : (i7 : Std.U32).val < 2 ^ 31 := by
+        have hf : imm19_12.val < 2 ^ 8 := by
+          rw [imm19_12_post1, Nat.shiftRight_eq_div_pow]
+          have h : (raw &&& 1044480#u32).val ≤ 1044480 := by
+            have hand : (raw &&& 1044480#u32).val ≤ (1044480#u32).val := by
+              simp only [UScalar.val, BitVec.toNat_and]; exact Nat.and_le_right
+            have hmval : (1044480#u32).val = 1044480 := by decide
+            omega
+          simp only [UScalar.val] at h ⊢; omega
+        rw [i7_post1, Nat.shiftLeft_eq]
+        have hle := Nat.mod_le (↑imm19_12 * 2 ^ 12) U32.size
+        simp only [UScalar.val] at hf hle ⊢; omega
+      have hi9 : (i9 : Std.U32).val < 2 ^ 31 := by
+        have hf : imm11.val < 2 ^ 12 := by
+          rw [imm11_post1, Nat.shiftRight_eq_div_pow]
+          have h : (raw &&& 1048576#u32).val < 2 ^ 32 := (raw &&& 1048576#u32).bv.isLt
+          simp only [UScalar.val] at h ⊢; omega
+        rw [i9_post1, Nat.shiftLeft_eq]
+        have hle := Nat.mod_le (↑imm11 * 2 ^ 11) U32.size
+        simp only [UScalar.val] at hf hle ⊢; omega
+      have hi11 : (i11 : Std.U32).val < 2 ^ 31 := by
+        have hf : imm10_1.val < 2 ^ 11 := by
+          rw [imm10_1_post1, Nat.shiftRight_eq_div_pow]
+          have h : (raw &&& 2145386496#u32).val < 2 ^ 32 := (raw &&& 2145386496#u32).bv.isLt
+          simp only [UScalar.val] at h ⊢; omega
+        rw [i11_post1, Nat.shiftLeft_eq]
+        have hle := Nat.mod_le (↑imm10_1 * 2 ^ 1) U32.size
+        simp only [UScalar.val] at hf hle ⊢; omega
+      have : (i6 ||| i7 ||| i9 ||| i11).val < 2 ^ 31 := by
+        simp only [UScalar.val, BitVec.toNat_or] at hi6 hi7 hi9 hi11 ⊢
+        exact Nat.or_lt_two_pow (Nat.or_lt_two_pow (Nat.or_lt_two_pow hi6 hi7) hi9) hi11
+      simp only [UScalar.val] at this ⊢; omega
+    · refine ⟨?_, i1_post2⟩
+      rw [i1_post1, Nat.shiftRight_eq_div_pow]
+      have h : (↑(raw &&& 3968#u32) : Nat) ≤ 3968 := by
+        simp only [UScalar.val, BitVec.toNat_and]; exact le_trans Nat.and_le_right (by decide)
+      omega
+  obtain ⟨d, hd, hpost⟩ := WP.spec_imp_exists spec
+  exact ⟨d, hd, hpost⟩
+
+theorem src_a_imm_ok (self : zisk_inst_builder.ZiskInstBuilder) (v : Std.U64) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.src_a_imm self v = ok z := ⟨_, rfl⟩
+
+theorem src_b_lastc_ok (self : zisk_inst_builder.ZiskInstBuilder) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.src_b_lastc self = ok z := ⟨_, rfl⟩
+
+theorem set_pc_ok (self : zisk_inst_builder.ZiskInstBuilder) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.set_pc self = ok z := ⟨_, rfl⟩
+
+/-- `store_pc_reg` is `store_reg … spc := true`, hence total for `0 ≤ off < 32`. -/
+theorem store_pc_reg_ok (self : zisk_inst_builder.ZiskInstBuilder) (off : Std.I64) (usp : Bool)
+    (hlo : 0 ≤ off.val) (hhi : off.val < 32) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.store_pc_reg self off usp = ok z := by
+  rw [zisk_inst_builder.ZiskInstBuilder.store_pc_reg]; exact store_reg_ok self off usp true hlo hhi
+
+/-- `lui` is total for `rd < 32` (`src_a_imm`/`src_b_imm` unconditional; `store_reg` on rd). -/
+theorem lui_ok (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (inst_size : Std.U64) (h3 : i.rd.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.lui self i inst_size = ok ctx := by
+  obtain ⟨z0, hz0⟩ := new_ok i
+  obtain ⟨z1, hz1⟩ := src_a_imm_ok z0 0#u64
+  obtain ⟨z2, hz2⟩ := src_b_imm_ok z1 (IScalar.hcast UScalarTy.U64 i.imm)
+  obtain ⟨z3, hz3⟩ := op_zisk_ok z2 zisk_ops.ZiskOp.CopyB
+  obtain ⟨z4, hz4⟩ := store_reg_ok z3 (UScalar.hcast IScalarTy.I64 i.rd) false false
+    (by rw [hcast_u32_i64_val]; exact_mod_cast Nat.zero_le _)
+    (by rw [hcast_u32_i64_val]; exact_mod_cast h3)
+  obtain ⟨z5, hz5⟩ := j_ok z4 (UScalar.hcast IScalarTy.I64 inst_size) (UScalar.hcast IScalarTy.I64 inst_size)
+  obtain ⟨z6, hz6⟩ := build_ok z5
+  obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z6
+  refine ⟨{ s1 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.lui]
+  simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hz5, hz6, hs1]
+
+/-- `auipc` is total for `rd < 32` (`store_pc_reg` on rd; `j 4#i64 (cast imm)`). -/
+theorem auipc_ok (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (h3 : i.rd.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.auipc self i = ok ctx := by
+  obtain ⟨z0, hz0⟩ := new_ok i
+  obtain ⟨z1, hz1⟩ := src_a_imm_ok z0 0#u64
+  obtain ⟨z2, hz2⟩ := src_b_imm_ok z1 0#u64
+  obtain ⟨z3, hz3⟩ := op_zisk_ok z2 zisk_ops.ZiskOp.Flag
+  obtain ⟨z4, hz4⟩ := store_pc_reg_ok z3 (UScalar.hcast IScalarTy.I64 i.rd) false
+    (by rw [hcast_u32_i64_val]; exact_mod_cast Nat.zero_le _)
+    (by rw [hcast_u32_i64_val]; exact_mod_cast h3)
+  obtain ⟨z5, hz5⟩ := j_ok z4 4#i64 (IScalar.cast IScalarTy.I64 i.imm)
+  obtain ⟨z6, hz6⟩ := build_ok z5
+  obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z6
+  refine ⟨{ s1 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.auipc]
+  simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hz5, hz6, hs1]
+
+/-- `jal` is total for `rd < 32` (`store_pc_reg` on rd; `j (cast imm) (hcast inst_size)`). -/
+theorem jal_ok (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (inst_size : Std.U64) (h3 : i.rd.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.jal self i inst_size = ok ctx := by
+  obtain ⟨z0, hz0⟩ := new_ok i
+  obtain ⟨z1, hz1⟩ := src_a_imm_ok z0 0#u64
+  obtain ⟨z2, hz2⟩ := src_b_imm_ok z1 0#u64
+  obtain ⟨z3, hz3⟩ := op_zisk_ok z2 zisk_ops.ZiskOp.Flag
+  obtain ⟨z4, hz4⟩ := store_pc_reg_ok z3 (UScalar.hcast IScalarTy.I64 i.rd) false
+    (by rw [hcast_u32_i64_val]; exact_mod_cast Nat.zero_le _)
+    (by rw [hcast_u32_i64_val]; exact_mod_cast h3)
+  obtain ⟨z5, hz5⟩ := j_ok z4 (IScalar.cast IScalarTy.I64 i.imm) (UScalar.hcast IScalarTy.I64 inst_size)
+  obtain ⟨z6, hz6⟩ := build_ok z5
+  obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z6
+  refine ⟨{ s1 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.jal]
+  simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hz5, hz6, hs1]
+
+/-- `nop` is total (no register operands; FENCE lowers here). -/
+theorem nop_ok (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (inst_size : Std.U64) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.nop self i inst_size = ok ctx := by
+  obtain ⟨z0, hz0⟩ := new_ok i
+  obtain ⟨z1, hz1⟩ := src_a_imm_ok z0 0#u64
+  obtain ⟨z2, hz2⟩ := src_b_imm_ok z1 0#u64
+  obtain ⟨z3, hz3⟩ := op_zisk_ok z2 zisk_ops.ZiskOp.Flag
+  obtain ⟨z4, hz4⟩ := j_ok z3 (UScalar.hcast IScalarTy.I64 inst_size) (UScalar.hcast IScalarTy.I64 inst_size)
+  obtain ⟨z5, hz5⟩ := build_ok z4
+  obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z5
+  refine ⟨{ s1 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.nop]
+  simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hz5, hs1]
+
+/-- Second-row `rom_address + 1` is total at the transpile call site (`= 0`). -/
+theorem add_one_at_zero_ok (r : Std.U64) (hr : r = 0#u64) :
+    ∃ z, r + 1#u64 = ok z := by subst hr; exact ⟨_, rfl⟩
+
+/-- Second-row `inst_size - 1` is total at the transpile call site (`inst_size = 4`). -/
+theorem hcast4_sub_one_ok :
+    ∃ z, (UScalar.hcast IScalarTy.I64 4#u64 : Std.I64) - 1#i64 = ok z := ⟨_, rfl⟩
+
+/-- `jalr` is total for `rs1 < 32`, `rd < 32` and `rom_address = 0` (the transpile
+call site).  Handles the `i.imm % 4` TWO-ROW split: Row A emits one instruction,
+Row B emits two (the `rom_address + 1` / `inst_size - 1` arithmetic is total at
+`rom_address = 0`, `inst_size = 4`). -/
+theorem jalr_ok (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput)
+    (h1 : i.rs1.val < 32) (h3 : i.rd.val < 32) (hrom : i.rom_address = 0#u64) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.jalr self i 4#u64 = ok ctx := by
+  rw [riscv2zisk_context.Riscv2ZiskContext.jalr]
+  obtain ⟨m, hm, _⟩ := WP.spec_imp_exists (IScalar.rem_spec i.imm (y := 4#i32) (by decide))
+  simp only [hm, bind_ok, Bind.bind]
+  by_cases hcond : m = 0#i32
+  · rw [if_pos hcond]
+    obtain ⟨z0, hz0⟩ := new_ok i
+    obtain ⟨z1, hz1⟩ := src_a_imm_ok z0 riscv2zisk_context.Riscv2ZiskContext.jalr.JALR_MASK
+    obtain ⟨z2, hz2⟩ := src_b_reg_ok z1 (UScalar.cast UScalarTy.U64 i.rs1) false
+      (by rw [cast_u32_u64_val]; exact h1)
+    obtain ⟨z3, hz3⟩ := op_zisk_ok z2 zisk_ops.ZiskOp.And
+    obtain ⟨z4, hz4⟩ := store_pc_reg_ok z3 (UScalar.hcast IScalarTy.I64 i.rd) false
+      (by rw [hcast_u32_i64_val]; exact_mod_cast Nat.zero_le _)
+      (by rw [hcast_u32_i64_val]; exact_mod_cast h3)
+    obtain ⟨z5, hz5⟩ := set_pc_ok z4
+    obtain ⟨z6, hz6⟩ := j_ok z5 (IScalar.cast IScalarTy.I64 i.imm) (UScalar.hcast IScalarTy.I64 4#u64)
+    obtain ⟨z7, hz7⟩ := build_ok z6
+    obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z7
+    refine ⟨{ s1 with extract_marker := () }, ?_⟩
+    simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hz5, hz6, hz7, hs1]
+  · rw [if_neg hcond]
+    obtain ⟨z0, hz0⟩ := new_ok i
+    obtain ⟨z1, hz1⟩ := src_a_imm_ok z0 (IScalar.hcast UScalarTy.U64 i.imm)
+    obtain ⟨z2, hz2⟩ := src_b_reg_ok z1 (UScalar.cast UScalarTy.U64 i.rs1) false
+      (by rw [cast_u32_u64_val]; exact h1)
+    obtain ⟨z3, hz3⟩ := op_zisk_ok z2 zisk_ops.ZiskOp.Add
+    obtain ⟨z4, hz4⟩ := j_ok z3 1#i64 1#i64
+    obtain ⟨z5, hz5⟩ := build_ok z4
+    obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z5
+    obtain ⟨roma, hroma⟩ := add_one_at_zero_ok i.rom_address hrom
+    obtain ⟨z6, hz6⟩ := new_raw_ok roma
+    obtain ⟨z7, hz7⟩ := src_a_imm_ok z6 riscv2zisk_context.Riscv2ZiskContext.jalr.JALR_MASK
+    obtain ⟨z8, hz8⟩ := src_b_lastc_ok z7
+    obtain ⟨z9, hz9⟩ := op_zisk_ok z8 zisk_ops.ZiskOp.And
+    obtain ⟨z10, hz10⟩ := store_pc_reg_ok z9 (UScalar.hcast IScalarTy.I64 i.rd) false
+      (by rw [hcast_u32_i64_val]; exact_mod_cast Nat.zero_le _)
+      (by rw [hcast_u32_i64_val]; exact_mod_cast h3)
+    obtain ⟨z11, hz11⟩ := set_pc_ok z10
+    obtain ⟨six, hsix⟩ := hcast4_sub_one_ok
+    obtain ⟨z12, hz12⟩ := j_ok z11 0#i64 six
+    obtain ⟨z13, hz13⟩ := build_ok z12
+    obtain ⟨s2, hs2⟩ := insert_inst_ok { s1 with extract_marker := () } roma z13
+    refine ⟨{ s2 with extract_marker := () }, ?_⟩
+    simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hz5, hs1, hroma,
+      hz6, hz7, hz8, hz9, hz10, hz11, hsix, hz12, hz13, hs2]
+
+/-- The default lowering context the transpile pipeline threads into the dispatcher. -/
+def defCtx : riscv2zisk_context.Riscv2ZiskContext :=
+  { extract_inst := none, extract_marker := (), input_precompile := none,
+    output_precompile := none, input_precompile_reg := none, output_precompile_reg := none }
+
+/-! ## 9. Index-width totality — DISCHARGES the `hw` premise of §6.
+
+`ind_width` (`ProductionM2.lean:2622`) returns `ok` on exactly the four legal
+access widths and `fail panic` on everything else.  The dispatcher's load/store
+arms pass only those four literals (`Lb/Lbu/Sb` → 1, `Lh/Lhu/Sh` → 2,
+`Lw/Lwu/Sw` → 4, `Ld/Sd` → 8, `ProductionM2.lean:3396-3460`), so the `hw`
+hypothesis that §6's `load_op_typed_ok` / `store_op_typed_ok` take as an argument
+is supplied here rather than assumed at the use site.
+
+(The June draft of this module stated `hw` as a premise and asserted in prose
+that it was "discharged `⟨_, rfl⟩` for `w ∈ {1,2,4,8}`" without ever proving it.
+These four lemmas are that missing proof.) -/
+
+theorem ind_width_ok_1 (s : zisk_inst_builder.ZiskInstBuilder) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.ind_width s 1#u64 = ok z := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.ind_width]; exact ⟨_, rfl⟩
+
+theorem ind_width_ok_2 (s : zisk_inst_builder.ZiskInstBuilder) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.ind_width s 2#u64 = ok z := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.ind_width]; exact ⟨_, rfl⟩
+
+theorem ind_width_ok_4 (s : zisk_inst_builder.ZiskInstBuilder) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.ind_width s 4#u64 = ok z := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.ind_width]; exact ⟨_, rfl⟩
+
+theorem ind_width_ok_8 (s : zisk_inst_builder.ZiskInstBuilder) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.ind_width s 8#u64 = ok z := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.ind_width]; exact ⟨_, rfl⟩
+
+/-! ## 10. `immediate_op_or_x0_copyb_typed` totality (ADDI / XORI / ORI).
+
+Same shape as `immediate_op_typed` except that the op choice is an `if i.rs1 = 0`
+between `op_zisk … CopyB` and `op_zisk … op` (`ProductionM2.lean:2567-2591`).
+`op_zisk` is unconditionally total, so BOTH arms return `ok` and totality needs
+only `rs1 < 32 ∧ rd < 32` — in particular NO `rs1 ≠ 0` (that side condition
+belongs to the *pins*, which must know which arm ran, not to totality). -/
+
+theorem immediate_op_or_x0_copyb_typed_ok
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp) (inst_size : Std.U64)
+    (h1 : i.rs1.val < 32) (h3 : i.rd.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.immediate_op_or_x0_copyb_typed
+      self i op inst_size = ok ctx := by
+  obtain ⟨z0, hz0⟩ := new_ok i
+  obtain ⟨z1, hz1⟩ := src_a_reg_ok z0 (UScalar.cast UScalarTy.U64 i.rs1) false
+    (by rw [cast_u32_u64_val]; exact h1)
+  obtain ⟨z2, hz2⟩ := src_b_imm_ok z1 (IScalar.hcast UScalarTy.U64 i.imm)
+  obtain ⟨z3, hz3⟩ :
+      ∃ z, (if i.rs1 = 0#u32
+              then zisk_inst_builder.ZiskInstBuilder.op_zisk z2 zisk_ops.ZiskOp.CopyB
+              else zisk_inst_builder.ZiskInstBuilder.op_zisk z2 op) = ok z := by
+    split
+    · exact op_zisk_ok z2 zisk_ops.ZiskOp.CopyB
+    · exact op_zisk_ok z2 op
+  obtain ⟨z4, hz4⟩ := store_reg_ok z3 (UScalar.hcast IScalarTy.I64 i.rd) false false
+    (by rw [hcast_u32_i64_val]; exact_mod_cast Nat.zero_le _)
+    (by rw [hcast_u32_i64_val]; exact_mod_cast h3)
+  obtain ⟨z5, hz5⟩ := j_ok z4 (UScalar.hcast IScalarTy.I64 inst_size)
+    (UScalar.hcast IScalarTy.I64 inst_size)
+  obtain ⟨z6, hz6⟩ := build_ok z5
+  obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z6
+  refine ⟨{ s1 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.immediate_op_or_x0_copyb_typed]
+  simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hz5, hz6, hs1]
+
+/-! ## 11. DISPATCHER-level totality: `lower_rv64im_single_row_input` SUCCEEDS.
+
+Every theorem in `Extraction/Dispatch.lean` presupposes
+`lower_rv64im_single_row_input self ri <Opcode> hni = ok ctx`.  This section
+proves that presupposition, for all 63 RV64IM opcodes, from the register-field
+bounds alone.
+
+Each proof names the entry point the dispatcher routes to
+(`ProductionM2.lean:2915-3460`), obtains its totality witness from §3-§10, and
+closes the arm by rewriting the dispatcher's `match` and discharging the routing
+guards with the SAME side conditions `Extraction/Dispatch.lean` already states
+for that opcode — the two hypothesis sets are deliberately identical, so §12 can
+compose them without introducing anything new.
+
+Register-bound hypotheses used, per family (these are the honest premises; §12's
+closing note records what still supplies them):
+  * register / M ops: `rs1, rs2, rd < 32`   * branches: `rs1, rs2 < 32`
+  * immediates:       `rs1, rd < 32`        * loads:    `rs1, rd < 32`
+  * stores:           `rs1, rs2 < 32`       * LUI/AUIPC/JAL: `rd < 32`
+  * JALR: `rs1, rd < 32` and `rom_address = 0` (the value
+    `extract_transpile_rv64im_raw` passes, `ProductionM2.lean:3657`)
+  * FENCE: none. -/
+
+local macro "regtot" nm:ident "," opc:term "," zop:term : command => do
+  let d := Lean.mkIdentFrom nm (nm.getId.appendAfter "_dispatch_total")
+  `(theorem $d:ident (self : riscv2zisk_context.Riscv2ZiskContext)
+      (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+      (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+      ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri $opc hni = ok ctx := by
+    obtain ⟨c, hc⟩ := create_register_op_typed_ok { self with extract_marker := () } ri
+      $zop 4#u64 h1 h2 h3
+    refine ⟨{ c with extract_marker := () }, ?_⟩
+    rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+    simp only [Bind.bind, bind_ok, hc])
+
+local macro "brtot" nm:ident "," opc:term "," zop:term "," neg:term : command => do
+  let d := Lean.mkIdentFrom nm (nm.getId.appendAfter "_dispatch_total")
+  `(theorem $d:ident (self : riscv2zisk_context.Riscv2ZiskContext)
+      (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+      (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+      ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri $opc hni = ok ctx := by
+    obtain ⟨c, hc⟩ := create_branch_op_typed_ok { self with extract_marker := () } ri
+      $zop $neg 4#u64 h1 h2
+    refine ⟨{ c with extract_marker := () }, ?_⟩
+    rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+    simp only [Bind.bind, bind_ok, hc])
+
+local macro "immtot" nm:ident "," opc:term "," zop:term : command => do
+  let d := Lean.mkIdentFrom nm (nm.getId.appendAfter "_dispatch_total")
+  `(theorem $d:ident (self : riscv2zisk_context.Riscv2ZiskContext)
+      (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+      (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+      ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri $opc hni = ok ctx := by
+    obtain ⟨c, hc⟩ := immediate_op_typed_ok { self with extract_marker := () } ri
+      $zop 4#u64 h1 h3
+    refine ⟨{ c with extract_marker := () }, ?_⟩
+    rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+    simp only [Bind.bind, bind_ok, hc])
+
+local macro "x0tot" nm:ident "," opc:term "," zop:term : command => do
+  let d := Lean.mkIdentFrom nm (nm.getId.appendAfter "_dispatch_total")
+  `(theorem $d:ident (self : riscv2zisk_context.Riscv2ZiskContext)
+      (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+      (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+      ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri $opc hni = ok ctx := by
+    obtain ⟨c, hc⟩ := immediate_op_or_x0_copyb_typed_ok { self with extract_marker := () } ri
+      $zop 4#u64 h1 h3
+    refine ⟨{ c with extract_marker := () }, ?_⟩
+    rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+    simp only [Bind.bind, bind_ok, hc])
+
+local macro "ldtot" nm:ident "," opc:term "," zop:term "," w:term "," iw:term : command => do
+  let d := Lean.mkIdentFrom nm (nm.getId.appendAfter "_dispatch_total")
+  `(theorem $d:ident (self : riscv2zisk_context.Riscv2ZiskContext)
+      (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+      (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+      ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri $opc hni = ok ctx := by
+    obtain ⟨c, hc⟩ := load_op_typed_ok { self with extract_marker := () } ri
+      $zop $w 4#u64 $iw h1 h3
+    refine ⟨{ c with extract_marker := () }, ?_⟩
+    rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+    simp only [Bind.bind, bind_ok, hc])
+
+local macro "sttot" nm:ident "," opc:term "," zop:term "," w:term "," iw:term : command => do
+  let d := Lean.mkIdentFrom nm (nm.getId.appendAfter "_dispatch_total")
+  `(theorem $d:ident (self : riscv2zisk_context.Riscv2ZiskContext)
+      (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+      (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+      ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri $opc hni = ok ctx := by
+    obtain ⟨c, hc⟩ := store_op_typed_ok { self with extract_marker := () } ri
+      $zop $w 4#u64 $iw h1 h2
+    refine ⟨{ c with extract_marker := () }, ?_⟩
+    rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+    simp only [Bind.bind, bind_ok, hc])
+
+-- Register ALU / M ops (unconditional dispatcher routing).
+regtot sub, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sub, zisk_ops.ZiskOp.Sub
+regtot sll, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sll, zisk_ops.ZiskOp.Sll
+regtot slt, riscv2zisk_single_row.Rv64imSingleRowOpcode.Slt, zisk_ops.ZiskOp.Lt
+regtot sltu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sltu, zisk_ops.ZiskOp.Ltu
+regtot xor, riscv2zisk_single_row.Rv64imSingleRowOpcode.Xor, zisk_ops.ZiskOp.Xor
+regtot srl, riscv2zisk_single_row.Rv64imSingleRowOpcode.Srl, zisk_ops.ZiskOp.Srl
+regtot sra, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sra, zisk_ops.ZiskOp.Sra
+regtot and, riscv2zisk_single_row.Rv64imSingleRowOpcode.And, zisk_ops.ZiskOp.And
+regtot addw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Addw, zisk_ops.ZiskOp.AddW
+regtot subw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Subw, zisk_ops.ZiskOp.SubW
+regtot sllw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sllw, zisk_ops.ZiskOp.SllW
+regtot srlw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Srlw, zisk_ops.ZiskOp.SrlW
+regtot sraw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sraw, zisk_ops.ZiskOp.SraW
+regtot mul, riscv2zisk_single_row.Rv64imSingleRowOpcode.Mul, zisk_ops.ZiskOp.Mul
+regtot mulh, riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulh, zisk_ops.ZiskOp.Mulh
+regtot mulhsu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulhsu, zisk_ops.ZiskOp.Mulsuh
+regtot mulhu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulhu, zisk_ops.ZiskOp.Muluh
+regtot mulw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulw, zisk_ops.ZiskOp.MulW
+regtot div, riscv2zisk_single_row.Rv64imSingleRowOpcode.Div, zisk_ops.ZiskOp.Div
+regtot divu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Divu, zisk_ops.ZiskOp.Divu
+regtot divw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Divw, zisk_ops.ZiskOp.DivW
+regtot divuw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Divuw, zisk_ops.ZiskOp.DivuW
+regtot rem, riscv2zisk_single_row.Rv64imSingleRowOpcode.Rem, zisk_ops.ZiskOp.Rem
+regtot remu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Remu, zisk_ops.ZiskOp.Remu
+regtot remw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Remw, zisk_ops.ZiskOp.RemW
+regtot remuw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Remuw, zisk_ops.ZiskOp.RemuW
+
+-- Branches.
+brtot beq, riscv2zisk_single_row.Rv64imSingleRowOpcode.Beq, zisk_ops.ZiskOp.Eq, false
+brtot bne, riscv2zisk_single_row.Rv64imSingleRowOpcode.Bne, zisk_ops.ZiskOp.Eq, true
+brtot blt, riscv2zisk_single_row.Rv64imSingleRowOpcode.Blt, zisk_ops.ZiskOp.Lt, false
+brtot bge, riscv2zisk_single_row.Rv64imSingleRowOpcode.Bge, zisk_ops.ZiskOp.Lt, true
+brtot bltu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Bltu, zisk_ops.ZiskOp.Ltu, false
+brtot bgeu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Bgeu, zisk_ops.ZiskOp.Ltu, true
+
+-- Plain immediates (`immediate_op_typed`).
+immtot slli, riscv2zisk_single_row.Rv64imSingleRowOpcode.Slli, zisk_ops.ZiskOp.Sll
+immtot slti, riscv2zisk_single_row.Rv64imSingleRowOpcode.Slti, zisk_ops.ZiskOp.Lt
+immtot sltiu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sltiu, zisk_ops.ZiskOp.Ltu
+immtot srli, riscv2zisk_single_row.Rv64imSingleRowOpcode.Srli, zisk_ops.ZiskOp.Srl
+immtot srai, riscv2zisk_single_row.Rv64imSingleRowOpcode.Srai, zisk_ops.ZiskOp.Sra
+immtot andi, riscv2zisk_single_row.Rv64imSingleRowOpcode.Andi, zisk_ops.ZiskOp.And
+immtot slliw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Slliw, zisk_ops.ZiskOp.SllW
+immtot srliw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Srliw, zisk_ops.ZiskOp.SrlW
+immtot sraiw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sraiw, zisk_ops.ZiskOp.SraW
+
+-- XORI / ORI (`immediate_op_or_x0_copyb_typed`; total on BOTH op arms).
+x0tot xori, riscv2zisk_single_row.Rv64imSingleRowOpcode.Xori, zisk_ops.ZiskOp.Xor
+x0tot ori, riscv2zisk_single_row.Rv64imSingleRowOpcode.Ori, zisk_ops.ZiskOp.Or
+
+-- Loads / stores (the `hw` premise supplied by §9, never assumed).
+ldtot lb, riscv2zisk_single_row.Rv64imSingleRowOpcode.Lb, zisk_ops.ZiskOp.SignExtendB, 1#u64, ind_width_ok_1
+ldtot lbu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Lbu, zisk_ops.ZiskOp.CopyB, 1#u64, ind_width_ok_1
+ldtot lh, riscv2zisk_single_row.Rv64imSingleRowOpcode.Lh, zisk_ops.ZiskOp.SignExtendH, 2#u64, ind_width_ok_2
+ldtot lhu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Lhu, zisk_ops.ZiskOp.CopyB, 2#u64, ind_width_ok_2
+ldtot lw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Lw, zisk_ops.ZiskOp.SignExtendW, 4#u64, ind_width_ok_4
+ldtot lwu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Lwu, zisk_ops.ZiskOp.CopyB, 4#u64, ind_width_ok_4
+ldtot ld, riscv2zisk_single_row.Rv64imSingleRowOpcode.Ld, zisk_ops.ZiskOp.CopyB, 8#u64, ind_width_ok_8
+sttot sb, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sb, zisk_ops.ZiskOp.CopyB, 1#u64, ind_width_ok_1
+sttot sh, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sh, zisk_ops.ZiskOp.CopyB, 2#u64, ind_width_ok_2
+sttot sw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sw, zisk_ops.ZiskOp.CopyB, 4#u64, ind_width_ok_4
+sttot sd, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sd, zisk_ops.ZiskOp.CopyB, 8#u64, ind_width_ok_8
+
+
+/-! ### 11.1 Control arms (LUI / AUIPC / JAL / JALR / FENCE).
+
+All five route unconditionally; only JALR carries a routing-independent premise
+(`rom_address = 0`, needed for its second-row `rom_address + 1`). -/
+
+theorem lui_dispatch_total (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+      self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lui hni = ok ctx := by
+  obtain ⟨c, hc⟩ := lui_ok { self with extract_marker := () } ri 4#u64 h3
+  refine ⟨{ c with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+  simp only [Bind.bind, bind_ok, hc]
+
+theorem auipc_dispatch_total (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+      self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Auipc hni = ok ctx := by
+  obtain ⟨c, hc⟩ := auipc_ok { self with extract_marker := () } ri h3
+  refine ⟨{ c with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+  simp only [Bind.bind, bind_ok, hc]
+
+theorem jal_dispatch_total (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+      self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Jal hni = ok ctx := by
+  obtain ⟨c, hc⟩ := jal_ok { self with extract_marker := () } ri 4#u64 h3
+  refine ⟨{ c with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+  simp only [Bind.bind, bind_ok, hc]
+
+/-- JALR is the one two-row arm: when `imm % 4 ≠ 0` the lowerer emits a second
+instruction at `rom_address + 1`, so totality needs the transpile call site's
+`rom_address = 0` (`ProductionM2.lean:3657`). -/
+theorem jalr_dispatch_total (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) (hrom : ri.rom_address = 0#u64) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+      self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Jalr hni = ok ctx := by
+  obtain ⟨c, hc⟩ := jalr_ok { self with extract_marker := () } ri h1 h3 hrom
+  refine ⟨{ c with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+  simp only [Bind.bind, bind_ok, hc]
+
+/-- FENCE lowers through `nop`, which reads no register field: totality is
+UNCONDITIONAL. -/
+theorem fence_dispatch_total (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+      self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Fence hni = ok ctx := by
+  obtain ⟨c, hc⟩ := nop_ok { self with extract_marker := () } ri 4#u64
+  refine ⟨{ c with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+  simp only [Bind.bind, bind_ok, hc]
+
+/-! ### 11.2 Guarded arms (ADD / OR / ADDI / ADDIW).
+
+These four are the only opcodes whose dispatcher arm branches before reaching a
+builder.  The routing hypotheses below are VERBATIM the ones
+`Extraction/Dispatch.lean` already states for the same opcode
+(`add_dispatch_static_pins`, `or_dispatch_static_pins`, … ) — §12 composes the
+two without adding anything. -/
+
+set_option maxHeartbeats 2000000 in
+theorem add_dispatch_total (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (hprec : self.input_precompile = none)
+    (hrd : ri.rd ≠ 0#u32) (hrs1 : ri.rs1 ≠ 0#u32) (hrs2 : ri.rs2 ≠ 0#u32)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+      self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Add hni = ok ctx := by
+  obtain ⟨c, hc⟩ := create_register_op_typed_ok
+    { self with extract_marker := (), input_precompile := none } ri
+    zisk_ops.ZiskOp.Add 4#u64 h1 h2 h3
+  refine ⟨{ c with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+  simp only [hprec, riscv2zisk_single_row.CSR_DMA_MEMCMP_ADDR, Bind.bind, bind_ok]
+  simp [ne_eq, hrd, hrs1, hrs2, reduceIte,
+    show ((0#u32 : Std.U32) = 2068#u32) = False from by decide, hc]
+
+set_option maxHeartbeats 2000000 in
+theorem or_dispatch_total (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (hrs1 : ri.rs1 ≠ 0#u32) (hrs2 : ri.rs2 ≠ 0#u32)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+      self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Or hni = ok ctx := by
+  obtain ⟨c, hc⟩ := create_register_op_typed_ok { self with extract_marker := () } ri
+    zisk_ops.ZiskOp.Or 4#u64 h1 h2 h3
+  refine ⟨{ c with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+  rw [if_neg hrs1, if_neg hrs2]
+  simp only [Bind.bind, bind_ok, hc]
+
+set_option maxHeartbeats 2000000 in
+theorem addi_dispatch_total (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (hrd : ri.rd ≠ 0#u32) (himm : ri.imm ≠ 0#i32)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+      self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Addi hni = ok ctx := by
+  obtain ⟨c, hc⟩ := immediate_op_or_x0_copyb_typed_ok { self with extract_marker := () } ri
+    zisk_ops.ZiskOp.Add 4#u64 h1 h3
+  refine ⟨{ c with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+  rw [if_neg hrd, if_neg himm]
+  simp only [Bind.bind, bind_ok, hc]
+
+set_option maxHeartbeats 2000000 in
+theorem addiw_dispatch_total (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (hrd : ri.rd ≠ 0#u32)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+      self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Addiw hni = ok ctx := by
+  obtain ⟨c, hc⟩ := immediate_op_typed_ok { self with extract_marker := () } ri
+    zisk_ops.ZiskOp.AddW 4#u64 h1 h3
+  refine ⟨{ c with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+  rw [if_neg hrd]
+  simp only [Bind.bind, bind_ok, hc]
+
+/-! ## 12. The discharge: #111's dispatcher pins WITHOUT the `= ok ctx` premise.
+
+Each theorem below is the corresponding `<op>_dispatch_static_pins` of
+`Extraction/Dispatch.lean` with its `h : lower_rv64im_single_row_input … = ok ctx`
+hypothesis REMOVED — supplied instead by §11.  The remaining hypotheses are
+exactly (§11's register-field bounds) ∪ (the routing side conditions
+`Extraction/Dispatch.lean` already required); nothing else is introduced, and the
+proofs are a two-line composition of the two existing results.
+
+What this does and does NOT close.
+
+  * CLOSED.  "The lowerer might fail, so the pins could be vacuous" is no longer
+    a possibility for any of the 63 opcodes: the witness is exhibited.
+  * NOT CLOSED, and stated as premises rather than hidden: the register-field
+    bounds (`rs1, rs2, rd < 32`).  §1-§8 prove them for each LEAF decoder
+    (`decode_r_bounds`, `decode_i_bounds`, `decode_s_bounds`, `decode_b_bounds`,
+    `decode_u_bounds`, `decode_j_bounds`), but nothing here connects those to
+    `decode_32_core`, so a caller starting from a raw 32-bit word must still
+    supply them.  Closing that connection is what would make totality of
+    `extract_transpile_rv64im_raw` premise-free.
+  * NOT CLOSED: `rom_address = 0` for JALR (the transpile call site's value).
+  * NOT CLOSED: anything about WHAT the lowered row means — that is the raw-word
+    join (#61 Phase 0), which this module is deliberately independent of. -/
+
+
+/-! ### 12.1 Register / M ops. -/
+
+theorem sub_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sub hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 11#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sub_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, sub_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem and_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.And hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 14#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := and_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, and_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem xor_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Xor hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 16#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := xor_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, xor_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem slt_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slt hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 7#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := slt_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, slt_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem sltu_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sltu hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 6#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sltu_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, sltu_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem sll_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sll hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 33#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sll_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, sll_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem srl_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srl hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 34#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := srl_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, srl_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem sra_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sra hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 35#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sra_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, sra_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem addw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Addw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 26#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := addw_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, addw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem subw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Subw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 27#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := subw_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, subw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem sllw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sllw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 36#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sllw_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, sllw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem srlw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srlw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 37#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := srlw_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, srlw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem sraw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sraw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 38#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sraw_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, sraw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem mul_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mul hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 180#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := mul_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, mul_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem mulh_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulh hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 181#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := mulh_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, mulh_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem mulhsu_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulhsu hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 179#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := mulhsu_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, mulhsu_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem mulhu_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulhu hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 177#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := mulhu_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, mulhu_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem mulw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 182#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := mulw_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, mulw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem div_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Div hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 186#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := div_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, div_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem divu_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Divu hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 184#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := divu_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, divu_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem divw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Divw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 190#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := divw_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, divw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem divuw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Divuw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 188#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := divuw_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, divuw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem rem_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Rem hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 187#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := rem_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, rem_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem remu_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Remu hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 185#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := remu_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, remu_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem remw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Remw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 191#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := remw_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, remw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem remuw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Remuw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 189#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := remuw_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, remuw_dispatch_static_pins self ri hni ctx hctx⟩
+
+/-! ### 12.2 Branches. -/
+
+theorem beq_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Beq hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 9#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := beq_dispatch_total self ri hni h1 h2
+  exact ⟨ctx, hctx, beq_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem bne_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bne hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 9#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := bne_dispatch_total self ri hni h1 h2
+  exact ⟨ctx, hctx, bne_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem blt_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Blt hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 7#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := blt_dispatch_total self ri hni h1 h2
+  exact ⟨ctx, hctx, blt_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem bge_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bge hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 7#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := bge_dispatch_total self ri hni h1 h2
+  exact ⟨ctx, hctx, bge_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem bltu_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bltu hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 6#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := bltu_dispatch_total self ri hni h1 h2
+  exact ⟨ctx, hctx, bltu_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem bgeu_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bgeu hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 6#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := bgeu_dispatch_total self ri hni h1 h2
+  exact ⟨ctx, hctx, bgeu_dispatch_static_pins self ri hni ctx hctx⟩
+
+/-! ### 12.3 Plain immediates. -/
+
+theorem slli_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slli hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 33#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := slli_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, slli_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem srli_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srli hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 34#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := srli_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, srli_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem srai_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srai hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 35#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := srai_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, srai_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem slti_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slti hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 7#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := slti_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, slti_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem sltiu_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sltiu hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 6#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sltiu_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, sltiu_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem andi_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Andi hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 14#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := andi_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, andi_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem slliw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slliw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 36#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := slliw_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, slliw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem srliw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srliw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 37#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := srliw_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, srliw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem sraiw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sraiw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 38#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sraiw_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, sraiw_dispatch_static_pins self ri hni ctx hctx⟩
+
+/-! ### 12.4 XORI / ORI (the `rs1 ≠ 0#u32` op-arm condition is #111's, unchanged). -/
+
+theorem xori_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (hrs1 : ri.rs1 ≠ 0#u32) (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Xori hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 16#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := xori_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, xori_dispatch_static_pins self ri hni ctx hrs1 hctx⟩
+
+theorem ori_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (hrs1 : ri.rs1 ≠ 0#u32) (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Ori hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 15#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := ori_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, ori_dispatch_static_pins self ri hni ctx hrs1 hctx⟩
+
+/-! ### 12.5 Loads. -/
+
+theorem lb_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lb hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 39#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := lb_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, lb_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem lh_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lh hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 40#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := lh_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, lh_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem lw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 41#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := lw_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, lw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem lbu_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lbu hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := lbu_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, lbu_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem lhu_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lhu hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := lhu_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, lhu_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem lwu_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lwu hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := lwu_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, lwu_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem ld_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Ld hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := ld_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, ld_dispatch_static_pins self ri hni ctx hctx⟩
+
+/-! ### 12.6 Stores. -/
+
+theorem sb_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sb hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sb_dispatch_total self ri hni h1 h2
+  exact ⟨ctx, hctx, sb_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem sh_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sh hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sh_dispatch_total self ri hni h1 h2
+  exact ⟨ctx, hctx, sh_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem sw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sw_dispatch_total self ri hni h1 h2
+  exact ⟨ctx, hctx, sw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem sd_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sd hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sd_dispatch_total self ri hni h1 h2
+  exact ⟨ctx, hctx, sd_dispatch_static_pins self ri hni ctx hctx⟩
+
+/-! ### 12.7 Control arms (LUI / AUIPC / JAL / JALR / FENCE).
+
+`auipc` / `jal` / `jalr` keep exactly the `store_pc` shape #111 proves: AUIPC's
+static pins do not mention `store_pc` at all, and JAL's carry it as the
+implication guarded by a nonzero `rd` cast (`store_reg`'s `offset = 0 ⇒ ok self`
+early return).  Those are unchanged here; only the `= ok ctx` premise is gone. -/
+
+theorem lui_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lui hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := lui_dispatch_total self ri hni h3
+  exact ⟨ctx, hctx, lui_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem auipc_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Auipc hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 0#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false := by
+  obtain ⟨ctx, hctx⟩ := auipc_dispatch_total self ri hni h3
+  exact ⟨ctx, hctx, auipc_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem jal_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Jal hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 0#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧
+        ((UScalar.hcast IScalarTy.I64 ri.rd : Std.I64) ≠ 0#i64 → zib.i.store_pc = true) := by
+  obtain ⟨ctx, hctx⟩ := jal_dispatch_total self ri hni h3
+  exact ⟨ctx, hctx, jal_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem jalr_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) (hrom : ri.rom_address = 0#u64) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Jalr hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 14#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = true := by
+  obtain ⟨ctx, hctx⟩ := jalr_dispatch_total self ri hni h1 h3 hrom
+  exact ⟨ctx, hctx, jalr_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem fence_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Fence hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 0#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := fence_dispatch_total self ri hni
+  exact ⟨ctx, hctx, fence_dispatch_static_pins self ri hni ctx hctx⟩
+
+/-! ### 12.8 Guarded arms (ADD / OR / ADDI / ADDIW).
+
+The routing hypotheses are #111's, verbatim; the bound hypotheses are §11's. -/
+
+theorem add_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (hprec : self.input_precompile = none)
+    (hrd : ri.rd ≠ 0#u32) (hrs1 : ri.rs1 ≠ 0#u32) (hrs2 : ri.rs2 ≠ 0#u32)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Add hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 10#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := add_dispatch_total self ri hni hprec hrd hrs1 hrs2 h1 h2 h3
+  exact ⟨ctx, hctx, add_dispatch_static_pins self ri hni ctx hprec hrd hrs1 hrs2 hctx⟩
+
+theorem or_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (hrs1 : ri.rs1 ≠ 0#u32) (hrs2 : ri.rs2 ≠ 0#u32)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Or hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 15#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := or_dispatch_total self ri hni hrs1 hrs2 h1 h2 h3
+  exact ⟨ctx, hctx, or_dispatch_static_pins self ri hni ctx hrs1 hrs2 hctx⟩
+
+theorem addi_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (hrd : ri.rd ≠ 0#u32) (himm : ri.imm ≠ 0#i32) (hrs1 : ri.rs1 ≠ 0#u32)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Addi hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 10#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := addi_dispatch_total self ri hni hrd himm h1 h3
+  exact ⟨ctx, hctx, addi_dispatch_static_pins self ri hni ctx hrd himm hrs1 hctx⟩
+
+theorem addiw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (hrd : ri.rd ≠ 0#u32) (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Addiw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 26#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := addiw_dispatch_total self ri hni hrd h1 h3
+  exact ⟨ctx, hctx, addiw_dispatch_static_pins self ri hni ctx hrd hctx⟩
+
+end ZiskFv.Compliance.Extraction

--- a/ZiskFv/Compliance/AeneasBridgeTrust/Extraction/Totality.lean
+++ b/ZiskFv/Compliance/AeneasBridgeTrust/Extraction/Totality.lean
@@ -1126,17 +1126,43 @@ proofs are a two-line composition of the two existing results.
 What this does and does NOT close.
 
   * CLOSED.  "The lowerer might fail, so the pins could be vacuous" is no longer
-    a possibility for any of the 63 opcodes: the witness is exhibited.
+    a possibility for any of the 63 opcodes: the witness is exhibited, through
+    the real production entry point.
+
   * NOT CLOSED, and stated as premises rather than hidden: the register-field
-    bounds (`rs1, rs2, rd < 32`).  §1-§8 prove them for each LEAF decoder
+    bounds `rs1, rs2, rd < 32`.  §1-§8 prove them for each LEAF decoder
     (`decode_r_bounds`, `decode_i_bounds`, `decode_s_bounds`, `decode_b_bounds`,
-    `decode_u_bounds`, `decode_j_bounds`), but nothing here connects those to
-    `decode_32_core`, so a caller starting from a raw 32-bit word must still
-    supply them.  Closing that connection is what would make totality of
-    `extract_transpile_rv64im_raw` premise-free.
-  * NOT CLOSED: `rom_address = 0` for JALR (the transpile call site's value).
-  * NOT CLOSED: anything about WHAT the lowered row means — that is the raw-word
-    join (#61 Phase 0), which this module is deliberately independent of. -/
+    `decode_u_bounds`, `decode_j_bounds`), but nothing connects those to
+    `decode_32_core`, so a caller starting from a raw 32-bit word must supply
+    them.
+
+  * NOT CLOSED: `rom_address = 0` for JALR — the value the transpile call site
+    passes (`ProductionM2.lean:3657`), needed for the two-row arm's
+    `rom_address + 1`.
+
+  * NOT CLOSED: anything about WHAT the lowered row means.  That is the raw-word
+    join (#61 Phase 0); this module is deliberately independent of it.
+
+A premise-free `∃ e, extract_transpile_rv64im_raw raw = ok e` does NOT follow
+from §11 alone, and it is worth recording exactly why, so the gap is not
+mis-scoped as "just connect the decoder bounds":
+
+  1. a bound on `decode_32_core`'s `rd`/`rs1`/`rs2` (the leaf lemmas exist; the
+     ~120-arm dispatch over them does not), plus the unset-field defaults from
+     `DecodedRv64im.new` (`ProductionM2.lean:254-268`);
+  2. totality of the three degenerate builders §11 never reaches, because for
+     ADD/OR/ADDI/ADDIW the dispatcher routes AWAY from the op builder exactly
+     when §11's routing hypotheses fail: `copyb` (rs1 = 0 or rs2 = 0, or ADDI
+     with imm = 0), `hint` (ADDI with rd = 0 and rs1 or rs2 nonzero), and
+     `create_precompiled_op_typed` (the DMA-CSR path, ruled out here by
+     `input_precompile = none`).  `nop`, the fourth such target, is the one
+     already covered — `nop_ok` in §8, used by `fence_dispatch_total`;
+  3. a case analysis over `lowering_opcode` (`ProductionM2.lean:1144`) tying the
+     decoded `RiscvOpcode` to the `Rv64imSingleRowOpcode` each §11 lemma is
+     indexed by.
+
+Item 2 is the substantive one: those arms are lowering behaviour this module has
+no lemma about at all, not a missing plumbing step. -/
 
 
 /-! ### 12.1 Register / M ops. -/
@@ -1145,7 +1171,8 @@ theorem sub_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sub hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sub hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 11#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1156,7 +1183,8 @@ theorem and_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.And hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.And hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 14#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1167,7 +1195,8 @@ theorem xor_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Xor hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Xor hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 16#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1178,7 +1207,8 @@ theorem slt_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slt hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slt hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 7#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1189,7 +1219,8 @@ theorem sltu_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sltu hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sltu hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 6#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1200,7 +1231,8 @@ theorem sll_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sll hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sll hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 33#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1211,7 +1243,8 @@ theorem srl_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srl hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srl hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 34#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1222,7 +1255,8 @@ theorem sra_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sra hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sra hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 35#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1233,7 +1267,8 @@ theorem addw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Addw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Addw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 26#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1244,7 +1279,8 @@ theorem subw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Subw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Subw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 27#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1255,7 +1291,8 @@ theorem sllw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sllw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sllw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 36#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1266,7 +1303,8 @@ theorem srlw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srlw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srlw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 37#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1277,7 +1315,8 @@ theorem sraw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sraw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sraw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 38#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1288,7 +1327,8 @@ theorem mul_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mul hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mul hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 180#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1299,7 +1339,8 @@ theorem mulh_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulh hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulh hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 181#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1310,7 +1351,8 @@ theorem mulhsu_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulhsu hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulhsu hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 179#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1321,7 +1363,8 @@ theorem mulhu_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulhu hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulhu hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 177#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1332,7 +1375,8 @@ theorem mulw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 182#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1343,7 +1387,8 @@ theorem div_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Div hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Div hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 186#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1354,7 +1399,8 @@ theorem divu_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Divu hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Divu hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 184#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1365,7 +1411,8 @@ theorem divw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Divw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Divw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 190#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1376,7 +1423,8 @@ theorem divuw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Divuw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Divuw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 188#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1387,7 +1435,8 @@ theorem rem_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Rem hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Rem hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 187#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1398,7 +1447,8 @@ theorem remu_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Remu hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Remu hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 185#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1409,7 +1459,8 @@ theorem remw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Remw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Remw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 191#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1420,7 +1471,8 @@ theorem remuw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Remuw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Remuw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 189#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1433,7 +1485,8 @@ theorem beq_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Beq hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Beq hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 9#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1444,7 +1497,8 @@ theorem bne_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bne hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bne hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 9#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1455,7 +1509,8 @@ theorem blt_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Blt hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Blt hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 7#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1466,7 +1521,8 @@ theorem bge_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bge hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bge hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 7#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1477,7 +1533,8 @@ theorem bltu_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bltu hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bltu hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 6#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1488,7 +1545,8 @@ theorem bgeu_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bgeu hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bgeu hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 6#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1501,7 +1559,8 @@ theorem slli_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slli hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slli hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 33#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1512,7 +1571,8 @@ theorem srli_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srli hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srli hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 34#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1523,7 +1583,8 @@ theorem srai_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srai hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srai hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 35#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1534,7 +1595,8 @@ theorem slti_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slti hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slti hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 7#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1545,7 +1607,8 @@ theorem sltiu_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sltiu hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sltiu hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 6#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1556,7 +1619,8 @@ theorem andi_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Andi hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Andi hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 14#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1567,7 +1631,8 @@ theorem slliw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slliw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slliw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 36#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1578,7 +1643,8 @@ theorem srliw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srliw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srliw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 37#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1589,7 +1655,8 @@ theorem sraiw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sraiw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sraiw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 38#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1602,7 +1669,8 @@ theorem xori_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (hrs1 : ri.rs1 ≠ 0#u32) (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Xori hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Xori hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 16#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1613,7 +1681,8 @@ theorem ori_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (hrs1 : ri.rs1 ≠ 0#u32) (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Ori hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Ori hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 15#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1626,7 +1695,8 @@ theorem lb_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lb hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lb hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 39#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1637,7 +1707,8 @@ theorem lh_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lh hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lh hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 40#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1648,7 +1719,8 @@ theorem lw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 41#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1659,7 +1731,8 @@ theorem lbu_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lbu hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lbu hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1670,7 +1743,8 @@ theorem lhu_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lhu hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lhu hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1681,7 +1755,8 @@ theorem lwu_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lwu hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lwu hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1692,7 +1767,8 @@ theorem ld_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Ld hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Ld hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1705,7 +1781,8 @@ theorem sb_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sb hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sb hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1716,7 +1793,8 @@ theorem sh_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sh hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sh hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1727,7 +1805,8 @@ theorem sw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1738,7 +1817,8 @@ theorem sd_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sd hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sd hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by


### PR DESCRIPTION
Part of #61 (S9), spike **S1**. Design context: `docs/ai/research/NOTE_61_RAWWORD_JOIN_DESIGN.md`.

Proves the ZisK lowerer **succeeds** for all 63 RV64IM opcodes — a side condition that #111's static decode pins and the block-2 dynamic pins currently *assume*.

## Why this lands alone

#61's Phase 0 is blocked on the raw-word join. The design document deliberately scopes this spike to land independently: it has no dependence on the serialization the rest of route (c) must repair, it has the smallest merge surface, and it is a genuine trust reduction on its own — so it keeps its value even if the rest of the route dies.

## What is proved

Totality of the **real production lowerer** — `riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input`, reached through the Aeneas extraction in `ProductionM2.lean`, the same entry point the ELF transpiler uses. Not a re-implementation; a re-implementation would discharge nothing.

## Honest scope — three things a reviewer should not have to discover

1. **The 63 theorems are not premise-free.** `ri.rs1.val < 32`, `ri.rs2.val < 32`, `ri.rd.val < 32` remain caller-supplied (plus `ri.rom_address = 0#u64` for JALR, the transpile call site's value). The earlier sections prove those bounds for each *leaf* decoder, but they are not yet threaded into the per-opcode statements.
2. **Zero downstream consumers today.** The `_dispatch_static_pins` / `_dispatch_extracted_rowMode_pins` family is referenced nowhere else in the tree, so this discharges an obligation nothing currently invokes. That is the honest characterisation: it is a prerequisite banked, not a premise removed from a live theorem.
3. **~762 of the added lines are a verbatim recovery** of the unmerged June branch `a16bd97c` (#159 block 3), byte-identical where recovered, repaired where it had drifted against today's tree.

A premise-free `∃ e, extract_transpile_rv64im_raw raw = ok e` needs three further things beyond this spike, one of which is substantive rather than plumbing; they are named in the module.

## Gates

- `lake build` — green, 9119 jobs, **default target** (no `+module`), module imported from `ZiskFv.lean` as the reachability gate requires
- `check-all.sh` — 18/18
- `check-all-semantic.sh` — 19/19

No new axioms/`sorry`/`native_decide`.
