### PR TITLE
Prove inhabitation for the LD/SD committed rows and the sign path (#61 S3)

### DIFF
--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -196,6 +196,11 @@ import ZiskFv.Compliance.AeneasBridgeTrust.Extraction
 -- (`zisk_decoder_accepts_supported_shape`) + completeness-obligation discharge
 -- (`real_decoder_accepts_in_shape`), proven in-build off the real Aeneas decoder.
 import ZiskFv.Compliance.AeneasBridgeTrust.Decode
+-- eth-act/zisk-fv#61 Phase-0 step S2: the cited line-by-line transcription of
+-- ZisK's ROM-row emitter (`rom.rs:204-260`) and its agreement with the in-tree
+-- PIL-mirroring `packFlags` / `BitVec.toInt` readings. Standalone; nothing in
+-- `root_soundness` depends on it yet (the raw-word binding is Phase-0 step S3).
+import ZiskFv.Compliance.RomRowSerialization
 import ZiskFv.Soundness
 import ZiskFv.Completeness.Rv
 -- Quarantined aspirational route; kept here so it stays built/verified, but the

--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -201,6 +201,9 @@ import ZiskFv.Compliance.AeneasBridgeTrust.Decode
 -- PIL-mirroring `packFlags` / `BitVec.toInt` readings. Standalone; nothing in
 -- `root_soundness` depends on it yet (the raw-word binding is Phase-0 step S3).
 import ZiskFv.Compliance.RomRowSerialization
+-- eth-act/zisk-fv#61 Phase-0 step S3: inhabitation of that serialization on real
+-- in-tree committed ROM rows, through the production Aeneas-extracted lowerer.
+import ZiskFv.Compliance.RomRowInhabitation
 import ZiskFv.Soundness
 import ZiskFv.Completeness.Rv
 -- Quarantined aspirational route; kept here so it stays built/verified, but the

--- a/ZiskFv/Compliance/RomRowInhabitation.lean
+++ b/ZiskFv/Compliance/RomRowInhabitation.lean
@@ -39,7 +39,7 @@ What the layout map still does NOT pin: that entry `k` sits where the *binary*
 places word `k`.  That is the meaning of the caller's address map, not a theorem
 here, and it stays a named residual (design note §6).
 
-## Result of the spike (read this before reusing anything below)
+## What was established (read this before reusing anything below)
 
 * INHABITED, against rows already committed in `SdLdSpinWitness.lean`:
   the LD row `sdLdLdProgramRow` (the one with `b_src_ind := true`, which

--- a/ZiskFv/Compliance/RomRowInhabitation.lean
+++ b/ZiskFv/Compliance/RomRowInhabitation.lean
@@ -329,8 +329,8 @@ it is a hand-built AIR witness from `#221`.
 
 `ldX3ZeroX1_unfold` is the step that runs the extracted decoder: it reduces
 `decode_32_core` on a literal word and reads off `rd = 3`, `rs1 = 1`, `rs2 = 0`,
-`imm = 0`.  The lowering itself does NOT reduce — `Std.Usize`'s width is the
-opaque `System.Platform.numBits` — which is why §1-§3 exist. -/
+`imm = 0`.  The lowering itself does NOT reduce, because `Std.Usize`'s width is
+the (irreducible) `System.Platform.numBits`, which is why §1-§3 exist. -/
 
 /-- `ld x3, 0(x1)`. -/
 def rawLdX3ZeroX1 : BitVec 32 := BitVec.ofNat 32 0x0000B183

--- a/ZiskFv/Compliance/RomRowInhabitation.lean
+++ b/ZiskFv/Compliance/RomRowInhabitation.lean
@@ -1,0 +1,400 @@
+/-
+ZiskFv/Compliance/RomRowInhabitation.lean  (eth-act/zisk-fv#61, Phase-0 step S3)
+
+INHABITATION for the ROM-row serialization of `Compliance/RomRowSerialization.lean`.
+
+S2 proved that a serialization is faithfully transcribed from
+`zisk/state-machines/rom/src/rom.rs:204-260`.  It did NOT prove that any
+committed ROM row IS the serialization of the lowering of a raw 32-bit RISC-V
+word.  Without that, a `ProgramBinding`-style premise could be satisfied by
+nothing and every theorem over it would be green and empty.
+
+This file runs concrete 32-bit words through the REAL production lowerer
+`zisk_core.aeneas_extract.extract_transpile_rv64im_raw`
+(`trust/aeneas/ProductionM2.lean:3645`), serializes the result with S2's
+`romRowOf`, and compares against rows that already exist in the tree.
+
+Kernel-sound: no `axiom` / `sorry` / `native_decide` / `bv_decide`.
+
+## The ROM-layout (`line`) question, stated explicitly
+
+`extract_transpile_rv64im_raw` hard-codes `rom_address := 0#u64`
+(`ProductionM2.lean:3656`), so its extract always has `paddr = 0`, while a
+committed ROM row sits at its real address (`rom.rs:238` emits `line :=
+F::from_u64(inst.paddr)`).  S2 deliberately made `romRowOf` read `e.paddr`
+rather than take `line` as a parameter, because June's parameterized
+`serializeExtract` left the eleventh slot unconstrained.
+
+The resolution here is NOT to drop the slot.  `romMessageOfRawAt` reinstates the
+address by overriding `paddr`, and `ld_rom_address_reaches_only_paddr` /
+`sd_rom_address_reaches_only_paddr` PROVE that this override is exactly what the
+production lowerer would have produced had it been handed that address: for the
+load and store arms, `rom_address` reaches the emitted instruction only through
+`ZiskInstBuilder::new`'s `paddr` (`ProductionM2.lean:2164-2177`) and
+`insert_inst`'s discarded key (`:2192`).  Those theorems are stated with the ROM
+address universally quantified, so a future ZisK making any other row field
+pc-dependent breaks them.
+
+What the layout map still does NOT pin: that entry `k` sits where the *binary*
+places word `k`.  That is the meaning of the caller's address map, not a theorem
+here, and it stays a named residual (design note §6).
+
+## Result of the spike (read this before reusing anything below)
+
+* INHABITED, against rows already committed in `SdLdSpinWitness.lean`:
+  the LD row `sdLdLdProgramRow` (the one with `b_src_ind := true`, which
+  falsifies June's `SRC_IND = 3` literal) and the SD row `sdLdSdProgramRow`.
+* INHABITED, sign path: `ld x5, -8(x2)` — the `i64` reinterpretation of
+  `rom.rs:226-236`, where June's second defect lived.  Its committed counterpart
+  is written here (`ldNegEightProgramRow`); no negative-offset load exists
+  elsewhere in the tree.
+* NOT INHABITED: the four ADDI/SLLI rows and the JAL row of the SAME witness.
+  See §6.  This is a property of the hand-built witness, not of the ROM emitter:
+  those rows were written to satisfy the AIR, and they differ from what ZisK's
+  transpiler emits for the corresponding instructions.  `ProgramBinding` is
+  therefore FALSE for `sdLdProgram` as it stands.
+-/
+import ZiskFv.Compliance.RomRowSerialization
+import ZiskFv.Compliance.AeneasBridgeTrust.Decode.Leaves
+
+open Aeneas Aeneas.Std Result zisk_core
+open Goldilocks
+
+namespace ZiskFv.Compliance.RomRowInhabitation
+
+open ZiskFv.Channels.ZiskRomBus (ZiskRomMessage)
+open ZiskFv.AirsClean.Main (RomFlagBits packFlags)
+open ZiskFv.Compliance.Decode (toU32)
+open ZiskFv.Compliance.RomRowSerialization
+open zisk_core.aeneas_extract (ZiskInstExtract)
+open zisk_inst_builder (ZiskInstBuilder)
+
+set_option maxRecDepth 100000
+
+/-! ## 1. The two `Usize` register-range constants, reduced past `System.Platform.numBits`
+
+`REGS_IN_MAIN_FROM` / `REGS_IN_MAIN_TO` are `Std.Usize`, whose width is the
+OPAQUE `System.Platform.numBits`, so the builder's register-class comparisons do
+not reduce.  Both constants cast to the same fixed-width value on either
+platform, which is what the four lemmas below establish; from there the
+comparisons are decidable. -/
+
+theorem cast_regs_from_u64 :
+    (UScalar.cast UScalarTy.U64 zisk_registers.REGS_IN_MAIN_FROM : Std.U64) = 1#u64 := by
+  simp only [zisk_registers.REGS_IN_MAIN_FROM, UScalar.cast, BitVec.truncate_eq_setWidth]
+  apply congrArg UScalar.mk
+  apply BitVec.eq_of_toNat_eq
+  simp only [BitVec.toNat_setWidth]
+  rfl
+
+theorem cast_regs_to_u64 :
+    (UScalar.cast UScalarTy.U64 zisk_registers.REGS_IN_MAIN_TO : Std.U64) = 31#u64 := by
+  simp only [zisk_registers.REGS_IN_MAIN_TO, UScalar.cast, BitVec.truncate_eq_setWidth]
+  apply congrArg UScalar.mk
+  apply BitVec.eq_of_toNat_eq
+  simp only [BitVec.toNat_setWidth]
+  rfl
+
+theorem hcast_regs_from_i64 :
+    (UScalar.hcast IScalarTy.I64 zisk_registers.REGS_IN_MAIN_FROM : Std.I64) = 1#i64 := by
+  simp only [zisk_registers.REGS_IN_MAIN_FROM, UScalar.hcast, BitVec.truncate_eq_setWidth]
+  apply congrArg IScalar.mk
+  apply BitVec.eq_of_toNat_eq
+  simp only [BitVec.toNat_setWidth]
+  rfl
+
+theorem hcast_regs_to_i64 :
+    (UScalar.hcast IScalarTy.I64 zisk_registers.REGS_IN_MAIN_TO : Std.I64) = 31#i64 := by
+  simp only [zisk_registers.REGS_IN_MAIN_TO, UScalar.hcast, BitVec.truncate_eq_setWidth]
+  apply congrArg IScalar.mk
+  apply BitVec.eq_of_toNat_eq
+  simp only [BitVec.toNat_setWidth]
+  rfl
+
+/-! ## 2. Builder steps on the in-main-register-file branch
+
+`src_a_reg` / `src_b_reg` / `store_reg` each have three register classes
+(`reg = 0` → immediate zero, out-of-range → `SRC_MEM` / `STORE_MEM`, in range →
+`SRC_REG` / `STORE_REG`).  With the numBits comparisons reduced by §1 the class
+is decidable, so these lemmas give the exact resulting builder rather than the
+"pins are preserved" statement of `Extraction/Helpers.lean`. -/
+
+theorem src_a_reg_in_main (self : ZiskInstBuilder) (reg : Std.U64)
+    (hne : ¬ (reg = 0#u64)) (hlo : ¬ (reg < 1#u64)) (hhi : ¬ (31#u64 < reg)) :
+    ZiskInstBuilder.src_a_reg self reg false
+      = ok { i :=
+          { self.i with
+            a_src := zisk_inst.SRC_REG, a_use_sp_imm1 := 0#u64, a_offset_imm0 := reg } } := by
+  simp only [ZiskInstBuilder.src_a_reg, lift, Bind.bind, bind_ok,
+    cast_regs_from_u64, cast_regs_to_u64, gt_iff_lt]
+  rw [if_neg hne, if_neg hlo, if_neg hhi]
+  simp
+
+theorem src_b_reg_in_main (self : ZiskInstBuilder) (reg : Std.U64)
+    (hne : ¬ (reg = 0#u64)) (hlo : ¬ (reg < 1#u64)) (hhi : ¬ (31#u64 < reg)) :
+    ZiskInstBuilder.src_b_reg self reg false
+      = ok { i :=
+          { self.i with
+            b_src := zisk_inst.SRC_REG, b_use_sp_imm1 := 0#u64, b_offset_imm0 := reg } } := by
+  simp only [ZiskInstBuilder.src_b_reg, lift, Bind.bind, bind_ok,
+    cast_regs_from_u64, cast_regs_to_u64, gt_iff_lt]
+  rw [if_neg hne, if_neg hlo, if_neg hhi]
+  simp
+
+theorem store_reg_in_main (self : ZiskInstBuilder) (off : Std.I64)
+    (hne : ¬ (off = 0#i64)) (hlo : ¬ (off < 1#i64)) (hhi : ¬ (31#i64 < off)) :
+    ZiskInstBuilder.store_reg self off false false
+      = ok { i :=
+          { self.i with
+            store_pc := false, store_use_sp := false,
+            store := zisk_inst.STORE_REG, store_offset := off } } := by
+  simp only [ZiskInstBuilder.store_reg, lift, Bind.bind, bind_ok,
+    hcast_regs_from_i64, hcast_regs_to_i64, gt_iff_lt]
+  rw [if_neg hne, if_neg hlo, if_neg hhi]
+
+/-! ## 3. The LD lowering, with the ROM address left free
+
+`ProductionM2.lean:3432-3437` sends `Ld` to `load_op_typed … CopyB 8 4`, i.e.
+`load_op_with_reg_offset … 0#i64` (`:2771-2780`).  The theorem below computes the
+whole arm, for ANY ROM address `a`: it is the load-family analogue of the `_pins`
+lemmas of `Extraction/Helpers.lean`, but total — every field of the emitted
+`ZiskInst` is pinned, not just the five static ones. -/
+
+/-- The `ZiskInst` `load_op_typed … CopyB 8 4` builds for a load whose `rs1` and
+    `rd` are both in the main register file: `a` is the ROM address, `aoff` the
+    `rs1` index, `boff` the sign-extended displacement, `soff` the `rd` index. -/
+def ldInstAt (a aoff boff : Std.U64) (soff : Std.I64) : zisk_inst.ZiskInst where
+  paddr := a
+  store_pc := false
+  store_use_sp := false
+  store := zisk_inst.STORE_REG
+  store_offset := soff
+  set_pc := false
+  is_precompiled := false
+  ind_width := 8#u64
+  «end» := false
+  a_src := zisk_inst.SRC_REG
+  a_use_sp_imm1 := 0#u64
+  a_offset_imm0 := aoff
+  b_src := zisk_inst.SRC_IND
+  b_use_sp_imm1 := 0#u64
+  b_offset_imm0 := boff
+  jmp_offset1 := 4#i64
+  jmp_offset2 := 4#i64
+  is_external_op := false
+  op := 1#u8
+  op_type := zisk_inst.ZiskOperationType.Internal
+  m32 := false
+  input_size := 0#u64
+  sorted_pc_list_index := 0#usize
+
+/-- The empty lowering context `extract_transpile_rv64im_raw` starts from
+    (`ProductionM2.lean:3660-3667`). -/
+def emptyCtx : riscv2zisk_context.Riscv2ZiskContext where
+  extract_inst := none
+  extract_marker := ()
+  input_precompile := none
+  output_precompile := none
+  input_precompile_reg := none
+  output_precompile_reg := none
+
+set_option maxHeartbeats 2000000 in
+/-- **The LD arm, computed.**  `a` is universally quantified, so the statement
+    also says exactly how the ROM address reaches the row: through `paddr` and
+    nothing else. -/
+theorem ld_lowering_ctx (a : Std.U64) (rd rs1 rs2 : Std.U32) (imm : Std.I32)
+    (hrs1ne : ¬ ((UScalar.cast UScalarTy.U64 rs1 : Std.U64) = 0#u64))
+    (hrs1lo : ¬ ((UScalar.cast UScalarTy.U64 rs1 : Std.U64) < 1#u64))
+    (hrs1hi : ¬ ((31#u64 : Std.U64) < (UScalar.cast UScalarTy.U64 rs1 : Std.U64)))
+    (hadd : ((UScalar.hcast IScalarTy.I64 rd : Std.I64) + (0#i64 : Std.I64))
+              = ok (UScalar.hcast IScalarTy.I64 rd : Std.I64))
+    (hrdne : ¬ ((UScalar.hcast IScalarTy.I64 rd : Std.I64) = 0#i64))
+    (hrdlo : ¬ ((UScalar.hcast IScalarTy.I64 rd : Std.I64) < 1#i64))
+    (hrdhi : ¬ ((31#i64 : Std.I64) < (UScalar.hcast IScalarTy.I64 rd : Std.I64))) :
+    riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input emptyCtx
+        { rom_address := a, rd := rd, rs1 := rs1, rs2 := rs2, imm := imm }
+        riscv2zisk_single_row.Rv64imSingleRowOpcode.Ld false
+      = ok { emptyCtx with
+              extract_inst := some
+                { i := ldInstAt a (UScalar.cast UScalarTy.U64 rs1)
+                        (IScalar.hcast UScalarTy.U64 imm) (UScalar.hcast IScalarTy.I64 rd) } } := by
+  simp only [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input,
+    riscv2zisk_context.Riscv2ZiskContext.load_op_typed,
+    riscv2zisk_context.Riscv2ZiskContext.load_op_with_reg_offset,
+    ZiskInstBuilder.new_for_rv64im_lowering, ZiskInstBuilder.new,
+    ZiskInstBuilder.Insts.CoreDefaultDefault.default,
+    zisk_inst.ZiskInst.Insts.CoreDefaultDefault.default,
+    ZiskInstBuilder.ind_width, ZiskInstBuilder.src_b_ind,
+    ZiskInstBuilder.op_zisk, ZiskInstBuilder.set_runtime_op_fields,
+    ZiskInstBuilder.j, ZiskInstBuilder.build,
+    riscv2zisk_context.Riscv2ZiskContext.insert_inst,
+    src_a_reg_in_main _ _ hrs1ne hrs1lo hrs1hi,
+    store_reg_in_main _ _ hrdne hrdlo hrdhi,
+    hadd, lift, Bind.bind, bind_ok]
+  rfl
+
+/-- The extract the ROM emitter reads, for the same row. -/
+def ldExtractAt (a aoff boff : Std.U64) (soff : Std.I64) : ZiskInstExtract where
+  paddr := a
+  store_pc := false
+  store_use_sp := false
+  store := zisk_inst.STORE_REG
+  store_offset := soff
+  set_pc := false
+  is_precompiled := false
+  ind_width := 8#u64
+  «end» := false
+  a_src := zisk_inst.SRC_REG
+  a_use_sp_imm1 := 0#u64
+  a_offset_imm0 := aoff
+  b_src := zisk_inst.SRC_IND
+  b_use_sp_imm1 := 0#u64
+  b_offset_imm0 := boff
+  jmp_offset1 := 4#i64
+  jmp_offset2 := 4#i64
+  is_external_op := false
+  op := 1#u8
+  op_type_id := 1#u32
+  m32 := false
+  input_size := 0#u64
+  sorted_pc_list_index := 0#usize
+
+theorem from_inst_ldInstAt (a aoff boff : Std.U64) (soff : Std.I64) :
+    aeneas_extract.ZiskInstExtract.from_inst (ldInstAt a aoff boff soff)
+      = ok (ldExtractAt a aoff boff soff) := rfl
+
+/-- **The ROM address reaches the LD row only through `paddr`.**  Overriding
+    `paddr` on the `rom_address := 0` extract gives back exactly the extract the
+    lowerer produces when handed `a`.  This is what licenses `romMessageOfRawAt`
+    below to reinstate an address that `extract_transpile_rv64im_raw` hard-codes
+    to `0`; a future ZisK making any other row field pc-dependent would break
+    this proof rather than pass silently. -/
+theorem ld_rom_address_reaches_only_paddr (a : Std.U64) (rd rs1 rs2 : Std.U32) (imm : Std.I32)
+    (hrs1ne : ¬ ((UScalar.cast UScalarTy.U64 rs1 : Std.U64) = 0#u64))
+    (hrs1lo : ¬ ((UScalar.cast UScalarTy.U64 rs1 : Std.U64) < 1#u64))
+    (hrs1hi : ¬ ((31#u64 : Std.U64) < (UScalar.cast UScalarTy.U64 rs1 : Std.U64)))
+    (hadd : ((UScalar.hcast IScalarTy.I64 rd : Std.I64) + (0#i64 : Std.I64))
+              = ok (UScalar.hcast IScalarTy.I64 rd : Std.I64))
+    (hrdne : ¬ ((UScalar.hcast IScalarTy.I64 rd : Std.I64) = 0#i64))
+    (hrdlo : ¬ ((UScalar.hcast IScalarTy.I64 rd : Std.I64) < 1#i64))
+    (hrdhi : ¬ ((31#i64 : Std.I64) < (UScalar.hcast IScalarTy.I64 rd : Std.I64))) :
+    (do
+      let ctx ←
+        riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input emptyCtx
+          { rom_address := a, rd := rd, rs1 := rs1, rs2 := rs2, imm := imm }
+          riscv2zisk_single_row.Rv64imSingleRowOpcode.Ld false
+      let zib ← core.option.Option.unwrap ctx.extract_inst
+      aeneas_extract.ZiskInstExtract.from_inst zib.i)
+      = (do
+      let e ← (do
+        let ctx ←
+          riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input emptyCtx
+            { rom_address := 0#u64, rd := rd, rs1 := rs1, rs2 := rs2, imm := imm }
+            riscv2zisk_single_row.Rv64imSingleRowOpcode.Ld false
+        let zib ← core.option.Option.unwrap ctx.extract_inst
+        aeneas_extract.ZiskInstExtract.from_inst zib.i)
+      ok { e with paddr := a }) := by
+  rw [ld_lowering_ctx a rd rs1 rs2 imm hrs1ne hrs1lo hrs1hi hadd hrdne hrdlo hrdhi,
+      ld_lowering_ctx 0#u64 rd rs1 rs2 imm hrs1ne hrs1lo hrs1hi hadd hrdne hrdlo hrdhi]
+  rfl
+
+/-! ## 4. From a raw 32-bit word to a ROM message -/
+
+/-- The eleven-slot ROM message ZisK's `compute_trace_rom` emits for the word
+    `raw` sitting at ROM address `addr`.  The `paddr` override is licensed by
+    `ld_rom_address_reaches_only_paddr` / `sd_rom_address_reaches_only_paddr`,
+    not assumed.  A word the lowerer rejects still returns `ok` with the default
+    row and `accepted := false` (`ProductionM2.lean:3652-3653`), so a caller must
+    also demand `accepted = true`; the witnesses below all establish that. -/
+def romMessageOfRawAt (addr : Std.U64) (raw : BitVec 32) : Result (ZiskRomMessage FGL) := do
+  let r ← aeneas_extract.extract_transpile_rv64im_raw (toU32 raw)
+  ok (romRowOf { r.row with paddr := addr })
+
+/-! ## 5. Witness 1 — the committed LD row of `SdLdSpinWitness`
+
+`ld x3, 0(x1)` is `0x0000B183`.  `SdLdSpinWitness.sdLdLdProgramRow` sits at ROM
+address 20 and is the row whose `b_src_ind` bit falsifies June's `SRC_IND = 3`
+literal (design note §3.1).  Nothing about that row was written for this proof:
+it is a hand-built AIR witness from `#221`.
+
+`ldX3ZeroX1_unfold` is the step that runs the extracted decoder: it reduces
+`decode_32_core` on a literal word and reads off `rd = 3`, `rs1 = 1`, `rs2 = 0`,
+`imm = 0`.  The lowering itself does NOT reduce — `Std.Usize`'s width is the
+opaque `System.Platform.numBits` — which is why §1-§3 exist. -/
+
+/-- `ld x3, 0(x1)`. -/
+def rawLdX3ZeroX1 : BitVec 32 := BitVec.ofNat 32 0x0000B183
+
+/-- What the extracted decoder reports for `ld x3, 0(x1)`. -/
+def ldX3ZeroX1Decode : aeneas_extract.Rv64imDecodeExtract where
+  supported := true
+  opcode_id := 59#u32
+  format_id := 1#u32
+  funct3 := 3#u32
+  funct7 := 0#u32
+  rd := 3#u32
+  rs1 := 1#u32
+  rs2 := 0#u32
+  imm := 0#i32
+  pred := 0#u32
+  succ := 0#u32
+
+/-- `store_reg`'s `rd + reg_offset` with `reg_offset = 0` (`ProductionM2.lean:2757`),
+    for `rd = x3`.  Stated as a named lemma because elaborating it inline as a
+    `rfl` argument overflows the elaborator's stack. -/
+theorem hcast_x3_add_zero :
+    ((UScalar.hcast IScalarTy.I64 (3#u32) : Std.I64) + (0#i64 : Std.I64))
+      = ok (UScalar.hcast IScalarTy.I64 (3#u32) : Std.I64) := rfl
+
+set_option maxHeartbeats 2000000 in
+theorem ldX3ZeroX1_unfold :
+    aeneas_extract.extract_transpile_rv64im_raw (toU32 rawLdX3ZeroX1)
+      = (do
+      let ctx ←
+        riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input emptyCtx
+          { rom_address := 0#u64, rd := 3#u32, rs1 := 1#u32, rs2 := 0#u32, imm := 0#i32 }
+          riscv2zisk_single_row.Rv64imSingleRowOpcode.Ld false
+      let zib ← core.option.Option.unwrap ctx.extract_inst
+      let row ← aeneas_extract.ZiskInstExtract.from_inst zib.i
+      ok { accepted := true, decode := ldX3ZeroX1Decode, row := row }) := by
+  with_unfolding_all rfl
+
+set_option maxHeartbeats 2000000 in
+/-- **The whole production transpile of `ld x3, 0(x1)`**, decode record included.
+    `accepted = true`, so this is a word the lowerer really accepts. -/
+theorem ldX3ZeroX1_transpile :
+    aeneas_extract.extract_transpile_rv64im_raw (toU32 rawLdX3ZeroX1)
+      = ok { accepted := true, decode := ldX3ZeroX1Decode,
+             row := ldExtractAt 0#u64 1#u64 0#u64 3#i64 } := by
+  rw [ldX3ZeroX1_unfold,
+    ld_lowering_ctx 0#u64 3#u32 1#u32 0#u32 0#i32
+      (by decide) (by decide) (by decide) hcast_x3_add_zero (by decide) (by decide) (by decide)]
+  rfl
+
+/-- Placing an already-computed load extract at another ROM address moves only
+    `paddr`; folds `romMessageOfRawAt`'s layout argument in. -/
+theorem ldExtractAt_paddr (a b aoff boff : Std.U64) (soff : Std.I64) :
+    { ldExtractAt a aoff boff soff with paddr := b } = ldExtractAt b aoff boff soff := rfl
+
+/-- **The serialized lowering of `ld x3, 0(x1)`, at any ROM address.** -/
+theorem romMessageOfRawAt_ldX3ZeroX1 (addr : Std.U64) :
+    romMessageOfRawAt addr rawLdX3ZeroX1
+      = ok (romRowOf (ldExtractAt addr 1#u64 0#u64 3#i64)) := by
+  simp only [romMessageOfRawAt, ldX3ZeroX1_transpile, ldExtractAt_paddr,
+    Bind.bind, bind_ok]
+
+/-- **Inhabitation, witness 1.**  The committed LD row of the SD/LD spin witness
+    IS the ROM serialization of the lowering of a real 32-bit RISC-V word.
+
+    All eleven slots are pinned, `line` included: the address enters through
+    `romMessageOfRawAt`'s layout argument, and `ld_rom_address_reaches_only_paddr`
+    says that is exactly what the lowerer emits at that address. -/
+theorem sdLdLdProgramRow_inhabited :
+    romMessageOfRawAt 20#u64 rawLdX3ZeroX1
+      = ok ZiskFv.Compliance.SdLdSpinWitness.sdLdLdProgramRow := by
+  rw [romMessageOfRawAt_ldX3ZeroX1]
+  exact congrArg ok
+    (romRowOf_eq_sdLdLdProgramRow (ldExtractAt 20#u64 1#u64 0#u64 3#i64)
+      rfl rfl rfl rfl rfl rfl rfl rfl rfl rfl rfl rfl rfl rfl rfl rfl)
+
+end ZiskFv.Compliance.RomRowInhabitation

--- a/ZiskFv/Compliance/RomRowInhabitation.lean
+++ b/ZiskFv/Compliance/RomRowInhabitation.lean
@@ -397,4 +397,317 @@ theorem sdLdLdProgramRow_inhabited :
     (romRowOf_eq_sdLdLdProgramRow (ldExtractAt 20#u64 1#u64 0#u64 3#i64)
       rfl rfl rfl rfl rfl rfl rfl rfl rfl rfl rfl rfl rfl rfl rfl rfl)
 
+/-! ## 6. Witness 2 — a negative-offset load
+
+`rom.rs:226-236` reinterprets the two `u64` offset slots as `i64` before choosing
+the `F::from_u64` / `F::neg` branch.  June's `serializeExtract` used the unsigned
+`UScalar.val`, which agrees with the ROM emitter only while the slot stays below
+`2^63` — i.e. never for a negative RISC-V displacement, because `IScalar.hcast`
+sign-extends (`Aeneas/Std/Scalar/Casts.lean:41-43`).  The SD/LD witness's
+displacements are `0` and `2`, so it does not exercise that path.
+
+`ld x5, -8(x2)` is `0xFF813283`.  It has no committed counterpart anywhere in the
+tree, so the expected row is written out here — in the same literal style as the
+`SdLdSpinWitness` rows, and independently of the lowerer.  That makes this a
+lowering-side check: it shows the sign path lands on the sign-correct field
+element, not that some other module already commits to this row. -/
+
+/-- `ld x5, -8(x2)`. -/
+def rawLdX5NegEightX2 : BitVec 32 := BitVec.ofNat 32 0xFF813283
+
+def ldX5NegEightX2Decode : aeneas_extract.Rv64imDecodeExtract where
+  supported := true
+  opcode_id := 59#u32
+  format_id := 1#u32
+  funct3 := 3#u32
+  funct7 := 0#u32
+  rd := 5#u32
+  rs1 := 2#u32
+  rs2 := 0#u32
+  imm := (-8)#i32
+  pred := 0#u32
+  succ := 0#u32
+
+theorem hcast_x5_add_zero :
+    ((UScalar.hcast IScalarTy.I64 (5#u32) : Std.I64) + (0#i64 : Std.I64))
+      = ok (UScalar.hcast IScalarTy.I64 (5#u32) : Std.I64) := rfl
+
+set_option maxHeartbeats 2000000 in
+theorem ldX5NegEightX2_unfold :
+    aeneas_extract.extract_transpile_rv64im_raw (toU32 rawLdX5NegEightX2)
+      = (do
+      let ctx ←
+        riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input emptyCtx
+          { rom_address := 0#u64, rd := 5#u32, rs1 := 2#u32, rs2 := 0#u32, imm := (-8)#i32 }
+          riscv2zisk_single_row.Rv64imSingleRowOpcode.Ld false
+      let zib ← core.option.Option.unwrap ctx.extract_inst
+      let row ← aeneas_extract.ZiskInstExtract.from_inst zib.i
+      ok { accepted := true, decode := ldX5NegEightX2Decode, row := row }) := by
+  with_unfolding_all rfl
+
+set_option maxHeartbeats 2000000 in
+/-- The lowering sign-extends the displacement: `b_offset_imm0 = 2^64 - 8`.  This
+    is the value June's unsigned serialization would have pushed into the field
+    verbatim. -/
+theorem ldX5NegEightX2_transpile :
+    aeneas_extract.extract_transpile_rv64im_raw (toU32 rawLdX5NegEightX2)
+      = ok { accepted := true, decode := ldX5NegEightX2Decode,
+             row := ldExtractAt 0#u64 2#u64 18446744073709551608#u64 5#i64 } := by
+  rw [ldX5NegEightX2_unfold,
+    ld_lowering_ctx 0#u64 5#u32 2#u32 0#u32 (-8)#i32
+      (by decide) (by decide) (by decide) hcast_x5_add_zero (by decide) (by decide) (by decide)]
+  rfl
+
+theorem romMessageOfRawAt_ldX5NegEightX2 (addr : Std.U64) :
+    romMessageOfRawAt addr rawLdX5NegEightX2
+      = ok (romRowOf (ldExtractAt addr 2#u64 18446744073709551608#u64 5#i64)) := by
+  simp only [romMessageOfRawAt, ldX5NegEightX2_transpile, ldExtractAt_paddr,
+    Bind.bind, bind_ok]
+
+/-- The row a `SdLdSpinWitness`-style witness would have to commit for
+    `ld x5, -8(x2)` at ROM address 36.  Written in the same literal style as the
+    committed rows; the flag record is the SAME `sdLdLdBits` those rows use. -/
+def ldNegEightProgramRow : ZiskRomMessage FGL :=
+  { line := 36, a_offset_imm0 := 2, a_imm1 := 0, b_offset_imm0 := -8, b_imm1 := 0,
+    ind_width := 8, op := ZiskFv.Trusted.OP_COPYB, store_offset := 5, jmp_offset1 := 4,
+    jmp_offset2 := 4,
+    flags := packFlags ZiskFv.Compliance.SdLdSpinWitness.sdLdLdBits }
+
+set_option maxHeartbeats 2000000 in
+/-- **Inhabitation, witness 2 — the sign path.**  The serialized lowering of
+    `ld x5, -8(x2)` at ROM address 36 is the negative-displacement row, with
+    `b_offset_imm0 = -8` in the field. -/
+theorem ldNegEightProgramRow_inhabited :
+    romMessageOfRawAt 36#u64 rawLdX5NegEightX2 = ok ldNegEightProgramRow := by
+  rw [romMessageOfRawAt_ldX5NegEightX2]
+  refine congrArg ok ?_
+  have hbits :
+      romFlagBitsOf (ldExtractAt 36#u64 2#u64 18446744073709551608#u64 5#i64)
+        = ZiskFv.Compliance.SdLdSpinWitness.sdLdLdBits :=
+    romFlagBitsOf_eq_sdLdLdBits _ rfl rfl rfl rfl rfl rfl rfl rfl
+  have ha : ¬ ((ldExtractAt 36#u64 2#u64 18446744073709551608#u64 5#i64).a_src
+      = zisk_inst.SRC_IMM) := by
+    simp only [ldExtractAt, zisk_inst.SRC_REG, zisk_inst.SRC_IMM]; decide
+  have hb : ¬ ((ldExtractAt 36#u64 2#u64 18446744073709551608#u64 5#i64).b_src
+      = zisk_inst.SRC_IMM) := by
+    simp only [ldExtractAt, zisk_inst.SRC_IND, zisk_inst.SRC_IMM]; decide
+  simp only [romRowOf, ldNegEightProgramRow, ZiskRomMessage.mk.injEq]
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
+    first
+      | rw [romFlagsNat_cast_eq_packFlags, hbits]
+      | rw [if_neg ha]
+      | rw [if_neg hb]
+      | (rw [romSignedField_eq_intCast]; decide)
+      | decide
+
+/-- **The sign path bites.**  The serialized displacement is `-8`, and that is
+    NOT the unsigned reading of the same slot: the two differ by `2^64`, which is
+    `2^32 - 1 ≠ 0` in Goldilocks.  So a negative-offset load is exactly where a
+    `UScalar.val` serialization would make `ProgramBinding` false. -/
+theorem ldNegEight_b_offset_ne_unsigned :
+    (romRowOf (ldExtractAt 36#u64 2#u64 18446744073709551608#u64 5#i64)).b_offset_imm0
+      ≠ ((18446744073709551608 : ℕ) : FGL) := by
+  simp only [romRowOf, romSignedField_eq_intCast]
+  decide
+
+/-! ## 7. Witness 3 — the committed SD row of `SdLdSpinWitness`
+
+`sd x2, 0(x1)` is `0x0020B023`.  `ProductionM2.lean:3456-3461` sends `Sd` to
+`store_op_typed … CopyB 8 4` = `store_op_with_reg_offset … 0#u64` (`:2690-2699`). -/
+
+/-- The `ZiskInst` `store_op_typed … CopyB 8 4` builds for a store whose `rs1`
+    and `rs2` are both in the main register file. -/
+def sdInstAt (a aoff boff : Std.U64) (soff : Std.I64) : zisk_inst.ZiskInst where
+  paddr := a
+  store_pc := false
+  store_use_sp := false
+  store := zisk_inst.STORE_IND
+  store_offset := soff
+  set_pc := false
+  is_precompiled := false
+  ind_width := 8#u64
+  «end» := false
+  a_src := zisk_inst.SRC_REG
+  a_use_sp_imm1 := 0#u64
+  a_offset_imm0 := aoff
+  b_src := zisk_inst.SRC_REG
+  b_use_sp_imm1 := 0#u64
+  b_offset_imm0 := boff
+  jmp_offset1 := 4#i64
+  jmp_offset2 := 4#i64
+  is_external_op := false
+  op := 1#u8
+  op_type := zisk_inst.ZiskOperationType.Internal
+  m32 := false
+  input_size := 0#u64
+  sorted_pc_list_index := 0#usize
+
+def sdExtractAt (a aoff boff : Std.U64) (soff : Std.I64) : ZiskInstExtract where
+  paddr := a
+  store_pc := false
+  store_use_sp := false
+  store := zisk_inst.STORE_IND
+  store_offset := soff
+  set_pc := false
+  is_precompiled := false
+  ind_width := 8#u64
+  «end» := false
+  a_src := zisk_inst.SRC_REG
+  a_use_sp_imm1 := 0#u64
+  a_offset_imm0 := aoff
+  b_src := zisk_inst.SRC_REG
+  b_use_sp_imm1 := 0#u64
+  b_offset_imm0 := boff
+  jmp_offset1 := 4#i64
+  jmp_offset2 := 4#i64
+  is_external_op := false
+  op := 1#u8
+  op_type_id := 1#u32
+  m32 := false
+  input_size := 0#u64
+  sorted_pc_list_index := 0#usize
+
+theorem sdExtractAt_paddr (a b aoff boff : Std.U64) (soff : Std.I64) :
+    { sdExtractAt a aoff boff soff with paddr := b } = sdExtractAt b aoff boff soff := rfl
+
+set_option maxHeartbeats 2000000 in
+/-- **The SD arm, computed**, again with the ROM address left free. -/
+theorem sd_lowering_ctx (a : Std.U64) (rd rs1 rs2 : Std.U32) (imm : Std.I32)
+    (hrs1ne : ¬ ((UScalar.cast UScalarTy.U64 rs1 : Std.U64) = 0#u64))
+    (hrs1lo : ¬ ((UScalar.cast UScalarTy.U64 rs1 : Std.U64) < 1#u64))
+    (hrs1hi : ¬ ((31#u64 : Std.U64) < (UScalar.cast UScalarTy.U64 rs1 : Std.U64)))
+    (hadd : ((UScalar.cast UScalarTy.U64 rs2 : Std.U64) + (0#u64 : Std.U64))
+              = ok (UScalar.cast UScalarTy.U64 rs2 : Std.U64))
+    (hrs2ne : ¬ ((UScalar.cast UScalarTy.U64 rs2 : Std.U64) = 0#u64))
+    (hrs2lo : ¬ ((UScalar.cast UScalarTy.U64 rs2 : Std.U64) < 1#u64))
+    (hrs2hi : ¬ ((31#u64 : Std.U64) < (UScalar.cast UScalarTy.U64 rs2 : Std.U64))) :
+    riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input emptyCtx
+        { rom_address := a, rd := rd, rs1 := rs1, rs2 := rs2, imm := imm }
+        riscv2zisk_single_row.Rv64imSingleRowOpcode.Sd false
+      = ok { emptyCtx with
+              extract_inst := some
+                { i := sdInstAt a (UScalar.cast UScalarTy.U64 rs1)
+                        (UScalar.cast UScalarTy.U64 rs2) (IScalar.cast IScalarTy.I64 imm) } } := by
+  simp only [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input,
+    riscv2zisk_context.Riscv2ZiskContext.store_op_typed,
+    riscv2zisk_context.Riscv2ZiskContext.store_op_with_reg_offset,
+    ZiskInstBuilder.new_for_rv64im_lowering, ZiskInstBuilder.new,
+    ZiskInstBuilder.Insts.CoreDefaultDefault.default,
+    zisk_inst.ZiskInst.Insts.CoreDefaultDefault.default,
+    ZiskInstBuilder.ind_width, ZiskInstBuilder.store_ind,
+    ZiskInstBuilder.op_zisk, ZiskInstBuilder.set_runtime_op_fields,
+    ZiskInstBuilder.j, ZiskInstBuilder.build,
+    riscv2zisk_context.Riscv2ZiskContext.insert_inst,
+    src_a_reg_in_main _ _ hrs1ne hrs1lo hrs1hi,
+    src_b_reg_in_main _ _ hrs2ne hrs2lo hrs2hi,
+    hadd, lift, Bind.bind, bind_ok]
+  rfl
+
+/-- **The ROM address reaches the SD row only through `paddr`.** -/
+theorem sd_rom_address_reaches_only_paddr (a : Std.U64) (rd rs1 rs2 : Std.U32) (imm : Std.I32)
+    (hrs1ne : ¬ ((UScalar.cast UScalarTy.U64 rs1 : Std.U64) = 0#u64))
+    (hrs1lo : ¬ ((UScalar.cast UScalarTy.U64 rs1 : Std.U64) < 1#u64))
+    (hrs1hi : ¬ ((31#u64 : Std.U64) < (UScalar.cast UScalarTy.U64 rs1 : Std.U64)))
+    (hadd : ((UScalar.cast UScalarTy.U64 rs2 : Std.U64) + (0#u64 : Std.U64))
+              = ok (UScalar.cast UScalarTy.U64 rs2 : Std.U64))
+    (hrs2ne : ¬ ((UScalar.cast UScalarTy.U64 rs2 : Std.U64) = 0#u64))
+    (hrs2lo : ¬ ((UScalar.cast UScalarTy.U64 rs2 : Std.U64) < 1#u64))
+    (hrs2hi : ¬ ((31#u64 : Std.U64) < (UScalar.cast UScalarTy.U64 rs2 : Std.U64))) :
+    (do
+      let ctx ←
+        riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input emptyCtx
+          { rom_address := a, rd := rd, rs1 := rs1, rs2 := rs2, imm := imm }
+          riscv2zisk_single_row.Rv64imSingleRowOpcode.Sd false
+      let zib ← core.option.Option.unwrap ctx.extract_inst
+      aeneas_extract.ZiskInstExtract.from_inst zib.i)
+      = (do
+      let e ← (do
+        let ctx ←
+          riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input emptyCtx
+            { rom_address := 0#u64, rd := rd, rs1 := rs1, rs2 := rs2, imm := imm }
+            riscv2zisk_single_row.Rv64imSingleRowOpcode.Sd false
+        let zib ← core.option.Option.unwrap ctx.extract_inst
+        aeneas_extract.ZiskInstExtract.from_inst zib.i)
+      ok { e with paddr := a }) := by
+  rw [sd_lowering_ctx a rd rs1 rs2 imm hrs1ne hrs1lo hrs1hi hadd hrs2ne hrs2lo hrs2hi,
+      sd_lowering_ctx 0#u64 rd rs1 rs2 imm hrs1ne hrs1lo hrs1hi hadd hrs2ne hrs2lo hrs2hi]
+  rfl
+
+/-- `sd x2, 0(x1)`. -/
+def rawSdX2ZeroX1 : BitVec 32 := BitVec.ofNat 32 0x0020B023
+
+def sdX2ZeroX1Decode : aeneas_extract.Rv64imDecodeExtract where
+  supported := true
+  opcode_id := 63#u32
+  format_id := 3#u32
+  funct3 := 3#u32
+  funct7 := 0#u32
+  rd := 0#u32
+  rs1 := 1#u32
+  rs2 := 2#u32
+  imm := 0#i32
+  pred := 0#u32
+  succ := 0#u32
+
+theorem cast_x2_add_zero :
+    ((UScalar.cast UScalarTy.U64 (2#u32) : Std.U64) + (0#u64 : Std.U64))
+      = ok (UScalar.cast UScalarTy.U64 (2#u32) : Std.U64) := rfl
+
+set_option maxHeartbeats 2000000 in
+theorem sdX2ZeroX1_unfold :
+    aeneas_extract.extract_transpile_rv64im_raw (toU32 rawSdX2ZeroX1)
+      = (do
+      let ctx ←
+        riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input emptyCtx
+          { rom_address := 0#u64, rd := 0#u32, rs1 := 1#u32, rs2 := 2#u32, imm := 0#i32 }
+          riscv2zisk_single_row.Rv64imSingleRowOpcode.Sd false
+      let zib ← core.option.Option.unwrap ctx.extract_inst
+      let row ← aeneas_extract.ZiskInstExtract.from_inst zib.i
+      ok { accepted := true, decode := sdX2ZeroX1Decode, row := row }) := by
+  with_unfolding_all rfl
+
+set_option maxHeartbeats 2000000 in
+theorem sdX2ZeroX1_transpile :
+    aeneas_extract.extract_transpile_rv64im_raw (toU32 rawSdX2ZeroX1)
+      = ok { accepted := true, decode := sdX2ZeroX1Decode,
+             row := sdExtractAt 0#u64 1#u64 2#u64 0#i64 } := by
+  rw [sdX2ZeroX1_unfold,
+    sd_lowering_ctx 0#u64 0#u32 1#u32 2#u32 0#i32
+      (by decide) (by decide) (by decide) cast_x2_add_zero (by decide) (by decide) (by decide)]
+  rfl
+
+theorem romMessageOfRawAt_sdX2ZeroX1 (addr : Std.U64) :
+    romMessageOfRawAt addr rawSdX2ZeroX1
+      = ok (romRowOf (sdExtractAt addr 1#u64 2#u64 0#i64)) := by
+  simp only [romMessageOfRawAt, sdX2ZeroX1_transpile, sdExtractAt_paddr,
+    Bind.bind, bind_ok]
+
+set_option maxHeartbeats 2000000 in
+/-- **Inhabitation, witness 3.**  The committed SD row of the SD/LD spin witness
+    is likewise the ROM serialization of the lowering of a real word. -/
+theorem sdLdSdProgramRow_inhabited :
+    romMessageOfRawAt 16#u64 rawSdX2ZeroX1
+      = ok ZiskFv.Compliance.SdLdSpinWitness.sdLdSdProgramRow := by
+  rw [romMessageOfRawAt_sdX2ZeroX1]
+  refine congrArg ok ?_
+  have ha : ¬ ((sdExtractAt 16#u64 1#u64 2#u64 0#i64).a_src = zisk_inst.SRC_IMM) := by
+    simp only [sdExtractAt, zisk_inst.SRC_REG, zisk_inst.SRC_IMM]; decide
+  have hb : ¬ ((sdExtractAt 16#u64 1#u64 2#u64 0#i64).b_src = zisk_inst.SRC_IMM) := by
+    simp only [sdExtractAt, zisk_inst.SRC_REG, zisk_inst.SRC_IMM]; decide
+  have hbits : romFlagBitsOf (sdExtractAt 16#u64 1#u64 2#u64 0#i64)
+      = ZiskFv.Compliance.SdLdSpinWitness.sdLdSdBits := by
+    simp only [romFlagBitsOf, sdExtractAt, ZiskFv.Compliance.SdLdSpinWitness.sdLdSdBits,
+      zisk_inst.SRC_REG, zisk_inst.SRC_IMM, zisk_inst.SRC_MEM, zisk_inst.SRC_IND,
+      zisk_inst.STORE_REG, zisk_inst.STORE_MEM, zisk_inst.STORE_IND]
+    rfl
+  simp only [romRowOf, ZiskFv.Compliance.SdLdSpinWitness.sdLdSdProgramRow,
+    ZiskRomMessage.mk.injEq]
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
+    first
+      | rw [romFlagsNat_cast_eq_packFlags, hbits]
+      | rw [if_neg ha]
+      | rw [if_neg hb]
+      | (rw [romSignedField_eq_intCast]; decide)
+      | decide
+
 end ZiskFv.Compliance.RomRowInhabitation

--- a/ZiskFv/Compliance/RomRowInhabitation.lean
+++ b/ZiskFv/Compliance/RomRowInhabitation.lean
@@ -48,11 +48,21 @@ here, and it stays a named residual (design note §6).
   `rom.rs:226-236`, where June's second defect lived.  Its committed counterpart
   is written here (`ldNegEightProgramRow`); no negative-offset load exists
   elsewhere in the tree.
-* NOT INHABITED: the four ADDI/SLLI rows and the JAL row of the SAME witness.
-  See §6.  This is a property of the hand-built witness, not of the ROM emitter:
-  those rows were written to satisfy the AIR, and they differ from what ZisK's
-  transpiler emits for the corresponding instructions.  `ProgramBinding` is
-  therefore FALSE for `sdLdProgram` as it stands.
+* NOT INHABITED: the other five rows of the SAME witness (three ADDI, one SLLI,
+  one JAL).  §8 PROVES this for the SLLI row `sdLdSlliX1ProgramRow`: ten slots
+  agree with the lowering of `slli x1, x1, 24` and `ind_width` does not (committed
+  `8`, lowered `0`).  For the three ADDI rows and the JAL row the same `ind_width`
+  divergence was observed by EVALUATING the extracted lowerer (`#eval`), and for
+  the two `addi rd, x0, imm` rows the `op` and `is_external_op` slots diverge as
+  well (ZisK emits `CopyB`/internal, the rows commit to `OP_ADD`/external); those
+  four rows are NOT proved here, and this file makes no Lean claim about them.
+
+  This is a property of the hand-built witness, not of the ROM emitter: those
+  rows were written to satisfy the AIR, and `ind_width` is unconstrained for
+  non-load/store ops, so the author was free to pick `8`.  Consequence: a
+  `ProgramBinding`-style premise quantified over ALL entries of `sdLdProgram` is
+  false, so that witness cannot be used to show such a premise non-vacuous —
+  only its SD and LD rows can.
 -/
 import ZiskFv.Compliance.RomRowSerialization
 import ZiskFv.Compliance.AeneasBridgeTrust.Decode.Leaves
@@ -709,5 +719,227 @@ theorem sdLdSdProgramRow_inhabited :
       | rw [if_neg hb]
       | (rw [romSignedField_eq_intCast]; decide)
       | decide
+
+/-! ## 8. The five rows of the SAME witness that are NOT inhabited
+
+The four ADDI/SLLI rows and the JAL row of `sdLdProgram` are *not* ROM images.
+This section proves it for the SLLI row, which is the cleanest case: ten of the
+eleven slots agree with the lowering of `slli x1, x1, 24`, and `ind_width` does
+not — the committed row says `8`, the lowering says `0`.
+
+Why `0`.  `ZiskInstBuilder.ind_width` has exactly two call sites in the whole
+extracted lowerer, `store_op_with_reg_offset` (`ProductionM2.lean:2675`) and
+`load_op_with_reg_offset` (`:2752`); every other arm leaves the field at the
+`ZiskInst` default, which is `0#u64` (`:2135`).  The two-call-site claim is a
+grep over `trust/aeneas/ProductionM2.lean` and is NOT proved here; what IS proved
+here is `zisk_default_ind_width` and the full SLLI arm below, which is the
+instance that matters for this witness.
+
+The ADDI rows diverge more widely still: for `addi rd, x0, imm` ZisK's
+`immediate_op_or_x0_copyb_typed` (`ProductionM2.lean:2578-2581`) emits `CopyB`
+(op 1, `Internal`, `is_external_op = false`), while `sdLdAddiX1A0ProgramRow` /
+`sdLdAddiX2ProgramRow` commit to `OP_ADD` with `is_external_op = true`.  Both
+rows are legitimate ZisK rows with the same semantics; only the second is what
+the transpiler produces.  That divergence is recorded here in prose and left
+unproved — the SLLI case already settles the question this section exists to
+answer.
+
+**Consequence.**  A `ProgramBinding`-style premise quantified over all entries of
+`sdLdProgram` is FALSE.  The SD/LD spin witness is a constraint-satisfying AIR
+witness, not a transpiled program image, so it cannot be used to demonstrate
+non-vacuity of such a premise; only its SD and LD rows can. -/
+
+/-- The `ZiskInst` default `ind_width` (`ProductionM2.lean:2135`). -/
+theorem zisk_default_ind_width :
+    (do let z ← ZiskInstBuilder.new 0#u64; ok z.i.ind_width) = ok 0#u64 := rfl
+
+/-- The `ZiskInst` `immediate_op_typed … Sll 4` builds. -/
+def sllInstAt (a aoff boff : Std.U64) (soff : Std.I64) : zisk_inst.ZiskInst where
+  paddr := a
+  store_pc := false
+  store_use_sp := false
+  store := zisk_inst.STORE_REG
+  store_offset := soff
+  set_pc := false
+  is_precompiled := false
+  ind_width := 0#u64
+  «end» := false
+  a_src := zisk_inst.SRC_REG
+  a_use_sp_imm1 := 0#u64
+  a_offset_imm0 := aoff
+  b_src := zisk_inst.SRC_IMM
+  b_use_sp_imm1 := 0#u64
+  b_offset_imm0 := boff
+  jmp_offset1 := 4#i64
+  jmp_offset2 := 4#i64
+  is_external_op := true
+  op := 33#u8
+  op_type := zisk_inst.ZiskOperationType.BinaryE
+  m32 := false
+  input_size := 0#u64
+  sorted_pc_list_index := 0#usize
+
+def sllExtractAt (a aoff boff : Std.U64) (soff : Std.I64) : ZiskInstExtract where
+  paddr := a
+  store_pc := false
+  store_use_sp := false
+  store := zisk_inst.STORE_REG
+  store_offset := soff
+  set_pc := false
+  is_precompiled := false
+  ind_width := 0#u64
+  «end» := false
+  a_src := zisk_inst.SRC_REG
+  a_use_sp_imm1 := 0#u64
+  a_offset_imm0 := aoff
+  b_src := zisk_inst.SRC_IMM
+  b_use_sp_imm1 := 0#u64
+  b_offset_imm0 := boff
+  jmp_offset1 := 4#i64
+  jmp_offset2 := 4#i64
+  is_external_op := true
+  op := 33#u8
+  op_type_id := 4#u32
+  m32 := false
+  input_size := 0#u64
+  sorted_pc_list_index := 0#usize
+
+theorem sllExtractAt_paddr (a b aoff boff : Std.U64) (soff : Std.I64) :
+    { sllExtractAt a aoff boff soff with paddr := b } = sllExtractAt b aoff boff soff := rfl
+
+/-- `slli x1, x1, 24`. -/
+def rawSlliX1X1TwentyFour : BitVec 32 := BitVec.ofNat 32 0x01809093
+
+def slliX1X1TwentyFourDecode : aeneas_extract.Rv64imDecodeExtract where
+  supported := true
+  opcode_id := 35#u32
+  format_id := 1#u32
+  funct3 := 1#u32
+  funct7 := 0#u32
+  rd := 1#u32
+  rs1 := 1#u32
+  rs2 := 0#u32
+  imm := 24#i32
+  pred := 0#u32
+  succ := 0#u32
+
+set_option maxHeartbeats 2000000 in
+theorem slli_lowering_ctx (a : Std.U64) :
+    riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input emptyCtx
+        { rom_address := a, rd := 1#u32, rs1 := 1#u32, rs2 := 0#u32, imm := 24#i32 }
+        riscv2zisk_single_row.Rv64imSingleRowOpcode.Slli false
+      = ok { emptyCtx with
+              extract_inst := some { i := sllInstAt a 1#u64 24#u64 1#i64 } } := by
+  simp only [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input,
+    riscv2zisk_context.Riscv2ZiskContext.immediate_op_typed,
+    ZiskInstBuilder.new_for_rv64im_lowering, ZiskInstBuilder.new,
+    ZiskInstBuilder.Insts.CoreDefaultDefault.default,
+    zisk_inst.ZiskInst.Insts.CoreDefaultDefault.default,
+    ZiskInstBuilder.src_b_imm,
+    ZiskInstBuilder.op_zisk, ZiskInstBuilder.set_runtime_op_fields,
+    ZiskInstBuilder.j, ZiskInstBuilder.build,
+    riscv2zisk_context.Riscv2ZiskContext.insert_inst,
+    src_a_reg_in_main _ (UScalar.cast UScalarTy.U64 (1#u32))
+      (by decide) (by decide) (by decide),
+    store_reg_in_main _ (UScalar.hcast IScalarTy.I64 (1#u32))
+      (by decide) (by decide) (by decide),
+    lift, Bind.bind, bind_ok]
+  rfl
+
+set_option maxHeartbeats 2000000 in
+theorem slliX1X1TwentyFour_unfold :
+    aeneas_extract.extract_transpile_rv64im_raw (toU32 rawSlliX1X1TwentyFour)
+      = (do
+      let ctx ←
+        riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input emptyCtx
+          { rom_address := 0#u64, rd := 1#u32, rs1 := 1#u32, rs2 := 0#u32, imm := 24#i32 }
+          riscv2zisk_single_row.Rv64imSingleRowOpcode.Slli false
+      let zib ← core.option.Option.unwrap ctx.extract_inst
+      let row ← aeneas_extract.ZiskInstExtract.from_inst zib.i
+      ok { accepted := true, decode := slliX1X1TwentyFourDecode, row := row }) := by
+  with_unfolding_all rfl
+
+set_option maxHeartbeats 2000000 in
+theorem slliX1X1TwentyFour_transpile :
+    aeneas_extract.extract_transpile_rv64im_raw (toU32 rawSlliX1X1TwentyFour)
+      = ok { accepted := true, decode := slliX1X1TwentyFourDecode,
+             row := sllExtractAt 0#u64 1#u64 24#u64 1#i64 } := by
+  rw [slliX1X1TwentyFour_unfold, slli_lowering_ctx 0#u64]
+  rfl
+
+theorem romMessageOfRawAt_slliX1X1TwentyFour (addr : Std.U64) :
+    romMessageOfRawAt addr rawSlliX1X1TwentyFour
+      = ok (romRowOf (sllExtractAt addr 1#u64 24#u64 1#i64)) := by
+  simp only [romMessageOfRawAt, slliX1X1TwentyFour_transpile, sllExtractAt_paddr,
+    Bind.bind, bind_ok]
+
+set_option maxHeartbeats 2000000 in
+/-- **Ten of the eleven slots of the committed SLLI row are the lowering's.**
+    Stated slot by slot so the single disagreement is unmistakable and so a
+    future change that breaks one of the agreeing slots fails here. -/
+theorem slli_row_agrees_except_ind_width :
+    (romRowOf (sllExtractAt 4#u64 1#u64 24#u64 1#i64)).line
+        = ZiskFv.Compliance.SdLdSpinWitness.sdLdSlliX1ProgramRow.line
+    ∧ (romRowOf (sllExtractAt 4#u64 1#u64 24#u64 1#i64)).a_offset_imm0
+        = ZiskFv.Compliance.SdLdSpinWitness.sdLdSlliX1ProgramRow.a_offset_imm0
+    ∧ (romRowOf (sllExtractAt 4#u64 1#u64 24#u64 1#i64)).a_imm1
+        = ZiskFv.Compliance.SdLdSpinWitness.sdLdSlliX1ProgramRow.a_imm1
+    ∧ (romRowOf (sllExtractAt 4#u64 1#u64 24#u64 1#i64)).b_offset_imm0
+        = ZiskFv.Compliance.SdLdSpinWitness.sdLdSlliX1ProgramRow.b_offset_imm0
+    ∧ (romRowOf (sllExtractAt 4#u64 1#u64 24#u64 1#i64)).b_imm1
+        = ZiskFv.Compliance.SdLdSpinWitness.sdLdSlliX1ProgramRow.b_imm1
+    ∧ (romRowOf (sllExtractAt 4#u64 1#u64 24#u64 1#i64)).op
+        = ZiskFv.Compliance.SdLdSpinWitness.sdLdSlliX1ProgramRow.op
+    ∧ (romRowOf (sllExtractAt 4#u64 1#u64 24#u64 1#i64)).store_offset
+        = ZiskFv.Compliance.SdLdSpinWitness.sdLdSlliX1ProgramRow.store_offset
+    ∧ (romRowOf (sllExtractAt 4#u64 1#u64 24#u64 1#i64)).jmp_offset1
+        = ZiskFv.Compliance.SdLdSpinWitness.sdLdSlliX1ProgramRow.jmp_offset1
+    ∧ (romRowOf (sllExtractAt 4#u64 1#u64 24#u64 1#i64)).jmp_offset2
+        = ZiskFv.Compliance.SdLdSpinWitness.sdLdSlliX1ProgramRow.jmp_offset2
+    ∧ (romRowOf (sllExtractAt 4#u64 1#u64 24#u64 1#i64)).flags
+        = ZiskFv.Compliance.SdLdSpinWitness.sdLdSlliX1ProgramRow.flags := by
+  have ha : ¬ ((sllExtractAt 4#u64 1#u64 24#u64 1#i64).a_src = zisk_inst.SRC_IMM) := by
+    simp only [sllExtractAt, zisk_inst.SRC_REG, zisk_inst.SRC_IMM]; decide
+  have hb : (sllExtractAt 4#u64 1#u64 24#u64 1#i64).b_src = zisk_inst.SRC_IMM := rfl
+  have hbits : romFlagBitsOf (sllExtractAt 4#u64 1#u64 24#u64 1#i64)
+      = ZiskFv.Compliance.SdLdSpinWitness.addiX1Bits := by
+    simp only [romFlagBitsOf, sllExtractAt, ZiskFv.Compliance.SdLdSpinWitness.addiX1Bits,
+      zisk_inst.SRC_REG, zisk_inst.SRC_IMM, zisk_inst.SRC_MEM, zisk_inst.SRC_IND,
+      zisk_inst.STORE_REG, zisk_inst.STORE_MEM, zisk_inst.STORE_IND]
+    rfl
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
+    simp only [romRowOf, ZiskFv.Compliance.SdLdSpinWitness.sdLdSlliX1ProgramRow] <;>
+    first
+      | rw [romFlagsNat_cast_eq_packFlags, hbits]
+      | rw [if_neg ha]
+      | (rw [if_pos hb]; decide)
+      | (rw [romSignedField_eq_intCast]; decide)
+      | decide
+
+/-- **…and the eleventh slot disagrees.**  The committed row carries
+    `ind_width = 8`; the lowering of `slli x1, x1, 24` carries `0`. -/
+theorem slli_row_ind_width_disagrees :
+    (romRowOf (sllExtractAt 4#u64 1#u64 24#u64 1#i64)).ind_width
+      ≠ ZiskFv.Compliance.SdLdSpinWitness.sdLdSlliX1ProgramRow.ind_width := by
+  simp only [romRowOf, sllExtractAt, ZiskFv.Compliance.SdLdSpinWitness.sdLdSlliX1ProgramRow]
+  decide
+
+/-- **The committed SLLI row is NOT the ROM image of the word it claims to
+    execute, at any ROM address.**  Together with §5-§7 this is the honest state
+    of the SD/LD spin witness: its load and store rows are transpiler output, its
+    ALU rows are not. -/
+theorem sdLdSlliX1ProgramRow_not_inhabited_by_its_word (addr : Std.U64) :
+    romMessageOfRawAt addr rawSlliX1X1TwentyFour
+      ≠ ok ZiskFv.Compliance.SdLdSpinWitness.sdLdSlliX1ProgramRow := by
+  rw [romMessageOfRawAt_slliX1X1TwentyFour]
+  intro h
+  have h' : romRowOf (sllExtractAt addr 1#u64 24#u64 1#i64)
+      = ZiskFv.Compliance.SdLdSpinWitness.sdLdSlliX1ProgramRow := by
+    injection h
+  have : (romRowOf (sllExtractAt addr 1#u64 24#u64 1#i64)).ind_width
+      = ZiskFv.Compliance.SdLdSpinWitness.sdLdSlliX1ProgramRow.ind_width := by rw [h']
+  simp only [romRowOf, sllExtractAt,
+    ZiskFv.Compliance.SdLdSpinWitness.sdLdSlliX1ProgramRow] at this
+  exact absurd this (by decide)
 
 end ZiskFv.Compliance.RomRowInhabitation

--- a/ZiskFv/Compliance/RomRowSerialization.lean
+++ b/ZiskFv/Compliance/RomRowSerialization.lean
@@ -1,0 +1,596 @@
+/-
+ZiskFv/Compliance/RomRowSerialization.lean  (eth-act/zisk-fv#61, Phase-0 step S2)
+
+Line-by-line transcription of ZisK's ROM-row emitter,
+`zisk/state-machines/rom/src/rom.rs:204-260` (`RomSM::compute_trace_rom`), together
+with its `zisk/core/src/zisk_inst.rs:289-308` (`ZiskInst::get_flags`) flag packing.
+
+WHY THIS FILE EXISTS.  An accepted ZisK trace commits to a *lowered* eleven-slot
+`ZiskRomMessage` per instruction, never to a 32-bit RISC-V word.  Any future
+raw-word binding (`trace.program k = <serialization of the lowering of word k>`)
+is only as strong as the serialization it names, and a plausible-looking but
+wrong serialization yields green theorems over a false premise.  So the
+serialization is written TWICE, independently, and the two forms are proven
+equal:
+
+  * `romFlagsNat` / `romRowOf` — the *Rust-shaped* transcription: the `|`/`<<`
+    flag chain of `zisk_inst.rs:290-305`, the `if v >= 0 … else F::neg …`
+    branches of `rom.rs:211-235`, the `SRC_IMM` gates of `rom.rs:240-244`, and
+    the Fcall→CopyB opcode remap of `rom.rs:248-255`.  Every field carries its
+    `rom.rs` line.
+  * `romRowSpec` — the *field-shaped* form: signed slots as the ring image of
+    `BitVec.toInt`, and flags as `packFlags`, the PIL-mirroring packing that
+    already exists in `ZiskFv/AirsClean/Main/Circuit.lean` and that every
+    committed witness row in the tree is written against.  `packFlags` was NOT
+    written for this proof; the agreement theorem therefore checks the Rust
+    emitter against an independently maintained in-tree definition.
+
+`romRowOf_eq_romRowSpec` is the agreement theorem.  A slipped bit position, a
+dropped `SRC_IMM` gate, or a sign error fails that proof instead of passing
+silently.
+
+The strength of that claim depends entirely on the two forms being *different
+expressions*, so this is stated precisely rather than assumed.  An earlier draft
+wrote five slots (`line`, `a_imm1`, `b_imm1`, `ind_width`, `op`) identically in
+both, or via a shared helper; on those the equality was `rfl` and the
+cross-check had NO power — a misreading of `rom.rs` transcribed into both forms
+would have proved anyway.  Adversarial review caught it: dropping the Fcall
+remap from the shared `romOpField` left the agreement theorem still provable.
+`romRowSpec` now spells the `SRC_IMM` gate multiplicatively and the Fcall remap
+inline, so those slots are genuinely cross-checked; the mutation that previously
+survived is now rejected by this theorem.  `line` and `ind_width` remain
+identical plain casts with no branch structure to disagree about, so nothing is
+claimed for them.
+
+WHAT THE AGREEMENT THEOREM DOES *NOT* SAY.  It is a statement about
+serialization only.  It does not say that any committed `trace.program` is the
+image of a raw program, it does not run the Aeneas-extracted lowerer, and it
+does not fix the ROM layout (`rom.rs:205` sorts by `paddr`; `line` here is
+`e.paddr`, and whether `e.paddr` is the address the binary places the word at is
+not addressed by anything in this file).  Those are Phase-0 step S3 and issue #61's
+`ProgramBinding`.
+
+Kernel-sound: no `axiom` / `sorry` / `native_decide` / `bv_decide`.
+-/
+import ProductionM2
+import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.Helpers
+import ZiskFv.Compliance.SdLdSpinWitness
+
+open Aeneas Aeneas.Std Result zisk_core
+open Goldilocks
+
+namespace ZiskFv.Compliance.RomRowSerialization
+
+open ZiskFv.Channels.ZiskRomBus (ZiskRomMessage)
+open ZiskFv.AirsClean.Main (RomFlagBits packFlags)
+open ZiskFv.AirsClean (boolF)
+open zisk_core.aeneas_extract (ZiskInstExtract)
+
+/-! ## 1. Opcode codes used by the `rom.rs:248-255` Fcall→CopyB remap
+
+`rom.rs` compares `inst.op` against `ZiskOp::{Fcall, FcallGet, FcallParam}.code()`
+and rewrites those three to `ZiskOp::CopyB.code()`.  The literals below are tied
+back to the extracted `ZiskOp::code` so a stale constant fails a proof. -/
+
+/-- `ZiskOp::CopyB.code()` (`ProductionM2.lean:1594`). -/
+def CODE_COPYB : Std.U8 := 1#u8
+/-- `ZiskOp::FcallParam.code()` (`ProductionM2.lean:1667`). -/
+def CODE_FCALL_PARAM : Std.U8 := 246#u8
+/-- `ZiskOp::Fcall.code()` (`ProductionM2.lean:1668`). -/
+def CODE_FCALL : Std.U8 := 247#u8
+/-- `ZiskOp::FcallGet.code()` (`ProductionM2.lean:1669`). -/
+def CODE_FCALL_GET : Std.U8 := 248#u8
+
+theorem code_copyb : zisk_ops.ZiskOp.code .CopyB = ok CODE_COPYB := rfl
+theorem code_fcall_param : zisk_ops.ZiskOp.code .FcallParam = ok CODE_FCALL_PARAM := rfl
+theorem code_fcall : zisk_ops.ZiskOp.code .Fcall = ok CODE_FCALL := rfl
+theorem code_fcall_get : zisk_ops.ZiskOp.code .FcallGet = ok CODE_FCALL_GET := rfl
+
+/-! ## 2. The signed field conversion of `rom.rs:211-235`
+
+Five ROM slots (`jmp_offset1`, `jmp_offset2`, `store_offset`, `a_offset_imm0`,
+`b_offset_imm0`) go through the same shape:
+
+```rust
+let f = if v >= 0 { F::from_u64(v as u64) } else { F::neg(F::from_u64((-v) as u64)) };
+```
+
+For the three `i64` fields `v` is the field itself; for the two `u64` fields
+(`a_offset_imm0`, `b_offset_imm0`) `rom.rs:226`/`:231` first *reinterpret* the
+bits as `i64` (`inst.a_offset_imm0 as i64 >= 0`).  Both cases are the same
+function of the 64 underlying bits, which is why it is written once here. -/
+
+/-- Transcription of `rom.rs:211-235`.  `w` is the raw 64-bit machine word of the
+    slot; `w.toInt` is Rust's `as i64` reinterpretation and `-w` is Rust's
+    wrapping `i64` negation, so this is literal down to the `i64::MIN` edge. -/
+def romSignedField (w : BitVec 64) : FGL :=
+  if 0 ≤ w.toInt then          -- rom.rs:211 / :216 / :221 / :226 / :231  `v >= 0`
+    ((w.toNat : ℕ) : FGL)      -- rom.rs:212 / :217 / :222 / :227 / :232  `F::from_u64(v as u64)`
+  else
+    -(((-w).toNat : ℕ) : FGL)  -- rom.rs:214 / :219 / :224 / :229 / :234  `F::neg(F::from_u64((-v) as u64))`
+
+/-- The independently written form: `romSignedField` is the ring image of the
+    *signed* value of the slot.  This is the identity June's `serializeExtract`
+    got wrong for `a/b_offset_imm0` (it used `UScalar.val : ℕ`, the unsigned
+    value). -/
+theorem romSignedField_eq_intCast (w : BitVec 64) :
+    romSignedField w = ((w.toInt : ℤ) : FGL) := by
+  have hb : w.toNat < 2 ^ 64 := w.isLt
+  have hle : w.toNat ≤ 2 ^ 64 := le_of_lt hb
+  have hdef : w.toInt =
+      if 2 * w.toNat < 2 ^ 64 then (w.toNat : ℤ) else (w.toNat : ℤ) - 2 ^ 64 := rfl
+  unfold romSignedField
+  by_cases hc : 2 * w.toNat < 2 ^ 64
+  · have hInt : w.toInt = (w.toNat : ℤ) := by rw [hdef, if_pos hc]
+    rw [if_pos (by rw [hInt]; positivity), hInt]
+    push_cast
+    ring
+  · have hInt : w.toInt = (w.toNat : ℤ) - 2 ^ 64 := by rw [hdef, if_neg hc]
+    have hpos : 0 < w.toNat := by omega
+    have hnn : ¬ (0 ≤ w.toInt) := by rw [hInt]; push_cast; omega
+    have hneg : (-w).toNat = 2 ^ 64 - w.toNat := by
+      rw [BitVec.toNat_neg]; omega
+    rw [if_neg hnn, hneg, Nat.cast_sub hle, hInt]
+    push_cast
+    ring
+
+/-! ## 3. The flag word of `zisk_inst.rs:289-308`
+
+`get_flags` builds a `u64` by OR-ing sixteen shifted single bits.  Every operand
+is `(bool as u64) << k` with `k ≤ 15`, so the value is `< 2^16` and the `u64`
+arithmetic is exact; the transcription is therefore written over `ℕ`, where
+`|||` and `<<<` agree with Rust's `|` and `<<`.  `romFlagsNat_lt` proves the
+`< 2^16` bound rather than assuming it. -/
+
+/-- Rust's `bool as u64`. -/
+@[reducible] def natOfBool (b : Bool) : ℕ := if b then 1 else 0
+
+/-- Transcription of `ZiskInst::get_flags` (`zisk_inst.rs:289-308`).  Bit
+    positions and predicates are copied line by line; the source constants are
+    the *extracted* `zisk_inst.SRC_*` / `zisk_inst.STORE_*` — `SRC_IMM`
+    (`ProductionM2.lean:2081`), `SRC_MEM` (`:2264`), `SRC_IND` (`:2704`),
+    `SRC_REG` (`:2259`), `STORE_MEM` (`:2004`), `STORE_IND` (`:2636`),
+    `STORE_REG` (`:1999`) — never numeric literals. -/
+def romFlagsNat (e : ZiskInstExtract) : ℕ :=
+  1                                                                          -- zisk_inst.rs:290
+  ||| (natOfBool (decide (e.a_src = zisk_inst.SRC_IMM)) <<< 1)               -- zisk_inst.rs:291
+  ||| (natOfBool (decide (e.a_src = zisk_inst.SRC_MEM)) <<< 2)               -- zisk_inst.rs:292
+  ||| (natOfBool e.is_precompiled <<< 3)                                     -- zisk_inst.rs:293
+  ||| (natOfBool (decide (e.b_src = zisk_inst.SRC_IMM)) <<< 4)               -- zisk_inst.rs:294
+  ||| (natOfBool (decide (e.b_src = zisk_inst.SRC_MEM)) <<< 5)               -- zisk_inst.rs:295
+  ||| (natOfBool e.is_external_op <<< 6)                                     -- zisk_inst.rs:296
+  ||| (natOfBool e.store_pc <<< 7)                                           -- zisk_inst.rs:297
+  ||| (natOfBool (decide (e.store = zisk_inst.STORE_MEM)) <<< 8)             -- zisk_inst.rs:298
+  ||| (natOfBool (decide (e.store = zisk_inst.STORE_IND)) <<< 9)             -- zisk_inst.rs:299
+  ||| (natOfBool e.set_pc <<< 10)                                            -- zisk_inst.rs:300
+  ||| (natOfBool e.m32 <<< 11)                                               -- zisk_inst.rs:301
+  ||| (natOfBool (decide (e.b_src = zisk_inst.SRC_IND)) <<< 12)              -- zisk_inst.rs:302
+  ||| (natOfBool (decide (e.a_src = zisk_inst.SRC_REG)) <<< 13)              -- zisk_inst.rs:303
+  ||| (natOfBool (decide (e.b_src = zisk_inst.SRC_REG)) <<< 14)              -- zisk_inst.rs:304
+  ||| (natOfBool (decide (e.store = zisk_inst.STORE_REG)) <<< 15)            -- zisk_inst.rs:305
+
+/-- The `RomFlagBits` record the in-tree PIL-mirroring `packFlags` consumes.
+    Same predicates, no bit positions: `packFlags` supplies those. -/
+def romFlagBitsOf (e : ZiskInstExtract) : RomFlagBits where
+  a_src_imm := decide (e.a_src = zisk_inst.SRC_IMM)
+  a_src_mem := decide (e.a_src = zisk_inst.SRC_MEM)
+  is_precompiled := e.is_precompiled
+  b_src_imm := decide (e.b_src = zisk_inst.SRC_IMM)
+  b_src_mem := decide (e.b_src = zisk_inst.SRC_MEM)
+  is_external_op := e.is_external_op
+  store_pc := e.store_pc
+  store_mem := decide (e.store = zisk_inst.STORE_MEM)
+  store_ind := decide (e.store = zisk_inst.STORE_IND)
+  set_pc := e.set_pc
+  m32 := e.m32
+  b_src_ind := decide (e.b_src = zisk_inst.SRC_IND)
+  a_src_reg := decide (e.a_src = zisk_inst.SRC_REG)
+  b_src_reg := decide (e.b_src = zisk_inst.SRC_REG)
+  store_reg := decide (e.store = zisk_inst.STORE_REG)
+
+/-- One link of the OR chain: OR-ing an accumulator that fits strictly below
+    `2 ^ i` with a single bit shifted to position `i` is addition. -/
+private theorem or_bit_step {acc i : ℕ} (h : acc < 2 ^ i) (b : Bool) :
+    acc ||| (natOfBool b <<< i) = acc + (if b then 2 ^ i else 0) := by
+  cases b
+  · simp [natOfBool]
+  · simp only [natOfBool, if_pos]
+    rw [Nat.shiftLeft_eq, one_mul, Nat.or_comm]
+    have := Nat.two_pow_add_eq_or_of_lt h 1
+    simp only [mul_one] at this
+    omega
+
+private theorem or_bit_bound {acc i : ℕ} (h : acc < 2 ^ i) (b : Bool) :
+    acc + (if b then 2 ^ i else 0) < 2 ^ (i + 1) := by
+  have : (2:ℕ) ^ (i + 1) = 2 ^ i + 2 ^ i := by ring
+  cases b <;> simp <;> omega
+
+/-- The `< 2^16` bound the `ℕ`-typed transcription relies on: the Rust `u64`
+    arithmetic in `get_flags` never wraps. -/
+theorem romFlagsNat_lt (e : ZiskInstExtract) : romFlagsNat e < 2 ^ 16 := by
+  have h0 : (1 : ℕ) < 2 ^ 1 := by norm_num
+  unfold romFlagsNat
+  rw [or_bit_step h0]
+  have h1 := or_bit_bound h0 (decide (e.a_src = zisk_inst.SRC_IMM))
+  rw [or_bit_step h1]
+  have h2 := or_bit_bound h1 (decide (e.a_src = zisk_inst.SRC_MEM))
+  rw [or_bit_step h2]
+  have h3 := or_bit_bound h2 e.is_precompiled
+  rw [or_bit_step h3]
+  have h4 := or_bit_bound h3 (decide (e.b_src = zisk_inst.SRC_IMM))
+  rw [or_bit_step h4]
+  have h5 := or_bit_bound h4 (decide (e.b_src = zisk_inst.SRC_MEM))
+  rw [or_bit_step h5]
+  have h6 := or_bit_bound h5 e.is_external_op
+  rw [or_bit_step h6]
+  have h7 := or_bit_bound h6 e.store_pc
+  rw [or_bit_step h7]
+  have h8 := or_bit_bound h7 (decide (e.store = zisk_inst.STORE_MEM))
+  rw [or_bit_step h8]
+  have h9 := or_bit_bound h8 (decide (e.store = zisk_inst.STORE_IND))
+  rw [or_bit_step h9]
+  have h10 := or_bit_bound h9 e.set_pc
+  rw [or_bit_step h10]
+  have h11 := or_bit_bound h10 e.m32
+  rw [or_bit_step h11]
+  have h12 := or_bit_bound h11 (decide (e.b_src = zisk_inst.SRC_IND))
+  rw [or_bit_step h12]
+  have h13 := or_bit_bound h12 (decide (e.a_src = zisk_inst.SRC_REG))
+  rw [or_bit_step h13]
+  have h14 := or_bit_bound h13 (decide (e.b_src = zisk_inst.SRC_REG))
+  rw [or_bit_step h14]
+  exact or_bit_bound h14 (decide (e.store = zisk_inst.STORE_REG))
+
+/-- The additive normal form of the OR chain. -/
+theorem romFlagsNat_eq_sum (e : ZiskInstExtract) :
+    romFlagsNat e =
+      1
+      + (if decide (e.a_src = zisk_inst.SRC_IMM) then 2 ^ 1 else 0)
+      + (if decide (e.a_src = zisk_inst.SRC_MEM) then 2 ^ 2 else 0)
+      + (if e.is_precompiled then 2 ^ 3 else 0)
+      + (if decide (e.b_src = zisk_inst.SRC_IMM) then 2 ^ 4 else 0)
+      + (if decide (e.b_src = zisk_inst.SRC_MEM) then 2 ^ 5 else 0)
+      + (if e.is_external_op then 2 ^ 6 else 0)
+      + (if e.store_pc then 2 ^ 7 else 0)
+      + (if decide (e.store = zisk_inst.STORE_MEM) then 2 ^ 8 else 0)
+      + (if decide (e.store = zisk_inst.STORE_IND) then 2 ^ 9 else 0)
+      + (if e.set_pc then 2 ^ 10 else 0)
+      + (if e.m32 then 2 ^ 11 else 0)
+      + (if decide (e.b_src = zisk_inst.SRC_IND) then 2 ^ 12 else 0)
+      + (if decide (e.a_src = zisk_inst.SRC_REG) then 2 ^ 13 else 0)
+      + (if decide (e.b_src = zisk_inst.SRC_REG) then 2 ^ 14 else 0)
+      + (if decide (e.store = zisk_inst.STORE_REG) then 2 ^ 15 else 0) := by
+  have h0 : (1 : ℕ) < 2 ^ 1 := by norm_num
+  unfold romFlagsNat
+  rw [or_bit_step h0]
+  have h1 := or_bit_bound h0 (decide (e.a_src = zisk_inst.SRC_IMM))
+  rw [or_bit_step h1]
+  have h2 := or_bit_bound h1 (decide (e.a_src = zisk_inst.SRC_MEM))
+  rw [or_bit_step h2]
+  have h3 := or_bit_bound h2 e.is_precompiled
+  rw [or_bit_step h3]
+  have h4 := or_bit_bound h3 (decide (e.b_src = zisk_inst.SRC_IMM))
+  rw [or_bit_step h4]
+  have h5 := or_bit_bound h4 (decide (e.b_src = zisk_inst.SRC_MEM))
+  rw [or_bit_step h5]
+  have h6 := or_bit_bound h5 e.is_external_op
+  rw [or_bit_step h6]
+  have h7 := or_bit_bound h6 e.store_pc
+  rw [or_bit_step h7]
+  have h8 := or_bit_bound h7 (decide (e.store = zisk_inst.STORE_MEM))
+  rw [or_bit_step h8]
+  have h9 := or_bit_bound h8 (decide (e.store = zisk_inst.STORE_IND))
+  rw [or_bit_step h9]
+  have h10 := or_bit_bound h9 e.set_pc
+  rw [or_bit_step h10]
+  have h11 := or_bit_bound h10 e.m32
+  rw [or_bit_step h11]
+  have h12 := or_bit_bound h11 (decide (e.b_src = zisk_inst.SRC_IND))
+  rw [or_bit_step h12]
+  have h13 := or_bit_bound h12 (decide (e.a_src = zisk_inst.SRC_REG))
+  rw [or_bit_step h13]
+  have h14 := or_bit_bound h13 (decide (e.b_src = zisk_inst.SRC_REG))
+  rw [or_bit_step h14]
+
+/-- **Rust emitter vs. PIL packing.**  The `|`/`<<` chain of
+    `zisk_inst.rs:290-305` and the additive `packFlags` of
+    `ZiskFv/AirsClean/Main/Circuit.lean` — an independently maintained in-tree
+    definition mirroring the PIL `romFlagsExpr` — denote the same field element.
+    A slipped bit position in either one breaks this. -/
+theorem romFlagsNat_cast_eq_packFlags (e : ZiskInstExtract) :
+    ((romFlagsNat e : ℕ) : FGL) = packFlags (romFlagBitsOf e) := by
+  have hc : ∀ (b : Bool) (c : ℕ),
+      (((if b then c else 0 : ℕ)) : FGL) = (c : FGL) * ZiskFv.AirsClean.boolF b := by
+    intro b c; cases b <;> simp [ZiskFv.AirsClean.boolF]
+  rw [romFlagsNat_eq_sum]
+  simp only [packFlags, romFlagBitsOf, Nat.cast_add, hc]
+  push_cast
+  ring
+
+/-! ## 4. The ROM row: `rom.rs:238-259`
+
+`rom.rs` reads a `zisk_inst::ZiskInst`; the transcription below is written over
+the extraction's `ZiskInstExtract`, because that is what
+`extract_transpile_rv64im_raw` returns.  That substitution is only legitimate if
+`ZiskInstExtract.from_inst` copies every field `rom.rs:211-259` touches
+unchanged, so it is proven rather than assumed. -/
+
+/-- `ZiskInstExtract.from_inst` (`ProductionM2.lean:1333`) preserves all eighteen
+    `ZiskInst` fields the ROM emitter reads.  (It differs from `ZiskInst` only in
+    replacing `op_type` by its discriminant `op_type_id`, which `rom.rs` never
+    reads.)  So `romRowOf` over the extract record is the same function of the
+    lowered instruction as `compute_trace_rom` is over `ZiskInst`. -/
+theorem from_inst_preserves_rom_fields {i : zisk_inst.ZiskInst} {e : ZiskInstExtract}
+    (h : zisk_core.aeneas_extract.ZiskInstExtract.from_inst i = ok e) :
+    e.paddr = i.paddr ∧ e.jmp_offset1 = i.jmp_offset1 ∧ e.jmp_offset2 = i.jmp_offset2
+      ∧ e.store_offset = i.store_offset ∧ e.a_offset_imm0 = i.a_offset_imm0
+      ∧ e.b_offset_imm0 = i.b_offset_imm0 ∧ e.a_src = i.a_src
+      ∧ e.a_use_sp_imm1 = i.a_use_sp_imm1 ∧ e.b_src = i.b_src
+      ∧ e.b_use_sp_imm1 = i.b_use_sp_imm1 ∧ e.ind_width = i.ind_width
+      ∧ e.op = i.op ∧ e.store = i.store ∧ e.store_pc = i.store_pc
+      ∧ e.set_pc = i.set_pc ∧ e.is_precompiled = i.is_precompiled
+      ∧ e.is_external_op = i.is_external_op ∧ e.m32 = i.m32 := by
+  simp only [zisk_core.aeneas_extract.ZiskInstExtract.from_inst] at h
+  obtain ⟨u, hu, hok⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  simp only [Result.ok.injEq] at hok
+  subst hok
+  refine ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl,
+    rfl, rfl, rfl⟩
+
+/-- Transcription of the opcode remap at `rom.rs:246-255`.  The three `Fcall`
+    variants are out of RV64IM scope, but the branch is transcribed rather than
+    dropped so that the claim "RV64IM never reaches it" stays a provable side
+    fact instead of a silent assumption. -/
+def romOpField (op : Std.U8) : FGL :=
+  if op = CODE_FCALL ∨ op = CODE_FCALL_GET ∨ op = CODE_FCALL_PARAM then
+    ((CODE_COPYB.val : ℕ) : FGL)   -- rom.rs:252  `F::from_u8(ZiskOp::CopyB.code())`
+  else
+    ((op.val : ℕ) : FGL)           -- rom.rs:254  `F::from_u8(inst.op)`
+
+/-- **The transcription.**  `rom.rs:238-259`, field by field.
+
+    `line` is `F::from_u64(inst.paddr)` (`rom.rs:238`), NOT a caller-supplied
+    parameter: June's `serializeExtract` threaded `line` in from outside, which
+    left the eleventh slot unconstrained by the binding.  A caller that wants a
+    different address must justify the `paddr` it feeds in. -/
+def romRowOf (e : ZiskInstExtract) : ZiskRomMessage FGL where
+  line := ((e.paddr.val : ℕ) : FGL)                                -- rom.rs:238
+  a_offset_imm0 := romSignedField e.a_offset_imm0.bv               -- rom.rs:226-230, :239
+  a_imm1 :=                                                        -- rom.rs:240-241
+    if e.a_src = zisk_inst.SRC_IMM then ((e.a_use_sp_imm1.val : ℕ) : FGL) else 0
+  b_offset_imm0 := romSignedField e.b_offset_imm0.bv               -- rom.rs:231-235, :242
+  b_imm1 :=                                                        -- rom.rs:243-244
+    if e.b_src = zisk_inst.SRC_IMM then ((e.b_use_sp_imm1.val : ℕ) : FGL) else 0
+  ind_width := ((e.ind_width.val : ℕ) : FGL)                       -- rom.rs:245
+  op := romOpField e.op                                            -- rom.rs:246-255
+  store_offset := romSignedField e.store_offset.bv                 -- rom.rs:221-225, :256
+  jmp_offset1 := romSignedField e.jmp_offset1.bv                   -- rom.rs:211-215, :257
+  jmp_offset2 := romSignedField e.jmp_offset2.bv                   -- rom.rs:216-220, :258
+  flags := ((romFlagsNat e : ℕ) : FGL)                             -- rom.rs:259
+
+/-- The field-shaped form of the same row.  Signed slots are the ring image of
+    the slot's signed value; `flags` is the in-tree `packFlags`.
+
+    Every slot with branch structure is written in a DIFFERENT shape from
+    `romRowOf` — signed slots via `BitVec.toInt` rather than the `if v >= 0`
+    split, the `SRC_IMM` gates multiplicatively rather than as an `if`, and the
+    Fcall remap inline rather than through the shared `romOpField`.  That is
+    load-bearing, not stylistic: a slot written identically in both forms makes
+    its half of `romRowOf_eq_romRowSpec` hold by `rfl`, which cross-checks
+    nothing.  `line` and `ind_width` are plain casts with no branch structure,
+    so they are identical and nothing is claimed for them. -/
+def romRowSpec (e : ZiskInstExtract) : ZiskRomMessage FGL where
+  line := ((e.paddr.val : ℕ) : FGL)
+  a_offset_imm0 := ((e.a_offset_imm0.bv.toInt : ℤ) : FGL)
+  -- Gate written multiplicatively, NOT as `romRowOf`'s `if`: the two forms must
+  -- be different expressions or this slot of the agreement is `rfl` and the
+  -- cross-check has no power over a dropped gate.
+  a_imm1 := (if e.a_src = zisk_inst.SRC_IMM then 1 else 0) * ((e.a_use_sp_imm1.val : ℕ) : FGL)
+  b_offset_imm0 := ((e.b_offset_imm0.bv.toInt : ℤ) : FGL)
+  b_imm1 := (if e.b_src = zisk_inst.SRC_IMM then 1 else 0) * ((e.b_use_sp_imm1.val : ℕ) : FGL)
+  ind_width := ((e.ind_width.val : ℕ) : FGL)
+  -- Remap spelled out here rather than sharing `romOpField`, for the same
+  -- reason: a shared helper cross-checks nothing.
+  op :=
+    if e.op = CODE_FCALL ∨ e.op = CODE_FCALL_GET ∨ e.op = CODE_FCALL_PARAM then
+      ((CODE_COPYB.val : ℕ) : FGL)
+    else
+      ((e.op.val : ℕ) : FGL)
+  store_offset := ((e.store_offset.val : ℤ) : FGL)
+  jmp_offset1 := ((e.jmp_offset1.val : ℤ) : FGL)
+  jmp_offset2 := ((e.jmp_offset2.val : ℤ) : FGL)
+  flags := packFlags (romFlagBitsOf e)
+
+/-- **Agreement.**  The Rust-shaped transcription and the field-shaped form
+    denote the same eleven-slot ROM message.
+
+    What it says: the `rom.rs` branch structure, the `zisk_inst.rs` bit chain,
+    and the in-tree `packFlags` / `BitVec.toInt` readings coincide, for every
+    lowered row.
+
+    What it does NOT say: nothing about `trace.program`, nothing about the raw
+    word, nothing about the ROM layout, and nothing about the extracted lowerer
+    (which does not appear in the statement). -/
+theorem romRowOf_eq_romRowSpec (e : ZiskInstExtract) : romRowOf e = romRowSpec e := by
+  simp only [romRowOf, romRowSpec, romOpField,
+    romSignedField_eq_intCast, romFlagsNat_cast_eq_packFlags,
+    Aeneas.Std.IScalar.val]
+  split_ifs <;> simp
+
+/-! ## 5. The three defects of the June serialization, confirmed against source
+
+`a16bd97c:ZiskFv/Compliance/TraceLevelExport/RawProgramBinding.lean` wrote this
+same serialization and got three things wrong.  Each is re-checked here against
+the Rust and the extraction, and each is shown to *bite* (to change the emitted
+field element), not merely to look different. -/
+
+/-- **Defect 1 — the `SRC_IND` literal.**  June wrote bit 12 as
+    `decide (e.b_src = 3#u64)`.  The extracted constant is `5`; `3` is
+    `SRC_STEP` (`zisk_inst.rs:49`, not reachable on the RV64IM path at all). -/
+theorem src_ind_eq_five : zisk_inst.SRC_IND = 5#u64 := by
+  unfold zisk_inst.SRC_IND; rfl
+
+theorem june_src_ind_literal_wrong : (3#u64 : Std.U64) ≠ zisk_inst.SRC_IND := by
+  rw [src_ind_eq_five]; decide
+
+/-- On every row the lowerer marks as indirect-`b` (every load and every store),
+    the corrected bit is set. -/
+theorem romFlagBitsOf_b_src_ind (e : ZiskInstExtract) (h : e.b_src = zisk_inst.SRC_IND) :
+    (romFlagBitsOf e).b_src_ind = true := by
+  simp [romFlagBitsOf, h]
+
+/-- ...and June's form clears it on exactly those rows. -/
+theorem june_b_src_ind_false (e : ZiskInstExtract) (h : e.b_src = zisk_inst.SRC_IND) :
+    decide (e.b_src = (3#u64 : Std.U64)) = false := by
+  rw [h, src_ind_eq_five]; decide
+
+/-- The bite: bit 12 is not absorbed by the packing.  Two `RomFlagBits` that
+    differ only in `b_src_ind` have different `flags` field elements, so a row
+    whose `b_src_ind` is computed wrongly can never equal the committed row. -/
+theorem packFlags_b_src_ind_sensitive (bits : RomFlagBits) :
+    packFlags { bits with b_src_ind := true } ≠ packFlags { bits with b_src_ind := false } := by
+  intro h
+  have hF : ZiskFv.AirsClean.boolF false = 0 := rfl
+  have hT : ZiskFv.AirsClean.boolF true = 1 := rfl
+  simp only [packFlags, hF, hT] at h
+  have h4096 : (4096 : FGL) = 0 := by linear_combination h
+  exact absurd h4096 (by decide)
+
+/-- **Defect 2 — the unsigned coercion.**  June serialized `a/b_offset_imm0` with
+    `UScalar.val : ℕ`; `rom.rs:226-236` reinterprets the bits as `i64` first.
+    The two differ by `2^64` in the field, which is `2^32 - 1 ≠ 0` in Goldilocks.
+    The witness is exactly the shape the extraction produces for a negative
+    load/store displacement (`IScalar.hcast` sign-extends, so `ld a0, -8(sp)`
+    yields `b_offset_imm0 = 2^64 - 8`). -/
+theorem romSignedField_ne_unsignedVal :
+    romSignedField (BitVec.ofInt 64 (-8)) ≠ (((BitVec.ofInt 64 (-8)).toNat : ℕ) : FGL) := by
+  have hInt : (BitVec.ofInt 64 (-8)).toInt = -8 := by decide
+  have hNat : (BitVec.ofInt 64 (-8)).toNat = 18446744073709551608 := by decide
+  rw [romSignedField_eq_intCast, hInt, hNat]
+  decide
+
+/-- **Defect 3 — the ungated `a_imm1` / `b_imm1`.**  `rom.rs:240-244` emits `0`
+    unless the corresponding source is `SRC_IMM`; June copied `*_use_sp_imm1`
+    unconditionally.  The transcription's gate makes the emitted value
+    independent of `*_use_sp_imm1` off the immediate path, which is why the
+    witness check below needs no hypothesis about those two fields. -/
+theorem romRowOf_a_imm1_of_not_imm (e : ZiskInstExtract) (h : e.a_src ≠ zisk_inst.SRC_IMM) :
+    (romRowOf e).a_imm1 = 0 := by
+  simp [romRowOf, h]
+
+theorem romRowOf_b_imm1_of_not_imm (e : ZiskInstExtract) (h : e.b_src ≠ zisk_inst.SRC_IMM) :
+    (romRowOf e).b_imm1 = 0 := by
+  simp [romRowOf, h]
+
+/-- Partial evidence that defect 3 is harmless *on the RV64IM path* — but not
+    free.  The load/store `b`-source setter writes `0` into `b_use_sp_imm1` when
+    `use_sp = false`, which is the only value RV64IM callers pass.
+
+    CORRECTION to the design note's setter list: `src_a_reg` / `src_b_reg`
+    (`ProductionM2.lean:2491`, `:2269`) do NOT uniformly land on
+    `SRC_REG`.  `reg = 0` delegates to `src_a_imm self 0#u64` (`:2105`, so
+    `a_src` becomes `SRC_IMM`), and a register outside
+    `[REGS_IN_MAIN_FROM, REGS_IN_MAIN_TO]`
+    lands on `SRC_MEM`.  All branches still write `0` when `use_sp = false`, but
+    the path statement ("`a_src ≠ SRC_IMM → a_use_sp_imm1 = 0` after the whole
+    lowering") therefore needs a three-way case split plus the call-ordering
+    argument, and belongs to Phase-0 step S3. -/
+theorem src_b_ind_no_sp {self out : zisk_inst_builder.ZiskInstBuilder} {offset : Std.U64}
+    (h : zisk_inst_builder.ZiskInstBuilder.src_b_ind self offset false = ok out) :
+    out.i.b_src = zisk_inst.SRC_IND ∧ out.i.b_use_sp_imm1 = 0#u64 := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.src_b_ind, if_false,
+    Bool.false_eq_true, Result.ok.injEq] at h
+  subst h
+  exact ⟨rfl, rfl⟩
+
+/-- **A fourth divergence from `rom.rs`, not listed in the design note.**  June's
+    `serializeExtract` wrote `op := (e.op.val : FGL)` with no remap;
+    `rom.rs:246-255` rewrites `Fcall` / `FcallGet` / `FcallParam` to `CopyB`.
+    The remap is not a no-op, so dropping it is a real divergence — benign only
+    if RV64IM provably never emits those three codes, which is *not* established
+    here (it is a lowering-path fact, i.e. Phase-0 step S3). -/
+theorem romOpField_remaps_fcall :
+    romOpField CODE_FCALL ≠ ((CODE_FCALL.val : ℕ) : FGL) := by
+  unfold romOpField CODE_COPYB CODE_FCALL CODE_FCALL_GET CODE_FCALL_PARAM
+  norm_num
+  decide
+
+/-! ## 6. Sanity gate against a hand-built in-tree witness row
+
+`ZiskFv/Compliance/SdLdSpinWitness.lean` builds `sdLdProgram` from hand-written
+`ZiskRomMessage` constants chosen to satisfy the ensemble constraints — not from
+any lowering.  Its LD entry sets `b_src_ind := true`, i.e. it is precisely a row
+the June serialization could not have produced from an `SRC_IND` lowering.  The
+theorem below checks the corrected transcription against that committed row.
+
+Note what is and is not established.  The hypotheses fix the *lowered* row's
+fields; they do not run `extract_transpile_rv64im_raw` on a raw LD word, so this
+is a serialization check, not an inhabitation proof.  Closing that gap — deriving
+these field values from a concrete `BitVec 32` through the extracted lowerer — is
+Phase-0 step S3. -/
+
+open ZiskFv.Compliance.SdLdSpinWitness (sdLdLdBits sdLdLdProgramRow)
+
+/-- The LD row's flag bits are exactly what the corrected predicates compute for
+    an `a`-register / `b`-indirect / register-store lowering. -/
+theorem romFlagBitsOf_eq_sdLdLdBits (e : ZiskInstExtract)
+    (h_a_src : e.a_src = zisk_inst.SRC_REG)
+    (h_b_src : e.b_src = zisk_inst.SRC_IND)
+    (h_store : e.store = zisk_inst.STORE_REG)
+    (h_prec : e.is_precompiled = false)
+    (h_ext : e.is_external_op = false)
+    (h_store_pc : e.store_pc = false)
+    (h_set_pc : e.set_pc = false)
+    (h_m32 : e.m32 = false) :
+    romFlagBitsOf e = sdLdLdBits := by
+  unfold romFlagBitsOf sdLdLdBits
+  rw [h_a_src, h_b_src, h_store, h_prec, h_ext, h_store_pc, h_set_pc, h_m32]
+  unfold zisk_inst.SRC_REG zisk_inst.SRC_IND zisk_inst.SRC_IMM zisk_inst.SRC_MEM
+    zisk_inst.STORE_REG zisk_inst.STORE_MEM zisk_inst.STORE_IND
+  rfl
+
+/-- **The gate.**  A lowered row with the LD shape serializes, under the
+    corrected transcription, to the committed `sdLdLdProgramRow` — including the
+    `b_src_ind` bit that falsifies the June form. -/
+theorem romRowOf_eq_sdLdLdProgramRow (e : ZiskInstExtract)
+    (h_paddr : e.paddr = 20#u64)
+    (h_a_src : e.a_src = zisk_inst.SRC_REG)
+    (h_a_off : e.a_offset_imm0 = 1#u64)
+    (h_b_src : e.b_src = zisk_inst.SRC_IND)
+    (h_b_off : e.b_offset_imm0 = 0#u64)
+    (h_ind : e.ind_width = 8#u64)
+    (h_op : e.op = CODE_COPYB)
+    (h_store : e.store = zisk_inst.STORE_REG)
+    (h_soff : e.store_offset = 3#i64)
+    (h_j1 : e.jmp_offset1 = 4#i64)
+    (h_j2 : e.jmp_offset2 = 4#i64)
+    (h_prec : e.is_precompiled = false)
+    (h_ext : e.is_external_op = false)
+    (h_store_pc : e.store_pc = false)
+    (h_set_pc : e.set_pc = false)
+    (h_m32 : e.m32 = false) :
+    romRowOf e = sdLdLdProgramRow := by
+  have hbits := romFlagBitsOf_eq_sdLdLdBits e h_a_src h_b_src h_store h_prec h_ext
+    h_store_pc h_set_pc h_m32
+  have ha : e.a_src ≠ zisk_inst.SRC_IMM := by
+    rw [h_a_src]; unfold zisk_inst.SRC_REG zisk_inst.SRC_IMM; decide
+  have hbb : e.b_src ≠ zisk_inst.SRC_IMM := by
+    rw [h_b_src]; unfold zisk_inst.SRC_IND zisk_inst.SRC_IMM; decide
+  have hop : romOpField e.op = ZiskFv.Trusted.OP_COPYB := by
+    rw [h_op]
+    unfold romOpField CODE_COPYB CODE_FCALL CODE_FCALL_GET CODE_FCALL_PARAM
+    norm_num [ZiskFv.Trusted.OP_COPYB]
+  simp only [romRowOf, sdLdLdProgramRow, ZiskRomMessage.mk.injEq]
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, hop, ?_, ?_, ?_, ?_⟩
+  · rw [h_paddr]; decide
+  · rw [h_a_off]; decide
+  · rw [if_neg ha]
+  · rw [h_b_off]; decide
+  · rw [if_neg hbb]
+  · rw [h_ind]; decide
+  · rw [h_soff]; decide
+  · rw [h_j1]; decide
+  · rw [h_j2]; decide
+  · rw [romFlagsNat_cast_eq_packFlags, hbits]
+
+end ZiskFv.Compliance.RomRowSerialization


### PR DESCRIPTION
Part of #61 (S9), spike **S3**: inhabitation. Carries #302's `RomRowSerialization.lean` as a cherry-pick, so it needs a rebase (not a merge) if #302 lands first.

S2 (#302) proved a serialization is faithfully transcribed. It did **not** prove that any honest committed ROM row *is* the serialization of the lowering of some raw word — without that, `ProgramBinding` could be satisfied by nothing, and the theorems above it would be green over an empty premise.

## Proved

Kernel-sound, axiom closure `{propext, Classical.choice, Quot.sound}`:

- `sdLdLdProgramRow_inhabited` — the committed LD row of `SdLdSpinWitness`, the one with `b_src_ind := true` that falsifies June's `SRC_IND = 3` bug.
- the SD row.
- a negative-offset load, exercising the sign path (`rom.rs:226-236`, `i64` reinterpretation and negation) where the second June defect lived.

**Kill criterion not hit** — no honest constraint-satisfying row was found that is provably not the lowering of any 32-bit word. Route (c) survives.

## The negative finding — needs an owner ruling

**Five of the seven rows of `sdLdProgram` are not ROM images.** The ADDI/SLLI/JAL rows are not the lowering of their natural pre-image at any ROM address.

Why this is not the declared kill criterion: what is shown is "not the lowering of *its own expected word*", not "not the lowering of *any* word". The distinction is real and was kept.

What it means: the spin witnesses are **hand-built to satisfy constraints, not transpiled from real ELF** — exactly the risk `docs/ai/research/NOTE_61_RAWWORD_JOIN_DESIGN.md` §4.1 predicted. So they cannot carry an inhabitation demonstration for all rows. Inhabitation over a whole program needs a transpiled witness.

## Honest limits

- The five-row observations were made with `#eval` (compiler, not kernel) — observations, not theorems.
- The declared spike artifact, `ProgramBinding` over all seven rows, was **not** produced. Reviewers flagged that `status: completed` undersells this.
- `ldNegEightProgramRow` is written in this file with no independent in-tree counterpart, so that witness lacks the third-party-data property the LD/SD ones have.
- "The load and store arms cover 11 ops" appears in the agent's deliverable and is false as written — it is proved for `Ld` and `Sd` only.
- `extract_transpile_rv64im_raw` hard-codes `rom_address := 0#u64`, so the extracted row's `paddr` is 0 while a committed row sits at its real address. Handled by carrying the ROM layout explicitly rather than dropping the `line` slot; what the binding then pins is stated in the module.

Gates: `lake build`, `check-all.sh` 18/18, `check-all-semantic.sh` 19/19. No new axioms/`sorry`/`native_decide`.
