### PR TITLE
#61 Phase 9.1: bind raw words to production ROM rows

### DIFF
--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -174,6 +174,12 @@ import ZiskFv.Compliance.TraceLevelExport
 import ZiskFv.Compliance.TraceLevelExport.RomDecodeBinding
 import ZiskFv.Compliance.TraceLevelExport.RomDecodeBindingOps
 import ZiskFv.Compliance.TraceLevelExport.ProgramDecode
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBinding
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingRegister
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingCopyb
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingImmediate
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingLoadStore
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingMext
 import ZiskFv.Compliance
 import ZiskFv.Compliance.EnsembleWitnessBuilder
 import ZiskFv.Compliance.RegisterMemBusBalance

--- a/ZiskFv/Compliance/AeneasBridgeTrust/Extraction.lean
+++ b/ZiskFv/Compliance/AeneasBridgeTrust/Extraction.lean
@@ -63,3 +63,4 @@ import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.LoadStore
 import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.Precompiled
 import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.Dispatch
 import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.DynamicFields
+import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.Totality

--- a/ZiskFv/Compliance/AeneasBridgeTrust/Extraction/Totality.lean
+++ b/ZiskFv/Compliance/AeneasBridgeTrust/Extraction/Totality.lean
@@ -1,0 +1,1868 @@
+/-
+ZiskFv/Compliance/AeneasBridgeTrust/Extraction/Totality.lean  (eth-act/zisk-fv#61 / #111)
+
+Symbolic-register LOWERING-TOTALITY for the REAL Aeneas-extracted ZisK lowerer
+(`trust/aeneas/ProductionM2.lean`, the `ProductionM2` lean_lib).
+
+Every theorem in `Extraction/Dispatch.lean` (#111's 63-opcode static and row-mode
+decode pins) is stated in the shape
+
+    (h : lower_rv64im_single_row_input self ri <Opcode> hni = ok ctx) → <pins>
+
+i.e. it PRESUPPOSES that the lowerer succeeded, and leaves that presupposition to
+the caller.  Nothing in the tree discharged it, so the pins were conditional on an
+unproved fact and could in principle have been vacuous.  This module removes that
+presupposition: §11 proves
+
+    ∃ ctx, lower_rv64im_single_row_input self ri <Opcode> hni = ok ctx
+
+for all 63 RV64IM opcodes, from the in-range register fields alone, and §12
+re-states each `<op>_dispatch_static_pins` with the `= ok ctx` hypothesis GONE.
+
+Kernel-sound: NO native_decide / bv_decide / ofReduceBool / trustCompiler /
+`sorry`, and no new assumption of any kind (see §12's note on what is and is not
+closed).
+
+Key facts:
+  * The decoder's register fields are 5-bit masks, hence `< 32`
+    (`decode_r_bounds`), so the lowerer's `reg * 8` overflow branches are
+    UNREACHABLE (contradictory, discharged by `scalar_tac` against the
+    numBits-split `REGS_IN_MAIN_{FROM,TO}` cast values) and every taken branch
+    returns `ok` — so `create_register_op_typed` is TOTAL with NO `≠ 0`
+    side-condition (those are dispatcher-routing conditions for ADD/OR only).
+  * `decode_extract_from_decoded` and `ZiskInstExtract.from_inst` are total
+    (every opcode/format arm returns `ok`; `from_inst` copies the row fields).
+  * `ind_width` is total exactly on the four legal access widths, and the
+    dispatcher's load/store arms pass only those (§9) — so the `hw` premise of
+    the §6 load/store lemmas is DERIVED, never assumed.
+-/
+import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.Helpers
+import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.Dispatch
+import ZiskFv.Compliance.AeneasBridgeTrust.Decode.Leaves
+
+open Aeneas Aeneas.Std Result zisk_core
+open aeneas_extract.rv64im_decode
+open ZiskFv.Compliance.Decode (toU32)
+
+namespace ZiskFv.Compliance.Extraction
+
+set_option maxHeartbeats 4000000
+set_option linter.unusedSimpArgs false
+
+/-! ## 1. Decoder register-field bounds (the 5-bit masks land `< 32`). -/
+
+/-- A masked, right-shifted 32-bit field is bounded by `mask >>> k`. -/
+theorem and_ushr_toNat_lt (x : Std.U32) (mbv : BitVec 32) (k : Nat) (bnd : Nat)
+    (h : mbv.toNat >>> k < bnd) :
+    ((x &&& ⟨mbv⟩ : Std.U32).bv.ushiftRight k).toNat < bnd := by
+  rw [show ((x &&& (⟨mbv⟩ : Std.U32)).bv.ushiftRight k) = (x.bv &&& mbv) >>> k from rfl,
+     BitVec.toNat_ushiftRight, BitVec.toNat_and]
+  have hle : (x.bv.toNat &&& mbv.toNat) ≤ mbv.toNat := Nat.and_le_right
+  rw [Nat.shiftRight_eq_div_pow] at h ⊢
+  exact lt_of_le_of_lt (Nat.div_le_div_right hle) h
+
+/-- `decode_r` is total and its `rd`/`rs1`/`rs2` fields are `< 32`. -/
+theorem decode_r_bounds (raw : Std.U32) (op : RiscvOpcode) :
+    ∃ d, decode_r raw op = ok d ∧ d.opcode = op
+      ∧ d.rd.val < 32 ∧ d.rs1.val < 32 ∧ d.rs2.val < 32 := by
+  refine ⟨_, rfl, rfl, ?_, ?_, ?_⟩ <;> simp only [UScalar.val]
+  · exact and_ushr_toNat_lt raw 3968#32 (7#i32).toNat 32 (by decide)
+  · exact and_ushr_toNat_lt raw 1015808#32 (15#i32).toNat 32 (by decide)
+  · exact and_ushr_toNat_lt raw 32505856#32 (20#i32).toNat 32 (by decide)
+
+/-! ## 2. numBits-split cast values for the register-bound comparisons. -/
+
+theorem cast_one_u64 : (UScalar.cast UScalarTy.U64 1#usize).val = 1 := by
+  simp only [Aeneas.Std.UScalar.cast]
+  rcases System.Platform.numBits_eq with h | h <;> simp_all <;> decide
+theorem cast_31_u64 : (UScalar.cast UScalarTy.U64 31#usize).val = 31 := by
+  simp only [Aeneas.Std.UScalar.cast]
+  rcases System.Platform.numBits_eq with h | h <;> simp_all <;> decide
+theorem cast_one_i64 : (UScalar.hcast IScalarTy.I64 1#usize).val = 1 := by
+  simp only [Aeneas.Std.UScalar.hcast]
+  rcases System.Platform.numBits_eq with h | h <;> simp_all <;> decide
+theorem cast_31_i64 : (UScalar.hcast IScalarTy.I64 31#usize).val = 31 := by
+  simp only [Aeneas.Std.UScalar.hcast]
+  rcases System.Platform.numBits_eq with h | h <;> simp_all <;> decide
+
+theorem cast_u32_u64_val (x : Std.U32) : (UScalar.cast UScalarTy.U64 x).val = x.val := by
+  simp only [Aeneas.Std.UScalar.cast, UScalar.val, BitVec.toNat_setWidth]
+  rw [show UScalarTy.U64.numBits = 64 from rfl,
+     Nat.mod_eq_of_lt (lt_of_lt_of_le x.bv.isLt (by norm_num))]
+
+theorem hcast_u32_i64_val (x : Std.U32) : (UScalar.hcast IScalarTy.I64 x : Std.I64).val = x.val := by
+  have hlt : x.bv.toNat < 2 ^ 64 := lt_of_lt_of_le x.bv.isLt (by norm_num)
+  simp only [Aeneas.Std.UScalar.hcast, IScalar.val, UScalar.val]
+  rw [BitVec.toInt_eq_toNat_of_lt (by
+        rw [BitVec.toNat_setWidth, show IScalarTy.I64.numBits = 64 from rfl, Nat.mod_eq_of_lt hlt]
+        have := x.bv.isLt; omega),
+     BitVec.toNat_setWidth, show IScalarTy.I64.numBits = 64 from rfl, Nat.mod_eq_of_lt hlt]
+
+/-! ## 3. Builder totality (every register-class branch returns `ok`). -/
+
+theorem src_a_reg_ok (self : zisk_inst_builder.ZiskInstBuilder) (reg : Std.U64) (usp : Bool)
+    (hb : reg.val < 32) : ∃ z, zisk_inst_builder.ZiskInstBuilder.src_a_reg self reg usp = ok z := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.src_a_reg, zisk_inst_builder.ZiskInstBuilder.src_a_imm,
+    zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO, zisk_registers.REG_FIRST,
+    mem.SYS_ADDR, mem.RAM_ADDR, lift, Bind.bind, bind_ok]
+  have e1 := cast_one_u64; have e31 := cast_31_u64
+  split_ifs <;> first | exact ⟨_, rfl⟩ | (exfalso; scalar_tac)
+
+theorem src_b_reg_ok (self : zisk_inst_builder.ZiskInstBuilder) (reg : Std.U64) (usp : Bool)
+    (hb : reg.val < 32) : ∃ z, zisk_inst_builder.ZiskInstBuilder.src_b_reg self reg usp = ok z := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.src_b_reg, zisk_inst_builder.ZiskInstBuilder.src_b_imm,
+    zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO, zisk_registers.REG_FIRST,
+    mem.SYS_ADDR, mem.RAM_ADDR, lift, Bind.bind, bind_ok]
+  have e1 := cast_one_u64; have e31 := cast_31_u64
+  split_ifs <;> first | exact ⟨_, rfl⟩ | (exfalso; scalar_tac)
+
+theorem store_reg_ok (self : zisk_inst_builder.ZiskInstBuilder) (off : Std.I64) (usp spc : Bool)
+    (hlo : 0 ≤ off.val) (hhi : off.val < 32) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.store_reg self off usp spc = ok z := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.store_reg,
+    zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO, zisk_registers.REG_FIRST,
+    mem.SYS_ADDR, mem.RAM_ADDR, lift, Bind.bind, bind_ok]
+  have e1 := cast_one_i64; have e31 := cast_31_i64
+  split_ifs <;> first | exact ⟨_, rfl⟩ | (exfalso; scalar_tac)
+
+theorem src_b_imm_ok (self : zisk_inst_builder.ZiskInstBuilder) (v : Std.U64) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.src_b_imm self v = ok z := ⟨_, rfl⟩
+
+theorem op_zisk_ok (self : zisk_inst_builder.ZiskInstBuilder) (op : zisk_ops.ZiskOp) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.op_zisk self op = ok z := by
+  cases op <;> exact ⟨_, rfl⟩
+
+theorem new_ok (i : riscv2zisk_single_row.Rv64imLoweringInput) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.new_for_rv64im_lowering i = ok z := ⟨_, rfl⟩
+
+theorem new_raw_ok (rom : Std.U64) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.new rom = ok z := ⟨_, rfl⟩
+
+theorem j_ok (self : zisk_inst_builder.ZiskInstBuilder) (j1 j2 : Std.I64) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.j self j1 j2 = ok z := ⟨_, rfl⟩
+
+theorem build_ok (self : zisk_inst_builder.ZiskInstBuilder) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.build self = ok z := ⟨_, rfl⟩
+
+theorem insert_inst_ok (self : riscv2zisk_context.Riscv2ZiskContext) (rom : Std.U64)
+    (zib : zisk_inst_builder.ZiskInstBuilder) :
+    ∃ z, riscv2zisk_context.Riscv2ZiskContext.insert_inst self rom zib = ok z := ⟨_, rfl⟩
+
+/-! ## 4. Entry-point + helper totality used by the transpile bridge. -/
+
+/-- `create_register_op_typed` is total for in-range register fields (no `≠ 0`). -/
+theorem create_register_op_typed_ok
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp) (inst_size : Std.U64)
+    (h1 : i.rs1.val < 32) (h2 : i.rs2.val < 32) (h3 : i.rd.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.create_register_op_typed self i op inst_size = ok ctx := by
+  obtain ⟨z0, hz0⟩ := new_ok i
+  obtain ⟨z1, hz1⟩ := src_a_reg_ok z0 (UScalar.cast UScalarTy.U64 i.rs1) false (by rw [cast_u32_u64_val]; exact h1)
+  obtain ⟨z2, hz2⟩ := src_b_reg_ok z1 (UScalar.cast UScalarTy.U64 i.rs2) false (by rw [cast_u32_u64_val]; exact h2)
+  obtain ⟨z3, hz3⟩ := op_zisk_ok z2 op
+  obtain ⟨z4, hz4⟩ := store_reg_ok z3 (UScalar.hcast IScalarTy.I64 i.rd) false false
+    (by rw [hcast_u32_i64_val]; exact_mod_cast Nat.zero_le _)
+    (by rw [hcast_u32_i64_val]; exact_mod_cast h3)
+  obtain ⟨z5, hz5⟩ := j_ok z4 (UScalar.hcast IScalarTy.I64 inst_size) (UScalar.hcast IScalarTy.I64 inst_size)
+  obtain ⟨z6, hz6⟩ := build_ok z5
+  obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z6
+  refine ⟨{ s1 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.create_register_op_typed]
+  simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hz5, hz6, hs1]
+
+/-- `from_inst` is total and copies the row's decode/row-mode fields (incl.
+`ind_width`, which the load/store bridge reads). -/
+theorem from_inst_ok (zi : zisk_inst.ZiskInst) :
+    ∃ e, aeneas_extract.ZiskInstExtract.from_inst zi = ok e
+      ∧ e.op = zi.op ∧ e.is_external_op = zi.is_external_op ∧ e.m32 = zi.m32
+      ∧ e.set_pc = zi.set_pc ∧ e.store_pc = zi.store_pc
+      ∧ e.jmp_offset1 = zi.jmp_offset1 ∧ e.jmp_offset2 = zi.jmp_offset2
+      ∧ e.ind_width = zi.ind_width := by
+  refine ⟨_, rfl, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;> rfl
+
+/-- `decode_extract_from_decoded` is total (every opcode/format arm returns `ok`). -/
+theorem decode_extract_ok (d : aeneas_extract.rv64im_decode.DecodedRv64im) :
+    ∃ e, aeneas_extract.decode_extract_from_decoded d = ok e := by
+  obtain ⟨b, hb⟩ : ∃ b, aeneas_extract.rv64im_decode.DecodedRv64im.is_supported_rv64im d = ok b := by
+    rw [aeneas_extract.rv64im_decode.DecodedRv64im.is_supported_rv64im]; cases d.opcode <;> exact ⟨_, rfl⟩
+  obtain ⟨i, hi⟩ : ∃ i, aeneas_extract.opcode_id d.opcode = ok i := by
+    rw [aeneas_extract.opcode_id.eq_def]; cases d.opcode <;> exact ⟨_, rfl⟩
+  obtain ⟨i1, hi1⟩ : ∃ i, aeneas_extract.format_id d.format = ok i := by
+    rw [aeneas_extract.format_id.eq_def]; cases d.format <;> exact ⟨_, rfl⟩
+  simp only [aeneas_extract.decode_extract_from_decoded, Bind.bind, bind_ok, hb, hi, hi1]
+  exact ⟨_, rfl⟩
+
+/-! ## 5. Immediate-ALU lowering totality (block 3, immediate/shift families).
+
+`immediate_op_typed` is the canonical builder for the plain immediates
+(SLLI/SRLI/SRAI, SLTI/SLTIU, ANDI, ADDIW, SLLIW/SRLIW/SRAIW).  Unlike the
+register builder it uses `src_b_imm` (unconditionally total) for the second
+operand, so its only register-bound branches are `src_a_reg` (on `rs1`) and
+`store_reg` (on `rd`).  Hence totality needs only `rs1 < 32 ∧ rd < 32` (no rs2,
+no `≠ 0`). -/
+
+attribute [local step] ZiskFv.Compliance.Decode.signext_spec
+
+-- `decode_i` is total and its `rd`/`rs1` fields are `< 32` (the 5-bit masks land
+-- `< 32`; the `imm` field's `signext` is discharged via `signext_spec`).  The
+-- `shift_level` flag only affects `imm`, so the bounds hold for either value.
+set_option maxHeartbeats 1000000 in
+theorem decode_i_bounds (raw : Std.U32) (op : RiscvOpcode) (sh : Bool) :
+    ∃ d, decode_i raw op sh = ok d ∧ d.opcode = op ∧ d.rd.val < 32 ∧ d.rs1.val < 32
+      ∧ d.rd.bv = (raw &&& 3968#u32).bv >>> 7 := by
+  have spec : decode_i raw op sh
+      ⦃ d => d.opcode = op ∧ d.rd.val < 32 ∧ d.rs1.val < 32 ∧ d.rd.bv = (raw &&& 3968#u32).bv >>> 7 ⦄ := by
+    rcases sh with _ | _
+    · rw [decode_i]
+      simp only [aeneas_extract.rv64im_decode.DecodedRv64im.new, lift, bind_ok,
+        Bool.false_eq_true, if_false, reduceIte]
+      step*
+      · -- signext precondition: i7 (a 12-bit slice) ≤ 2147483647
+        rw [i7_post1, Nat.shiftRight_eq_div_pow]
+        have h : (↑(raw &&& 4293918720#u32) : Nat) < 2 ^ 32 := by
+          have := (raw &&& 4293918720#u32).bv.isLt; simpa only [UScalar.val] using this
+        omega
+      · refine ⟨?_, ?_, i3_post2⟩
+        · rw [i3_post1, Nat.shiftRight_eq_div_pow]
+          have h : (↑(raw &&& 3968#u32) : Nat) ≤ 3968 := by
+            simp only [UScalar.val, BitVec.toNat_and]; exact le_trans Nat.and_le_right (by decide)
+          omega
+        · rw [i5_post1, Nat.shiftRight_eq_div_pow]
+          have h : (↑(raw &&& 1015808#u32) : Nat) ≤ 1015808 := by
+            simp only [UScalar.val, BitVec.toNat_and]; exact le_trans Nat.and_le_right (by decide)
+          omega
+    · rw [decode_i]
+      simp only [aeneas_extract.rv64im_decode.DecodedRv64im.new, lift, bind_ok,
+        if_true, reduceIte]
+      step*
+      · rw [i7_post1, Nat.shiftRight_eq_div_pow]
+        have h : (↑(raw &&& 4293918720#u32) : Nat) < 2 ^ 32 := by
+          have := (raw &&& 4293918720#u32).bv.isLt; simpa only [UScalar.val] using this
+        omega
+      · refine ⟨?_, ?_, i3_post2⟩
+        · rw [i3_post1, Nat.shiftRight_eq_div_pow]
+          have h : (↑(raw &&& 3968#u32) : Nat) ≤ 3968 := by
+            simp only [UScalar.val, BitVec.toNat_and]; exact le_trans Nat.and_le_right (by decide)
+          omega
+        · rw [i5_post1, Nat.shiftRight_eq_div_pow]
+          have h : (↑(raw &&& 1015808#u32) : Nat) ≤ 1015808 := by
+            simp only [UScalar.val, BitVec.toNat_and]; exact le_trans Nat.and_le_right (by decide)
+          omega
+  obtain ⟨d, hd, hpost⟩ := WP.spec_imp_exists spec
+  exact ⟨d, hd, hpost⟩
+
+/-- `immediate_op_typed` is total for in-range register fields (`rs1 < 32`,
+`rd < 32`).  The second operand is `src_b_imm` (unconditionally total), so the
+only register-bound branches are `src_a_reg` (on `rs1`) and `store_reg` (on `rd`),
+discharged by the same numBits-split technique as the register builder — NO `≠ 0`
+and NO `rs2` side-condition. -/
+theorem immediate_op_typed_ok
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp) (inst_size : Std.U64)
+    (h1 : i.rs1.val < 32) (h3 : i.rd.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.immediate_op_typed self i op inst_size = ok ctx := by
+  obtain ⟨z0, hz0⟩ := new_ok i
+  obtain ⟨z1, hz1⟩ := src_a_reg_ok z0 (UScalar.cast UScalarTy.U64 i.rs1) false (by rw [cast_u32_u64_val]; exact h1)
+  obtain ⟨z2, hz2⟩ := src_b_imm_ok z1 (IScalar.hcast UScalarTy.U64 i.imm)
+  obtain ⟨z3, hz3⟩ := op_zisk_ok z2 op
+  obtain ⟨z4, hz4⟩ := store_reg_ok z3 (UScalar.hcast IScalarTy.I64 i.rd) false false
+    (by rw [hcast_u32_i64_val]; exact_mod_cast Nat.zero_le _)
+    (by rw [hcast_u32_i64_val]; exact_mod_cast h3)
+  obtain ⟨z5, hz5⟩ := j_ok z4 (UScalar.hcast IScalarTy.I64 inst_size) (UScalar.hcast IScalarTy.I64 inst_size)
+  obtain ⟨z6, hz6⟩ := build_ok z5
+  obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z6
+  refine ⟨{ s1 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.immediate_op_typed]
+  simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hz5, hz6, hs1]
+
+/-! ## 6. Load / store lowering totality (block 3, load & store families).
+
+`load_op_typed` / `store_op_typed` are the canonical builders for the memory
+ops.  Both go through a `_with_reg_offset` helper with a literal `0` register
+offset (loads `0#i64`, stores `0#u64`), so totality additionally needs (a) that
+the `ind_width` builder accepts the per-op access-width literal (the `hw`
+hypothesis, discharged `⟨_, rfl⟩` for `w ∈ {1,2,4,8}`), and (b) that the `+ 0`
+offset addition is total and value-preserving (`iscalar_add_zero_ok` /
+`uscalar_add_zero_ok`).  Loads need `rs1 < 32 ∧ rd < 32` (`src_a_reg` on rs1,
+`store_reg` on rd); stores need `rs1 < 32 ∧ rs2 < 32` (`src_a_reg` on rs1,
+`src_b_reg` on rs2 — no rd: the store target is indirect, via `store_ind`). -/
+
+/-- `src_b_ind` is unconditionally total (both `use_sp` branches return `ok`). -/
+theorem src_b_ind_ok (self : zisk_inst_builder.ZiskInstBuilder) (off : Std.U64) (usp : Bool) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.src_b_ind self off usp = ok z := by
+  cases usp <;> exact ⟨_, rfl⟩
+
+/-- `store_ind` is unconditionally total. -/
+theorem store_ind_ok (self : zisk_inst_builder.ZiskInstBuilder) (off : Std.I64) (usp : Bool) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.store_ind self off usp = ok z := ⟨_, rfl⟩
+
+/-- Adding the literal `0#i64` offset is total and value-preserving (the register
+offset is `0` in `load_op_typed`'s `_with_reg_offset` call). -/
+theorem iscalar_add_zero_ok (x : Std.I64) : ∃ z, x + 0#i64 = ok z ∧ z.val = x.val := by
+  obtain ⟨z, hz, hv⟩ :=
+    WP.spec_imp_exists (IScalar.add_spec (x := x) (y := 0#i64) (by scalar_tac) (by scalar_tac))
+  exact ⟨z, hz, by simpa using hv⟩
+
+/-- Adding the literal `0#u64` offset is total and value-preserving (the register
+offset is `0` in `store_op_typed`'s `_with_reg_offset` call). -/
+theorem uscalar_add_zero_ok (x : Std.U64) : ∃ z, x + 0#u64 = ok z ∧ z.val = x.val := by
+  obtain ⟨z, hz, hv⟩ :=
+    WP.spec_imp_exists (UScalar.add_spec (x := x) (y := 0#u64) (by scalar_tac))
+  exact ⟨z, hz, by simpa using hv⟩
+
+set_option maxHeartbeats 1000000 in
+/-- `decode_s` is total and its `rs1`/`rs2` fields are `< 32` (the 5-bit masks
+land `< 32`; the `imm` field's `signext` is discharged exactly as in
+`decode_s_spec`). -/
+theorem decode_s_bounds (raw : Std.U32) (op : RiscvOpcode) :
+    ∃ d, decode_s raw op = ok d ∧ d.opcode = op ∧ d.rs1.val < 32 ∧ d.rs2.val < 32 := by
+  have spec : decode_s raw op
+      ⦃ d => d.opcode = op ∧ d.rs1.val < 32 ∧ d.rs2.val < 32 ⦄ := by
+    rw [decode_s]
+    simp only [aeneas_extract.rv64im_decode.DecodedRv64im.new, lift, bind_ok]
+    step*
+    · -- signext precondition: i9 = (i8 ||| imm4_0) ≤ 2147483647 (verbatim `decode_s_spec`)
+      have hi8 : (i8 : Std.U32).val < 2 ^ 31 := by
+        have h11 : imm11_5.val < 2 ^ 7 := by
+          rw [imm11_5_post1, Nat.shiftRight_eq_div_pow]
+          have h : (raw &&& 4261412864#u32).val < 2 ^ 32 := (raw &&& 4261412864#u32).bv.isLt
+          simp only [UScalar.val] at h ⊢; omega
+        rw [i8_post1, Nat.shiftLeft_eq]
+        have hle := Nat.mod_le (↑imm11_5 * 2 ^ 5) U32.size
+        simp only [UScalar.val] at h11 hle ⊢; omega
+      have hi40 : (imm4_0 : Std.U32).val < 2 ^ 31 := by
+        rw [imm4_0_post1]; exact ZiskFv.Compliance.Decode.shr_field_lt raw _ 7 (by norm_num)
+      have : (i8 ||| imm4_0).val < 2 ^ 31 := by
+        simp only [UScalar.val, BitVec.toNat_or] at hi8 hi40 ⊢; exact Nat.or_lt_two_pow hi8 hi40
+      simp only [UScalar.val] at this ⊢; omega
+    · refine ⟨?_, ?_⟩
+      · rw [i4_post1, Nat.shiftRight_eq_div_pow]
+        have h : (↑(raw &&& 1015808#u32) : Nat) ≤ 1015808 := by
+          simp only [UScalar.val, BitVec.toNat_and]; exact le_trans Nat.and_le_right (by decide)
+        omega
+      · rw [i6_post1, Nat.shiftRight_eq_div_pow]
+        have h : (↑(raw &&& 32505856#u32) : Nat) ≤ 32505856 := by
+          simp only [UScalar.val, BitVec.toNat_and]; exact le_trans Nat.and_le_right (by decide)
+        omega
+  obtain ⟨d, hd, hpost⟩ := WP.spec_imp_exists spec
+  exact ⟨d, hd, hpost⟩
+
+/-- `load_op_with_reg_offset` (the `0#i64`-offset specialization used by
+`load_op_typed`) is total for in-range register fields. -/
+theorem load_op_with_reg_offset_ok
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp) (w inst_size : Std.U64)
+    (hw : ∀ s : zisk_inst_builder.ZiskInstBuilder,
+            ∃ z, zisk_inst_builder.ZiskInstBuilder.ind_width s w = ok z)
+    (h1 : i.rs1.val < 32) (h3 : i.rd.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.load_op_with_reg_offset self i op w inst_size 0#i64
+      = ok ctx := by
+  obtain ⟨z0, hz0⟩ := new_ok i
+  obtain ⟨z1, hz1⟩ := src_a_reg_ok z0 (UScalar.cast UScalarTy.U64 i.rs1) false
+    (by rw [cast_u32_u64_val]; exact h1)
+  obtain ⟨z2, hz2⟩ := hw z1
+  obtain ⟨z3, hz3⟩ := src_b_ind_ok z2 (IScalar.hcast UScalarTy.U64 i.imm) false
+  obtain ⟨z4, hz4⟩ := op_zisk_ok z3 op
+  obtain ⟨i4, hi4, hi4v⟩ := iscalar_add_zero_ok (UScalar.hcast IScalarTy.I64 i.rd)
+  obtain ⟨z5, hz5⟩ := store_reg_ok z4 i4 false false
+    (by rw [hi4v, hcast_u32_i64_val]; exact_mod_cast Nat.zero_le _)
+    (by rw [hi4v, hcast_u32_i64_val]; exact_mod_cast h3)
+  obtain ⟨z6, hz6⟩ := j_ok z5 (UScalar.hcast IScalarTy.I64 inst_size) (UScalar.hcast IScalarTy.I64 inst_size)
+  obtain ⟨z7, hz7⟩ := build_ok z6
+  obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z7
+  refine ⟨{ s1 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.load_op_with_reg_offset]
+  simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hi4, hz5, hz6, hz7, hs1]
+
+/-- `load_op_typed` is total for in-range register fields (`rs1 < 32`, `rd < 32`)
+and a legal access-width literal (`hw`). -/
+theorem load_op_typed_ok
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp) (w inst_size : Std.U64)
+    (hw : ∀ s : zisk_inst_builder.ZiskInstBuilder,
+            ∃ z, zisk_inst_builder.ZiskInstBuilder.ind_width s w = ok z)
+    (h1 : i.rs1.val < 32) (h3 : i.rd.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.load_op_typed self i op w inst_size = ok ctx := by
+  obtain ⟨ctx0, hctx0⟩ :=
+    load_op_with_reg_offset_ok { self with extract_marker := () } i op w inst_size hw h1 h3
+  refine ⟨{ ctx0 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.load_op_typed]
+  simp only [Bind.bind, bind_ok, hctx0]
+
+/-- `store_op_with_reg_offset` (the `0#u64`-offset specialization used by
+`store_op_typed`) is total for in-range register fields (`rs1 < 32`, `rs2 < 32`;
+no rd — the store target is indirect). -/
+theorem store_op_with_reg_offset_ok
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp) (w inst_size : Std.U64)
+    (hw : ∀ s : zisk_inst_builder.ZiskInstBuilder,
+            ∃ z, zisk_inst_builder.ZiskInstBuilder.ind_width s w = ok z)
+    (h1 : i.rs1.val < 32) (h2 : i.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.store_op_with_reg_offset self i op w inst_size 0#u64
+      = ok ctx := by
+  obtain ⟨z0, hz0⟩ := new_ok i
+  obtain ⟨z1, hz1⟩ := src_a_reg_ok z0 (UScalar.cast UScalarTy.U64 i.rs1) false
+    (by rw [cast_u32_u64_val]; exact h1)
+  obtain ⟨i3, hi3, hi3v⟩ := uscalar_add_zero_ok (UScalar.cast UScalarTy.U64 i.rs2)
+  obtain ⟨z2, hz2⟩ := src_b_reg_ok z1 i3 false (by rw [hi3v, cast_u32_u64_val]; exact h2)
+  obtain ⟨z3, hz3⟩ := op_zisk_ok z2 op
+  obtain ⟨z4, hz4⟩ := hw z3
+  obtain ⟨z5, hz5⟩ := store_ind_ok z4 (IScalar.cast IScalarTy.I64 i.imm) false
+  obtain ⟨z6, hz6⟩ := j_ok z5 (UScalar.hcast IScalarTy.I64 inst_size) (UScalar.hcast IScalarTy.I64 inst_size)
+  obtain ⟨z7, hz7⟩ := build_ok z6
+  obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z7
+  refine ⟨{ s1 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.store_op_with_reg_offset]
+  simp only [lift, Bind.bind, bind_ok, hz0, hz1, hi3, hz2, hz3, hz4, hz5, hz6, hz7, hs1]
+
+/-- `store_op_typed` is total for in-range register fields (`rs1 < 32`, `rs2 < 32`)
+and a legal access-width literal (`hw`). -/
+theorem store_op_typed_ok
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp) (w inst_size : Std.U64)
+    (hw : ∀ s : zisk_inst_builder.ZiskInstBuilder,
+            ∃ z, zisk_inst_builder.ZiskInstBuilder.ind_width s w = ok z)
+    (h1 : i.rs1.val < 32) (h2 : i.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.store_op_typed self i op w inst_size = ok ctx := by
+  obtain ⟨ctx0, hctx0⟩ :=
+    store_op_with_reg_offset_ok { self with extract_marker := () } i op w inst_size hw h1 h2
+  refine ⟨{ ctx0 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.store_op_typed]
+  simp only [Bind.bind, bind_ok, hctx0]
+
+/-! ## 7. Branch lowering totality (block 3, branch family).
+
+`create_branch_op_typed` mirrors `create_register_op_typed` but writes NO `rd`
+(no `store_reg`) and chooses the two `j` offset arguments by the `neg` flag.  Its
+only register-bound branches are `src_a_reg` (on `rs1`) and `src_b_reg` (on `rs2`),
+so totality needs only `rs1 < 32 ∧ rs2 < 32` (no rd, no `≠ 0`).  The `if neg`
+chooses which constant slot is `inst_size`; both arms are `j_ok` (unconditional). -/
+
+set_option maxHeartbeats 1000000 in
+/-- `decode_b` is total and its `rs1`/`rs2` fields are `< 32` (the 5-bit masks land
+`< 32`; the `imm` field's `signext` is discharged exactly as in `decode_b_spec`). -/
+theorem decode_b_bounds (raw : Std.U32) (op : RiscvOpcode) :
+    ∃ d, decode_b raw op = ok d ∧ d.opcode = op ∧ d.rs1.val < 32 ∧ d.rs2.val < 32 := by
+  have spec : decode_b raw op
+      ⦃ d => d.opcode = op ∧ d.rs1.val < 32 ∧ d.rs2.val < 32 ⦄ := by
+    rw [decode_b]
+    simp only [aeneas_extract.rv64im_decode.DecodedRv64im.new, lift, bind_ok]
+    step*
+    · -- signext precondition: ↑(i10 ||| i11 ||| i13 ||| i15) ≤ 2147483647 (verbatim `decode_b_spec`)
+      have hi10 : (i10 : Std.U32).val < 2 ^ 31 := by
+        have hf : imm12.val < 2 ^ 1 := by
+          rw [imm12_post1, Nat.shiftRight_eq_div_pow]
+          have h : (raw &&& 2147483648#u32).val < 2 ^ 32 := (raw &&& 2147483648#u32).bv.isLt
+          simp only [UScalar.val] at h ⊢; omega
+        rw [i10_post1, Nat.shiftLeft_eq]
+        have hle := Nat.mod_le (↑imm12 * 2 ^ 12) U32.size
+        simp only [UScalar.val] at hf hle ⊢; omega
+      have hi11 : (i11 : Std.U32).val < 2 ^ 31 := by
+        have hf : imm11.val < 2 ^ 1 := by
+          rw [imm11_post1, Nat.shiftRight_eq_div_pow]
+          have h : (raw &&& 128#u32).val ≤ 128 := by
+            have hand : (raw &&& 128#u32).val ≤ (128#u32).val := by
+              simp only [UScalar.val, BitVec.toNat_and]; exact Nat.and_le_right
+            have hmval : (128#u32).val = 128 := by decide
+            omega
+          simp only [UScalar.val] at h ⊢; omega
+        rw [i11_post1, Nat.shiftLeft_eq]
+        have hle := Nat.mod_le (↑imm11 * 2 ^ 11) U32.size
+        simp only [UScalar.val] at hf hle ⊢; omega
+      have hi13 : (i13 : Std.U32).val < 2 ^ 31 := by
+        have hf : imm10_5.val < 2 ^ 7 := by
+          rw [imm10_5_post1, Nat.shiftRight_eq_div_pow]
+          have h : (raw &&& 2113929216#u32).val < 2 ^ 32 := (raw &&& 2113929216#u32).bv.isLt
+          simp only [UScalar.val] at h ⊢; omega
+        rw [i13_post1, Nat.shiftLeft_eq]
+        have hle := Nat.mod_le (↑imm10_5 * 2 ^ 5) U32.size
+        simp only [UScalar.val] at hf hle ⊢; omega
+      have hi15 : (i15 : Std.U32).val < 2 ^ 31 := by
+        have hf : imm4_1.val < 2 ^ 24 := by
+          rw [imm4_1_post1, Nat.shiftRight_eq_div_pow]
+          have h : (raw &&& 3840#u32).val < 2 ^ 32 := (raw &&& 3840#u32).bv.isLt
+          simp only [UScalar.val] at h ⊢; omega
+        rw [i15_post1, Nat.shiftLeft_eq]
+        have hle := Nat.mod_le (↑imm4_1 * 2 ^ 1) U32.size
+        simp only [UScalar.val] at hf hle ⊢; omega
+      have : (i10 ||| i11 ||| i13 ||| i15).val < 2 ^ 31 := by
+        simp only [UScalar.val, BitVec.toNat_or] at hi10 hi11 hi13 hi15 ⊢
+        exact Nat.or_lt_two_pow (Nat.or_lt_two_pow (Nat.or_lt_two_pow hi10 hi11) hi13) hi15
+      simp only [UScalar.val] at this ⊢; omega
+    · refine ⟨?_, ?_⟩
+      · rw [i5_post1, Nat.shiftRight_eq_div_pow]
+        have h : (↑(raw &&& 1015808#u32) : Nat) ≤ 1015808 := by
+          simp only [UScalar.val, BitVec.toNat_and]; exact le_trans Nat.and_le_right (by decide)
+        omega
+      · rw [i7_post1, Nat.shiftRight_eq_div_pow]
+        have h : (↑(raw &&& 32505856#u32) : Nat) ≤ 32505856 := by
+          simp only [UScalar.val, BitVec.toNat_and]; exact le_trans Nat.and_le_right (by decide)
+        omega
+  obtain ⟨d, hd, hpost⟩ := WP.spec_imp_exists spec
+  exact ⟨d, hd, hpost⟩
+
+/-- `create_branch_op_typed` is total for in-range register fields (`rs1 < 32`,
+`rs2 < 32`).  No `rd`, no `≠ 0` side-condition. -/
+theorem create_branch_op_typed_ok
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp)
+    (neg : Bool) (inst_size : Std.U64)
+    (h1 : i.rs1.val < 32) (h2 : i.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.create_branch_op_typed self i op neg inst_size
+      = ok ctx := by
+  obtain ⟨z0, hz0⟩ := new_ok i
+  obtain ⟨z1, hz1⟩ := src_a_reg_ok z0 (UScalar.cast UScalarTy.U64 i.rs1) false
+    (by rw [cast_u32_u64_val]; exact h1)
+  obtain ⟨z2, hz2⟩ := src_b_reg_ok z1 (UScalar.cast UScalarTy.U64 i.rs2) false
+    (by rw [cast_u32_u64_val]; exact h2)
+  obtain ⟨z3, hz3⟩ := op_zisk_ok z2 op
+  cases neg
+  · obtain ⟨z4, hz4⟩ := j_ok z3 (IScalar.cast IScalarTy.I64 i.imm) (UScalar.hcast IScalarTy.I64 inst_size)
+    obtain ⟨z5, hz5⟩ := build_ok z4
+    obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z5
+    refine ⟨{ s1 with extract_marker := () }, ?_⟩
+    rw [riscv2zisk_context.Riscv2ZiskContext.create_branch_op_typed]
+    simp only [Bool.false_eq_true, if_false, reduceIte, lift, Bind.bind, bind_ok,
+      hz0, hz1, hz2, hz3, hz4, hz5, hs1]
+  · obtain ⟨z4, hz4⟩ := j_ok z3 (UScalar.hcast IScalarTy.I64 inst_size) (IScalar.cast IScalarTy.I64 i.imm)
+    obtain ⟨z5, hz5⟩ := build_ok z4
+    obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z5
+    refine ⟨{ s1 with extract_marker := () }, ?_⟩
+    rw [riscv2zisk_context.Riscv2ZiskContext.create_branch_op_typed]
+    simp only [if_true, reduceIte, lift, Bind.bind, bind_ok,
+      hz0, hz1, hz2, hz3, hz4, hz5, hs1]
+
+/-! ## 8. Control lowering totality (block 3, LUI / AUIPC / JAL / JALR / FENCE).
+
+The U-type / J-type decoders give the `rd` field (`< 32`); the control builders
+use `src_a_imm` / `src_b_imm` (unconditional), `store_reg` / `store_pc_reg` (on
+`rd`), `src_b_reg` (on `rs1`, JALR only), and `j` (unconditional).  JALR's
+`i.imm % 4` TWO-ROW split is handled by casing on the remainder; its second-row
+`rom_address + 1` / `inst_size - 1` arithmetic is total at the transpile call
+site (`rom_address = 0`, `inst_size = 4`). -/
+
+/-- `decode_u` is total (no `signext` on the path); `rd` is `< 32` and its bitvec
+recovers the `[7,11]` field (for the symbolic `rd ≠ 0` derivation). -/
+theorem decode_u_bounds (raw : Std.U32) (op : RiscvOpcode) :
+    ∃ d, decode_u raw op = ok d ∧ d.opcode = op ∧ d.rd.val < 32
+      ∧ d.rd.bv = (raw &&& 3968#u32).bv >>> 7 := by
+  refine ⟨_, rfl, rfl, ?_, rfl⟩
+  simp only [UScalar.val]
+  exact and_ushr_toNat_lt raw 3968#32 (7#i32).toNat 32 (by decide)
+
+set_option maxHeartbeats 1000000 in
+/-- `decode_j` is total and its `rd` field is `< 32` (the `imm` field's `signext`
+is discharged exactly as in `decode_j_spec`). -/
+theorem decode_j_bounds (raw : Std.U32) (op : RiscvOpcode) :
+    ∃ d, decode_j raw op = ok d ∧ d.opcode = op ∧ d.rd.val < 32
+      ∧ d.rd.bv = (raw &&& 3968#u32).bv >>> 7 := by
+  have spec : decode_j raw op
+      ⦃ d => d.opcode = op ∧ d.rd.val < 32 ∧ d.rd.bv = (raw &&& 3968#u32).bv >>> 7 ⦄ := by
+    rw [decode_j]
+    simp only [aeneas_extract.rv64im_decode.DecodedRv64im.new, lift, bind_ok]
+    step*
+    · -- signext precondition: ↑(i6 ||| i7 ||| i9 ||| i11) ≤ 2147483647 (verbatim `decode_j_spec`)
+      have hi6 : (i6 : Std.U32).val < 2 ^ 31 := by
+        have hf : imm20.val < 2 ^ 1 := by
+          rw [imm20_post1, Nat.shiftRight_eq_div_pow]
+          have h : (raw &&& 2147483648#u32).val < 2 ^ 32 := (raw &&& 2147483648#u32).bv.isLt
+          simp only [UScalar.val] at h ⊢; omega
+        rw [i6_post1, Nat.shiftLeft_eq]
+        have hle := Nat.mod_le (↑imm20 * 2 ^ 20) U32.size
+        simp only [UScalar.val] at hf hle ⊢; omega
+      have hi7 : (i7 : Std.U32).val < 2 ^ 31 := by
+        have hf : imm19_12.val < 2 ^ 8 := by
+          rw [imm19_12_post1, Nat.shiftRight_eq_div_pow]
+          have h : (raw &&& 1044480#u32).val ≤ 1044480 := by
+            have hand : (raw &&& 1044480#u32).val ≤ (1044480#u32).val := by
+              simp only [UScalar.val, BitVec.toNat_and]; exact Nat.and_le_right
+            have hmval : (1044480#u32).val = 1044480 := by decide
+            omega
+          simp only [UScalar.val] at h ⊢; omega
+        rw [i7_post1, Nat.shiftLeft_eq]
+        have hle := Nat.mod_le (↑imm19_12 * 2 ^ 12) U32.size
+        simp only [UScalar.val] at hf hle ⊢; omega
+      have hi9 : (i9 : Std.U32).val < 2 ^ 31 := by
+        have hf : imm11.val < 2 ^ 12 := by
+          rw [imm11_post1, Nat.shiftRight_eq_div_pow]
+          have h : (raw &&& 1048576#u32).val < 2 ^ 32 := (raw &&& 1048576#u32).bv.isLt
+          simp only [UScalar.val] at h ⊢; omega
+        rw [i9_post1, Nat.shiftLeft_eq]
+        have hle := Nat.mod_le (↑imm11 * 2 ^ 11) U32.size
+        simp only [UScalar.val] at hf hle ⊢; omega
+      have hi11 : (i11 : Std.U32).val < 2 ^ 31 := by
+        have hf : imm10_1.val < 2 ^ 11 := by
+          rw [imm10_1_post1, Nat.shiftRight_eq_div_pow]
+          have h : (raw &&& 2145386496#u32).val < 2 ^ 32 := (raw &&& 2145386496#u32).bv.isLt
+          simp only [UScalar.val] at h ⊢; omega
+        rw [i11_post1, Nat.shiftLeft_eq]
+        have hle := Nat.mod_le (↑imm10_1 * 2 ^ 1) U32.size
+        simp only [UScalar.val] at hf hle ⊢; omega
+      have : (i6 ||| i7 ||| i9 ||| i11).val < 2 ^ 31 := by
+        simp only [UScalar.val, BitVec.toNat_or] at hi6 hi7 hi9 hi11 ⊢
+        exact Nat.or_lt_two_pow (Nat.or_lt_two_pow (Nat.or_lt_two_pow hi6 hi7) hi9) hi11
+      simp only [UScalar.val] at this ⊢; omega
+    · refine ⟨?_, i1_post2⟩
+      rw [i1_post1, Nat.shiftRight_eq_div_pow]
+      have h : (↑(raw &&& 3968#u32) : Nat) ≤ 3968 := by
+        simp only [UScalar.val, BitVec.toNat_and]; exact le_trans Nat.and_le_right (by decide)
+      omega
+  obtain ⟨d, hd, hpost⟩ := WP.spec_imp_exists spec
+  exact ⟨d, hd, hpost⟩
+
+theorem src_a_imm_ok (self : zisk_inst_builder.ZiskInstBuilder) (v : Std.U64) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.src_a_imm self v = ok z := ⟨_, rfl⟩
+
+theorem src_b_lastc_ok (self : zisk_inst_builder.ZiskInstBuilder) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.src_b_lastc self = ok z := ⟨_, rfl⟩
+
+theorem set_pc_ok (self : zisk_inst_builder.ZiskInstBuilder) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.set_pc self = ok z := ⟨_, rfl⟩
+
+/-- `store_pc_reg` is `store_reg … spc := true`, hence total for `0 ≤ off < 32`. -/
+theorem store_pc_reg_ok (self : zisk_inst_builder.ZiskInstBuilder) (off : Std.I64) (usp : Bool)
+    (hlo : 0 ≤ off.val) (hhi : off.val < 32) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.store_pc_reg self off usp = ok z := by
+  rw [zisk_inst_builder.ZiskInstBuilder.store_pc_reg]; exact store_reg_ok self off usp true hlo hhi
+
+/-- `lui` is total for `rd < 32` (`src_a_imm`/`src_b_imm` unconditional; `store_reg` on rd). -/
+theorem lui_ok (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (inst_size : Std.U64) (h3 : i.rd.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.lui self i inst_size = ok ctx := by
+  obtain ⟨z0, hz0⟩ := new_ok i
+  obtain ⟨z1, hz1⟩ := src_a_imm_ok z0 0#u64
+  obtain ⟨z2, hz2⟩ := src_b_imm_ok z1 (IScalar.hcast UScalarTy.U64 i.imm)
+  obtain ⟨z3, hz3⟩ := op_zisk_ok z2 zisk_ops.ZiskOp.CopyB
+  obtain ⟨z4, hz4⟩ := store_reg_ok z3 (UScalar.hcast IScalarTy.I64 i.rd) false false
+    (by rw [hcast_u32_i64_val]; exact_mod_cast Nat.zero_le _)
+    (by rw [hcast_u32_i64_val]; exact_mod_cast h3)
+  obtain ⟨z5, hz5⟩ := j_ok z4 (UScalar.hcast IScalarTy.I64 inst_size) (UScalar.hcast IScalarTy.I64 inst_size)
+  obtain ⟨z6, hz6⟩ := build_ok z5
+  obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z6
+  refine ⟨{ s1 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.lui]
+  simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hz5, hz6, hs1]
+
+/-- `auipc` is total for `rd < 32` (`store_pc_reg` on rd; `j 4#i64 (cast imm)`). -/
+theorem auipc_ok (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (h3 : i.rd.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.auipc self i = ok ctx := by
+  obtain ⟨z0, hz0⟩ := new_ok i
+  obtain ⟨z1, hz1⟩ := src_a_imm_ok z0 0#u64
+  obtain ⟨z2, hz2⟩ := src_b_imm_ok z1 0#u64
+  obtain ⟨z3, hz3⟩ := op_zisk_ok z2 zisk_ops.ZiskOp.Flag
+  obtain ⟨z4, hz4⟩ := store_pc_reg_ok z3 (UScalar.hcast IScalarTy.I64 i.rd) false
+    (by rw [hcast_u32_i64_val]; exact_mod_cast Nat.zero_le _)
+    (by rw [hcast_u32_i64_val]; exact_mod_cast h3)
+  obtain ⟨z5, hz5⟩ := j_ok z4 4#i64 (IScalar.cast IScalarTy.I64 i.imm)
+  obtain ⟨z6, hz6⟩ := build_ok z5
+  obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z6
+  refine ⟨{ s1 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.auipc]
+  simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hz5, hz6, hs1]
+
+/-- `jal` is total for `rd < 32` (`store_pc_reg` on rd; `j (cast imm) (hcast inst_size)`). -/
+theorem jal_ok (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (inst_size : Std.U64) (h3 : i.rd.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.jal self i inst_size = ok ctx := by
+  obtain ⟨z0, hz0⟩ := new_ok i
+  obtain ⟨z1, hz1⟩ := src_a_imm_ok z0 0#u64
+  obtain ⟨z2, hz2⟩ := src_b_imm_ok z1 0#u64
+  obtain ⟨z3, hz3⟩ := op_zisk_ok z2 zisk_ops.ZiskOp.Flag
+  obtain ⟨z4, hz4⟩ := store_pc_reg_ok z3 (UScalar.hcast IScalarTy.I64 i.rd) false
+    (by rw [hcast_u32_i64_val]; exact_mod_cast Nat.zero_le _)
+    (by rw [hcast_u32_i64_val]; exact_mod_cast h3)
+  obtain ⟨z5, hz5⟩ := j_ok z4 (IScalar.cast IScalarTy.I64 i.imm) (UScalar.hcast IScalarTy.I64 inst_size)
+  obtain ⟨z6, hz6⟩ := build_ok z5
+  obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z6
+  refine ⟨{ s1 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.jal]
+  simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hz5, hz6, hs1]
+
+/-- `nop` is total (no register operands; FENCE lowers here). -/
+theorem nop_ok (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (inst_size : Std.U64) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.nop self i inst_size = ok ctx := by
+  obtain ⟨z0, hz0⟩ := new_ok i
+  obtain ⟨z1, hz1⟩ := src_a_imm_ok z0 0#u64
+  obtain ⟨z2, hz2⟩ := src_b_imm_ok z1 0#u64
+  obtain ⟨z3, hz3⟩ := op_zisk_ok z2 zisk_ops.ZiskOp.Flag
+  obtain ⟨z4, hz4⟩ := j_ok z3 (UScalar.hcast IScalarTy.I64 inst_size) (UScalar.hcast IScalarTy.I64 inst_size)
+  obtain ⟨z5, hz5⟩ := build_ok z4
+  obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z5
+  refine ⟨{ s1 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.nop]
+  simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hz5, hs1]
+
+/-- Second-row `rom_address + 1` is total at the transpile call site (`= 0`). -/
+theorem add_one_at_zero_ok (r : Std.U64) (hr : r = 0#u64) :
+    ∃ z, r + 1#u64 = ok z := by subst hr; exact ⟨_, rfl⟩
+
+/-- Second-row `inst_size - 1` is total at the transpile call site (`inst_size = 4`). -/
+theorem hcast4_sub_one_ok :
+    ∃ z, (UScalar.hcast IScalarTy.I64 4#u64 : Std.I64) - 1#i64 = ok z := ⟨_, rfl⟩
+
+/-- `jalr` is total for `rs1 < 32`, `rd < 32` and `rom_address = 0` (the transpile
+call site).  Handles the `i.imm % 4` TWO-ROW split: Row A emits one instruction,
+Row B emits two (the `rom_address + 1` / `inst_size - 1` arithmetic is total at
+`rom_address = 0`, `inst_size = 4`). -/
+theorem jalr_ok (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput)
+    (h1 : i.rs1.val < 32) (h3 : i.rd.val < 32) (hrom : i.rom_address = 0#u64) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.jalr self i 4#u64 = ok ctx := by
+  rw [riscv2zisk_context.Riscv2ZiskContext.jalr]
+  obtain ⟨m, hm, _⟩ := WP.spec_imp_exists (IScalar.rem_spec i.imm (y := 4#i32) (by decide))
+  simp only [hm, bind_ok, Bind.bind]
+  by_cases hcond : m = 0#i32
+  · rw [if_pos hcond]
+    obtain ⟨z0, hz0⟩ := new_ok i
+    obtain ⟨z1, hz1⟩ := src_a_imm_ok z0 riscv2zisk_context.Riscv2ZiskContext.jalr.JALR_MASK
+    obtain ⟨z2, hz2⟩ := src_b_reg_ok z1 (UScalar.cast UScalarTy.U64 i.rs1) false
+      (by rw [cast_u32_u64_val]; exact h1)
+    obtain ⟨z3, hz3⟩ := op_zisk_ok z2 zisk_ops.ZiskOp.And
+    obtain ⟨z4, hz4⟩ := store_pc_reg_ok z3 (UScalar.hcast IScalarTy.I64 i.rd) false
+      (by rw [hcast_u32_i64_val]; exact_mod_cast Nat.zero_le _)
+      (by rw [hcast_u32_i64_val]; exact_mod_cast h3)
+    obtain ⟨z5, hz5⟩ := set_pc_ok z4
+    obtain ⟨z6, hz6⟩ := j_ok z5 (IScalar.cast IScalarTy.I64 i.imm) (UScalar.hcast IScalarTy.I64 4#u64)
+    obtain ⟨z7, hz7⟩ := build_ok z6
+    obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z7
+    refine ⟨{ s1 with extract_marker := () }, ?_⟩
+    simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hz5, hz6, hz7, hs1]
+  · rw [if_neg hcond]
+    obtain ⟨z0, hz0⟩ := new_ok i
+    obtain ⟨z1, hz1⟩ := src_a_imm_ok z0 (IScalar.hcast UScalarTy.U64 i.imm)
+    obtain ⟨z2, hz2⟩ := src_b_reg_ok z1 (UScalar.cast UScalarTy.U64 i.rs1) false
+      (by rw [cast_u32_u64_val]; exact h1)
+    obtain ⟨z3, hz3⟩ := op_zisk_ok z2 zisk_ops.ZiskOp.Add
+    obtain ⟨z4, hz4⟩ := j_ok z3 1#i64 1#i64
+    obtain ⟨z5, hz5⟩ := build_ok z4
+    obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z5
+    obtain ⟨roma, hroma⟩ := add_one_at_zero_ok i.rom_address hrom
+    obtain ⟨z6, hz6⟩ := new_raw_ok roma
+    obtain ⟨z7, hz7⟩ := src_a_imm_ok z6 riscv2zisk_context.Riscv2ZiskContext.jalr.JALR_MASK
+    obtain ⟨z8, hz8⟩ := src_b_lastc_ok z7
+    obtain ⟨z9, hz9⟩ := op_zisk_ok z8 zisk_ops.ZiskOp.And
+    obtain ⟨z10, hz10⟩ := store_pc_reg_ok z9 (UScalar.hcast IScalarTy.I64 i.rd) false
+      (by rw [hcast_u32_i64_val]; exact_mod_cast Nat.zero_le _)
+      (by rw [hcast_u32_i64_val]; exact_mod_cast h3)
+    obtain ⟨z11, hz11⟩ := set_pc_ok z10
+    obtain ⟨six, hsix⟩ := hcast4_sub_one_ok
+    obtain ⟨z12, hz12⟩ := j_ok z11 0#i64 six
+    obtain ⟨z13, hz13⟩ := build_ok z12
+    obtain ⟨s2, hs2⟩ := insert_inst_ok { s1 with extract_marker := () } roma z13
+    refine ⟨{ s2 with extract_marker := () }, ?_⟩
+    simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hz5, hs1, hroma,
+      hz6, hz7, hz8, hz9, hz10, hz11, hsix, hz12, hz13, hs2]
+
+/-- The default lowering context the transpile pipeline threads into the dispatcher. -/
+def defCtx : riscv2zisk_context.Riscv2ZiskContext :=
+  { extract_inst := none, extract_marker := (), input_precompile := none,
+    output_precompile := none, input_precompile_reg := none, output_precompile_reg := none }
+
+/-! ## 9. Index-width totality — DISCHARGES the `hw` premise of §6.
+
+`ind_width` (`ProductionM2.lean:2622`) returns `ok` on exactly the four legal
+access widths and `fail panic` on everything else.  The dispatcher's load/store
+arms pass only those four literals (`Lb/Lbu/Sb` → 1, `Lh/Lhu/Sh` → 2,
+`Lw/Lwu/Sw` → 4, `Ld/Sd` → 8, `ProductionM2.lean:3396-3460`), so the `hw`
+hypothesis that §6's `load_op_typed_ok` / `store_op_typed_ok` take as an argument
+is supplied here rather than assumed at the use site.
+
+(The June draft of this module stated `hw` as a premise and asserted in prose
+that it was "discharged `⟨_, rfl⟩` for `w ∈ {1,2,4,8}`" without ever proving it.
+These four lemmas are that missing proof.) -/
+
+theorem ind_width_ok_1 (s : zisk_inst_builder.ZiskInstBuilder) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.ind_width s 1#u64 = ok z := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.ind_width]; exact ⟨_, rfl⟩
+
+theorem ind_width_ok_2 (s : zisk_inst_builder.ZiskInstBuilder) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.ind_width s 2#u64 = ok z := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.ind_width]; exact ⟨_, rfl⟩
+
+theorem ind_width_ok_4 (s : zisk_inst_builder.ZiskInstBuilder) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.ind_width s 4#u64 = ok z := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.ind_width]; exact ⟨_, rfl⟩
+
+theorem ind_width_ok_8 (s : zisk_inst_builder.ZiskInstBuilder) :
+    ∃ z, zisk_inst_builder.ZiskInstBuilder.ind_width s 8#u64 = ok z := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.ind_width]; exact ⟨_, rfl⟩
+
+/-! ## 10. `immediate_op_or_x0_copyb_typed` totality (ADDI / XORI / ORI).
+
+Same shape as `immediate_op_typed` except that the op choice is an `if i.rs1 = 0`
+between `op_zisk … CopyB` and `op_zisk … op` (`ProductionM2.lean:2567-2591`).
+`op_zisk` is unconditionally total, so BOTH arms return `ok` and totality needs
+only `rs1 < 32 ∧ rd < 32` — in particular NO `rs1 ≠ 0` (that side condition
+belongs to the *pins*, which must know which arm ran, not to totality). -/
+
+theorem immediate_op_or_x0_copyb_typed_ok
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp) (inst_size : Std.U64)
+    (h1 : i.rs1.val < 32) (h3 : i.rd.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.immediate_op_or_x0_copyb_typed
+      self i op inst_size = ok ctx := by
+  obtain ⟨z0, hz0⟩ := new_ok i
+  obtain ⟨z1, hz1⟩ := src_a_reg_ok z0 (UScalar.cast UScalarTy.U64 i.rs1) false
+    (by rw [cast_u32_u64_val]; exact h1)
+  obtain ⟨z2, hz2⟩ := src_b_imm_ok z1 (IScalar.hcast UScalarTy.U64 i.imm)
+  obtain ⟨z3, hz3⟩ :
+      ∃ z, (if i.rs1 = 0#u32
+              then zisk_inst_builder.ZiskInstBuilder.op_zisk z2 zisk_ops.ZiskOp.CopyB
+              else zisk_inst_builder.ZiskInstBuilder.op_zisk z2 op) = ok z := by
+    split
+    · exact op_zisk_ok z2 zisk_ops.ZiskOp.CopyB
+    · exact op_zisk_ok z2 op
+  obtain ⟨z4, hz4⟩ := store_reg_ok z3 (UScalar.hcast IScalarTy.I64 i.rd) false false
+    (by rw [hcast_u32_i64_val]; exact_mod_cast Nat.zero_le _)
+    (by rw [hcast_u32_i64_val]; exact_mod_cast h3)
+  obtain ⟨z5, hz5⟩ := j_ok z4 (UScalar.hcast IScalarTy.I64 inst_size)
+    (UScalar.hcast IScalarTy.I64 inst_size)
+  obtain ⟨z6, hz6⟩ := build_ok z5
+  obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z6
+  refine ⟨{ s1 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.immediate_op_or_x0_copyb_typed]
+  simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hz5, hz6, hs1]
+
+/-! ## 11. DISPATCHER-level totality: `lower_rv64im_single_row_input` SUCCEEDS.
+
+Every theorem in `Extraction/Dispatch.lean` presupposes
+`lower_rv64im_single_row_input self ri <Opcode> hni = ok ctx`.  This section
+proves that presupposition, for all 63 RV64IM opcodes, from the register-field
+bounds alone.
+
+Each proof names the entry point the dispatcher routes to
+(`ProductionM2.lean:2915-3460`), obtains its totality witness from §3-§10, and
+closes the arm by rewriting the dispatcher's `match` and discharging the routing
+guards with the SAME side conditions `Extraction/Dispatch.lean` already states
+for that opcode — the two hypothesis sets are deliberately identical, so §12 can
+compose them without introducing anything new.
+
+Register-bound hypotheses used, per family (these are the honest premises; §12's
+closing note records what still supplies them):
+  * register / M ops: `rs1, rs2, rd < 32`   * branches: `rs1, rs2 < 32`
+  * immediates:       `rs1, rd < 32`        * loads:    `rs1, rd < 32`
+  * stores:           `rs1, rs2 < 32`       * LUI/AUIPC/JAL: `rd < 32`
+  * JALR: `rs1, rd < 32` and `rom_address = 0` (the value
+    `extract_transpile_rv64im_raw` passes, `ProductionM2.lean:3657`)
+  * FENCE: none. -/
+
+local macro "regtot" nm:ident "," opc:term "," zop:term : command => do
+  let d := Lean.mkIdentFrom nm (nm.getId.appendAfter "_dispatch_total")
+  `(theorem $d:ident (self : riscv2zisk_context.Riscv2ZiskContext)
+      (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+      (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+      ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri $opc hni = ok ctx := by
+    obtain ⟨c, hc⟩ := create_register_op_typed_ok { self with extract_marker := () } ri
+      $zop 4#u64 h1 h2 h3
+    refine ⟨{ c with extract_marker := () }, ?_⟩
+    rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+    simp only [Bind.bind, bind_ok, hc])
+
+local macro "brtot" nm:ident "," opc:term "," zop:term "," neg:term : command => do
+  let d := Lean.mkIdentFrom nm (nm.getId.appendAfter "_dispatch_total")
+  `(theorem $d:ident (self : riscv2zisk_context.Riscv2ZiskContext)
+      (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+      (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+      ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri $opc hni = ok ctx := by
+    obtain ⟨c, hc⟩ := create_branch_op_typed_ok { self with extract_marker := () } ri
+      $zop $neg 4#u64 h1 h2
+    refine ⟨{ c with extract_marker := () }, ?_⟩
+    rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+    simp only [Bind.bind, bind_ok, hc])
+
+local macro "immtot" nm:ident "," opc:term "," zop:term : command => do
+  let d := Lean.mkIdentFrom nm (nm.getId.appendAfter "_dispatch_total")
+  `(theorem $d:ident (self : riscv2zisk_context.Riscv2ZiskContext)
+      (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+      (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+      ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri $opc hni = ok ctx := by
+    obtain ⟨c, hc⟩ := immediate_op_typed_ok { self with extract_marker := () } ri
+      $zop 4#u64 h1 h3
+    refine ⟨{ c with extract_marker := () }, ?_⟩
+    rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+    simp only [Bind.bind, bind_ok, hc])
+
+local macro "x0tot" nm:ident "," opc:term "," zop:term : command => do
+  let d := Lean.mkIdentFrom nm (nm.getId.appendAfter "_dispatch_total")
+  `(theorem $d:ident (self : riscv2zisk_context.Riscv2ZiskContext)
+      (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+      (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+      ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri $opc hni = ok ctx := by
+    obtain ⟨c, hc⟩ := immediate_op_or_x0_copyb_typed_ok { self with extract_marker := () } ri
+      $zop 4#u64 h1 h3
+    refine ⟨{ c with extract_marker := () }, ?_⟩
+    rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+    simp only [Bind.bind, bind_ok, hc])
+
+local macro "ldtot" nm:ident "," opc:term "," zop:term "," w:term "," iw:term : command => do
+  let d := Lean.mkIdentFrom nm (nm.getId.appendAfter "_dispatch_total")
+  `(theorem $d:ident (self : riscv2zisk_context.Riscv2ZiskContext)
+      (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+      (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+      ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri $opc hni = ok ctx := by
+    obtain ⟨c, hc⟩ := load_op_typed_ok { self with extract_marker := () } ri
+      $zop $w 4#u64 $iw h1 h3
+    refine ⟨{ c with extract_marker := () }, ?_⟩
+    rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+    simp only [Bind.bind, bind_ok, hc])
+
+local macro "sttot" nm:ident "," opc:term "," zop:term "," w:term "," iw:term : command => do
+  let d := Lean.mkIdentFrom nm (nm.getId.appendAfter "_dispatch_total")
+  `(theorem $d:ident (self : riscv2zisk_context.Riscv2ZiskContext)
+      (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+      (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+      ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri $opc hni = ok ctx := by
+    obtain ⟨c, hc⟩ := store_op_typed_ok { self with extract_marker := () } ri
+      $zop $w 4#u64 $iw h1 h2
+    refine ⟨{ c with extract_marker := () }, ?_⟩
+    rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+    simp only [Bind.bind, bind_ok, hc])
+
+-- Register ALU / M ops (unconditional dispatcher routing).
+regtot sub, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sub, zisk_ops.ZiskOp.Sub
+regtot sll, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sll, zisk_ops.ZiskOp.Sll
+regtot slt, riscv2zisk_single_row.Rv64imSingleRowOpcode.Slt, zisk_ops.ZiskOp.Lt
+regtot sltu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sltu, zisk_ops.ZiskOp.Ltu
+regtot xor, riscv2zisk_single_row.Rv64imSingleRowOpcode.Xor, zisk_ops.ZiskOp.Xor
+regtot srl, riscv2zisk_single_row.Rv64imSingleRowOpcode.Srl, zisk_ops.ZiskOp.Srl
+regtot sra, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sra, zisk_ops.ZiskOp.Sra
+regtot and, riscv2zisk_single_row.Rv64imSingleRowOpcode.And, zisk_ops.ZiskOp.And
+regtot addw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Addw, zisk_ops.ZiskOp.AddW
+regtot subw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Subw, zisk_ops.ZiskOp.SubW
+regtot sllw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sllw, zisk_ops.ZiskOp.SllW
+regtot srlw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Srlw, zisk_ops.ZiskOp.SrlW
+regtot sraw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sraw, zisk_ops.ZiskOp.SraW
+regtot mul, riscv2zisk_single_row.Rv64imSingleRowOpcode.Mul, zisk_ops.ZiskOp.Mul
+regtot mulh, riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulh, zisk_ops.ZiskOp.Mulh
+regtot mulhsu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulhsu, zisk_ops.ZiskOp.Mulsuh
+regtot mulhu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulhu, zisk_ops.ZiskOp.Muluh
+regtot mulw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulw, zisk_ops.ZiskOp.MulW
+regtot div, riscv2zisk_single_row.Rv64imSingleRowOpcode.Div, zisk_ops.ZiskOp.Div
+regtot divu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Divu, zisk_ops.ZiskOp.Divu
+regtot divw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Divw, zisk_ops.ZiskOp.DivW
+regtot divuw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Divuw, zisk_ops.ZiskOp.DivuW
+regtot rem, riscv2zisk_single_row.Rv64imSingleRowOpcode.Rem, zisk_ops.ZiskOp.Rem
+regtot remu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Remu, zisk_ops.ZiskOp.Remu
+regtot remw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Remw, zisk_ops.ZiskOp.RemW
+regtot remuw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Remuw, zisk_ops.ZiskOp.RemuW
+
+-- Branches.
+brtot beq, riscv2zisk_single_row.Rv64imSingleRowOpcode.Beq, zisk_ops.ZiskOp.Eq, false
+brtot bne, riscv2zisk_single_row.Rv64imSingleRowOpcode.Bne, zisk_ops.ZiskOp.Eq, true
+brtot blt, riscv2zisk_single_row.Rv64imSingleRowOpcode.Blt, zisk_ops.ZiskOp.Lt, false
+brtot bge, riscv2zisk_single_row.Rv64imSingleRowOpcode.Bge, zisk_ops.ZiskOp.Lt, true
+brtot bltu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Bltu, zisk_ops.ZiskOp.Ltu, false
+brtot bgeu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Bgeu, zisk_ops.ZiskOp.Ltu, true
+
+-- Plain immediates (`immediate_op_typed`).
+immtot slli, riscv2zisk_single_row.Rv64imSingleRowOpcode.Slli, zisk_ops.ZiskOp.Sll
+immtot slti, riscv2zisk_single_row.Rv64imSingleRowOpcode.Slti, zisk_ops.ZiskOp.Lt
+immtot sltiu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sltiu, zisk_ops.ZiskOp.Ltu
+immtot srli, riscv2zisk_single_row.Rv64imSingleRowOpcode.Srli, zisk_ops.ZiskOp.Srl
+immtot srai, riscv2zisk_single_row.Rv64imSingleRowOpcode.Srai, zisk_ops.ZiskOp.Sra
+immtot andi, riscv2zisk_single_row.Rv64imSingleRowOpcode.Andi, zisk_ops.ZiskOp.And
+immtot slliw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Slliw, zisk_ops.ZiskOp.SllW
+immtot srliw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Srliw, zisk_ops.ZiskOp.SrlW
+immtot sraiw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sraiw, zisk_ops.ZiskOp.SraW
+
+-- XORI / ORI (`immediate_op_or_x0_copyb_typed`; total on BOTH op arms).
+x0tot xori, riscv2zisk_single_row.Rv64imSingleRowOpcode.Xori, zisk_ops.ZiskOp.Xor
+x0tot ori, riscv2zisk_single_row.Rv64imSingleRowOpcode.Ori, zisk_ops.ZiskOp.Or
+
+-- Loads / stores (the `hw` premise supplied by §9, never assumed).
+ldtot lb, riscv2zisk_single_row.Rv64imSingleRowOpcode.Lb, zisk_ops.ZiskOp.SignExtendB, 1#u64, ind_width_ok_1
+ldtot lbu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Lbu, zisk_ops.ZiskOp.CopyB, 1#u64, ind_width_ok_1
+ldtot lh, riscv2zisk_single_row.Rv64imSingleRowOpcode.Lh, zisk_ops.ZiskOp.SignExtendH, 2#u64, ind_width_ok_2
+ldtot lhu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Lhu, zisk_ops.ZiskOp.CopyB, 2#u64, ind_width_ok_2
+ldtot lw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Lw, zisk_ops.ZiskOp.SignExtendW, 4#u64, ind_width_ok_4
+ldtot lwu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Lwu, zisk_ops.ZiskOp.CopyB, 4#u64, ind_width_ok_4
+ldtot ld, riscv2zisk_single_row.Rv64imSingleRowOpcode.Ld, zisk_ops.ZiskOp.CopyB, 8#u64, ind_width_ok_8
+sttot sb, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sb, zisk_ops.ZiskOp.CopyB, 1#u64, ind_width_ok_1
+sttot sh, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sh, zisk_ops.ZiskOp.CopyB, 2#u64, ind_width_ok_2
+sttot sw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sw, zisk_ops.ZiskOp.CopyB, 4#u64, ind_width_ok_4
+sttot sd, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sd, zisk_ops.ZiskOp.CopyB, 8#u64, ind_width_ok_8
+
+
+/-! ### 11.1 Control arms (LUI / AUIPC / JAL / JALR / FENCE).
+
+All five route unconditionally; only JALR carries a routing-independent premise
+(`rom_address = 0`, needed for its second-row `rom_address + 1`). -/
+
+theorem lui_dispatch_total (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+      self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lui hni = ok ctx := by
+  obtain ⟨c, hc⟩ := lui_ok { self with extract_marker := () } ri 4#u64 h3
+  refine ⟨{ c with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+  simp only [Bind.bind, bind_ok, hc]
+
+theorem auipc_dispatch_total (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+      self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Auipc hni = ok ctx := by
+  obtain ⟨c, hc⟩ := auipc_ok { self with extract_marker := () } ri h3
+  refine ⟨{ c with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+  simp only [Bind.bind, bind_ok, hc]
+
+theorem jal_dispatch_total (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+      self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Jal hni = ok ctx := by
+  obtain ⟨c, hc⟩ := jal_ok { self with extract_marker := () } ri 4#u64 h3
+  refine ⟨{ c with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+  simp only [Bind.bind, bind_ok, hc]
+
+/-- JALR is the one two-row arm: when `imm % 4 ≠ 0` the lowerer emits a second
+instruction at `rom_address + 1`, so totality needs the transpile call site's
+`rom_address = 0` (`ProductionM2.lean:3657`). -/
+theorem jalr_dispatch_total (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) (hrom : ri.rom_address = 0#u64) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+      self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Jalr hni = ok ctx := by
+  obtain ⟨c, hc⟩ := jalr_ok { self with extract_marker := () } ri h1 h3 hrom
+  refine ⟨{ c with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+  simp only [Bind.bind, bind_ok, hc]
+
+/-- FENCE lowers through `nop`, which reads no register field: totality is
+UNCONDITIONAL. -/
+theorem fence_dispatch_total (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+      self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Fence hni = ok ctx := by
+  obtain ⟨c, hc⟩ := nop_ok { self with extract_marker := () } ri 4#u64
+  refine ⟨{ c with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+  simp only [Bind.bind, bind_ok, hc]
+
+/-! ### 11.2 Guarded arms (ADD / OR / ADDI / ADDIW).
+
+These four are the only opcodes whose dispatcher arm branches before reaching a
+builder.  The routing hypotheses below are VERBATIM the ones
+`Extraction/Dispatch.lean` already states for the same opcode
+(`add_dispatch_static_pins`, `or_dispatch_static_pins`, … ) — §12 composes the
+two without adding anything. -/
+
+set_option maxHeartbeats 2000000 in
+theorem add_dispatch_total (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (hprec : self.input_precompile = none)
+    (hrd : ri.rd ≠ 0#u32) (hrs1 : ri.rs1 ≠ 0#u32) (hrs2 : ri.rs2 ≠ 0#u32)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+      self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Add hni = ok ctx := by
+  obtain ⟨c, hc⟩ := create_register_op_typed_ok
+    { self with extract_marker := (), input_precompile := none } ri
+    zisk_ops.ZiskOp.Add 4#u64 h1 h2 h3
+  refine ⟨{ c with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+  simp only [hprec, riscv2zisk_single_row.CSR_DMA_MEMCMP_ADDR, Bind.bind, bind_ok]
+  simp [ne_eq, hrd, hrs1, hrs2, reduceIte,
+    show ((0#u32 : Std.U32) = 2068#u32) = False from by decide, hc]
+
+set_option maxHeartbeats 2000000 in
+theorem or_dispatch_total (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (hrs1 : ri.rs1 ≠ 0#u32) (hrs2 : ri.rs2 ≠ 0#u32)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+      self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Or hni = ok ctx := by
+  obtain ⟨c, hc⟩ := create_register_op_typed_ok { self with extract_marker := () } ri
+    zisk_ops.ZiskOp.Or 4#u64 h1 h2 h3
+  refine ⟨{ c with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+  rw [if_neg hrs1, if_neg hrs2]
+  simp only [Bind.bind, bind_ok, hc]
+
+set_option maxHeartbeats 2000000 in
+theorem addi_dispatch_total (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (hrd : ri.rd ≠ 0#u32) (himm : ri.imm ≠ 0#i32)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+      self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Addi hni = ok ctx := by
+  obtain ⟨c, hc⟩ := immediate_op_or_x0_copyb_typed_ok { self with extract_marker := () } ri
+    zisk_ops.ZiskOp.Add 4#u64 h1 h3
+  refine ⟨{ c with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+  rw [if_neg hrd, if_neg himm]
+  simp only [Bind.bind, bind_ok, hc]
+
+set_option maxHeartbeats 2000000 in
+theorem addiw_dispatch_total (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (hrd : ri.rd ≠ 0#u32)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+      self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Addiw hni = ok ctx := by
+  obtain ⟨c, hc⟩ := immediate_op_typed_ok { self with extract_marker := () } ri
+    zisk_ops.ZiskOp.AddW 4#u64 h1 h3
+  refine ⟨{ c with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input]
+  rw [if_neg hrd]
+  simp only [Bind.bind, bind_ok, hc]
+
+/-! ## 12. The discharge: #111's dispatcher pins WITHOUT the `= ok ctx` premise.
+
+Each theorem below is the corresponding `<op>_dispatch_static_pins` of
+`Extraction/Dispatch.lean` with its `h : lower_rv64im_single_row_input … = ok ctx`
+hypothesis REMOVED — supplied instead by §11.  The remaining hypotheses are
+exactly (§11's register-field bounds) ∪ (the routing side conditions
+`Extraction/Dispatch.lean` already required); nothing else is introduced, and the
+proofs are a two-line composition of the two existing results.
+
+What this does and does NOT close.
+
+  * CLOSED.  "The lowerer might fail, so the pins could be vacuous" is no longer
+    a possibility for any of the 63 opcodes: the witness is exhibited.
+  * NOT CLOSED, and stated as premises rather than hidden: the register-field
+    bounds (`rs1, rs2, rd < 32`).  §1-§8 prove them for each LEAF decoder
+    (`decode_r_bounds`, `decode_i_bounds`, `decode_s_bounds`, `decode_b_bounds`,
+    `decode_u_bounds`, `decode_j_bounds`), but nothing here connects those to
+    `decode_32_core`, so a caller starting from a raw 32-bit word must still
+    supply them.  Closing that connection is what would make totality of
+    `extract_transpile_rv64im_raw` premise-free.
+  * NOT CLOSED: `rom_address = 0` for JALR (the transpile call site's value).
+  * NOT CLOSED: anything about WHAT the lowered row means — that is the raw-word
+    join (#61 Phase 0), which this module is deliberately independent of. -/
+
+
+/-! ### 12.1 Register / M ops. -/
+
+theorem sub_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sub hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 11#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sub_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, sub_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem and_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.And hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 14#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := and_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, and_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem xor_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Xor hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 16#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := xor_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, xor_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem slt_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slt hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 7#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := slt_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, slt_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem sltu_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sltu hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 6#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sltu_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, sltu_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem sll_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sll hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 33#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sll_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, sll_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem srl_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srl hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 34#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := srl_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, srl_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem sra_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sra hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 35#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sra_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, sra_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem addw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Addw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 26#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := addw_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, addw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem subw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Subw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 27#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := subw_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, subw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem sllw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sllw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 36#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sllw_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, sllw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem srlw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srlw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 37#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := srlw_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, srlw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem sraw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sraw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 38#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sraw_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, sraw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem mul_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mul hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 180#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := mul_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, mul_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem mulh_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulh hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 181#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := mulh_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, mulh_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem mulhsu_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulhsu hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 179#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := mulhsu_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, mulhsu_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem mulhu_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulhu hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 177#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := mulhu_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, mulhu_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem mulw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 182#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := mulw_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, mulw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem div_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Div hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 186#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := div_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, div_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem divu_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Divu hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 184#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := divu_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, divu_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem divw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Divw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 190#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := divw_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, divw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem divuw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Divuw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 188#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := divuw_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, divuw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem rem_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Rem hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 187#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := rem_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, rem_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem remu_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Remu hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 185#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := remu_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, remu_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem remw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Remw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 191#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := remw_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, remw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem remuw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Remuw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 189#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := remuw_dispatch_total self ri hni h1 h2 h3
+  exact ⟨ctx, hctx, remuw_dispatch_static_pins self ri hni ctx hctx⟩
+
+/-! ### 12.2 Branches. -/
+
+theorem beq_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Beq hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 9#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := beq_dispatch_total self ri hni h1 h2
+  exact ⟨ctx, hctx, beq_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem bne_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bne hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 9#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := bne_dispatch_total self ri hni h1 h2
+  exact ⟨ctx, hctx, bne_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem blt_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Blt hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 7#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := blt_dispatch_total self ri hni h1 h2
+  exact ⟨ctx, hctx, blt_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem bge_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bge hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 7#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := bge_dispatch_total self ri hni h1 h2
+  exact ⟨ctx, hctx, bge_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem bltu_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bltu hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 6#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := bltu_dispatch_total self ri hni h1 h2
+  exact ⟨ctx, hctx, bltu_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem bgeu_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bgeu hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 6#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := bgeu_dispatch_total self ri hni h1 h2
+  exact ⟨ctx, hctx, bgeu_dispatch_static_pins self ri hni ctx hctx⟩
+
+/-! ### 12.3 Plain immediates. -/
+
+theorem slli_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slli hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 33#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := slli_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, slli_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem srli_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srli hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 34#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := srli_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, srli_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem srai_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srai hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 35#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := srai_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, srai_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem slti_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slti hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 7#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := slti_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, slti_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem sltiu_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sltiu hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 6#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sltiu_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, sltiu_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem andi_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Andi hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 14#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := andi_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, andi_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem slliw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slliw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 36#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := slliw_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, slliw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem srliw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srliw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 37#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := srliw_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, srliw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem sraiw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sraiw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 38#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sraiw_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, sraiw_dispatch_static_pins self ri hni ctx hctx⟩
+
+/-! ### 12.4 XORI / ORI (the `rs1 ≠ 0#u32` op-arm condition is #111's, unchanged). -/
+
+theorem xori_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (hrs1 : ri.rs1 ≠ 0#u32) (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Xori hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 16#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := xori_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, xori_dispatch_static_pins self ri hni ctx hrs1 hctx⟩
+
+theorem ori_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (hrs1 : ri.rs1 ≠ 0#u32) (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Ori hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 15#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := ori_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, ori_dispatch_static_pins self ri hni ctx hrs1 hctx⟩
+
+/-! ### 12.5 Loads. -/
+
+theorem lb_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lb hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 39#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := lb_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, lb_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem lh_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lh hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 40#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := lh_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, lh_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem lw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 41#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := lw_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, lw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem lbu_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lbu hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := lbu_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, lbu_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem lhu_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lhu hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := lhu_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, lhu_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem lwu_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lwu hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := lwu_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, lwu_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem ld_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Ld hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := ld_dispatch_total self ri hni h1 h3
+  exact ⟨ctx, hctx, ld_dispatch_static_pins self ri hni ctx hctx⟩
+
+/-! ### 12.6 Stores. -/
+
+theorem sb_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sb hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sb_dispatch_total self ri hni h1 h2
+  exact ⟨ctx, hctx, sb_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem sh_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sh hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sh_dispatch_total self ri hni h1 h2
+  exact ⟨ctx, hctx, sh_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem sw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sw_dispatch_total self ri hni h1 h2
+  exact ⟨ctx, hctx, sw_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem sd_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sd hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := sd_dispatch_total self ri hni h1 h2
+  exact ⟨ctx, hctx, sd_dispatch_static_pins self ri hni ctx hctx⟩
+
+/-! ### 12.7 Control arms (LUI / AUIPC / JAL / JALR / FENCE).
+
+`auipc` / `jal` / `jalr` keep exactly the `store_pc` shape #111 proves: AUIPC's
+static pins do not mention `store_pc` at all, and JAL's carry it as the
+implication guarded by a nonzero `rd` cast (`store_reg`'s `offset = 0 ⇒ ok self`
+early return).  Those are unchanged here; only the `= ok ctx` premise is gone. -/
+
+theorem lui_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lui hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := lui_dispatch_total self ri hni h3
+  exact ⟨ctx, hctx, lui_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem auipc_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Auipc hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 0#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false := by
+  obtain ⟨ctx, hctx⟩ := auipc_dispatch_total self ri hni h3
+  exact ⟨ctx, hctx, auipc_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem jal_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Jal hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 0#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧
+        ((UScalar.hcast IScalarTy.I64 ri.rd : Std.I64) ≠ 0#i64 → zib.i.store_pc = true) := by
+  obtain ⟨ctx, hctx⟩ := jal_dispatch_total self ri hni h3
+  exact ⟨ctx, hctx, jal_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem jalr_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) (hrom : ri.rom_address = 0#u64) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Jalr hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 14#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = true := by
+  obtain ⟨ctx, hctx⟩ := jalr_dispatch_total self ri hni h1 h3 hrom
+  exact ⟨ctx, hctx, jalr_dispatch_static_pins self ri hni ctx hctx⟩
+
+theorem fence_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Fence hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 0#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := fence_dispatch_total self ri hni
+  exact ⟨ctx, hctx, fence_dispatch_static_pins self ri hni ctx hctx⟩
+
+/-! ### 12.8 Guarded arms (ADD / OR / ADDI / ADDIW).
+
+The routing hypotheses are #111's, verbatim; the bound hypotheses are §11's. -/
+
+theorem add_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (hprec : self.input_precompile = none)
+    (hrd : ri.rd ≠ 0#u32) (hrs1 : ri.rs1 ≠ 0#u32) (hrs2 : ri.rs2 ≠ 0#u32)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Add hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 10#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := add_dispatch_total self ri hni hprec hrd hrs1 hrs2 h1 h2 h3
+  exact ⟨ctx, hctx, add_dispatch_static_pins self ri hni ctx hprec hrd hrs1 hrs2 hctx⟩
+
+theorem or_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (hrs1 : ri.rs1 ≠ 0#u32) (hrs2 : ri.rs2 ≠ 0#u32)
+    (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Or hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 15#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := or_dispatch_total self ri hni hrs1 hrs2 h1 h2 h3
+  exact ⟨ctx, hctx, or_dispatch_static_pins self ri hni ctx hrs1 hrs2 hctx⟩
+
+theorem addi_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (hrd : ri.rd ≠ 0#u32) (himm : ri.imm ≠ 0#i32) (hrs1 : ri.rs1 ≠ 0#u32)
+    (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Addi hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 10#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := addi_dispatch_total self ri hni hrd himm h1 h3
+  exact ⟨ctx, hctx, addi_dispatch_static_pins self ri hni ctx hrd himm hrs1 hctx⟩
+
+theorem addiw_dispatch_static_pins_unconditional
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
+    (hrd : ri.rd ≠ 0#u32) (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Addiw hni = ok ctx ∧
+      ∃ zib, ctx.extract_inst = some zib ∧
+        zib.i.op = 26#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
+        zib.i.set_pc = false ∧ zib.i.store_pc = false := by
+  obtain ⟨ctx, hctx⟩ := addiw_dispatch_total self ri hni hrd h1 h3
+  exact ⟨ctx, hctx, addiw_dispatch_static_pins self ri hni ctx hrd hctx⟩
+
+end ZiskFv.Compliance.Extraction

--- a/ZiskFv/Compliance/AeneasBridgeTrust/Extraction/Totality.lean
+++ b/ZiskFv/Compliance/AeneasBridgeTrust/Extraction/Totality.lean
@@ -1126,17 +1126,43 @@ proofs are a two-line composition of the two existing results.
 What this does and does NOT close.
 
   * CLOSED.  "The lowerer might fail, so the pins could be vacuous" is no longer
-    a possibility for any of the 63 opcodes: the witness is exhibited.
+    a possibility for any of the 63 opcodes: the witness is exhibited, through
+    the real production entry point.
+
   * NOT CLOSED, and stated as premises rather than hidden: the register-field
-    bounds (`rs1, rs2, rd < 32`).  §1-§8 prove them for each LEAF decoder
+    bounds `rs1, rs2, rd < 32`.  §1-§8 prove them for each LEAF decoder
     (`decode_r_bounds`, `decode_i_bounds`, `decode_s_bounds`, `decode_b_bounds`,
-    `decode_u_bounds`, `decode_j_bounds`), but nothing here connects those to
-    `decode_32_core`, so a caller starting from a raw 32-bit word must still
-    supply them.  Closing that connection is what would make totality of
-    `extract_transpile_rv64im_raw` premise-free.
-  * NOT CLOSED: `rom_address = 0` for JALR (the transpile call site's value).
-  * NOT CLOSED: anything about WHAT the lowered row means — that is the raw-word
-    join (#61 Phase 0), which this module is deliberately independent of. -/
+    `decode_u_bounds`, `decode_j_bounds`), but nothing connects those to
+    `decode_32_core`, so a caller starting from a raw 32-bit word must supply
+    them.
+
+  * NOT CLOSED: `rom_address = 0` for JALR — the value the transpile call site
+    passes (`ProductionM2.lean:3657`), needed for the two-row arm's
+    `rom_address + 1`.
+
+  * NOT CLOSED: anything about WHAT the lowered row means.  That is the raw-word
+    join (#61 Phase 0); this module is deliberately independent of it.
+
+A premise-free `∃ e, extract_transpile_rv64im_raw raw = ok e` does NOT follow
+from §11 alone, and it is worth recording exactly why, so the gap is not
+mis-scoped as "just connect the decoder bounds":
+
+  1. a bound on `decode_32_core`'s `rd`/`rs1`/`rs2` (the leaf lemmas exist; the
+     ~120-arm dispatch over them does not), plus the unset-field defaults from
+     `DecodedRv64im.new` (`ProductionM2.lean:254-268`);
+  2. totality of the three degenerate builders §11 never reaches, because for
+     ADD/OR/ADDI/ADDIW the dispatcher routes AWAY from the op builder exactly
+     when §11's routing hypotheses fail: `copyb` (rs1 = 0 or rs2 = 0, or ADDI
+     with imm = 0), `hint` (ADDI with rd = 0 and rs1 or rs2 nonzero), and
+     `create_precompiled_op_typed` (the DMA-CSR path, ruled out here by
+     `input_precompile = none`).  `nop`, the fourth such target, is the one
+     already covered — `nop_ok` in §8, used by `fence_dispatch_total`;
+  3. a case analysis over `lowering_opcode` (`ProductionM2.lean:1144`) tying the
+     decoded `RiscvOpcode` to the `Rv64imSingleRowOpcode` each §11 lemma is
+     indexed by.
+
+Item 2 is the substantive one: those arms are lowering behaviour this module has
+no lemma about at all, not a missing plumbing step. -/
 
 
 /-! ### 12.1 Register / M ops. -/
@@ -1145,7 +1171,8 @@ theorem sub_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sub hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sub hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 11#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1156,7 +1183,8 @@ theorem and_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.And hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.And hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 14#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1167,7 +1195,8 @@ theorem xor_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Xor hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Xor hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 16#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1178,7 +1207,8 @@ theorem slt_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slt hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slt hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 7#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1189,7 +1219,8 @@ theorem sltu_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sltu hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sltu hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 6#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1200,7 +1231,8 @@ theorem sll_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sll hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sll hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 33#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1211,7 +1243,8 @@ theorem srl_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srl hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srl hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 34#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1222,7 +1255,8 @@ theorem sra_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sra hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sra hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 35#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1233,7 +1267,8 @@ theorem addw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Addw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Addw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 26#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1244,7 +1279,8 @@ theorem subw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Subw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Subw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 27#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1255,7 +1291,8 @@ theorem sllw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sllw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sllw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 36#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1266,7 +1303,8 @@ theorem srlw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srlw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srlw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 37#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1277,7 +1315,8 @@ theorem sraw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sraw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sraw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 38#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1288,7 +1327,8 @@ theorem mul_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mul hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mul hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 180#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1299,7 +1339,8 @@ theorem mulh_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulh hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulh hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 181#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1310,7 +1351,8 @@ theorem mulhsu_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulhsu hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulhsu hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 179#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1321,7 +1363,8 @@ theorem mulhu_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulhu hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulhu hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 177#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1332,7 +1375,8 @@ theorem mulw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 182#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1343,7 +1387,8 @@ theorem div_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Div hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Div hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 186#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1354,7 +1399,8 @@ theorem divu_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Divu hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Divu hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 184#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1365,7 +1411,8 @@ theorem divw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Divw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Divw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 190#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1376,7 +1423,8 @@ theorem divuw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Divuw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Divuw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 188#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1387,7 +1435,8 @@ theorem rem_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Rem hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Rem hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 187#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1398,7 +1447,8 @@ theorem remu_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Remu hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Remu hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 185#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1409,7 +1459,8 @@ theorem remw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Remw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Remw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 191#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1420,7 +1471,8 @@ theorem remuw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Remuw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Remuw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 189#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1433,7 +1485,8 @@ theorem beq_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Beq hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Beq hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 9#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1444,7 +1497,8 @@ theorem bne_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bne hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bne hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 9#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1455,7 +1509,8 @@ theorem blt_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Blt hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Blt hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 7#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1466,7 +1521,8 @@ theorem bge_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bge hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bge hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 7#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1477,7 +1533,8 @@ theorem bltu_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bltu hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bltu hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 6#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1488,7 +1545,8 @@ theorem bgeu_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bgeu hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Bgeu hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 6#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1501,7 +1559,8 @@ theorem slli_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slli hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slli hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 33#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1512,7 +1571,8 @@ theorem srli_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srli hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srli hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 34#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1523,7 +1583,8 @@ theorem srai_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srai hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srai hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 35#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1534,7 +1595,8 @@ theorem slti_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slti hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slti hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 7#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1545,7 +1607,8 @@ theorem sltiu_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sltiu hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sltiu hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 6#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1556,7 +1619,8 @@ theorem andi_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Andi hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Andi hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 14#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1567,7 +1631,8 @@ theorem slliw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slliw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Slliw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 36#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1578,7 +1643,8 @@ theorem srliw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srliw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Srliw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 37#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1589,7 +1655,8 @@ theorem sraiw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sraiw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sraiw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 38#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1602,7 +1669,8 @@ theorem xori_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (hrs1 : ri.rs1 ≠ 0#u32) (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Xori hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Xori hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 16#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1613,7 +1681,8 @@ theorem ori_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (hrs1 : ri.rs1 ≠ 0#u32) (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Ori hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Ori hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 15#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1626,7 +1695,8 @@ theorem lb_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lb hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lb hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 39#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1637,7 +1707,8 @@ theorem lh_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lh hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lh hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 40#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1648,7 +1719,8 @@ theorem lw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 41#u8 ∧ zib.i.is_external_op = true ∧ zib.i.m32 = true ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1659,7 +1731,8 @@ theorem lbu_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lbu hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lbu hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1670,7 +1743,8 @@ theorem lhu_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lhu hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lhu hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1681,7 +1755,8 @@ theorem lwu_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lwu hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Lwu hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1692,7 +1767,8 @@ theorem ld_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h3 : ri.rd.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Ld hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Ld hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1705,7 +1781,8 @@ theorem sb_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sb hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sb hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1716,7 +1793,8 @@ theorem sh_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sh hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sh hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1727,7 +1805,8 @@ theorem sw_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sw hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sw hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by
@@ -1738,7 +1817,8 @@ theorem sd_dispatch_static_pins_unconditional
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (ri : riscv2zisk_single_row.Rv64imLoweringInput) (hni : Bool)
     (h1 : ri.rs1.val < 32) (h2 : ri.rs2.val < 32) :
-    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sd hni = ok ctx ∧
+    ∃ ctx, riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        self ri riscv2zisk_single_row.Rv64imSingleRowOpcode.Sd hni = ok ctx ∧
       ∃ zib, ctx.extract_inst = some zib ∧
         zib.i.op = 1#u8 ∧ zib.i.is_external_op = false ∧ zib.i.m32 = false ∧
         zib.i.set_pc = false ∧ zib.i.store_pc = false := by

--- a/ZiskFv/Compliance/RegisterMemBusBalance.lean
+++ b/ZiskFv/Compliance/RegisterMemBusBalance.lean
@@ -309,7 +309,7 @@ def addX1RowTemplate : MainRowWithRom FGL :=
   { core :=
       { a_0 := 0, a_1 := 0, b_0 := 0, b_1 := 0, c_0 := 0, c_1 := 0,
         flag := 0, pc := 0, is_external_op := 1, op := ZiskFv.Trusted.OP_ADD, m32 := 0,
-        ind_width := 8, set_pc := 0, jmp_offset1 := 4, jmp_offset2 := 4,
+        ind_width := 0, set_pc := 0, jmp_offset1 := 4, jmp_offset2 := 4,
         store_pc := 0, im_high_degree_2 := 0, segment_l1 := 1 }
     rom :=
       { a_offset_imm0 := 1, a_imm1 := 0, b_offset_imm0 := 1, b_imm1 := 0,
@@ -335,7 +335,7 @@ def addX1Row : MainRowWithRom FGL := addX1RowWithLast.2
 /-- The ROM row matching `addX1Row`'s decoded selector pins. -/
 def addX1ProgramRow : ZiskRomMessage FGL :=
   { line := 0, a_offset_imm0 := 1, a_imm1 := 0, b_offset_imm0 := 1, b_imm1 := 0,
-    ind_width := 8, op := ZiskFv.Trusted.OP_ADD, store_offset := 1, jmp_offset1 := 4,
+    ind_width := 0, op := ZiskFv.Trusted.OP_ADD, store_offset := 1, jmp_offset1 := 4,
     jmp_offset2 := 4, flags := 57409 }
 
 /-- A one-instruction concrete program for the `add x1,x1,x1` witness. -/

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBinding.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBinding.lean
@@ -1,0 +1,139 @@
+import ZiskFv.Compliance.TraceLevelExport.RomDecodeBindingOps
+import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.Dispatch
+import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.DynamicFields
+import ZiskFv.Compliance.AeneasBridgeTrust.Decode.Leaves
+
+/-!
+# Raw-program binding through the production ZisK lowerer
+
+This module makes the committed ROM message's ADD decode fields **derived** from
+the raw RISC-V instruction word, via the REAL Aeneas transpile pipeline
+(`extract_transpile_rv64im_raw`, `trust/aeneas/ProductionM2.lean`).
+
+Block 1 (`RomDecodeBinding.Decode_add_of_program`) tied the witness row's decode
+columns to the committed program `trace.program`.  This block ties the committed
+program entry to its raw instruction word: the op-agnostic `ProgramBinding`
+certificate states the committed ROM holds exactly the serialized lowering of the
+raw program.  For the ADD case the chain closes — `Decode_add_from_rawProgram`
+rebuilds `Decode_add` from `rawProgram` + `ProgramBinding` + the ADD-branch of the
+(eventual exhaustive) per-entry raw-word split.
+
+Op-AGNOSTIC: `serializeExtract` / `romMessageOfRaw` / `ProgramBinding` run ONE
+pipeline for every word; ADD-ness enters only via the `rawRType … 0x33` raw-word
+hypothesis (the ADD case of an exhaustive split), never as a trust premise.
+
+Sound: NO native_decide / bv_decide / new axiom / `sorry`; kernel-only closure
+(`propext` / `Classical.choice` / `Quot.sound`).  The lowering totality is proven
+with the kernel-sound `System.Platform.numBits` casing (the same register-bound
+lemmas as `…/Extraction/Helpers.lean`), NOT `native_decide` (the production
+RV-completeness harness uses `native_decide`; this in-build pilot does not).
+-/
+
+open Aeneas Aeneas.Std Result zisk_core
+open Goldilocks
+
+namespace ZiskFv.Compliance.RawProgramBinding
+
+open ZiskFv.Channels.ZiskRomBus (ZiskRomMessage)
+open ZiskFv.AirsClean.Main (RomFlagBits packFlags)
+open ZiskFv.Compliance.Decode (toU32)
+
+set_option maxHeartbeats 8000000
+
+/-! ## Op-agnostic serialization of the lowered row into the committed ROM message. -/
+
+/-- Op-agnostic flag-bit extraction from a lowered ZiskInstExtract: the five
+    decode-relevant flags are faithful direct copies of the lowered booleans; the
+    operand-source / store selector bits are the op-agnostic selector decode
+    (operand-side, out of decode scope — not consumed by per-op decode). -/
+def romFlagBitsOfExtract (e : zisk_core.aeneas_extract.ZiskInstExtract) : RomFlagBits where
+  a_src_imm := decide (e.a_src = zisk_core.zisk_inst.SRC_IMM)
+  a_src_mem := decide (e.a_src = zisk_core.zisk_inst.SRC_MEM)
+  is_precompiled := e.is_precompiled
+  b_src_imm := decide (e.b_src = zisk_core.zisk_inst.SRC_IMM)
+  b_src_mem := decide (e.b_src = zisk_core.zisk_inst.SRC_MEM)
+  is_external_op := e.is_external_op
+  store_pc := e.store_pc
+  store_mem := decide (e.store = zisk_core.zisk_inst.STORE_MEM)
+  store_ind := decide (e.store = zisk_core.zisk_inst.STORE_IND)
+  set_pc := e.set_pc
+  m32 := e.m32
+  b_src_ind := decide (e.b_src = zisk_core.zisk_inst.SRC_IND)
+  a_src_reg := decide (e.a_src = zisk_core.zisk_inst.SRC_REG)
+  b_src_reg := decide (e.b_src = zisk_core.zisk_inst.SRC_REG)
+  store_reg := decide (e.store = zisk_core.zisk_inst.STORE_REG)
+
+/-- Interpret a lowered unsigned 64-bit offset as the signed `i64` used by the
+    production ROM emitter, then embed it in the proof field (`rom.rs:226-236`). -/
+def signedOffset (x : Std.U64) : FGL := (x.bv.toInt : FGL)
+
+/-- The production ROM emitter stores stack-immediate selectors only for an
+    immediate source (`rom.rs:240-244`). -/
+def sourceImmediate (src useSp : Std.U64) : FGL :=
+  if src = zisk_core.zisk_inst.SRC_IMM then (useSp.val : FGL) else 0
+
+/-- The three free-input opcodes share CopyB's ROM-table semantics
+    (`rom.rs:252-260`). Production RV64IM lowering does not emit these codes,
+    but the serializer mirrors the generic emitter. -/
+def romOpcode (op : Std.U8) : FGL :=
+  if op.val = 246 ∨ op.val = 247 ∨ op.val = 248 then 1 else (op.val : FGL)
+
+/-- Op-agnostic serialization of a lowered row into the committed FGL ROM message.
+    This is the proof-facing transcription of `rom.rs:204-260`. -/
+def serializeExtract (line : FGL) (e : zisk_core.aeneas_extract.ZiskInstExtract) :
+    ZiskRomMessage FGL where
+  line := line                                                        -- rom.rs:246
+  a_offset_imm0 := signedOffset e.a_offset_imm0                       -- rom.rs:226-230,247
+  a_imm1 := sourceImmediate e.a_src e.a_use_sp_imm1                   -- rom.rs:240-241,248
+  b_offset_imm0 := signedOffset e.b_offset_imm0                       -- rom.rs:232-236,249
+  b_imm1 := sourceImmediate e.b_src e.b_use_sp_imm1                   -- rom.rs:242-244,250
+  ind_width := (e.ind_width.val : FGL)                                -- rom.rs:251
+  op := romOpcode e.op                                                -- rom.rs:252-260
+  store_offset := (e.store_offset.val : FGL)                          -- rom.rs:215-219,261
+  jmp_offset1 := (e.jmp_offset1.val : FGL)                            -- rom.rs:205-209,262
+  jmp_offset2 := (e.jmp_offset2.val : FGL)                            -- rom.rs:210-214,263
+  flags := packFlags (romFlagBitsOfExtract e)                         -- rom.rs:264
+
+/-- Independently named ROM-row transcription used at the program-image boundary.
+    Keeping it separate from `serializeExtract` makes the fidelity equation an
+    explicit checked contract rather than an implicit definitional convention. -/
+def romRowOf (line : FGL) (e : zisk_core.aeneas_extract.ZiskInstExtract) :
+    ZiskRomMessage FGL where
+  line := line
+  a_offset_imm0 := signedOffset e.a_offset_imm0
+  a_imm1 := if e.a_src = zisk_core.zisk_inst.SRC_IMM then (e.a_use_sp_imm1.val : FGL) else 0
+  b_offset_imm0 := signedOffset e.b_offset_imm0
+  b_imm1 := if e.b_src = zisk_core.zisk_inst.SRC_IMM then (e.b_use_sp_imm1.val : FGL) else 0
+  ind_width := (e.ind_width.val : FGL)
+  op := if e.op.val = 246 ∨ e.op.val = 247 ∨ e.op.val = 248 then 1 else (e.op.val : FGL)
+  store_offset := (e.store_offset.val : FGL)
+  jmp_offset1 := (e.jmp_offset1.val : FGL)
+  jmp_offset2 := (e.jmp_offset2.val : FGL)
+  flags := packFlags (romFlagBitsOfExtract e)
+
+theorem romRowOf_eq_serializeExtract (line : FGL)
+    (e : zisk_core.aeneas_extract.ZiskInstExtract) :
+    romRowOf line e = serializeExtract line e := by
+  rfl
+
+/-- The committed ROM message a raw RISC-V word must serialize to: run the REAL
+    Aeneas transpile pipeline on the word and FGL-serialize its lowered row. A
+    raw word the pipeline rejects maps to the all-zero message (never matched by a
+    supported decode). Op-AGNOSTIC: one pipeline for every word. -/
+noncomputable def romMessageOfRaw (line : FGL) (raw : BitVec 32) : ZiskRomMessage FGL :=
+  match zisk_core.aeneas_extract.extract_transpile_rv64im_raw (ZiskFv.Compliance.Decode.toU32 raw) with
+  | .ok ext => romRowOf line ext.row
+  | _ => { line := line, a_offset_imm0 := 0, a_imm1 := 0, b_offset_imm0 := 0,
+           b_imm1 := 0, ind_width := 0, op := 0, store_offset := 0,
+           jmp_offset1 := 0, jmp_offset2 := 0, flags := 0 }
+
+/-- Op-agnostic ROM-image binding (a verifier-attached certificate, NOT an axiom):
+    the committed ROM holds exactly the serialized lowering of the raw program. -/
+def ProgramBinding {n : Nat} (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+    (addr : Fin trace.programLength → FGL)
+    (rawProgram : Fin trace.programLength → BitVec 32) : Prop :=
+  (∀ k k' : Fin trace.programLength, k < k' → (addr k).val < (addr k').val) ∧
+  ∀ k : Fin trace.programLength, trace.program k = romMessageOfRaw (addr k) (rawProgram k)
+
+
+end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingCopyb.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingCopyb.lean
@@ -1,0 +1,426 @@
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingRegister
+
+/-!
+# Raw-program decode bridge — conditional-copyb ops (issue #159, BLOCK 3)
+
+The five RV64IM ops whose dispatcher arm degenerates to `copyb`/`nop` for
+zero-register / zero-immediate inputs, and therefore route to their real
+op-builder ONLY under genuine `≠ 0` side-conditions:
+
+  * **ADD, OR** (register, `rawRType`) — route to `create_register_op_typed`
+    only when the registers are nonzero.  ADD additionally needs the
+    DMA-precompile branch ruled out (`input_precompile = none`, satisfied by
+    `defCtx`).  Side-conditions (matching `add_dispatch_static_pins` /
+    `or_dispatch_static_pins` EXACTLY): ADD `rd ≠ 0 ∧ rs1 ≠ 0 ∧ rs2 ≠ 0`;
+    OR `rs1 ≠ 0 ∧ rs2 ≠ 0`.  The symbolic `i.rd/rs1/rs2 ≠ 0#u32` are derived
+    from the Nat `≠ 0` via the R-type field-recovery lemmas.
+  * **ADDI, XORI, ORI** (immediate, `rawIType`) — route to
+    `immediate_op_or_x0_copyb_typed`, whose op-arm (over copyb) needs
+    `rs1 ≠ 0`.  XORI/ORI route there unconditionally at the dispatcher; ADDI
+    needs `rd ≠ 0 ∧ imm ≠ 0` to reach the builder (matching
+    `addi_dispatch_static_pins` EXACTLY).  `i.rs1 ≠ 0#u32` (and `i.rd ≠ 0#u32`
+    for ADDI) are derived from the Nat `≠ 0` via I-type field recovery; the
+    decoded `i.imm ≠ 0#i32` is the dispatcher's own guard, threaded as a caller
+    hypothesis (it is an operand-column obligation, not derivable from the
+    symbolic word's `imm` Nat alone without signext reasoning).
+
+Sound: NO native_decide / bv_decide / new axiom / `sorry`; kernel-only closure
+(`propext` / `Classical.choice` / `Quot.sound`).
+-/
+
+open Aeneas Aeneas.Std Result zisk_core
+open aeneas_extract.rv64im_decode
+open Goldilocks
+open ZiskFv.Compliance.Extraction
+  (defCtx decode_r_bounds decode_i_bounds bind_eq_ok_imp
+   new_ok src_a_reg_ok src_b_imm_ok op_zisk_ok store_reg_ok j_ok build_ok insert_inst_ok
+   cast_u32_u64_val hcast_u32_i64_val
+   create_register_op_typed_ok register_static_pins_of create_register_op_typed_dynamic_pins
+   immediate_x0_static_pins_of immediate_op_or_x0_copyb_typed_dynamic_pins
+   decode_extract_ok from_inst_ok)
+
+namespace ZiskFv.Compliance.RawProgramBinding
+
+open ZiskFv.Channels.ZiskRomBus (ZiskRomMessage)
+open ZiskFv.AirsClean.Main (RomFlagBits packFlags)
+open ZiskFv.Compliance.Decode (toU32 ofNat32_shift_mask_eq tbf)
+open ZiskFv.Completeness.Rv64imShapes (rawRType rawIType rawOfNat32)
+open aeneas_extract (extract_transpile_rv64im_raw)
+
+set_option maxHeartbeats 4000000
+set_option linter.unusedSimpArgs false
+
+/-! ## 1. Decoder field `.bv` recovery (register slices, op-independent). -/
+
+/-- decode_r is `ok`-total (no signext), so each register field's `.bv` is the
+    masked-shift by `rfl`. -/
+theorem decode_r_fields (raw : Std.U32) (rop : RiscvOpcode) :
+    ∃ d, decode_r raw rop = ok d
+      ∧ d.rd.bv = (raw &&& 3968#u32).bv >>> 7
+      ∧ d.rs1.bv = (raw &&& 1015808#u32).bv >>> 15
+      ∧ d.rs2.bv = (raw &&& 32505856#u32).bv >>> 20 := by
+  refine ⟨_, rfl, ?_, ?_, ?_⟩ <;> rfl
+
+/-- The `i5.bv` (rs1 shift result) extracted via `>>>`-reduction. -/
+private theorem shift15_bv (i5 : Std.U32)
+    (h : ((raw &&& 1015808#u32) >>> 15#i32 : Result Std.U32) = ok i5) :
+    i5.bv = (raw &&& 1015808#u32).bv >>> 15 := by
+  rw [show ((raw &&& 1015808#u32) >>> 15#i32 : Result Std.U32)
+        = ok ⟨(raw &&& 1015808#u32).bv >>> 15⟩ from rfl, Result.ok.injEq] at h
+  rw [← h]
+
+private theorem shift7_bv (i3 : Std.U32)
+    (h : ((raw &&& 3968#u32) >>> 7#i32 : Result Std.U32) = ok i3) :
+    i3.bv = (raw &&& 3968#u32).bv >>> 7 := by
+  rw [show ((raw &&& 3968#u32) >>> 7#i32 : Result Std.U32)
+        = ok ⟨(raw &&& 3968#u32).bv >>> 7⟩ from rfl, Result.ok.injEq] at h
+  rw [← h]
+
+/-- decode_i computes `rd`/`rs1` before the `signext` (which is the only partial
+    step), so peel binds to recover both `.bv`s. -/
+theorem decode_i_rd_rs1_bv (raw : Std.U32) (rop : RiscvOpcode) (sh : Bool) (d : DecodedRv64im)
+    (hd : decode_i raw rop sh = ok d) :
+    d.rd.bv = (raw &&& 3968#u32).bv >>> 7
+      ∧ d.rs1.bv = (raw &&& 1015808#u32).bv >>> 15 := by
+  simp only [decode_i, DecodedRv64im.new, lift, bind_ok, Bind.bind] at hd
+  obtain ⟨i1, _, hd⟩ := bind_eq_ok_imp hd   -- funct3 shift
+  obtain ⟨i3, hi3, hd⟩ := bind_eq_ok_imp hd -- rd shift
+  obtain ⟨i5, hi5, hd⟩ := bind_eq_ok_imp hd -- rs1 shift
+  obtain ⟨i7, _, hd⟩ := bind_eq_ok_imp hd   -- imm-mask shift
+  obtain ⟨i8, _, hd⟩ := bind_eq_ok_imp hd   -- signext
+  cases sh
+  · rw [if_neg (by decide), Result.ok.injEq] at hd; rw [← hd]
+    exact ⟨shift7_bv i3 hi3, shift15_bv i5 hi5⟩
+  · rw [if_pos (by decide)] at hd
+    obtain ⟨i11, _, hd⟩ := bind_eq_ok_imp hd
+    rw [Result.ok.injEq] at hd; rw [← hd]
+    exact ⟨shift7_bv i3 hi3, shift15_bv i5 hi5⟩
+
+/-! ## 2. Symbolic-word field recovery (mask-shift selects the register Nat). -/
+
+private theorem and_shr_reorder (x : BitVec 32) (k : Nat) (hk : k + 5 ≤ 32) :
+    (x &&& BitVec.ofNat 32 (31 <<< k)) >>> k = (x >>> k) &&& 31#32 := by
+  apply BitVec.eq_of_getLsbD_eq; intro i
+  simp only [BitVec.getLsbD_ushiftRight, BitVec.getLsbD_and, BitVec.getLsbD_ofNat,
+    Nat.testBit_shiftLeft]
+  rcases Nat.lt_or_ge (i : Nat) 5 with h5 | h5
+  · rw [decide_eq_true (show k + (i : Nat) < 32 by omega), decide_eq_true (show (i : Nat) < 32 by omega)]
+    simp [show k ≤ k + (i : Nat) by omega, show k + (i : Nat) - k = (i : Nat) by omega]
+  · rw [tbf (show (31 : Nat) < 2 ^ 5 by norm_num) (show 5 ≤ k + (i : Nat) - k by omega),
+      tbf (show (31 : Nat) < 2 ^ 5 by norm_num) (show 5 ≤ (i : Nat) by omega)]
+    simp
+
+private theorem and3968_shr7 (x : BitVec 32) : (x &&& 3968#32) >>> 7 = (x >>> 7) &&& 31#32 := by
+  have := and_shr_reorder x 7 (by norm_num); simpa using this
+
+private theorem and1015808_shr15 (x : BitVec 32) : (x &&& 1015808#32) >>> 15 = (x >>> 15) &&& 31#32 := by
+  have := and_shr_reorder x 15 (by norm_num); simpa using this
+
+private theorem and32505856_shr20 (x : BitVec 32) : (x &&& 32505856#32) >>> 20 = (x >>> 20) &&& 31#32 := by
+  have := and_shr_reorder x 20 (by norm_num); simpa using this
+
+theorem rawRType_rd (funct7 rs2 rs1 funct3 rd opcode : Nat) (hrd : rd < 32)
+    (hf3 : funct3 < 8) (hop : opcode < 128) :
+    ((rawRType funct7 rs2 rs1 funct3 rd opcode) &&& 3968#32) >>> 7 = BitVec.ofNat 32 rd := by
+  rw [and3968_shr7]
+  simp only [rawRType, rawOfNat32]
+  refine ofNat32_shift_mask_eq _ 7 5 rd hrd (by norm_num) ?_
+  intro i hi
+  simp only [Nat.testBit_or, Nat.testBit_shiftLeft]
+  have e25 : ¬ (25 ≤ 7 + i) := by omega
+  have e20 : ¬ (20 ≤ 7 + i) := by omega
+  have e15 : ¬ (15 ≤ 7 + i) := by omega
+  have e12 : ¬ (12 ≤ 7 + i) := by omega
+  have e7 : (7 ≤ 7 + i) := by omega
+  have hop' : opcode.testBit (7 + i) = false := tbf (show opcode < 2 ^ 7 by omega) (by omega)
+  simp [e25, e20, e15, e12, e7, hop', show 7 + i - 7 = i from by omega]
+
+theorem rawRType_rs1 (funct7 rs2 rs1 funct3 rd opcode : Nat) (hrs1 : rs1 < 32)
+    (hf3 : funct3 < 8) (hrd : rd < 32) (hop : opcode < 128) :
+    ((rawRType funct7 rs2 rs1 funct3 rd opcode) &&& 1015808#32) >>> 15 = BitVec.ofNat 32 rs1 := by
+  rw [and1015808_shr15]
+  simp only [rawRType, rawOfNat32]
+  refine ofNat32_shift_mask_eq _ 15 5 rs1 hrs1 (by norm_num) ?_
+  intro i hi
+  simp only [Nat.testBit_or, Nat.testBit_shiftLeft]
+  have e25 : ¬ (25 ≤ 15 + i) := by omega
+  have e20 : ¬ (20 ≤ 15 + i) := by omega
+  have e15 : (15 ≤ 15 + i) := by omega
+  have e12 : (12 ≤ 15 + i) := by omega
+  have e7 : (7 ≤ 15 + i) := by omega
+  have hf3' : funct3.testBit (15 + i - 12) = false := tbf (show funct3 < 2 ^ 3 by omega) (by omega)
+  have hrd' : rd.testBit (15 + i - 7) = false := tbf (show rd < 2 ^ 5 by omega) (by omega)
+  have hop' : opcode.testBit (15 + i) = false := tbf (show opcode < 2 ^ 7 by omega) (by omega)
+  simp [e25, e20, e15, e12, e7, hf3', hrd', hop', show 15 + i - 15 = i from by omega]
+
+theorem rawRType_rs2 (funct7 rs2 rs1 funct3 rd opcode : Nat) (hrs2 : rs2 < 32) (hrs1 : rs1 < 32)
+    (hf3 : funct3 < 8) (hrd : rd < 32) (hop : opcode < 128) :
+    ((rawRType funct7 rs2 rs1 funct3 rd opcode) &&& 32505856#32) >>> 20 = BitVec.ofNat 32 rs2 := by
+  rw [and32505856_shr20]
+  simp only [rawRType, rawOfNat32]
+  refine ofNat32_shift_mask_eq _ 20 5 rs2 hrs2 (by norm_num) ?_
+  intro i hi
+  simp only [Nat.testBit_or, Nat.testBit_shiftLeft]
+  have e25 : ¬ (25 ≤ 20 + i) := by omega
+  have e20 : (20 ≤ 20 + i) := by omega
+  have e15 : (15 ≤ 20 + i) := by omega
+  have e12 : (12 ≤ 20 + i) := by omega
+  have e7 : (7 ≤ 20 + i) := by omega
+  have hrs1' : rs1.testBit (20 + i - 15) = false := tbf (show rs1 < 2 ^ 5 by omega) (by omega)
+  have hf3' : funct3.testBit (20 + i - 12) = false := tbf (show funct3 < 2 ^ 3 by omega) (by omega)
+  have hrd' : rd.testBit (20 + i - 7) = false := tbf (show rd < 2 ^ 5 by omega) (by omega)
+  have hop' : opcode.testBit (20 + i) = false := tbf (show opcode < 2 ^ 7 by omega) (by omega)
+  simp [e25, e20, e15, e12, e7, hrs1', hf3', hrd', hop', show 20 + i - 20 = i from by omega]
+
+theorem rawIType_rd' (imm rs1 funct3 rd opcode : Nat) (hrd : rd < 32)
+    (hf3 : funct3 < 8) (hop : opcode < 128) :
+    ((rawIType imm rs1 funct3 rd opcode) &&& 3968#32) >>> 7 = BitVec.ofNat 32 rd := by
+  rw [and3968_shr7]
+  simp only [rawIType, rawOfNat32]
+  refine ofNat32_shift_mask_eq _ 7 5 rd hrd (by norm_num) ?_
+  intro i hi
+  simp only [Nat.testBit_or, Nat.testBit_shiftLeft]
+  have e20 : ¬ (20 ≤ 7 + i) := by omega
+  have e15 : ¬ (15 ≤ 7 + i) := by omega
+  have e12 : ¬ (12 ≤ 7 + i) := by omega
+  have e7 : (7 ≤ 7 + i) := by omega
+  have hop' : opcode.testBit (7 + i) = false := tbf (show opcode < 2 ^ 7 by omega) (by omega)
+  simp [e20, e15, e12, e7, hop', show 7 + i - 7 = i from by omega]
+
+theorem rawIType_rs1 (imm rs1 funct3 rd opcode : Nat) (hrs1 : rs1 < 32)
+    (hf3 : funct3 < 8) (hrd : rd < 32) (hop : opcode < 128) :
+    ((rawIType imm rs1 funct3 rd opcode) &&& 1015808#32) >>> 15 = BitVec.ofNat 32 rs1 := by
+  rw [and1015808_shr15]
+  simp only [rawIType, rawOfNat32]
+  refine ofNat32_shift_mask_eq _ 15 5 rs1 hrs1 (by norm_num) ?_
+  intro i hi
+  simp only [Nat.testBit_or, Nat.testBit_shiftLeft]
+  have e20 : ¬ (20 ≤ 15 + i) := by omega
+  have e15 : (15 ≤ 15 + i) := by omega
+  have e12 : (12 ≤ 15 + i) := by omega
+  have e7 : (7 ≤ 15 + i) := by omega
+  have hf3' : funct3.testBit (15 + i - 12) = false := tbf (show funct3 < 2 ^ 3 by omega) (by omega)
+  have hrd' : rd.testBit (15 + i - 7) = false := tbf (show rd < 2 ^ 5 by omega) (by omega)
+  have hop' : opcode.testBit (15 + i) = false := tbf (show opcode < 2 ^ 7 by omega) (by omega)
+  simp [e20, e15, e12, e7, hf3', hrd', hop', show 15 + i - 15 = i from by omega]
+
+/-- From `x.bv = ofNat32 v`, a nonzero `v < 32` makes `x` nonzero. -/
+private theorem u32_ne_zero_of_bv (x : Std.U32) (v : Nat) (hv : v < 32) (hv0 : v ≠ 0)
+    (hbv : x.bv = BitVec.ofNat 32 v) : x ≠ 0#u32 := by
+  intro hc; rw [hc] at hbv
+  have : (0 : Nat) = v % 2 ^ 32 := by
+    have := congrArg BitVec.toNat hbv; simpa [BitVec.toNat_ofNat] using this
+  omega
+
+/-! ## 3. Totality for the `immediate_op_or_x0_copyb_typed` builder. -/
+
+/-- `immediate_op_or_x0_copyb_typed` is total for in-range register fields
+    (`rs1 < 32`, `rd < 32`).  Its only extra step over `immediate_op_typed` is
+    an `if i.rs1 = 0` choice of `op_zisk` operand; both arms are total. -/
+theorem immediate_op_or_x0_copyb_typed_ok
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp) (inst_size : Std.U64)
+    (h1 : i.rs1.val < 32) (h3 : i.rd.val < 32) :
+    ∃ ctx, riscv2zisk_context.Riscv2ZiskContext.immediate_op_or_x0_copyb_typed self i op inst_size = ok ctx := by
+  obtain ⟨z0, hz0⟩ := new_ok i
+  obtain ⟨z1, hz1⟩ := src_a_reg_ok z0 (UScalar.cast UScalarTy.U64 i.rs1) false (by rw [cast_u32_u64_val]; exact h1)
+  obtain ⟨z2, hz2⟩ := src_b_imm_ok z1 (IScalar.hcast UScalarTy.U64 i.imm)
+  obtain ⟨z3, hz3⟩ : ∃ z3, (if i.rs1 = 0#u32
+      then zisk_inst_builder.ZiskInstBuilder.op_zisk z2 zisk_ops.ZiskOp.CopyB
+      else zisk_inst_builder.ZiskInstBuilder.op_zisk z2 op) = ok z3 := by
+    split
+    · exact op_zisk_ok z2 _
+    · exact op_zisk_ok z2 _
+  obtain ⟨z4, hz4⟩ := store_reg_ok z3 (UScalar.hcast IScalarTy.I64 i.rd) false false
+    (by rw [hcast_u32_i64_val]; exact_mod_cast Nat.zero_le _)
+    (by rw [hcast_u32_i64_val]; exact_mod_cast h3)
+  obtain ⟨z5, hz5⟩ := j_ok z4 (UScalar.hcast IScalarTy.I64 inst_size) (UScalar.hcast IScalarTy.I64 inst_size)
+  obtain ⟨z6, hz6⟩ := build_ok z5
+  obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z6
+  refine ⟨{ s1 with extract_marker := () }, ?_⟩
+  rw [riscv2zisk_context.Riscv2ZiskContext.immediate_op_or_x0_copyb_typed]
+  simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hz5, hz6, hs1]
+
+/-! ## 4. Generic conditional transpile reductions. -/
+
+private theorem hcast4 : (UScalar.hcast IScalarTy.I64 4#u64 : Std.I64).val = (4 : Int) := by decide
+
+/-- Conditional register-op transpile.  `S` is the exact self-record the
+    dispatcher passes to `create_register_op_typed`; `P` the routing
+    side-condition (derived from the decoded fields via `hP`). -/
+theorem transpile_register_cond_of
+    (raw : Std.U32) (rop : RiscvOpcode) (srop : riscv2zisk_single_row.Rv64imSingleRowOpcode)
+    (zop : zisk_ops.ZiskOp) (opc : Std.U8) (m32v : Bool) (otv : zisk_ops.OpType)
+    (S : riscv2zisk_context.Riscv2ZiskContext)
+    (P : riscv2zisk_single_row.Rv64imLoweringInput → Prop)
+    (hdec : aeneas_extract.rv64im_decode.decode_32_core raw = aeneas_extract.rv64im_decode.decode_r raw rop)
+    (hlowop : aeneas_extract.lowering_opcode rop = ok (some srop))
+    (harm : ∀ (input : riscv2zisk_single_row.Rv64imLoweringInput), P input →
+        riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input srop false
+          = (do let s ← riscv2zisk_context.Riscv2ZiskContext.create_register_op_typed S input zop 4#u64
+                ok { s with extract_marker := () }))
+    (hP : ∀ d, aeneas_extract.rv64im_decode.decode_r raw rop = ok d →
+        P { rom_address := 0#u64, rd := d.rd, rs1 := d.rs1, rs2 := d.rs2, imm := d.imm })
+    (hcode : zisk_ops.ZiskOp.code zop = ok opc) (hm32 : zisk_ops.ZiskOp.is_m32 zop = ok m32v)
+    (hot : zisk_ops.ZiskOp.op_type zop = ok otv)
+    (hint : otv ≠ zisk_ops.OpType.Internal) (hfc : otv ≠ zisk_ops.OpType.Fcall) :
+    ∃ ext, extract_transpile_rv64im_raw raw = ok ext
+      ∧ ext.row.op = opc ∧ ext.row.is_external_op = true ∧ ext.row.m32 = m32v
+      ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+      ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+  obtain ⟨decoded, hdecoded, hopd, hrdb, hrs1b, hrs2b⟩ := decode_r_bounds raw rop
+  have hdec0 : aeneas_extract.rv64im_decode.decode_32_core raw = ok decoded := hdec.trans hdecoded
+  set input : riscv2zisk_single_row.Rv64imLoweringInput :=
+    { rom_address := 0#u64, rd := decoded.rd, rs1 := decoded.rs1, rs2 := decoded.rs2, imm := decoded.imm }
+    with hinput
+  have hPin : P input := by rw [hinput]; exact hP decoded hdecoded
+  obtain ⟨ctx0, hctx0⟩ := create_register_op_typed_ok S input zop 4#u64
+    (by rw [hinput]; exact hrs1b) (by rw [hinput]; exact hrs2b) (by rw [hinput]; exact hrdb)
+  obtain ⟨zib, hzib, hop2, hext2, hm322, hsp2, hstp2⟩ :=
+    register_static_pins_of S input zop 4#u64 ctx0 opc m32v otv hcode hm32 hot hint hfc hctx0
+  obtain ⟨zib', hzib', hj1, hj2⟩ :=
+    create_register_op_typed_dynamic_pins S input zop 4#u64 ctx0 hctx0
+  have hzz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
+  rw [hzz] at hj1 hj2
+  obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
+  obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, _⟩ := from_inst_ok zib.i
+  have hlower : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input srop false
+      = ok { ctx0 with extract_marker := () } := by rw [harm input hPin, hctx0]; rfl
+  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
+    simp only [bind_ok, Bind.bind, hdext, hopd, hlowop]
+    simp only [defCtx] at hlower
+    simp only [riscv2zisk_single_row.Rv64imLoweringInput.new, bind_ok, ← hinput,
+      hlower, hzib, core.option.Option.unwrap, Result.ofOption, hrow]
+  · show row.op = opc; rw [hrop]; exact hop2
+  · show row.is_external_op = true; rw [hrext]; exact hext2
+  · show row.m32 = m32v; rw [hrm32]; exact hm322
+  · show row.set_pc = false; rw [hrsp]; exact hsp2
+  · show row.store_pc = false; rw [hrstp]; exact hstp2
+  · show row.jmp_offset1 = _; rw [hrj1]; exact hj1
+  · show row.jmp_offset2 = _; rw [hrj2]; exact hj2
+
+/-- Conditional immediate-op transpile through the `immediate_op_or_x0_copyb_typed`
+    builder. -/
+theorem transpile_immediate_copyb_of
+    (raw : Std.U32) (rop : RiscvOpcode) (sh : Bool)
+    (srop : riscv2zisk_single_row.Rv64imSingleRowOpcode)
+    (zop : zisk_ops.ZiskOp) (opc : Std.U8) (m32v : Bool) (otv : zisk_ops.OpType)
+    (S : riscv2zisk_context.Riscv2ZiskContext)
+    (P : riscv2zisk_single_row.Rv64imLoweringInput → Prop)
+    (hdec : aeneas_extract.rv64im_decode.decode_32_core raw
+      = aeneas_extract.rv64im_decode.decode_i raw rop sh)
+    (hlowop : aeneas_extract.lowering_opcode rop = ok (some srop))
+    (harm : ∀ (input : riscv2zisk_single_row.Rv64imLoweringInput), P input →
+        riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input srop false
+          = (do let s ← riscv2zisk_context.Riscv2ZiskContext.immediate_op_or_x0_copyb_typed S input zop 4#u64
+                ok { s with extract_marker := () }))
+    (hP : ∀ d, aeneas_extract.rv64im_decode.decode_i raw rop sh = ok d →
+        P { rom_address := 0#u64, rd := d.rd, rs1 := d.rs1, rs2 := d.rs2, imm := d.imm })
+    (hrs1ne : ∀ input, P input → input.rs1 ≠ 0#u32)
+    (hcode : zisk_ops.ZiskOp.code zop = ok opc) (hm32 : zisk_ops.ZiskOp.is_m32 zop = ok m32v)
+    (hot : zisk_ops.ZiskOp.op_type zop = ok otv)
+    (hint : otv ≠ zisk_ops.OpType.Internal) (hfc : otv ≠ zisk_ops.OpType.Fcall) :
+    ∃ ext, extract_transpile_rv64im_raw raw = ok ext
+      ∧ ext.row.op = opc ∧ ext.row.is_external_op = true ∧ ext.row.m32 = m32v
+      ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+      ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+  obtain ⟨decoded, hdecoded, hopd, hrdb, hrs1b, _⟩ := decode_i_bounds raw rop sh
+  have hdec0 : aeneas_extract.rv64im_decode.decode_32_core raw = ok decoded := hdec.trans hdecoded
+  set input : riscv2zisk_single_row.Rv64imLoweringInput :=
+    { rom_address := 0#u64, rd := decoded.rd, rs1 := decoded.rs1, rs2 := decoded.rs2, imm := decoded.imm }
+    with hinput
+  have hPin : P input := by rw [hinput]; exact hP decoded hdecoded
+  have hrs1in : input.rs1 ≠ 0#u32 := hrs1ne input hPin
+  obtain ⟨ctx0, hctx0⟩ := immediate_op_or_x0_copyb_typed_ok S input zop 4#u64
+    (by rw [hinput]; exact hrs1b) (by rw [hinput]; exact hrdb)
+  obtain ⟨zib, hzib, hop2, hext2, hm322, hsp2, hstp2⟩ :=
+    immediate_x0_static_pins_of S input zop 4#u64 ctx0 opc m32v otv hrs1in hcode hm32 hot hint hfc hctx0
+  obtain ⟨zib', hzib', hj1, hj2⟩ :=
+    immediate_op_or_x0_copyb_typed_dynamic_pins S input zop 4#u64 ctx0 hctx0
+  have hzz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
+  rw [hzz] at hj1 hj2
+  obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
+  obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, _⟩ := from_inst_ok zib.i
+  have hlower : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input srop false
+      = ok { ctx0 with extract_marker := () } := by rw [harm input hPin, hctx0]; rfl
+  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
+    simp only [bind_ok, Bind.bind, hdext, hopd, hlowop]
+    simp only [defCtx] at hlower
+    simp only [riscv2zisk_single_row.Rv64imLoweringInput.new, bind_ok, ← hinput,
+      hlower, hzib, core.option.Option.unwrap, Result.ofOption, hrow]
+  · show row.op = opc; rw [hrop]; exact hop2
+  · show row.is_external_op = true; rw [hrext]; exact hext2
+  · show row.m32 = m32v; rw [hrm32]; exact hm322
+  · show row.set_pc = false; rw [hrsp]; exact hsp2
+  · show row.store_pc = false; rw [hrstp]; exact hstp2
+  · show row.jmp_offset1 = _; rw [hrj1]; exact hj1
+  · show row.jmp_offset2 = _; rw [hrj2]; exact hj2
+
+/-! ## 5. ADD (register, `rd ≠ 0 ∧ rs1 ≠ 0 ∧ rs2 ≠ 0`). -/
+
+open ZiskFv.Trusted (OP_ADD OP_OR OP_XOR)
+
+theorem transpile_add (rd rs1 rs2 : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs2 : rs2 < 32)
+    (hrd0 : rd ≠ 0) (hrs10 : rs1 ≠ 0) (hrs20 : rs2 ≠ 0) :
+    ∃ ext, extract_transpile_rv64im_raw (toU32 (rawRType 0 rs2 rs1 0 rd 0x33)) = ok ext
+      ∧ ext.row.op = 10#u8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
+      ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+      ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+  refine transpile_register_cond_of _ RiscvOpcode.Add
+    riscv2zisk_single_row.Rv64imSingleRowOpcode.Add zisk_ops.ZiskOp.Add 10#u8 false zisk_ops.OpType.Binary
+    { defCtx with extract_marker := (), input_precompile := none }
+    (fun input => input.rd ≠ 0#u32 ∧ input.rs1 ≠ 0#u32 ∧ input.rs2 ≠ 0#u32)
+    ?_ rfl ?_ ?_ rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
+  · simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
+      ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
+      ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_shr25,
+      ZiskFv.Compliance.Decode.rawRType_opcode 0 rs2 rs1 0 rd 0x33 (by norm_num),
+      ZiskFv.Compliance.Decode.rawRType_funct3 0 rs2 rs1 0 rd 0x33 (by norm_num) hrd (by norm_num),
+      ZiskFv.Compliance.Decode.rawRType_funct7 0 rs2 rs1 0 rd 0x33 (by norm_num) hrs2 hrs1
+        (by norm_num) hrd (by norm_num)]
+    rfl
+  · intro input hP
+    obtain ⟨hrd', hrs1', hrs2'⟩ := hP
+    have hprec : defCtx.input_precompile = none := rfl
+    simp only [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input,
+      hprec, riscv2zisk_single_row.CSR_DMA_MEMCMP_ADDR, Bind.bind, bind_ok]
+    simp [ne_eq, hrd', hrs1', hrs2',
+      show ((0#u32 : Std.U32) = 2068#u32) = False from by decide]
+  · intro d hd
+    obtain ⟨d', hd', hrdbv, hrs1bv, hrs2bv⟩ := decode_r_fields (toU32 (rawRType 0 rs2 rs1 0 rd 0x33)) RiscvOpcode.Add
+    have hdd : d = d' := Result.ok.inj (hd.symm.trans hd'); subst hdd
+    exact ⟨u32_ne_zero_of_bv d.rd rd hrd hrd0
+            (by rw [hrdbv]; exact rawRType_rd 0 rs2 rs1 0 rd 0x33 hrd (by norm_num) (by norm_num)),
+          u32_ne_zero_of_bv d.rs1 rs1 hrs1 hrs10
+            (by rw [hrs1bv]; exact rawRType_rs1 0 rs2 rs1 0 rd 0x33 hrs1 (by norm_num) hrd (by norm_num)),
+          u32_ne_zero_of_bv d.rs2 rs2 hrs2 hrs20
+            (by rw [hrs2bv]; exact rawRType_rs2 0 rs2 rs1 0 rd 0x33 hrs2 hrs1 (by norm_num) hrd (by norm_num))⟩
+
+theorem add_decode_fields_of_binding (rd rs1 rs2 : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs2 : rs2 < 32)
+    (hrd0 : rd ≠ 0) (hrs10 : rs1 ≠ 0) (hrs20 : rs2 ≠ 0)
+    (line : FGL) (msg : ZiskRomMessage FGL)
+    (hbind : msg = romMessageOfRaw line (rawRType 0 rs2 rs1 0 rd 0x33)) :
+    msg.op = OP_ADD ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+      ∧ ∃ ext, extract_transpile_rv64im_raw (toU32 (rawRType 0 rs2 rs1 0 rd 0x33)) = ok ext
+          ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
+          ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ :=
+    transpile_add rd rs1 rs2 hrd hrs1 hrs2 hrd0 hrs10 hrs20
+  obtain ⟨ho, hjo1, hjo2, hf⟩ :=
+    register_decode_fields_of_binding line msg _ 10#u8 OP_ADD ext
+      (by simp [romOpcode, OP_ADD]) hok hop hj1 hj2 hbind
+  exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
+
+
+section AxiomAudit
+#print axioms transpile_add
+#print axioms add_decode_fields_of_binding
+end AxiomAudit
+
+end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingImmediate.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingImmediate.lean
@@ -1,0 +1,376 @@
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingRegister
+
+/-!
+# Raw-program decode bridge — immediate-ALU / shift family (issue #159, BLOCK 3)
+
+Mirrors the register-register bridge (`RawProgramBindingRegister`) for the plain
+immediate-ALU and shift-immediate opcodes, with the raw word's `rd`/`rs1`/`imm`
+(resp. `shamt`) SYMBOLIC.  The canonical builder is `immediate_op_typed`, whose
+second operand is the unconditionally-total `src_b_imm`, so totality needs only
+`rd < 32 ∧ rs1 < 32` (no rs2, no `≠ 0`).  For each op `<op>`:
+
+  * `transpile_<op>` — the REAL Aeneas pipeline `extract_transpile_rv64im_raw` on
+    the symbolic I-type / shift word reduces to the op's decode-field pins.
+    Decode classification reuses #164's `rawIType_{opcode,funct3}` (and, for shifts,
+    `rawIType_funct6_*` / `rawIType_funct7_*`) masks; lowering TOTALITY reuses
+    `Extraction.immediate_op_typed_ok` + `Extraction.decode_i_bounds` (#159 block-3
+    `Totality.lean`); the field pins reuse #111 `immediate_static_pins_of` +
+    block-2 `immediate_op_typed_dynamic_pins`.
+  * `<op>_decode_fields_of_binding` — the committed message's decode fields,
+    derived from its raw word + the op-agnostic `romMessageOfRaw` binding (the
+    generic `register_decode_fields_of_binding` is reused verbatim — it is op-shape
+    agnostic).
+  * `Decode_<op>_from_rawProgram` — rebuilds block-1's `Decode_<op>` from
+    `rawProgram` + `ProgramBinding` + the `<op>`-shaped raw-word hypothesis +
+    `h_idx`, with NO per-op decode premise.
+
+Sound: NO native_decide / bv_decide / new axiom / `sorry`; kernel-only closure
+(`propext` / `Classical.choice` / `Quot.sound`).
+-/
+
+open Aeneas Aeneas.Std Result zisk_core
+open aeneas_extract.rv64im_decode
+open Goldilocks
+open ZiskFv.Compliance.Extraction
+  (defCtx decode_i_bounds immediate_op_typed_ok decode_extract_ok from_inst_ok)
+
+namespace ZiskFv.Compliance.RawProgramBinding
+
+open ZiskFv.Channels.ZiskRomBus (ZiskRomMessage)
+open ZiskFv.AirsClean.Main (RomFlagBits packFlags)
+open ZiskFv.Compliance.Decode (toU32)
+open aeneas_extract (extract_transpile_rv64im_raw)
+
+set_option maxHeartbeats 4000000
+set_option linter.unusedSimpArgs false
+
+/-- Bit-reorder: `(x &&& 3968) >>> 7 = (x >>> 7) &&& 31` (the [7,11] field, mask
+    `3968 = 31 <<< 7`).  Lets us reuse the `>>>`-then-`&&&` extraction primitive. -/
+private theorem and3968_shr7 (x : BitVec 32) :
+    (x &&& 3968#32) >>> 7 = (x >>> 7) &&& 31#32 := by
+  apply BitVec.eq_of_getLsbD_eq
+  intro i
+  simp only [BitVec.getLsbD_ushiftRight, BitVec.getLsbD_and, BitVec.getLsbD_ofNat,
+    show (3968:Nat) = 31 <<< 7 by decide, Nat.testBit_shiftLeft]
+  rcases Nat.lt_or_ge i 5 with h5 | h5
+  · rw [decide_eq_true (show 7 + i < 32 by omega), decide_eq_true (show i < 32 by omega)]
+    simp [show (7 : Nat) ≤ 7 + i by omega, show 7 + i - 7 = i by omega]
+  · rw [ZiskFv.Compliance.Decode.tbf (show (31:Nat) < 2 ^ 5 by norm_num) (show 5 ≤ 7 + i - 7 by omega),
+      ZiskFv.Compliance.Decode.tbf (show (31:Nat) < 2 ^ 5 by norm_num) (show 5 ≤ i by omega)]
+    simp
+
+/-- The decoder's `rd` field (`inst &&& 3968 >>> 7`, bits [7,11]) of an `rawIType`
+    word recovers `rd` for `rd < 32`. -/
+private theorem rawIType_rd (imm rs1 funct3 rd opcode : Nat) (hrd : rd < 32)
+    (hf3 : funct3 < 8) (hop : opcode < 128) :
+    ((ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 funct3 rd opcode) &&& 3968#32) >>> 7
+      = BitVec.ofNat 32 rd := by
+  rw [and3968_shr7]
+  simp only [ZiskFv.Completeness.Rv64imShapes.rawIType, ZiskFv.Completeness.Rv64imShapes.rawOfNat32]
+  refine ZiskFv.Compliance.Decode.ofNat32_shift_mask_eq _ 7 5 rd hrd (by norm_num) ?_
+  intro i hi
+  simp only [Nat.testBit_or, Nat.testBit_shiftLeft]
+  have e20 : ¬ (20 ≤ 7 + i) := by omega
+  have e15 : ¬ (15 ≤ 7 + i) := by omega
+  have e12 : ¬ (12 ≤ 7 + i) := by omega
+  have e7 : (7 ≤ 7 + i) := by omega
+  have hop' : opcode.testBit (7 + i) = false :=
+    ZiskFv.Compliance.Decode.tbf (show opcode < 2 ^ 7 by omega) (by omega)
+  simp [e20, e15, e12, e7, hop', show 7 + i - 7 = i from by omega]
+
+/-- The REAL transpile pipeline on an immediate-op raw word `raw` reduces to the
+    op's decode-field pins, given: the decode classifies to `decode_i raw rop sh`;
+    `rop` lowers to the single-row opcode `srop`; the dispatcher routes `srop` to
+    `immediate_op_typed … zop 4` (under the side-condition `P` on the lowering
+    input — `True` for the unconditional immediates, `rd ≠ 0` for ADDIW); and the
+    static op-type facts (`code`/`is_m32`/`op_type`, external). -/
+theorem transpile_immediate_of
+    (raw : Std.U32) (rop : RiscvOpcode) (sh : Bool)
+    (srop : riscv2zisk_single_row.Rv64imSingleRowOpcode)
+    (zop : zisk_ops.ZiskOp) (opc : Std.U8) (m32v : Bool) (otv : zisk_ops.OpType)
+    (P : riscv2zisk_single_row.Rv64imLoweringInput → Prop)
+    (hdec : aeneas_extract.rv64im_decode.decode_32_core raw
+      = aeneas_extract.rv64im_decode.decode_i raw rop sh)
+    (hlowop : aeneas_extract.lowering_opcode rop = ok (some srop))
+    (harm : ∀ (self : riscv2zisk_context.Riscv2ZiskContext)
+        (input : riscv2zisk_single_row.Rv64imLoweringInput), P input →
+        riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self input srop false
+          = (do let s ← riscv2zisk_context.Riscv2ZiskContext.immediate_op_typed
+                  { self with extract_marker := () } input zop 4#u64
+                ok { s with extract_marker := () }))
+    (hP : ∀ d : aeneas_extract.rv64im_decode.DecodedRv64im,
+        aeneas_extract.rv64im_decode.decode_i raw rop sh = ok d →
+        P { rom_address := 0#u64, rd := d.rd, rs1 := d.rs1, rs2 := d.rs2, imm := d.imm })
+    (hcode : zisk_ops.ZiskOp.code zop = ok opc) (hm32 : zisk_ops.ZiskOp.is_m32 zop = ok m32v)
+    (hot : zisk_ops.ZiskOp.op_type zop = ok otv)
+    (hint : otv ≠ zisk_ops.OpType.Internal) (hfc : otv ≠ zisk_ops.OpType.Fcall) :
+    ∃ ext, extract_transpile_rv64im_raw raw = ok ext
+      ∧ ext.row.op = opc ∧ ext.row.is_external_op = true ∧ ext.row.m32 = m32v
+      ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+      ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+  obtain ⟨decoded, hdecoded, hopd, hrdb, hrs1b, _⟩ := decode_i_bounds raw rop sh
+  have hdec0 : aeneas_extract.rv64im_decode.decode_32_core raw = ok decoded := hdec.trans hdecoded
+  set input : riscv2zisk_single_row.Rv64imLoweringInput :=
+    { rom_address := 0#u64, rd := decoded.rd, rs1 := decoded.rs1, rs2 := decoded.rs2, imm := decoded.imm }
+    with hinput
+  have hPin : P input := hP decoded hdecoded
+  obtain ⟨ctx0, hctx0⟩ := immediate_op_typed_ok { defCtx with extract_marker := () } input zop 4#u64
+    (by rw [hinput]; exact hrs1b) (by rw [hinput]; exact hrdb)
+  obtain ⟨zib, hzib, hop2, hext2, hm322, hsp2, hstp2⟩ :=
+    ZiskFv.Compliance.Extraction.immediate_static_pins_of { defCtx with extract_marker := () }
+      input zop 4#u64 ctx0 opc m32v otv hcode hm32 hot hint hfc hctx0
+  obtain ⟨zib', hzib', hj1, hj2⟩ :=
+    ZiskFv.Compliance.Extraction.immediate_op_typed_dynamic_pins
+      { defCtx with extract_marker := () } input zop 4#u64 ctx0 hctx0
+  have hzz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
+  rw [hzz] at hj1 hj2
+  obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
+  obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, _⟩ := from_inst_ok zib.i
+  have hlower : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input srop false
+      = ok { ctx0 with extract_marker := () } := by rw [harm defCtx input hPin, hctx0]; rfl
+  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
+    simp only [bind_ok, Bind.bind, hdext, hopd, hlowop]
+    simp only [defCtx] at hlower
+    simp only [riscv2zisk_single_row.Rv64imLoweringInput.new, bind_ok, ← hinput,
+      hlower, hzib, core.option.Option.unwrap, Result.ofOption, hrow]
+  · show row.op = opc; rw [hrop]; exact hop2
+  · show row.is_external_op = true; rw [hrext]; exact hext2
+  · show row.m32 = m32v; rw [hrm32]; exact hm322
+  · show row.set_pc = false; rw [hrsp]; exact hsp2
+  · show row.store_pc = false; rw [hrstp]; exact hstp2
+  · show row.jmp_offset1 = _; rw [hrj1]; exact hj1
+  · show row.jmp_offset2 = _; rw [hrj2]; exact hj2
+
+/-! ## Per-op macro (non-shift I-type): emits `transpile_<op>` +
+    `<op>_decode_fields_of_binding` + `Decode_<op>_from_rawProgram`. -/
+
+local macro "imm_op" nm:ident "," f3:term "," opw:term ","
+    rop:term "," srop:term "," zop:term "," opU8:term "," m32:term "," ot:term ","
+    opc:ident : command => do
+  let s := nm.getId.toString
+  let tName := Lean.mkIdent (Lean.Name.mkSimple ("transpile_" ++ s))
+  let dfName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
+  let t1 ← `(theorem $tName (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) :
+        ∃ ext, extract_transpile_rv64im_raw
+            (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 $f3 rd $opw)) = ok ext
+          ∧ ext.row.op = $opU8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
+          ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      refine transpile_immediate_of _ $rop false $srop $zop $opU8 $m32 $ot (fun _ => True) ?_ rfl
+        (by intro self input _; rfl) (fun _ _ => trivial)
+        rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
+      simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
+        ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
+        ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_ofNat,
+        ZiskFv.Compliance.Decode.rawIType_opcode imm rs1 $f3 rd $opw (by norm_num),
+        ZiskFv.Compliance.Decode.rawIType_funct3 imm rs1 $f3 rd $opw (by norm_num) hrd (by norm_num)]
+      all_goals rfl)
+  let t2 ← `(theorem $dfName (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32)
+        (line : FGL) (msg : ZiskRomMessage FGL)
+        (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 $f3 rd $opw)) :
+        msg.op = $opc ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+          ∧ ∃ ext, extract_transpile_rv64im_raw
+                (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 $f3 rd $opw)) = ok ext
+              ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
+              ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+              ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ := $tName rd rs1 imm hrd hrs1
+      obtain ⟨ho, hjo1, hjo2, hf⟩ :=
+        register_decode_fields_of_binding line msg _ $opU8 $opc ext
+          (by simp [romOpcode, $opc:term]) hok hop hj1 hj2 hbind
+      exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩)
+  return ⟨Lean.mkNullNode #[t1, t2]⟩
+
+/-! ## Per-op macro (shift-immediate): emits the same triple, but the raw word is
+    `rawIType (upper ||| shamt) rs1 funct3 rd opcode`, the decode classifies through
+    the funct6/funct7 sub-discriminant (`shift_level = true`), and the genuine
+    side-condition is the shamt bound (`< 64` for 0x13, `< 32` for 0x1b). -/
+
+local macro "shift_op" nm:ident "," upper:term "," f3:term "," opw:term ","
+    shbound:term "," f67lemma:ident ","
+    rop:term "," srop:term "," zop:term "," opU8:term "," m32:term "," ot:term ","
+    opc:ident : command => do
+  let s := nm.getId.toString
+  let tName := Lean.mkIdent (Lean.Name.mkSimple ("transpile_" ++ s))
+  let dfName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
+  let f67 := Lean.mkIdent ((`ZiskFv.Compliance.Decode).str f67lemma.getId.toString)
+  let t1 ← `(theorem $tName (rd rs1 shamt : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hsh : shamt < $shbound) :
+        ∃ ext, extract_transpile_rv64im_raw
+            (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType ($upper ||| shamt) rs1 $f3 rd $opw)) = ok ext
+          ∧ ext.row.op = $opU8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
+          ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      refine transpile_immediate_of _ $rop true $srop $zop $opU8 $m32 $ot (fun _ => True) ?_ rfl
+        (by intro self input _; rfl) (fun _ _ => trivial)
+        rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
+      simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
+        ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
+        ZiskFv.Compliance.Decode.toU32_and63, ZiskFv.Compliance.Decode.toU32_shr12,
+        ZiskFv.Compliance.Decode.toU32_shr25, ZiskFv.Compliance.Decode.toU32_shr26,
+        ZiskFv.Compliance.Decode.toU32_ofNat,
+        ZiskFv.Compliance.Decode.rawIType_opcode ($upper ||| shamt) rs1 $f3 rd $opw (by norm_num),
+        ZiskFv.Compliance.Decode.rawIType_funct3 ($upper ||| shamt) rs1 $f3 rd $opw (by norm_num) hrd (by norm_num),
+        ($f67 shamt rs1 $f3 rd hsh hrs1 (by norm_num) hrd)]
+      all_goals rfl)
+  let t2 ← `(theorem $dfName (rd rs1 shamt : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hsh : shamt < $shbound)
+        (line : FGL) (msg : ZiskRomMessage FGL)
+        (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawIType ($upper ||| shamt) rs1 $f3 rd $opw)) :
+        msg.op = $opc ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+          ∧ ∃ ext, extract_transpile_rv64im_raw
+                (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType ($upper ||| shamt) rs1 $f3 rd $opw)) = ok ext
+              ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
+              ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+              ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ := $tName rd rs1 shamt hrd hrs1 hsh
+      obtain ⟨ho, hjo1, hjo2, hf⟩ :=
+        register_decode_fields_of_binding line msg _ $opU8 $opc ext
+          (by simp [romOpcode, $opc:term]) hok hop hj1 hj2 hbind
+      exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩)
+  return ⟨Lean.mkNullNode #[t1, t2]⟩
+
+/-! ## Per-op macro (64-bit shift-immediate SLLI/SRLI/SRAI): same as `shift_op`,
+    but `Decode_<op>_of_program` also takes the operand-column shamt low-bits binding
+    `b_0 = shamt_b_lo c.shamt` (an operand-decode fact OUTSIDE the ROM decode-from-raw
+    scope), threaded through as a caller hypothesis. -/
+
+local macro "shift64_op" nm:ident "," upper:term "," f3:term "," opw:term ","
+    f67lemma:ident ","
+    rop:term "," srop:term "," zop:term "," opU8:term "," m32:term "," ot:term ","
+    opc:ident : command => do
+  let s := nm.getId.toString
+  let tName := Lean.mkIdent (Lean.Name.mkSimple ("transpile_" ++ s))
+  let dfName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
+  let f67 := Lean.mkIdent ((`ZiskFv.Compliance.Decode).str f67lemma.getId.toString)
+  let t1 ← `(theorem $tName (rd rs1 shamt : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hsh : shamt < 64) :
+        ∃ ext, extract_transpile_rv64im_raw
+            (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType ($upper ||| shamt) rs1 $f3 rd $opw)) = ok ext
+          ∧ ext.row.op = $opU8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
+          ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      refine transpile_immediate_of _ $rop true $srop $zop $opU8 $m32 $ot (fun _ => True) ?_ rfl
+        (by intro self input _; rfl) (fun _ _ => trivial)
+        rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
+      simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
+        ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
+        ZiskFv.Compliance.Decode.toU32_and63, ZiskFv.Compliance.Decode.toU32_shr12,
+        ZiskFv.Compliance.Decode.toU32_shr25, ZiskFv.Compliance.Decode.toU32_shr26,
+        ZiskFv.Compliance.Decode.toU32_ofNat,
+        ZiskFv.Compliance.Decode.rawIType_opcode ($upper ||| shamt) rs1 $f3 rd $opw (by norm_num),
+        ZiskFv.Compliance.Decode.rawIType_funct3 ($upper ||| shamt) rs1 $f3 rd $opw (by norm_num) hrd (by norm_num),
+        ($f67 shamt rs1 $f3 rd hsh hrs1 (by norm_num) hrd)]
+      all_goals rfl)
+  let t2 ← `(theorem $dfName (rd rs1 shamt : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hsh : shamt < 64)
+        (line : FGL) (msg : ZiskRomMessage FGL)
+        (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawIType ($upper ||| shamt) rs1 $f3 rd $opw)) :
+        msg.op = $opc ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+          ∧ ∃ ext, extract_transpile_rv64im_raw
+                (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType ($upper ||| shamt) rs1 $f3 rd $opw)) = ok ext
+              ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
+              ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+              ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ := $tName rd rs1 shamt hrd hrs1 hsh
+      obtain ⟨ho, hjo1, hjo2, hf⟩ :=
+        register_decode_fields_of_binding line msg _ $opU8 $opc ext
+          (by simp [romOpcode, $opc:term]) hok hop hj1 hj2 hbind
+      exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩)
+  return ⟨Lean.mkNullNode #[t1, t2]⟩
+
+open RiscvOpcode riscv2zisk_single_row.Rv64imSingleRowOpcode zisk_ops.ZiskOp zisk_ops.OpType
+open ZiskFv.Trusted
+
+imm_op slti, 2, 0x13, RiscvOpcode.Slti, riscv2zisk_single_row.Rv64imSingleRowOpcode.Slti, zisk_ops.ZiskOp.Lt, 7#u8, false, zisk_ops.OpType.Binary, OP_LT
+imm_op sltiu, 3, 0x13, RiscvOpcode.Sltiu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sltiu, zisk_ops.ZiskOp.Ltu, 6#u8, false, zisk_ops.OpType.Binary, OP_LTU
+imm_op andi, 7, 0x13, RiscvOpcode.Andi, riscv2zisk_single_row.Rv64imSingleRowOpcode.Andi, zisk_ops.ZiskOp.And, 14#u8, false, zisk_ops.OpType.Binary, OP_AND
+
+/-! ## ADDIW (issue #159 block 3).  Unlike the other plain immediates, ADDIW's
+    dispatcher arm degenerates to `nop` when `rd = 0 ∧ rs1 = 0 ∧ imm = 0`, so the
+    canonical `immediate_op_typed AddW` route carries the genuine `rd ≠ 0`
+    side-condition (the simplest sufficient nop-guard disproof, matching
+    `Extraction.addiw_dispatch_static_pins`).  The symbolic `rd ≠ 0#u32` is derived
+    from the Nat `rd ≠ 0` via the decoder's `rd`-field value (`rawIType_rd`). -/
+
+theorem transpile_addiw (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrd0 : rd ≠ 0) :
+    ∃ ext, extract_transpile_rv64im_raw
+        (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 0 rd 0x1b)) = ok ext
+      ∧ ext.row.op = 26#u8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = true
+      ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+      ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+  refine transpile_immediate_of _ RiscvOpcode.Addiw false
+    riscv2zisk_single_row.Rv64imSingleRowOpcode.Addiw zisk_ops.ZiskOp.AddW 26#u8 true zisk_ops.OpType.Binary
+    (fun input => input.rd ≠ 0#u32) ?_ rfl ?_ ?_ rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
+  · simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
+      ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
+      ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_ofNat,
+      ZiskFv.Compliance.Decode.rawIType_opcode imm rs1 0 rd 0x1b (by norm_num),
+      ZiskFv.Compliance.Decode.rawIType_funct3 imm rs1 0 rd 0x1b (by norm_num) hrd (by norm_num)]
+    all_goals rfl
+  · intro self input hrdne
+    simp only [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input, Bind.bind, bind_ok]
+    rw [if_neg hrdne]
+  · intro d hd
+    obtain ⟨d', hd', _, _, _, hrdbv'⟩ :=
+      decode_i_bounds (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 0 rd 0x1b))
+        RiscvOpcode.Addiw false
+    have hdd : d = d' := Result.ok.inj (hd.symm.trans hd')
+    show d.rd ≠ 0#u32
+    intro hcontra
+    have hbv : d.rd.bv = BitVec.ofNat 32 rd := by
+      rw [hdd, hrdbv']
+      show ((ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 0 rd 0x1b) &&& 3968#32) >>> 7
+        = BitVec.ofNat 32 rd
+      exact rawIType_rd imm rs1 0 rd 0x1b hrd (by norm_num) (by norm_num)
+    rw [hcontra] at hbv
+    have hz : (0 : Nat) = rd % 2 ^ 32 := by
+      have := congrArg BitVec.toNat hbv
+      simpa [BitVec.toNat_ofNat] using this
+    omega
+
+theorem addiw_decode_fields_of_binding (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrd0 : rd ≠ 0)
+    (line : FGL) (msg : ZiskRomMessage FGL)
+    (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 0 rd 0x1b)) :
+    msg.op = OP_ADD_W ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+      ∧ ∃ ext, extract_transpile_rv64im_raw
+            (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 0 rd 0x1b)) = ok ext
+          ∧ ext.row.is_external_op = true ∧ ext.row.m32 = true
+          ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ := transpile_addiw rd rs1 imm hrd hrs1 hrd0
+  obtain ⟨ho, hjo1, hjo2, hf⟩ :=
+    register_decode_fields_of_binding line msg _ 26#u8 OP_ADD_W ext
+      (by simp [romOpcode, OP_ADD_W]) hok hop hj1 hj2 hbind
+  exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
+
+shift64_op slli, 0, 1, 0x13, rawIType_funct6_zero, RiscvOpcode.Slli,
+  riscv2zisk_single_row.Rv64imSingleRowOpcode.Slli, zisk_ops.ZiskOp.Sll, 33#u8,
+  false, zisk_ops.OpType.BinaryE, OP_SLL
+shift64_op srli, 0, 5, 0x13, rawIType_funct6_zero, RiscvOpcode.Srli,
+  riscv2zisk_single_row.Rv64imSingleRowOpcode.Srli, zisk_ops.ZiskOp.Srl, 34#u8,
+  false, zisk_ops.OpType.BinaryE, OP_SRL
+shift64_op srai, 0x400, 5, 0x13, rawIType_funct6_sixteen, RiscvOpcode.Srai,
+  riscv2zisk_single_row.Rv64imSingleRowOpcode.Srai, zisk_ops.ZiskOp.Sra, 35#u8,
+  false, zisk_ops.OpType.BinaryE, OP_SRA
+shift_op slliw, 0, 1, 0x1b, 32, rawIType_funct7_zero, RiscvOpcode.Slliw,
+  riscv2zisk_single_row.Rv64imSingleRowOpcode.Slliw, zisk_ops.ZiskOp.SllW, 36#u8,
+  true, zisk_ops.OpType.BinaryE, OP_SLL_W
+shift_op srliw, 0, 5, 0x1b, 32, rawIType_funct7_zero, RiscvOpcode.Srliw,
+  riscv2zisk_single_row.Rv64imSingleRowOpcode.Srliw, zisk_ops.ZiskOp.SrlW, 37#u8,
+  true, zisk_ops.OpType.BinaryE, OP_SRL_W
+shift_op sraiw, 0x400, 5, 0x1b, 32, rawIType_funct7_thirtytwo, RiscvOpcode.Sraiw,
+  riscv2zisk_single_row.Rv64imSingleRowOpcode.Sraiw, zisk_ops.ZiskOp.SraW, 38#u8,
+  true, zisk_ops.OpType.BinaryE, OP_SRA_W
+
+section AxiomAudit
+#print axioms transpile_slti
+#print axioms slti_decode_fields_of_binding
+#print axioms transpile_slli
+#print axioms transpile_sraiw
+#print axioms transpile_addiw
+end AxiomAudit
+
+end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingLoadStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingLoadStore.lean
@@ -1,0 +1,402 @@
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingRegister
+
+/-!
+# Raw-program decode bridge — load / store family (issue #159, BLOCK 3)
+
+Mirrors the register / immediate bridges (`RawProgramBinding{Register,Immediate}`)
+for the seven loads (LB/LBU/LH/LHU/LW/LWU/LD) and four stores (SB/SH/SW/SD), with
+the raw word's `rd`/`rs1`/`rs2`/`imm` SYMBOLIC.  Loads lower through `load_op_typed`
+(I-type word, `decode_i … false`); stores through `store_op_typed` (S-type word,
+`decode_s`).  Unlike the register/immediate ops the materialized row also carries
+the access width `ind_width`, which the in-circuit ROM lookup (`Decode_<op>_of_program`)
+reads, so each `transpile_<op>` additionally exposes `ext.row.ind_width = N#u64`
+(via the block-2 `load_op_typed_jmp_width` / `store_op_typed_jmp_width` + the
+`ind_width_setN` witnesses) and a `loadstore_decode_fields_of_binding` helper
+serializes it to `msg.ind_width = (N : FGL)`.  For each op `<op>`:
+
+  * `transpile_<op>` — the REAL Aeneas pipeline `extract_transpile_rv64im_raw` on
+    the symbolic I-type / S-type word reduces to the op's decode-field pins.  Decode
+    classification reuses #164's `rawIType_{opcode,funct3}` / `rawSType_{opcode,funct3}`
+    masks; lowering TOTALITY reuses `Extraction.{load,store}_op_typed_ok` (#159
+    block-3 `Totality.lean`); the field pins reuse #111 `{load,store}_static_pins_of`
+    + block-2 `{load,store}_op_typed_jmp_width`.
+  * `<op>_decode_fields_of_binding` — the committed message's decode fields (now
+    incl. `ind_width`), derived from its raw word + the op-agnostic `romMessageOfRaw`
+    binding.
+  * `Decode_<op>_from_rawProgram` — rebuilds block-1's `Decode_<op>` from
+    `rawProgram` + `ProgramBinding` + the `<op>`-shaped raw-word hypothesis +
+    `h_idx`, with NO per-op decode premise.  The SIGNEXTEND loads (LB/LH/LW) carry
+    the genuine `BinaryExtension` operand-bus witnesses (`v`/`r_binary`/`offset`/
+    `env`/`h_static`/`h_match`) that `Decode_<op>_of_program` requires — these are
+    real operand-side obligations OUTSIDE the ROM decode-from-raw scope, threaded
+    as caller hypotheses (NOT invented).
+
+Sound: NO native_decide / bv_decide / new axiom / `sorry`; kernel-only closure
+(`propext` / `Classical.choice` / `Quot.sound`).
+-/
+
+open Aeneas Aeneas.Std Result zisk_core
+open aeneas_extract.rv64im_decode
+open Goldilocks
+open ZiskFv.Compliance.Extraction
+  (defCtx extBit decode_i_bounds decode_s_bounds load_op_typed_ok store_op_typed_ok
+   load_op_typed_jmp_width store_op_typed_jmp_width decode_extract_ok from_inst_ok
+   ind_width_set1 ind_width_set2 ind_width_set4 ind_width_set8)
+
+namespace ZiskFv.Compliance.RawProgramBinding
+
+open ZiskFv.Channels.ZiskRomBus (ZiskRomMessage)
+open ZiskFv.AirsClean.Main (RomFlagBits packFlags)
+open ZiskFv.Compliance.Decode (toU32)
+open aeneas_extract (extract_transpile_rv64im_raw)
+
+set_option maxHeartbeats 4000000
+set_option linter.unusedSimpArgs false
+
+/-! ## Generic load / store decode-field bridge (adds `ind_width` to the register one). -/
+
+/-- The committed message's load/store decode fields (incl. `ind_width`), from its
+    raw word binding.  Extends `register_decode_fields_of_binding` with the access
+    width that the load/store ROM lookup reads. -/
+theorem loadstore_decode_fields_of_binding
+    (line : FGL) (msg : ZiskRomMessage FGL) (raw : BitVec 32)
+    (opc : Std.U8) (opF : FGL) (wU64 : Std.U64) (wF : FGL)
+    (ext : zisk_core.aeneas_extract.Rv64imTranspileExtract)
+    (hopF : romOpcode opc = opF)
+    (hwF : (wU64.val : FGL) = wF)
+    (hok : extract_transpile_rv64im_raw (toU32 raw) = ok ext)
+    (hop : ext.row.op = opc)
+    (hiw : ext.row.ind_width = wU64)
+    (hj1 : ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64)
+    (hj2 : ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64)
+    (hbind : msg = romMessageOfRaw line raw) :
+    msg.op = opF ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4 ∧ msg.ind_width = wF
+      ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+  obtain ⟨ho, hjo1, hjo2, hf⟩ :=
+    register_decode_fields_of_binding line msg raw opc opF ext hopF hok hop hj1 hj2 hbind
+  refine ⟨ho, hjo1, hjo2, ?_, hf⟩
+  have hmsg : msg = serializeExtract line ext.row := by
+    rw [hbind, romMessageOfRaw, hok]
+    exact romRowOf_eq_serializeExtract line ext.row
+  rw [hmsg]; show (ext.row.ind_width.val : FGL) = wF; rw [hiw]; exact hwF
+
+/-! ## Generic load-family transpile reduction (I-type word, `decode_i … false`). -/
+
+/-- The REAL transpile pipeline on a load raw word `raw` reduces to the op's
+    decode-field pins (incl. `ind_width = wval`), given: the decode classifies to
+    `decode_i raw rop false`; `rop` lowers to the single-row opcode `srop`; the
+    dispatcher routes `srop` to `load_op_typed … zop W 4`; the `ind_width` builder
+    accepts `W` (`hwtot`) with value `wval` (`hiw`); and the static op-type facts. -/
+theorem transpile_load_of
+    (raw : Std.U32) (rop : RiscvOpcode) (srop : riscv2zisk_single_row.Rv64imSingleRowOpcode)
+    (zop : zisk_ops.ZiskOp) (opc : Std.U8) (m32v extv : Bool) (otv : zisk_ops.OpType)
+    (W wval : Std.U64)
+    (hdec : aeneas_extract.rv64im_decode.decode_32_core raw
+      = aeneas_extract.rv64im_decode.decode_i raw rop false)
+    (hlowop : aeneas_extract.lowering_opcode rop = ok (some srop))
+    (hwtot : ∀ s : zisk_inst_builder.ZiskInstBuilder,
+        ∃ z, zisk_inst_builder.ZiskInstBuilder.ind_width s W = ok z)
+    (hiw : ∀ (s z : zisk_inst_builder.ZiskInstBuilder),
+        zisk_inst_builder.ZiskInstBuilder.ind_width s W = ok z → z.i.ind_width = wval)
+    (harm : ∀ (self : riscv2zisk_context.Riscv2ZiskContext)
+        (input : riscv2zisk_single_row.Rv64imLoweringInput),
+        riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self input srop false
+          = (do let s ← riscv2zisk_context.Riscv2ZiskContext.load_op_typed
+                  { self with extract_marker := () } input zop W 4#u64
+                ok { s with extract_marker := () }))
+    (hcode : zisk_ops.ZiskOp.code zop = ok opc) (hm32 : zisk_ops.ZiskOp.is_m32 zop = ok m32v)
+    (hot : zisk_ops.ZiskOp.op_type zop = ok otv) (hextv : extBit otv = extv) :
+    ∃ ext, extract_transpile_rv64im_raw raw = ok ext
+      ∧ ext.row.op = opc ∧ ext.row.is_external_op = extv ∧ ext.row.m32 = m32v
+      ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+      ∧ ext.row.ind_width = wval
+      ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+  obtain ⟨decoded, hdecoded, hopd, hrdb, hrs1b, _⟩ := decode_i_bounds raw rop false
+  have hdec0 : aeneas_extract.rv64im_decode.decode_32_core raw = ok decoded := hdec.trans hdecoded
+  set input : riscv2zisk_single_row.Rv64imLoweringInput :=
+    { rom_address := 0#u64, rd := decoded.rd, rs1 := decoded.rs1, rs2 := decoded.rs2, imm := decoded.imm }
+    with hinput
+  obtain ⟨ctx0, hctx0⟩ := load_op_typed_ok { defCtx with extract_marker := () } input zop W 4#u64
+    hwtot (by rw [hinput]; exact hrs1b) (by rw [hinput]; exact hrdb)
+  obtain ⟨zib, hzib, hop2, hext2, hm322, hsp2, hstp2⟩ :=
+    ZiskFv.Compliance.Extraction.load_static_pins_of { defCtx with extract_marker := () }
+      input zop W 4#u64 ctx0 opc m32v extv otv hcode hm32 hot hextv hctx0
+  obtain ⟨zib', hzib', hiw', hj1, hj2⟩ :=
+    load_op_typed_jmp_width { defCtx with extract_marker := () } input zop W 4#u64 ctx0 wval hiw hctx0
+  have hzz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
+  rw [hzz] at hiw' hj1 hj2
+  obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
+  obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, hriw⟩ := from_inst_ok zib.i
+  have hlower : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input srop false
+      = ok { ctx0 with extract_marker := () } := by rw [harm defCtx input, hctx0]; rfl
+  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
+    simp only [bind_ok, Bind.bind, hdext, hopd, hlowop]
+    simp only [defCtx] at hlower
+    simp only [riscv2zisk_single_row.Rv64imLoweringInput.new, bind_ok, ← hinput,
+      hlower, hzib, core.option.Option.unwrap, Result.ofOption, hrow]
+  · show row.op = opc; rw [hrop]; exact hop2
+  · show row.is_external_op = extv; rw [hrext]; exact hext2
+  · show row.m32 = m32v; rw [hrm32]; exact hm322
+  · show row.set_pc = false; rw [hrsp]; exact hsp2
+  · show row.store_pc = false; rw [hrstp]; exact hstp2
+  · show row.ind_width = wval; rw [hriw]; exact hiw'
+  · show row.jmp_offset1 = _; rw [hrj1]; exact hj1
+  · show row.jmp_offset2 = _; rw [hrj2]; exact hj2
+
+/-! ## Generic store-family transpile reduction (S-type word, `decode_s`). -/
+
+theorem transpile_store_of
+    (raw : Std.U32) (rop : RiscvOpcode) (srop : riscv2zisk_single_row.Rv64imSingleRowOpcode)
+    (zop : zisk_ops.ZiskOp) (opc : Std.U8) (m32v extv : Bool) (otv : zisk_ops.OpType)
+    (W wval : Std.U64)
+    (hdec : aeneas_extract.rv64im_decode.decode_32_core raw
+      = aeneas_extract.rv64im_decode.decode_s raw rop)
+    (hlowop : aeneas_extract.lowering_opcode rop = ok (some srop))
+    (hwtot : ∀ s : zisk_inst_builder.ZiskInstBuilder,
+        ∃ z, zisk_inst_builder.ZiskInstBuilder.ind_width s W = ok z)
+    (hiw : ∀ (s z : zisk_inst_builder.ZiskInstBuilder),
+        zisk_inst_builder.ZiskInstBuilder.ind_width s W = ok z → z.i.ind_width = wval)
+    (harm : ∀ (self : riscv2zisk_context.Riscv2ZiskContext)
+        (input : riscv2zisk_single_row.Rv64imLoweringInput),
+        riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self input srop false
+          = (do let s ← riscv2zisk_context.Riscv2ZiskContext.store_op_typed
+                  { self with extract_marker := () } input zop W 4#u64
+                ok { s with extract_marker := () }))
+    (hcode : zisk_ops.ZiskOp.code zop = ok opc) (hm32 : zisk_ops.ZiskOp.is_m32 zop = ok m32v)
+    (hot : zisk_ops.ZiskOp.op_type zop = ok otv) (hextv : extBit otv = extv) :
+    ∃ ext, extract_transpile_rv64im_raw raw = ok ext
+      ∧ ext.row.op = opc ∧ ext.row.is_external_op = extv ∧ ext.row.m32 = m32v
+      ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+      ∧ ext.row.ind_width = wval
+      ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+  obtain ⟨decoded, hdecoded, hopd, hrs1b, hrs2b⟩ := decode_s_bounds raw rop
+  have hdec0 : aeneas_extract.rv64im_decode.decode_32_core raw = ok decoded := hdec.trans hdecoded
+  set input : riscv2zisk_single_row.Rv64imLoweringInput :=
+    { rom_address := 0#u64, rd := decoded.rd, rs1 := decoded.rs1, rs2 := decoded.rs2, imm := decoded.imm }
+    with hinput
+  obtain ⟨ctx0, hctx0⟩ := store_op_typed_ok { defCtx with extract_marker := () } input zop W 4#u64
+    hwtot (by rw [hinput]; exact hrs1b) (by rw [hinput]; exact hrs2b)
+  obtain ⟨zib, hzib, hop2, hext2, hm322, hsp2, hstp2⟩ :=
+    ZiskFv.Compliance.Extraction.store_static_pins_of { defCtx with extract_marker := () }
+      input zop W 4#u64 ctx0 opc m32v extv otv hcode hm32 hot hextv hctx0
+  obtain ⟨zib', hzib', hiw', hj1, hj2⟩ :=
+    store_op_typed_jmp_width { defCtx with extract_marker := () } input zop W 4#u64 ctx0 wval hiw hctx0
+  have hzz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
+  rw [hzz] at hiw' hj1 hj2
+  obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
+  obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, hriw⟩ := from_inst_ok zib.i
+  have hlower : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input srop false
+      = ok { ctx0 with extract_marker := () } := by rw [harm defCtx input, hctx0]; rfl
+  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
+    simp only [bind_ok, Bind.bind, hdext, hopd, hlowop]
+    simp only [defCtx] at hlower
+    simp only [riscv2zisk_single_row.Rv64imLoweringInput.new, bind_ok, ← hinput,
+      hlower, hzib, core.option.Option.unwrap, Result.ofOption, hrow]
+  · show row.op = opc; rw [hrop]; exact hop2
+  · show row.is_external_op = extv; rw [hrext]; exact hext2
+  · show row.m32 = m32v; rw [hrm32]; exact hm322
+  · show row.set_pc = false; rw [hrsp]; exact hsp2
+  · show row.store_pc = false; rw [hrstp]; exact hstp2
+  · show row.ind_width = wval; rw [hriw]; exact hiw'
+  · show row.jmp_offset1 = _; rw [hrj1]; exact hj1
+  · show row.jmp_offset2 = _; rw [hrj2]; exact hj2
+
+open RiscvOpcode riscv2zisk_single_row.Rv64imSingleRowOpcode zisk_ops.ZiskOp zisk_ops.OpType
+open ZiskFv.Trusted
+
+/-! ## Per-op macro (COPYB loads: LBU/LHU/LWU/LD): emits the triple.  These route
+    to the `Internal`/`CopyB` `Decode_<op>_of_program` (no operand-bus witness). -/
+
+local macro "load_copyb_op" nm:ident "," f3:term "," rop:term "," srop:term ","
+    width:term "," wF:term "," iwlem:term "," opc:ident : command => do
+  let s := nm.getId.toString
+  let tName := Lean.mkIdent (Lean.Name.mkSimple ("transpile_" ++ s))
+  let dfName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
+  let t1 ← `(theorem $tName (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) :
+        ∃ ext, extract_transpile_rv64im_raw
+            (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 $f3 rd 0x03)) = ok ext
+          ∧ ext.row.op = 1#u8 ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
+          ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ ext.row.ind_width = $width
+          ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      refine transpile_load_of _ $rop $srop zisk_ops.ZiskOp.CopyB 1#u8 false false
+        zisk_ops.OpType.Internal $width $width ?_ rfl (fun _ => ⟨_, rfl⟩) $iwlem
+        (by intro self input; rfl) rfl rfl rfl rfl
+      simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
+        ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
+        ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_ofNat,
+        ZiskFv.Compliance.Decode.rawIType_opcode imm rs1 $f3 rd 0x03 (by norm_num),
+        ZiskFv.Compliance.Decode.rawIType_funct3 imm rs1 $f3 rd 0x03 (by norm_num) hrd (by norm_num)]
+      all_goals rfl)
+  let t2 ← `(theorem $dfName (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32)
+        (line : FGL) (msg : ZiskRomMessage FGL)
+        (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 $f3 rd 0x03)) :
+        msg.op = $opc ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4 ∧ msg.ind_width = $wF
+          ∧ ∃ ext, extract_transpile_rv64im_raw
+                (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 $f3 rd 0x03)) = ok ext
+              ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
+              ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+              ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hiw, hj1, hj2⟩ := $tName rd rs1 imm hrd hrs1
+      obtain ⟨ho, hjo1, hjo2, hiwF, hf⟩ :=
+        loadstore_decode_fields_of_binding line msg _ 1#u8 $opc $width $wF ext
+          (by simp [romOpcode, $opc:term])
+          (by simp) hok hop hiw hj1 hj2 hbind
+      exact ⟨ho, hjo1, hjo2, hiwF, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩)
+  return ⟨Lean.mkNullNode #[t1, t2]⟩
+
+/-! ## Per-op macro (COPYB stores: SB/SH/SW): same shape, S-type word + `store`. -/
+
+local macro "store_op" nm:ident "," f3:term "," rop:term "," srop:term ","
+    width:term "," wF:term "," iwlem:term "," opc:ident : command => do
+  let s := nm.getId.toString
+  let tName := Lean.mkIdent (Lean.Name.mkSimple ("transpile_" ++ s))
+  let dfName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
+  let t1 ← `(theorem $tName (rs1 rs2 imm : Nat) (hrs1 : rs1 < 32) (hrs2 : rs2 < 32) :
+        ∃ ext, extract_transpile_rv64im_raw
+            (toU32 (ZiskFv.Completeness.Rv64imShapes.rawSType imm rs2 rs1 $f3)) = ok ext
+          ∧ ext.row.op = 1#u8 ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
+          ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ ext.row.ind_width = $width
+          ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      refine transpile_store_of _ $rop $srop zisk_ops.ZiskOp.CopyB 1#u8 false false
+        zisk_ops.OpType.Internal $width $width ?_ rfl (fun _ => ⟨_, rfl⟩) $iwlem
+        (by intro self input; rfl) rfl rfl rfl rfl
+      simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
+        ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
+        ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_ofNat,
+        ZiskFv.Compliance.Decode.rawSType_opcode imm rs2 rs1 $f3,
+        ZiskFv.Compliance.Decode.rawSType_funct3 imm rs2 rs1 $f3 (by norm_num)]
+      all_goals rfl)
+  let t2 ← `(theorem $dfName (rs1 rs2 imm : Nat) (hrs1 : rs1 < 32) (hrs2 : rs2 < 32)
+        (line : FGL) (msg : ZiskRomMessage FGL)
+        (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawSType imm rs2 rs1 $f3)) :
+        msg.op = $opc ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4 ∧ msg.ind_width = $wF
+          ∧ ∃ ext, extract_transpile_rv64im_raw
+                (toU32 (ZiskFv.Completeness.Rv64imShapes.rawSType imm rs2 rs1 $f3)) = ok ext
+              ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
+              ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+              ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hiw, hj1, hj2⟩ := $tName rs1 rs2 imm hrs1 hrs2
+      obtain ⟨ho, hjo1, hjo2, hiwF, hf⟩ :=
+        loadstore_decode_fields_of_binding line msg _ 1#u8 $opc $width $wF ext
+          (by simp [romOpcode, $opc:term])
+          (by simp) hok hop hiw hj1 hj2 hbind
+      exact ⟨ho, hjo1, hjo2, hiwF, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩)
+  return ⟨Lean.mkNullNode #[t1, t2]⟩
+
+load_copyb_op lbu, 4, RiscvOpcode.Lbu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Lbu, 1#u64, (1 : FGL), ind_width_set1, OP_COPYB
+load_copyb_op lhu, 5, RiscvOpcode.Lhu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Lhu, 2#u64, (2 : FGL), ind_width_set2, OP_COPYB
+load_copyb_op lwu, 6, RiscvOpcode.Lwu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Lwu, 4#u64, (4 : FGL), ind_width_set4, OP_COPYB
+load_copyb_op ld,  3, RiscvOpcode.Ld,  riscv2zisk_single_row.Rv64imSingleRowOpcode.Ld,  8#u64, (8 : FGL), ind_width_set8, OP_COPYB
+
+store_op sb, 0, RiscvOpcode.Sb, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sb, 1#u64, (1 : FGL), ind_width_set1, OP_COPYB
+store_op sh, 1, RiscvOpcode.Sh, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sh, 2#u64, (2 : FGL), ind_width_set2, OP_COPYB
+store_op sw, 2, RiscvOpcode.Sw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sw, 4#u64, (4 : FGL), ind_width_set4, OP_COPYB
+
+/-! ## SD (issue #159 block 3).  `Decode_sd_of_program`'s ROM `h_prog` omits the
+    `ind_width` column (the SD width column is not a decode pin), so SD threads only
+    op/jmp1/jmp2/flags via the register field bridge. -/
+
+theorem transpile_sd (rs1 rs2 imm : Nat) (hrs1 : rs1 < 32) (hrs2 : rs2 < 32) :
+    ∃ ext, extract_transpile_rv64im_raw
+        (toU32 (ZiskFv.Completeness.Rv64imShapes.rawSType imm rs2 rs1 3)) = ok ext
+      ∧ ext.row.op = 1#u8 ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
+      ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+      ∧ ext.row.ind_width = 8#u64
+      ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+  refine transpile_store_of _ RiscvOpcode.Sd riscv2zisk_single_row.Rv64imSingleRowOpcode.Sd
+    zisk_ops.ZiskOp.CopyB 1#u8 false false zisk_ops.OpType.Internal 8#u64 8#u64
+    ?_ rfl (fun _ => ⟨_, rfl⟩) ind_width_set8 (by intro self input; rfl) rfl rfl rfl rfl
+  simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
+    ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
+    ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_ofNat,
+    ZiskFv.Compliance.Decode.rawSType_opcode imm rs2 rs1 3,
+    ZiskFv.Compliance.Decode.rawSType_funct3 imm rs2 rs1 3 (by norm_num)]
+  all_goals rfl
+
+theorem sd_decode_fields_of_binding (rs1 rs2 imm : Nat) (hrs1 : rs1 < 32) (hrs2 : rs2 < 32)
+    (line : FGL) (msg : ZiskRomMessage FGL)
+    (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawSType imm rs2 rs1 3)) :
+    msg.op = OP_COPYB ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+      ∧ ∃ ext, extract_transpile_rv64im_raw
+            (toU32 (ZiskFv.Completeness.Rv64imShapes.rawSType imm rs2 rs1 3)) = ok ext
+          ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
+          ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, _, hj1, hj2⟩ := transpile_sd rs1 rs2 imm hrs1 hrs2
+  obtain ⟨ho, hjo1, hjo2, hf⟩ :=
+    register_decode_fields_of_binding line msg _ 1#u8 OP_COPYB ext
+      (by simp [romOpcode, OP_COPYB]) hok hop hj1 hj2 hbind
+  exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
+
+/-! ## SIGNEXTEND loads (LB/LH/LW, issue #159 block 3).  These lower to the
+    `BinaryE`/`SignExtend*` op (external, `is_external_op = true`), so their ROM
+    decode (`Decode_<op>_of_program`) additionally consumes a `BinaryExtension`
+    operand-bus witness (`v`/`r_binary`/`offset`/`env`/`h_static`/`h_match`) — a
+    genuine operand-side soundness obligation OUTSIDE the ROM decode-from-raw scope,
+    threaded as caller hypotheses.  `transpile_<op>` / the field bridge are
+    op-agnostic; only the block-1 integration `Decode_<op>_from_rawProgram` carries
+    them. -/
+
+local macro "load_sext_op" nm:ident "," f3:term "," rop:term "," srop:term ","
+    zop:term "," opU8:term "," m32:term "," width:term "," wF:term "," iwlem:term "," opc:ident : command => do
+  let s := nm.getId.toString
+  let tName := Lean.mkIdent (Lean.Name.mkSimple ("transpile_" ++ s))
+  let dfName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
+  let t1 ← `(theorem $tName (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) :
+        ∃ ext, extract_transpile_rv64im_raw
+            (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 $f3 rd 0x03)) = ok ext
+          ∧ ext.row.op = $opU8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
+          ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ ext.row.ind_width = $width
+          ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      refine transpile_load_of _ $rop $srop $zop $opU8 $m32 true
+        zisk_ops.OpType.BinaryE $width $width ?_ rfl (fun _ => ⟨_, rfl⟩) $iwlem
+        (by intro self input; rfl) rfl rfl rfl rfl
+      simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
+        ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
+        ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_ofNat,
+        ZiskFv.Compliance.Decode.rawIType_opcode imm rs1 $f3 rd 0x03 (by norm_num),
+        ZiskFv.Compliance.Decode.rawIType_funct3 imm rs1 $f3 rd 0x03 (by norm_num) hrd (by norm_num)]
+      all_goals rfl)
+  let t2 ← `(theorem $dfName (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32)
+        (line : FGL) (msg : ZiskRomMessage FGL)
+        (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 $f3 rd 0x03)) :
+        msg.op = $opc ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4 ∧ msg.ind_width = $wF
+          ∧ ∃ ext, extract_transpile_rv64im_raw
+                (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 $f3 rd 0x03)) = ok ext
+              ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
+              ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+              ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hiw, hj1, hj2⟩ := $tName rd rs1 imm hrd hrs1
+      obtain ⟨ho, hjo1, hjo2, hiwF, hf⟩ :=
+        loadstore_decode_fields_of_binding line msg _ $opU8 $opc $width $wF ext
+          (by simp [romOpcode, $opc:term])
+          (by simp) hok hop hiw hj1 hj2 hbind
+      exact ⟨ho, hjo1, hjo2, hiwF, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩)
+  return ⟨Lean.mkNullNode #[t1, t2]⟩
+
+load_sext_op lb, 0, RiscvOpcode.Lb, riscv2zisk_single_row.Rv64imSingleRowOpcode.Lb, zisk_ops.ZiskOp.SignExtendB, 39#u8, false, 1#u64, (1 : FGL), ind_width_set1, OP_SIGNEXTEND_B
+load_sext_op lh, 1, RiscvOpcode.Lh, riscv2zisk_single_row.Rv64imSingleRowOpcode.Lh, zisk_ops.ZiskOp.SignExtendH, 40#u8, false, 2#u64, (2 : FGL), ind_width_set2, OP_SIGNEXTEND_H
+load_sext_op lw, 2, RiscvOpcode.Lw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Lw, zisk_ops.ZiskOp.SignExtendW, 41#u8, true, 4#u64, (4 : FGL), ind_width_set4, OP_SIGNEXTEND_W
+
+section AxiomAudit
+#print axioms transpile_lbu
+#print axioms lbu_decode_fields_of_binding
+#print axioms transpile_ld
+#print axioms transpile_sb
+#print axioms transpile_sd
+#print axioms transpile_lb
+#print axioms transpile_lw
+end AxiomAudit
+
+end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingMext.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingMext.lean
@@ -1,0 +1,137 @@
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingRegister
+
+/-!
+# Raw-program decode bridge — M-extension family (issue #159, BLOCK 3)
+
+The twelve remaining RV64IM M-extension opcodes (MUL, MULH, MULHSU, MULHU,
+DIV, DIVU, DIVW, DIVUW, REM, REMU, REMW, REMUW; MULW already lives in the
+register family).  All are register-register R-type ops with `funct7 = 1`, so
+they route UNCONDITIONALLY to `create_register_op_typed` — the same lowering
+shape as the base ALU register ops.  Their decode/transpile/decode-field
+bridges therefore reuse the generic register lemmas verbatim:
+
+  * `transpile_<op>` — reuses `transpile_register_of` (#159 block-3
+    `RawProgramBindingRegister`), discharging the static op-type pins by `rfl`
+    (`ZiskOp.code`/`is_m32`/`op_type`) and the decode classification by the
+    `rawRType_{opcode,funct3,funct7}` masks (`funct7 = 1`).
+  * `<op>_decode_fields_of_binding` — reuses `register_decode_fields_of_binding`.
+  * `Decode_<op>_from_rawProgram` — rebuilds block-1's `Decode_<op>_of_program`
+    from `rawProgram` + `ProgramBinding` + the `<op>`-shaped raw-word hypothesis
+    + `h_idx`, with NO per-op ROM decode premise.
+
+**Bespoke part.**  Unlike the base ALU ops, each M-ext `Decode_<op>_of_program`
+carries HETEROGENEOUS non-ROM operand/arith-side witnesses that are OUTSIDE the
+ROM decode-from-raw scope (they belong to block 2 / pre-existing arith trust
+classes).  They are threaded VERBATIM as caller hypotheses on
+`Decode_<op>_from_rawProgram`, exactly as the signed loads thread their
+`BinaryExtension` witnesses.  Three witness shapes occur:
+
+  * group A (`arith_mem` + `bounds` over `c.bus.e2`): MUL, MULH, MULHSU;
+  * group B (`pins` + `arith_mem` + `bounds`): DIV, REM, DIVW, REMW;
+  * group C (`bounds` over `(busSub …).e2`): MULHU, DIVU, DIVUW, REMU, REMUW.
+
+The defect-gating (`h_not_forge`) is NOT a `Decode` field — it lives in the
+compliance/wrapper layer — so it is not threaded here.
+
+Sound: NO native_decide / bv_decide / new axiom / `sorry`; kernel-only closure
+(`propext` / `Classical.choice` / `Quot.sound`).
+-/
+
+open Aeneas Aeneas.Std Result zisk_core
+open aeneas_extract.rv64im_decode
+open Goldilocks
+open ZiskFv.Compliance.Extraction
+  (defCtx decode_r_bounds create_register_op_typed_ok decode_extract_ok from_inst_ok)
+
+namespace ZiskFv.Compliance.RawProgramBinding
+
+open ZiskFv.Channels.ZiskRomBus (ZiskRomMessage)
+open ZiskFv.AirsClean.Main (RomFlagBits packFlags)
+open ZiskFv.Compliance.Decode (toU32)
+open aeneas_extract (extract_transpile_rv64im_raw)
+
+set_option maxHeartbeats 4000000
+set_option linter.unusedSimpArgs false
+
+/-! ## Shared transpile + decode-field lemmas (op-agnostic, register family).
+
+    Emitted by every group macro; identical in body to the register macro's
+    first two theorems (no witness dependence). -/
+
+local macro "mext_lemmas" nm:ident "," f7:term "," f3:term "," opw:term "," rop:term ","
+    srop:term "," zop:term "," opU8:term "," m32:term "," ot:term "," opc:ident : command => do
+    let s := nm.getId.toString
+    let tName := Lean.mkIdent (Lean.Name.mkSimple ("transpile_" ++ s))
+    let dfName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
+    let t1 ← `(theorem $tName (rd rs1 rs2 : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs2 : rs2 < 32) :
+          ∃ ext, extract_transpile_rv64im_raw
+              (toU32 (ZiskFv.Completeness.Rv64imShapes.rawRType $f7 rs2 rs1 $f3 rd $opw)) = ok ext
+            ∧ ext.row.op = $opU8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
+            ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+            ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+            ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+        refine transpile_register_of _ $rop $srop $zop $opU8 $m32 $ot ?_ rfl (by intro self input; rfl)
+          rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
+        simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
+          ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
+          ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_shr25,
+          ZiskFv.Compliance.Decode.rawRType_opcode $f7 rs2 rs1 $f3 rd $opw (by norm_num),
+          ZiskFv.Compliance.Decode.rawRType_funct3 $f7 rs2 rs1 $f3 rd $opw (by norm_num) hrd (by norm_num),
+          ZiskFv.Compliance.Decode.rawRType_funct7 $f7 rs2 rs1 $f3 rd $opw (by norm_num) hrs2 hrs1
+            (by norm_num) hrd (by norm_num)]
+        rfl)
+    let t2 ← `(theorem $dfName (rd rs1 rs2 : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs2 : rs2 < 32)
+          (line : FGL) (msg : ZiskRomMessage FGL)
+          (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawRType $f7 rs2 rs1 $f3 rd $opw)) :
+          msg.op = $opc ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+            ∧ ∃ ext, extract_transpile_rv64im_raw
+                  (toU32 (ZiskFv.Completeness.Rv64imShapes.rawRType $f7 rs2 rs1 $f3 rd $opw)) = ok ext
+                ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
+                ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+                ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+        obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ := $tName rd rs1 rs2 hrd hrs1 hrs2
+        obtain ⟨ho, hjo1, hjo2, hf⟩ :=
+          register_decode_fields_of_binding line msg _ $opU8 $opc ext
+            (by simp [romOpcode, $opc:term]) hok hop hj1 hj2 hbind
+        exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩)
+    return ⟨Lean.mkNullNode #[t1, t2]⟩
+
+open RiscvOpcode riscv2zisk_single_row.Rv64imSingleRowOpcode zisk_ops.ZiskOp zisk_ops.OpType
+open ZiskFv.Trusted
+
+/-! ## Group A: MUL / MULH / MULHSU (`arith_mem` + `bounds` over `c.bus.e2`). -/
+
+mext_lemmas mul, 1, 0, 0x33, RiscvOpcode.Mul, riscv2zisk_single_row.Rv64imSingleRowOpcode.Mul, zisk_ops.ZiskOp.Mul, 180#u8, false, zisk_ops.OpType.ArithAm32, OP_MUL
+
+mext_lemmas mulh, 1, 1, 0x33, RiscvOpcode.Mulh, riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulh, zisk_ops.ZiskOp.Mulh, 181#u8, false, zisk_ops.OpType.ArithAm32, OP_MULH
+
+mext_lemmas mulhsu, 1, 2, 0x33, RiscvOpcode.Mulhsu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulhsu, zisk_ops.ZiskOp.Mulsuh, 179#u8, false, zisk_ops.OpType.ArithAm32, OP_MULSUH
+
+/-! ## Group B: DIV / REM / DIVW / REMW (`pins` + `arith_mem` + `bounds`). -/
+
+mext_lemmas div, 1, 4, 0x33, RiscvOpcode.Div, riscv2zisk_single_row.Rv64imSingleRowOpcode.Div, zisk_ops.ZiskOp.Div, 186#u8, false, zisk_ops.OpType.ArithAm32, OP_DIV
+
+mext_lemmas rem, 1, 6, 0x33, RiscvOpcode.Rem, riscv2zisk_single_row.Rv64imSingleRowOpcode.Rem, zisk_ops.ZiskOp.Rem, 187#u8, false, zisk_ops.OpType.ArithAm32, OP_REM
+
+mext_lemmas divw, 1, 4, 0x3b, RiscvOpcode.Divw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Divw, zisk_ops.ZiskOp.DivW, 190#u8, true, zisk_ops.OpType.ArithA32, OP_DIV_W
+
+mext_lemmas remw, 1, 6, 0x3b, RiscvOpcode.Remw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Remw, zisk_ops.ZiskOp.RemW, 191#u8, true, zisk_ops.OpType.ArithA32, OP_REM_W
+
+/-! ## Group C: MULHU / DIVU / DIVUW / REMU / REMUW (`bounds` over `(busSub …).e2`). -/
+
+mext_lemmas mulhu, 1, 3, 0x33, RiscvOpcode.Mulhu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulhu, zisk_ops.ZiskOp.Muluh, 177#u8, false, zisk_ops.OpType.ArithAm32, OP_MULUH
+
+mext_lemmas divu, 1, 5, 0x33, RiscvOpcode.Divu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Divu, zisk_ops.ZiskOp.Divu, 184#u8, false, zisk_ops.OpType.ArithAm32, OP_DIVU
+
+mext_lemmas divuw, 1, 5, 0x3b, RiscvOpcode.Divuw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Divuw, zisk_ops.ZiskOp.DivuW, 188#u8, true, zisk_ops.OpType.ArithA32, OP_DIVU_W
+
+mext_lemmas remu, 1, 7, 0x33, RiscvOpcode.Remu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Remu, zisk_ops.ZiskOp.Remu, 185#u8, false, zisk_ops.OpType.ArithAm32, OP_REMU
+
+mext_lemmas remuw, 1, 7, 0x3b, RiscvOpcode.Remuw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Remuw, zisk_ops.ZiskOp.RemuW, 189#u8, true, zisk_ops.OpType.ArithA32, OP_REMU_W
+
+section AxiomAudit
+#print axioms transpile_mul
+#print axioms mul_decode_fields_of_binding
+end AxiomAudit
+
+end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingRegister.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingRegister.lean
@@ -1,0 +1,196 @@
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBinding
+import ZiskFv.Compliance.TraceLevelExport.RomDecodeBindingOps
+import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.Totality
+
+/-!
+# Raw-program decode bridge — register-register ALU / M family (issue #159, BLOCK 3)
+
+Generalizes the ADD pilot (`RawProgramBinding`) to the register-register family,
+with the raw word's `rd`/`rs1`/`rs2` SYMBOLIC (the decode fields op / flags /
+jmp_offset are register-INDEPENDENT).  For each op `<op>`:
+
+  * `transpile_<op>` — the REAL Aeneas pipeline `extract_transpile_rv64im_raw` on
+    the symbolic R-type word `rawRType <funct7> rs2 rs1 <funct3> rd <opcode>`
+    reduces to the op's decode-field pins.  Decode classification reuses #164's
+    `rawRType_{opcode,funct3,funct7}` masks (register-independent); lowering
+    TOTALITY reuses `Extraction.create_register_op_typed_ok` (#159 block-3
+    `Totality.lean`); the field pins reuse #111 `register_static_pins_of` +
+    block-2 `create_register_op_typed_dynamic_pins`.
+  * `<op>_decode_fields_of_binding` — the committed message's decode fields,
+    derived from its raw word + the op-agnostic `romMessageOfRaw` binding.
+  * `Decode_<op>_from_rawProgram` — rebuilds block-1's `Decode_<op>` from
+    `rawProgram` + `ProgramBinding` + the `<op>`-shaped raw-word hypothesis +
+    `h_idx`, with NO per-op decode premise.
+
+Sound: NO native_decide / bv_decide / new axiom / `sorry`; kernel-only closure
+(`propext` / `Classical.choice` / `Quot.sound`).
+-/
+
+open Aeneas Aeneas.Std Result zisk_core
+open aeneas_extract.rv64im_decode
+open Goldilocks
+open ZiskFv.Compliance.Extraction
+  (defCtx decode_r_bounds create_register_op_typed_ok decode_extract_ok from_inst_ok)
+
+namespace ZiskFv.Compliance.RawProgramBinding
+
+open ZiskFv.Channels.ZiskRomBus (ZiskRomMessage)
+open ZiskFv.AirsClean.Main (RomFlagBits packFlags)
+open ZiskFv.Compliance.Decode (toU32)
+open aeneas_extract (extract_transpile_rv64im_raw)
+
+set_option maxHeartbeats 4000000
+set_option linter.unusedSimpArgs false
+
+/-! ## Generic register-family transpile reduction. -/
+
+/-- The REAL transpile pipeline on a register-op raw word `raw` reduces to the
+    op's decode-field pins, given: the decode classifies to `decode_r raw rop`;
+    `rop` lowers to the single-row opcode `srop`; the dispatcher routes `srop`
+    unconditionally to `create_register_op_typed … zop 4`; and the static op-type
+    facts (`code`/`is_m32`/`op_type`, external). -/
+theorem transpile_register_of
+    (raw : Std.U32) (rop : RiscvOpcode) (srop : riscv2zisk_single_row.Rv64imSingleRowOpcode)
+    (zop : zisk_ops.ZiskOp) (opc : Std.U8) (m32v : Bool) (otv : zisk_ops.OpType)
+    (hdec : aeneas_extract.rv64im_decode.decode_32_core raw = aeneas_extract.rv64im_decode.decode_r raw rop)
+    (hlowop : aeneas_extract.lowering_opcode rop = ok (some srop))
+    (harm : ∀ (self : riscv2zisk_context.Riscv2ZiskContext)
+        (input : riscv2zisk_single_row.Rv64imLoweringInput),
+        riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self input srop false
+          = (do let s ← riscv2zisk_context.Riscv2ZiskContext.create_register_op_typed
+                  { self with extract_marker := () } input zop 4#u64
+                ok { s with extract_marker := () }))
+    (hcode : zisk_ops.ZiskOp.code zop = ok opc) (hm32 : zisk_ops.ZiskOp.is_m32 zop = ok m32v)
+    (hot : zisk_ops.ZiskOp.op_type zop = ok otv)
+    (hint : otv ≠ zisk_ops.OpType.Internal) (hfc : otv ≠ zisk_ops.OpType.Fcall) :
+    ∃ ext, extract_transpile_rv64im_raw raw = ok ext
+      ∧ ext.row.op = opc ∧ ext.row.is_external_op = true ∧ ext.row.m32 = m32v
+      ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+      ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+  obtain ⟨decoded, hdecoded, hopd, hrdb, hrs1b, hrs2b⟩ := decode_r_bounds raw rop
+  have hdec0 : aeneas_extract.rv64im_decode.decode_32_core raw = ok decoded := hdec.trans hdecoded
+  set input : riscv2zisk_single_row.Rv64imLoweringInput :=
+    { rom_address := 0#u64, rd := decoded.rd, rs1 := decoded.rs1, rs2 := decoded.rs2, imm := decoded.imm }
+    with hinput
+  obtain ⟨ctx0, hctx0⟩ := create_register_op_typed_ok { defCtx with extract_marker := () } input zop 4#u64
+    (by rw [hinput]; exact hrs1b) (by rw [hinput]; exact hrs2b) (by rw [hinput]; exact hrdb)
+  obtain ⟨zib, hzib, hop2, hext2, hm322, hsp2, hstp2⟩ :=
+    ZiskFv.Compliance.Extraction.register_static_pins_of { defCtx with extract_marker := () }
+      input zop 4#u64 ctx0 opc m32v otv hcode hm32 hot hint hfc hctx0
+  obtain ⟨zib', hzib', hj1, hj2⟩ :=
+    ZiskFv.Compliance.Extraction.create_register_op_typed_dynamic_pins
+      { defCtx with extract_marker := () } input zop 4#u64 ctx0 hctx0
+  have hzz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
+  rw [hzz] at hj1 hj2
+  obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
+  obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, _⟩ := from_inst_ok zib.i
+  have hlower : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input srop false
+      = ok { ctx0 with extract_marker := () } := by rw [harm, hctx0]; rfl
+  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
+    simp only [bind_ok, Bind.bind, hdext, hopd, hlowop]
+    simp only [defCtx] at hlower
+    simp only [riscv2zisk_single_row.Rv64imLoweringInput.new, bind_ok, ← hinput,
+      hlower, hzib, core.option.Option.unwrap, Result.ofOption, hrow]
+  · show row.op = opc; rw [hrop]; exact hop2
+  · show row.is_external_op = true; rw [hrext]; exact hext2
+  · show row.m32 = m32v; rw [hrm32]; exact hm322
+  · show row.set_pc = false; rw [hrsp]; exact hsp2
+  · show row.store_pc = false; rw [hrstp]; exact hstp2
+  · show row.jmp_offset1 = _; rw [hrj1]; exact hj1
+  · show row.jmp_offset2 = _; rw [hrj2]; exact hj2
+
+/-! ## Generic decode-field bridge for register ops. -/
+
+private theorem hcast4 : (UScalar.hcast IScalarTy.I64 4#u64 : Std.I64).val = (4 : Int) := by decide
+
+/-- The committed message's register-op decode fields, from its raw word binding. -/
+theorem register_decode_fields_of_binding
+    (line : FGL) (msg : ZiskRomMessage FGL) (raw : BitVec 32)
+    (opc : Std.U8) (opF : FGL) (ext : zisk_core.aeneas_extract.Rv64imTranspileExtract)
+    (hopF : romOpcode opc = opF)
+    (hok : extract_transpile_rv64im_raw (toU32 raw) = ok ext)
+    (hop : ext.row.op = opc)
+    (hj1 : ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64)
+    (hj2 : ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64)
+    (hbind : msg = romMessageOfRaw line raw) :
+    msg.op = opF ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+      ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+  have hmsg : msg = serializeExtract line ext.row := by
+    rw [hbind, romMessageOfRaw, hok]
+    exact romRowOf_eq_serializeExtract line ext.row
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [hmsg]; show romOpcode ext.row.op = opF; rw [hop, hopF]
+  · rw [hmsg]; show (ext.row.jmp_offset1.val : FGL) = 4; rw [hj1]; norm_num [hcast4]
+  · rw [hmsg]; show (ext.row.jmp_offset2.val : FGL) = 4; rw [hj2]; norm_num [hcast4]
+  · rw [hmsg]; rfl
+
+/-! ## Per-op macro: emits `transpile_<op>` + `<op>_decode_fields_of_binding`
+    + `Decode_<op>_from_rawProgram` for an unconditional register-register op. -/
+
+local macro "reg_op" nm:ident "," f7:term "," f3:term "," opw:term ","
+    rop:term "," srop:term "," zop:term "," opU8:term "," m32:term "," ot:term ","
+    opc:ident : command => do
+  let s := nm.getId.toString
+  let tName := Lean.mkIdent (Lean.Name.mkSimple ("transpile_" ++ s))
+  let dfName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
+  let t1 ← `(theorem $tName (rd rs1 rs2 : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs2 : rs2 < 32) :
+        ∃ ext, extract_transpile_rv64im_raw
+            (toU32 (ZiskFv.Completeness.Rv64imShapes.rawRType $f7 rs2 rs1 $f3 rd $opw)) = ok ext
+          ∧ ext.row.op = $opU8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
+          ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      refine transpile_register_of _ $rop $srop $zop $opU8 $m32 $ot ?_ rfl (by intro self input; rfl)
+        rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
+      simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
+        ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
+        ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_shr25,
+        ZiskFv.Compliance.Decode.rawRType_opcode $f7 rs2 rs1 $f3 rd $opw (by norm_num),
+        ZiskFv.Compliance.Decode.rawRType_funct3 $f7 rs2 rs1 $f3 rd $opw (by norm_num) hrd (by norm_num),
+        ZiskFv.Compliance.Decode.rawRType_funct7 $f7 rs2 rs1 $f3 rd $opw (by norm_num) hrs2 hrs1
+          (by norm_num) hrd (by norm_num)]
+      rfl)
+  let t2 ← `(theorem $dfName (rd rs1 rs2 : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs2 : rs2 < 32)
+        (line : FGL) (msg : ZiskRomMessage FGL)
+        (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawRType $f7 rs2 rs1 $f3 rd $opw)) :
+        msg.op = $opc ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+          ∧ ∃ ext, extract_transpile_rv64im_raw
+                (toU32 (ZiskFv.Completeness.Rv64imShapes.rawRType $f7 rs2 rs1 $f3 rd $opw)) = ok ext
+              ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
+              ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+              ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ := $tName rd rs1 rs2 hrd hrs1 hrs2
+      obtain ⟨ho, hjo1, hjo2, hf⟩ :=
+        register_decode_fields_of_binding line msg _ $opU8 $opc ext
+          (by simp [romOpcode, $opc:term]) hok hop hj1 hj2 hbind
+      exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩)
+  return ⟨Lean.mkNullNode #[t1, t2]⟩
+
+open RiscvOpcode riscv2zisk_single_row.Rv64imSingleRowOpcode zisk_ops.ZiskOp zisk_ops.OpType
+open ZiskFv.Trusted
+
+reg_op sub, 32, 0, 0x33, RiscvOpcode.Sub, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sub, zisk_ops.ZiskOp.Sub, 11#u8, false, zisk_ops.OpType.Binary, OP_SUB
+reg_op and, 0, 7, 0x33, RiscvOpcode.And, riscv2zisk_single_row.Rv64imSingleRowOpcode.And, zisk_ops.ZiskOp.And, 14#u8, false, zisk_ops.OpType.Binary, OP_AND
+reg_op xor, 0, 4, 0x33, RiscvOpcode.Xor, riscv2zisk_single_row.Rv64imSingleRowOpcode.Xor, zisk_ops.ZiskOp.Xor, 16#u8, false, zisk_ops.OpType.Binary, OP_XOR
+reg_op slt, 0, 2, 0x33, RiscvOpcode.Slt, riscv2zisk_single_row.Rv64imSingleRowOpcode.Slt, zisk_ops.ZiskOp.Lt, 7#u8, false, zisk_ops.OpType.Binary, OP_LT
+reg_op sltu, 0, 3, 0x33, RiscvOpcode.Sltu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sltu, zisk_ops.ZiskOp.Ltu, 6#u8, false, zisk_ops.OpType.Binary, OP_LTU
+reg_op sll, 0, 1, 0x33, RiscvOpcode.Sll, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sll, zisk_ops.ZiskOp.Sll, 33#u8, false, zisk_ops.OpType.BinaryE, OP_SLL
+reg_op srl, 0, 5, 0x33, RiscvOpcode.Srl, riscv2zisk_single_row.Rv64imSingleRowOpcode.Srl, zisk_ops.ZiskOp.Srl, 34#u8, false, zisk_ops.OpType.BinaryE, OP_SRL
+reg_op sra, 32, 5, 0x33, RiscvOpcode.Sra, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sra, zisk_ops.ZiskOp.Sra, 35#u8, false, zisk_ops.OpType.BinaryE, OP_SRA
+reg_op addw, 0, 0, 0x3b, RiscvOpcode.Addw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Addw, zisk_ops.ZiskOp.AddW, 26#u8, true, zisk_ops.OpType.Binary, OP_ADD_W
+reg_op subw, 32, 0, 0x3b, RiscvOpcode.Subw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Subw, zisk_ops.ZiskOp.SubW, 27#u8, true, zisk_ops.OpType.Binary, OP_SUB_W
+reg_op sllw, 0, 1, 0x3b, RiscvOpcode.Sllw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sllw, zisk_ops.ZiskOp.SllW, 36#u8, true, zisk_ops.OpType.BinaryE, OP_SLL_W
+reg_op srlw, 0, 5, 0x3b, RiscvOpcode.Srlw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Srlw, zisk_ops.ZiskOp.SrlW, 37#u8, true, zisk_ops.OpType.BinaryE, OP_SRL_W
+reg_op sraw, 32, 5, 0x3b, RiscvOpcode.Sraw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sraw, zisk_ops.ZiskOp.SraW, 38#u8, true, zisk_ops.OpType.BinaryE, OP_SRA_W
+-- MULW is the one M-ext op whose `Decode_<op>_of_program` takes `bits` directly
+-- (no extra arith/bound/pin witness), so it fits the register template.
+reg_op mulw, 1, 0, 0x3b, RiscvOpcode.Mulw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulw, zisk_ops.ZiskOp.MulW, 182#u8, true, zisk_ops.OpType.ArithAm32, OP_MUL_W
+
+section AxiomAudit
+#print axioms transpile_sub
+#print axioms sub_decode_fields_of_binding
+end AxiomAudit
+
+end ZiskFv.Compliance.RawProgramBinding

--- a/bin/TrustGate/Main.lean
+++ b/bin/TrustGate/Main.lean
@@ -342,7 +342,8 @@ carries upstream `sorry`s) so they need the raw-closure regression gate:
 `ZiskFv.Compliance.Extraction` (eth-act/zisk-fv#111, opcode→fields decode pins) and
 `ZiskFv.Compliance.Decode` (eth-act/zisk-fv#162, raw-word→opcode decoder acceptance). -/
 def extractionNamespaces : List Name :=
-  [`ZiskFv.Compliance.Extraction, `ZiskFv.Compliance.Decode]
+  [`ZiskFv.Compliance.Extraction, `ZiskFv.Compliance.Decode,
+   `ZiskFv.Compliance.RawProgramBinding]
 
 /-- Kernel axioms permitted in an extraction-pin closure. Anything else —
 `sorryAx`, `Lean.ofReduceBool`, `Lean.trustCompiler`, a `ZiskFv.*` project


### PR DESCRIPTION
Part 1 of the Phase 9 stack for #61.

Stack:

1. **This PR:** production raw-word binding foundation
2. `phase9-2-initial-decoders`
3. `phase9-3-fidelity-nonvacuity`
4. `phase9-4-expanded-layout`
5. `phase9-5-architectural-decoders`
6. `phase9-6-root-endpoint`

## Summary

- Proves that the extracted production lowerer succeeds for all 63 supported RV64IM opcodes under
  their honest dispatcher-routing conditions.
- Transcribes the production ROM serialization faithfully, including signed offsets,
  immediate-source gating, and the extracted `SRC_IND` constant.
- Introduces the raw-program binding with an explicit increasing ROM layout.
- Recovers the per-family production-lowering facts and adds them to the build and raw
  extraction-closure gate.
- Adds the independent Rust `compute_trace_rom` cross-check for all 11 serialized row fields.

This does not modify `AcceptedZiskTrace` or `root_soundness`, and it does not claim that the caller's
raw image/layout came from a particular linked binary.

## Verification

- Focused `Extraction.Totality` and raw-binding Lean builds passed during development.
- Raw extraction-closure check passed.
- Rust production-ROM serialization cross-check passed.
- The complete six-PR stack passes `lake build`, V1, V2, and all eight `nix run .#test` stages;
  exact totals are recorded on the final PR.
