### PR TITLE
#61 Phase 9.2: construct initial raw program decoders

### DIFF
--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -185,6 +185,7 @@ import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingCopyb
 import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingImmediate
 import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingLoadStore
 import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingMext
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingControl
 import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingNonvacuity
 import ZiskFv.Compliance
 import ZiskFv.Compliance.EnsembleWitnessBuilder

--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -185,6 +185,7 @@ import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingCopyb
 import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingImmediate
 import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingLoadStore
 import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingMext
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingNonvacuity
 import ZiskFv.Compliance
 import ZiskFv.Compliance.EnsembleWitnessBuilder
 import ZiskFv.Compliance.RegisterMemBusBalance

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingControl.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingControl.lean
@@ -1,0 +1,777 @@
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingRegister
+
+/-!
+# Raw-program decode bridge — branch + control family (issue #159, BLOCK 3)
+
+Mirrors the register / immediate / load-store bridges
+(`RawProgramBinding{Register,Immediate,LoadStore}`) for the six RV64I branches
+(BEQ/BNE/BLT/BGE/BLTU/BGEU) and the five control ops (LUI/AUIPC/JAL/JALR/FENCE),
+with the raw word's register / immediate fields SYMBOLIC.
+
+  * BRANCHES (B-type word `rawBType`, `decode_b`) lower through
+    `create_branch_op_typed`.  `neg` flips the two `j` offsets: the CONSTANT
+    fall-through slot is `jmp_offset2` for the `neg = false` ops (BEQ/BLT/BLTU)
+    and `jmp_offset1` for the `neg = true` ops (BNE/BGE/BGEU).  The imm-target
+    slot is OUT of decode scope and not a decode pin (skipped).
+  * LUI / AUIPC (U-type word `rawUType`, `decode_u`) lower through `lui` /
+    `auipc`.  AUIPC's `store_pc = true` needs `rd ≠ 0` (the nop-guard disproof,
+    matching `auipc_static_pins_full`); the decode-relevant constant slot is
+    `jmp_offset1 = 4` (jmp_offset2 carries the imm target, skipped).
+  * JAL (J-type word `rawJType`, `decode_j`) lowers through `jal`; `store_pc =
+    true` needs `rd ≠ 0`.  The constant slot is `jmp_offset2 = 4` (jmp_offset1
+    carries the imm target, skipped).
+  * JALR (I-type word `rawIType … 0x67`, `decode_i … false`) lowers through
+    `jalr`, whose `i.imm % 4` TWO-ROW split makes `jmp_offset` a per-row
+    disjunction; `Decode_jalr_of_program` pins NO jmp_offset, so the bridge
+    threads only `op` / `flags` plus the genuine operand-side JALR witnesses
+    (a/c masks, flag, offset bridge/even/no-wrap) as caller hypotheses.
+  * FENCE (supported-FENCE word `rawSupportedFence`, `decode_fence`) lowers
+    through `nop`; both jump slots are the constant fall-through (`= 4`).  The
+    claim-side `fm = 0` / `rs = x0` / `rd = x0` are threaded as caller
+    hypotheses (the FENCE defect scope, matching `Decode_fence_of_program`).
+
+For each op `<op>` this module retains:
+  * `transpile_<op>` — the REAL Aeneas pipeline `extract_transpile_rv64im_raw`
+    reduces to the op's decode-field pins.
+  * `<op>_decode_fields_of_binding` — the committed message's decode fields,
+    from its raw word + the op-agnostic `romMessageOfRaw` binding.
+
+The historical `Decode_<op>_from_rawProgram` endpoints and `RawDecode_<op>`
+bundles targeted a retired decode interface and are deliberately not restored.
+
+Sound: NO native_decide / bv_decide / new axiom / `sorry`; kernel-only closure
+(`propext` / `Classical.choice` / `Quot.sound`).
+-/
+
+open Aeneas Aeneas.Std Result zisk_core
+open aeneas_extract.rv64im_decode
+open Goldilocks
+open ZiskFv.Compliance.Extraction
+  (defCtx decode_b_bounds decode_u_bounds decode_j_bounds decode_i_bounds
+   create_branch_op_typed_ok lui_ok auipc_ok jal_ok jalr_ok nop_ok
+   decode_extract_ok from_inst_ok)
+
+namespace ZiskFv.Compliance.RawProgramBinding
+
+open ZiskFv.Channels.ZiskRomBus (ZiskRomMessage)
+open ZiskFv.AirsClean.Main (RomFlagBits packFlags)
+open ZiskFv.Compliance.Decode (toU32)
+open aeneas_extract (extract_transpile_rv64im_raw)
+
+set_option maxHeartbeats 4000000
+set_option linter.unusedSimpArgs false
+
+private theorem hcast4' : (UScalar.hcast IScalarTy.I64 4#u64 : Std.I64).val = (4 : Int) := by decide
+
+/-! ## Decoder `rd`-field recovery (`[7,11]` bits) and the symbolic `rd ≠ 0`
+derivations, for the AUIPC / JAL / JALR `store_pc = true` nop-guard.  All
+kernel-sound (`ofNat32_shift_mask_eq`, no native_decide). -/
+
+private theorem and3968_shr7 (x : BitVec 32) : (x &&& 3968#32) >>> 7 = (x >>> 7) &&& 31#32 := by
+  apply BitVec.eq_of_getLsbD_eq; intro i
+  simp only [BitVec.getLsbD_ushiftRight, BitVec.getLsbD_and, BitVec.getLsbD_ofNat,
+    show (3968:Nat) = 31 <<< 7 by decide, Nat.testBit_shiftLeft]
+  rcases Nat.lt_or_ge i 5 with h5 | h5
+  · rw [decide_eq_true (show 7 + i < 32 by omega), decide_eq_true (show i < 32 by omega)]
+    simp [show (7 : Nat) ≤ 7 + i by omega, show 7 + i - 7 = i by omega]
+  · rw [ZiskFv.Compliance.Decode.tbf (show (31:Nat) < 2 ^ 5 by norm_num) (show 5 ≤ 7 + i - 7 by omega),
+      ZiskFv.Compliance.Decode.tbf (show (31:Nat) < 2 ^ 5 by norm_num) (show 5 ≤ i by omega)]
+    simp
+
+private theorem rawUType_rd (imm rd opcode : Nat) (hrd : rd < 32) (hop : opcode < 128) :
+    ((ZiskFv.Completeness.Rv64imShapes.rawUType imm rd opcode) &&& 3968#32) >>> 7
+      = BitVec.ofNat 32 rd := by
+  rw [and3968_shr7]
+  simp only [ZiskFv.Completeness.Rv64imShapes.rawUType, ZiskFv.Completeness.Rv64imShapes.rawOfNat32]
+  refine ZiskFv.Compliance.Decode.ofNat32_shift_mask_eq _ 7 5 rd hrd (by norm_num) ?_
+  intro i hi
+  have hmask : (4294963200).testBit (7 + i) = false := by interval_cases i <;> decide
+  simp only [Nat.testBit_or, Nat.testBit_shiftLeft, Nat.testBit_and]
+  have e7 : (7 ≤ 7 + i) := by omega
+  have hop' : opcode.testBit (7 + i) = false :=
+    ZiskFv.Compliance.Decode.tbf (show opcode < 2 ^ 7 by omega) (by omega)
+  simp [e7, hop', hmask, show 7 + i - 7 = i from by omega]
+
+private theorem rawJType_rd (imm rd : Nat) (hrd : rd < 32) :
+    ((ZiskFv.Completeness.Rv64imShapes.rawJType imm rd) &&& 3968#32) >>> 7 = BitVec.ofNat 32 rd := by
+  rw [and3968_shr7]
+  simp only [ZiskFv.Completeness.Rv64imShapes.rawJType, ZiskFv.Completeness.Rv64imShapes.rawOfNat32]
+  refine ZiskFv.Compliance.Decode.ofNat32_shift_mask_eq _ 7 5 rd hrd (by norm_num) ?_
+  intro i hi
+  simp only [Nat.testBit_or, Nat.testBit_shiftLeft, Nat.testBit_and]
+  have e7 : (7 ≤ 7 + i) := by omega
+  have h12 : ¬ (12 ≤ 7 + i) := by omega
+  have h20 : ¬ (20 ≤ 7 + i) := by omega
+  have h21 : ¬ (21 ≤ 7 + i) := by omega
+  have h31 : ¬ (31 ≤ 7 + i) := by omega
+  have h6f : (111).testBit (7 + i) = false :=
+    ZiskFv.Compliance.Decode.tbf (show 111 < 2 ^ 7 by norm_num) (by omega)
+  simp [e7, h12, h20, h21, h31, h6f, show 7 + i - 7 = i from by omega]
+
+private theorem rawIType_rd (imm rs1 funct3 rd opcode : Nat) (hrd : rd < 32) (hf3 : funct3 < 8)
+    (hop : opcode < 128) :
+    ((ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 funct3 rd opcode) &&& 3968#32) >>> 7
+      = BitVec.ofNat 32 rd := by
+  rw [and3968_shr7]
+  simp only [ZiskFv.Completeness.Rv64imShapes.rawIType, ZiskFv.Completeness.Rv64imShapes.rawOfNat32]
+  refine ZiskFv.Compliance.Decode.ofNat32_shift_mask_eq _ 7 5 rd hrd (by norm_num) ?_
+  intro i hi
+  simp only [Nat.testBit_or, Nat.testBit_shiftLeft]
+  have e20 : ¬ (20 ≤ 7 + i) := by omega
+  have e15 : ¬ (15 ≤ 7 + i) := by omega
+  have e12 : ¬ (12 ≤ 7 + i) := by omega
+  have e7 : (7 ≤ 7 + i) := by omega
+  have hop' : opcode.testBit (7 + i) = false :=
+    ZiskFv.Compliance.Decode.tbf (show opcode < 2 ^ 7 by omega) (by omega)
+  simp [e20, e15, e12, e7, hop', show 7 + i - 7 = i from by omega]
+
+private theorem rd_ne_zero_u32 (drd : Std.U32) (rd : Nat) (hrd : rd < 32) (hrd0 : rd ≠ 0)
+    (hbv : drd.bv = BitVec.ofNat 32 rd) : drd ≠ 0#u32 := by
+  intro hc
+  rw [hc] at hbv
+  have hz : (0 : Nat) = rd % 2 ^ 32 := by
+    have := congrArg BitVec.toNat hbv
+    simpa [BitVec.toNat_ofNat] using this
+  omega
+
+private theorem rd_ne_zero_i64 (drd : Std.U32) (rd : Nat) (hrd : rd < 32) (hrd0 : rd ≠ 0)
+    (hbv : drd.bv = BitVec.ofNat 32 rd) : (UScalar.hcast IScalarTy.I64 drd : Std.I64) ≠ 0#i64 := by
+  intro hc
+  have hval : (UScalar.hcast IScalarTy.I64 drd : Std.I64).val = drd.val :=
+    ZiskFv.Compliance.Extraction.hcast_u32_i64_val drd
+  rw [hc] at hval
+  have hz : drd.bv.toNat = 0 := by
+    have h1 : ((drd.val : Int)) = 0 := by rw [← hval]; decide
+    have h2 : drd.val = 0 := by exact_mod_cast h1
+    exact h2
+  rw [hbv, BitVec.toNat_ofNat] at hz
+  omega
+
+/-- op + flags only (no jump pin), for JALR. -/
+theorem op_flags_of_binding
+    (line : FGL) (msg : ZiskRomMessage FGL) (raw : BitVec 32)
+    (opc : Std.U8) (opF : FGL) (ext : zisk_core.aeneas_extract.Rv64imTranspileExtract)
+    (hopF : romOpcode opc = opF)
+    (hok : extract_transpile_rv64im_raw (toU32 raw) = ok ext)
+    (hop : ext.row.op = opc)
+    (hbind : msg = romMessageOfRaw line raw) :
+    msg.op = opF ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+  have hmsg : msg = serializeExtract line ext.row := by
+    rw [hbind, romMessageOfRaw, hok]
+    exact romRowOf_eq_serializeExtract line ext.row
+  refine ⟨?_, ?_⟩
+  · rw [hmsg]; show romOpcode ext.row.op = opF; rw [hop, hopF]
+  · rw [hmsg]; rfl
+
+/-! ## Generic branch-family transpile reduction (B-type word, `decode_b`).
+
+`create_branch_op_typed` writes only `rs1` / `rs2` (no `rd`); the constant
+fall-through jump slot is `jmp_offset2` for `neg = false`, `jmp_offset1` for
+`neg = true`. -/
+
+theorem transpile_branch_of
+    (raw : Std.U32) (rop : RiscvOpcode) (srop : riscv2zisk_single_row.Rv64imSingleRowOpcode)
+    (op : zisk_ops.ZiskOp) (neg : Bool) (opc : Std.U8)
+    (hdec : aeneas_extract.rv64im_decode.decode_32_core raw
+      = aeneas_extract.rv64im_decode.decode_b raw rop)
+    (hlowop : aeneas_extract.lowering_opcode rop = ok (some srop))
+    (harm : ∀ (self : riscv2zisk_context.Riscv2ZiskContext)
+        (input : riscv2zisk_single_row.Rv64imLoweringInput),
+        riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input self input srop false
+          = (do let s ← riscv2zisk_context.Riscv2ZiskContext.create_branch_op_typed
+                  { self with extract_marker := () } input op neg 4#u64
+                ok { s with extract_marker := () }))
+    (hcode : zisk_ops.ZiskOp.code op = ok opc) (hm32 : zisk_ops.ZiskOp.is_m32 op = ok false)
+    (hot : zisk_ops.ZiskOp.op_type op = ok zisk_ops.OpType.Binary) :
+    ∃ ext, extract_transpile_rv64im_raw raw = ok ext
+      ∧ ext.row.op = opc ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
+      ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+      ∧ (neg = false → ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64)
+      ∧ (neg = true  → ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64) := by
+  obtain ⟨decoded, hdecoded, hopd, hrs1b, hrs2b⟩ := decode_b_bounds raw rop
+  have hdec0 : aeneas_extract.rv64im_decode.decode_32_core raw = ok decoded := hdec.trans hdecoded
+  set input : riscv2zisk_single_row.Rv64imLoweringInput :=
+    { rom_address := 0#u64, rd := decoded.rd, rs1 := decoded.rs1, rs2 := decoded.rs2, imm := decoded.imm }
+    with hinput
+  obtain ⟨ctx0, hctx0⟩ := create_branch_op_typed_ok { defCtx with extract_marker := () } input op neg 4#u64
+    (by rw [hinput]; exact hrs1b) (by rw [hinput]; exact hrs2b)
+  obtain ⟨zib, hzib, hop2, hext2, hm322, hsp2, hstp2⟩ :=
+    ZiskFv.Compliance.Extraction.branch_static_pins_of { defCtx with extract_marker := () }
+      input op neg 4#u64 ctx0 opc hcode hm32 hot hctx0
+  obtain ⟨zib', hzib', hjf, hjt⟩ :=
+    ZiskFv.Compliance.Extraction.create_branch_op_typed_dynamic_pins
+      { defCtx with extract_marker := () } input op neg 4#u64 ctx0 hctx0
+  have hzz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
+  rw [hzz] at hjf hjt
+  obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
+  obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, _⟩ := from_inst_ok zib.i
+  have hlower : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input srop false
+      = ok { ctx0 with extract_marker := () } := by rw [harm defCtx input, hctx0]; rfl
+  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
+    simp only [bind_ok, Bind.bind, hdext, hopd, hlowop]
+    simp only [defCtx] at hlower
+    simp only [riscv2zisk_single_row.Rv64imLoweringInput.new, bind_ok, ← hinput,
+      hlower, hzib, core.option.Option.unwrap, Result.ofOption, hrow]
+  · show row.op = opc; rw [hrop]; exact hop2
+  · show row.is_external_op = true; rw [hrext]; exact hext2
+  · show row.m32 = false; rw [hrm32]; exact hm322
+  · show row.set_pc = false; rw [hrsp]; exact hsp2
+  · show row.store_pc = false; rw [hrstp]; exact hstp2
+  · intro hf; show row.jmp_offset2 = _; rw [hrj2]; exact hjf hf
+  · intro ht; show row.jmp_offset1 = _; rw [hrj1]; exact hjt ht
+
+/-! ## Branch decode-field bridges (one constant jump slot, op, flags). -/
+
+/-- `neg = false` branch (BEQ/BLT/BLTU): the committed message's `op` /
+`jmp_offset2` / `flags`, from its raw word binding. -/
+theorem branch_decode_fields_false
+    (line : FGL) (msg : ZiskRomMessage FGL) (raw : BitVec 32)
+    (opc : Std.U8) (opF : FGL) (ext : zisk_core.aeneas_extract.Rv64imTranspileExtract)
+    (hopF : romOpcode opc = opF)
+    (hok : extract_transpile_rv64im_raw (toU32 raw) = ok ext)
+    (hop : ext.row.op = opc)
+    (hj2 : ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64)
+    (hbind : msg = romMessageOfRaw line raw) :
+    msg.op = opF ∧ msg.jmp_offset2 = 4
+      ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+  have hmsg : msg = serializeExtract line ext.row := by
+    rw [hbind, romMessageOfRaw, hok]
+    exact romRowOf_eq_serializeExtract line ext.row
+  refine ⟨?_, ?_, ?_⟩
+  · rw [hmsg]; show romOpcode ext.row.op = opF; rw [hop, hopF]
+  · rw [hmsg]; show (ext.row.jmp_offset2.val : FGL) = 4; rw [hj2]; norm_num [hcast4']
+  · rw [hmsg]; rfl
+
+/-- `neg = true` branch (BNE/BGE/BGEU): the committed message's `op` /
+`jmp_offset1` / `flags`, from its raw word binding. -/
+theorem branch_decode_fields_true
+    (line : FGL) (msg : ZiskRomMessage FGL) (raw : BitVec 32)
+    (opc : Std.U8) (opF : FGL) (ext : zisk_core.aeneas_extract.Rv64imTranspileExtract)
+    (hopF : romOpcode opc = opF)
+    (hok : extract_transpile_rv64im_raw (toU32 raw) = ok ext)
+    (hop : ext.row.op = opc)
+    (hj1 : ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64)
+    (hbind : msg = romMessageOfRaw line raw) :
+    msg.op = opF ∧ msg.jmp_offset1 = 4
+      ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+  have hmsg : msg = serializeExtract line ext.row := by
+    rw [hbind, romMessageOfRaw, hok]
+    exact romRowOf_eq_serializeExtract line ext.row
+  refine ⟨?_, ?_, ?_⟩
+  · rw [hmsg]; show romOpcode ext.row.op = opF; rw [hop, hopF]
+  · rw [hmsg]; show (ext.row.jmp_offset1.val : FGL) = 4; rw [hj1]; norm_num [hcast4']
+  · rw [hmsg]; rfl
+
+/-- The committed message's opcode, both fall-through offsets, and flags. -/
+theorem jump_decode_fields_of_binding
+    (line : FGL) (msg : ZiskRomMessage FGL) (raw : BitVec 32)
+    (opc : Std.U8) (opF : FGL) (ext : zisk_core.aeneas_extract.Rv64imTranspileExtract)
+    (hopF : romOpcode opc = opF)
+    (hok : extract_transpile_rv64im_raw (toU32 raw) = ok ext)
+    (hop : ext.row.op = opc)
+    (hj1 : ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64)
+    (hj2 : ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64)
+    (hbind : msg = romMessageOfRaw line raw) :
+    msg.op = opF ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+      ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+  have hmsg : msg = serializeExtract line ext.row := by
+    rw [hbind, romMessageOfRaw, hok]
+    exact romRowOf_eq_serializeExtract line ext.row
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [hmsg]; show romOpcode ext.row.op = opF; rw [hop, hopF]
+  · rw [hmsg]; show (ext.row.jmp_offset1.val : FGL) = 4; rw [hj1]; norm_num [hcast4']
+  · rw [hmsg]; show (ext.row.jmp_offset2.val : FGL) = 4; rw [hj2]; norm_num [hcast4']
+  · rw [hmsg]; rfl
+
+/-! ## Per-op macros for the branch family. -/
+
+open RiscvOpcode riscv2zisk_single_row.Rv64imSingleRowOpcode zisk_ops.ZiskOp zisk_ops.OpType
+open ZiskFv.Trusted
+
+/-- macro (neg = false branch: BEQ/BLT/BLTU; constant slot `jmp_offset2`). -/
+local macro "branch_false_op" nm:ident "," f3:term "," rop:term "," srop:term ","
+    op:term "," opU8:term "," opc:ident : command => do
+  let s := nm.getId.toString
+  let tName := Lean.mkIdent (Lean.Name.mkSimple ("transpile_" ++ s))
+  let dfName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
+  let t1 ← `(theorem $tName (rs1 rs2 imm : Nat) (hrs1 : rs1 < 32) (hrs2 : rs2 < 32) :
+        ∃ ext, extract_transpile_rv64im_raw
+            (toU32 (ZiskFv.Completeness.Rv64imShapes.rawBType imm rs2 rs1 $f3)) = ok ext
+          ∧ ext.row.op = $opU8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
+          ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      have hdec : aeneas_extract.rv64im_decode.decode_32_core
+            (toU32 (ZiskFv.Completeness.Rv64imShapes.rawBType imm rs2 rs1 $f3))
+          = aeneas_extract.rv64im_decode.decode_b
+            (toU32 (ZiskFv.Completeness.Rv64imShapes.rawBType imm rs2 rs1 $f3)) $rop := by
+        simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
+          ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
+          ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_ofNat,
+          ZiskFv.Compliance.Decode.rawBType_opcode imm rs2 rs1 $f3,
+          ZiskFv.Compliance.Decode.rawBType_funct3 imm rs2 rs1 $f3 (by norm_num)]
+        all_goals rfl
+      obtain ⟨ext, hok, hop, hieo, hm32, hsp, hstp, hjf, _⟩ :=
+        transpile_branch_of _ $rop $srop $op false $opU8 hdec rfl (by intro self input; rfl) rfl rfl rfl
+      exact ⟨ext, hok, hop, hieo, hm32, hsp, hstp, hjf rfl⟩)
+  let t2 ← `(theorem $dfName (rs1 rs2 imm : Nat) (hrs1 : rs1 < 32) (hrs2 : rs2 < 32)
+        (line : FGL) (msg : ZiskRomMessage FGL)
+        (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawBType imm rs2 rs1 $f3)) :
+        msg.op = $opc ∧ msg.jmp_offset2 = 4
+          ∧ ∃ ext, extract_transpile_rv64im_raw
+                (toU32 (ZiskFv.Completeness.Rv64imShapes.rawBType imm rs2 rs1 $f3)) = ok ext
+              ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
+              ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+              ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj2⟩ := $tName rs1 rs2 imm hrs1 hrs2
+      obtain ⟨ho, hjo2, hf⟩ :=
+        branch_decode_fields_false line msg _ $opU8 $opc ext
+          (by simp [romOpcode, $opc:term]) hok hop hj2 hbind
+      exact ⟨ho, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩)
+  return ⟨Lean.mkNullNode #[t1, t2]⟩
+
+/-- macro (neg = true branch: BNE/BGE/BGEU; constant slot `jmp_offset1`). -/
+local macro "branch_true_op" nm:ident "," f3:term "," rop:term "," srop:term ","
+    op:term "," opU8:term "," opc:ident : command => do
+  let s := nm.getId.toString
+  let tName := Lean.mkIdent (Lean.Name.mkSimple ("transpile_" ++ s))
+  let dfName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
+  let t1 ← `(theorem $tName (rs1 rs2 imm : Nat) (hrs1 : rs1 < 32) (hrs2 : rs2 < 32) :
+        ∃ ext, extract_transpile_rv64im_raw
+            (toU32 (ZiskFv.Completeness.Rv64imShapes.rawBType imm rs2 rs1 $f3)) = ok ext
+          ∧ ext.row.op = $opU8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
+          ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      have hdec : aeneas_extract.rv64im_decode.decode_32_core
+            (toU32 (ZiskFv.Completeness.Rv64imShapes.rawBType imm rs2 rs1 $f3))
+          = aeneas_extract.rv64im_decode.decode_b
+            (toU32 (ZiskFv.Completeness.Rv64imShapes.rawBType imm rs2 rs1 $f3)) $rop := by
+        simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
+          ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
+          ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_ofNat,
+          ZiskFv.Compliance.Decode.rawBType_opcode imm rs2 rs1 $f3,
+          ZiskFv.Compliance.Decode.rawBType_funct3 imm rs2 rs1 $f3 (by norm_num)]
+        all_goals rfl
+      obtain ⟨ext, hok, hop, hieo, hm32, hsp, hstp, _, hjt⟩ :=
+        transpile_branch_of _ $rop $srop $op true $opU8 hdec rfl (by intro self input; rfl) rfl rfl rfl
+      exact ⟨ext, hok, hop, hieo, hm32, hsp, hstp, hjt rfl⟩)
+  let t2 ← `(theorem $dfName (rs1 rs2 imm : Nat) (hrs1 : rs1 < 32) (hrs2 : rs2 < 32)
+        (line : FGL) (msg : ZiskRomMessage FGL)
+        (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawBType imm rs2 rs1 $f3)) :
+        msg.op = $opc ∧ msg.jmp_offset1 = 4
+          ∧ ∃ ext, extract_transpile_rv64im_raw
+                (toU32 (ZiskFv.Completeness.Rv64imShapes.rawBType imm rs2 rs1 $f3)) = ok ext
+              ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
+              ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+              ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1⟩ := $tName rs1 rs2 imm hrs1 hrs2
+      obtain ⟨ho, hjo1, hf⟩ :=
+        branch_decode_fields_true line msg _ $opU8 $opc ext
+          (by simp [romOpcode, $opc:term]) hok hop hj1 hbind
+      exact ⟨ho, hjo1, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩)
+  return ⟨Lean.mkNullNode #[t1, t2]⟩
+
+branch_false_op beq,  0, RiscvOpcode.Beq,  riscv2zisk_single_row.Rv64imSingleRowOpcode.Beq,  zisk_ops.ZiskOp.Eq,  9#u8, OP_EQ
+branch_true_op  bne,  1, RiscvOpcode.Bne,  riscv2zisk_single_row.Rv64imSingleRowOpcode.Bne,  zisk_ops.ZiskOp.Eq,  9#u8, OP_EQ
+branch_false_op blt,  4, RiscvOpcode.Blt,  riscv2zisk_single_row.Rv64imSingleRowOpcode.Blt,  zisk_ops.ZiskOp.Lt,  7#u8, OP_LT
+branch_true_op  bge,  5, RiscvOpcode.Bge,  riscv2zisk_single_row.Rv64imSingleRowOpcode.Bge,  zisk_ops.ZiskOp.Lt,  7#u8, OP_LT
+branch_false_op bltu, 6, RiscvOpcode.Bltu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Bltu, zisk_ops.ZiskOp.Ltu, 6#u8, OP_LTU
+branch_true_op  bgeu, 7, RiscvOpcode.Bgeu, riscv2zisk_single_row.Rv64imSingleRowOpcode.Bgeu, zisk_ops.ZiskOp.Ltu, 6#u8, OP_LTU
+
+/-! ## LUI (U-type word, `decode_u` → `lui` → `OP_COPYB`).  Both jump slots are
+the constant fall-through; the operand-side `b_0`/`b_1` immediate bridges are
+threaded as caller hypotheses (matching `Decode_lui_of_program`). -/
+
+theorem transpile_lui (rd imm : Nat) (hrd : rd < 32) :
+    ∃ ext, extract_transpile_rv64im_raw (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x37)) = ok ext
+      ∧ ext.row.op = 1#u8 ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
+      ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+      ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+  have hdec : aeneas_extract.rv64im_decode.decode_32_core
+        (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x37))
+      = aeneas_extract.rv64im_decode.decode_u
+        (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x37)) RiscvOpcode.Lui := by
+    simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
+      ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_ofNat,
+      ZiskFv.Compliance.Decode.rawUType_opcode imm rd 0x37 (by norm_num)]
+    all_goals rfl
+  obtain ⟨decoded, hdecoded, hopd, hrdb, _⟩ :=
+    decode_u_bounds (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x37)) RiscvOpcode.Lui
+  have hdec0 : aeneas_extract.rv64im_decode.decode_32_core
+      (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x37)) = ok decoded := hdec.trans hdecoded
+  set input : riscv2zisk_single_row.Rv64imLoweringInput :=
+    { rom_address := 0#u64, rd := decoded.rd, rs1 := decoded.rs1, rs2 := decoded.rs2, imm := decoded.imm }
+    with hinput
+  obtain ⟨ctx0, hctx0⟩ := lui_ok { defCtx with extract_marker := () } input 4#u64 (by rw [hinput]; exact hrdb)
+  obtain ⟨zib, hzib, hop2, hext2, hm322, hsp2, hstp2⟩ :=
+    ZiskFv.Compliance.Extraction.lui_static_pins { defCtx with extract_marker := () } input 4#u64 ctx0 hctx0
+  obtain ⟨zib', hzib', hj1, hj2⟩ :=
+    ZiskFv.Compliance.Extraction.lui_dynamic_pins { defCtx with extract_marker := () } input 4#u64 ctx0 hctx0
+  have hzz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
+  rw [hzz] at hj1 hj2
+  obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
+  obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, _⟩ := from_inst_ok zib.i
+  have harm : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input
+        riscv2zisk_single_row.Rv64imSingleRowOpcode.Lui false
+      = (do let s ← riscv2zisk_context.Riscv2ZiskContext.lui { defCtx with extract_marker := () } input 4#u64
+            ok { s with extract_marker := () }) := rfl
+  have hlower : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input
+      riscv2zisk_single_row.Rv64imSingleRowOpcode.Lui false = ok { ctx0 with extract_marker := () } := by
+    rw [harm, hctx0]; rfl
+  have hlowop : aeneas_extract.lowering_opcode RiscvOpcode.Lui
+      = ok (some riscv2zisk_single_row.Rv64imSingleRowOpcode.Lui) := rfl
+  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
+    simp only [bind_ok, Bind.bind, hdext, hopd, hlowop]
+    simp only [defCtx] at hlower
+    simp only [riscv2zisk_single_row.Rv64imLoweringInput.new, bind_ok, ← hinput,
+      hlower, hzib, core.option.Option.unwrap, Result.ofOption, hrow]
+  · show row.op = 1#u8; rw [hrop]; exact hop2
+  · show row.is_external_op = false; rw [hrext]; exact hext2
+  · show row.m32 = false; rw [hrm32]; exact hm322
+  · show row.set_pc = false; rw [hrsp]; exact hsp2
+  · show row.store_pc = false; rw [hrstp]; exact hstp2
+  · show row.jmp_offset1 = _; rw [hrj1]; exact hj1
+  · show row.jmp_offset2 = _; rw [hrj2]; exact hj2
+
+theorem lui_decode_fields_of_binding (rd imm : Nat) (hrd : rd < 32)
+    (line : FGL) (msg : ZiskRomMessage FGL)
+    (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x37)) :
+    msg.op = OP_COPYB ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+      ∧ ∃ ext, extract_transpile_rv64im_raw
+            (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x37)) = ok ext
+          ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
+          ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ := transpile_lui rd imm hrd
+  obtain ⟨ho, hjo1, hjo2, hf⟩ :=
+    jump_decode_fields_of_binding line msg _ 1#u8 OP_COPYB ext
+      (by simp [romOpcode, OP_COPYB]) hok hop hj1 hj2 hbind
+  exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
+
+/-! ## AUIPC (U-type word, `decode_u` → `auipc` → `OP_FLAG`, `store_pc = true`).
+The constant slot is `jmp_offset1 = 4` (`= 4#i64`, defeq `hcast 4#u64`); the
+`store_pc = true` needs `rd ≠ 0`.  jmp_offset2 is the imm target (skipped). -/
+
+theorem transpile_auipc (rd imm : Nat) (hrd : rd < 32) (hrd0 : rd ≠ 0) :
+    ∃ ext, extract_transpile_rv64im_raw (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x17)) = ok ext
+      ∧ ext.row.op = 0#u8 ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
+      ∧ ext.row.set_pc = false ∧ ext.row.store_pc = true
+      ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64 := by
+  have hdec : aeneas_extract.rv64im_decode.decode_32_core
+        (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x17))
+      = aeneas_extract.rv64im_decode.decode_u
+        (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x17)) RiscvOpcode.Auipc := by
+    simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
+      ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_ofNat,
+      ZiskFv.Compliance.Decode.rawUType_opcode imm rd 0x17 (by norm_num)]
+    all_goals rfl
+  obtain ⟨decoded, hdecoded, hopd, hrdb, hrdbv⟩ :=
+    decode_u_bounds (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x17)) RiscvOpcode.Auipc
+  have hdec0 : aeneas_extract.rv64im_decode.decode_32_core
+      (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x17)) = ok decoded := hdec.trans hdecoded
+  set input : riscv2zisk_single_row.Rv64imLoweringInput :=
+    { rom_address := 0#u64, rd := decoded.rd, rs1 := decoded.rs1, rs2 := decoded.rs2, imm := decoded.imm }
+    with hinput
+  have hbveq : decoded.rd.bv = BitVec.ofNat 32 rd := by
+    rw [hrdbv]
+    show ((ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x17) &&& 3968#32) >>> 7 = BitVec.ofNat 32 rd
+    exact rawUType_rd imm rd 0x17 hrd (by norm_num)
+  have hrd_ne : (UScalar.hcast IScalarTy.I64 input.rd : Std.I64) ≠ 0#i64 := by
+    rw [hinput]; exact rd_ne_zero_i64 decoded.rd rd hrd hrd0 hbveq
+  obtain ⟨ctx0, hctx0⟩ := auipc_ok { defCtx with extract_marker := () } input (by rw [hinput]; exact hrdb)
+  obtain ⟨zib, hzib, hop2, hext2, hm322, hsp2, hstp2⟩ :=
+    ZiskFv.Compliance.Extraction.auipc_static_pins_full { defCtx with extract_marker := () } input ctx0 hrd_ne hctx0
+  obtain ⟨zib', hzib', hj1⟩ :=
+    ZiskFv.Compliance.Extraction.auipc_dynamic_pins { defCtx with extract_marker := () } input ctx0 hctx0
+  have hzz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
+  rw [hzz] at hj1
+  obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
+  obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, _⟩ := from_inst_ok zib.i
+  have harm : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input
+        riscv2zisk_single_row.Rv64imSingleRowOpcode.Auipc false
+      = (do let s ← riscv2zisk_context.Riscv2ZiskContext.auipc { defCtx with extract_marker := () } input
+            ok { s with extract_marker := () }) := rfl
+  have hlower : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input
+      riscv2zisk_single_row.Rv64imSingleRowOpcode.Auipc false = ok { ctx0 with extract_marker := () } := by
+    rw [harm, hctx0]; rfl
+  have hlowop : aeneas_extract.lowering_opcode RiscvOpcode.Auipc
+      = ok (some riscv2zisk_single_row.Rv64imSingleRowOpcode.Auipc) := rfl
+  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
+    simp only [bind_ok, Bind.bind, hdext, hopd, hlowop]
+    simp only [defCtx] at hlower
+    simp only [riscv2zisk_single_row.Rv64imLoweringInput.new, bind_ok, ← hinput,
+      hlower, hzib, core.option.Option.unwrap, Result.ofOption, hrow]
+  · show row.op = 0#u8; rw [hrop]; exact hop2
+  · show row.is_external_op = false; rw [hrext]; exact hext2
+  · show row.m32 = false; rw [hrm32]; exact hm322
+  · show row.set_pc = false; rw [hrsp]; exact hsp2
+  · show row.store_pc = true; rw [hrstp]; exact hstp2
+  · show row.jmp_offset1 = _; rw [hrj1]; exact hj1
+
+theorem auipc_decode_fields_of_binding (rd imm : Nat) (hrd : rd < 32) (hrd0 : rd ≠ 0)
+    (line : FGL) (msg : ZiskRomMessage FGL)
+    (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x17)) :
+    msg.op = OP_FLAG ∧ msg.jmp_offset1 = 4
+      ∧ ∃ ext, extract_transpile_rv64im_raw
+            (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x17)) = ok ext
+          ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
+          ∧ ext.row.set_pc = false ∧ ext.row.store_pc = true
+          ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1⟩ := transpile_auipc rd imm hrd hrd0
+  obtain ⟨ho, hjo1, hf⟩ :=
+    branch_decode_fields_true line msg _ 0#u8 OP_FLAG ext
+      (by simp [romOpcode, OP_FLAG]) hok hop hj1 hbind
+  exact ⟨ho, hjo1, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
+
+/-! ## JAL (J-type word, `decode_j` → `jal` → `OP_FLAG`, `store_pc = true`).
+Constant slot `jmp_offset2 = 4`; `store_pc = true` needs `rd ≠ 0`.  jmp_offset1
+is the imm target (skipped). -/
+
+theorem transpile_jal (rd imm : Nat) (hrd : rd < 32) (hrd0 : rd ≠ 0) :
+    ∃ ext, extract_transpile_rv64im_raw (toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd)) = ok ext
+      ∧ ext.row.op = 0#u8 ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
+      ∧ ext.row.set_pc = false ∧ ext.row.store_pc = true
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+  have hdec : aeneas_extract.rv64im_decode.decode_32_core
+        (toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd))
+      = aeneas_extract.rv64im_decode.decode_j
+        (toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd)) RiscvOpcode.Jal := by
+    simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
+      ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_ofNat,
+      ZiskFv.Compliance.Decode.rawJType_opcode imm rd]
+    all_goals rfl
+  obtain ⟨decoded, hdecoded, hopd, hrdb, hrdbv⟩ :=
+    decode_j_bounds (toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd)) RiscvOpcode.Jal
+  have hdec0 : aeneas_extract.rv64im_decode.decode_32_core
+      (toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd)) = ok decoded := hdec.trans hdecoded
+  set input : riscv2zisk_single_row.Rv64imLoweringInput :=
+    { rom_address := 0#u64, rd := decoded.rd, rs1 := decoded.rs1, rs2 := decoded.rs2, imm := decoded.imm }
+    with hinput
+  have hbveq : decoded.rd.bv = BitVec.ofNat 32 rd := by
+    rw [hrdbv]
+    show ((ZiskFv.Completeness.Rv64imShapes.rawJType imm rd) &&& 3968#32) >>> 7 = BitVec.ofNat 32 rd
+    exact rawJType_rd imm rd hrd
+  have hrd_ne : (UScalar.hcast IScalarTy.I64 input.rd : Std.I64) ≠ 0#i64 := by
+    rw [hinput]; exact rd_ne_zero_i64 decoded.rd rd hrd hrd0 hbveq
+  obtain ⟨ctx0, hctx0⟩ := jal_ok { defCtx with extract_marker := () } input 4#u64 (by rw [hinput]; exact hrdb)
+  obtain ⟨zib, hzib, hop2, hext2, hm322, hsp2, hstp2cond⟩ :=
+    ZiskFv.Compliance.Extraction.jal_static_pins { defCtx with extract_marker := () } input 4#u64 ctx0 hctx0
+  obtain ⟨zib', hzib', _, hj2⟩ :=
+    ZiskFv.Compliance.Extraction.jal_dynamic_pins { defCtx with extract_marker := () } input 4#u64 ctx0 hctx0
+  have hzz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
+  rw [hzz] at hj2
+  obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
+  obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, _⟩ := from_inst_ok zib.i
+  have harm : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input
+        riscv2zisk_single_row.Rv64imSingleRowOpcode.Jal false
+      = (do let s ← riscv2zisk_context.Riscv2ZiskContext.jal { defCtx with extract_marker := () } input 4#u64
+            ok { s with extract_marker := () }) := rfl
+  have hlower : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input
+      riscv2zisk_single_row.Rv64imSingleRowOpcode.Jal false = ok { ctx0 with extract_marker := () } := by
+    rw [harm, hctx0]; rfl
+  have hlowop : aeneas_extract.lowering_opcode RiscvOpcode.Jal
+      = ok (some riscv2zisk_single_row.Rv64imSingleRowOpcode.Jal) := rfl
+  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
+    simp only [bind_ok, Bind.bind, hdext, hopd, hlowop]
+    simp only [defCtx] at hlower
+    simp only [riscv2zisk_single_row.Rv64imLoweringInput.new, bind_ok, ← hinput,
+      hlower, hzib, core.option.Option.unwrap, Result.ofOption, hrow]
+  · show row.op = 0#u8; rw [hrop]; exact hop2
+  · show row.is_external_op = false; rw [hrext]; exact hext2
+  · show row.m32 = false; rw [hrm32]; exact hm322
+  · show row.set_pc = false; rw [hrsp]; exact hsp2
+  · show row.store_pc = true; rw [hrstp]; exact hstp2cond (by rw [hinput] at hrd_ne ⊢; exact hrd_ne)
+  · show row.jmp_offset2 = _; rw [hrj2]; exact hj2
+
+theorem jal_decode_fields_of_binding (rd imm : Nat) (hrd : rd < 32) (hrd0 : rd ≠ 0)
+    (line : FGL) (msg : ZiskRomMessage FGL)
+    (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd)) :
+    msg.op = OP_FLAG ∧ msg.jmp_offset2 = 4
+      ∧ ∃ ext, extract_transpile_rv64im_raw
+            (toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd)) = ok ext
+          ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
+          ∧ ext.row.set_pc = false ∧ ext.row.store_pc = true
+          ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj2⟩ := transpile_jal rd imm hrd hrd0
+  obtain ⟨ho, hjo2, hf⟩ :=
+    branch_decode_fields_false line msg _ 0#u8 OP_FLAG ext
+      (by simp [romOpcode, OP_FLAG]) hok hop hj2 hbind
+  exact ⟨ho, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
+
+/-! ## JALR (I-type word `… 0x67`, `decode_i … false` → `jalr` → `OP_AND`,
+`set_pc = true`, `store_pc = true`).  The `i.imm % 4` TWO-ROW split is handled in
+`jalr_ok`; `Decode_jalr_of_program` pins NO jmp_offset, so the bridge threads only
+`op` / `flags`, plus the genuine operand-side JALR witnesses (`flag` / a-mask /
+c-mask / offset bridge / even / no-wrap) as caller hypotheses. -/
+
+theorem transpile_jalr (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrd0 : rd ≠ 0) :
+    ∃ ext, extract_transpile_rv64im_raw
+        (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 0 rd 0x67)) = ok ext
+      ∧ ext.row.op = 14#u8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
+      ∧ ext.row.set_pc = true ∧ ext.row.store_pc = true := by
+  have hdec : aeneas_extract.rv64im_decode.decode_32_core
+        (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 0 rd 0x67))
+      = aeneas_extract.rv64im_decode.decode_i
+        (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 0 rd 0x67)) RiscvOpcode.Jalr false := by
+    simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
+      ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_ofNat,
+      ZiskFv.Compliance.Decode.rawIType_opcode imm rs1 0 rd 0x67 (by norm_num)]
+    all_goals rfl
+  obtain ⟨decoded, hdecoded, hopd, hrdb, hrs1b, hrdbv⟩ :=
+    decode_i_bounds (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 0 rd 0x67)) RiscvOpcode.Jalr false
+  have hdec0 : aeneas_extract.rv64im_decode.decode_32_core
+      (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 0 rd 0x67)) = ok decoded := hdec.trans hdecoded
+  set input : riscv2zisk_single_row.Rv64imLoweringInput :=
+    { rom_address := 0#u64, rd := decoded.rd, rs1 := decoded.rs1, rs2 := decoded.rs2, imm := decoded.imm }
+    with hinput
+  have hbveq : decoded.rd.bv = BitVec.ofNat 32 rd := by
+    rw [hrdbv]
+    show ((ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 0 rd 0x67) &&& 3968#32) >>> 7
+      = BitVec.ofNat 32 rd
+    exact rawIType_rd imm rs1 0 rd 0x67 hrd (by norm_num) (by norm_num)
+  have hrd_ne : input.rd ≠ 0#u32 := by
+    rw [hinput]; exact rd_ne_zero_u32 decoded.rd rd hrd hrd0 hbveq
+  obtain ⟨ctx0, hctx0⟩ := jalr_ok { defCtx with extract_marker := () } input
+    (by rw [hinput]; exact hrs1b) (by rw [hinput]; exact hrdb) (by rw [hinput])
+  obtain ⟨zib, hzib, hop2, hext2, hm322, hsp2, hstp2⟩ :=
+    ZiskFv.Compliance.Extraction.jalr_static_pins_full { defCtx with extract_marker := () } input 4#u64 ctx0 hrd_ne hctx0
+  obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
+  obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, _⟩ := from_inst_ok zib.i
+  have harm : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input
+        riscv2zisk_single_row.Rv64imSingleRowOpcode.Jalr false
+      = (do let s ← riscv2zisk_context.Riscv2ZiskContext.jalr { defCtx with extract_marker := () } input 4#u64
+            ok { s with extract_marker := () }) := rfl
+  have hlower : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input
+      riscv2zisk_single_row.Rv64imSingleRowOpcode.Jalr false = ok { ctx0 with extract_marker := () } := by
+    rw [harm, hctx0]; rfl
+  have hlowop : aeneas_extract.lowering_opcode RiscvOpcode.Jalr
+      = ok (some riscv2zisk_single_row.Rv64imSingleRowOpcode.Jalr) := rfl
+  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
+    simp only [bind_ok, Bind.bind, hdext, hopd, hlowop]
+    simp only [defCtx] at hlower
+    simp only [riscv2zisk_single_row.Rv64imLoweringInput.new, bind_ok, ← hinput,
+      hlower, hzib, core.option.Option.unwrap, Result.ofOption, hrow]
+  · show row.op = 14#u8; rw [hrop]; exact hop2
+  · show row.is_external_op = true; rw [hrext]; exact hext2
+  · show row.m32 = false; rw [hrm32]; exact hm322
+  · show row.set_pc = true; rw [hrsp]; exact hsp2
+  · show row.store_pc = true; rw [hrstp]; exact hstp2
+
+theorem jalr_decode_fields_of_binding
+    (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrd0 : rd ≠ 0)
+    (line : FGL) (msg : ZiskRomMessage FGL)
+    (hbind : msg = romMessageOfRaw line
+      (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 0 rd 0x67)) :
+    msg.op = OP_AND
+      ∧ ∃ ext, extract_transpile_rv64im_raw
+            (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 0 rd 0x67)) = ok ext
+          ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
+          ∧ ext.row.set_pc = true ∧ ext.row.store_pc = true
+          ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc⟩ :=
+    transpile_jalr rd rs1 imm hrd hrs1 hrd0
+  obtain ⟨ho, hf⟩ :=
+    op_flags_of_binding line msg _ 14#u8 OP_AND ext
+      (by simp [romOpcode, OP_AND]) hok hop hbind
+  exact ⟨ho, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
+
+/-! ## FENCE (supported-FENCE word `rawSupportedFence`, `decode_fence` → `nop` →
+`OP_FLAG`).  Both jump slots are the constant fall-through; the claim-side
+`fm = 0` / `rs = x0` / `rd = x0` are threaded as caller hypotheses (the FENCE
+defect scope, matching `Decode_fence_of_program`). -/
+
+theorem transpile_fence (pred succ : Nat) (hp : pred < 16) (hs : succ < 16) :
+    ∃ ext, extract_transpile_rv64im_raw
+        (toU32 (ZiskFv.Completeness.Rv64imShapes.rawSupportedFence pred succ)) = ok ext
+      ∧ ext.row.op = 0#u8 ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
+      ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+      ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+  obtain ⟨decoded, hdec0, hopd⟩ :
+      ∃ d, aeneas_extract.rv64im_decode.decode_32_core
+          (toU32 (ZiskFv.Completeness.Rv64imShapes.rawSupportedFence pred succ)) = ok d
+        ∧ d.opcode = RiscvOpcode.Fence :=
+    ⟨_, by
+      simp only [aeneas_extract.rv64im_decode.decode_32_core, aeneas_extract.rv64im_decode.decode_fence,
+        aeneas_extract.rv64im_decode.DecodedRv64im.new, lift, bind_assoc, Bind.bind, bind_ok,
+        ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and28672,
+        ZiskFv.Compliance.Decode.toU32_and3968, ZiskFv.Compliance.Decode.toU32_and1015808,
+        ZiskFv.Compliance.Decode.toU32_and4027551616, ZiskFv.Compliance.Decode.toU32_and15,
+        ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_shr7,
+        ZiskFv.Compliance.Decode.toU32_shr15, ZiskFv.Compliance.Decode.toU32_shr20,
+        ZiskFv.Compliance.Decode.toU32_shr24, ZiskFv.Compliance.Decode.toU32_ofNat,
+        ZiskFv.Compliance.Decode.rawSupportedFence_opcode,
+        ZiskFv.Compliance.Decode.rawSupportedFence_funct3 pred succ hp hs,
+        ZiskFv.Compliance.Decode.rawSupportedFence_zeros pred succ hp hs]
+      rfl, rfl⟩
+  set input : riscv2zisk_single_row.Rv64imLoweringInput :=
+    { rom_address := 0#u64, rd := decoded.rd, rs1 := decoded.rs1, rs2 := decoded.rs2, imm := decoded.imm }
+    with hinput
+  obtain ⟨ctx0, hctx0⟩ := nop_ok { defCtx with extract_marker := () } input 4#u64
+  obtain ⟨zib, hzib, hop2, hext2, hm322, hsp2, hstp2⟩ :=
+    ZiskFv.Compliance.Extraction.nop_static_pins { defCtx with extract_marker := () } input 4#u64 ctx0 hctx0
+  obtain ⟨zib', hzib', hj1, hj2⟩ :=
+    ZiskFv.Compliance.Extraction.nop_dynamic_pins { defCtx with extract_marker := () } input 4#u64 ctx0 hctx0
+  have hzz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
+  rw [hzz] at hj1 hj2
+  obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
+  obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, _⟩ := from_inst_ok zib.i
+  have harm : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input
+        riscv2zisk_single_row.Rv64imSingleRowOpcode.Fence false
+      = (do let s ← riscv2zisk_context.Riscv2ZiskContext.nop { defCtx with extract_marker := () } input 4#u64
+            ok { s with extract_marker := () }) := rfl
+  have hlower : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input
+      riscv2zisk_single_row.Rv64imSingleRowOpcode.Fence false = ok { ctx0 with extract_marker := () } := by
+    rw [harm, hctx0]; rfl
+  have hlowop : aeneas_extract.lowering_opcode RiscvOpcode.Fence
+      = ok (some riscv2zisk_single_row.Rv64imSingleRowOpcode.Fence) := rfl
+  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
+    simp only [bind_ok, Bind.bind, hdext, hopd, hlowop]
+    simp only [defCtx] at hlower
+    simp only [riscv2zisk_single_row.Rv64imLoweringInput.new, bind_ok, ← hinput,
+      hlower, hzib, core.option.Option.unwrap, Result.ofOption, hrow]
+  · show row.op = 0#u8; rw [hrop]; exact hop2
+  · show row.is_external_op = false; rw [hrext]; exact hext2
+  · show row.m32 = false; rw [hrm32]; exact hm322
+  · show row.set_pc = false; rw [hrsp]; exact hsp2
+  · show row.store_pc = false; rw [hrstp]; exact hstp2
+  · show row.jmp_offset1 = _; rw [hrj1]; exact hj1
+  · show row.jmp_offset2 = _; rw [hrj2]; exact hj2
+
+theorem fence_decode_fields_of_binding
+    (pred succ : Nat) (hp : pred < 16) (hs : succ < 16)
+    (line : FGL) (msg : ZiskRomMessage FGL)
+    (hbind : msg = romMessageOfRaw line
+      (ZiskFv.Completeness.Rv64imShapes.rawSupportedFence pred succ)) :
+    msg.op = OP_FLAG ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+      ∧ ∃ ext, extract_transpile_rv64im_raw
+            (toU32 (ZiskFv.Completeness.Rv64imShapes.rawSupportedFence pred succ)) = ok ext
+          ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
+          ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ :=
+    transpile_fence pred succ hp hs
+  obtain ⟨ho, hjo1, hjo2, hf⟩ :=
+    jump_decode_fields_of_binding line msg _ 0#u8 OP_FLAG ext
+      (by simp [romOpcode, OP_FLAG]) hok hop hj1 hj2 hbind
+  exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
+
+section AxiomAudit
+#print axioms transpile_lui
+#print axioms transpile_auipc
+#print axioms transpile_jal
+#print axioms transpile_jalr
+#print axioms jalr_decode_fields_of_binding
+#print axioms transpile_fence
+#print axioms fence_decode_fields_of_binding
+#print axioms transpile_beq
+#print axioms beq_decode_fields_of_binding
+end AxiomAudit
+
+end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingControl.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingControl.lean
@@ -762,6 +762,71 @@ theorem fence_decode_fields_of_binding
       (by simp [romOpcode, OP_FLAG]) hok hop hj1 hj2 hbind
   exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
 
+/-! ## Current `ProgramDecode` retarget: FENCE. -/
+
+/-- Raw-program evidence for one supported FENCE step.  Only the claim-side
+    defect witnesses and the Main-row bound remain caller supplied; all
+    committed-ROM fields are recovered from the raw word. -/
+structure RawProgramDecode_fence {n : Nat}
+    (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_fence trace i)
+    (rawProgram : Fin trace.programLength → BitVec 32) where
+  h_idx : i.val + 1 < trace.mainTable.table.length
+  h_fm_zero : c.fm = 0#4
+  h_rs_x0 : ZiskFv.Compliance.Defects.IsX0Reg c.rs
+  h_rd_x0 : ZiskFv.Compliance.Defects.IsX0Reg c.rd
+  hLine : ∀ j : Fin trace.programLength,
+    (trace.program j).line =
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
+      rawProgram j =
+        ZiskFv.Completeness.Rv64imShapes.rawSupportedFence c.fenceP.toNat c.fenceS.toNat
+
+/-- Rebuild the current committed-program FENCE bundle from the raw program and
+    the op-agnostic production-lowering certificate. -/
+noncomputable def ProgramDecode_fence_from_rawProgram {n : Nat}
+    (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_fence trace i)
+    (addr : Fin trace.programLength → FGL)
+    (rawProgram : Fin trace.programLength → BitVec 32)
+    (hbind : ProgramBinding trace addr rawProgram)
+    (rawDecode : RawProgramDecode_fence trace i c rawProgram) :
+    ZiskFv.Compliance.RomDecodeBinding.ProgramDecode_fence trace i c := by
+  let pred := c.fenceP.toNat
+  let succ := c.fenceS.toNat
+  have hp : pred < 16 := by
+    simpa only [pred] using
+      (Aeneas.SimpScalar.BitVec.toNat_lt_two_pow c.fenceP 4 (by omega))
+  have hs : succ < 16 := by
+    simpa only [succ] using
+      (Aeneas.SimpScalar.BitVec.toNat_lt_two_pow c.fenceS 4 (by omega))
+  let ext := (transpile_fence pred succ hp hs).choose
+  obtain ⟨hok, hop, hieo, _hm32, hsetpc, _hstorepc, hj1, hj2⟩ :=
+    (transpile_fence pred succ hp hs).choose_spec
+  refine
+    { h_idx := rawDecode.h_idx
+      h_fm_zero := rawDecode.h_fm_zero
+      h_rs_x0 := rawDecode.h_rs_x0
+      h_rd_x0 := rawDecode.h_rd_x0
+      bits := romFlagBitsOfExtract ext.row
+      h_bits_ieo := ?_
+      h_bits_set_pc := ?_
+      h_prog := ?_ }
+  · simpa only [ext, romFlagBitsOfExtract] using hieo
+  · simpa only [ext, romFlagBitsOfExtract] using hsetpc
+  · intro j hline
+    have hbk : trace.program j =
+        romMessageOfRaw (addr j)
+          (ZiskFv.Completeness.Rv64imShapes.rawSupportedFence pred succ) := by
+      exact (hbind.2 j).trans
+        (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+    obtain ⟨ho, hjo1, hjo2, ext', hok', _hieo', _hm32', _hsetpc',
+        _hstorepc', hf⟩ :=
+      fence_decode_fields_of_binding pred succ hp hs
+        (addr j) (trace.program j) hbk
+    have hext : ext' = ext := Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
+    subst ext'
+    exact ⟨ho, hjo1, hjo2, hf⟩
+
 section AxiomAudit
 #print axioms transpile_lui
 #print axioms transpile_auipc
@@ -770,6 +835,7 @@ section AxiomAudit
 #print axioms jalr_decode_fields_of_binding
 #print axioms transpile_fence
 #print axioms fence_decode_fields_of_binding
+#print axioms ProgramDecode_fence_from_rawProgram
 #print axioms transpile_beq
 #print axioms beq_decode_fields_of_binding
 end AxiomAudit

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingCopyb.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingCopyb.lean
@@ -1,4 +1,4 @@
-import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingRegister
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingImmediate
 
 /-!
 # Raw-program decode bridge — conditional-copyb ops (issue #159, BLOCK 3)
@@ -360,6 +360,36 @@ theorem transpile_immediate_copyb_of
   · show row.jmp_offset1 = _; rw [hrj1]; exact hj1
   · show row.jmp_offset2 = _; rw [hrj2]; exact hj2
 
+private theorem copyb_hcast4 :
+    (UScalar.hcast IScalarTy.I64 4#u64 : Std.I64).val = (4 : Int) := by decide
+
+private theorem copyb_decode_fields_of_binding
+    (line : FGL) (msg : ZiskRomMessage FGL) (raw : BitVec 32)
+    (opc : Std.U8) (opF : FGL) (ext : zisk_core.aeneas_extract.Rv64imTranspileExtract)
+    (hopF : romOpcode opc = opF)
+    (hok : extract_transpile_rv64im_raw (toU32 raw) = ok ext)
+    (hop : ext.row.op = opc)
+    (hj1 : ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64)
+    (hj2 : ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64)
+    (hbind : msg = romMessageOfRaw line raw) :
+    msg.op = opF ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+      ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+  have hmsg : msg = serializeExtract line ext.row := by
+    rw [hbind, romMessageOfRaw, hok]
+    exact romRowOf_eq_serializeExtract line ext.row
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [hmsg]; show romOpcode ext.row.op = opF; rw [hop, hopF]
+  · rw [hmsg]
+    show (ext.row.jmp_offset1.val : FGL) = 4
+    rw [hj1]
+    norm_num [copyb_hcast4]
+  · rw [hmsg]
+    show (ext.row.jmp_offset2.val : FGL) = 4
+    rw [hj2]
+    norm_num [copyb_hcast4]
+  · rw [hmsg]
+    rfl
+
 /-! ## 5. ADD (register, `rd ≠ 0 ∧ rs1 ≠ 0 ∧ rs2 ≠ 0`). -/
 
 open ZiskFv.Trusted (OP_ADD OP_OR OP_XOR)
@@ -413,14 +443,202 @@ theorem add_decode_fields_of_binding (rd rs1 rs2 : Nat) (hrd : rd < 32) (hrs1 : 
   obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ :=
     transpile_add rd rs1 rs2 hrd hrs1 hrs2 hrd0 hrs10 hrs20
   obtain ⟨ho, hjo1, hjo2, hf⟩ :=
-    register_decode_fields_of_binding line msg _ 10#u8 OP_ADD ext
+    copyb_decode_fields_of_binding line msg _ 10#u8 OP_ADD ext
       (by simp [romOpcode, OP_ADD]) hok hop hj1 hj2 hbind
   exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
 
+/-! ## 6. OR (register, `rs1 ≠ 0 ∧ rs2 ≠ 0`). -/
+
+theorem transpile_or (rd rs1 rs2 : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs2 : rs2 < 32)
+    (hrs10 : rs1 ≠ 0) (hrs20 : rs2 ≠ 0) :
+    ∃ ext, extract_transpile_rv64im_raw (toU32 (rawRType 0 rs2 rs1 6 rd 0x33)) = ok ext
+      ∧ ext.row.op = 15#u8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
+      ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+      ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+  refine transpile_register_cond_of _ RiscvOpcode.Or
+    riscv2zisk_single_row.Rv64imSingleRowOpcode.Or zisk_ops.ZiskOp.Or 15#u8 false zisk_ops.OpType.Binary
+    { defCtx with extract_marker := () }
+    (fun input => input.rs1 ≠ 0#u32 ∧ input.rs2 ≠ 0#u32)
+    ?_ rfl ?_ ?_ rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
+  · simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
+      ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
+      ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_shr25,
+      ZiskFv.Compliance.Decode.rawRType_opcode 0 rs2 rs1 6 rd 0x33 (by norm_num),
+      ZiskFv.Compliance.Decode.rawRType_funct3 0 rs2 rs1 6 rd 0x33 (by norm_num) hrd (by norm_num),
+      ZiskFv.Compliance.Decode.rawRType_funct7 0 rs2 rs1 6 rd 0x33 (by norm_num) hrs2 hrs1
+        (by norm_num) hrd (by norm_num)]
+    rfl
+  · intro input hP
+    obtain ⟨hrs1', hrs2'⟩ := hP
+    simp only [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input, Bind.bind, bind_ok]
+    rw [if_neg hrs1', if_neg hrs2']
+  · intro d hd
+    obtain ⟨d', hd', _, hrs1bv, hrs2bv⟩ := decode_r_fields (toU32 (rawRType 0 rs2 rs1 6 rd 0x33)) RiscvOpcode.Or
+    have hdd : d = d' := Result.ok.inj (hd.symm.trans hd'); subst hdd
+    exact ⟨u32_ne_zero_of_bv d.rs1 rs1 hrs1 hrs10
+            (by rw [hrs1bv]; exact rawRType_rs1 0 rs2 rs1 6 rd 0x33 hrs1 (by norm_num) hrd (by norm_num)),
+          u32_ne_zero_of_bv d.rs2 rs2 hrs2 hrs20
+            (by rw [hrs2bv]; exact rawRType_rs2 0 rs2 rs1 6 rd 0x33 hrs2 hrs1 (by norm_num) hrd (by norm_num))⟩
+
+theorem or_decode_fields_of_binding (rd rs1 rs2 : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs2 : rs2 < 32)
+    (hrs10 : rs1 ≠ 0) (hrs20 : rs2 ≠ 0)
+    (line : FGL) (msg : ZiskRomMessage FGL)
+    (hbind : msg = romMessageOfRaw line (rawRType 0 rs2 rs1 6 rd 0x33)) :
+    msg.op = OP_OR ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+      ∧ ∃ ext, extract_transpile_rv64im_raw (toU32 (rawRType 0 rs2 rs1 6 rd 0x33)) = ok ext
+          ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
+          ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ :=
+    transpile_or rd rs1 rs2 hrd hrs1 hrs2 hrs10 hrs20
+  obtain ⟨ho, hjo1, hjo2, hf⟩ :=
+    copyb_decode_fields_of_binding line msg _ 15#u8 OP_OR ext
+      (by simp [romOpcode, OP_OR]) hok hop hj1 hj2 hbind
+  exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
+
+/-! ## 7. ADDI (immediate, `rd ≠ 0 ∧ imm ≠ 0 ∧ rs1 ≠ 0`; `imm ≠ 0` threaded). -/
+
+theorem transpile_addi (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32)
+    (hrd0 : rd ≠ 0) (hrs10 : rs1 ≠ 0)
+    (himm : ∀ d, aeneas_extract.rv64im_decode.decode_i (toU32 (rawIType imm rs1 0 rd 0x13))
+      RiscvOpcode.Addi false = ok d → d.imm ≠ 0#i32) :
+    ∃ ext, extract_transpile_rv64im_raw (toU32 (rawIType imm rs1 0 rd 0x13)) = ok ext
+      ∧ ext.row.op = 10#u8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
+      ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+      ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+  refine transpile_immediate_copyb_of _ RiscvOpcode.Addi false
+    riscv2zisk_single_row.Rv64imSingleRowOpcode.Addi zisk_ops.ZiskOp.Add 10#u8 false zisk_ops.OpType.Binary
+    { defCtx with extract_marker := () }
+    (fun input => input.rd ≠ 0#u32 ∧ input.imm ≠ 0#i32 ∧ input.rs1 ≠ 0#u32)
+    ?_ rfl ?_ ?_ (fun _ hP => hP.2.2) rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
+  · simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
+      ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
+      ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_ofNat,
+      ZiskFv.Compliance.Decode.rawIType_opcode imm rs1 0 rd 0x13 (by norm_num),
+      ZiskFv.Compliance.Decode.rawIType_funct3 imm rs1 0 rd 0x13 (by norm_num) hrd (by norm_num)]
+    all_goals rfl
+  · intro input hP
+    obtain ⟨hrd', himm', _⟩ := hP
+    simp only [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input, Bind.bind, bind_ok]
+    rw [if_neg hrd', if_neg himm']
+  · intro d hd
+    obtain ⟨hrdbv, hrs1bv⟩ :=
+      decode_i_rd_rs1_bv (toU32 (rawIType imm rs1 0 rd 0x13)) RiscvOpcode.Addi false d hd
+    exact ⟨u32_ne_zero_of_bv d.rd rd hrd hrd0
+            (by rw [hrdbv]; exact rawIType_rd' imm rs1 0 rd 0x13 hrd (by norm_num) (by norm_num)),
+          himm d hd,
+          u32_ne_zero_of_bv d.rs1 rs1 hrs1 hrs10
+            (by rw [hrs1bv]; exact rawIType_rs1 imm rs1 0 rd 0x13 hrs1 (by norm_num) hrd (by norm_num))⟩
+
+theorem addi_decode_fields_of_binding (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32)
+    (hrd0 : rd ≠ 0) (hrs10 : rs1 ≠ 0)
+    (himm : ∀ d, aeneas_extract.rv64im_decode.decode_i (toU32 (rawIType imm rs1 0 rd 0x13))
+      RiscvOpcode.Addi false = ok d → d.imm ≠ 0#i32)
+    (line : FGL) (msg : ZiskRomMessage FGL)
+    (hbind : msg = romMessageOfRaw line (rawIType imm rs1 0 rd 0x13)) :
+    msg.op = OP_ADD ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+      ∧ ∃ ext, extract_transpile_rv64im_raw (toU32 (rawIType imm rs1 0 rd 0x13)) = ok ext
+          ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
+          ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ :=
+    transpile_addi rd rs1 imm hrd hrs1 hrd0 hrs10 himm
+  obtain ⟨ho, hjo1, hjo2, hf⟩ :=
+    copyb_decode_fields_of_binding line msg _ 10#u8 OP_ADD ext
+      (by simp [romOpcode, OP_ADD]) hok hop hj1 hj2 hbind
+  exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
+
+/-! ## 8. XORI / ORI (immediate, dispatcher-unconditional; op-arm needs `rs1 ≠ 0`). -/
+
+theorem transpile_xori (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs10 : rs1 ≠ 0) :
+    ∃ ext, extract_transpile_rv64im_raw (toU32 (rawIType imm rs1 4 rd 0x13)) = ok ext
+      ∧ ext.row.op = 16#u8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
+      ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+      ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+  refine transpile_immediate_copyb_of _ RiscvOpcode.Xori false
+    riscv2zisk_single_row.Rv64imSingleRowOpcode.Xori zisk_ops.ZiskOp.Xor 16#u8 false zisk_ops.OpType.Binary
+    { defCtx with extract_marker := () }
+    (fun input => input.rs1 ≠ 0#u32)
+    ?_ rfl (fun _ _ => rfl) ?_ (fun _ hP => hP) rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
+  · simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
+      ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
+      ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_ofNat,
+      ZiskFv.Compliance.Decode.rawIType_opcode imm rs1 4 rd 0x13 (by norm_num),
+      ZiskFv.Compliance.Decode.rawIType_funct3 imm rs1 4 rd 0x13 (by norm_num) hrd (by norm_num)]
+    all_goals rfl
+  · intro d hd
+    obtain ⟨_, hrs1bv⟩ :=
+      decode_i_rd_rs1_bv (toU32 (rawIType imm rs1 4 rd 0x13)) RiscvOpcode.Xori false d hd
+    exact u32_ne_zero_of_bv d.rs1 rs1 hrs1 hrs10
+      (by rw [hrs1bv]; exact rawIType_rs1 imm rs1 4 rd 0x13 hrs1 (by norm_num) hrd (by norm_num))
+
+theorem xori_decode_fields_of_binding (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs10 : rs1 ≠ 0)
+    (line : FGL) (msg : ZiskRomMessage FGL)
+    (hbind : msg = romMessageOfRaw line (rawIType imm rs1 4 rd 0x13)) :
+    msg.op = OP_XOR ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+      ∧ ∃ ext, extract_transpile_rv64im_raw (toU32 (rawIType imm rs1 4 rd 0x13)) = ok ext
+          ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
+          ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ :=
+    transpile_xori rd rs1 imm hrd hrs1 hrs10
+  obtain ⟨ho, hjo1, hjo2, hf⟩ :=
+    copyb_decode_fields_of_binding line msg _ 16#u8 OP_XOR ext
+      (by simp [romOpcode, OP_XOR]) hok hop hj1 hj2 hbind
+  exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
+
+theorem transpile_ori (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs10 : rs1 ≠ 0) :
+    ∃ ext, extract_transpile_rv64im_raw (toU32 (rawIType imm rs1 6 rd 0x13)) = ok ext
+      ∧ ext.row.op = 15#u8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
+      ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+      ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+  refine transpile_immediate_copyb_of _ RiscvOpcode.Ori false
+    riscv2zisk_single_row.Rv64imSingleRowOpcode.Ori zisk_ops.ZiskOp.Or 15#u8 false zisk_ops.OpType.Binary
+    { defCtx with extract_marker := () }
+    (fun input => input.rs1 ≠ 0#u32)
+    ?_ rfl (fun _ _ => rfl) ?_ (fun _ hP => hP) rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
+  · simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
+      ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
+      ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_ofNat,
+      ZiskFv.Compliance.Decode.rawIType_opcode imm rs1 6 rd 0x13 (by norm_num),
+      ZiskFv.Compliance.Decode.rawIType_funct3 imm rs1 6 rd 0x13 (by norm_num) hrd (by norm_num)]
+    all_goals rfl
+  · intro d hd
+    obtain ⟨_, hrs1bv⟩ :=
+      decode_i_rd_rs1_bv (toU32 (rawIType imm rs1 6 rd 0x13)) RiscvOpcode.Ori false d hd
+    exact u32_ne_zero_of_bv d.rs1 rs1 hrs1 hrs10
+      (by rw [hrs1bv]; exact rawIType_rs1 imm rs1 6 rd 0x13 hrs1 (by norm_num) hrd (by norm_num))
+
+theorem ori_decode_fields_of_binding (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs10 : rs1 ≠ 0)
+    (line : FGL) (msg : ZiskRomMessage FGL)
+    (hbind : msg = romMessageOfRaw line (rawIType imm rs1 6 rd 0x13)) :
+    msg.op = OP_OR ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+      ∧ ∃ ext, extract_transpile_rv64im_raw (toU32 (rawIType imm rs1 6 rd 0x13)) = ok ext
+          ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
+          ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ :=
+    transpile_ori rd rs1 imm hrd hrs1 hrs10
+  obtain ⟨ho, hjo1, hjo2, hf⟩ :=
+    copyb_decode_fields_of_binding line msg _ 15#u8 OP_OR ext
+      (by simp [romOpcode, OP_OR]) hok hop hj1 hj2 hbind
+  exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
 
 section AxiomAudit
 #print axioms transpile_add
 #print axioms add_decode_fields_of_binding
+#print axioms transpile_or
+#print axioms or_decode_fields_of_binding
+#print axioms transpile_addi
+#print axioms addi_decode_fields_of_binding
+#print axioms transpile_xori
+#print axioms xori_decode_fields_of_binding
+#print axioms transpile_ori
+#print axioms ori_decode_fields_of_binding
 end AxiomAudit
 
 end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingImmediate.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingImmediate.lean
@@ -42,6 +42,7 @@ open ZiskFv.Compliance.Decode (toU32)
 open aeneas_extract (extract_transpile_rv64im_raw)
 
 set_option maxHeartbeats 4000000
+set_option maxRecDepth 10000
 set_option linter.unusedSimpArgs false
 
 /-- Bit-reorder: `(x &&& 3968) >>> 7 = (x >>> 7) &&& 31` (the [7,11] field, mask
@@ -78,6 +79,169 @@ private theorem rawIType_rd (imm rs1 funct3 rd opcode : Nat) (hrd : rd < 32)
     ZiskFv.Compliance.Decode.tbf (show opcode < 2 ^ 7 by omega) (by omega)
   simp [e20, e15, e12, e7, hop', show 7 + i - 7 = i from by omega]
 
+private theorem src_b_imm_pres_store (self z : zisk_inst_builder.ZiskInstBuilder)
+    (v : Std.U64)
+    (h : zisk_inst_builder.ZiskInstBuilder.src_b_imm self v = ok z) :
+    z.i.store_offset = self.i.store_offset ∧ z.i.store = self.i.store := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.src_b_imm,
+    lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
+  first
+  | (rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩)
+  | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+     rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩)
+  | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+     obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+     rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩)
+
+theorem src_b_imm_data_pins (self z : zisk_inst_builder.ZiskInstBuilder)
+    (v : Std.U64)
+    (h : zisk_inst_builder.ZiskInstBuilder.src_b_imm self v = ok z) :
+    z.i.b_src = zisk_inst.SRC_IMM ∧
+      z.i.b_use_sp_imm1.val = v.val / 4294967296 ∧
+      z.i.b_offset_imm0.val = v.val % 4294967296 := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.src_b_imm,
+    lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
+  obtain ⟨hi, hiEq, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  rw [Result.ok.injEq] at h
+  subst z
+  constructor
+  · rfl
+  constructor
+  · simp only [HShiftRight.hShiftRight, UScalar.shiftRight_IScalar, UScalar.shiftRight] at hiEq
+    rw [if_pos ZiskFv.Compliance.Extraction.i32_32_nonnegative,
+      if_pos ZiskFv.Compliance.Extraction.i32_32_toNat_lt_u64_numBits] at hiEq
+    rw [Result.ok.injEq] at hiEq
+    subst hi
+    change (v.bv >>> 32).toNat = v.bv.toNat / 4294967296
+    rw [BitVec.toNat_ushiftRight, Nat.shiftRight_eq_div_pow]
+  · change (v.bv &&& (4294967295 : BitVec 64)).toNat = v.bv.toNat % 4294967296
+    have hb := congrArg BitVec.toNat (BitVec.and_two_pow_sub_one_eq_mod v.bv 32)
+    convert hb using 1 <;> norm_num
+
+theorem op_zisk_pres_b (self z : zisk_inst_builder.ZiskInstBuilder)
+    (op : zisk_ops.ZiskOp)
+    (h : zisk_inst_builder.ZiskInstBuilder.op_zisk self op = ok z) :
+    z.i.b_src = self.i.b_src ∧ z.i.b_use_sp_imm1 = self.i.b_use_sp_imm1 ∧
+      z.i.b_offset_imm0 = self.i.b_offset_imm0 := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.op_zisk,
+    zisk_inst_builder.ZiskInstBuilder.set_runtime_op_fields,
+    core.convert.IntoFrom.into,
+    zisk_inst.ZiskOperationType.Insts.CoreConvertFromOpType.from,
+    Bind.bind] at h
+  obtain ⟨ot, hot, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨b, hb, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨cval, hc, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨self1, hself1, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨zot, hzot, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨i1, hi1, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨mval, hm, h4⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hself1
+  rw [Result.ok.injEq] at h h4
+  subst z
+  subst self1
+  exact ⟨rfl, rfl, rfl⟩
+
+theorem store_reg_pres_b (self z : zisk_inst_builder.ZiskInstBuilder)
+    (rd : Std.I64) (usp a : Bool)
+    (h : zisk_inst_builder.ZiskInstBuilder.store_reg self rd usp a = ok z) :
+    z.i.b_src = self.i.b_src ∧ z.i.b_use_sp_imm1 = self.i.b_use_sp_imm1 ∧
+      z.i.b_offset_imm0 = self.i.b_offset_imm0 := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.store_reg,
+    zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO,
+    zisk_registers.REG_FIRST, mem.SYS_ADDR, mem.RAM_ADDR,
+    lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
+  split_ifs at h <;>
+    first
+    | (rw [Result.ok.injEq] at h; subst z; exact ⟨rfl, rfl, rfl⟩)
+    | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+       rw [Result.ok.injEq] at h; subst z; exact ⟨rfl, rfl, rfl⟩)
+    | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+       obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+       rw [Result.ok.injEq] at h; subst z; exact ⟨rfl, rfl, rfl⟩)
+
+theorem j_pres_b (self z : zisk_inst_builder.ZiskInstBuilder)
+    (j1 j2 : Std.I64)
+    (h : zisk_inst_builder.ZiskInstBuilder.j self j1 j2 = ok z) :
+    z.i.b_src = self.i.b_src ∧ z.i.b_use_sp_imm1 = self.i.b_use_sp_imm1 ∧
+      z.i.b_offset_imm0 = self.i.b_offset_imm0 := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.j] at h
+  rw [Result.ok.injEq] at h
+  subst z
+  exact ⟨rfl, rfl, rfl⟩
+
+theorem immediate_op_typed_immediate_pins
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp)
+    (inst_size : Std.U64) (ctx : riscv2zisk_context.Riscv2ZiskContext)
+    (h : riscv2zisk_context.Riscv2ZiskContext.immediate_op_typed
+      self i op inst_size = ok ctx) :
+    ∃ zib, ctx.extract_inst = some zib ∧
+      zib.i.b_src = zisk_inst.SRC_IMM ∧
+      zib.i.b_use_sp_imm1.val = (IScalar.hcast UScalarTy.U64 i.imm).val / 4294967296 ∧
+      zib.i.b_offset_imm0.val = (IScalar.hcast UScalarTy.U64 i.imm).val % 4294967296 := by
+  simp only [riscv2zisk_context.Riscv2ZiskContext.immediate_op_typed,
+    lift, Bind.bind, bind_ok] at h
+  obtain ⟨z0, h0, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨z1, h1, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨z2, h2, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨z3, h3, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨z4, h4, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨z5, h5, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨z6, h6, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨s1, h7, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  rw [Result.ok.injEq] at h
+  subst h
+  obtain ⟨hsrc, hhi, hlo⟩ := src_b_imm_data_pins z1 z2 _ h2
+  obtain ⟨hos, hoh, hol⟩ := op_zisk_pres_b z2 z3 op h3
+  obtain ⟨hss, hsh, hsl⟩ := store_reg_pres_b z3 z4 _ _ _ h4
+  obtain ⟨hjs, hjh, hjl⟩ := j_pres_b z4 z5 _ _ h5
+  have hz65 := ZiskFv.Compliance.Extraction.build_eq _ _ h6
+  refine ⟨z6, ZiskFv.Compliance.Extraction.insert_inst_extract _ _ _ _ h7, ?_, ?_, ?_⟩
+  · rw [hz65, hjs, hss, hos, hsrc]
+  · rw [hz65, hjh, hsh, hoh, hhi]
+  · rw [hz65, hjl, hsl, hol, hlo]
+
+private theorem immediate_op_typed_store_pins
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp)
+    (inst_size : Std.U64) (ctx : riscv2zisk_context.Riscv2ZiskContext)
+    (hrd : i.rd.val < 32)
+    (h : riscv2zisk_context.Riscv2ZiskContext.immediate_op_typed
+      self i op inst_size = ok ctx) :
+    ∃ zib, ctx.extract_inst = some zib ∧
+      zib.i.store_offset.val = i.rd.val ∧ zib.i.store ≠ zisk_inst.STORE_IND := by
+  simp only [riscv2zisk_context.Riscv2ZiskContext.immediate_op_typed,
+    lift, Bind.bind, bind_ok] at h
+  obtain ⟨z0, h0, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨z1, h1, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨z2, h2, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨z3, h3, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨z4, h4, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨z5, h5, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨z6, h6, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨s1, h7, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  rw [Result.ok.injEq] at h
+  subst h
+  have h30 : z3.i.store_offset = 0#i64 ∧ z3.i.store = 0#u64 := by
+    simp only [zisk_inst_builder.ZiskInstBuilder.new_for_rv64im_lowering,
+      zisk_inst_builder.ZiskInstBuilder.new,
+      zisk_inst_builder.ZiskInstBuilder.Insts.CoreDefaultDefault.default,
+      zisk_inst.ZiskInst.Insts.CoreDefaultDefault.default,
+      bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h0
+    rw [Result.ok.injEq] at h0
+    subst z0
+    obtain ⟨ha0, ha1⟩ := src_a_reg_pres_store _ _ _ _ h1
+    obtain ⟨hb0, hb1⟩ := src_b_imm_pres_store _ _ _ h2
+    obtain ⟨ho0, ho1⟩ := op_zisk_pres_store _ _ _ h3
+    exact ⟨ho0.trans (hb0.trans ha0), ho1.trans (hb1.trans ha1)⟩
+  obtain ⟨hso, hst⟩ := store_reg_raw_index_pins z3 z4 i.rd hrd h30.1 h30.2 h4
+  obtain ⟨hjso, hjst⟩ := j_pres_store _ _ _ _ h5
+  have hz65 := ZiskFv.Compliance.Extraction.build_eq _ _ h6
+  refine ⟨z6, ZiskFv.Compliance.Extraction.insert_inst_extract _ _ _ _ h7, ?_, ?_⟩
+  · rw [hz65, hjso]
+    exact hso
+  · rw [hz65]
+    exact fun hh => hst (hjst.symm.trans hh)
+
 /-- The REAL transpile pipeline on an immediate-op raw word `raw` reduces to the
     op's decode-field pins, given: the decode classifies to `decode_i raw rop sh`;
     `rop` lowers to the single-row opcode `srop`; the dispatcher routes `srop` to
@@ -88,6 +252,8 @@ theorem transpile_immediate_of
     (raw : Std.U32) (rop : RiscvOpcode) (sh : Bool)
     (srop : riscv2zisk_single_row.Rv64imSingleRowOpcode)
     (zop : zisk_ops.ZiskOp) (opc : Std.U8) (m32v : Bool) (otv : zisk_ops.OpType)
+    (rdv : Nat)
+    (hrdv : ∀ d, aeneas_extract.rv64im_decode.decode_i raw rop sh = ok d → d.rd.val = rdv)
     (P : riscv2zisk_single_row.Rv64imLoweringInput → Prop)
     (hdec : aeneas_extract.rv64im_decode.decode_32_core raw
       = aeneas_extract.rv64im_decode.decode_i raw rop sh)
@@ -108,7 +274,13 @@ theorem transpile_immediate_of
       ∧ ext.row.op = opc ∧ ext.row.is_external_op = true ∧ ext.row.m32 = m32v
       ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
       ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
-      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.store_offset.val = rdv
+      ∧ ext.row.store ≠ zisk_inst.STORE_IND
+      ∧ ∃ d, aeneas_extract.rv64im_decode.decode_i raw rop sh = ok d
+        ∧ ext.row.b_src = zisk_inst.SRC_IMM
+        ∧ ext.row.b_use_sp_imm1.val = (IScalar.hcast UScalarTy.U64 d.imm).val / 4294967296
+        ∧ ext.row.b_offset_imm0.val = (IScalar.hcast UScalarTy.U64 d.imm).val % 4294967296 := by
   obtain ⟨decoded, hdecoded, hopd, hrdb, hrs1b, _⟩ := decode_i_bounds raw rop sh
   have hdec0 : aeneas_extract.rv64im_decode.decode_32_core raw = ok decoded := hdec.trans hdecoded
   set input : riscv2zisk_single_row.Rv64imLoweringInput :=
@@ -125,11 +297,51 @@ theorem transpile_immediate_of
       { defCtx with extract_marker := () } input zop 4#u64 ctx0 hctx0
   have hzz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
   rw [hzz] at hj1 hj2
+  obtain ⟨zib'', hzib'', hso, hsi⟩ :=
+    immediate_op_typed_store_pins { defCtx with extract_marker := () }
+      input zop 4#u64 ctx0 (by rw [hinput]; exact hrdb) hctx0
+  have hzz' : zib'' = zib := Option.some.inj (hzib''.symm.trans hzib)
+  rw [hzz'] at hso hsi
+  obtain ⟨zibI, hzibI, hbSrc, hbHi, hbLo⟩ :=
+    immediate_op_typed_immediate_pins { defCtx with extract_marker := () }
+      input zop 4#u64 ctx0 hctx0
+  have hzzI : zibI = zib := Option.some.inj (hzibI.symm.trans hzib)
+  rw [hzzI] at hbSrc hbHi hbLo
   obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
   obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, _⟩ := from_inst_ok zib.i
+  have hrStoreOffset : row.store_offset = zib.i.store_offset := by
+    rw [aeneas_extract.ZiskInstExtract.from_inst] at hrow
+    obtain ⟨i2, hi2, hrow⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
+  have hrStore : row.store = zib.i.store := by
+    rw [aeneas_extract.ZiskInstExtract.from_inst] at hrow
+    obtain ⟨i2, hi2, hrow⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
+  have hrBSrc : row.b_src = zib.i.b_src := by
+    rw [aeneas_extract.ZiskInstExtract.from_inst] at hrow
+    obtain ⟨i2, hi2, hrow⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
+  have hrBHi : row.b_use_sp_imm1 = zib.i.b_use_sp_imm1 := by
+    rw [aeneas_extract.ZiskInstExtract.from_inst] at hrow
+    obtain ⟨i2, hi2, hrow⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
+  have hrBLo : row.b_offset_imm0 = zib.i.b_offset_imm0 := by
+    rw [aeneas_extract.ZiskInstExtract.from_inst] at hrow
+    obtain ⟨i2, hi2, hrow⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
   have hlower : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input srop false
       = ok { ctx0 with extract_marker := () } := by rw [harm defCtx input hPin, hctx0]; rfl
-  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
     simp only [bind_ok, Bind.bind, hdext, hopd, hlowop]
     simp only [defCtx] at hlower
@@ -142,6 +354,17 @@ theorem transpile_immediate_of
   · show row.store_pc = false; rw [hrstp]; exact hstp2
   · show row.jmp_offset1 = _; rw [hrj1]; exact hj1
   · show row.jmp_offset2 = _; rw [hrj2]; exact hj2
+  · show row.store_offset.val = rdv
+    rw [hrStoreOffset, hso]
+    rw [hinput]
+    exact_mod_cast hrdv decoded hdecoded
+  · show row.store ≠ zisk_inst.STORE_IND
+    rw [hrStore]
+    exact hsi
+  · refine ⟨decoded, hdecoded, ?_, ?_, ?_⟩
+    · rw [hrBSrc]; exact hbSrc
+    · rw [hrBHi]; exact hbHi
+    · rw [hrBLo]; exact hbLo
 
 /-! ## Per-op macro (non-shift I-type): emits `transpile_<op>` +
     `<op>_decode_fields_of_binding` + `Decode_<op>_from_rawProgram`. -/
@@ -158,10 +381,25 @@ local macro "imm_op" nm:ident "," f3:term "," opw:term ","
           ∧ ext.row.op = $opU8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
           ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
           ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
-          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
-      refine transpile_immediate_of _ $rop false $srop $zop $opU8 $m32 $ot (fun _ => True) ?_ rfl
+          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+          ∧ ext.row.store_offset.val = rd
+          ∧ ext.row.store ≠ zisk_inst.STORE_IND
+          ∧ ∃ d, aeneas_extract.rv64im_decode.decode_i
+              (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 $f3 rd $opw)) $rop false = ok d
+            ∧ ext.row.b_src = zisk_inst.SRC_IMM
+            ∧ ext.row.b_use_sp_imm1.val = (IScalar.hcast UScalarTy.U64 d.imm).val / 4294967296
+            ∧ ext.row.b_offset_imm0.val = (IScalar.hcast UScalarTy.U64 d.imm).val % 4294967296 := by
+      refine transpile_immediate_of _ $rop false $srop $zop $opU8 $m32 $ot rd ?_ (fun _ => True) ?_ rfl
         (by intro self input _; rfl) (fun _ _ => trivial)
         rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
+      · intro d hd
+        obtain ⟨d', hd', _, _, _, hrdbv'⟩ := decode_i_bounds _ $rop false
+        have hdd : d = d' := Result.ok.inj (hd.symm.trans hd')
+        rw [hdd]
+        change d'.rd.bv.toNat = rd
+        rw [show d'.rd.bv = BitVec.ofNat 32 rd from by
+          rw [hrdbv']; exact rawIType_rd imm rs1 $f3 rd $opw hrd (by norm_num) (by norm_num)]
+        simp [UScalar.val, BitVec.toNat_ofNat, Nat.mod_eq_of_lt] <;> omega
       simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
         ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
         ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_ofNat,
@@ -172,16 +410,18 @@ local macro "imm_op" nm:ident "," f3:term "," opw:term ","
         (line : FGL) (msg : ZiskRomMessage FGL)
         (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 $f3 rd $opw)) :
         msg.op = $opc ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+          ∧ msg.store_offset = (rd : FGL)
           ∧ ∃ ext, extract_transpile_rv64im_raw
                 (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 $f3 rd $opw)) = ok ext
               ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
               ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
               ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
-      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ := $tName rd rs1 imm hrd hrs1
-      obtain ⟨ho, hjo1, hjo2, hf⟩ :=
-        register_decode_fields_of_binding line msg _ $opU8 $opc ext
-          (by simp [romOpcode, $opc:term]) hok hop hj1 hj2 hbind
-      exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩)
+      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2, hso, hsi, hb⟩ :=
+        $tName rd rs1 imm hrd hrs1
+      obtain ⟨ho, hjo1, hjo2, hmso, _, hf⟩ :=
+        register_decode_fields_of_binding line msg _ $opU8 $opc rd ext
+          (by simp [romOpcode, $opc:term]) hok hop hj1 hj2 hso hsi hbind
+      exact ⟨ho, hjo1, hjo2, hmso, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩)
   return ⟨Lean.mkNullNode #[t1, t2]⟩
 
 /-! ## Per-op macro (shift-immediate): emits the same triple, but the raw word is
@@ -203,10 +443,25 @@ local macro "shift_op" nm:ident "," upper:term "," f3:term "," opw:term ","
           ∧ ext.row.op = $opU8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
           ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
           ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
-          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
-      refine transpile_immediate_of _ $rop true $srop $zop $opU8 $m32 $ot (fun _ => True) ?_ rfl
+          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+          ∧ ext.row.store_offset.val = rd
+          ∧ ext.row.store ≠ zisk_inst.STORE_IND
+          ∧ ∃ d, aeneas_extract.rv64im_decode.decode_i
+              (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType ($upper ||| shamt) rs1 $f3 rd $opw)) $rop true = ok d
+            ∧ ext.row.b_src = zisk_inst.SRC_IMM
+            ∧ ext.row.b_use_sp_imm1.val = (IScalar.hcast UScalarTy.U64 d.imm).val / 4294967296
+            ∧ ext.row.b_offset_imm0.val = (IScalar.hcast UScalarTy.U64 d.imm).val % 4294967296 := by
+      refine transpile_immediate_of _ $rop true $srop $zop $opU8 $m32 $ot rd ?_ (fun _ => True) ?_ rfl
         (by intro self input _; rfl) (fun _ _ => trivial)
         rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
+      · intro d hd
+        obtain ⟨d', hd', _, _, _, hrdbv'⟩ := decode_i_bounds _ $rop true
+        have hdd : d = d' := Result.ok.inj (hd.symm.trans hd')
+        rw [hdd]
+        change d'.rd.bv.toNat = rd
+        rw [show d'.rd.bv = BitVec.ofNat 32 rd from by
+          rw [hrdbv']; exact rawIType_rd ($upper ||| shamt) rs1 $f3 rd $opw hrd (by norm_num) (by norm_num)]
+        simp [UScalar.val, BitVec.toNat_ofNat, Nat.mod_eq_of_lt] <;> omega
       simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
         ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
         ZiskFv.Compliance.Decode.toU32_and63, ZiskFv.Compliance.Decode.toU32_shr12,
@@ -220,16 +475,18 @@ local macro "shift_op" nm:ident "," upper:term "," f3:term "," opw:term ","
         (line : FGL) (msg : ZiskRomMessage FGL)
         (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawIType ($upper ||| shamt) rs1 $f3 rd $opw)) :
         msg.op = $opc ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+          ∧ msg.store_offset = (rd : FGL)
           ∧ ∃ ext, extract_transpile_rv64im_raw
                 (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType ($upper ||| shamt) rs1 $f3 rd $opw)) = ok ext
               ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
               ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
               ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
-      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ := $tName rd rs1 shamt hrd hrs1 hsh
-      obtain ⟨ho, hjo1, hjo2, hf⟩ :=
-        register_decode_fields_of_binding line msg _ $opU8 $opc ext
-          (by simp [romOpcode, $opc:term]) hok hop hj1 hj2 hbind
-      exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩)
+      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2, hso, hsi, hb⟩ :=
+        $tName rd rs1 shamt hrd hrs1 hsh
+      obtain ⟨ho, hjo1, hjo2, hmso, _, hf⟩ :=
+        register_decode_fields_of_binding line msg _ $opU8 $opc rd ext
+          (by simp [romOpcode, $opc:term]) hok hop hj1 hj2 hso hsi hbind
+      exact ⟨ho, hjo1, hjo2, hmso, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩)
   return ⟨Lean.mkNullNode #[t1, t2]⟩
 
 /-! ## Per-op macro (64-bit shift-immediate SLLI/SRLI/SRAI): same as `shift_op`,
@@ -251,10 +508,25 @@ local macro "shift64_op" nm:ident "," upper:term "," f3:term "," opw:term ","
           ∧ ext.row.op = $opU8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
           ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
           ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
-          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
-      refine transpile_immediate_of _ $rop true $srop $zop $opU8 $m32 $ot (fun _ => True) ?_ rfl
+          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+          ∧ ext.row.store_offset.val = rd
+          ∧ ext.row.store ≠ zisk_inst.STORE_IND
+          ∧ ∃ d, aeneas_extract.rv64im_decode.decode_i
+              (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType ($upper ||| shamt) rs1 $f3 rd $opw)) $rop true = ok d
+            ∧ ext.row.b_src = zisk_inst.SRC_IMM
+            ∧ ext.row.b_use_sp_imm1.val = (IScalar.hcast UScalarTy.U64 d.imm).val / 4294967296
+            ∧ ext.row.b_offset_imm0.val = (IScalar.hcast UScalarTy.U64 d.imm).val % 4294967296 := by
+      refine transpile_immediate_of _ $rop true $srop $zop $opU8 $m32 $ot rd ?_ (fun _ => True) ?_ rfl
         (by intro self input _; rfl) (fun _ _ => trivial)
         rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
+      · intro d hd
+        obtain ⟨d', hd', _, _, _, hrdbv'⟩ := decode_i_bounds _ $rop true
+        have hdd : d = d' := Result.ok.inj (hd.symm.trans hd')
+        rw [hdd]
+        change d'.rd.bv.toNat = rd
+        rw [show d'.rd.bv = BitVec.ofNat 32 rd from by
+          rw [hrdbv']; exact rawIType_rd ($upper ||| shamt) rs1 $f3 rd $opw hrd (by norm_num) (by norm_num)]
+        simp [UScalar.val, BitVec.toNat_ofNat, Nat.mod_eq_of_lt] <;> omega
       simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
         ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
         ZiskFv.Compliance.Decode.toU32_and63, ZiskFv.Compliance.Decode.toU32_shr12,
@@ -268,16 +540,18 @@ local macro "shift64_op" nm:ident "," upper:term "," f3:term "," opw:term ","
         (line : FGL) (msg : ZiskRomMessage FGL)
         (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawIType ($upper ||| shamt) rs1 $f3 rd $opw)) :
         msg.op = $opc ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+          ∧ msg.store_offset = (rd : FGL)
           ∧ ∃ ext, extract_transpile_rv64im_raw
                 (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType ($upper ||| shamt) rs1 $f3 rd $opw)) = ok ext
               ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
               ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
               ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
-      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ := $tName rd rs1 shamt hrd hrs1 hsh
-      obtain ⟨ho, hjo1, hjo2, hf⟩ :=
-        register_decode_fields_of_binding line msg _ $opU8 $opc ext
-          (by simp [romOpcode, $opc:term]) hok hop hj1 hj2 hbind
-      exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩)
+      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2, hso, hsi, hb⟩ :=
+        $tName rd rs1 shamt hrd hrs1 hsh
+      obtain ⟨ho, hjo1, hjo2, hmso, _, hf⟩ :=
+        register_decode_fields_of_binding line msg _ $opU8 $opc rd ext
+          (by simp [romOpcode, $opc:term]) hok hop hj1 hj2 hso hsi hbind
+      exact ⟨ho, hjo1, hjo2, hmso, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩)
   return ⟨Lean.mkNullNode #[t1, t2]⟩
 
 open RiscvOpcode riscv2zisk_single_row.Rv64imSingleRowOpcode zisk_ops.ZiskOp zisk_ops.OpType
@@ -300,9 +574,26 @@ theorem transpile_addiw (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hr
       ∧ ext.row.op = 26#u8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = true
       ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
       ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
-      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.store_offset.val = rd
+      ∧ ext.row.store ≠ zisk_inst.STORE_IND
+      ∧ ∃ d, aeneas_extract.rv64im_decode.decode_i
+          (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 0 rd 0x1b))
+            RiscvOpcode.Addiw false = ok d
+        ∧ ext.row.b_src = zisk_inst.SRC_IMM
+        ∧ ext.row.b_use_sp_imm1.val = (IScalar.hcast UScalarTy.U64 d.imm).val / 4294967296
+        ∧ ext.row.b_offset_imm0.val = (IScalar.hcast UScalarTy.U64 d.imm).val % 4294967296 := by
   refine transpile_immediate_of _ RiscvOpcode.Addiw false
     riscv2zisk_single_row.Rv64imSingleRowOpcode.Addiw zisk_ops.ZiskOp.AddW 26#u8 true zisk_ops.OpType.Binary
+    rd (by
+      intro d hd
+      obtain ⟨d', hd', _, _, _, hrdbv'⟩ := decode_i_bounds _ RiscvOpcode.Addiw false
+      have hdd : d = d' := Result.ok.inj (hd.symm.trans hd')
+      rw [hdd]
+      change d'.rd.bv.toNat = rd
+      rw [show d'.rd.bv = BitVec.ofNat 32 rd from by
+        rw [hrdbv']; exact rawIType_rd imm rs1 0 rd 0x1b hrd (by norm_num) (by norm_num)]
+      simp [UScalar.val, BitVec.toNat_ofNat, Nat.mod_eq_of_lt] <;> omega)
     (fun input => input.rd ≠ 0#u32) ?_ rfl ?_ ?_ rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
   · simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
       ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
@@ -335,16 +626,18 @@ theorem addiw_decode_fields_of_binding (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 
     (line : FGL) (msg : ZiskRomMessage FGL)
     (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 0 rd 0x1b)) :
     msg.op = OP_ADD_W ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+      ∧ msg.store_offset = (rd : FGL)
       ∧ ∃ ext, extract_transpile_rv64im_raw
             (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 0 rd 0x1b)) = ok ext
           ∧ ext.row.is_external_op = true ∧ ext.row.m32 = true
           ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
           ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
-  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ := transpile_addiw rd rs1 imm hrd hrs1 hrd0
-  obtain ⟨ho, hjo1, hjo2, hf⟩ :=
-    register_decode_fields_of_binding line msg _ 26#u8 OP_ADD_W ext
-      (by simp [romOpcode, OP_ADD_W]) hok hop hj1 hj2 hbind
-  exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
+  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2, hso, hsi, hb⟩ :=
+    transpile_addiw rd rs1 imm hrd hrs1 hrd0
+  obtain ⟨ho, hjo1, hjo2, hmso, _, hf⟩ :=
+    register_decode_fields_of_binding line msg _ 26#u8 OP_ADD_W rd ext
+      (by simp [romOpcode, OP_ADD_W]) hok hop hj1 hj2 hso hsi hbind
+  exact ⟨ho, hjo1, hjo2, hmso, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
 
 shift64_op slli, 0, 1, 0x13, rawIType_funct6_zero, RiscvOpcode.Slli,
   riscv2zisk_single_row.Rv64imSingleRowOpcode.Slli, zisk_ops.ZiskOp.Sll, 33#u8,
@@ -365,12 +658,178 @@ shift_op sraiw, 0x400, 5, 0x1b, 32, rawIType_funct7_thirtytwo, RiscvOpcode.Sraiw
   riscv2zisk_single_row.Rv64imSingleRowOpcode.Sraiw, zisk_ops.ZiskOp.SraW, 38#u8,
   true, zisk_ops.OpType.BinaryE, OP_SRA_W
 
+/-! ## Current `ProgramDecode` retarget: shift-immediate families. -/
+
+local macro "shift_program_decode" nm:ident "," upper:term "," f3:term "," opw:term ","
+    shbound:term : command => do
+  let s := nm.getId.toString
+  let rawName := Lean.mkIdent (Lean.Name.mkSimple ("RawProgramDecode_" ++ s))
+  let ctorName := Lean.mkIdent (Lean.Name.mkSimple ("ProgramDecode_" ++ s ++ "_from_rawProgram"))
+  let transpileName := Lean.mkIdent (Lean.Name.mkSimple ("transpile_" ++ s))
+  let fieldsName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
+  let claimName := Lean.mkIdent ((`ZiskFv.Compliance).str ("Claim_" ++ s))
+  let programName := Lean.mkIdent ((`ZiskFv.Compliance.RomDecodeBinding).str ("ProgramDecode_" ++ s))
+  let t1 ← `(structure $rawName {n : Nat}
+      (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+      (i : Fin trace.numInstructions) (c : $claimName trace i)
+      (rawProgram : Fin trace.programLength → BitVec 32) where
+    h_idx : i.val + 1 < trace.mainTable.table.length
+    h_b_lo_t :
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).b_0 i.val =
+        ZiskFv.Trusted.shamt_b_lo c.shamt
+    hLine : ∀ j : Fin trace.programLength,
+      (trace.program j).line =
+          (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
+        rawProgram j =
+          ZiskFv.Completeness.Rv64imShapes.rawIType
+            ($upper ||| c.shamt.toNat) (regidx_to_fin c.r1).val $f3
+            (regidx_to_fin c.rd).val $opw)
+  let t2 ← `(noncomputable def $ctorName {n : Nat}
+      (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+      (i : Fin trace.numInstructions) (c : $claimName trace i)
+      (addr : Fin trace.programLength → FGL)
+      (rawProgram : Fin trace.programLength → BitVec 32)
+      (hbind : ProgramBinding trace addr rawProgram)
+      (rawDecode : $rawName trace i c rawProgram) :
+      $programName trace i c := by
+    let rd := (regidx_to_fin c.rd).val
+    let rs1 := (regidx_to_fin c.r1).val
+    let shamt := c.shamt.toNat
+    have hsh : shamt < $shbound := by
+      simp only [shamt]
+      exact c.shamt.isLt
+    let ext := ($transpileName rd rs1 shamt (regidx_to_fin c.rd).isLt
+      (regidx_to_fin c.r1).isLt hsh).choose
+    obtain ⟨hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2,
+        hstoreOffset, hstoreInd, hb⟩ :=
+      ($transpileName rd rs1 shamt (regidx_to_fin c.rd).isLt
+        (regidx_to_fin c.r1).isLt hsh).choose_spec
+    refine
+      { h_idx := rawDecode.h_idx
+        h_b_lo_t := by
+          exact rawDecode.h_b_lo_t
+        bits := romFlagBitsOfExtract ext.row
+        h_bits_ieo := ?_
+        h_bits_m32 := ?_
+        h_bits_set_pc := ?_
+        h_bits_store_pc := ?_
+        h_bits_store_ind := ?_
+        h_prog := ?_ }
+    · simpa only [ext, romFlagBitsOfExtract] using hieo
+    · simpa only [ext, romFlagBitsOfExtract] using hm32
+    · simpa only [ext, romFlagBitsOfExtract] using hsetpc
+    · simpa only [ext, romFlagBitsOfExtract] using hstorepc
+    · simp only [romFlagBitsOfExtract]
+      exact decide_eq_false hstoreInd
+    · intro j hline
+      have hbk : trace.program j =
+          romMessageOfRaw (addr j)
+            (ZiskFv.Completeness.Rv64imShapes.rawIType
+              ($upper ||| shamt) rs1 $f3 rd $opw) := by
+        exact (hbind.2 j).trans
+          (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+      obtain ⟨ho, hjo1, hjo2, hso, ext', hok', hieo', hm32', hsetpc',
+          hstorepc', hf⟩ :=
+        $fieldsName rd rs1 shamt (regidx_to_fin c.rd).isLt
+          (regidx_to_fin c.r1).isLt hsh (addr j) (trace.program j) hbk
+      have hext : ext' = ext :=
+        Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
+      subst ext'
+      refine ⟨ho, hjo1, hjo2, ?_, hf⟩
+      rw [hso]
+      simp only [rd, Transpiler.ind]
+      apply Fin.ext
+      change (regidx_to_fin c.rd).val % GL_prime = (regidx_to_fin c.rd).val
+      exact Nat.mod_eq_of_lt (lt_trans (regidx_to_fin c.rd).isLt (by norm_num)))
+  return ⟨Lean.mkNullNode #[t1, t2]⟩
+
+shift_program_decode slli, 0, 1, 0x13, 64
+shift_program_decode srli, 0, 5, 0x13, 64
+shift_program_decode srai, 0x400, 5, 0x13, 64
+
+local macro "shiftw_program_decode" nm:ident "," upper:term "," f3:term ","
+    shget:term : command => do
+  let s := nm.getId.toString
+  let rawName := Lean.mkIdent (Lean.Name.mkSimple ("RawProgramDecode_" ++ s))
+  let ctorName := Lean.mkIdent (Lean.Name.mkSimple ("ProgramDecode_" ++ s ++ "_from_rawProgram"))
+  let transpileName := Lean.mkIdent (Lean.Name.mkSimple ("transpile_" ++ s))
+  let fieldsName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
+  let claimName := Lean.mkIdent ((`ZiskFv.Compliance).str ("Claim_" ++ s))
+  let programName := Lean.mkIdent ((`ZiskFv.Compliance.RomDecodeBinding).str ("ProgramDecode_" ++ s))
+  let t1 ← `(structure $rawName {n : Nat}
+      (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+      (i : Fin trace.numInstructions) (c : $claimName trace i)
+      (rawProgram : Fin trace.programLength → BitVec 32) where
+    h_idx : i.val + 1 < trace.mainTable.table.length
+    hLine : ∀ j : Fin trace.programLength,
+      (trace.program j).line =
+          (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
+        rawProgram j =
+          ZiskFv.Completeness.Rv64imShapes.rawIType
+            ($upper ||| ($shget c).shamt.toNat) (regidx_to_fin c.r1).val $f3
+            (regidx_to_fin c.rd).val 0x1b)
+  let t2 ← `(noncomputable def $ctorName {n : Nat}
+      (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+      (i : Fin trace.numInstructions) (c : $claimName trace i)
+      (addr : Fin trace.programLength → FGL)
+      (rawProgram : Fin trace.programLength → BitVec 32)
+      (hbind : ProgramBinding trace addr rawProgram)
+      (rawDecode : $rawName trace i c rawProgram) :
+      $programName trace i c := by
+    let rd := (regidx_to_fin c.rd).val
+    let rs1 := (regidx_to_fin c.r1).val
+    let shamt := ($shget c).shamt.toNat
+    have hsh : shamt < 32 := by simp only [shamt]; exact ($shget c).shamt.isLt
+    let ext := ($transpileName rd rs1 shamt (regidx_to_fin c.rd).isLt
+      (regidx_to_fin c.r1).isLt hsh).choose
+    obtain ⟨hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2,
+        hstoreOffset, hstoreInd, hb⟩ :=
+      ($transpileName rd rs1 shamt (regidx_to_fin c.rd).isLt
+        (regidx_to_fin c.r1).isLt hsh).choose_spec
+    refine
+      { h_idx := rawDecode.h_idx
+        bits := romFlagBitsOfExtract ext.row
+        h_bits_ieo := by simpa only [ext, romFlagBitsOfExtract] using hieo
+        h_bits_m32 := by simpa only [ext, romFlagBitsOfExtract] using hm32
+        h_bits_set_pc := by simpa only [ext, romFlagBitsOfExtract] using hsetpc
+        h_bits_store_pc := by simpa only [ext, romFlagBitsOfExtract] using hstorepc
+        h_bits_store_ind := by
+          simp only [romFlagBitsOfExtract]; exact decide_eq_false hstoreInd
+        h_prog := by
+          intro j hline
+          have hbk : trace.program j =
+              romMessageOfRaw (addr j)
+                (ZiskFv.Completeness.Rv64imShapes.rawIType
+                  ($upper ||| shamt) rs1 $f3 rd 0x1b) := by
+            exact (hbind.2 j).trans
+              (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+          obtain ⟨ho, hjo1, hjo2, hso, ext', hok', hieo', hm32', hsetpc',
+              hstorepc', hf⟩ :=
+            $fieldsName rd rs1 shamt (regidx_to_fin c.rd).isLt
+              (regidx_to_fin c.r1).isLt hsh (addr j) (trace.program j) hbk
+          have hext : ext' = ext :=
+            Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
+          subst ext'
+          refine ⟨ho, hjo1, hjo2, ?_, hf⟩
+          rw [hso]
+          simp only [rd, Transpiler.ind]
+          apply Fin.ext
+          change (regidx_to_fin c.rd).val % GL_prime = (regidx_to_fin c.rd).val
+          exact Nat.mod_eq_of_lt (lt_trans (regidx_to_fin c.rd).isLt (by norm_num)) })
+  return ⟨Lean.mkNullNode #[t1, t2]⟩
+
+shiftw_program_decode slliw, 0, 1, ZiskFv.Compliance.Claim_slliw.slliw_input
+shiftw_program_decode srliw, 0, 5, ZiskFv.Compliance.Claim_srliw.srliw_input
+shiftw_program_decode sraiw, 0x400, 5, ZiskFv.Compliance.Claim_sraiw.sraiw_input
+
 section AxiomAudit
 #print axioms transpile_slti
 #print axioms slti_decode_fields_of_binding
 #print axioms transpile_slli
 #print axioms transpile_sraiw
 #print axioms transpile_addiw
+#print axioms ProgramDecode_slli_from_rawProgram
+#print axioms ProgramDecode_sraiw_from_rawProgram
 end AxiomAudit
 
 end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingMext.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingMext.lean
@@ -53,6 +53,38 @@ open aeneas_extract (extract_transpile_rv64im_raw)
 set_option maxHeartbeats 4000000
 set_option linter.unusedSimpArgs false
 
+private theorem mextRawRTypeRd (funct7 rs2 rs1 funct3 rd opcode : Nat)
+    (hrd : rd < 32) (hop : opcode < 128) :
+    ((ZiskFv.Completeness.Rv64imShapes.rawRType funct7 rs2 rs1 funct3 rd opcode) >>> 7)
+        &&& 31#32 = BitVec.ofNat 32 rd := by
+  simp only [ZiskFv.Completeness.Rv64imShapes.rawRType,
+    ZiskFv.Completeness.Rv64imShapes.rawOfNat32]
+  refine ZiskFv.Compliance.Decode.ofNat32_shift_mask_eq _ 7 5 rd hrd (by norm_num) ?_
+  intro bit hbit
+  simp only [Nat.testBit_or, Nat.testBit_shiftLeft]
+  have e25 : ¬ (7 + bit ≥ 25) := by omega
+  have e20 : ¬ (7 + bit ≥ 20) := by omega
+  have e15 : ¬ (7 + bit ≥ 15) := by omega
+  have e12 : ¬ (7 + bit ≥ 12) := by omega
+  have e7 : 7 + bit ≥ 7 := by omega
+  have hop' : opcode.testBit (7 + bit) = false :=
+    Nat.testBit_eq_false_of_lt (lt_of_lt_of_le hop
+      (by calc (128 : Nat) = 2 ^ 7 := rfl
+           _ ≤ 2 ^ (7 + bit) := Nat.pow_le_pow_right (by norm_num) (by omega)))
+  simp [e25, e20, e15, e12, e7, hop', show 7 + bit - 7 = bit from by omega]
+
+private theorem mextAnd3968Ushift7 (x : BitVec 32) :
+    (x &&& 3968#32) >>> 7 = (x >>> 7) &&& 31#32 := by
+  apply BitVec.eq_of_getLsbD_eq
+  intro i
+  by_cases hi : (i : Nat) < 32
+  · interval_cases i <;>
+      simp [BitVec.getLsbD_ushiftRight, BitVec.getLsbD_and,
+        BitVec.getLsbD_ofNat, Nat.testBit]
+  · have hi7 : ¬(i : Nat) + 7 < 32 := by omega
+    simp [BitVec.getLsbD_ushiftRight, BitVec.getLsbD_and,
+      BitVec.getLsbD_ofNat, hi, hi7]
+
 /-! ## Shared transpile + decode-field lemmas (op-agnostic, register family).
 
     Emitted by every group macro; identical in body to the register macro's
@@ -69,9 +101,45 @@ local macro "mext_lemmas" nm:ident "," f7:term "," f3:term "," opw:term "," rop:
             ∧ ext.row.op = $opU8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
             ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
             ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
-            ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
-        refine transpile_register_of _ $rop $srop $zop $opU8 $m32 $ot ?_ rfl (by intro self input; rfl)
+            ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+            ∧ ext.row.store_offset.val = rd
+            ∧ ext.row.store ≠ zisk_inst.STORE_IND := by
+        refine transpile_register_of _ $rop $srop $zop $opU8 $m32 $ot rd ?_ ?_ rfl
+          (by intro self input; rfl)
           rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
+        · intro d hd
+          rw [aeneas_extract.rv64im_decode.decode_r] at hd
+          simp only [aeneas_extract.rv64im_decode.DecodedRv64im.new, lift, bind_ok,
+            Bind.bind] at hd
+          obtain ⟨i1, hi1, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+          obtain ⟨i3, hi3, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+          obtain ⟨i5, hi5, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+          obtain ⟨i7, hi7, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+          obtain ⟨i9, hi9, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+          rw [Result.ok.injEq] at hd
+          subst d
+          have hi3' : i3 = toU32 (BitVec.ofNat 32 rd) := by
+            have hcalc :
+                (toU32 (ZiskFv.Completeness.Rv64imShapes.rawRType
+                      $f7 rs2 rs1 $f3 rd $opw) &&& 3968#u32) >>> 7#i32 =
+                  ok (toU32 (BitVec.ofNat 32 rd)) := by
+              change (toU32
+                  (ZiskFv.Completeness.Rv64imShapes.rawRType
+                    $f7 rs2 rs1 $f3 rd $opw &&& 3968#32)) >>> 7#i32 =
+                ok (toU32 (BitVec.ofNat 32 rd))
+              rw [show (toU32
+                    (ZiskFv.Completeness.Rv64imShapes.rawRType
+                      $f7 rs2 rs1 $f3 rd $opw &&& 3968#32)) >>> 7#i32 =
+                  ok (toU32
+                    ((ZiskFv.Completeness.Rv64imShapes.rawRType
+                      $f7 rs2 rs1 $f3 rd $opw &&& 3968#32) >>> 7)) by rfl]
+              rw [mextAnd3968Ushift7,
+                mextRawRTypeRd $f7 rs2 rs1 $f3 rd $opw hrd (by norm_num)]
+            rw [hcalc] at hi3
+            exact (Result.ok.inj hi3).symm
+          rw [hi3']
+          simp only [UScalar.val, BitVec.toNat_ofNat]
+          exact Nat.mod_eq_of_lt (lt_trans hrd (by norm_num))
         simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
           ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
           ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_shr25,
@@ -84,16 +152,19 @@ local macro "mext_lemmas" nm:ident "," f7:term "," f3:term "," opw:term "," rop:
           (line : FGL) (msg : ZiskRomMessage FGL)
           (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawRType $f7 rs2 rs1 $f3 rd $opw)) :
           msg.op = $opc ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+            ∧ msg.store_offset = (rd : FGL)
             ∧ ∃ ext, extract_transpile_rv64im_raw
                   (toU32 (ZiskFv.Completeness.Rv64imShapes.rawRType $f7 rs2 rs1 $f3 rd $opw)) = ok ext
                 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
                 ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+                ∧ (romFlagBitsOfExtract ext.row).store_ind = false
                 ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
-        obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ := $tName rd rs1 rs2 hrd hrs1 hrs2
-        obtain ⟨ho, hjo1, hjo2, hf⟩ :=
-          register_decode_fields_of_binding line msg _ $opU8 $opc ext
-            (by simp [romOpcode, $opc:term]) hok hop hj1 hj2 hbind
-        exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩)
+        obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2,
+            hstoreOffset, hstoreInd⟩ := $tName rd rs1 rs2 hrd hrs1 hrs2
+        obtain ⟨ho, hjo1, hjo2, hso, hsi, hf⟩ :=
+          register_decode_fields_of_binding line msg _ $opU8 $opc rd ext
+            (by simp [romOpcode, $opc:term]) hok hop hj1 hj2 hstoreOffset hstoreInd hbind
+        exact ⟨ho, hjo1, hjo2, hso, ext, hok, hieo, hm32, hsetpc, hstorepc, hsi, hf⟩)
     return ⟨Lean.mkNullNode #[t1, t2]⟩
 
 open RiscvOpcode riscv2zisk_single_row.Rv64imSingleRowOpcode zisk_ops.ZiskOp zisk_ops.OpType
@@ -129,9 +200,185 @@ mext_lemmas remu, 1, 7, 0x33, RiscvOpcode.Remu, riscv2zisk_single_row.Rv64imSing
 
 mext_lemmas remuw, 1, 7, 0x3b, RiscvOpcode.Remuw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Remuw, zisk_ops.ZiskOp.RemuW, 189#u8, true, zisk_ops.OpType.ArithA32, OP_REMU_W
 
+/-! ## Current `ProgramDecode` constructors. -/
+
+local macro "mext_program_decode_ab" nm:ident "," f3:term "," opw:term : command => do
+  let s := nm.getId.toString
+  let rawName := Lean.mkIdent (Lean.Name.mkSimple ("RawProgramDecode_" ++ s))
+  let ctorName := Lean.mkIdent (Lean.Name.mkSimple ("ProgramDecode_" ++ s ++ "_from_rawProgram"))
+  let transpileName := Lean.mkIdent (Lean.Name.mkSimple ("transpile_" ++ s))
+  let fieldsName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
+  let claimName := Lean.mkIdent ((`ZiskFv.Compliance).str ("Claim_" ++ s))
+  let programName :=
+    Lean.mkIdent ((`ZiskFv.Compliance.RomDecodeBinding).str ("ProgramDecode_" ++ s))
+  let t1 ← `(structure $rawName {n : Nat}
+      (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+      (i : Fin trace.numInstructions) (c : $claimName trace i)
+      (rawProgram : Fin trace.programLength → BitVec 32) where
+    h_idx : i.val + 1 < trace.mainTable.table.length
+    arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val
+      (ZiskFv.Compliance.busSub trace i (ZiskFv.Compliance.Pilot.execRowOf trace i)).e2
+    bounds : ZiskFv.Compliance.ByteBounds
+      (ZiskFv.Compliance.busSub trace i (ZiskFv.Compliance.Pilot.execRowOf trace i)).e2
+    hLine : ∀ j : Fin trace.programLength,
+      (trace.program j).line =
+          (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
+        rawProgram j = ZiskFv.Completeness.Rv64imShapes.rawRType 1
+          (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val $f3
+          (regidx_to_fin c.rd).val $opw)
+  let t2 ← `(noncomputable def $ctorName {n : Nat}
+      (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+      (i : Fin trace.numInstructions) (c : $claimName trace i)
+      (addr : Fin trace.programLength → FGL)
+      (rawProgram : Fin trace.programLength → BitVec 32)
+      (hbind : ProgramBinding trace addr rawProgram)
+      (rawDecode : $rawName trace i c rawProgram) :
+      $programName trace i c := by
+    let rd := (regidx_to_fin c.rd).val
+    let rs1 := (regidx_to_fin c.r1).val
+    let rs2 := (regidx_to_fin c.r2).val
+    let ext := ($transpileName rd rs1 rs2 (regidx_to_fin c.rd).isLt
+      (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt).choose
+    obtain ⟨hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2,
+        hstoreOffset, hstoreInd⟩ :=
+      ($transpileName rd rs1 rs2 (regidx_to_fin c.rd).isLt
+        (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt).choose_spec
+    refine
+      { h_idx := rawDecode.h_idx
+        arith_mem := rawDecode.arith_mem
+        bounds := rawDecode.bounds
+        bits := romFlagBitsOfExtract ext.row
+        h_bits_ieo := by simpa only [ext, romFlagBitsOfExtract] using hieo
+        h_bits_m32 := by simpa only [ext, romFlagBitsOfExtract] using hm32
+        h_bits_set_pc := by simpa only [ext, romFlagBitsOfExtract] using hsetpc
+        h_bits_store_pc := by simpa only [ext, romFlagBitsOfExtract] using hstorepc
+        h_bits_store_ind := by
+          simp only [romFlagBitsOfExtract]
+          exact decide_eq_false hstoreInd
+        h_prog := ?_ }
+    intro j hline
+    have hbk : trace.program j = romMessageOfRaw (addr j)
+        (ZiskFv.Completeness.Rv64imShapes.rawRType 1 rs2 rs1 $f3 rd $opw) := by
+      exact (hbind.2 j).trans
+        (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+    obtain ⟨ho, hjo1, hjo2, hso, ext', hok', hieo', hm32', hsetpc',
+        hstorepc', hstoreInd', hf⟩ :=
+      $fieldsName rd rs1 rs2 (regidx_to_fin c.rd).isLt
+        (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt
+        (addr j) (trace.program j) hbk
+    have hext : ext' = ext :=
+      Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
+    subst ext'
+    refine ⟨ho, hjo1, hjo2, ?_, hf⟩
+    rw [hso]
+    simp only [rd, Transpiler.ind]
+    apply Fin.ext
+    change (regidx_to_fin c.rd).val % GL_prime = (regidx_to_fin c.rd).val
+    exact Nat.mod_eq_of_lt (lt_trans (regidx_to_fin c.rd).isLt (by norm_num)))
+  return ⟨Lean.mkNullNode #[t1, t2]⟩
+
+local macro "mext_program_decode_c" nm:ident "," f3:term "," opw:term : command => do
+  let s := nm.getId.toString
+  let rawName := Lean.mkIdent (Lean.Name.mkSimple ("RawProgramDecode_" ++ s))
+  let ctorName := Lean.mkIdent (Lean.Name.mkSimple ("ProgramDecode_" ++ s ++ "_from_rawProgram"))
+  let transpileName := Lean.mkIdent (Lean.Name.mkSimple ("transpile_" ++ s))
+  let fieldsName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
+  let claimName := Lean.mkIdent ((`ZiskFv.Compliance).str ("Claim_" ++ s))
+  let programName :=
+    Lean.mkIdent ((`ZiskFv.Compliance.RomDecodeBinding).str ("ProgramDecode_" ++ s))
+  let t1 ← `(structure $rawName {n : Nat}
+      (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+      (i : Fin trace.numInstructions) (c : $claimName trace i)
+      (rawProgram : Fin trace.programLength → BitVec 32) where
+    h_idx : i.val + 1 < trace.mainTable.table.length
+    bounds : ZiskFv.Compliance.ByteBounds
+      (ZiskFv.Compliance.busSub trace i (ZiskFv.Compliance.Pilot.execRowOf trace i)).e2
+    hLine : ∀ j : Fin trace.programLength,
+      (trace.program j).line =
+          (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
+        rawProgram j = ZiskFv.Completeness.Rv64imShapes.rawRType 1
+          (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val $f3
+          (regidx_to_fin c.rd).val $opw)
+  let t2 ← `(noncomputable def $ctorName {n : Nat}
+      (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+      (i : Fin trace.numInstructions) (c : $claimName trace i)
+      (addr : Fin trace.programLength → FGL)
+      (rawProgram : Fin trace.programLength → BitVec 32)
+      (hbind : ProgramBinding trace addr rawProgram)
+      (rawDecode : $rawName trace i c rawProgram) :
+      $programName trace i c := by
+    let rd := (regidx_to_fin c.rd).val
+    let rs1 := (regidx_to_fin c.r1).val
+    let rs2 := (regidx_to_fin c.r2).val
+    let ext := ($transpileName rd rs1 rs2 (regidx_to_fin c.rd).isLt
+      (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt).choose
+    obtain ⟨hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2,
+        hstoreOffset, hstoreInd⟩ :=
+      ($transpileName rd rs1 rs2 (regidx_to_fin c.rd).isLt
+        (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt).choose_spec
+    refine
+      { h_idx := rawDecode.h_idx
+        bounds := rawDecode.bounds
+        bits := romFlagBitsOfExtract ext.row
+        h_bits_ieo := by simpa only [ext, romFlagBitsOfExtract] using hieo
+        h_bits_m32 := by simpa only [ext, romFlagBitsOfExtract] using hm32
+        h_bits_set_pc := by simpa only [ext, romFlagBitsOfExtract] using hsetpc
+        h_bits_store_pc := by simpa only [ext, romFlagBitsOfExtract] using hstorepc
+        h_bits_store_ind := by
+          simp only [romFlagBitsOfExtract]
+          exact decide_eq_false hstoreInd
+        h_prog := ?_ }
+    intro j hline
+    have hbk : trace.program j = romMessageOfRaw (addr j)
+        (ZiskFv.Completeness.Rv64imShapes.rawRType 1 rs2 rs1 $f3 rd $opw) := by
+      exact (hbind.2 j).trans
+        (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+    obtain ⟨ho, hjo1, hjo2, hso, ext', hok', hieo', hm32', hsetpc',
+        hstorepc', hstoreInd', hf⟩ :=
+      $fieldsName rd rs1 rs2 (regidx_to_fin c.rd).isLt
+        (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt
+        (addr j) (trace.program j) hbk
+    have hext : ext' = ext :=
+      Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
+    subst ext'
+    refine ⟨ho, hjo1, hjo2, ?_, hf⟩
+    rw [hso]
+    simp only [rd, Transpiler.ind]
+    apply Fin.ext
+    change (regidx_to_fin c.rd).val % GL_prime = (regidx_to_fin c.rd).val
+    exact Nat.mod_eq_of_lt (lt_trans (regidx_to_fin c.rd).isLt (by norm_num)))
+  return ⟨Lean.mkNullNode #[t1, t2]⟩
+
+mext_program_decode_ab mul, 0, 0x33
+mext_program_decode_ab mulh, 1, 0x33
+mext_program_decode_ab mulhsu, 2, 0x33
+mext_program_decode_ab div, 4, 0x33
+mext_program_decode_ab rem, 6, 0x33
+mext_program_decode_ab divw, 4, 0x3b
+mext_program_decode_ab remw, 6, 0x3b
+
+mext_program_decode_c mulhu, 3, 0x33
+mext_program_decode_c divu, 5, 0x33
+mext_program_decode_c divuw, 5, 0x3b
+mext_program_decode_c remu, 7, 0x33
+mext_program_decode_c remuw, 7, 0x3b
+
 section AxiomAudit
 #print axioms transpile_mul
 #print axioms mul_decode_fields_of_binding
+#print axioms ProgramDecode_mul_from_rawProgram
+#print axioms ProgramDecode_mulh_from_rawProgram
+#print axioms ProgramDecode_mulhsu_from_rawProgram
+#print axioms ProgramDecode_mulhu_from_rawProgram
+#print axioms ProgramDecode_div_from_rawProgram
+#print axioms ProgramDecode_rem_from_rawProgram
+#print axioms ProgramDecode_divw_from_rawProgram
+#print axioms ProgramDecode_remw_from_rawProgram
+#print axioms ProgramDecode_divu_from_rawProgram
+#print axioms ProgramDecode_divuw_from_rawProgram
+#print axioms ProgramDecode_remu_from_rawProgram
+#print axioms ProgramDecode_remuw_from_rawProgram
 end AxiomAudit
 
 end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingNonvacuity.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingNonvacuity.lean
@@ -1,0 +1,228 @@
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingCopyb
+import ZiskFv.Compliance.SingleAddWitness
+
+/-!
+# Raw-program binding non-vacuity
+
+This module proves that the binding is inhabited by the independently
+hand-authored and verifier-accepted `add x1, x1, x1` witness. The committed ROM
+row is a literal witness input, not defined through `romMessageOfRaw`.
+-/
+
+open Goldilocks
+
+namespace ZiskFv.Compliance.RawProgramBinding
+
+open ZiskFv.Compliance.SingleAddWitness
+open Aeneas Aeneas.Std Result zisk_core
+
+private theorem fromInstFullPins (zi : zisk_inst.ZiskInst) :
+    ∃ row, aeneas_extract.ZiskInstExtract.from_inst zi = ok row ∧
+      row.op = zi.op ∧ row.is_external_op = zi.is_external_op ∧ row.m32 = zi.m32 ∧
+      row.set_pc = zi.set_pc ∧ row.store_pc = zi.store_pc ∧
+      row.jmp_offset1 = zi.jmp_offset1 ∧ row.jmp_offset2 = zi.jmp_offset2 ∧
+      row.a_src = zi.a_src ∧ row.a_use_sp_imm1 = zi.a_use_sp_imm1 ∧
+      row.a_offset_imm0 = zi.a_offset_imm0 ∧ row.b_src = zi.b_src ∧
+      row.b_use_sp_imm1 = zi.b_use_sp_imm1 ∧ row.b_offset_imm0 = zi.b_offset_imm0 ∧
+      row.ind_width = zi.ind_width ∧ row.store = zi.store ∧
+      row.store_offset = zi.store_offset ∧ row.is_precompiled = zi.is_precompiled := by
+  refine ⟨_, rfl, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;> rfl
+
+set_option maxHeartbeats 2000000 in
+private theorem createRegisterAddX1FullPins
+    (input : riscv2zisk_single_row.Rv64imLoweringInput)
+    (ctx : riscv2zisk_context.Riscv2ZiskContext)
+    (hrd : input.rd.val = 1) (hrs1 : input.rs1.val = 1) (hrs2 : input.rs2.val = 1)
+    (h : riscv2zisk_context.Riscv2ZiskContext.create_register_op_typed
+      { Extraction.defCtx with extract_marker := (), input_precompile := none }
+      input zisk_ops.ZiskOp.Add 4#u64 = ok ctx) :
+    ∃ zib, ctx.extract_inst = some zib ∧
+      zib.i.a_src = zisk_inst.SRC_REG ∧ zib.i.a_use_sp_imm1 = 0#u64 ∧
+      zib.i.a_offset_imm0.val = 1 ∧ zib.i.b_src = zisk_inst.SRC_REG ∧
+      zib.i.b_use_sp_imm1 = 0#u64 ∧ zib.i.b_offset_imm0.val = 1 ∧
+      zib.i.ind_width = 0#u64 ∧ zib.i.store = zisk_inst.STORE_REG ∧
+      zib.i.store_offset.val = 1 ∧ zib.i.is_precompiled = false := by
+  simp only [riscv2zisk_context.Riscv2ZiskContext.create_register_op_typed,
+    zisk_inst_builder.ZiskInstBuilder.new_for_rv64im_lowering,
+    zisk_inst_builder.ZiskInstBuilder.new,
+    zisk_inst_builder.ZiskInstBuilder.Insts.CoreDefaultDefault.default,
+    zisk_inst.ZiskInst.Insts.CoreDefaultDefault.default,
+    zisk_inst_builder.ZiskInstBuilder.src_a_reg,
+    zisk_inst_builder.ZiskInstBuilder.src_b_reg,
+    zisk_inst_builder.ZiskInstBuilder.op_zisk,
+    zisk_inst_builder.ZiskInstBuilder.set_runtime_op_fields,
+    zisk_ops.ZiskOp.op_type, zisk_ops.ZiskOp.code, zisk_ops.ZiskOp.is_m32,
+    zisk_ops.ZiskOp.input_size, core.convert.IntoFrom.into,
+    zisk_inst.ZiskOperationType.Insts.CoreConvertFromOpType.from,
+    zisk_inst_builder.ZiskInstBuilder.store_reg,
+    zisk_inst_builder.ZiskInstBuilder.j, zisk_inst_builder.ZiskInstBuilder.build,
+    riscv2zisk_context.Riscv2ZiskContext.insert_inst,
+    zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO,
+    zisk_registers.REG_FIRST, mem.SYS_ADDR, mem.RAM_ADDR,
+    zisk_inst.SRC_REG, zisk_inst.STORE_REG, lift, Bind.bind, bind_ok] at h
+  have ca := Extraction.cast_u32_u64_val input.rs1
+  have cb := Extraction.cast_u32_u64_val input.rs2
+  have cs := Extraction.hcast_u32_i64_val input.rd
+  have eu1 := Extraction.cast_one_u64
+  have eu31 := Extraction.cast_31_u64
+  have ei1 := Extraction.cast_one_i64
+  have ei31 := Extraction.cast_31_i64
+  split_ifs at h <;> (try scalar_tac)
+  all_goals
+    simp only [bind_ok, Bind.bind] at h
+    rw [Result.ok.injEq] at h
+    subst ctx
+    refine ⟨_, rfl, ?_⟩
+    simp [zisk_inst.SRC_REG, zisk_inst.STORE_REG, ca, cb, cs, hrd, hrs1, hrs2]
+
+private theorem transpileAddX1FullPins
+    (ext : aeneas_extract.Rv64imTranspileExtract)
+    (hext : aeneas_extract.extract_transpile_rv64im_raw
+      (ZiskFv.Compliance.Decode.toU32
+        (Completeness.Rv64imShapes.rawRType 0 1 1 0 1 0x33)) = ok ext) :
+    ext.row.a_src = zisk_inst.SRC_REG ∧ ext.row.a_use_sp_imm1 = 0#u64 ∧
+      ext.row.a_offset_imm0.val = 1 ∧ ext.row.b_src = zisk_inst.SRC_REG ∧
+      ext.row.b_use_sp_imm1 = 0#u64 ∧ ext.row.b_offset_imm0.val = 1 ∧
+      ext.row.ind_width = 0#u64 ∧ ext.row.store = zisk_inst.STORE_REG ∧
+      ext.row.store_offset.val = 1 ∧ ext.row.is_precompiled = false := by
+  let raw := ZiskFv.Compliance.Decode.toU32
+    (Completeness.Rv64imShapes.rawRType 0 1 1 0 1 0x33)
+  have hdec : aeneas_extract.rv64im_decode.decode_32_core raw =
+      aeneas_extract.rv64im_decode.decode_r raw
+        aeneas_extract.rv64im_decode.RiscvOpcode.Add := by
+    simp only [raw, aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc,
+      Bind.bind, bind_ok, ZiskFv.Compliance.Decode.toU32_and127,
+      ZiskFv.Compliance.Decode.toU32_and7, ZiskFv.Compliance.Decode.toU32_shr12,
+      ZiskFv.Compliance.Decode.toU32_shr25,
+      ZiskFv.Compliance.Decode.rawRType_opcode 0 1 1 0 1 0x33 (by norm_num),
+      ZiskFv.Compliance.Decode.rawRType_funct3 0 1 1 0 1 0x33
+        (by norm_num) (by norm_num) (by norm_num),
+      ZiskFv.Compliance.Decode.rawRType_funct7 0 1 1 0 1 0x33
+        (by norm_num) (by norm_num) (by norm_num) (by norm_num) (by norm_num) (by norm_num)]
+    rfl
+  obtain ⟨decoded, hdecoded, hopd, hrdb, hrs1b, hrs2b⟩ :=
+    Extraction.decode_r_bounds raw aeneas_extract.rv64im_decode.RiscvOpcode.Add
+  have hdec0 : aeneas_extract.rv64im_decode.decode_32_core raw = ok decoded :=
+    hdec.trans hdecoded
+  obtain ⟨decoded', hdecoded', hrdbv, hrs1bv, hrs2bv⟩ :=
+    decode_r_fields raw aeneas_extract.rv64im_decode.RiscvOpcode.Add
+  have hdd : decoded = decoded' := Result.ok.inj (hdecoded.symm.trans hdecoded')
+  subst decoded'
+  have hrd : decoded.rd.val = 1 := by
+    have hm := rawRType_rd 0 1 1 0 1 0x33 (by norm_num) (by norm_num) (by norm_num)
+    have hm' : (raw &&& 3968#u32).bv >>> 7 = 1#32 := by simpa [raw] using hm
+    exact congrArg BitVec.toNat (hrdbv.trans hm')
+  have hrs1 : decoded.rs1.val = 1 := by
+    have hm := rawRType_rs1 0 1 1 0 1 0x33
+      (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+    have hm' : (raw &&& 1015808#u32).bv >>> 15 = 1#32 := by simpa [raw] using hm
+    exact congrArg BitVec.toNat (hrs1bv.trans hm')
+  have hrs2 : decoded.rs2.val = 1 := by
+    have hm := rawRType_rs2 0 1 1 0 1 0x33
+      (by norm_num) (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+    have hm' : (raw &&& 32505856#u32).bv >>> 20 = 1#32 := by simpa [raw] using hm
+    exact congrArg BitVec.toNat (hrs2bv.trans hm')
+  have hrdeq : decoded.rd = 1#u32 := by
+    apply UScalar.eq_of_val_eq
+    simpa using hrd
+  have hrs1eq : decoded.rs1 = 1#u32 := by
+    apply UScalar.eq_of_val_eq
+    simpa using hrs1
+  have hrs2eq : decoded.rs2 = 1#u32 := by
+    apply UScalar.eq_of_val_eq
+    simpa using hrs2
+  let input : riscv2zisk_single_row.Rv64imLoweringInput :=
+    { rom_address := 0#u64, rd := decoded.rd, rs1 := decoded.rs1,
+      rs2 := decoded.rs2, imm := decoded.imm }
+  obtain ⟨ctx0, hctx0⟩ := Extraction.create_register_op_typed_ok
+    { Extraction.defCtx with extract_marker := (), input_precompile := none }
+    input zisk_ops.ZiskOp.Add 4#u64
+    (by simp [input, hrs1]) (by simp [input, hrs2]) (by simp [input, hrd])
+  obtain ⟨zib, hzib, ha, hau, hao, hb, hbu, hbo, hiw, hs, hso, hip⟩ :=
+    createRegisterAddX1FullPins input ctx0
+      (by simp [input, hrd]) (by simp [input, hrs1]) (by simp [input, hrs2]) hctx0
+  obtain ⟨dext, hdext⟩ := Extraction.decode_extract_ok decoded
+  obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, hra, hrau, hraoff,
+    hrb, hrbu, hrboff, hriw, hrs, hrso, hrip⟩ := fromInstFullPins zib.i
+  have hlower :
+      riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        Extraction.defCtx input riscv2zisk_single_row.Rv64imSingleRowOpcode.Add false =
+          ok { ctx0 with extract_marker := () } := by
+    simp only [input, hrdeq, hrs1eq, hrs2eq] at hctx0
+    rw [show
+      { Extraction.defCtx with extract_marker := (), input_precompile := none } =
+        Extraction.defCtx from rfl] at hctx0
+    have hprec : Extraction.defCtx.input_precompile = none := rfl
+    simp only [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input,
+      hprec, riscv2zisk_single_row.CSR_DMA_MEMCMP_ADDR, Bind.bind, bind_ok]
+    simp [input, ne_eq, hrdeq, hrs1eq, hrs2eq,
+      show ((0#u32 : Std.U32) = 2068#u32) = False from by decide]
+    rw [show
+      { Extraction.defCtx with extract_marker := (), input_precompile := none } =
+        Extraction.defCtx from rfl, hctx0]
+    rfl
+  have hext' : aeneas_extract.extract_transpile_rv64im_raw raw =
+      ok { accepted := true, decode := dext, row := row } := by
+    rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
+    simp only [bind_ok, Bind.bind, hdext, hopd, input,
+      show aeneas_extract.lowering_opcode
+        aeneas_extract.rv64im_decode.RiscvOpcode.Add =
+          ok (some riscv2zisk_single_row.Rv64imSingleRowOpcode.Add) from rfl]
+    change
+      (do
+        let ctx ← riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+          Extraction.defCtx input riscv2zisk_single_row.Rv64imSingleRowOpcode.Add false
+        let zib : zisk_inst_builder.ZiskInstBuilder ←
+          core.option.Option.unwrap ctx.extract_inst
+        let row : aeneas_extract.ZiskInstExtract ←
+          aeneas_extract.ZiskInstExtract.from_inst zib.i
+        ok ({ accepted := true, decode := dext, row := row } :
+          aeneas_extract.Rv64imTranspileExtract)) =
+      ok { accepted := true, decode := dext, row := row }
+    simp only [hlower, Bind.bind, bind_ok, hzib, core.option.Option.unwrap,
+      Result.ofOption, hrow]
+  have he : ext = { accepted := true, decode := dext, row := row } :=
+    Result.ok.inj (hext.symm.trans (by simpa [raw] using hext'))
+  have herow : ext.row = row := congrArg aeneas_extract.Rv64imTranspileExtract.row he
+  rw [herow, hra, hrau, hraoff, hrb, hrbu, hrboff, hriw, hrs, hrso, hrip]
+  exact ⟨ha, hau, hao, hb, hbu, hbo, hiw, hs, hso, hip⟩
+
+def singleAddAddr : Fin singleAddAcceptedTrace.programLength → FGL := fun _ => 0
+
+def singleAddRawProgram : Fin singleAddAcceptedTrace.programLength → BitVec 32 :=
+  fun _ => 0x001080b3
+
+theorem singleAddProgramBinding :
+    ProgramBinding singleAddAcceptedTrace singleAddAddr singleAddRawProgram := by
+  constructor
+  · intro k k' h
+    fin_cases k
+    fin_cases k'
+    simp at h
+  · intro k
+    fin_cases k
+    change RegisterMemBusBalance.addX1ProgramRow = romMessageOfRaw 0 0x001080b3
+    obtain ⟨ext, hext, hstatic⟩ := transpile_add 1 1 1 (by omega) (by omega) (by omega)
+      (by omega) (by omega) (by omega)
+    have hraw : (Completeness.Rv64imShapes.rawRType 0 1 1 0 1 0x33 : BitVec 32)
+        = 0x001080b3 := by decide
+    rw [hraw] at hext
+    obtain ⟨ha, hau, hao, hb, hbu, hbo, hiw, hs, hso, hip⟩ :=
+      transpileAddX1FullPins ext (by simpa [hraw] using hext)
+    obtain ⟨hop, hie, hm32, hset, hstorepc, hj1, hj2⟩ := hstatic
+    have hcast4 : (UScalar.hcast IScalarTy.I64 4#u64 : Std.I64).val = 4 := by decide
+    have haeq : ext.row.a_offset_imm0 = 1#u64 := UScalar.eq_of_val_eq hao
+    have hbeq : ext.row.b_offset_imm0 = 1#u64 := UScalar.eq_of_val_eq hbo
+    rw [romMessageOfRaw, hext]
+    congr 1 <;>
+      simp [RegisterMemBusBalance.addX1ProgramRow, romRowOf, signedOffset, sourceImmediate,
+        romOpcode, romFlagBitsOfExtract, ZiskFv.AirsClean.Main.packFlags,
+        ha, hau, hao, haeq, hb, hbu, hbo, hbeq, hiw, hs, hso, hip,
+        hop, hie, hm32, hset, hstorepc, hj1, hj2, hcast4,
+        zisk_inst.SRC_IMM, zisk_inst.SRC_MEM, zisk_inst.SRC_IND,
+        zisk_inst.SRC_REG, zisk_inst.STORE_MEM, zisk_inst.STORE_IND,
+        zisk_inst.STORE_REG, ZiskFv.AirsClean.boolF]
+
+#print axioms singleAddProgramBinding
+
+end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingRegister.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingRegister.lean
@@ -76,7 +76,7 @@ private theorem and3968_ushift7 (x : BitVec 32) :
     simp [BitVec.getLsbD_ushiftRight, BitVec.getLsbD_and,
       BitVec.getLsbD_ofNat, hi, hi7]
 
-private theorem store_reg_raw_index_pins
+theorem store_reg_raw_index_pins
     (self z : zisk_inst_builder.ZiskInstBuilder) (rd : Std.U32)
     (hrd : rd.val < 32)
     (hzero : self.i.store_offset = 0#i64) (hstore : self.i.store = 0#u64)
@@ -102,7 +102,7 @@ private theorem store_reg_raw_index_pins
        · simp [zisk_inst.STORE_REG, zisk_inst.STORE_IND])
     | (exfalso; scalar_tac)
 
-private theorem src_a_reg_pres_store (self z : zisk_inst_builder.ZiskInstBuilder)
+theorem src_a_reg_pres_store (self z : zisk_inst_builder.ZiskInstBuilder)
     (reg : Std.U64) (usp : Bool)
     (h : zisk_inst_builder.ZiskInstBuilder.src_a_reg self reg usp = ok z) :
     z.i.store_offset = self.i.store_offset ∧ z.i.store = self.i.store := by
@@ -138,7 +138,7 @@ private theorem src_b_reg_pres_store (self z : zisk_inst_builder.ZiskInstBuilder
        obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
        rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩)
 
-private theorem op_zisk_pres_store (self z : zisk_inst_builder.ZiskInstBuilder)
+theorem op_zisk_pres_store (self z : zisk_inst_builder.ZiskInstBuilder)
     (op : zisk_ops.ZiskOp)
     (h : zisk_inst_builder.ZiskInstBuilder.op_zisk self op = ok z) :
     z.i.store_offset = self.i.store_offset ∧ z.i.store = self.i.store := by
@@ -159,7 +159,7 @@ private theorem op_zisk_pres_store (self z : zisk_inst_builder.ZiskInstBuilder)
   subst h4
   exact ⟨rfl, rfl⟩
 
-private theorem j_pres_store (self z : zisk_inst_builder.ZiskInstBuilder)
+theorem j_pres_store (self z : zisk_inst_builder.ZiskInstBuilder)
     (j1 j2 : Std.I64)
     (h : zisk_inst_builder.ZiskInstBuilder.j self j1 j2 = ok z) :
     z.i.store_offset = self.i.store_offset ∧ z.i.store = self.i.store := by
@@ -168,7 +168,7 @@ private theorem j_pres_store (self z : zisk_inst_builder.ZiskInstBuilder)
   subst h
   exact ⟨rfl, rfl⟩
 
-private theorem create_register_op_typed_store_pins
+theorem create_register_op_typed_store_pins
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp)
     (inst_size : Std.U64) (ctx : riscv2zisk_context.Riscv2ZiskContext)

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingRegister.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingRegister.lean
@@ -1,5 +1,5 @@
 import ZiskFv.Compliance.TraceLevelExport.RawProgramBinding
-import ZiskFv.Compliance.TraceLevelExport.RomDecodeBindingOps
+import ZiskFv.Compliance.TraceLevelExport.ProgramDecode
 import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.Totality
 
 /-!
@@ -44,6 +44,173 @@ set_option linter.unusedSimpArgs false
 
 /-! ## Generic register-family transpile reduction. -/
 
+private theorem rawRType_rd (funct7 rs2 rs1 funct3 rd opcode : Nat)
+    (hrd : rd < 32) (hop : opcode < 128) :
+    ((ZiskFv.Completeness.Rv64imShapes.rawRType funct7 rs2 rs1 funct3 rd opcode) >>> 7)
+        &&& 31#32 = BitVec.ofNat 32 rd := by
+  simp only [ZiskFv.Completeness.Rv64imShapes.rawRType,
+    ZiskFv.Completeness.Rv64imShapes.rawOfNat32]
+  refine ZiskFv.Compliance.Decode.ofNat32_shift_mask_eq _ 7 5 rd hrd (by norm_num) ?_
+  intro bit hbit
+  simp only [Nat.testBit_or, Nat.testBit_shiftLeft]
+  have e25 : ¬ (7 + bit ≥ 25) := by omega
+  have e20 : ¬ (7 + bit ≥ 20) := by omega
+  have e15 : ¬ (7 + bit ≥ 15) := by omega
+  have e12 : ¬ (7 + bit ≥ 12) := by omega
+  have e7 : 7 + bit ≥ 7 := by omega
+  have hop' : opcode.testBit (7 + bit) = false :=
+    Nat.testBit_eq_false_of_lt (lt_of_lt_of_le hop
+      (by calc (128 : Nat) = 2 ^ 7 := rfl
+           _ ≤ 2 ^ (7 + bit) := Nat.pow_le_pow_right (by norm_num) (by omega)))
+  simp [e25, e20, e15, e12, e7, hop', show 7 + bit - 7 = bit from by omega]
+
+private theorem and3968_ushift7 (x : BitVec 32) :
+    (x &&& 3968#32) >>> 7 = (x >>> 7) &&& 31#32 := by
+  apply BitVec.eq_of_getLsbD_eq
+  intro i
+  by_cases hi : (i : Nat) < 32
+  · interval_cases i <;>
+      simp [BitVec.getLsbD_ushiftRight, BitVec.getLsbD_and,
+        BitVec.getLsbD_ofNat, Nat.testBit]
+  · have hi7 : ¬(i : Nat) + 7 < 32 := by omega
+    simp [BitVec.getLsbD_ushiftRight, BitVec.getLsbD_and,
+      BitVec.getLsbD_ofNat, hi, hi7]
+
+private theorem store_reg_raw_index_pins
+    (self z : zisk_inst_builder.ZiskInstBuilder) (rd : Std.U32)
+    (hrd : rd.val < 32)
+    (hzero : self.i.store_offset = 0#i64) (hstore : self.i.store = 0#u64)
+    (h : zisk_inst_builder.ZiskInstBuilder.store_reg self
+      (UScalar.hcast IScalarTy.I64 rd) false false = ok z) :
+    z.i.store_offset.val = rd.val ∧ z.i.store ≠ zisk_inst.STORE_IND := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.store_reg,
+    zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO,
+    zisk_registers.REG_FIRST, mem.SYS_ADDR, mem.RAM_ADDR,
+    lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
+  have e1 := ZiskFv.Compliance.Extraction.cast_one_i64
+  have e31 := ZiskFv.Compliance.Extraction.cast_31_i64
+  have erd := ZiskFv.Compliance.Extraction.hcast_u32_i64_val rd
+  split_ifs at h <;>
+    first
+    | (rw [Result.ok.injEq] at h; subst h
+       constructor
+       · scalar_tac
+       · simp [hstore, zisk_inst.STORE_IND])
+    | (rw [Result.ok.injEq] at h; subst h
+       constructor
+       · scalar_tac
+       · simp [zisk_inst.STORE_REG, zisk_inst.STORE_IND])
+    | (exfalso; scalar_tac)
+
+private theorem src_a_reg_pres_store (self z : zisk_inst_builder.ZiskInstBuilder)
+    (reg : Std.U64) (usp : Bool)
+    (h : zisk_inst_builder.ZiskInstBuilder.src_a_reg self reg usp = ok z) :
+    z.i.store_offset = self.i.store_offset ∧ z.i.store = self.i.store := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.src_a_reg,
+    zisk_inst_builder.ZiskInstBuilder.src_a_imm,
+    zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO,
+    zisk_registers.REG_FIRST, mem.SYS_ADDR, mem.RAM_ADDR,
+    lift, Bind.bind, bind_ok] at h
+  split_ifs at h <;> (try simp only [bind_ok] at h) <;>
+    first
+    | (rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩)
+    | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+       rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩)
+    | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+       obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+       rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩)
+
+private theorem src_b_reg_pres_store (self z : zisk_inst_builder.ZiskInstBuilder)
+    (reg : Std.U64) (usp : Bool)
+    (h : zisk_inst_builder.ZiskInstBuilder.src_b_reg self reg usp = ok z) :
+    z.i.store_offset = self.i.store_offset ∧ z.i.store = self.i.store := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.src_b_reg,
+    zisk_inst_builder.ZiskInstBuilder.src_b_imm,
+    zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO,
+    zisk_registers.REG_FIRST, mem.SYS_ADDR, mem.RAM_ADDR,
+    lift, Bind.bind, bind_ok] at h
+  split_ifs at h <;> (try simp only [bind_ok] at h) <;>
+    first
+    | (rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩)
+    | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+       rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩)
+    | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+       obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+       rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩)
+
+private theorem op_zisk_pres_store (self z : zisk_inst_builder.ZiskInstBuilder)
+    (op : zisk_ops.ZiskOp)
+    (h : zisk_inst_builder.ZiskInstBuilder.op_zisk self op = ok z) :
+    z.i.store_offset = self.i.store_offset ∧ z.i.store = self.i.store := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.op_zisk,
+    zisk_inst_builder.ZiskInstBuilder.set_runtime_op_fields,
+    core.convert.IntoFrom.into,
+    zisk_inst.ZiskOperationType.Insts.CoreConvertFromOpType.from,
+    Bind.bind] at h
+  obtain ⟨ot, hot, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨b, hb, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨cval, hc, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨self1, hself1, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨zot, hzot, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨i1, hi1, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨mval, hm, h4⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hself1
+  rw [Result.ok.injEq] at h h4
+  subst h
+  subst h4
+  exact ⟨rfl, rfl⟩
+
+private theorem j_pres_store (self z : zisk_inst_builder.ZiskInstBuilder)
+    (j1 j2 : Std.I64)
+    (h : zisk_inst_builder.ZiskInstBuilder.j self j1 j2 = ok z) :
+    z.i.store_offset = self.i.store_offset ∧ z.i.store = self.i.store := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.j] at h
+  rw [Result.ok.injEq] at h
+  subst h
+  exact ⟨rfl, rfl⟩
+
+private theorem create_register_op_typed_store_pins
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp)
+    (inst_size : Std.U64) (ctx : riscv2zisk_context.Riscv2ZiskContext)
+    (hrd : i.rd.val < 32)
+    (h : riscv2zisk_context.Riscv2ZiskContext.create_register_op_typed
+      self i op inst_size = ok ctx) :
+    ∃ zib, ctx.extract_inst = some zib ∧
+      zib.i.store_offset.val = i.rd.val ∧ zib.i.store ≠ zisk_inst.STORE_IND := by
+  simp only [riscv2zisk_context.Riscv2ZiskContext.create_register_op_typed,
+    lift, Bind.bind, bind_ok] at h
+  obtain ⟨z0, h0, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨z1, h1, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨z2, h2, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨z3, h3, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨z4, h4, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨z5, h5, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨z6, h6, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨s1, h7, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  rw [Result.ok.injEq] at h
+  subst h
+  have h30 : z3.i.store_offset = 0#i64 ∧ z3.i.store = 0#u64 := by
+    simp only [zisk_inst_builder.ZiskInstBuilder.new_for_rv64im_lowering,
+      zisk_inst_builder.ZiskInstBuilder.new,
+      zisk_inst_builder.ZiskInstBuilder.Insts.CoreDefaultDefault.default,
+      zisk_inst.ZiskInst.Insts.CoreDefaultDefault.default,
+      bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h0
+    rw [Result.ok.injEq] at h0
+    subst z0
+    obtain ⟨ha0, ha1⟩ := src_a_reg_pres_store _ _ _ _ h1
+    obtain ⟨hb0, hb1⟩ := src_b_reg_pres_store _ _ _ _ h2
+    obtain ⟨ho0, ho1⟩ := op_zisk_pres_store _ _ _ h3
+    exact ⟨ho0.trans (hb0.trans ha0), ho1.trans (hb1.trans ha1)⟩
+  obtain ⟨hso, hst⟩ := store_reg_raw_index_pins z3 z4 i.rd hrd h30.1 h30.2 h4
+  obtain ⟨hjso, hjst⟩ := j_pres_store _ _ _ _ h5
+  have hz65 := ZiskFv.Compliance.Extraction.build_eq _ _ h6
+  refine ⟨z6, ZiskFv.Compliance.Extraction.insert_inst_extract _ _ _ _ h7, ?_, ?_⟩
+  · rw [hz65]
+    rw [hjso]
+    exact hso
+  · rw [hz65]
+    exact fun hh => hst (hjst.symm.trans hh)
+
 /-- The REAL transpile pipeline on a register-op raw word `raw` reduces to the
     op's decode-field pins, given: the decode classifies to `decode_r raw rop`;
     `rop` lowers to the single-row opcode `srop`; the dispatcher routes `srop`
@@ -52,6 +219,8 @@ set_option linter.unusedSimpArgs false
 theorem transpile_register_of
     (raw : Std.U32) (rop : RiscvOpcode) (srop : riscv2zisk_single_row.Rv64imSingleRowOpcode)
     (zop : zisk_ops.ZiskOp) (opc : Std.U8) (m32v : Bool) (otv : zisk_ops.OpType)
+    (rdv : Nat)
+    (hrdv : ∀ d, aeneas_extract.rv64im_decode.decode_r raw rop = ok d → d.rd.val = rdv)
     (hdec : aeneas_extract.rv64im_decode.decode_32_core raw = aeneas_extract.rv64im_decode.decode_r raw rop)
     (hlowop : aeneas_extract.lowering_opcode rop = ok (some srop))
     (harm : ∀ (self : riscv2zisk_context.Riscv2ZiskContext)
@@ -67,7 +236,9 @@ theorem transpile_register_of
       ∧ ext.row.op = opc ∧ ext.row.is_external_op = true ∧ ext.row.m32 = m32v
       ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
       ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
-      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.store_offset.val = rdv
+      ∧ ext.row.store ≠ zisk_inst.STORE_IND := by
   obtain ⟨decoded, hdecoded, hopd, hrdb, hrs1b, hrs2b⟩ := decode_r_bounds raw rop
   have hdec0 : aeneas_extract.rv64im_decode.decode_32_core raw = ok decoded := hdec.trans hdecoded
   set input : riscv2zisk_single_row.Rv64imLoweringInput :=
@@ -83,11 +254,28 @@ theorem transpile_register_of
       { defCtx with extract_marker := () } input zop 4#u64 ctx0 hctx0
   have hzz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
   rw [hzz] at hj1 hj2
+  obtain ⟨zibS, hzibS, hstoreOffset, hstoreInd⟩ :=
+    create_register_op_typed_store_pins
+      { defCtx with extract_marker := () } input zop 4#u64 ctx0 (by rw [hinput]; exact hrdb) hctx0
+  have hzzS : zibS = zib := Option.some.inj (hzibS.symm.trans hzib)
+  rw [hzzS] at hstoreOffset hstoreInd
   obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
   obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, _⟩ := from_inst_ok zib.i
   have hlower : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input srop false
       = ok { ctx0 with extract_marker := () } := by rw [harm, hctx0]; rfl
-  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  have hrStoreOffset : row.store_offset = zib.i.store_offset := by
+    rw [aeneas_extract.ZiskInstExtract.from_inst] at hrow
+    obtain ⟨i2, hi2, hrow⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
+  have hrStore : row.store = zib.i.store := by
+    rw [aeneas_extract.ZiskInstExtract.from_inst] at hrow
+    obtain ⟨i2, hi2, hrow⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
+  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
     simp only [bind_ok, Bind.bind, hdext, hopd, hlowop]
     simp only [defCtx] at hlower
@@ -100,6 +288,13 @@ theorem transpile_register_of
   · show row.store_pc = false; rw [hrstp]; exact hstp2
   · show row.jmp_offset1 = _; rw [hrj1]; exact hj1
   · show row.jmp_offset2 = _; rw [hrj2]; exact hj2
+  · show row.store_offset.val = rdv
+    rw [hrStoreOffset, hstoreOffset]
+    rw [hinput]
+    exact_mod_cast hrdv decoded hdecoded
+  · show row.store ≠ zisk_inst.STORE_IND
+    rw [hrStore]
+    exact hstoreInd
 
 /-! ## Generic decode-field bridge for register ops. -/
 
@@ -108,22 +303,33 @@ private theorem hcast4 : (UScalar.hcast IScalarTy.I64 4#u64 : Std.I64).val = (4 
 /-- The committed message's register-op decode fields, from its raw word binding. -/
 theorem register_decode_fields_of_binding
     (line : FGL) (msg : ZiskRomMessage FGL) (raw : BitVec 32)
-    (opc : Std.U8) (opF : FGL) (ext : zisk_core.aeneas_extract.Rv64imTranspileExtract)
+    (opc : Std.U8) (opF : FGL) (rdv : Nat)
+    (ext : zisk_core.aeneas_extract.Rv64imTranspileExtract)
     (hopF : romOpcode opc = opF)
     (hok : extract_transpile_rv64im_raw (toU32 raw) = ok ext)
     (hop : ext.row.op = opc)
     (hj1 : ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64)
     (hj2 : ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64)
+    (hstoreOffset : ext.row.store_offset.val = rdv)
+    (hstoreInd : ext.row.store ≠ zisk_inst.STORE_IND)
     (hbind : msg = romMessageOfRaw line raw) :
     msg.op = opF ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+      ∧ msg.store_offset = (rdv : FGL)
+      ∧ (romFlagBitsOfExtract ext.row).store_ind = false
       ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
   have hmsg : msg = serializeExtract line ext.row := by
     rw [hbind, romMessageOfRaw, hok]
     exact romRowOf_eq_serializeExtract line ext.row
-  refine ⟨?_, ?_, ?_, ?_⟩
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
   · rw [hmsg]; show romOpcode ext.row.op = opF; rw [hop, hopF]
   · rw [hmsg]; show (ext.row.jmp_offset1.val : FGL) = 4; rw [hj1]; norm_num [hcast4]
   · rw [hmsg]; show (ext.row.jmp_offset2.val : FGL) = 4; rw [hj2]; norm_num [hcast4]
+  · rw [hmsg]
+    show (ext.row.store_offset.val : FGL) = (rdv : FGL)
+    rw [hstoreOffset]
+    norm_num
+  · simp only [romFlagBitsOfExtract]
+    exact decide_eq_false hstoreInd
   · rw [hmsg]; rfl
 
 /-! ## Per-op macro: emits `transpile_<op>` + `<op>_decode_fields_of_binding`
@@ -141,9 +347,46 @@ local macro "reg_op" nm:ident "," f7:term "," f3:term "," opw:term ","
           ∧ ext.row.op = $opU8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
           ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
           ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
-          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
-      refine transpile_register_of _ $rop $srop $zop $opU8 $m32 $ot ?_ rfl (by intro self input; rfl)
+          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+          ∧ ext.row.store_offset.val = rd
+          ∧ ext.row.store ≠ zisk_inst.STORE_IND := by
+      refine transpile_register_of _ $rop $srop $zop $opU8 $m32 $ot rd ?_ ?_ rfl
+        (by intro self input; rfl)
         rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
+      · intro d hd
+        rw [aeneas_extract.rv64im_decode.decode_r] at hd
+        simp only [aeneas_extract.rv64im_decode.DecodedRv64im.new, lift, bind_ok,
+          Bind.bind] at hd
+        obtain ⟨i1, hi1, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+        obtain ⟨i3, hi3, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+        obtain ⟨i5, hi5, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+        obtain ⟨i7, hi7, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+        obtain ⟨i9, hi9, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+        rw [Result.ok.injEq] at hd
+        subst d
+        have hi3' :
+            i3 = toU32 (BitVec.ofNat 32 rd) := by
+          have hcalc :
+              (toU32 (ZiskFv.Completeness.Rv64imShapes.rawRType
+                    $f7 rs2 rs1 $f3 rd $opw) &&& 3968#u32) >>> 7#i32 =
+                ok (toU32 (BitVec.ofNat 32 rd)) := by
+            change (toU32
+                (ZiskFv.Completeness.Rv64imShapes.rawRType
+                  $f7 rs2 rs1 $f3 rd $opw &&& 3968#32)) >>> 7#i32 =
+              ok (toU32 (BitVec.ofNat 32 rd))
+            rw [show (toU32
+                  (ZiskFv.Completeness.Rv64imShapes.rawRType
+                    $f7 rs2 rs1 $f3 rd $opw &&& 3968#32)) >>> 7#i32 =
+                ok (toU32
+                  ((ZiskFv.Completeness.Rv64imShapes.rawRType
+                    $f7 rs2 rs1 $f3 rd $opw &&& 3968#32) >>> 7)) by rfl]
+            rw [and3968_ushift7,
+              rawRType_rd $f7 rs2 rs1 $f3 rd $opw hrd (by norm_num)]
+          rw [hcalc] at hi3
+          exact (Result.ok.inj hi3).symm
+        rw [hi3']
+        simp only [UScalar.val, BitVec.toNat_ofNat]
+        exact Nat.mod_eq_of_lt (lt_trans hrd (by norm_num))
       simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
         ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
         ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_shr25,
@@ -156,16 +399,19 @@ local macro "reg_op" nm:ident "," f7:term "," f3:term "," opw:term ","
         (line : FGL) (msg : ZiskRomMessage FGL)
         (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawRType $f7 rs2 rs1 $f3 rd $opw)) :
         msg.op = $opc ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+          ∧ msg.store_offset = (rd : FGL)
           ∧ ∃ ext, extract_transpile_rv64im_raw
                 (toU32 (ZiskFv.Completeness.Rv64imShapes.rawRType $f7 rs2 rs1 $f3 rd $opw)) = ok ext
               ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
               ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+              ∧ (romFlagBitsOfExtract ext.row).store_ind = false
               ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
-      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ := $tName rd rs1 rs2 hrd hrs1 hrs2
-      obtain ⟨ho, hjo1, hjo2, hf⟩ :=
-        register_decode_fields_of_binding line msg _ $opU8 $opc ext
-          (by simp [romOpcode, $opc:term]) hok hop hj1 hj2 hbind
-      exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩)
+      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2, hstoreOffset, hstoreInd⟩ :=
+        $tName rd rs1 rs2 hrd hrs1 hrs2
+      obtain ⟨ho, hjo1, hjo2, hso, hsi, hf⟩ :=
+        register_decode_fields_of_binding line msg _ $opU8 $opc rd ext
+          (by simp [romOpcode, $opc:term]) hok hop hj1 hj2 hstoreOffset hstoreInd hbind
+      exact ⟨ho, hjo1, hjo2, hso, ext, hok, hieo, hm32, hsetpc, hstorepc, hsi, hf⟩)
   return ⟨Lean.mkNullNode #[t1, t2]⟩
 
 open RiscvOpcode riscv2zisk_single_row.Rv64imSingleRowOpcode zisk_ops.ZiskOp zisk_ops.OpType
@@ -188,9 +434,82 @@ reg_op sraw, 32, 5, 0x3b, RiscvOpcode.Sraw, riscv2zisk_single_row.Rv64imSingleRo
 -- (no extra arith/bound/pin witness), so it fits the register template.
 reg_op mulw, 1, 0, 0x3b, RiscvOpcode.Mulw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Mulw, zisk_ops.ZiskOp.MulW, 182#u8, true, zisk_ops.OpType.ArithAm32, OP_MUL_W
 
+/-! ## Current `ProgramDecode` retarget: unconditional SUB pilot. -/
+
+/-- Raw-program evidence for one SUB step. The raw word is stated directly in
+    terms of the claim registers, so the destination-register pin required by
+    `ProgramDecode_sub.h_prog` is not a separate caller premise. -/
+structure RawProgramDecode_sub {n : Nat}
+    (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_sub trace i)
+    (rawProgram : Fin trace.programLength → BitVec 32) where
+  h_idx : i.val + 1 < trace.mainTable.table.length
+  hLine : ∀ j : Fin trace.programLength,
+    (trace.program j).line =
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
+      rawProgram j =
+        ZiskFv.Completeness.Rv64imShapes.rawRType 32
+          (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val 0
+          (regidx_to_fin c.rd).val 0x33
+
+/-- Rebuild the current committed-program SUB bundle from the raw program and
+    the op-agnostic production-lowering certificate. -/
+noncomputable def ProgramDecode_sub_from_rawProgram {n : Nat}
+    (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_sub trace i)
+    (addr : Fin trace.programLength → FGL)
+    (rawProgram : Fin trace.programLength → BitVec 32)
+    (hbind : ProgramBinding trace addr rawProgram)
+    (rawDecode : RawProgramDecode_sub trace i c rawProgram) :
+    ZiskFv.Compliance.RomDecodeBinding.ProgramDecode_sub trace i c := by
+  let rd := (regidx_to_fin c.rd).val
+  let rs1 := (regidx_to_fin c.r1).val
+  let rs2 := (regidx_to_fin c.r2).val
+  let ext := (transpile_sub rd rs1 rs2 (regidx_to_fin c.rd).isLt
+    (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt).choose
+  obtain ⟨hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2,
+      hstoreOffset, hstoreInd⟩ :=
+    (transpile_sub rd rs1 rs2 (regidx_to_fin c.rd).isLt
+      (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt).choose_spec
+  refine
+    { h_idx := rawDecode.h_idx
+      bits := romFlagBitsOfExtract ext.row
+      h_bits_ieo := ?_
+      h_bits_m32 := ?_
+      h_bits_set_pc := ?_
+      h_bits_store_pc := ?_
+      h_bits_store_ind := ?_
+      h_prog := ?_ }
+  · simpa only [ext, romFlagBitsOfExtract] using hieo
+  · simpa only [ext, romFlagBitsOfExtract] using hm32
+  · simpa only [ext, romFlagBitsOfExtract] using hsetpc
+  · simpa only [ext, romFlagBitsOfExtract] using hstorepc
+  · simp only [romFlagBitsOfExtract]
+    exact decide_eq_false hstoreInd
+  · intro j hline
+    have hbk : trace.program j =
+        romMessageOfRaw (addr j)
+          (ZiskFv.Completeness.Rv64imShapes.rawRType 32 rs2 rs1 0 rd 0x33) := by
+      exact (hbind.2 j).trans
+        (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+    obtain ⟨ho, hjo1, hjo2, hso, ext', hok', hieo', hm32', hsetpc',
+        hstorepc', hstoreInd', hf⟩ :=
+      sub_decode_fields_of_binding rd rs1 rs2 (regidx_to_fin c.rd).isLt
+        (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt
+        (addr j) (trace.program j) hbk
+    have hext : ext' = ext := Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
+    subst ext'
+    refine ⟨ho, hjo1, hjo2, ?_, hf⟩
+    rw [hso]
+    simp only [rd, Transpiler.ind]
+    apply Fin.ext
+    change (regidx_to_fin c.rd).val % GL_prime = (regidx_to_fin c.rd).val
+    exact Nat.mod_eq_of_lt (lt_trans (regidx_to_fin c.rd).isLt (by norm_num))
+
 section AxiomAudit
 #print axioms transpile_sub
 #print axioms sub_decode_fields_of_binding
+#print axioms ProgramDecode_sub_from_rawProgram
 end AxiomAudit
 
 end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingRegister.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingRegister.lean
@@ -506,10 +506,104 @@ noncomputable def ProgramDecode_sub_from_rawProgram {n : Nat}
     change (regidx_to_fin c.rd).val % GL_prime = (regidx_to_fin c.rd).val
     exact Nat.mod_eq_of_lt (lt_trans (regidx_to_fin c.rd).isLt (by norm_num))
 
+/-! ## Remaining unconditional register-family `ProgramDecode` bundles. -/
+
+local macro "reg_program_decode" nm:ident "," f7:term "," f3:term "," opw:term : command => do
+  let s := nm.getId.toString
+  let rawName := Lean.mkIdent (Lean.Name.mkSimple ("RawProgramDecode_" ++ s))
+  let ctorName := Lean.mkIdent (Lean.Name.mkSimple ("ProgramDecode_" ++ s ++ "_from_rawProgram"))
+  let transpileName := Lean.mkIdent (Lean.Name.mkSimple ("transpile_" ++ s))
+  let fieldsName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
+  let claimName := Lean.mkIdent ((`ZiskFv.Compliance).str ("Claim_" ++ s))
+  let programName :=
+    Lean.mkIdent ((`ZiskFv.Compliance.RomDecodeBinding).str ("ProgramDecode_" ++ s))
+  let t1 ← `(structure $rawName {n : Nat}
+      (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+      (i : Fin trace.numInstructions) (c : $claimName trace i)
+      (rawProgram : Fin trace.programLength → BitVec 32) where
+    h_idx : i.val + 1 < trace.mainTable.table.length
+    hLine : ∀ j : Fin trace.programLength,
+      (trace.program j).line =
+          (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
+        rawProgram j =
+          ZiskFv.Completeness.Rv64imShapes.rawRType $f7
+            (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val $f3
+            (regidx_to_fin c.rd).val $opw)
+  let t2 ← `(noncomputable def $ctorName {n : Nat}
+      (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+      (i : Fin trace.numInstructions) (c : $claimName trace i)
+      (addr : Fin trace.programLength → FGL)
+      (rawProgram : Fin trace.programLength → BitVec 32)
+      (hbind : ProgramBinding trace addr rawProgram)
+      (rawDecode : $rawName trace i c rawProgram) :
+      $programName trace i c := by
+    let rd := (regidx_to_fin c.rd).val
+    let rs1 := (regidx_to_fin c.r1).val
+    let rs2 := (regidx_to_fin c.r2).val
+    let ext := ($transpileName rd rs1 rs2 (regidx_to_fin c.rd).isLt
+      (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt).choose
+    obtain ⟨hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2,
+        hstoreOffset, hstoreInd⟩ :=
+      ($transpileName rd rs1 rs2 (regidx_to_fin c.rd).isLt
+        (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt).choose_spec
+    refine
+      { h_idx := rawDecode.h_idx
+        bits := romFlagBitsOfExtract ext.row
+        h_bits_ieo := ?_
+        h_bits_m32 := ?_
+        h_bits_set_pc := ?_
+        h_bits_store_pc := ?_
+        h_bits_store_ind := ?_
+        h_prog := ?_ }
+    · simpa only [ext, romFlagBitsOfExtract] using hieo
+    · simpa only [ext, romFlagBitsOfExtract] using hm32
+    · simpa only [ext, romFlagBitsOfExtract] using hsetpc
+    · simpa only [ext, romFlagBitsOfExtract] using hstorepc
+    · simp only [romFlagBitsOfExtract]
+      exact decide_eq_false hstoreInd
+    · intro j hline
+      have hbk : trace.program j =
+          romMessageOfRaw (addr j)
+            (ZiskFv.Completeness.Rv64imShapes.rawRType $f7 rs2 rs1 $f3 rd $opw) := by
+        exact (hbind.2 j).trans
+          (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+      obtain ⟨ho, hjo1, hjo2, hso, ext', hok', hieo', hm32', hsetpc',
+          hstorepc', hstoreInd', hf⟩ :=
+        $fieldsName rd rs1 rs2 (regidx_to_fin c.rd).isLt
+          (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt
+          (addr j) (trace.program j) hbk
+      have hext : ext' = ext :=
+        Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
+      subst ext'
+      refine ⟨ho, hjo1, hjo2, ?_, hf⟩
+      rw [hso]
+      simp only [rd, Transpiler.ind]
+      apply Fin.ext
+      change (regidx_to_fin c.rd).val % GL_prime = (regidx_to_fin c.rd).val
+      exact Nat.mod_eq_of_lt (lt_trans (regidx_to_fin c.rd).isLt (by norm_num)))
+  return ⟨Lean.mkNullNode #[t1, t2]⟩
+
+reg_program_decode and, 0, 7, 0x33
+reg_program_decode xor, 0, 4, 0x33
+reg_program_decode slt, 0, 2, 0x33
+reg_program_decode sltu, 0, 3, 0x33
+reg_program_decode sll, 0, 1, 0x33
+reg_program_decode srl, 0, 5, 0x33
+reg_program_decode sra, 32, 5, 0x33
+reg_program_decode addw, 0, 0, 0x3b
+reg_program_decode subw, 32, 0, 0x3b
+reg_program_decode sllw, 0, 1, 0x3b
+reg_program_decode srlw, 0, 5, 0x3b
+reg_program_decode sraw, 32, 5, 0x3b
+reg_program_decode mulw, 1, 0, 0x3b
+
 section AxiomAudit
 #print axioms transpile_sub
 #print axioms sub_decode_fields_of_binding
 #print axioms ProgramDecode_sub_from_rawProgram
+#print axioms ProgramDecode_and_from_rawProgram
+#print axioms ProgramDecode_sraw_from_rawProgram
+#print axioms ProgramDecode_mulw_from_rawProgram
 end AxiomAudit
 
 end ZiskFv.Compliance.RawProgramBinding


### PR DESCRIPTION
Part 2 of the Phase 9 stack for #61. Base: `phase9-1-raw-binding`.

## Summary

- Retargets the recovered raw-word facts to the current `ProgramDecode` API.
- Derives the fifth committed-program clause, `store_offset`, from the production destination
  selector and the raw word's destination field.
- Adds current constructors for register, M-extension, shift-immediate, conditional CopyB, and
  FENCE families.
- Adds a first independent single-ADD inhabitant for the raw-program binding.

The genuine dispatcher side conditions remain explicit. This trades committed-ROM column equations
for raw-word bit-field equations; it does not rename them into hidden assumptions.

## Stack

1. `phase9-1-raw-binding`
2. **This PR**
3. `phase9-3-fidelity-nonvacuity`
4. `phase9-4-expanded-layout`
5. `phase9-5-architectural-decoders`
6. `phase9-6-root-endpoint`

## Verification

Focused family builds and representative axiom-closure checks passed. The complete stack's full
repository gates are recorded on PR 6.
