### PR TITLE
#61 Phase 9.3: prove raw binding fidelity and non-vacuity

### DIFF
--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -187,6 +187,7 @@ import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingLoadStore
 import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingMext
 import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingControl
 import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingNonvacuity
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingMemoryNonvacuity
 import ZiskFv.Compliance
 import ZiskFv.Compliance.EnsembleWitnessBuilder
 import ZiskFv.Compliance.RegisterMemBusBalance

--- a/ZiskFv/Compliance/AeneasBridgeTrust/Extraction/Totality.lean
+++ b/ZiskFv/Compliance/AeneasBridgeTrust/Extraction/Totality.lean
@@ -180,6 +180,31 @@ theorem from_inst_ok (zi : zisk_inst.ZiskInst) :
       ∧ e.ind_width = zi.ind_width := by
   refine ⟨_, rfl, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;> rfl
 
+/-- `from_inst` copies every instruction field consumed by ROM serialization.
+The operation-type discriminant is the only converted field and is deliberately
+outside this projection lemma. -/
+theorem from_inst_full_fields (zi : zisk_inst.ZiskInst) :
+    ∃ e, aeneas_extract.ZiskInstExtract.from_inst zi = ok e
+      ∧ e.a_src = zi.a_src
+      ∧ e.a_use_sp_imm1 = zi.a_use_sp_imm1
+      ∧ e.a_offset_imm0 = zi.a_offset_imm0
+      ∧ e.b_src = zi.b_src
+      ∧ e.b_use_sp_imm1 = zi.b_use_sp_imm1
+      ∧ e.b_offset_imm0 = zi.b_offset_imm0
+      ∧ e.ind_width = zi.ind_width
+      ∧ e.op = zi.op
+      ∧ e.store = zi.store
+      ∧ e.store_offset = zi.store_offset
+      ∧ e.jmp_offset1 = zi.jmp_offset1
+      ∧ e.jmp_offset2 = zi.jmp_offset2
+      ∧ e.set_pc = zi.set_pc
+      ∧ e.store_pc = zi.store_pc
+      ∧ e.is_external_op = zi.is_external_op
+      ∧ e.m32 = zi.m32 := by
+  refine ⟨_, rfl, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;> rfl
+
+#print axioms from_inst_full_fields
+
 /-- `decode_extract_from_decoded` is total (every opcode/format arm returns `ok`). -/
 theorem decode_extract_ok (d : aeneas_extract.rv64im_decode.DecodedRv64im) :
     ∃ e, aeneas_extract.decode_extract_from_decoded d = ok e := by

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingControl.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingControl.lean
@@ -276,6 +276,15 @@ theorem auipc_negative_rom_target_mismatch :
       (BitVec.signExtend 64 ((524288#20) ++ (0#12))).toNat := by
   decide
 
+/-- Representative backward-branch counterexample to all six current branch
+    committed-program interfaces.  The aligned immediate `4096#13` denotes
+    `-4096`; production embeds that signed offset in FGL, while the interfaces
+    ask for its unsigned 64-bit value. -/
+theorem branch_negative_rom_target_mismatch :
+    ((((BitVec.signExtend 64 (4096#13)).toInt : Int) : FGL).val) ≠
+      (BitVec.signExtend 64 (4096#13)).toNat := by
+  decide
+
 private theorem rawJType_rd (imm rd : Nat) (hrd : rd < 32) :
     ((ZiskFv.Completeness.Rv64imShapes.rawJType imm rd) &&& 3968#32) >>> 7 = BitVec.ofNat 32 rd := by
   rw [and3968_shr7]
@@ -1163,6 +1172,7 @@ section AxiomAudit
 #print axioms transpile_lui
 #print axioms transpile_auipc
 #print axioms auipc_negative_rom_target_mismatch
+#print axioms branch_negative_rom_target_mismatch
 #print axioms transpile_jal
 #print axioms transpile_jalr
 #print axioms jalr_decode_fields_of_binding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingControl.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingControl.lean
@@ -63,6 +63,108 @@ set_option linter.unusedSimpArgs false
 
 private theorem hcast4' : (UScalar.hcast IScalarTy.I64 4#u64 : Std.I64).val = (4 : Int) := by decide
 
+private theorem store_reg_raw_index_pins_any
+    (self z : zisk_inst_builder.ZiskInstBuilder) (rd : Std.U32)
+    (hrd : rd.val < 32) (storePc : Bool)
+    (hzero : self.i.store_offset = 0#i64) (hstore : self.i.store = 0#u64)
+    (h : zisk_inst_builder.ZiskInstBuilder.store_reg self
+      (UScalar.hcast IScalarTy.I64 rd) false storePc = ok z) :
+    z.i.store_offset.val = rd.val ∧ z.i.store ≠ zisk_inst.STORE_IND := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.store_reg,
+    zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO,
+    zisk_registers.REG_FIRST, mem.SYS_ADDR, mem.RAM_ADDR,
+    lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
+  have e1 := ZiskFv.Compliance.Extraction.cast_one_i64
+  have e31 := ZiskFv.Compliance.Extraction.cast_31_i64
+  have erd := ZiskFv.Compliance.Extraction.hcast_u32_i64_val rd
+  split_ifs at h <;>
+    first
+    | (rw [Result.ok.injEq] at h; subst h
+       constructor
+       · scalar_tac
+       · simp [hstore, zisk_inst.STORE_IND])
+    | (rw [Result.ok.injEq] at h; subst h
+       constructor
+       · scalar_tac
+       · simp [zisk_inst.STORE_REG, zisk_inst.STORE_IND])
+    | (exfalso; scalar_tac)
+
+private theorem lui_store_pins
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (instSize : Std.U64)
+    (ctx : riscv2zisk_context.Riscv2ZiskContext)
+    (hrd : i.rd.val < 32)
+    (h : riscv2zisk_context.Riscv2ZiskContext.lui self i instSize = ok ctx) :
+    ∃ zib, ctx.extract_inst = some zib ∧
+      zib.i.store_offset.val = i.rd.val ∧ zib.i.store ≠ zisk_inst.STORE_IND := by
+  simp only [
+    riscv2zisk_context.Riscv2ZiskContext.lui,
+    zisk_inst_builder.ZiskInstBuilder.new_for_rv64im_lowering,
+    zisk_inst_builder.ZiskInstBuilder.new,
+    zisk_inst_builder.ZiskInstBuilder.Insts.CoreDefaultDefault.default,
+    zisk_inst.ZiskInst.Insts.CoreDefaultDefault.default,
+    zisk_inst_builder.ZiskInstBuilder.src_a_imm,
+    zisk_inst_builder.ZiskInstBuilder.src_b_imm,
+    zisk_inst_builder.ZiskInstBuilder.op_zisk,
+    zisk_ops.ZiskOp.op_type, zisk_ops.ZiskOp.code,
+    zisk_ops.ZiskOp.input_size, zisk_ops.ZiskOp.is_m32,
+    core.convert.IntoFrom.into,
+    zisk_inst.ZiskOperationType.Insts.CoreConvertFromOpType.from,
+    zisk_inst_builder.ZiskInstBuilder.set_runtime_op_fields,
+    zisk_inst_builder.ZiskInstBuilder.j,
+    zisk_inst_builder.ZiskInstBuilder.build,
+    riscv2zisk_context.Riscv2ZiskContext.insert_inst,
+    UScalar.hcast, IScalar.hcast, lift, reduceIte,
+    HShiftRight.hShiftRight, UScalar.shiftRight_IScalar, UScalar.shiftRight,
+    ZiskFv.Compliance.Extraction.i32_32_nonnegative,
+    ZiskFv.Compliance.Extraction.i32_32_toNat_lt_u64_numBits,
+    bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
+  obtain ⟨zib, hstore, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨hso, hsi⟩ :=
+    store_reg_raw_index_pins_any _ _ i.rd hrd false (by rfl) (by rfl) hstore
+  rw [Result.ok.injEq] at h
+  subst h
+  exact ⟨_, rfl, by simpa using hso, by simpa using hsi⟩
+
+private theorem auipc_store_jmp_pins
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput)
+    (ctx : riscv2zisk_context.Riscv2ZiskContext)
+    (hrd : i.rd.val < 32)
+    (h : riscv2zisk_context.Riscv2ZiskContext.auipc self i = ok ctx) :
+    ∃ zib, ctx.extract_inst = some zib ∧
+      zib.i.store_offset.val = i.rd.val ∧ zib.i.store ≠ zisk_inst.STORE_IND ∧
+      zib.i.jmp_offset2 = IScalar.cast IScalarTy.I64 i.imm := by
+  simp only [
+    riscv2zisk_context.Riscv2ZiskContext.auipc,
+    zisk_inst_builder.ZiskInstBuilder.new_for_rv64im_lowering,
+    zisk_inst_builder.ZiskInstBuilder.new,
+    zisk_inst_builder.ZiskInstBuilder.Insts.CoreDefaultDefault.default,
+    zisk_inst.ZiskInst.Insts.CoreDefaultDefault.default,
+    zisk_inst_builder.ZiskInstBuilder.src_a_imm,
+    zisk_inst_builder.ZiskInstBuilder.src_b_imm,
+    zisk_inst_builder.ZiskInstBuilder.op_zisk,
+    zisk_ops.ZiskOp.op_type, zisk_ops.ZiskOp.code,
+    zisk_ops.ZiskOp.input_size, zisk_ops.ZiskOp.is_m32,
+    core.convert.IntoFrom.into,
+    zisk_inst.ZiskOperationType.Insts.CoreConvertFromOpType.from,
+    zisk_inst_builder.ZiskInstBuilder.set_runtime_op_fields,
+    zisk_inst_builder.ZiskInstBuilder.store_pc_reg,
+    zisk_inst_builder.ZiskInstBuilder.j,
+    zisk_inst_builder.ZiskInstBuilder.build,
+    riscv2zisk_context.Riscv2ZiskContext.insert_inst,
+    lift, reduceIte,
+    HShiftRight.hShiftRight, UScalar.shiftRight_IScalar, UScalar.shiftRight,
+    ZiskFv.Compliance.Extraction.i32_32_nonnegative,
+    ZiskFv.Compliance.Extraction.i32_32_toNat_lt_u64_numBits,
+    bind_ok, Bind.bind] at h
+  obtain ⟨zib, hstore, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨hso, hsi⟩ :=
+    store_reg_raw_index_pins_any _ _ i.rd hrd true (by rfl) (by rfl) hstore
+  rw [Result.ok.injEq] at h
+  subst h
+  exact ⟨_, rfl, by simpa using hso, by simpa using hsi, rfl⟩
+
 /-! ## Decoder `rd`-field recovery (`[7,11]` bits) and the symbolic `rd ≠ 0`
 derivations, for the AUIPC / JAL / JALR `store_pc = true` nop-guard.  All
 kernel-sound (`ofNat32_shift_mask_eq`, no native_decide). -/
@@ -91,6 +193,88 @@ private theorem rawUType_rd (imm rd opcode : Nat) (hrd : rd < 32) (hop : opcode 
   have hop' : opcode.testBit (7 + i) = false :=
     ZiskFv.Compliance.Decode.tbf (show opcode < 2 ^ 7 by omega) (by omega)
   simp [e7, hop', hmask, show 7 + i - 7 = i from by omega]
+
+private theorem decode_u_rawUType_imm
+    (imm : BitVec 20) (rd opcode : Nat)
+    (hrd : rd < 32) (hopcode : opcode < 128)
+    (rop : RiscvOpcode) (d : DecodedRv64im)
+    (hd : decode_u (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType
+      (imm ++ (0 : BitVec 12)).toNat rd opcode)) rop = ok d) :
+    (IScalar.hcast UScalarTy.U64 d.imm).bv =
+      BitVec.signExtend 64 (imm ++ (0 : BitVec 12)) := by
+  simp only [decode_u, DecodedRv64im.new, lift, bind_ok, Bind.bind] at hd
+  obtain ⟨_i1, _, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+  obtain ⟨i2, hi2, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+  obtain ⟨i3, hi3, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+  rw [Result.ok.injEq] at hd
+  rw [← hd]
+  have hi2bv : i2.bv =
+      (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType
+        (imm ++ (0 : BitVec 12)).toNat rd opcode) &&& 4294963200#u32).bv >>> 12 := by
+    rw [show ((toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType
+        (imm ++ (0 : BitVec 12)).toNat rd opcode) &&& 4294963200#u32) >>> 12#i32 :
+      Result Std.U32) = ok ⟨(toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType
+        (imm ++ (0 : BitVec 12)).toNat rd opcode) &&& 4294963200#u32).bv >>> 12⟩
+      from rfl, Result.ok.injEq] at hi2
+    exact (congrArg UScalar.bv hi2).symm
+  have hi3bv : i3.bv = i2.bv <<< 12 := by
+    rw [show (i2 <<< 12#i32 : Result Std.U32) = ok ⟨i2.bv <<< 12⟩ from rfl,
+      Result.ok.injEq] at hi3
+    exact (congrArg UScalar.bv hi3).symm
+  change BitVec.signExtend 64 i3.bv =
+    BitVec.signExtend 64 (imm ++ (0 : BitVec 12))
+  rw [hi3bv, hi2bv]
+  congr 1
+  simp only [toU32, ZiskFv.Completeness.Rv64imShapes.rawUType,
+    ZiskFv.Completeness.Rv64imShapes.rawOfNat32]
+  have hlow (k : Nat) (hk : k < 12) :
+      (imm ++ (0 : BitVec 12)).getLsbD k = false := by
+    rw [BitVec.getLsbD_append, if_pos hk]
+    simp
+  have hrdBit (k : Nat) (hk : 5 ≤ k) : rd.testBit k = false :=
+    ZiskFv.Compliance.Decode.tbf (show rd < 2 ^ 5 by omega) hk
+  have hopBit (k : Nat) (hk : 7 ≤ k) : opcode.testBit k = false :=
+    ZiskFv.Compliance.Decode.tbf (show opcode < 2 ^ 7 by omega) hk
+  have hrdHigh (k : Nat) (hk : 12 ≤ k) :
+      (BitVec.ofNat 32 (rd <<< 7)).getLsbD k = false := by
+    simp [BitVec.getLsbD_ofNat, Nat.testBit_shiftLeft, hk,
+      hrdBit (k - 7) (by omega)]
+  have hopHigh (k : Nat) (hk : 12 ≤ k) :
+      (BitVec.ofNat 32 opcode).getLsbD k = false := by
+    simp [BitVec.getLsbD_ofNat, hopBit k (by omega)]
+  apply BitVec.eq_of_getLsbD_eq
+  intro k
+  by_cases hk : k < 32
+  · by_cases hk12 : k < 12
+    · interval_cases k <;>
+        simp [hlow, BitVec.getLsbD_ushiftRight, BitVec.getLsbD_shiftLeft,
+          BitVec.getLsbD_and, BitVec.getLsbD_ofNat, Nat.testBit] <;>
+        first
+        | (have hz := hlow _ (by omega)
+           simpa only [BitVec.getLsbD_eq_getElem (by omega)] using hz)
+    · interval_cases k <;>
+        simp [BitVec.getLsbD_ushiftRight, BitVec.getLsbD_shiftLeft,
+          BitVec.getLsbD_and, BitVec.getLsbD_ofNat, BitVec.getLsbD_append,
+          Nat.testBit_or, Nat.testBit_shiftLeft, Nat.testBit_and,
+          Nat.testBit_mod_two_pow, Nat.testBit, hrdBit, hopBit] <;>
+        first
+        | (rw [show (BitVec.ofNat 32 (rd <<< 7))[_] = false by
+                 rw [← BitVec.getLsbD_eq_getElem (by omega)]
+                 exact hrdHigh _ (by omega),
+               show (BitVec.ofNat 32 opcode)[_] = false by
+                 rw [← BitVec.getLsbD_eq_getElem (by omega)]
+                 exact hopHigh _ (by omega)]
+           simp)
+  · simp [BitVec.getLsbD, hk]
+
+/-- Kernel counterexample to the current AUIPC committed-program interface for
+    the smallest negative U-immediate (`0x80000 << 12`).  Production embeds the
+    signed offset in FGL, while `ProgramDecode_auipc` asks for its unsigned
+    64-bit value. -/
+theorem auipc_negative_rom_target_mismatch :
+    ((((BitVec.signExtend 64 ((524288#20) ++ (0#12))).toInt : Int) : FGL).val) ≠
+      (BitVec.signExtend 64 ((524288#20) ++ (0#12))).toNat := by
+  decide
 
 private theorem rawJType_rd (imm rd : Nat) (hrd : rd < 32) :
     ((ZiskFv.Completeness.Rv64imShapes.rawJType imm rd) &&& 3968#32) >>> 7 = BitVec.ofNat 32 rd := by
@@ -387,7 +571,9 @@ theorem transpile_lui (rd imm : Nat) (hrd : rd < 32) :
       ∧ ext.row.op = 1#u8 ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
       ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
       ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
-      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.store_offset.val = rd
+      ∧ ext.row.store ≠ zisk_inst.STORE_IND := by
   have hdec : aeneas_extract.rv64im_decode.decode_32_core
         (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x37))
       = aeneas_extract.rv64im_decode.decode_u
@@ -396,7 +582,7 @@ theorem transpile_lui (rd imm : Nat) (hrd : rd < 32) :
       ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_ofNat,
       ZiskFv.Compliance.Decode.rawUType_opcode imm rd 0x37 (by norm_num)]
     all_goals rfl
-  obtain ⟨decoded, hdecoded, hopd, hrdb, _⟩ :=
+  obtain ⟨decoded, hdecoded, hopd, hrdb, hrdbv⟩ :=
     decode_u_bounds (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x37)) RiscvOpcode.Lui
   have hdec0 : aeneas_extract.rv64im_decode.decode_32_core
       (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x37)) = ok decoded := hdec.trans hdecoded
@@ -410,6 +596,11 @@ theorem transpile_lui (rd imm : Nat) (hrd : rd < 32) :
     ZiskFv.Compliance.Extraction.lui_dynamic_pins { defCtx with extract_marker := () } input 4#u64 ctx0 hctx0
   have hzz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
   rw [hzz] at hj1 hj2
+  obtain ⟨zibS, hzibS, hstoreOffset, hstoreInd⟩ :=
+    lui_store_pins { defCtx with extract_marker := () } input 4#u64 ctx0
+      (by rw [hinput]; exact hrdb) hctx0
+  have hzzS : zibS = zib := Option.some.inj (hzibS.symm.trans hzib)
+  rw [hzzS] at hstoreOffset hstoreInd
   obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
   obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, _⟩ := from_inst_ok zib.i
   have harm : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input
@@ -421,7 +612,19 @@ theorem transpile_lui (rd imm : Nat) (hrd : rd < 32) :
     rw [harm, hctx0]; rfl
   have hlowop : aeneas_extract.lowering_opcode RiscvOpcode.Lui
       = ok (some riscv2zisk_single_row.Rv64imSingleRowOpcode.Lui) := rfl
-  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  have hrStoreOffset : row.store_offset = zib.i.store_offset := by
+    rw [aeneas_extract.ZiskInstExtract.from_inst] at hrow
+    obtain ⟨i2, hi2, hrow⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
+  have hrStore : row.store = zib.i.store := by
+    rw [aeneas_extract.ZiskInstExtract.from_inst] at hrow
+    obtain ⟨i2, hi2, hrow⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
+  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
     simp only [bind_ok, Bind.bind, hdext, hopd, hlowop]
     simp only [defCtx] at hlower
@@ -434,21 +637,35 @@ theorem transpile_lui (rd imm : Nat) (hrd : rd < 32) :
   · show row.store_pc = false; rw [hrstp]; exact hstp2
   · show row.jmp_offset1 = _; rw [hrj1]; exact hj1
   · show row.jmp_offset2 = _; rw [hrj2]; exact hj2
+  · show row.store_offset.val = rd
+    rw [hrStoreOffset, hstoreOffset, hinput]
+    exact_mod_cast (show decoded.rd.val = rd by
+      change decoded.rd.bv.toNat = rd
+      rw [hrdbv]
+      change (((ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x37) &&&
+        3968#32) >>> 7).toNat = rd
+      rw [rawUType_rd imm rd 0x37 hrd (by norm_num), BitVec.toNat_ofNat]
+      omega)
+  · show row.store ≠ zisk_inst.STORE_IND
+    rw [hrStore]
+    exact hstoreInd
 
 theorem lui_decode_fields_of_binding (rd imm : Nat) (hrd : rd < 32)
     (line : FGL) (msg : ZiskRomMessage FGL)
     (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x37)) :
     msg.op = OP_COPYB ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+      ∧ msg.store_offset = (rd : FGL)
       ∧ ∃ ext, extract_transpile_rv64im_raw
             (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x37)) = ok ext
           ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
           ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
           ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
-  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ := transpile_lui rd imm hrd
-  obtain ⟨ho, hjo1, hjo2, hf⟩ :=
-    jump_decode_fields_of_binding line msg _ 1#u8 OP_COPYB ext
-      (by simp [romOpcode, OP_COPYB]) hok hop hj1 hj2 hbind
-  exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
+  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2, hso, hsi⟩ :=
+    transpile_lui rd imm hrd
+  obtain ⟨ho, hjo1, hjo2, hmso, _, hf⟩ :=
+    register_decode_fields_of_binding line msg _ 1#u8 OP_COPYB rd ext
+      (by simp [romOpcode, OP_COPYB]) hok hop hj1 hj2 hso hsi hbind
+  exact ⟨ho, hjo1, hjo2, hmso, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
 
 /-! ## AUIPC (U-type word, `decode_u` → `auipc` → `OP_FLAG`, `store_pc = true`).
 The constant slot is `jmp_offset1 = 4` (`= 4#i64`, defeq `hcast 4#u64`); the
@@ -458,7 +675,13 @@ theorem transpile_auipc (rd imm : Nat) (hrd : rd < 32) (hrd0 : rd ≠ 0) :
     ∃ ext, extract_transpile_rv64im_raw (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x17)) = ok ext
       ∧ ext.row.op = 0#u8 ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
       ∧ ext.row.set_pc = false ∧ ext.row.store_pc = true
-      ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.store_offset.val = rd
+      ∧ ext.row.store ≠ zisk_inst.STORE_IND
+      ∧ ∃ d, decode_u
+          (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x17))
+            RiscvOpcode.Auipc = ok d
+        ∧ ext.row.jmp_offset2 = IScalar.cast IScalarTy.I64 d.imm := by
   have hdec : aeneas_extract.rv64im_decode.decode_32_core
         (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x17))
       = aeneas_extract.rv64im_decode.decode_u
@@ -487,6 +710,11 @@ theorem transpile_auipc (rd imm : Nat) (hrd : rd < 32) (hrd0 : rd ≠ 0) :
     ZiskFv.Compliance.Extraction.auipc_dynamic_pins { defCtx with extract_marker := () } input ctx0 hctx0
   have hzz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
   rw [hzz] at hj1
+  obtain ⟨zibS, hzibS, hstoreOffset, hstoreInd, hj2⟩ :=
+    auipc_store_jmp_pins { defCtx with extract_marker := () } input ctx0
+      (by rw [hinput]; exact hrdb) hctx0
+  have hzzS : zibS = zib := Option.some.inj (hzibS.symm.trans hzib)
+  rw [hzzS] at hstoreOffset hstoreInd hj2
   obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
   obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, _⟩ := from_inst_ok zib.i
   have harm : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input
@@ -498,7 +726,19 @@ theorem transpile_auipc (rd imm : Nat) (hrd : rd < 32) (hrd0 : rd ≠ 0) :
     rw [harm, hctx0]; rfl
   have hlowop : aeneas_extract.lowering_opcode RiscvOpcode.Auipc
       = ok (some riscv2zisk_single_row.Rv64imSingleRowOpcode.Auipc) := rfl
-  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  have hrStoreOffset : row.store_offset = zib.i.store_offset := by
+    rw [aeneas_extract.ZiskInstExtract.from_inst] at hrow
+    obtain ⟨i2, hi2, hrow⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
+  have hrStore : row.store = zib.i.store := by
+    rw [aeneas_extract.ZiskInstExtract.from_inst] at hrow
+    obtain ⟨i2, hi2, hrow⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
+  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
     simp only [bind_ok, Bind.bind, hdext, hopd, hlowop]
     simp only [defCtx] at hlower
@@ -510,21 +750,51 @@ theorem transpile_auipc (rd imm : Nat) (hrd : rd < 32) (hrd0 : rd ≠ 0) :
   · show row.set_pc = false; rw [hrsp]; exact hsp2
   · show row.store_pc = true; rw [hrstp]; exact hstp2
   · show row.jmp_offset1 = _; rw [hrj1]; exact hj1
+  · show row.store_offset.val = rd
+    rw [hrStoreOffset, hstoreOffset, hinput]
+    exact_mod_cast (show decoded.rd.val = rd by
+      change decoded.rd.bv.toNat = rd
+      rw [hrdbv]
+      change (((ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x17) &&&
+        3968#32) >>> 7).toNat = rd
+      rw [rawUType_rd imm rd 0x17 hrd (by norm_num), BitVec.toNat_ofNat]
+      omega)
+  · show row.store ≠ zisk_inst.STORE_IND
+    rw [hrStore]
+    exact hstoreInd
+  · refine ⟨decoded, hdecoded, ?_⟩
+    rw [hrj2, hj2, hinput]
 
 theorem auipc_decode_fields_of_binding (rd imm : Nat) (hrd : rd < 32) (hrd0 : rd ≠ 0)
     (line : FGL) (msg : ZiskRomMessage FGL)
     (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x17)) :
     msg.op = OP_FLAG ∧ msg.jmp_offset1 = 4
+      ∧ msg.store_offset = (rd : FGL)
       ∧ ∃ ext, extract_transpile_rv64im_raw
             (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x17)) = ok ext
           ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
           ∧ ext.row.set_pc = false ∧ ext.row.store_pc = true
           ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
-  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1⟩ := transpile_auipc rd imm hrd hrd0
-  obtain ⟨ho, hjo1, hf⟩ :=
-    branch_decode_fields_true line msg _ 0#u8 OP_FLAG ext
-      (by simp [romOpcode, OP_FLAG]) hok hop hj1 hbind
-  exact ⟨ho, hjo1, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
+  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hso, hsi, hdyn⟩ :=
+    transpile_auipc rd imm hrd hrd0
+  have hmsg : msg = serializeExtract line ext.row := by
+    rw [hbind, romMessageOfRaw, hok]
+    exact romRowOf_eq_serializeExtract line ext.row
+  refine ⟨?_, ?_, ?_, ext, hok, hieo, hm32, hsetpc, hstorepc, ?_⟩
+  · rw [hmsg]
+    show romOpcode ext.row.op = OP_FLAG
+    rw [hop]
+    simp [romOpcode, OP_FLAG]
+  · rw [hmsg]
+    show (ext.row.jmp_offset1.val : FGL) = 4
+    rw [hj1]
+    norm_num [hcast4']
+  · rw [hmsg]
+    show (ext.row.store_offset.val : FGL) = (rd : FGL)
+    rw [hso]
+    norm_num
+  · rw [hmsg]
+    rfl
 
 /-! ## JAL (J-type word, `decode_j` → `jal` → `OP_FLAG`, `store_pc = true`).
 Constant slot `jmp_offset2 = 4`; `store_pc = true` needs `rd ≠ 0`.  jmp_offset1
@@ -762,7 +1032,69 @@ theorem fence_decode_fields_of_binding
       (by simp [romOpcode, OP_FLAG]) hok hop hj1 hj2 hbind
   exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
 
-/-! ## Current `ProgramDecode` retarget: FENCE. -/
+/-! ## Current `ProgramDecode` retarget: U-type controls and FENCE. -/
+
+structure RawProgramDecode_lui {n : Nat}
+    (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_lui trace i)
+    (rawProgram : Fin trace.programLength → BitVec 32) where
+  h_idx : i.val + 1 < trace.mainTable.table.length
+  h_imm_lo_nat :
+    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).b_0 i.val).val
+      = (c.imm ++ (0 : BitVec 12)).toNat
+  h_imm_hi_nat :
+    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).b_1 i.val).val
+      = (BitVec.signExtend 64 (c.imm ++ (0 : BitVec 12))).toNat / 4294967296
+  hLine : ∀ j : Fin trace.programLength,
+    (trace.program j).line =
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
+      rawProgram j = ZiskFv.Completeness.Rv64imShapes.rawUType
+        (c.imm ++ (0 : BitVec 12)).toNat (regidx_to_fin c.rd).val 0x37
+
+noncomputable def ProgramDecode_lui_from_rawProgram {n : Nat}
+    (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_lui trace i)
+    (addr : Fin trace.programLength → FGL)
+    (rawProgram : Fin trace.programLength → BitVec 32)
+    (hbind : ProgramBinding trace addr rawProgram)
+    (rawDecode : RawProgramDecode_lui trace i c rawProgram) :
+    ZiskFv.Compliance.RomDecodeBinding.ProgramDecode_lui trace i c := by
+  let rd := (regidx_to_fin c.rd).val
+  let imm := (c.imm ++ (0 : BitVec 12)).toNat
+  let ext := (transpile_lui rd imm (regidx_to_fin c.rd).isLt).choose
+  obtain ⟨hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2, hso, hsi⟩ :=
+    (transpile_lui rd imm (regidx_to_fin c.rd).isLt).choose_spec
+  refine
+    { h_idx := rawDecode.h_idx
+      h_imm_lo_nat := rawDecode.h_imm_lo_nat
+      h_imm_hi_nat := rawDecode.h_imm_hi_nat
+      bits := romFlagBitsOfExtract ext.row
+      h_bits_ieo := by simpa only [ext, romFlagBitsOfExtract] using hieo
+      h_bits_m32 := by simpa only [ext, romFlagBitsOfExtract] using hm32
+      h_bits_set_pc := by simpa only [ext, romFlagBitsOfExtract] using hsetpc
+      h_bits_store_pc := by simpa only [ext, romFlagBitsOfExtract] using hstorepc
+      h_bits_store_ind := by
+        simp only [romFlagBitsOfExtract]
+        exact decide_eq_false hsi
+      h_prog := by
+        intro j hline
+        have hbk : trace.program j = romMessageOfRaw (addr j)
+            (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x37) := by
+          exact (hbind.2 j).trans
+            (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+        obtain ⟨ho, hjo1, hjo2, hs, ext', hok', hieo', hm32', hsetpc',
+            hstorepc', hf⟩ :=
+          lui_decode_fields_of_binding rd imm (regidx_to_fin c.rd).isLt
+            (addr j) (trace.program j) hbk
+        have hext : ext' = ext :=
+          Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
+        subst ext'
+        refine ⟨ho, hjo1, hjo2, ?_, hf⟩
+        rw [hs]
+        simp only [rd, Transpiler.ind]
+        apply Fin.ext
+        change (regidx_to_fin c.rd).val % GL_prime = (regidx_to_fin c.rd).val
+        exact Nat.mod_eq_of_lt (lt_trans (regidx_to_fin c.rd).isLt (by norm_num)) }
 
 /-- Raw-program evidence for one supported FENCE step.  Only the claim-side
     defect witnesses and the Main-row bound remain caller supplied; all
@@ -830,11 +1162,13 @@ noncomputable def ProgramDecode_fence_from_rawProgram {n : Nat}
 section AxiomAudit
 #print axioms transpile_lui
 #print axioms transpile_auipc
+#print axioms auipc_negative_rom_target_mismatch
 #print axioms transpile_jal
 #print axioms transpile_jalr
 #print axioms jalr_decode_fields_of_binding
 #print axioms transpile_fence
 #print axioms fence_decode_fields_of_binding
+#print axioms ProgramDecode_lui_from_rawProgram
 #print axioms ProgramDecode_fence_from_rawProgram
 #print axioms transpile_beq
 #print axioms beq_decode_fields_of_binding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingControl.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingControl.lean
@@ -285,6 +285,15 @@ theorem branch_negative_rom_target_mismatch :
       (BitVec.signExtend 64 (4096#13)).toNat := by
   decide
 
+/-- Representative backward-JAL counterexample to the current committed-program
+    interface.  The aligned immediate `1048576#21` denotes `-1048576`;
+    production embeds that signed offset in FGL, while `ProgramDecode_jal`
+    asks for its unsigned 64-bit value. -/
+theorem jal_negative_rom_target_mismatch :
+    ((((BitVec.signExtend 64 (1048576#21)).toInt : Int) : FGL).val) ≠
+      (BitVec.signExtend 64 (1048576#21)).toNat := by
+  decide
+
 private theorem rawJType_rd (imm rd : Nat) (hrd : rd < 32) :
     ((ZiskFv.Completeness.Rv64imShapes.rawJType imm rd) &&& 3968#32) >>> 7 = BitVec.ofNat 32 rd := by
   rw [and3968_shr7]
@@ -1173,6 +1182,7 @@ section AxiomAudit
 #print axioms transpile_auipc
 #print axioms auipc_negative_rom_target_mismatch
 #print axioms branch_negative_rom_target_mismatch
+#print axioms jal_negative_rom_target_mismatch
 #print axioms transpile_jal
 #print axioms transpile_jalr
 #print axioms jalr_decode_fields_of_binding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingCopyb.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingCopyb.lean
@@ -1,4 +1,5 @@
 import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingImmediate
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBitfields
 
 /-!
 # Raw-program decode bridge — conditional-copyb ops (issue #159, BLOCK 3)
@@ -212,6 +213,33 @@ private theorem u32_ne_zero_of_bv (x : Std.U32) (v : Nat) (hv : v < 32) (hv0 : v
     have := congrArg BitVec.toNat hbv; simpa [BitVec.toNat_ofNat] using this
   omega
 
+private theorem decode_i_rawIType_imm64
+    (imm rs1 funct3 rd opcode : Nat) (hrs1 : rs1 < 32) (hf3 : funct3 < 8)
+    (hrd : rd < 32) (hop : opcode < 128) (rop : RiscvOpcode) (d : DecodedRv64im)
+    (hd : decode_i (toU32 (rawIType imm rs1 funct3 rd opcode)) rop false = ok d) :
+    (IScalar.hcast UScalarTy.U64 d.imm).val =
+      (BitVec.signExtend 64 (BitVec.ofNat 12 imm)).toNat := by
+  have hb := decode_i_rawIType_imm imm rs1 funct3 rd opcode hrs1 hf3 hrd hop rop d hd
+  change (BitVec.signExtend 64 d.imm.bv).toNat =
+    (BitVec.signExtend 64 (BitVec.ofNat 12 imm)).toNat
+  rw [hb]
+  have hbmod :
+      (BitVec.ofNat 12 imm).toInt.bmod 4294967296 = (BitVec.ofNat 12 imm).toInt := by
+    rw [Int.bmod_def]
+    have hlo : (-2048 : Int) ≤ (BitVec.ofNat 12 imm).toInt :=
+      BitVec.toInt_intMin_le _
+    have hhi : (BitVec.ofNat 12 imm).toInt < (2048 : Int) := BitVec.toInt_lt
+    by_cases h : 0 ≤ (BitVec.ofNat 12 imm).toInt
+    · have hem : (BitVec.ofNat 12 imm).toInt % ((4294967296 : Nat) : Int) =
+          (BitVec.ofNat 12 imm).toInt := Int.emod_eq_of_lt h (by omega)
+      rw [hem]
+      split <;> omega
+    · have hem : (BitVec.ofNat 12 imm).toInt % ((4294967296 : Nat) : Int) =
+          (BitVec.ofNat 12 imm).toInt + 4294967296 := by omega
+      rw [hem]
+      split <;> omega
+  simp only [BitVec.signExtend, BitVec.toInt_ofInt, hbmod]
+
 /-! ## 3. Totality for the `immediate_op_or_x0_copyb_typed` builder. -/
 
 /-- `immediate_op_or_x0_copyb_typed` is total for in-range register fields
@@ -241,6 +269,108 @@ theorem immediate_op_or_x0_copyb_typed_ok
   rw [riscv2zisk_context.Riscv2ZiskContext.immediate_op_or_x0_copyb_typed]
   simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hz5, hz6, hs1]
 
+private theorem copyb_src_b_imm_pres_store (self z : zisk_inst_builder.ZiskInstBuilder)
+    (v : Std.U64)
+    (h : zisk_inst_builder.ZiskInstBuilder.src_b_imm self v = ok z) :
+    z.i.store_offset = self.i.store_offset ∧ z.i.store = self.i.store := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.src_b_imm,
+    lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
+  first
+  | (rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩)
+  | (obtain ⟨_, _, h⟩ := bind_eq_ok_imp h
+     rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩)
+  | (obtain ⟨_, _, h⟩ := bind_eq_ok_imp h
+     obtain ⟨_, _, h⟩ := bind_eq_ok_imp h
+     rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩)
+
+/-- The conditional immediate builder preserves the honest destination-register
+    store pins through either `CopyB` or the requested operation arm. -/
+theorem immediate_op_or_x0_copyb_typed_store_pins
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp)
+    (inst_size : Std.U64) (ctx : riscv2zisk_context.Riscv2ZiskContext)
+    (hrd : i.rd.val < 32)
+    (h : riscv2zisk_context.Riscv2ZiskContext.immediate_op_or_x0_copyb_typed
+      self i op inst_size = ok ctx) :
+    ∃ zib, ctx.extract_inst = some zib ∧
+      zib.i.store_offset.val = i.rd.val ∧ zib.i.store ≠ zisk_inst.STORE_IND := by
+  simp only [riscv2zisk_context.Riscv2ZiskContext.immediate_op_or_x0_copyb_typed,
+    lift, Bind.bind, bind_ok] at h
+  obtain ⟨z0, h0, h⟩ := bind_eq_ok_imp h
+  obtain ⟨z1, h1, h⟩ := bind_eq_ok_imp h
+  obtain ⟨z2, h2, h⟩ := bind_eq_ok_imp h
+  obtain ⟨z3, h3, h⟩ := bind_eq_ok_imp h
+  obtain ⟨z4, h4, h⟩ := bind_eq_ok_imp h
+  obtain ⟨z5, h5, h⟩ := bind_eq_ok_imp h
+  obtain ⟨z6, h6, h⟩ := bind_eq_ok_imp h
+  obtain ⟨s1, h7, h⟩ := bind_eq_ok_imp h
+  rw [Result.ok.injEq] at h
+  subst h
+  have h30 : z3.i.store_offset = 0#i64 ∧ z3.i.store = 0#u64 := by
+    simp only [zisk_inst_builder.ZiskInstBuilder.new_for_rv64im_lowering,
+      zisk_inst_builder.ZiskInstBuilder.new,
+      zisk_inst_builder.ZiskInstBuilder.Insts.CoreDefaultDefault.default,
+      zisk_inst.ZiskInst.Insts.CoreDefaultDefault.default,
+      bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h0
+    rw [Result.ok.injEq] at h0
+    subst z0
+    obtain ⟨ha0, ha1⟩ := src_a_reg_pres_store _ _ _ _ h1
+    obtain ⟨hb0, hb1⟩ := copyb_src_b_imm_pres_store _ _ _ h2
+    have hopStore : z3.i.store_offset = z2.i.store_offset ∧ z3.i.store = z2.i.store := by
+      split at h3
+      · exact op_zisk_pres_store _ _ _ h3
+      · exact op_zisk_pres_store _ _ _ h3
+    obtain ⟨ho0, ho1⟩ := hopStore
+    exact ⟨ho0.trans (hb0.trans ha0), ho1.trans (hb1.trans ha1)⟩
+  obtain ⟨hso, hst⟩ := store_reg_raw_index_pins z3 z4 i.rd hrd h30.1 h30.2 h4
+  obtain ⟨hjso, hjst⟩ := j_pres_store _ _ _ _ h5
+  have hz65 := ZiskFv.Compliance.Extraction.build_eq _ _ h6
+  refine ⟨z6, ZiskFv.Compliance.Extraction.insert_inst_extract _ _ _ _ h7, ?_, ?_⟩
+  · rw [hz65, hjso]
+    exact hso
+  · rw [hz65]
+    exact fun hh => hst (hjst.symm.trans hh)
+
+/-- The conditional immediate builder preserves the exact 64-bit immediate
+    split written by `src_b_imm` through either operation arm. -/
+theorem immediate_op_or_x0_copyb_typed_immediate_pins
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp)
+    (inst_size : Std.U64) (ctx : riscv2zisk_context.Riscv2ZiskContext)
+    (h : riscv2zisk_context.Riscv2ZiskContext.immediate_op_or_x0_copyb_typed
+      self i op inst_size = ok ctx) :
+    ∃ zib, ctx.extract_inst = some zib ∧
+      zib.i.b_src = zisk_inst.SRC_IMM ∧
+      zib.i.b_use_sp_imm1.val = (IScalar.hcast UScalarTy.U64 i.imm).val / 4294967296 ∧
+      zib.i.b_offset_imm0.val = (IScalar.hcast UScalarTy.U64 i.imm).val % 4294967296 := by
+  simp only [riscv2zisk_context.Riscv2ZiskContext.immediate_op_or_x0_copyb_typed,
+    lift, Bind.bind, bind_ok] at h
+  obtain ⟨z0, h0, h⟩ := bind_eq_ok_imp h
+  obtain ⟨z1, h1, h⟩ := bind_eq_ok_imp h
+  obtain ⟨z2, h2, h⟩ := bind_eq_ok_imp h
+  obtain ⟨z3, h3, h⟩ := bind_eq_ok_imp h
+  obtain ⟨z4, h4, h⟩ := bind_eq_ok_imp h
+  obtain ⟨z5, h5, h⟩ := bind_eq_ok_imp h
+  obtain ⟨z6, h6, h⟩ := bind_eq_ok_imp h
+  obtain ⟨s1, h7, h⟩ := bind_eq_ok_imp h
+  rw [Result.ok.injEq] at h
+  subst h
+  obtain ⟨hsrc, hhi, hlo⟩ := src_b_imm_data_pins z1 z2 _ h2
+  have hopPins : z3.i.b_src = z2.i.b_src ∧
+      z3.i.b_use_sp_imm1 = z2.i.b_use_sp_imm1 ∧
+      z3.i.b_offset_imm0 = z2.i.b_offset_imm0 := by
+    split at h3
+    · exact op_zisk_pres_b z2 z3 _ h3
+    · exact op_zisk_pres_b z2 z3 _ h3
+  obtain ⟨hos, hoh, hol⟩ := hopPins
+  obtain ⟨hss, hsh, hsl⟩ := store_reg_pres_b z3 z4 _ _ _ h4
+  obtain ⟨hjs, hjh, hjl⟩ := j_pres_b z4 z5 _ _ h5
+  have hz65 := ZiskFv.Compliance.Extraction.build_eq _ _ h6
+  refine ⟨z6, ZiskFv.Compliance.Extraction.insert_inst_extract _ _ _ _ h7, ?_, ?_, ?_⟩
+  · rw [hz65, hjs, hss, hos, hsrc]
+  · rw [hz65, hjh, hsh, hoh, hhi]
+  · rw [hz65, hjl, hsl, hol, hlo]
+
 /-! ## 4. Generic conditional transpile reductions. -/
 
 private theorem hcast4 : (UScalar.hcast IScalarTy.I64 4#u64 : Std.I64).val = (4 : Int) := by decide
@@ -251,6 +381,8 @@ private theorem hcast4 : (UScalar.hcast IScalarTy.I64 4#u64 : Std.I64).val = (4 
 theorem transpile_register_cond_of
     (raw : Std.U32) (rop : RiscvOpcode) (srop : riscv2zisk_single_row.Rv64imSingleRowOpcode)
     (zop : zisk_ops.ZiskOp) (opc : Std.U8) (m32v : Bool) (otv : zisk_ops.OpType)
+    (rdv : Nat)
+    (hrdv : ∀ d, aeneas_extract.rv64im_decode.decode_r raw rop = ok d → d.rd.val = rdv)
     (S : riscv2zisk_context.Riscv2ZiskContext)
     (P : riscv2zisk_single_row.Rv64imLoweringInput → Prop)
     (hdec : aeneas_extract.rv64im_decode.decode_32_core raw = aeneas_extract.rv64im_decode.decode_r raw rop)
@@ -268,7 +400,9 @@ theorem transpile_register_cond_of
       ∧ ext.row.op = opc ∧ ext.row.is_external_op = true ∧ ext.row.m32 = m32v
       ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
       ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
-      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.store_offset.val = rdv
+      ∧ ext.row.store ≠ zisk_inst.STORE_IND := by
   obtain ⟨decoded, hdecoded, hopd, hrdb, hrs1b, hrs2b⟩ := decode_r_bounds raw rop
   have hdec0 : aeneas_extract.rv64im_decode.decode_32_core raw = ok decoded := hdec.trans hdecoded
   set input : riscv2zisk_single_row.Rv64imLoweringInput :=
@@ -283,11 +417,29 @@ theorem transpile_register_cond_of
     create_register_op_typed_dynamic_pins S input zop 4#u64 ctx0 hctx0
   have hzz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
   rw [hzz] at hj1 hj2
+  obtain ⟨zib'', hzib'', hso, hsi⟩ :=
+    create_register_op_typed_store_pins S input zop 4#u64 ctx0
+      (by rw [hinput]; exact hrdb) hctx0
+  have hzz' : zib'' = zib := Option.some.inj (hzib''.symm.trans hzib)
+  rw [hzz'] at hso hsi
   obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
   obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, _⟩ := from_inst_ok zib.i
+  have hrStoreOffset : row.store_offset = zib.i.store_offset := by
+    rw [aeneas_extract.ZiskInstExtract.from_inst] at hrow
+    obtain ⟨i2, hi2, hrow⟩ := bind_eq_ok_imp hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
+  have hrStore : row.store = zib.i.store := by
+    rw [aeneas_extract.ZiskInstExtract.from_inst] at hrow
+    obtain ⟨i2, hi2, hrow⟩ := bind_eq_ok_imp hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
   have hlower : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input srop false
       = ok { ctx0 with extract_marker := () } := by rw [harm input hPin, hctx0]; rfl
-  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  refine ⟨{ accepted := true, decode := dext, row := row },
+    ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
     simp only [bind_ok, Bind.bind, hdext, hopd, hlowop]
     simp only [defCtx] at hlower
@@ -300,6 +452,12 @@ theorem transpile_register_cond_of
   · show row.store_pc = false; rw [hrstp]; exact hstp2
   · show row.jmp_offset1 = _; rw [hrj1]; exact hj1
   · show row.jmp_offset2 = _; rw [hrj2]; exact hj2
+  · show row.store_offset.val = rdv
+    rw [hrStoreOffset, hso, hinput]
+    exact_mod_cast hrdv decoded hdecoded
+  · show row.store ≠ zisk_inst.STORE_IND
+    rw [hrStore]
+    exact hsi
 
 /-- Conditional immediate-op transpile through the `immediate_op_or_x0_copyb_typed`
     builder. -/
@@ -307,6 +465,10 @@ theorem transpile_immediate_copyb_of
     (raw : Std.U32) (rop : RiscvOpcode) (sh : Bool)
     (srop : riscv2zisk_single_row.Rv64imSingleRowOpcode)
     (zop : zisk_ops.ZiskOp) (opc : Std.U8) (m32v : Bool) (otv : zisk_ops.OpType)
+    (rdv imm64 : Nat)
+    (hrdv : ∀ d, aeneas_extract.rv64im_decode.decode_i raw rop sh = ok d → d.rd.val = rdv)
+    (himm64 : ∀ d, aeneas_extract.rv64im_decode.decode_i raw rop sh = ok d →
+      (IScalar.hcast UScalarTy.U64 d.imm).val = imm64)
     (S : riscv2zisk_context.Riscv2ZiskContext)
     (P : riscv2zisk_single_row.Rv64imLoweringInput → Prop)
     (hdec : aeneas_extract.rv64im_decode.decode_32_core raw
@@ -326,7 +488,12 @@ theorem transpile_immediate_copyb_of
       ∧ ext.row.op = opc ∧ ext.row.is_external_op = true ∧ ext.row.m32 = m32v
       ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
       ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
-      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.store_offset.val = rdv
+      ∧ ext.row.store ≠ zisk_inst.STORE_IND
+      ∧ ext.row.b_src = zisk_inst.SRC_IMM
+      ∧ ext.row.b_use_sp_imm1.val = imm64 / 4294967296
+      ∧ ext.row.b_offset_imm0.val = imm64 % 4294967296 := by
   obtain ⟨decoded, hdecoded, hopd, hrdb, hrs1b, _⟩ := decode_i_bounds raw rop sh
   have hdec0 : aeneas_extract.rv64im_decode.decode_32_core raw = ok decoded := hdec.trans hdecoded
   set input : riscv2zisk_single_row.Rv64imLoweringInput :=
@@ -342,11 +509,29 @@ theorem transpile_immediate_copyb_of
     immediate_op_or_x0_copyb_typed_dynamic_pins S input zop 4#u64 ctx0 hctx0
   have hzz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
   rw [hzz] at hj1 hj2
+  obtain ⟨zib'', hzib'', hso, hsi⟩ :=
+    immediate_op_or_x0_copyb_typed_store_pins S input zop 4#u64 ctx0
+      (by rw [hinput]; exact hrdb) hctx0
+  have hzz' : zib'' = zib := Option.some.inj (hzib''.symm.trans hzib)
+  rw [hzz'] at hso hsi
+  obtain ⟨zib''', hzib''', hbsrc, hbhi, hblo⟩ :=
+    immediate_op_or_x0_copyb_typed_immediate_pins S input zop 4#u64 ctx0 hctx0
+  have hzz'' : zib''' = zib := Option.some.inj (hzib'''.symm.trans hzib)
+  rw [hzz''] at hbsrc hbhi hblo
   obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
   obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, _⟩ := from_inst_ok zib.i
+  have hrFields : row.store_offset = zib.i.store_offset ∧ row.store = zib.i.store ∧
+      row.b_src = zib.i.b_src ∧ row.b_use_sp_imm1 = zib.i.b_use_sp_imm1 ∧
+      row.b_offset_imm0 = zib.i.b_offset_imm0 := by
+    rw [aeneas_extract.ZiskInstExtract.from_inst] at hrow
+    obtain ⟨i2, hi2, hrow⟩ := bind_eq_ok_imp hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    exact ⟨rfl, rfl, rfl, rfl, rfl⟩
   have hlower : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input srop false
       = ok { ctx0 with extract_marker := () } := by rw [harm input hPin, hctx0]; rfl
-  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  refine ⟨{ accepted := true, decode := dext, row := row },
+    ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
     simp only [bind_ok, Bind.bind, hdext, hopd, hlowop]
     simp only [defCtx] at hlower
@@ -359,6 +544,19 @@ theorem transpile_immediate_copyb_of
   · show row.store_pc = false; rw [hrstp]; exact hstp2
   · show row.jmp_offset1 = _; rw [hrj1]; exact hj1
   · show row.jmp_offset2 = _; rw [hrj2]; exact hj2
+  · show row.store_offset.val = rdv
+    rw [hrFields.1, hso, hinput]
+    exact_mod_cast hrdv decoded hdecoded
+  · show row.store ≠ zisk_inst.STORE_IND
+    rw [hrFields.2.1]
+    exact hsi
+  · show row.b_src = zisk_inst.SRC_IMM
+    rw [hrFields.2.2.1]
+    exact hbsrc
+  · show row.b_use_sp_imm1.val = imm64 / 4294967296
+    rw [hrFields.2.2.2.1, hbhi, hinput, himm64 decoded hdecoded]
+  · show row.b_offset_imm0.val = imm64 % 4294967296
+    rw [hrFields.2.2.2.2, hblo, hinput, himm64 decoded hdecoded]
 
 private theorem copyb_hcast4 :
     (UScalar.hcast IScalarTy.I64 4#u64 : Std.I64).val = (4 : Int) := by decide
@@ -390,6 +588,79 @@ private theorem copyb_decode_fields_of_binding
   · rw [hmsg]
     rfl
 
+private theorem copyb_serializeExtract_immediate_value
+    (line : FGL) (e : aeneas_extract.ZiskInstExtract) (v : Std.U64)
+    (hsrc : e.b_src = zisk_inst.SRC_IMM)
+    (hhi : e.b_use_sp_imm1.val = v.val / 4294967296)
+    (hlo : e.b_offset_imm0.val = v.val % 4294967296) :
+    BitVec.ofNat 64
+        ((serializeExtract line e).b_offset_imm0.val
+          + (serializeExtract line e).b_imm1.val * 4294967296) = v.bv := by
+  apply BitVec.eq_of_toNat_eq
+  simp only [serializeExtract, signedOffset, sourceImmediate, hsrc, if_pos,
+    BitVec.toNat_ofNat, UScalar.val]
+  have hloInt : e.b_offset_imm0.bv.toInt = v.val % 4294967296 := by
+    have hvmod : v.val % 4294967296 < 4294967296 := Nat.mod_lt _ (by norm_num)
+    have hnat : e.b_offset_imm0.bv.toNat = v.val % 4294967296 := hlo
+    rw [BitVec.toInt, if_pos (by rw [hnat]; omega)]
+    exact_mod_cast hnat
+  have hhiNat : e.b_use_sp_imm1.bv.toNat = v.val / 4294967296 := by exact hhi
+  rw [hloInt, hhiNat]
+  have hloBound : v.val % 4294967296 < GL_prime :=
+    lt_trans (Nat.mod_lt _ (by norm_num)) (by norm_num)
+  have hhiBound : v.val / 4294967296 < GL_prime := by
+    have hv : v.val < 2 ^ 64 := v.bv.isLt
+    omega
+  norm_num [Fin.val_ofNat, Nat.mod_eq_of_lt hloBound, Nat.mod_eq_of_lt hhiBound]
+  have hem : ((v.val % 4294967296 : Int) % (GL_prime : Int)) =
+      (v.val % 4294967296 : Int) :=
+    Int.emod_eq_of_lt (by omega) (by exact_mod_cast hloBound)
+  rw [hem]
+  have hto : (v.val % 4294967296 : Int).toNat = v.val % 4294967296 := by
+    rfl
+  rw [hto]
+  have hvdecomp :
+      v.val % 4294967296 + (v.val / 4294967296) * 4294967296 = v.val := by
+    simpa [Nat.mul_comm] using Nat.mod_add_div v.val 4294967296
+  rw [hvdecomp]
+  exact Nat.mod_eq_of_lt v.bv.isLt
+
+private theorem copyb_immediate_decode_fields_of_binding
+    (line : FGL) (msg : ZiskRomMessage FGL) (raw : BitVec 32)
+    (opc : Std.U8) (opF : FGL) (rdv : Nat) (immv : BitVec 12)
+    (ext : zisk_core.aeneas_extract.Rv64imTranspileExtract)
+    (hopF : romOpcode opc = opF)
+    (hok : extract_transpile_rv64im_raw (toU32 raw) = ok ext)
+    (hop : ext.row.op = opc)
+    (hj1 : ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64)
+    (hj2 : ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64)
+    (hso : ext.row.store_offset.val = rdv)
+    (hsi : ext.row.store ≠ zisk_inst.STORE_IND)
+    (hsrc : ext.row.b_src = zisk_inst.SRC_IMM)
+    (hhi : ext.row.b_use_sp_imm1.val = (BitVec.signExtend 64 immv).toNat / 4294967296)
+    (hlo : ext.row.b_offset_imm0.val = (BitVec.signExtend 64 immv).toNat % 4294967296)
+    (hbind : msg = romMessageOfRaw line raw) :
+    msg.op = opF ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+      ∧ msg.store_offset = (rdv : FGL)
+      ∧ (romFlagBitsOfExtract ext.row).store_ind = false
+      ∧ (romFlagBitsOfExtract ext.row).b_src_imm = true
+      ∧ BitVec.signExtend 64 immv =
+          BitVec.ofNat 64 (msg.b_offset_imm0.val + msg.b_imm1.val * 4294967296)
+      ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
+  obtain ⟨ho, hj1', hj2', hso', hsi', hf⟩ :=
+    register_decode_fields_of_binding line msg raw opc opF rdv ext hopF hok hop hj1 hj2
+      hso hsi hbind
+  have hmsg : msg = serializeExtract line ext.row := by
+    rw [hbind, romMessageOfRaw, hok]
+    exact romRowOf_eq_serializeExtract line ext.row
+  refine ⟨ho, hj1', hj2', hso', hsi', ?_, ?_, hf⟩
+  · simp only [romFlagBitsOfExtract]
+    exact decide_eq_true hsrc
+  · rw [hmsg]
+    symm
+    exact copyb_serializeExtract_immediate_value line ext.row
+      (⟨BitVec.signExtend 64 immv⟩ : Std.U64) hsrc hhi hlo
+
 /-! ## 5. ADD (register, `rd ≠ 0 ∧ rs1 ≠ 0 ∧ rs2 ≠ 0`). -/
 
 open ZiskFv.Trusted (OP_ADD OP_OR OP_XOR)
@@ -400,12 +671,25 @@ theorem transpile_add (rd rs1 rs2 : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs2
       ∧ ext.row.op = 10#u8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
       ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
       ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
-      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.store_offset.val = rd
+      ∧ ext.row.store ≠ zisk_inst.STORE_IND := by
   refine transpile_register_cond_of _ RiscvOpcode.Add
     riscv2zisk_single_row.Rv64imSingleRowOpcode.Add zisk_ops.ZiskOp.Add 10#u8 false zisk_ops.OpType.Binary
+    rd ?_
     { defCtx with extract_marker := (), input_precompile := none }
     (fun input => input.rd ≠ 0#u32 ∧ input.rs1 ≠ 0#u32 ∧ input.rs2 ≠ 0#u32)
     ?_ rfl ?_ ?_ rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
+  · intro d hd
+    obtain ⟨d', hd', hrdbv, _, _⟩ :=
+      decode_r_fields (toU32 (rawRType 0 rs2 rs1 0 rd 0x33)) RiscvOpcode.Add
+    have hdd : d = d' := Result.ok.inj (hd.symm.trans hd')
+    rw [hdd]
+    change d'.rd.bv.toNat = rd
+    rw [hrdbv]
+    change (((rawRType 0 rs2 rs1 0 rd 0x33) &&& 3968#32) >>> 7).toNat = rd
+    rw [rawRType_rd 0 rs2 rs1 0 rd 0x33 hrd (by norm_num) (by norm_num)]
+    simp [UScalar.val, BitVec.toNat_ofNat, Nat.mod_eq_of_lt] <;> omega
   · simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
       ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
       ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_shr25,
@@ -436,16 +720,19 @@ theorem add_decode_fields_of_binding (rd rs1 rs2 : Nat) (hrd : rd < 32) (hrs1 : 
     (line : FGL) (msg : ZiskRomMessage FGL)
     (hbind : msg = romMessageOfRaw line (rawRType 0 rs2 rs1 0 rd 0x33)) :
     msg.op = OP_ADD ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+      ∧ msg.store_offset = (rd : FGL)
       ∧ ∃ ext, extract_transpile_rv64im_raw (toU32 (rawRType 0 rs2 rs1 0 rd 0x33)) = ok ext
           ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
           ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ (romFlagBitsOfExtract ext.row).store_ind = false
           ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
-  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ :=
+  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2, hso, hsi⟩ :=
     transpile_add rd rs1 rs2 hrd hrs1 hrs2 hrd0 hrs10 hrs20
-  obtain ⟨ho, hjo1, hjo2, hf⟩ :=
-    copyb_decode_fields_of_binding line msg _ 10#u8 OP_ADD ext
-      (by simp [romOpcode, OP_ADD]) hok hop hj1 hj2 hbind
-  exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
+  obtain ⟨ho, hjo1, hjo2, hmso, hstoreInd, hf⟩ :=
+    register_decode_fields_of_binding line msg _ 10#u8 OP_ADD rd ext
+      (by simp [romOpcode, OP_ADD]) hok hop hj1 hj2 hso hsi hbind
+  exact ⟨ho, hjo1, hjo2, hmso, ext, hok, hieo, hm32, hsetpc, hstorepc,
+    hstoreInd, hf⟩
 
 /-! ## 6. OR (register, `rs1 ≠ 0 ∧ rs2 ≠ 0`). -/
 
@@ -455,12 +742,25 @@ theorem transpile_or (rd rs1 rs2 : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs2 
       ∧ ext.row.op = 15#u8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
       ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
       ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
-      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.store_offset.val = rd
+      ∧ ext.row.store ≠ zisk_inst.STORE_IND := by
   refine transpile_register_cond_of _ RiscvOpcode.Or
     riscv2zisk_single_row.Rv64imSingleRowOpcode.Or zisk_ops.ZiskOp.Or 15#u8 false zisk_ops.OpType.Binary
+    rd ?_
     { defCtx with extract_marker := () }
     (fun input => input.rs1 ≠ 0#u32 ∧ input.rs2 ≠ 0#u32)
     ?_ rfl ?_ ?_ rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
+  · intro d hd
+    obtain ⟨d', hd', hrdbv, _, _⟩ :=
+      decode_r_fields (toU32 (rawRType 0 rs2 rs1 6 rd 0x33)) RiscvOpcode.Or
+    have hdd : d = d' := Result.ok.inj (hd.symm.trans hd')
+    rw [hdd]
+    change d'.rd.bv.toNat = rd
+    rw [hrdbv]
+    change (((rawRType 0 rs2 rs1 6 rd 0x33) &&& 3968#32) >>> 7).toNat = rd
+    rw [rawRType_rd 0 rs2 rs1 6 rd 0x33 hrd (by norm_num) (by norm_num)]
+    simp [UScalar.val, BitVec.toNat_ofNat, Nat.mod_eq_of_lt] <;> omega
   · simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
       ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
       ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_shr25,
@@ -486,16 +786,140 @@ theorem or_decode_fields_of_binding (rd rs1 rs2 : Nat) (hrd : rd < 32) (hrs1 : r
     (line : FGL) (msg : ZiskRomMessage FGL)
     (hbind : msg = romMessageOfRaw line (rawRType 0 rs2 rs1 6 rd 0x33)) :
     msg.op = OP_OR ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+      ∧ msg.store_offset = (rd : FGL)
       ∧ ∃ ext, extract_transpile_rv64im_raw (toU32 (rawRType 0 rs2 rs1 6 rd 0x33)) = ok ext
           ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
           ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ (romFlagBitsOfExtract ext.row).store_ind = false
           ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
-  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ :=
+  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2, hso, hsi⟩ :=
     transpile_or rd rs1 rs2 hrd hrs1 hrs2 hrs10 hrs20
-  obtain ⟨ho, hjo1, hjo2, hf⟩ :=
-    copyb_decode_fields_of_binding line msg _ 15#u8 OP_OR ext
-      (by simp [romOpcode, OP_OR]) hok hop hj1 hj2 hbind
-  exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
+  obtain ⟨ho, hjo1, hjo2, hmso, hstoreInd, hf⟩ :=
+    register_decode_fields_of_binding line msg _ 15#u8 OP_OR rd ext
+      (by simp [romOpcode, OP_OR]) hok hop hj1 hj2 hso hsi hbind
+  exact ⟨ho, hjo1, hjo2, hmso, ext, hok, hieo, hm32, hsetpc, hstorepc,
+    hstoreInd, hf⟩
+
+structure RawProgramDecode_add {n : Nat}
+    (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_add trace i)
+    (rawProgram : Fin trace.programLength → BitVec 32) where
+  h_idx : i.val + 1 < trace.mainTable.table.length
+  hrd0 : (regidx_to_fin c.rd).val ≠ 0
+  hrs10 : (regidx_to_fin c.r1).val ≠ 0
+  hrs20 : (regidx_to_fin c.r2).val ≠ 0
+  hLine : ∀ j : Fin trace.programLength,
+    (trace.program j).line =
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
+      rawProgram j = rawRType 0 (regidx_to_fin c.r2).val
+        (regidx_to_fin c.r1).val 0 (regidx_to_fin c.rd).val 0x33
+
+noncomputable def ProgramDecode_add_from_rawProgram {n : Nat}
+    (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_add trace i)
+    (addr : Fin trace.programLength → FGL)
+    (rawProgram : Fin trace.programLength → BitVec 32)
+    (hbind : ProgramBinding trace addr rawProgram)
+    (rawDecode : RawProgramDecode_add trace i c rawProgram) :
+    ZiskFv.Compliance.RomDecodeBinding.ProgramDecode_add trace i c := by
+  let rd := (regidx_to_fin c.rd).val
+  let rs1 := (regidx_to_fin c.r1).val
+  let rs2 := (regidx_to_fin c.r2).val
+  let ext := (transpile_add rd rs1 rs2 (regidx_to_fin c.rd).isLt
+    (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt rawDecode.hrd0
+    rawDecode.hrs10 rawDecode.hrs20).choose
+  obtain ⟨hok, _, hieo, hm32, hsetpc, hstorepc, _, _, _, hstoreInd⟩ :=
+    (transpile_add rd rs1 rs2 (regidx_to_fin c.rd).isLt
+      (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt rawDecode.hrd0
+      rawDecode.hrs10 rawDecode.hrs20).choose_spec
+  refine
+    { h_idx := rawDecode.h_idx
+      bits := romFlagBitsOfExtract ext.row
+      h_bits_ieo := by simpa only [ext, romFlagBitsOfExtract] using hieo
+      h_bits_m32 := by simpa only [ext, romFlagBitsOfExtract] using hm32
+      h_bits_set_pc := by simpa only [ext, romFlagBitsOfExtract] using hsetpc
+      h_bits_store_pc := by simpa only [ext, romFlagBitsOfExtract] using hstorepc
+      h_bits_store_ind := by
+        simp only [romFlagBitsOfExtract]
+        exact decide_eq_false hstoreInd
+      h_prog := ?_ }
+  intro j hline
+  have hbk : trace.program j =
+      romMessageOfRaw (addr j) (rawRType 0 rs2 rs1 0 rd 0x33) := by
+    exact (hbind.2 j).trans
+      (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+  obtain ⟨ho, hj1, hj2, hso, ext', hok', _, _, _, _, _, hf⟩ :=
+    add_decode_fields_of_binding rd rs1 rs2 (regidx_to_fin c.rd).isLt
+      (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt rawDecode.hrd0
+      rawDecode.hrs10 rawDecode.hrs20 (addr j) (trace.program j) hbk
+  have hext : ext' = ext := Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
+  subst ext'
+  refine ⟨ho, hj1, hj2, ?_, hf⟩
+  rw [hso]
+  simp only [rd, Transpiler.ind]
+  apply Fin.ext
+  change (regidx_to_fin c.rd).val % GL_prime = (regidx_to_fin c.rd).val
+  exact Nat.mod_eq_of_lt (lt_trans (regidx_to_fin c.rd).isLt (by norm_num))
+
+structure RawProgramDecode_or {n : Nat}
+    (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_or trace i)
+    (rawProgram : Fin trace.programLength → BitVec 32) where
+  h_idx : i.val + 1 < trace.mainTable.table.length
+  hrs10 : (regidx_to_fin c.r1).val ≠ 0
+  hrs20 : (regidx_to_fin c.r2).val ≠ 0
+  hLine : ∀ j : Fin trace.programLength,
+    (trace.program j).line =
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
+      rawProgram j = rawRType 0 (regidx_to_fin c.r2).val
+        (regidx_to_fin c.r1).val 6 (regidx_to_fin c.rd).val 0x33
+
+noncomputable def ProgramDecode_or_from_rawProgram {n : Nat}
+    (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_or trace i)
+    (addr : Fin trace.programLength → FGL)
+    (rawProgram : Fin trace.programLength → BitVec 32)
+    (hbind : ProgramBinding trace addr rawProgram)
+    (rawDecode : RawProgramDecode_or trace i c rawProgram) :
+    ZiskFv.Compliance.RomDecodeBinding.ProgramDecode_or trace i c := by
+  let rd := (regidx_to_fin c.rd).val
+  let rs1 := (regidx_to_fin c.r1).val
+  let rs2 := (regidx_to_fin c.r2).val
+  let ext := (transpile_or rd rs1 rs2 (regidx_to_fin c.rd).isLt
+    (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt rawDecode.hrs10
+    rawDecode.hrs20).choose
+  obtain ⟨hok, _, hieo, hm32, hsetpc, hstorepc, _, _, _, hstoreInd⟩ :=
+    (transpile_or rd rs1 rs2 (regidx_to_fin c.rd).isLt
+      (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt rawDecode.hrs10
+      rawDecode.hrs20).choose_spec
+  refine
+    { h_idx := rawDecode.h_idx
+      bits := romFlagBitsOfExtract ext.row
+      h_bits_ieo := by simpa only [ext, romFlagBitsOfExtract] using hieo
+      h_bits_m32 := by simpa only [ext, romFlagBitsOfExtract] using hm32
+      h_bits_set_pc := by simpa only [ext, romFlagBitsOfExtract] using hsetpc
+      h_bits_store_pc := by simpa only [ext, romFlagBitsOfExtract] using hstorepc
+      h_bits_store_ind := by
+        simp only [romFlagBitsOfExtract]
+        exact decide_eq_false hstoreInd
+      h_prog := ?_ }
+  intro j hline
+  have hbk : trace.program j =
+      romMessageOfRaw (addr j) (rawRType 0 rs2 rs1 6 rd 0x33) := by
+    exact (hbind.2 j).trans
+      (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+  obtain ⟨ho, hj1, hj2, hso, ext', hok', _, _, _, _, _, hf⟩ :=
+    or_decode_fields_of_binding rd rs1 rs2 (regidx_to_fin c.rd).isLt
+      (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt rawDecode.hrs10
+      rawDecode.hrs20 (addr j) (trace.program j) hbk
+  have hext : ext' = ext := Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
+  subst ext'
+  refine ⟨ho, hj1, hj2, ?_, hf⟩
+  rw [hso]
+  simp only [rd, Transpiler.ind]
+  apply Fin.ext
+  change (regidx_to_fin c.rd).val % GL_prime = (regidx_to_fin c.rd).val
+  exact Nat.mod_eq_of_lt (lt_trans (regidx_to_fin c.rd).isLt (by norm_num))
 
 /-! ## 7. ADDI (immediate, `rd ≠ 0 ∧ imm ≠ 0 ∧ rs1 ≠ 0`; `imm ≠ 0` threaded). -/
 
@@ -507,12 +931,30 @@ theorem transpile_addi (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32)
       ∧ ext.row.op = 10#u8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
       ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
       ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
-      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.store_offset.val = rd ∧ ext.row.store ≠ zisk_inst.STORE_IND
+      ∧ ext.row.b_src = zisk_inst.SRC_IMM
+      ∧ ext.row.b_use_sp_imm1.val =
+        (BitVec.signExtend 64 (BitVec.ofNat 12 imm)).toNat / 4294967296
+      ∧ ext.row.b_offset_imm0.val =
+        (BitVec.signExtend 64 (BitVec.ofNat 12 imm)).toNat % 4294967296 := by
   refine transpile_immediate_copyb_of _ RiscvOpcode.Addi false
     riscv2zisk_single_row.Rv64imSingleRowOpcode.Addi zisk_ops.ZiskOp.Add 10#u8 false zisk_ops.OpType.Binary
+    rd (BitVec.signExtend 64 (BitVec.ofNat 12 imm)).toNat ?_ ?_
     { defCtx with extract_marker := () }
     (fun input => input.rd ≠ 0#u32 ∧ input.imm ≠ 0#i32 ∧ input.rs1 ≠ 0#u32)
     ?_ rfl ?_ ?_ (fun _ hP => hP.2.2) rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
+  · intro d hd
+    obtain ⟨hrdbv, _⟩ := decode_i_rd_rs1_bv _ RiscvOpcode.Addi false d hd
+    change d.rd.bv.toNat = rd
+    rw [hrdbv]
+    change (((rawIType imm rs1 0 rd 0x13) &&& 3968#32) >>> 7).toNat = rd
+    rw [rawIType_rd' imm rs1 0 rd 0x13 hrd (by norm_num) (by norm_num)]
+    simp [BitVec.toNat_ofNat]
+    omega
+  · intro d hd
+    exact decode_i_rawIType_imm64 imm rs1 0 rd 0x13 hrs1 (by norm_num) hrd
+      (by norm_num) RiscvOpcode.Addi d hd
   · simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
       ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
       ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_ofNat,
@@ -539,16 +981,24 @@ theorem addi_decode_fields_of_binding (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 :
     (line : FGL) (msg : ZiskRomMessage FGL)
     (hbind : msg = romMessageOfRaw line (rawIType imm rs1 0 rd 0x13)) :
     msg.op = OP_ADD ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+      ∧ msg.store_offset = (rd : FGL)
       ∧ ∃ ext, extract_transpile_rv64im_raw (toU32 (rawIType imm rs1 0 rd 0x13)) = ok ext
           ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
           ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ (romFlagBitsOfExtract ext.row).store_ind = false
+          ∧ (romFlagBitsOfExtract ext.row).b_src_imm = true
+          ∧ BitVec.signExtend 64 (BitVec.ofNat 12 imm) =
+              BitVec.ofNat 64 (msg.b_offset_imm0.val + msg.b_imm1.val * 4294967296)
           ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
-  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ :=
+  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2,
+      hso, hsi, hsrc, hhi, hlo⟩ :=
     transpile_addi rd rs1 imm hrd hrs1 hrd0 hrs10 himm
-  obtain ⟨ho, hjo1, hjo2, hf⟩ :=
-    copyb_decode_fields_of_binding line msg _ 10#u8 OP_ADD ext
-      (by simp [romOpcode, OP_ADD]) hok hop hj1 hj2 hbind
-  exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
+  obtain ⟨ho, hjo1, hjo2, hmso, hstoreInd, hbsrc, himmv, hf⟩ :=
+    copyb_immediate_decode_fields_of_binding line msg _ 10#u8 OP_ADD rd
+      (BitVec.ofNat 12 imm) ext (by simp [romOpcode, OP_ADD]) hok hop hj1 hj2
+      hso hsi hsrc hhi hlo hbind
+  exact ⟨ho, hjo1, hjo2, hmso, ext, hok, hieo, hm32, hsetpc, hstorepc,
+    hstoreInd, hbsrc, himmv, hf⟩
 
 /-! ## 8. XORI / ORI (immediate, dispatcher-unconditional; op-arm needs `rs1 ≠ 0`). -/
 
@@ -557,12 +1007,30 @@ theorem transpile_xori (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs
       ∧ ext.row.op = 16#u8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
       ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
       ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
-      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.store_offset.val = rd ∧ ext.row.store ≠ zisk_inst.STORE_IND
+      ∧ ext.row.b_src = zisk_inst.SRC_IMM
+      ∧ ext.row.b_use_sp_imm1.val =
+        (BitVec.signExtend 64 (BitVec.ofNat 12 imm)).toNat / 4294967296
+      ∧ ext.row.b_offset_imm0.val =
+        (BitVec.signExtend 64 (BitVec.ofNat 12 imm)).toNat % 4294967296 := by
   refine transpile_immediate_copyb_of _ RiscvOpcode.Xori false
     riscv2zisk_single_row.Rv64imSingleRowOpcode.Xori zisk_ops.ZiskOp.Xor 16#u8 false zisk_ops.OpType.Binary
+    rd (BitVec.signExtend 64 (BitVec.ofNat 12 imm)).toNat ?_ ?_
     { defCtx with extract_marker := () }
     (fun input => input.rs1 ≠ 0#u32)
     ?_ rfl (fun _ _ => rfl) ?_ (fun _ hP => hP) rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
+  · intro d hd
+    obtain ⟨hrdbv, _⟩ := decode_i_rd_rs1_bv _ RiscvOpcode.Xori false d hd
+    change d.rd.bv.toNat = rd
+    rw [hrdbv]
+    change (((rawIType imm rs1 4 rd 0x13) &&& 3968#32) >>> 7).toNat = rd
+    rw [rawIType_rd' imm rs1 4 rd 0x13 hrd (by norm_num) (by norm_num)]
+    simp [BitVec.toNat_ofNat]
+    omega
+  · intro d hd
+    exact decode_i_rawIType_imm64 imm rs1 4 rd 0x13 hrs1 (by norm_num) hrd
+      (by norm_num) RiscvOpcode.Xori d hd
   · simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
       ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
       ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_ofNat,
@@ -579,28 +1047,54 @@ theorem xori_decode_fields_of_binding (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 :
     (line : FGL) (msg : ZiskRomMessage FGL)
     (hbind : msg = romMessageOfRaw line (rawIType imm rs1 4 rd 0x13)) :
     msg.op = OP_XOR ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+      ∧ msg.store_offset = (rd : FGL)
       ∧ ∃ ext, extract_transpile_rv64im_raw (toU32 (rawIType imm rs1 4 rd 0x13)) = ok ext
           ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
           ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ (romFlagBitsOfExtract ext.row).store_ind = false
+          ∧ (romFlagBitsOfExtract ext.row).b_src_imm = true
+          ∧ BitVec.signExtend 64 (BitVec.ofNat 12 imm) =
+              BitVec.ofNat 64 (msg.b_offset_imm0.val + msg.b_imm1.val * 4294967296)
           ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
-  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ :=
+  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2,
+      hso, hsi, hsrc, hhi, hlo⟩ :=
     transpile_xori rd rs1 imm hrd hrs1 hrs10
-  obtain ⟨ho, hjo1, hjo2, hf⟩ :=
-    copyb_decode_fields_of_binding line msg _ 16#u8 OP_XOR ext
-      (by simp [romOpcode, OP_XOR]) hok hop hj1 hj2 hbind
-  exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
+  obtain ⟨ho, hjo1, hjo2, hmso, hstoreInd, hbsrc, himmv, hf⟩ :=
+    copyb_immediate_decode_fields_of_binding line msg _ 16#u8 OP_XOR rd
+      (BitVec.ofNat 12 imm) ext (by simp [romOpcode, OP_XOR]) hok hop hj1 hj2
+      hso hsi hsrc hhi hlo hbind
+  exact ⟨ho, hjo1, hjo2, hmso, ext, hok, hieo, hm32, hsetpc, hstorepc,
+    hstoreInd, hbsrc, himmv, hf⟩
 
 theorem transpile_ori (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs10 : rs1 ≠ 0) :
     ∃ ext, extract_transpile_rv64im_raw (toU32 (rawIType imm rs1 6 rd 0x13)) = ok ext
       ∧ ext.row.op = 15#u8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
       ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
       ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
-      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.store_offset.val = rd ∧ ext.row.store ≠ zisk_inst.STORE_IND
+      ∧ ext.row.b_src = zisk_inst.SRC_IMM
+      ∧ ext.row.b_use_sp_imm1.val =
+        (BitVec.signExtend 64 (BitVec.ofNat 12 imm)).toNat / 4294967296
+      ∧ ext.row.b_offset_imm0.val =
+        (BitVec.signExtend 64 (BitVec.ofNat 12 imm)).toNat % 4294967296 := by
   refine transpile_immediate_copyb_of _ RiscvOpcode.Ori false
     riscv2zisk_single_row.Rv64imSingleRowOpcode.Ori zisk_ops.ZiskOp.Or 15#u8 false zisk_ops.OpType.Binary
+    rd (BitVec.signExtend 64 (BitVec.ofNat 12 imm)).toNat ?_ ?_
     { defCtx with extract_marker := () }
     (fun input => input.rs1 ≠ 0#u32)
     ?_ rfl (fun _ _ => rfl) ?_ (fun _ hP => hP) rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
+  · intro d hd
+    obtain ⟨hrdbv, _⟩ := decode_i_rd_rs1_bv _ RiscvOpcode.Ori false d hd
+    change d.rd.bv.toNat = rd
+    rw [hrdbv]
+    change (((rawIType imm rs1 6 rd 0x13) &&& 3968#32) >>> 7).toNat = rd
+    rw [rawIType_rd' imm rs1 6 rd 0x13 hrd (by norm_num) (by norm_num)]
+    simp [BitVec.toNat_ofNat]
+    omega
+  · intro d hd
+    exact decode_i_rawIType_imm64 imm rs1 6 rd 0x13 hrs1 (by norm_num) hrd
+      (by norm_num) RiscvOpcode.Ori d hd
   · simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
       ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
       ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_ofNat,
@@ -617,28 +1111,220 @@ theorem ori_decode_fields_of_binding (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : 
     (line : FGL) (msg : ZiskRomMessage FGL)
     (hbind : msg = romMessageOfRaw line (rawIType imm rs1 6 rd 0x13)) :
     msg.op = OP_OR ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4
+      ∧ msg.store_offset = (rd : FGL)
       ∧ ∃ ext, extract_transpile_rv64im_raw (toU32 (rawIType imm rs1 6 rd 0x13)) = ok ext
           ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
           ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
+          ∧ (romFlagBitsOfExtract ext.row).store_ind = false
+          ∧ (romFlagBitsOfExtract ext.row).b_src_imm = true
+          ∧ BitVec.signExtend 64 (BitVec.ofNat 12 imm) =
+              BitVec.ofNat 64 (msg.b_offset_imm0.val + msg.b_imm1.val * 4294967296)
           ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
-  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2⟩ :=
+  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2,
+      hso, hsi, hsrc, hhi, hlo⟩ :=
     transpile_ori rd rs1 imm hrd hrs1 hrs10
-  obtain ⟨ho, hjo1, hjo2, hf⟩ :=
-    copyb_decode_fields_of_binding line msg _ 15#u8 OP_OR ext
-      (by simp [romOpcode, OP_OR]) hok hop hj1 hj2 hbind
-  exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
+  obtain ⟨ho, hjo1, hjo2, hmso, hstoreInd, hbsrc, himmv, hf⟩ :=
+    copyb_immediate_decode_fields_of_binding line msg _ 15#u8 OP_OR rd
+      (BitVec.ofNat 12 imm) ext (by simp [romOpcode, OP_OR]) hok hop hj1 hj2
+      hso hsi hsrc hhi hlo hbind
+  exact ⟨ho, hjo1, hjo2, hmso, ext, hok, hieo, hm32, hsetpc, hstorepc,
+    hstoreInd, hbsrc, himmv, hf⟩
+
+local macro "copyb_imm_program_decode" nm:ident "," f3:term : command => do
+  let s := nm.getId.toString
+  let rawName := Lean.mkIdent (Lean.Name.mkSimple ("RawProgramDecode_" ++ s))
+  let ctorName := Lean.mkIdent (Lean.Name.mkSimple ("ProgramDecode_" ++ s ++ "_from_rawProgram"))
+  let transpileName := Lean.mkIdent (Lean.Name.mkSimple ("transpile_" ++ s))
+  let fieldsName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
+  let claimName := Lean.mkIdent ((`ZiskFv.Compliance).str ("Claim_" ++ s))
+  let programName :=
+    Lean.mkIdent ((`ZiskFv.Compliance.RomDecodeBinding).str ("ProgramDecode_" ++ s))
+  let t1 ← `(structure $rawName {n : Nat}
+      (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+      (i : Fin trace.numInstructions) (c : $claimName trace i)
+      (rawProgram : Fin trace.programLength → BitVec 32) where
+    h_idx : i.val + 1 < trace.mainTable.table.length
+    hrs10 : (regidx_to_fin c.r1).val ≠ 0
+    hLine : ∀ j : Fin trace.programLength,
+      (trace.program j).line =
+          (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
+        rawProgram j = rawIType c.imm.toNat (regidx_to_fin c.r1).val $f3
+          (regidx_to_fin c.rd).val 0x13)
+  let t2 ← `(noncomputable def $ctorName {n : Nat}
+      (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+      (i : Fin trace.numInstructions) (c : $claimName trace i)
+      (addr : Fin trace.programLength → FGL)
+      (rawProgram : Fin trace.programLength → BitVec 32)
+      (hbind : ProgramBinding trace addr rawProgram)
+      (rawDecode : $rawName trace i c rawProgram) :
+      $programName trace i c := by
+    let rd := (regidx_to_fin c.rd).val
+    let rs1 := (regidx_to_fin c.r1).val
+    let imm := c.imm.toNat
+    let ext := ($transpileName rd rs1 imm (regidx_to_fin c.rd).isLt
+      (regidx_to_fin c.r1).isLt rawDecode.hrs10).choose
+    obtain ⟨hok, _, hieo, hm32, hsetpc, hstorepc, _, _, _, hstoreInd,
+        hsrc, _, _⟩ :=
+      ($transpileName rd rs1 imm (regidx_to_fin c.rd).isLt
+        (regidx_to_fin c.r1).isLt rawDecode.hrs10).choose_spec
+    refine
+      { h_idx := rawDecode.h_idx
+        bits := romFlagBitsOfExtract ext.row
+        h_bits_ieo := by simpa only [ext, romFlagBitsOfExtract] using hieo
+        h_bits_m32 := by simpa only [ext, romFlagBitsOfExtract] using hm32
+        h_bits_set_pc := by simpa only [ext, romFlagBitsOfExtract] using hsetpc
+        h_bits_store_pc := by simpa only [ext, romFlagBitsOfExtract] using hstorepc
+        h_bits_store_ind := by
+          simp only [romFlagBitsOfExtract]
+          exact decide_eq_false hstoreInd
+        h_bits_b_src_imm := by
+          simp only [romFlagBitsOfExtract]
+          exact decide_eq_true hsrc
+        h_prog := ?_ }
+    intro j hline
+    have hbk : trace.program j =
+        romMessageOfRaw (addr j) (rawIType imm rs1 $f3 rd 0x13) := by
+      exact (hbind.2 j).trans
+        (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+    obtain ⟨ho, hj1, hj2, hso, ext', hok', _, _, _, _, _, _, himm, hf⟩ :=
+      $fieldsName rd rs1 imm (regidx_to_fin c.rd).isLt
+        (regidx_to_fin c.r1).isLt rawDecode.hrs10 (addr j) (trace.program j) hbk
+    have hext : ext' = ext :=
+      Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
+    subst ext'
+    refine ⟨ho, hj1, hj2, ?_, ?_, hf⟩
+    · rw [hso]
+      simp only [rd, Transpiler.ind]
+      apply Fin.ext
+      change (regidx_to_fin c.rd).val % GL_prime = (regidx_to_fin c.rd).val
+      exact Nat.mod_eq_of_lt (lt_trans (regidx_to_fin c.rd).isLt (by norm_num))
+    · simpa only [imm, BitVec.ofNat_toNat] using himm)
+  return ⟨Lean.mkNullNode #[t1, t2]⟩
+
+copyb_imm_program_decode xori, 4
+copyb_imm_program_decode ori, 6
+
+private theorem signExtend32_ne_zero {x : BitVec 12} (hx : x ≠ 0#12) :
+    BitVec.signExtend 32 x ≠ 0#32 := by
+  intro h
+  apply hx
+  apply BitVec.eq_of_toInt_eq
+  have ht := congrArg BitVec.toInt h
+  have hbmod : x.toInt.bmod 4294967296 = x.toInt := by
+    rw [Int.bmod_def]
+    have hlo : (-2048 : Int) ≤ x.toInt := BitVec.toInt_intMin_le _
+    have hhi : x.toInt < (2048 : Int) := BitVec.toInt_lt
+    by_cases hn : 0 ≤ x.toInt
+    · have hem : x.toInt % ((4294967296 : Nat) : Int) = x.toInt :=
+        Int.emod_eq_of_lt hn (by omega)
+      rw [hem]
+      split <;> omega
+    · have hem : x.toInt % ((4294967296 : Nat) : Int) = x.toInt + 4294967296 := by
+        omega
+      rw [hem]
+      split <;> omega
+  simpa only [BitVec.signExtend, BitVec.toInt_ofInt, hbmod, BitVec.toInt_zero] using ht
+
+private theorem decode_i_rawIType_imm_ne_zero
+    (imm rs1 rd : Nat) (hrs1 : rs1 < 32) (hrd : rd < 32)
+    (himm : BitVec.ofNat 12 imm ≠ 0#12)
+    (d : DecodedRv64im)
+    (hd : decode_i (toU32 (rawIType imm rs1 0 rd 0x13))
+      RiscvOpcode.Addi false = ok d) :
+    d.imm ≠ 0#i32 := by
+  intro hz
+  apply signExtend32_ne_zero himm
+  rw [← decode_i_rawIType_imm imm rs1 0 rd 0x13 hrs1 (by norm_num) hrd
+    (by norm_num) RiscvOpcode.Addi d hd, hz]
+  rfl
+
+structure RawProgramDecode_addi {n : Nat}
+    (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_addi trace i)
+    (rawProgram : Fin trace.programLength → BitVec 32) where
+  h_idx : i.val + 1 < trace.mainTable.table.length
+  hrd0 : (regidx_to_fin c.rd).val ≠ 0
+  hrs10 : (regidx_to_fin c.r1).val ≠ 0
+  himm0 : c.imm ≠ 0#12
+  hLine : ∀ j : Fin trace.programLength,
+    (trace.program j).line =
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
+      rawProgram j = rawIType c.imm.toNat (regidx_to_fin c.r1).val 0
+        (regidx_to_fin c.rd).val 0x13
+
+noncomputable def ProgramDecode_addi_from_rawProgram {n : Nat}
+    (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_addi trace i)
+    (addr : Fin trace.programLength → FGL)
+    (rawProgram : Fin trace.programLength → BitVec 32)
+    (hbind : ProgramBinding trace addr rawProgram)
+    (rawDecode : RawProgramDecode_addi trace i c rawProgram) :
+    ZiskFv.Compliance.RomDecodeBinding.ProgramDecode_addi trace i c := by
+  let rd := (regidx_to_fin c.rd).val
+  let rs1 := (regidx_to_fin c.r1).val
+  let imm := c.imm.toNat
+  have himm12 : BitVec.ofNat 12 imm ≠ 0#12 := by
+    simpa only [imm, BitVec.ofNat_toNat] using rawDecode.himm0
+  have himm : ∀ d, decode_i (toU32 (rawIType imm rs1 0 rd 0x13))
+      RiscvOpcode.Addi false = ok d → d.imm ≠ 0#i32 :=
+    fun d hd => decode_i_rawIType_imm_ne_zero imm rs1 rd
+      (regidx_to_fin c.r1).isLt (regidx_to_fin c.rd).isLt himm12 d hd
+  let ext := (transpile_addi rd rs1 imm (regidx_to_fin c.rd).isLt
+    (regidx_to_fin c.r1).isLt rawDecode.hrd0 rawDecode.hrs10 himm).choose
+  obtain ⟨hok, _, hieo, hm32, hsetpc, hstorepc, _, _, _, hstoreInd,
+      hsrc, _, _⟩ :=
+    (transpile_addi rd rs1 imm (regidx_to_fin c.rd).isLt
+      (regidx_to_fin c.r1).isLt rawDecode.hrd0 rawDecode.hrs10 himm).choose_spec
+  refine
+    { h_idx := rawDecode.h_idx
+      bits := romFlagBitsOfExtract ext.row
+      h_bits_ieo := by simpa only [ext, romFlagBitsOfExtract] using hieo
+      h_bits_m32 := by simpa only [ext, romFlagBitsOfExtract] using hm32
+      h_bits_set_pc := by simpa only [ext, romFlagBitsOfExtract] using hsetpc
+      h_bits_store_pc := by simpa only [ext, romFlagBitsOfExtract] using hstorepc
+      h_bits_store_ind := by
+        simp only [romFlagBitsOfExtract]
+        exact decide_eq_false hstoreInd
+      h_bits_b_src_imm := by
+        simp only [romFlagBitsOfExtract]
+        exact decide_eq_true hsrc
+      h_prog := ?_ }
+  intro j hline
+  have hbk : trace.program j =
+      romMessageOfRaw (addr j) (rawIType imm rs1 0 rd 0x13) := by
+    exact (hbind.2 j).trans
+      (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+  obtain ⟨ho, hj1, hj2, hso, ext', hok', _, _, _, _, _, _, himmv, hf⟩ :=
+    addi_decode_fields_of_binding rd rs1 imm (regidx_to_fin c.rd).isLt
+      (regidx_to_fin c.r1).isLt rawDecode.hrd0 rawDecode.hrs10 himm
+      (addr j) (trace.program j) hbk
+  have hext : ext' = ext :=
+    Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
+  subst ext'
+  refine ⟨ho, hj1, hj2, ?_, ?_, hf⟩
+  · rw [hso]
+    simp only [rd, Transpiler.ind]
+    apply Fin.ext
+    change (regidx_to_fin c.rd).val % GL_prime = (regidx_to_fin c.rd).val
+    exact Nat.mod_eq_of_lt (lt_trans (regidx_to_fin c.rd).isLt (by norm_num))
+  · simpa only [imm, BitVec.ofNat_toNat] using himmv
 
 section AxiomAudit
 #print axioms transpile_add
 #print axioms add_decode_fields_of_binding
+#print axioms ProgramDecode_add_from_rawProgram
 #print axioms transpile_or
 #print axioms or_decode_fields_of_binding
+#print axioms ProgramDecode_or_from_rawProgram
 #print axioms transpile_addi
 #print axioms addi_decode_fields_of_binding
+#print axioms ProgramDecode_addi_from_rawProgram
 #print axioms transpile_xori
 #print axioms xori_decode_fields_of_binding
+#print axioms ProgramDecode_xori_from_rawProgram
 #print axioms transpile_ori
 #print axioms ori_decode_fields_of_binding
+#print axioms ProgramDecode_ori_from_rawProgram
 end AxiomAudit
 
 end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingImmediate.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingImmediate.lean
@@ -1,4 +1,5 @@
 import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingRegister
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBitfields
 
 /-!
 # Raw-program decode bridge — immediate-ALU / shift family (issue #159, BLOCK 3)
@@ -822,6 +823,232 @@ shiftw_program_decode slliw, 0, 1, ZiskFv.Compliance.Claim_slliw.slliw_input
 shiftw_program_decode srliw, 0, 5, ZiskFv.Compliance.Claim_srliw.srliw_input
 shiftw_program_decode sraiw, 0x400, 5, ZiskFv.Compliance.Claim_sraiw.sraiw_input
 
+/-! ## Current `ProgramDecode` retarget: plain immediate families. -/
+
+private theorem signExtend64_signExtend32 (v : BitVec 12) :
+    BitVec.signExtend 64 (BitVec.signExtend 32 v) = BitVec.signExtend 64 v := by
+  apply BitVec.eq_of_getLsbD_eq
+  intro k
+  by_cases hk : k < 64
+  · interval_cases k <;>
+      simp [BitVec.getLsbD_signExtend, BitVec.getElem_signExtend,
+        BitVec.msb_signExtend]
+  · simp [BitVec.getLsbD_signExtend, hk]
+
+private theorem immediate_rom_value
+    (imm : BitVec 12) (d : DecodedRv64im)
+    (hdimm : d.imm.bv = BitVec.signExtend 32 imm)
+    (row : aeneas_extract.ZiskInstExtract)
+    (hsrc : row.b_src = zisk_inst.SRC_IMM)
+    (hhi : row.b_use_sp_imm1.val = (IScalar.hcast UScalarTy.U64 d.imm).val / 4294967296)
+    (hlo : row.b_offset_imm0.val = (IScalar.hcast UScalarTy.U64 d.imm).val % 4294967296) :
+    BitVec.signExtend 64 imm =
+      BitVec.ofNat 64
+        ((romRowOf (0 : FGL) row).b_offset_imm0.val
+          + (romRowOf (0 : FGL) row).b_imm1.val * 4294967296) := by
+  have hv :
+      (IScalar.hcast UScalarTy.U64 d.imm).val =
+        (BitVec.signExtend 64 imm).toNat := by
+    change (BitVec.signExtend 64 d.imm.bv).toNat =
+      (BitVec.signExtend 64 imm).toNat
+    rw [hdimm, signExtend64_signExtend32]
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_ofNat]
+  simp only [romRowOf, sourceImmediate, hsrc, if_pos, UScalar.val]
+  have hloBound : row.b_offset_imm0.bv.toNat < 2 ^ 32 := by
+    rw [show row.b_offset_imm0.bv.toNat =
+      (IScalar.hcast UScalarTy.U64 d.imm).val % 4294967296 by
+        simpa only [UScalar.val] using hlo]
+    exact Nat.mod_lt _ (by norm_num)
+  have hsigned : (signedOffset row.b_offset_imm0).val =
+      row.b_offset_imm0.bv.toNat := by
+    have hnonneg : 2 * row.b_offset_imm0.val < 18446744073709551616 := by
+      change 2 * row.b_offset_imm0.bv.toNat < 18446744073709551616
+      norm_num at hloBound ⊢
+      omega
+    have hsignedF : signedOffset row.b_offset_imm0 =
+        (row.b_offset_imm0.bv.toNat : FGL) := by
+      simp [signedOffset, BitVec.toInt, if_pos hnonneg]
+    rw [hsignedF]
+    exact Nat.mod_eq_of_lt (lt_trans hloBound (by norm_num))
+  rw [hsigned]
+  have hhi' : row.b_use_sp_imm1.bv.toNat =
+      (IScalar.hcast UScalarTy.U64 d.imm).val / 4294967296 := by
+    simpa only [UScalar.val] using hhi
+  have hlo' : row.b_offset_imm0.bv.toNat =
+      (IScalar.hcast UScalarTy.U64 d.imm).val % 4294967296 := by
+    simpa only [UScalar.val] using hlo
+  rw [hhi', hlo', hv]
+  have hhigh :
+      (((BitVec.signExtend 64 imm).toNat / 4294967296 : Nat) : FGL).val =
+        (BitVec.signExtend 64 imm).toNat / 4294967296 := by
+    exact Nat.mod_eq_of_lt (by
+      have := (BitVec.signExtend 64 imm).isLt
+      norm_num at this ⊢
+      exact Nat.div_lt_of_lt_mul (by omega))
+  rw [hhigh]
+  rw [Nat.mod_add_div']
+  exact (Nat.mod_eq_of_lt (BitVec.isLt _)).symm
+
+local macro "imm_program_decode" nm:ident "," f3:term "," opw:term ","
+    rop:term : command => do
+  let s := nm.getId.toString
+  let rawName := Lean.mkIdent (Lean.Name.mkSimple ("RawProgramDecode_" ++ s))
+  let ctorName := Lean.mkIdent (Lean.Name.mkSimple ("ProgramDecode_" ++ s ++ "_from_rawProgram"))
+  let transpileName := Lean.mkIdent (Lean.Name.mkSimple ("transpile_" ++ s))
+  let fieldsName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
+  let claimName := Lean.mkIdent ((`ZiskFv.Compliance).str ("Claim_" ++ s))
+  let programName := Lean.mkIdent ((`ZiskFv.Compliance.RomDecodeBinding).str ("ProgramDecode_" ++ s))
+  let t1 ← `(structure $rawName {n : Nat}
+      (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+      (i : Fin trace.numInstructions) (c : $claimName trace i)
+      (rawProgram : Fin trace.programLength → BitVec 32) where
+    h_idx : i.val + 1 < trace.mainTable.table.length
+    hLine : ∀ j : Fin trace.programLength,
+      (trace.program j).line =
+          (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
+        rawProgram j =
+          ZiskFv.Completeness.Rv64imShapes.rawIType c.imm.toNat
+            (regidx_to_fin c.r1).val $f3 (regidx_to_fin c.rd).val $opw)
+  let t2 ← `(noncomputable def $ctorName {n : Nat}
+      (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+      (i : Fin trace.numInstructions) (c : $claimName trace i)
+      (addr : Fin trace.programLength → FGL)
+      (rawProgram : Fin trace.programLength → BitVec 32)
+      (hbind : ProgramBinding trace addr rawProgram)
+      (rawDecode : $rawName trace i c rawProgram) :
+      $programName trace i c := by
+    let rd := (regidx_to_fin c.rd).val
+    let rs1 := (regidx_to_fin c.r1).val
+    let imm := c.imm.toNat
+    let ext := ($transpileName rd rs1 imm (regidx_to_fin c.rd).isLt
+      (regidx_to_fin c.r1).isLt).choose
+    obtain ⟨hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2,
+        hstoreOffset, hstoreInd, hrowImm⟩ :=
+      ($transpileName rd rs1 imm (regidx_to_fin c.rd).isLt
+        (regidx_to_fin c.r1).isLt).choose_spec
+    let hd := hrowImm.choose
+    obtain ⟨hdecode, hsrc, hhi, hlo⟩ := hrowImm.choose_spec
+    have hdimm : hd.imm.bv = BitVec.signExtend 32 c.imm := by
+      simpa only [imm, BitVec.ofNat_toNat] using
+        (decode_i_rawIType_imm imm rs1 $f3 rd $opw
+          (regidx_to_fin c.r1).isLt (by norm_num) (regidx_to_fin c.rd).isLt
+          (by norm_num) $rop hd hdecode)
+    refine
+      { h_idx := rawDecode.h_idx
+        bits := romFlagBitsOfExtract ext.row
+        h_bits_ieo := by simpa only [ext, romFlagBitsOfExtract] using hieo
+        h_bits_m32 := by simpa only [ext, romFlagBitsOfExtract] using hm32
+        h_bits_set_pc := by simpa only [ext, romFlagBitsOfExtract] using hsetpc
+        h_bits_store_pc := by simpa only [ext, romFlagBitsOfExtract] using hstorepc
+        h_bits_store_ind := by
+          simp only [romFlagBitsOfExtract]; exact decide_eq_false hstoreInd
+        h_bits_b_src_imm := by
+          simp only [romFlagBitsOfExtract]
+          exact decide_eq_true hsrc
+        h_prog := by
+          intro j hline
+          have hbk : trace.program j =
+              romMessageOfRaw (addr j)
+                (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 $f3 rd $opw) := by
+            exact (hbind.2 j).trans
+              (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+          obtain ⟨ho, hjo1, hjo2, hso, ext', hok', hieo', hm32', hsetpc',
+              hstorepc', hf⟩ :=
+            $fieldsName rd rs1 imm (regidx_to_fin c.rd).isLt
+              (regidx_to_fin c.r1).isLt (addr j) (trace.program j) hbk
+          have hext : ext' = ext :=
+            Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
+          subst ext'
+          refine ⟨ho, hjo1, hjo2, ?_, ?_, hf⟩
+          · rw [hso]
+            simp only [rd, Transpiler.ind]
+            apply Fin.ext
+            change (regidx_to_fin c.rd).val % GL_prime = (regidx_to_fin c.rd).val
+            exact Nat.mod_eq_of_lt (lt_trans (regidx_to_fin c.rd).isLt (by norm_num))
+          · rw [hbk, romMessageOfRaw, hok]
+            simpa only using
+              (immediate_rom_value c.imm hd hdimm ext.row hsrc hhi hlo) })
+  return ⟨Lean.mkNullNode #[t1, t2]⟩
+
+imm_program_decode slti, 2, 0x13, RiscvOpcode.Slti
+imm_program_decode sltiu, 3, 0x13, RiscvOpcode.Sltiu
+imm_program_decode andi, 7, 0x13, RiscvOpcode.Andi
+
+structure RawProgramDecode_addiw {n : Nat}
+    (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_addiw trace i)
+    (rawProgram : Fin trace.programLength → BitVec 32) where
+  h_idx : i.val + 1 < trace.mainTable.table.length
+  h_rd_ne_zero : (regidx_to_fin c.rd).val ≠ 0
+  hLine : ∀ j : Fin trace.programLength,
+    (trace.program j).line =
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
+      rawProgram j =
+        ZiskFv.Completeness.Rv64imShapes.rawIType c.imm.toNat
+          (regidx_to_fin c.r1).val 0 (regidx_to_fin c.rd).val 0x1b
+
+noncomputable def ProgramDecode_addiw_from_rawProgram {n : Nat}
+    (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_addiw trace i)
+    (addr : Fin trace.programLength → FGL)
+    (rawProgram : Fin trace.programLength → BitVec 32)
+    (hbind : ProgramBinding trace addr rawProgram)
+    (rawDecode : RawProgramDecode_addiw trace i c rawProgram) :
+    ZiskFv.Compliance.RomDecodeBinding.ProgramDecode_addiw trace i c := by
+  let rd := (regidx_to_fin c.rd).val
+  let rs1 := (regidx_to_fin c.r1).val
+  let imm := c.imm.toNat
+  let ext := (transpile_addiw rd rs1 imm (regidx_to_fin c.rd).isLt
+    (regidx_to_fin c.r1).isLt rawDecode.h_rd_ne_zero).choose
+  obtain ⟨hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, hj2,
+      hstoreOffset, hstoreInd, hrowImm⟩ :=
+    (transpile_addiw rd rs1 imm (regidx_to_fin c.rd).isLt
+      (regidx_to_fin c.r1).isLt rawDecode.h_rd_ne_zero).choose_spec
+  let hd := hrowImm.choose
+  obtain ⟨hdecode, hsrc, hhi, hlo⟩ := hrowImm.choose_spec
+  have hdimm : hd.imm.bv = BitVec.signExtend 32 c.imm := by
+    simpa only [imm, BitVec.ofNat_toNat] using
+      (decode_i_rawIType_imm imm rs1 0 rd 0x1b
+        (regidx_to_fin c.r1).isLt (by norm_num) (regidx_to_fin c.rd).isLt
+        (by norm_num) RiscvOpcode.Addiw hd hdecode)
+  refine
+    { h_idx := rawDecode.h_idx
+      bits := romFlagBitsOfExtract ext.row
+      h_bits_ieo := by simpa only [ext, romFlagBitsOfExtract] using hieo
+      h_bits_m32 := by simpa only [ext, romFlagBitsOfExtract] using hm32
+      h_bits_set_pc := by simpa only [ext, romFlagBitsOfExtract] using hsetpc
+      h_bits_store_pc := by simpa only [ext, romFlagBitsOfExtract] using hstorepc
+      h_bits_store_ind := by
+        simp only [romFlagBitsOfExtract]; exact decide_eq_false hstoreInd
+      h_bits_b_src_imm := by
+        simp only [romFlagBitsOfExtract]; exact decide_eq_true hsrc
+      h_prog := by
+        intro j hline
+        have hbk : trace.program j =
+            romMessageOfRaw (addr j)
+              (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 0 rd 0x1b) := by
+          exact (hbind.2 j).trans
+            (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+        obtain ⟨ho, hjo1, hjo2, hso, ext', hok', hieo', hm32', hsetpc',
+            hstorepc', hf⟩ :=
+          addiw_decode_fields_of_binding rd rs1 imm (regidx_to_fin c.rd).isLt
+            (regidx_to_fin c.r1).isLt rawDecode.h_rd_ne_zero
+            (addr j) (trace.program j) hbk
+        have hext : ext' = ext :=
+          Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
+        subst ext'
+        refine ⟨ho, hjo1, hjo2, ?_, ?_, hf⟩
+        · rw [hso]
+          simp only [rd, Transpiler.ind]
+          apply Fin.ext
+          change (regidx_to_fin c.rd).val % GL_prime = (regidx_to_fin c.rd).val
+          exact Nat.mod_eq_of_lt
+            (lt_trans (regidx_to_fin c.rd).isLt (by norm_num))
+        · rw [hbk, romMessageOfRaw, hok]
+          simpa only using
+            (immediate_rom_value c.imm hd hdimm ext.row hsrc hhi hlo) }
+
 section AxiomAudit
 #print axioms transpile_slti
 #print axioms slti_decode_fields_of_binding
@@ -830,6 +1057,10 @@ section AxiomAudit
 #print axioms transpile_addiw
 #print axioms ProgramDecode_slli_from_rawProgram
 #print axioms ProgramDecode_sraiw_from_rawProgram
+#print axioms ProgramDecode_slti_from_rawProgram
+#print axioms ProgramDecode_sltiu_from_rawProgram
+#print axioms ProgramDecode_andi_from_rawProgram
+#print axioms ProgramDecode_addiw_from_rawProgram
 end AxiomAudit
 
 end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingLoadStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingLoadStore.lean
@@ -1,4 +1,5 @@
 import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingImmediate
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBitfields
 
 /-!
 # Raw-program decode bridge — load / store family (issue #159, BLOCK 3)
@@ -96,6 +97,22 @@ theorem store_reg_i64_index_pins (self z : zisk_inst_builder.ZiskInstBuilder)
        · simp [zisk_inst.STORE_REG, zisk_inst.STORE_IND])
     | (exfalso; scalar_tac)
 
+theorem store_reg_i64_is_reg (self z : zisk_inst_builder.ZiskInstBuilder)
+    (rd : Std.I64) (hrd0 : 0 ≤ rd.val) (hrd : rd.val < 32) (hrdne : rd.val ≠ 0)
+    (h : self.store_reg rd false false = ok z) :
+    z.i.store = zisk_inst.STORE_REG := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.store_reg,
+    zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO,
+    zisk_registers.REG_FIRST, mem.SYS_ADDR, mem.RAM_ADDR,
+    lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
+  have e1 := ZiskFv.Compliance.Extraction.cast_one_i64
+  have e31 := ZiskFv.Compliance.Extraction.cast_31_i64
+  split_ifs at h <;>
+    first
+    | (rw [Result.ok.injEq] at h; subst h; simp [zisk_inst.STORE_REG])
+    | (exfalso; scalar_tac)
+  all_goals exfalso; scalar_tac
+
 theorem load_op_typed_full_pins
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp)
@@ -110,6 +127,7 @@ theorem load_op_typed_full_pins
       ∧ zib.i.b_offset_imm0 = IScalar.hcast UScalarTy.U64 i.imm
       ∧ zib.i.store_offset.val = i.rd.val
       ∧ zib.i.store ≠ zisk_inst.STORE_IND
+      ∧ (i.rd.val ≠ 0 → zib.i.store = zisk_inst.STORE_REG)
       ∧ zib.i.jmp_offset1 = UScalar.hcast IScalarTy.I64 inst_size
       ∧ zib.i.jmp_offset2 = UScalar.hcast IScalarTy.I64 inst_size := by
   simp only [riscv2zisk_context.Riscv2ZiskContext.load_op_typed,
@@ -169,7 +187,7 @@ theorem load_op_typed_full_pins
   have hiw6 := (ZiskFv.Compliance.Extraction.j_pres_data _ _ _ _ h6).1
   have hz := ZiskFv.Compliance.Extraction.build_eq _ _ h7
   refine ⟨z7, ZiskFv.Compliance.Extraction.insert_inst_extract _ _ _ _ h8,
-    ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+    ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · rw [hz, hiw6, hiw5, hiw4, hiw3, hiw2]
   · rw [hz, hjsb, hss, hos, hbs]
   · rw [hz, hjlb, hsl, hol, hbo]
@@ -177,6 +195,16 @@ theorem load_op_typed_full_pins
       ZiskFv.Compliance.Extraction.hcast_u32_i64_val]
   · rw [hz]
     exact fun hh => hst (hjst.symm.trans hh)
+  · intro hrdne
+    rw [hz, hjst]
+    exact store_reg_i64_is_reg z4 z5 iadd
+      (by rw [hiadd', hiaddval,
+        ZiskFv.Compliance.Extraction.hcast_u32_i64_val]; omega)
+      (by rw [hiadd', hiaddval,
+        ZiskFv.Compliance.Extraction.hcast_u32_i64_val]; exact_mod_cast hrd)
+      (by rw [hiadd', hiaddval,
+        ZiskFv.Compliance.Extraction.hcast_u32_i64_val]; exact_mod_cast hrdne)
+      h5
   · rw [hz, hj1]
   · rw [hz, hj2]
 
@@ -356,7 +384,13 @@ theorem transpile_load_of
       ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
       ∧ ext.row.ind_width = wval
       ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
-      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ∃ d, aeneas_extract.rv64im_decode.decode_i raw rop false = ok d
+        ∧ ext.row.b_src = zisk_inst.SRC_IND
+        ∧ ext.row.b_offset_imm0 = IScalar.hcast UScalarTy.U64 d.imm
+        ∧ ext.row.store_offset.val = d.rd.val
+        ∧ ext.row.store ≠ zisk_inst.STORE_IND
+        ∧ (d.rd.val ≠ 0 → ext.row.store = zisk_inst.STORE_REG) := by
   obtain ⟨decoded, hdecoded, hopd, hrdb, hrs1b, _⟩ := decode_i_bounds raw rop false
   have hdec0 : aeneas_extract.rv64im_decode.decode_32_core raw = ok decoded := hdec.trans hdecoded
   set input : riscv2zisk_single_row.Rv64imLoweringInput :=
@@ -371,11 +405,41 @@ theorem transpile_load_of
     load_op_typed_jmp_width { defCtx with extract_marker := () } input zop W 4#u64 ctx0 wval hiw hctx0
   have hzz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
   rw [hzz] at hiw' hj1 hj2
+  obtain ⟨zib'', hzib'', hiw'', hbSrc, hbOff, hstoreOff, hstore, hstoreReg,
+      hj1', hj2'⟩ :=
+    load_op_typed_full_pins { defCtx with extract_marker := () } input zop W 4#u64
+      wval ctx0 (by rw [hinput]; exact hrdb) hiw hctx0
+  have hzz' : zib'' = zib := Option.some.inj (hzib''.symm.trans hzib)
+  rw [hzz'] at hbSrc hbOff hstoreOff hstore hstoreReg
   obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
   obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, hriw⟩ := from_inst_ok zib.i
+  have hrBSrc : row.b_src = zib.i.b_src := by
+    rw [aeneas_extract.ZiskInstExtract.from_inst] at hrow
+    obtain ⟨_, _, hrow⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
+  have hrBOff : row.b_offset_imm0 = zib.i.b_offset_imm0 := by
+    rw [aeneas_extract.ZiskInstExtract.from_inst] at hrow
+    obtain ⟨_, _, hrow⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
+  have hrStoreOff : row.store_offset = zib.i.store_offset := by
+    rw [aeneas_extract.ZiskInstExtract.from_inst] at hrow
+    obtain ⟨_, _, hrow⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
+  have hrStore : row.store = zib.i.store := by
+    rw [aeneas_extract.ZiskInstExtract.from_inst] at hrow
+    obtain ⟨_, _, hrow⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
   have hlower : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input srop false
       = ok { ctx0 with extract_marker := () } := by rw [harm defCtx input, hctx0]; rfl
-  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
     simp only [bind_ok, Bind.bind, hdext, hopd, hlowop]
     simp only [defCtx] at hlower
@@ -389,6 +453,14 @@ theorem transpile_load_of
   · show row.ind_width = wval; rw [hriw]; exact hiw'
   · show row.jmp_offset1 = _; rw [hrj1]; exact hj1
   · show row.jmp_offset2 = _; rw [hrj2]; exact hj2
+  · refine ⟨decoded, hdecoded, ?_, ?_, ?_, ?_, ?_⟩
+    · rw [hrBSrc]; exact hbSrc
+    · rw [hrBOff, hbOff, hinput]
+    · rw [hrStoreOff, hstoreOff, hinput]
+    · rw [hrStore]; exact hstore
+    · intro hne
+      rw [hrStore]
+      exact hstoreReg (by rw [hinput]; exact hne)
 
 /-! ## Generic store-family transpile reduction (S-type word, `decode_s`). -/
 
@@ -416,7 +488,10 @@ theorem transpile_store_of
       ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
       ∧ ext.row.ind_width = wval
       ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
-      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ∃ d, decode_s raw rop = ok d
+        ∧ ext.row.store = zisk_inst.STORE_IND
+        ∧ ext.row.store_offset = IScalar.cast IScalarTy.I64 d.imm := by
   obtain ⟨decoded, hdecoded, hopd, hrs1b, hrs2b⟩ := decode_s_bounds raw rop
   have hdec0 : aeneas_extract.rv64im_decode.decode_32_core raw = ok decoded := hdec.trans hdecoded
   set input : riscv2zisk_single_row.Rv64imLoweringInput :=
@@ -431,11 +506,29 @@ theorem transpile_store_of
     store_op_typed_jmp_width { defCtx with extract_marker := () } input zop W 4#u64 ctx0 wval hiw hctx0
   have hzz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
   rw [hzz] at hiw' hj1 hj2
+  obtain ⟨zib'', hzib'', hiw'', hbSrc, hstore, hstoreOff, hj1', hj2',
+      hsetpc', hstorepc', hcode', hm32', ot', hot', hext'⟩ :=
+    store_op_typed_full_pins { defCtx with extract_marker := () } input zop W 4#u64
+      wval ctx0 hiw hctx0
+  have hzz' : zib'' = zib := Option.some.inj (hzib''.symm.trans hzib)
+  rw [hzz'] at hstore hstoreOff
   obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
   obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, hriw⟩ := from_inst_ok zib.i
+  have hrStoreOff : row.store_offset = zib.i.store_offset := by
+    rw [aeneas_extract.ZiskInstExtract.from_inst] at hrow
+    obtain ⟨_, _, hrow⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
+  have hrStore : row.store = zib.i.store := by
+    rw [aeneas_extract.ZiskInstExtract.from_inst] at hrow
+    obtain ⟨_, _, hrow⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
   have hlower : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input srop false
       = ok { ctx0 with extract_marker := () } := by rw [harm defCtx input, hctx0]; rfl
-  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
     simp only [bind_ok, Bind.bind, hdext, hopd, hlowop]
     simp only [defCtx] at hlower
@@ -449,6 +542,9 @@ theorem transpile_store_of
   · show row.ind_width = wval; rw [hriw]; exact hiw'
   · show row.jmp_offset1 = _; rw [hrj1]; exact hj1
   · show row.jmp_offset2 = _; rw [hrj2]; exact hj2
+  · refine ⟨decoded, hdecoded, ?_, ?_⟩
+    · rw [hrStore]; exact hstore
+    · rw [hrStoreOff, hstoreOff, hinput]
 
 open RiscvOpcode riscv2zisk_single_row.Rv64imSingleRowOpcode zisk_ops.ZiskOp zisk_ops.OpType
 open ZiskFv.Trusted
@@ -468,7 +564,15 @@ local macro "load_copyb_op" nm:ident "," f3:term "," rop:term "," srop:term ","
           ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
           ∧ ext.row.ind_width = $width
           ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
-          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+          ∧ ∃ d, decode_i
+              (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 $f3 rd 0x03))
+                $rop false = ok d
+            ∧ ext.row.b_src = zisk_inst.SRC_IND
+            ∧ ext.row.b_offset_imm0 = IScalar.hcast UScalarTy.U64 d.imm
+            ∧ ext.row.store_offset.val = d.rd.val
+            ∧ ext.row.store ≠ zisk_inst.STORE_IND
+            ∧ (d.rd.val ≠ 0 → ext.row.store = zisk_inst.STORE_REG) := by
       refine transpile_load_of _ $rop $srop zisk_ops.ZiskOp.CopyB 1#u8 false false
         zisk_ops.OpType.Internal $width $width ?_ rfl (fun _ => ⟨_, rfl⟩) $iwlem
         (by intro self input; rfl) rfl rfl rfl rfl
@@ -487,7 +591,8 @@ local macro "load_copyb_op" nm:ident "," f3:term "," rop:term "," srop:term ","
               ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
               ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
               ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
-      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hiw, hj1, hj2⟩ := $tName rd rs1 imm hrd hrs1
+      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hiw, hj1, hj2, _⟩ :=
+        $tName rd rs1 imm hrd hrs1
       obtain ⟨ho, hjo1, hjo2, hiwF, hf⟩ :=
         loadstore_decode_fields_of_binding line msg _ 1#u8 $opc $width $wF ext
           (by simp [romOpcode, $opc:term])
@@ -509,7 +614,12 @@ local macro "store_op" nm:ident "," f3:term "," rop:term "," srop:term ","
           ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
           ∧ ext.row.ind_width = $width
           ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
-          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+          ∧ ∃ d, decode_s
+              (toU32 (ZiskFv.Completeness.Rv64imShapes.rawSType imm rs2 rs1 $f3))
+                $rop = ok d
+            ∧ ext.row.store = zisk_inst.STORE_IND
+            ∧ ext.row.store_offset = IScalar.cast IScalarTy.I64 d.imm := by
       refine transpile_store_of _ $rop $srop zisk_ops.ZiskOp.CopyB 1#u8 false false
         zisk_ops.OpType.Internal $width $width ?_ rfl (fun _ => ⟨_, rfl⟩) $iwlem
         (by intro self input; rfl) rfl rfl rfl rfl
@@ -528,7 +638,8 @@ local macro "store_op" nm:ident "," f3:term "," rop:term "," srop:term ","
               ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
               ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
               ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
-      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hiw, hj1, hj2⟩ := $tName rs1 rs2 imm hrs1 hrs2
+      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hiw, hj1, hj2, _⟩ :=
+        $tName rs1 rs2 imm hrs1 hrs2
       obtain ⟨ho, hjo1, hjo2, hiwF, hf⟩ :=
         loadstore_decode_fields_of_binding line msg _ 1#u8 $opc $width $wF ext
           (by simp [romOpcode, $opc:term])
@@ -556,7 +667,12 @@ theorem transpile_sd (rs1 rs2 imm : Nat) (hrs1 : rs1 < 32) (hrs2 : rs2 < 32) :
       ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
       ∧ ext.row.ind_width = 8#u64
       ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
-      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ∃ d, decode_s
+          (toU32 (ZiskFv.Completeness.Rv64imShapes.rawSType imm rs2 rs1 3))
+            RiscvOpcode.Sd = ok d
+        ∧ ext.row.store = zisk_inst.STORE_IND
+        ∧ ext.row.store_offset = IScalar.cast IScalarTy.I64 d.imm := by
   refine transpile_store_of _ RiscvOpcode.Sd riscv2zisk_single_row.Rv64imSingleRowOpcode.Sd
     zisk_ops.ZiskOp.CopyB 1#u8 false false zisk_ops.OpType.Internal 8#u64 8#u64
     ?_ rfl (fun _ => ⟨_, rfl⟩) ind_width_set8 (by intro self input; rfl) rfl rfl rfl rfl
@@ -576,7 +692,8 @@ theorem sd_decode_fields_of_binding (rs1 rs2 imm : Nat) (hrs1 : rs1 < 32) (hrs2 
           ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
           ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
           ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
-  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, _, hj1, hj2⟩ := transpile_sd rs1 rs2 imm hrs1 hrs2
+  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, _, hj1, hj2, _⟩ :=
+    transpile_sd rs1 rs2 imm hrs1 hrs2
   have hmsg : msg = serializeExtract line ext.row := by
     rw [hbind, romMessageOfRaw, hok]
     exact romRowOf_eq_serializeExtract line ext.row
@@ -610,7 +727,15 @@ local macro "load_sext_op" nm:ident "," f3:term "," rop:term "," srop:term ","
           ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
           ∧ ext.row.ind_width = $width
           ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
-          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+          ∧ ∃ d, decode_i
+              (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 $f3 rd 0x03))
+                $rop false = ok d
+            ∧ ext.row.b_src = zisk_inst.SRC_IND
+            ∧ ext.row.b_offset_imm0 = IScalar.hcast UScalarTy.U64 d.imm
+            ∧ ext.row.store_offset.val = d.rd.val
+            ∧ ext.row.store ≠ zisk_inst.STORE_IND
+            ∧ (d.rd.val ≠ 0 → ext.row.store = zisk_inst.STORE_REG) := by
       refine transpile_load_of _ $rop $srop $zop $opU8 $m32 true
         zisk_ops.OpType.BinaryE $width $width ?_ rfl (fun _ => ⟨_, rfl⟩) $iwlem
         (by intro self input; rfl) rfl rfl rfl rfl
@@ -629,7 +754,8 @@ local macro "load_sext_op" nm:ident "," f3:term "," rop:term "," srop:term ","
               ∧ ext.row.is_external_op = true ∧ ext.row.m32 = $m32
               ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
               ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
-      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hiw, hj1, hj2⟩ := $tName rd rs1 imm hrd hrs1
+      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hiw, hj1, hj2, _⟩ :=
+        $tName rd rs1 imm hrd hrs1
       obtain ⟨ho, hjo1, hjo2, hiwF, hf⟩ :=
         loadstore_decode_fields_of_binding line msg _ $opU8 $opc $width $wF ext
           (by simp [romOpcode, $opc:term])
@@ -641,6 +767,157 @@ load_sext_op lb, 0, RiscvOpcode.Lb, riscv2zisk_single_row.Rv64imSingleRowOpcode.
 load_sext_op lh, 1, RiscvOpcode.Lh, riscv2zisk_single_row.Rv64imSingleRowOpcode.Lh, zisk_ops.ZiskOp.SignExtendH, 40#u8, false, 2#u64, (2 : FGL), ind_width_set2, OP_SIGNEXTEND_H
 load_sext_op lw, 2, RiscvOpcode.Lw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Lw, zisk_ops.ZiskOp.SignExtendW, 41#u8, true, 4#u64, (4 : FGL), ind_width_set4, OP_SIGNEXTEND_W
 
+/-! ## Current `ProgramDecode` retarget: store family. -/
+
+private theorem store_rom_offset (imm : BitVec 12) (d : DecodedRv64im)
+    (hdimm : (IScalar.hcast UScalarTy.U64 d.imm).bv = BitVec.signExtend 64 imm) :
+    ((IScalar.cast IScalarTy.I64 d.imm).val : FGL) =
+      ((BitVec.signExtend 64 imm).toInt : FGL) := by
+  congr 1
+  change (BitVec.signExtend 64 d.imm.bv).toInt = _
+  rw [show BitVec.signExtend 64 d.imm.bv = BitVec.signExtend 64 imm by
+    simpa only using hdimm]
+
+local macro "store_program_decode" nm:ident "," inp:term "," f3:term ","
+    rop:term : command => do
+  let s := nm.getId.toString
+  let rawName := Lean.mkIdent (Lean.Name.mkSimple ("RawProgramDecode_" ++ s))
+  let ctorName := Lean.mkIdent (Lean.Name.mkSimple ("ProgramDecode_" ++ s ++ "_from_rawProgram"))
+  let transpileName := Lean.mkIdent (Lean.Name.mkSimple ("transpile_" ++ s))
+  let fieldsName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
+  let claimName := Lean.mkIdent ((`ZiskFv.Compliance).str ("Claim_" ++ s))
+  let programName := Lean.mkIdent ((`ZiskFv.Compliance.RomDecodeBinding).str ("ProgramDecode_" ++ s))
+  let decodeFieldsName := Lean.mkIdent `decode_s_rawSType_fields
+  let t1 ← `(structure $rawName {n : Nat}
+      (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+      (i : Fin trace.numInstructions) (c : $claimName trace i)
+      (rawProgram : Fin trace.programLength → BitVec 32) where
+    h_idx : i.val + 1 < trace.mainTable.table.length
+    hLine : ∀ j : Fin trace.programLength,
+      (trace.program j).line =
+          (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
+        rawProgram j =
+          ZiskFv.Completeness.Rv64imShapes.rawSType ($inp c).imm.toNat
+            ($inp c).r2.toNat ($inp c).r1.toNat $f3)
+  let t2 ← `(noncomputable def $ctorName {n : Nat}
+      (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+      (i : Fin trace.numInstructions) (c : $claimName trace i)
+      (addr : Fin trace.programLength → FGL)
+      (rawProgram : Fin trace.programLength → BitVec 32)
+      (hbind : ProgramBinding trace addr rawProgram)
+      (rawDecode : $rawName trace i c rawProgram) :
+      $programName trace i c := by
+    let rs1 := ($inp c).r1.toNat
+    let rs2 := ($inp c).r2.toNat
+    let imm := ($inp c).imm.toNat
+    let ext := ($transpileName rs1 rs2 imm ($inp c).r1.isLt ($inp c).r2.isLt).choose
+    obtain ⟨hok, hop, hieo, hm32, hsetpc, hstorepc, hiw, hj1, hj2, hrowStore⟩ :=
+      ($transpileName rs1 rs2 imm ($inp c).r1.isLt ($inp c).r2.isLt).choose_spec
+    let d := hrowStore.choose
+    obtain ⟨hdecode, hstore, hstoreOff⟩ := hrowStore.choose_spec
+    have hdfields := $decodeFieldsName imm rs2 rs1 $f3
+      ($inp c).r2.isLt ($inp c).r1.isLt (by norm_num) $rop d hdecode
+    have hdimm : (IScalar.hcast UScalarTy.U64 d.imm).bv =
+        BitVec.signExtend 64 ($inp c).imm := by
+      simpa only [imm, BitVec.ofNat_toNat] using hdfields.2.2
+    refine
+      { h_idx := rawDecode.h_idx
+        bits := romFlagBitsOfExtract ext.row
+        h_bits_ieo := by simpa only [ext, romFlagBitsOfExtract] using hieo
+        h_bits_set_pc := by simpa only [ext, romFlagBitsOfExtract] using hsetpc
+        h_bits_store_pc := by simpa only [ext, romFlagBitsOfExtract] using hstorepc
+        h_bits_store_ind := by
+          simp only [romFlagBitsOfExtract]
+          exact decide_eq_true hstore
+        h_prog := by
+          intro j hline
+          have hbk : trace.program j =
+              romMessageOfRaw (addr j)
+                (ZiskFv.Completeness.Rv64imShapes.rawSType imm rs2 rs1 $f3) := by
+            exact (hbind.2 j).trans
+              (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+          obtain ⟨ho, hjo1, hjo2, hiwF, ext', hok', hieo', hm32', hsetpc',
+              hstorepc', hf⟩ :=
+            $fieldsName rs1 rs2 imm ($inp c).r1.isLt ($inp c).r2.isLt
+              (addr j) (trace.program j) hbk
+          have hext : ext' = ext :=
+            Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
+          subst ext'
+          refine ⟨ho, hjo1, hjo2, hiwF, ?_, hf⟩
+          rw [hbk, romMessageOfRaw, hok]
+          show (ext.row.store_offset.val : FGL) =
+            ((BitVec.signExtend 64 ($inp c).imm).toInt : FGL)
+          rw [hstoreOff]
+          exact store_rom_offset ($inp c).imm d hdimm })
+  return ⟨Lean.mkNullNode #[t1, t2]⟩
+
+store_program_decode sb, ZiskFv.Compliance.Claim_sb.sb_input, 0, RiscvOpcode.Sb
+store_program_decode sh, ZiskFv.Compliance.Claim_sh.sh_input, 1, RiscvOpcode.Sh
+store_program_decode sw, ZiskFv.Compliance.Claim_sw.sw_input, 2, RiscvOpcode.Sw
+
+structure RawProgramDecode_sd {n : Nat}
+    (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_sd trace i)
+    (rawProgram : Fin trace.programLength → BitVec 32) where
+  h_idx : i.val + 1 < trace.mainTable.table.length
+  hLine : ∀ j : Fin trace.programLength,
+    (trace.program j).line =
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
+      rawProgram j =
+        ZiskFv.Completeness.Rv64imShapes.rawSType c.sd_input.imm.toNat
+          c.sd_input.r2.toNat c.sd_input.r1.toNat 3
+
+noncomputable def ProgramDecode_sd_from_rawProgram {n : Nat}
+    (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_sd trace i)
+    (addr : Fin trace.programLength → FGL)
+    (rawProgram : Fin trace.programLength → BitVec 32)
+    (hbind : ProgramBinding trace addr rawProgram)
+    (rawDecode : RawProgramDecode_sd trace i c rawProgram) :
+    ZiskFv.Compliance.RomDecodeBinding.ProgramDecode_sd trace i c := by
+  let rs1 := c.sd_input.r1.toNat
+  let rs2 := c.sd_input.r2.toNat
+  let imm := c.sd_input.imm.toNat
+  let ext := (transpile_sd rs1 rs2 imm c.sd_input.r1.isLt c.sd_input.r2.isLt).choose
+  obtain ⟨hok, hop, hieo, hm32, hsetpc, hstorepc, hiw, hj1, hj2, hrowStore⟩ :=
+    (transpile_sd rs1 rs2 imm c.sd_input.r1.isLt c.sd_input.r2.isLt).choose_spec
+  let d := hrowStore.choose
+  obtain ⟨hdecode, hstore, hstoreOff⟩ := hrowStore.choose_spec
+  have hdfields := decode_s_rawSType_fields imm rs2 rs1 3
+    c.sd_input.r2.isLt c.sd_input.r1.isLt (by norm_num) RiscvOpcode.Sd d hdecode
+  have hdimm : (IScalar.hcast UScalarTy.U64 d.imm).bv =
+      BitVec.signExtend 64 c.sd_input.imm := by
+    simpa only [imm, BitVec.ofNat_toNat] using hdfields.2.2
+  refine
+    { h_idx := rawDecode.h_idx
+      bits := romFlagBitsOfExtract ext.row
+      h_bits_ieo := by simpa only [ext, romFlagBitsOfExtract] using hieo
+      h_bits_set_pc := by simpa only [ext, romFlagBitsOfExtract] using hsetpc
+      h_bits_store_pc := by simpa only [ext, romFlagBitsOfExtract] using hstorepc
+      h_bits_store_ind := by
+        simp only [romFlagBitsOfExtract]
+        exact decide_eq_true hstore
+      h_prog := by
+        intro j hline
+        have hbk : trace.program j =
+            romMessageOfRaw (addr j)
+              (ZiskFv.Completeness.Rv64imShapes.rawSType imm rs2 rs1 3) := by
+          exact (hbind.2 j).trans
+            (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+        obtain ⟨ho, hjo1, hjo2, ext', hok', hieo', hm32', hsetpc',
+            hstorepc', hf⟩ :=
+          sd_decode_fields_of_binding rs1 rs2 imm c.sd_input.r1.isLt c.sd_input.r2.isLt
+            (addr j) (trace.program j) hbk
+        have hext : ext' = ext :=
+          Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
+        subst ext'
+        refine ⟨ho, hjo1, hjo2, ?_, hf⟩
+        rw [hbk, romMessageOfRaw, hok]
+        show (ext.row.store_offset.val : FGL) =
+          ((BitVec.signExtend 64 c.sd_input.imm).toInt : FGL)
+        rw [hstoreOff]
+        exact store_rom_offset c.sd_input.imm d hdimm }
+
 section AxiomAudit
 #print axioms transpile_lbu
 #print axioms lbu_decode_fields_of_binding
@@ -649,6 +926,10 @@ section AxiomAudit
 #print axioms transpile_sd
 #print axioms transpile_lb
 #print axioms transpile_lw
+#print axioms ProgramDecode_sb_from_rawProgram
+#print axioms ProgramDecode_sh_from_rawProgram
+#print axioms ProgramDecode_sw_from_rawProgram
+#print axioms ProgramDecode_sd_from_rawProgram
 end AxiomAudit
 
 end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingLoadStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingLoadStore.lean
@@ -210,6 +210,223 @@ theorem load_op_typed_full_pins
 
 #print axioms load_op_typed_full_pins
 
+private def loadOperandPins (before after : zisk_inst_builder.ZiskInstBuilder) : Prop :=
+  after.i.a_src = before.i.a_src
+    ∧ after.i.a_use_sp_imm1 = before.i.a_use_sp_imm1
+    ∧ after.i.a_offset_imm0 = before.i.a_offset_imm0
+
+private theorem loadOperandPins_trans {a b c : zisk_inst_builder.ZiskInstBuilder}
+    (hab : loadOperandPins a b) (hbc : loadOperandPins b c) : loadOperandPins a c := by
+  rcases hab with ⟨ha1, ha2, ha3⟩
+  rcases hbc with ⟨ha1', ha2', ha3'⟩
+  exact ⟨ha1'.trans ha1, ha2'.trans ha2, ha3'.trans ha3⟩
+
+private theorem loadOperandPins_ind_width (self z : zisk_inst_builder.ZiskInstBuilder)
+    (w : Std.U64) (h : self.ind_width w = ok z) : loadOperandPins self z := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.ind_width] at h
+  split at h <;>
+    first
+    | (rw [Result.ok.injEq] at h; subst z; exact ⟨rfl, rfl, rfl⟩)
+    | simp at h
+
+private theorem loadOperandPins_src_b_ind (self z : zisk_inst_builder.ZiskInstBuilder)
+    (off : Std.U64) (usp : Bool) (h : self.src_b_ind off usp = ok z) :
+    loadOperandPins self z := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.src_b_ind, bind_ok, Bind.bind] at h
+  split_ifs at h <;> (rw [Result.ok.injEq] at h; subst z; exact ⟨rfl, rfl, rfl⟩)
+
+private theorem loadOperandPins_op_zisk (self z : zisk_inst_builder.ZiskInstBuilder)
+    (op : zisk_ops.ZiskOp) (hinput : zisk_ops.ZiskOp.input_size op = ok 0#u64)
+    (h : self.op_zisk op = ok z) :
+    z.i.a_src = self.i.a_src ∧ z.i.a_use_sp_imm1 = self.i.a_use_sp_imm1
+      ∧ z.i.a_offset_imm0 = self.i.a_offset_imm0 ∧ z.i.is_precompiled = false := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.op_zisk,
+    zisk_inst_builder.ZiskInstBuilder.set_runtime_op_fields,
+    core.convert.IntoFrom.into,
+    zisk_inst.ZiskOperationType.Insts.CoreConvertFromOpType.from, Bind.bind] at h
+  obtain ⟨ot, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨b, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨cval, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨self1, hself1, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨zot, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨i1, hi1, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨mval, _, hself1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hself1
+  rw [hinput] at hi1
+  injection hi1 with hi1
+  subst i1
+  rw [Result.ok.injEq] at h hself1
+  subst h
+  subst hself1
+  exact ⟨rfl, rfl, rfl, by norm_num⟩
+
+private theorem loadOperandPins_store_reg (self z : zisk_inst_builder.ZiskInstBuilder)
+    (rd : Std.I64) (usp ais : Bool) (h : self.store_reg rd usp ais = ok z) :
+    loadOperandPins self z := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.store_reg,
+    zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO,
+    zisk_registers.REG_FIRST, mem.SYS_ADDR, mem.RAM_ADDR,
+    lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
+  split_ifs at h <;> (try simp only [bind_ok] at h) <;>
+    first
+    | (rw [Result.ok.injEq] at h; subst z; exact ⟨rfl, rfl, rfl⟩)
+    | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+       rw [Result.ok.injEq] at h; subst z; exact ⟨rfl, rfl, rfl⟩)
+    | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+       obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+       rw [Result.ok.injEq] at h; subst z; exact ⟨rfl, rfl, rfl⟩)
+
+private theorem precompiled_pres_store_reg (self z : zisk_inst_builder.ZiskInstBuilder)
+    (rd : Std.I64) (usp ais : Bool) (h : self.store_reg rd usp ais = ok z) :
+    z.i.is_precompiled = self.i.is_precompiled := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.store_reg,
+    zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO,
+    zisk_registers.REG_FIRST, mem.SYS_ADDR, mem.RAM_ADDR,
+    lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
+  split_ifs at h <;> (try simp only [bind_ok] at h) <;>
+    first
+    | (rw [Result.ok.injEq] at h; subst z; rfl)
+    | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+       rw [Result.ok.injEq] at h; subst z; rfl)
+    | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+       obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+       rw [Result.ok.injEq] at h; subst z; rfl)
+
+private theorem loadOperandPins_j (self z : zisk_inst_builder.ZiskInstBuilder)
+    (j1 j2 : Std.I64) (h : self.j j1 j2 = ok z) : loadOperandPins self z := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.j, bind_ok, Bind.bind] at h
+  rw [Result.ok.injEq] at h
+  subst z
+  exact ⟨rfl, rfl, rfl⟩
+
+private theorem loadOperandPins_build (self z : zisk_inst_builder.ZiskInstBuilder)
+    (h : self.build = ok z) : loadOperandPins self z := by
+  rw [ZiskFv.Compliance.Extraction.build_eq self z h]
+  exact ⟨rfl, rfl, rfl⟩
+
+private theorem src_a_reg_u32_nonzero_pins (self z : zisk_inst_builder.ZiskInstBuilder)
+    (rs1 : Std.U32) (hrs1 : rs1.val < 32) (hrs1ne : rs1.val ≠ 0)
+    (h : self.src_a_reg (UScalar.cast UScalarTy.U64 rs1) false = ok z) :
+    z.i.a_src = zisk_inst.SRC_REG ∧ z.i.a_use_sp_imm1 = 0#u64
+      ∧ z.i.a_offset_imm0.val = rs1.val := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.src_a_reg,
+    zisk_inst_builder.ZiskInstBuilder.src_a_imm,
+    zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO,
+    zisk_registers.REG_FIRST, mem.SYS_ADDR, mem.RAM_ADDR,
+    lift, Bind.bind, bind_ok] at h
+  have hc := ZiskFv.Compliance.Extraction.cast_u32_u64_val rs1
+  have e1 := ZiskFv.Compliance.Extraction.cast_one_u64
+  have e31 := ZiskFv.Compliance.Extraction.cast_31_u64
+  simp only [Bool.false_eq_true, if_false] at h
+  split_ifs at h <;> (try simp only [bind_ok] at h) <;>
+    first
+    | (rw [Result.ok.injEq] at h; subst z
+       simp [zisk_inst.SRC_REG, hc])
+    | (exfalso; scalar_tac)
+  all_goals exfalso; scalar_tac
+
+theorem load_op_typed_nonzero_rs1_full_pins
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp)
+    (w inst_size wval : Std.U64) (ctx : riscv2zisk_context.Riscv2ZiskContext)
+    (hrd : i.rd.val < 32) (hrs1 : i.rs1.val < 32) (hrs1ne : i.rs1.val ≠ 0)
+    (hinput : zisk_ops.ZiskOp.input_size op = ok 0#u64)
+    (hiw : ∀ (s z : zisk_inst_builder.ZiskInstBuilder),
+      s.ind_width w = ok z → z.i.ind_width = wval)
+    (h : self.load_op_typed i op w inst_size = ok ctx) :
+    ∃ zib, ctx.extract_inst = some zib
+      ∧ zib.i.a_src = zisk_inst.SRC_REG
+      ∧ zib.i.a_offset_imm0.val = i.rs1.val
+      ∧ zib.i.a_use_sp_imm1 = 0#u64
+      ∧ zib.i.b_src = zisk_inst.SRC_IND
+      ∧ zib.i.b_offset_imm0 = IScalar.hcast UScalarTy.U64 i.imm
+      ∧ zib.i.store_offset.val = i.rd.val
+      ∧ zib.i.store ≠ zisk_inst.STORE_IND
+      ∧ (i.rd.val ≠ 0 → zib.i.store = zisk_inst.STORE_REG)
+      ∧ zib.i.ind_width = wval
+      ∧ zib.i.jmp_offset1 = UScalar.hcast IScalarTy.I64 inst_size
+      ∧ zib.i.jmp_offset2 = UScalar.hcast IScalarTy.I64 inst_size
+      ∧ zib.i.is_precompiled = false := by
+  obtain ⟨zib, hzib, hiw', hbSrc, hbOff, hstoreOff, hstore, hstoreReg, hj1, hj2⟩ :=
+    load_op_typed_full_pins self i op w inst_size wval ctx hrd hiw h
+  simp only [riscv2zisk_context.Riscv2ZiskContext.load_op_typed,
+    Bind.bind, bind_ok] at h
+  obtain ⟨s1, hs1, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  rw [Result.ok.injEq] at h
+  subst h
+  simp only [riscv2zisk_context.Riscv2ZiskContext.load_op_with_reg_offset,
+    lift, Bind.bind, bind_ok] at hs1
+  obtain ⟨z0, h0, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨z1, h1, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨z2, h2, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨z3, h3, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨z4, h4, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨iadd, hadd, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨z5, h5, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨z6, h6, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨z7, h7, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨s2, h8, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  rw [Result.ok.injEq] at hs1
+  subst hs1
+  obtain ⟨haSrc, haSp, haOff⟩ := src_a_reg_u32_nonzero_pins z0 z1 i.rs1 hrs1 hrs1ne h1
+  obtain ⟨haSrc4, haSp4, haOff4, hpre4⟩ := loadOperandPins_op_zisk z3 z4 op hinput h4
+  have hp12 := loadOperandPins_ind_width z1 z2 w h2
+  have hp23 := loadOperandPins_src_b_ind z2 z3 _ _ h3
+  have hp45 := loadOperandPins_store_reg z4 z5 iadd false false h5
+  have hp56 := loadOperandPins_j z5 z6 _ _ h6
+  have hp67 := loadOperandPins_build z6 z7 h7
+  have hp14 : loadOperandPins z1 z4 :=
+    loadOperandPins_trans (loadOperandPins_trans hp12 hp23)
+      ⟨haSrc4, haSp4, haOff4⟩
+  have hp17 := loadOperandPins_trans (loadOperandPins_trans (loadOperandPins_trans hp14 hp45) hp56) hp67
+  rcases hp17 with ⟨haSrc7, haSp7, haOff7⟩
+  have hzz : zib = z7 := Option.some.inj (hzib.symm.trans
+    (ZiskFv.Compliance.Extraction.insert_inst_extract _ _ _ _ h8))
+  subst zib
+  refine ⟨z7, ZiskFv.Compliance.Extraction.insert_inst_extract _ _ _ _ h8,
+    haSrc7.trans haSrc, ?_, haSp7.trans haSp, hbSrc, hbOff, hstoreOff, hstore,
+    hstoreReg, hiw', hj1, hj2, ?_⟩
+  · rw [haOff7]
+    exact haOff
+  · have hp45' : z5.i.is_precompiled = false := by
+      rw [← hpre4]
+      exact precompiled_pres_store_reg z4 z5 iadd false false h5
+    have hp56' : z6.i.is_precompiled = false := by
+      rw [← hp45']
+      simp only [zisk_inst_builder.ZiskInstBuilder.j, bind_ok, Bind.bind] at h6
+      rw [Result.ok.injEq] at h6
+      subst z6
+      rfl
+    rw [ZiskFv.Compliance.Extraction.build_eq z6 z7 h7]
+    exact hp56'
+
+#print axioms load_op_typed_nonzero_rs1_full_pins
+
+theorem ld_op_typed_nonzero_rs1_full_pins
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput)
+    (inst_size wval : Std.U64) (ctx : riscv2zisk_context.Riscv2ZiskContext)
+    (hrd : i.rd.val < 32) (hrs1 : i.rs1.val < 32) (hrs1ne : i.rs1.val ≠ 0)
+    (hiw : ∀ (s z : zisk_inst_builder.ZiskInstBuilder),
+      s.ind_width 8#u64 = ok z → z.i.ind_width = wval)
+    (h : self.load_op_typed i zisk_ops.ZiskOp.CopyB 8#u64 inst_size = ok ctx) :
+    ∃ zib, ctx.extract_inst = some zib
+      ∧ zib.i.a_src = zisk_inst.SRC_REG
+      ∧ zib.i.a_offset_imm0.val = i.rs1.val
+      ∧ zib.i.a_use_sp_imm1 = 0#u64
+      ∧ zib.i.b_src = zisk_inst.SRC_IND
+      ∧ zib.i.b_offset_imm0 = IScalar.hcast UScalarTy.U64 i.imm
+      ∧ zib.i.store_offset.val = i.rd.val
+      ∧ zib.i.store ≠ zisk_inst.STORE_IND
+      ∧ (i.rd.val ≠ 0 → zib.i.store = zisk_inst.STORE_REG)
+      ∧ zib.i.ind_width = wval
+      ∧ zib.i.jmp_offset1 = UScalar.hcast IScalarTy.I64 inst_size
+      ∧ zib.i.jmp_offset2 = UScalar.hcast IScalarTy.I64 inst_size
+      ∧ zib.i.is_precompiled = false :=
+  load_op_typed_nonzero_rs1_full_pins self i zisk_ops.ZiskOp.CopyB 8#u64
+    inst_size wval ctx hrd hrs1 hrs1ne rfl hiw h
+
+#print axioms ld_op_typed_nonzero_rs1_full_pins
+
 theorem src_b_reg_not_ind (self z : zisk_inst_builder.ZiskInstBuilder)
     (reg : Std.U64) (usp : Bool) (h : self.src_b_reg reg usp = ok z) :
     z.i.b_src ≠ zisk_inst.SRC_IND := by

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingLoadStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingLoadStore.lean
@@ -1,4 +1,4 @@
-import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingRegister
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingImmediate
 
 /-!
 # Raw-program decode bridge — load / store family (issue #159, BLOCK 3)
@@ -52,6 +52,135 @@ open aeneas_extract (extract_transpile_rv64im_raw)
 
 set_option maxHeartbeats 4000000
 set_option linter.unusedSimpArgs false
+
+theorem src_b_ind_full_pins (self z : zisk_inst_builder.ZiskInstBuilder)
+    (off : Std.U64) (usp : Bool)
+    (h : self.src_b_ind off usp = ok z) :
+    z.i.b_src = zisk_inst.SRC_IND ∧ z.i.b_offset_imm0 = off
+      ∧ z.i.store_offset = self.i.store_offset ∧ z.i.store = self.i.store := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.src_b_ind,
+    zisk_inst.SRC_IND, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
+  split_ifs at h <;>
+    (rw [Result.ok.injEq] at h; subst h
+     exact ⟨by simp [zisk_inst.SRC_IND], rfl, rfl, rfl⟩)
+
+theorem ind_width_pres_store (self z : zisk_inst_builder.ZiskInstBuilder)
+    (w : Std.U64) (h : self.ind_width w = ok z) :
+    z.i.store_offset = self.i.store_offset ∧ z.i.store = self.i.store := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.ind_width] at h
+  split at h <;>
+    first
+    | (rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩)
+    | simp at h
+
+theorem store_reg_i64_index_pins (self z : zisk_inst_builder.ZiskInstBuilder)
+    (rd : Std.I64) (hrd0 : 0 ≤ rd.val) (hrd : rd.val < 32)
+    (hzero : self.i.store_offset = 0#i64) (hstore : self.i.store = 0#u64)
+    (h : self.store_reg rd false false = ok z) :
+    z.i.store_offset.val = rd.val ∧ z.i.store ≠ zisk_inst.STORE_IND := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.store_reg,
+    zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO,
+    zisk_registers.REG_FIRST, mem.SYS_ADDR, mem.RAM_ADDR,
+    lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
+  have e1 := ZiskFv.Compliance.Extraction.cast_one_i64
+  have e31 := ZiskFv.Compliance.Extraction.cast_31_i64
+  split_ifs at h <;>
+    first
+    | (rw [Result.ok.injEq] at h; subst h
+       constructor
+       · scalar_tac
+       · simp [hstore, zisk_inst.STORE_IND])
+    | (rw [Result.ok.injEq] at h; subst h
+       constructor
+       · scalar_tac
+       · simp [zisk_inst.STORE_REG, zisk_inst.STORE_IND])
+    | (exfalso; scalar_tac)
+
+theorem load_op_typed_full_pins
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp)
+    (w inst_size wval : Std.U64) (ctx : riscv2zisk_context.Riscv2ZiskContext)
+    (hrd : i.rd.val < 32)
+    (hiw : ∀ (s z : zisk_inst_builder.ZiskInstBuilder),
+      s.ind_width w = ok z → z.i.ind_width = wval)
+    (h : self.load_op_typed i op w inst_size = ok ctx) :
+    ∃ zib, ctx.extract_inst = some zib
+      ∧ zib.i.ind_width = wval
+      ∧ zib.i.b_src = zisk_inst.SRC_IND
+      ∧ zib.i.b_offset_imm0 = IScalar.hcast UScalarTy.U64 i.imm
+      ∧ zib.i.store_offset.val = i.rd.val
+      ∧ zib.i.store ≠ zisk_inst.STORE_IND
+      ∧ zib.i.jmp_offset1 = UScalar.hcast IScalarTy.I64 inst_size
+      ∧ zib.i.jmp_offset2 = UScalar.hcast IScalarTy.I64 inst_size := by
+  simp only [riscv2zisk_context.Riscv2ZiskContext.load_op_typed,
+    Bind.bind, bind_ok] at h
+  obtain ⟨s1, hs1, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  rw [Result.ok.injEq] at h
+  subst h
+  simp only [riscv2zisk_context.Riscv2ZiskContext.load_op_with_reg_offset,
+    lift, Bind.bind, bind_ok] at hs1
+  obtain ⟨z0, h0, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨z1, h1, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨z2, h2, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨z3, h3, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨z4, h4, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨iadd, hadd, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨z5, h5, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨z6, h6, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨z7, h7, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨s2, h8, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  rw [Result.ok.injEq] at hs1
+  subst hs1
+  have hbase : z4.i.store_offset = 0#i64 ∧ z4.i.store = 0#u64 := by
+    simp only [zisk_inst_builder.ZiskInstBuilder.new_for_rv64im_lowering,
+      zisk_inst_builder.ZiskInstBuilder.new,
+      zisk_inst_builder.ZiskInstBuilder.Insts.CoreDefaultDefault.default,
+      zisk_inst.ZiskInst.Insts.CoreDefaultDefault.default,
+      bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h0
+    rw [Result.ok.injEq] at h0
+    subst z0
+    obtain ⟨ha0, ha1⟩ := src_a_reg_pres_store _ _ _ _ h1
+    obtain ⟨hw0, hw1⟩ := ind_width_pres_store _ _ _ h2
+    obtain ⟨_, _, hb0, hb1⟩ := src_b_ind_full_pins _ _ _ _ h3
+    obtain ⟨ho0, ho1⟩ := op_zisk_pres_store _ _ _ h4
+    exact ⟨ho0.trans (hb0.trans (hw0.trans ha0)),
+      ho1.trans (hb1.trans (hw1.trans ha1))⟩
+  obtain ⟨iadd', hiadd', hiaddval⟩ :=
+    ZiskFv.Compliance.Extraction.iscalar_add_zero_ok
+      (UScalar.hcast IScalarTy.I64 i.rd)
+  rw [hadd] at hiadd'
+  injection hiadd' with hiadd'
+  obtain ⟨hso, hst⟩ := store_reg_i64_index_pins z4 z5 iadd
+    (by rw [hiadd', hiaddval,
+      ZiskFv.Compliance.Extraction.hcast_u32_i64_val]; omega)
+    (by rw [hiadd', hiaddval,
+      ZiskFv.Compliance.Extraction.hcast_u32_i64_val]; exact_mod_cast hrd)
+    hbase.1 hbase.2 h5
+  obtain ⟨hjs, hjst⟩ := j_pres_store _ _ _ _ h6
+  obtain ⟨hbs, hbo, _, _⟩ := src_b_ind_full_pins z2 z3 _ _ h3
+  obtain ⟨hos, _, hol⟩ := op_zisk_pres_b z3 z4 op h4
+  obtain ⟨hss, _, hsl⟩ := store_reg_pres_b z4 z5 _ _ _ h5
+  obtain ⟨hjsb, _, hjlb⟩ := j_pres_b z5 z6 _ _ h6
+  obtain ⟨hj1, hj2⟩ := ZiskFv.Compliance.Extraction.j_jmp _ _ _ _ h6
+  have hiw2 := hiw _ _ h2
+  have hiw3 := (ZiskFv.Compliance.Extraction.src_b_ind_set _ _ _ _ h3).2
+  have hiw4 := (ZiskFv.Compliance.Extraction.op_zisk_pres_data _ _ _ h4).1
+  have hiw5 := (ZiskFv.Compliance.Extraction.store_reg_pres_data _ _ _ _ _ h5).1
+  have hiw6 := (ZiskFv.Compliance.Extraction.j_pres_data _ _ _ _ h6).1
+  have hz := ZiskFv.Compliance.Extraction.build_eq _ _ h7
+  refine ⟨z7, ZiskFv.Compliance.Extraction.insert_inst_extract _ _ _ _ h8,
+    ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · rw [hz, hiw6, hiw5, hiw4, hiw3, hiw2]
+  · rw [hz, hjsb, hss, hos, hbs]
+  · rw [hz, hjlb, hsl, hol, hbo]
+  · rw [hz, hjs, hso, hiadd', hiaddval,
+      ZiskFv.Compliance.Extraction.hcast_u32_i64_val]
+  · rw [hz]
+    exact fun hh => hst (hjst.symm.trans hh)
+  · rw [hz, hj1]
+  · rw [hz, hj2]
+
+#print axioms load_op_typed_full_pins
 
 /-! ## Generic load / store decode-field bridge (adds `ind_width` to the register one). -/
 

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingLoadStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingLoadStore.lean
@@ -55,6 +55,9 @@ set_option linter.unusedSimpArgs false
 
 /-! ## Generic load / store decode-field bridge (adds `ind_width` to the register one). -/
 
+private theorem loadstore_hcast4 :
+    (UScalar.hcast IScalarTy.I64 4#u64 : Std.I64).val = (4 : Int) := by decide
+
 /-- The committed message's load/store decode fields (incl. `ind_width`), from its
     raw word binding.  Extends `register_decode_fields_of_binding` with the access
     width that the load/store ROM lookup reads. -/
@@ -72,13 +75,17 @@ theorem loadstore_decode_fields_of_binding
     (hbind : msg = romMessageOfRaw line raw) :
     msg.op = opF ∧ msg.jmp_offset1 = 4 ∧ msg.jmp_offset2 = 4 ∧ msg.ind_width = wF
       ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
-  obtain ⟨ho, hjo1, hjo2, hf⟩ :=
-    register_decode_fields_of_binding line msg raw opc opF ext hopF hok hop hj1 hj2 hbind
-  refine ⟨ho, hjo1, hjo2, ?_, hf⟩
   have hmsg : msg = serializeExtract line ext.row := by
     rw [hbind, romMessageOfRaw, hok]
     exact romRowOf_eq_serializeExtract line ext.row
-  rw [hmsg]; show (ext.row.ind_width.val : FGL) = wF; rw [hiw]; exact hwF
+  refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  · rw [hmsg]; show romOpcode ext.row.op = opF; rw [hop, hopF]
+  · rw [hmsg]; show (ext.row.jmp_offset1.val : FGL) = 4
+    rw [hj1]; norm_num [loadstore_hcast4]
+  · rw [hmsg]; show (ext.row.jmp_offset2.val : FGL) = 4
+    rw [hj2]; norm_num [loadstore_hcast4]
+  · rw [hmsg]; show (ext.row.ind_width.val : FGL) = wF; rw [hiw]; exact hwF
+  · rw [hmsg]; rfl
 
 /-! ## Generic load-family transpile reduction (I-type word, `decode_i … false`). -/
 
@@ -332,10 +339,17 @@ theorem sd_decode_fields_of_binding (rs1 rs2 imm : Nat) (hrs1 : rs1 < 32) (hrs2 
           ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
           ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
   obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, _, hj1, hj2⟩ := transpile_sd rs1 rs2 imm hrs1 hrs2
-  obtain ⟨ho, hjo1, hjo2, hf⟩ :=
-    register_decode_fields_of_binding line msg _ 1#u8 OP_COPYB ext
-      (by simp [romOpcode, OP_COPYB]) hok hop hj1 hj2 hbind
-  exact ⟨ho, hjo1, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
+  have hmsg : msg = serializeExtract line ext.row := by
+    rw [hbind, romMessageOfRaw, hok]
+    exact romRowOf_eq_serializeExtract line ext.row
+  refine ⟨?_, ?_, ?_, ext, hok, hieo, hm32, hsetpc, hstorepc, ?_⟩
+  · rw [hmsg]; show romOpcode ext.row.op = OP_COPYB
+    rw [hop]; simp [romOpcode, OP_COPYB]
+  · rw [hmsg]; show (ext.row.jmp_offset1.val : FGL) = 4
+    rw [hj1]; norm_num [loadstore_hcast4]
+  · rw [hmsg]; show (ext.row.jmp_offset2.val : FGL) = 4
+    rw [hj2]; norm_num [loadstore_hcast4]
+  · rw [hmsg]; rfl
 
 /-! ## SIGNEXTEND loads (LB/LH/LW, issue #159 block 3).  These lower to the
     `BinaryE`/`SignExtend*` op (external, `is_external_op = true`), so their ROM

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingLoadStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingLoadStore.lean
@@ -182,6 +182,115 @@ theorem load_op_typed_full_pins
 
 #print axioms load_op_typed_full_pins
 
+theorem src_b_reg_not_ind (self z : zisk_inst_builder.ZiskInstBuilder)
+    (reg : Std.U64) (usp : Bool) (h : self.src_b_reg reg usp = ok z) :
+    z.i.b_src ≠ zisk_inst.SRC_IND := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.src_b_reg,
+    zisk_inst_builder.ZiskInstBuilder.src_b_imm,
+    zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO,
+    zisk_registers.REG_FIRST, mem.SYS_ADDR, mem.RAM_ADDR,
+    lift, Bind.bind, bind_ok] at h
+  split_ifs at h <;> (try simp only [bind_ok] at h) <;>
+    first
+    | (rw [Result.ok.injEq] at h; subst h
+       simp [zisk_inst.SRC_IMM, zisk_inst.SRC_REG, zisk_inst.SRC_MEM,
+         zisk_inst.SRC_IND])
+    | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+       rw [Result.ok.injEq] at h; subst h
+       simp [zisk_inst.SRC_IMM, zisk_inst.SRC_REG, zisk_inst.SRC_MEM,
+         zisk_inst.SRC_IND])
+    | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+       obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+       rw [Result.ok.injEq] at h; subst h
+       simp [zisk_inst.SRC_IMM, zisk_inst.SRC_REG, zisk_inst.SRC_MEM,
+         zisk_inst.SRC_IND])
+
+theorem store_ind_full_pins (self z : zisk_inst_builder.ZiskInstBuilder)
+    (off : Std.I64) (usp : Bool) (h : self.store_ind off usp = ok z) :
+    z.i.store = zisk_inst.STORE_IND ∧ z.i.store_offset = off
+      ∧ z.i.b_src = self.i.b_src ∧ z.i.ind_width = self.i.ind_width := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.store_ind, zisk_inst.STORE_IND] at h
+  rw [Result.ok.injEq] at h
+  subst z
+  exact ⟨by simp [zisk_inst.STORE_IND], rfl, rfl, rfl⟩
+
+theorem ind_width_pres_b (self z : zisk_inst_builder.ZiskInstBuilder)
+    (w : Std.U64) (h : self.ind_width w = ok z) :
+    z.i.b_src = self.i.b_src := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.ind_width] at h
+  split at h <;>
+    first
+    | (rw [Result.ok.injEq] at h; subst h; rfl)
+    | simp at h
+
+theorem store_op_typed_full_pins
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp)
+    (w inst_size wval : Std.U64) (ctx : riscv2zisk_context.Riscv2ZiskContext)
+    (hiw : ∀ (s z : zisk_inst_builder.ZiskInstBuilder),
+      s.ind_width w = ok z → z.i.ind_width = wval)
+    (h : self.store_op_typed i op w inst_size = ok ctx) :
+    ∃ zib, ctx.extract_inst = some zib
+      ∧ zib.i.ind_width = wval
+      ∧ zib.i.b_src ≠ zisk_inst.SRC_IND
+      ∧ zib.i.store = zisk_inst.STORE_IND
+      ∧ zib.i.store_offset = IScalar.cast IScalarTy.I64 i.imm
+      ∧ zib.i.jmp_offset1 = UScalar.hcast IScalarTy.I64 inst_size
+      ∧ zib.i.jmp_offset2 = UScalar.hcast IScalarTy.I64 inst_size
+      ∧ zib.i.set_pc = false ∧ zib.i.store_pc = false
+      ∧ zisk_ops.ZiskOp.code op = ok zib.i.op
+      ∧ zisk_ops.ZiskOp.is_m32 op = ok zib.i.m32
+      ∧ ∃ ot, zisk_ops.ZiskOp.op_type op = ok ot
+        ∧ zib.i.is_external_op = extBit ot := by
+  have hpins :=
+    ZiskFv.Compliance.Extraction.store_op_typed_pins self i op w inst_size ctx h
+  simp only [riscv2zisk_context.Riscv2ZiskContext.store_op_typed,
+    Bind.bind, bind_ok] at h
+  obtain ⟨s1, hs1, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  rw [Result.ok.injEq] at h
+  subst h
+  simp only [riscv2zisk_context.Riscv2ZiskContext.store_op_with_reg_offset,
+    lift, Bind.bind, bind_ok] at hs1
+  obtain ⟨z0, h0, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨z1, h1, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨ioff, hoff, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨z2, h2, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨z3, h3, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨z4, h4, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨z5, h5, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨z6, h6, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨z7, h7, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  obtain ⟨s2, h8, hs1⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hs1
+  rw [Result.ok.injEq] at hs1
+  subst hs1
+  have hb2 := src_b_reg_not_ind z1 z2 _ _ h2
+  obtain ⟨hb3, _, _⟩ := op_zisk_pres_b z2 z3 op h3
+  have hb4 := ind_width_pres_b _ _ _ h4
+  obtain ⟨hst5, hso5, hb5, hiw5⟩ := store_ind_full_pins z4 z5 _ _ h5
+  obtain ⟨hjb, _, _⟩ := j_pres_b z5 z6 _ _ h6
+  obtain ⟨hj1, hj2⟩ := ZiskFv.Compliance.Extraction.j_jmp _ _ _ _ h6
+  have hiw4 := hiw _ _ h4
+  have hiw6 := (ZiskFv.Compliance.Extraction.j_pres_data _ _ _ _ h6).1
+  obtain ⟨hjs, hjst⟩ := j_pres_store _ _ _ _ h6
+  have hz := ZiskFv.Compliance.Extraction.build_eq _ _ h7
+  obtain ⟨zp, hzp, hsp, hstp, hcode, hm32, ot, hot, hext⟩ := hpins
+  have heq : zp = z7 := by
+    rw [ZiskFv.Compliance.Extraction.insert_inst_extract _ _ _ _ h8] at hzp
+    injection hzp with heq
+    exact heq.symm
+  subst zp
+  refine ⟨z7, ZiskFv.Compliance.Extraction.insert_inst_extract _ _ _ _ h8,
+    ?_, ?_, ?_, ?_, ?_, ?_, hsp, hstp, hcode, hm32, ot, hot, hext⟩
+  · rw [hz, hiw6, hiw5, hiw4]
+  · rw [hz, hjb, hb5, hb4, hb3]
+    exact hb2
+  · rw [hz, hjst, hst5]
+  · rw [hz, hjs, hso5]
+  · rw [hz, hj1]
+  · rw [hz, hj2]
+
+#print axioms store_op_typed_full_pins
+
 /-! ## Generic load / store decode-field bridge (adds `ind_width` to the register one). -/
 
 private theorem loadstore_hcast4 :

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingMemoryNonvacuity.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingMemoryNonvacuity.lean
@@ -1,0 +1,705 @@
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingLoadStore
+import ZiskFv.Compliance.EnsembleWitnessBuilder
+import ZiskFv.AirsClean.FullEnsemble.Balance.Classification
+
+/-!
+# Raw memory-program binding non-vacuity
+
+An all-empty execution witness can still commit a non-empty ROM image.  This
+kernel witness uses that separation to exercise production serialization for
+SD, LD at offset zero, and LD at signed offset `-8`, without fabricating a
+mutable-memory execution timeline.
+-/
+
+open Goldilocks
+open Air.Flat
+open ZiskFv.Compliance.Extraction
+  (defCtx decode_i_bounds decode_s_bounds load_op_typed_ok store_op_typed_ok ind_width_set8
+   decode_extract_ok from_inst_full_fields load_static_pins_of)
+
+namespace ZiskFv.Compliance.RawProgramBinding
+
+open ZiskFv.AirsClean.FullEnsemble (fullRv64imEnsemble fullRv64imSoundEnsemble)
+open ZiskFv.AirsClean.ZiskInstructionRom (Program)
+open ZiskFv.Channels.ZiskRomBus (ZiskRomMessage)
+open Aeneas Aeneas.Std Result zisk_core
+
+set_option maxHeartbeats 8000000
+set_option maxRecDepth 10000
+
+def memorySdRow : ZiskRomMessage FGL :=
+  { line := 0, a_offset_imm0 := 1, a_imm1 := 0, b_offset_imm0 := 2, b_imm1 := 0,
+    ind_width := 8, op := 1, store_offset := 0, jmp_offset1 := 4,
+    jmp_offset2 := 4, flags := 25089 }
+
+def memoryLdZeroRow : ZiskRomMessage FGL :=
+  { line := 4, a_offset_imm0 := 1, a_imm1 := 0, b_offset_imm0 := 0, b_imm1 := 0,
+    ind_width := 8, op := 1, store_offset := 3, jmp_offset1 := 4,
+    jmp_offset2 := 4, flags := 45057 }
+
+def memoryLdNegativeRow : ZiskRomMessage FGL :=
+  { line := 8, a_offset_imm0 := 1, a_imm1 := 0,
+    b_offset_imm0 := 18446744069414584313, b_imm1 := 0,
+    ind_width := 8, op := 1, store_offset := 4, jmp_offset1 := 4,
+    jmp_offset2 := 4, flags := 45057 }
+
+def memoryProgram : Program 3
+  | ⟨0, _⟩ => memorySdRow
+  | ⟨1, _⟩ => memoryLdZeroRow
+  | ⟨2, _⟩ => memoryLdNegativeRow
+
+private def emptyData : ProverData FGL := fun _ _ => #[]
+
+private def memoryWitness : EnsembleWitness (fullRv64imEnsemble 3 memoryProgram).ensemble :=
+  EnsembleWitness.ofRows (fullRv64imEnsemble 3 memoryProgram).ensemble emptyData ()
+    (fun _ => []) (by intro i row hrow; simp at hrow)
+    (by intro i columns hcolumns; simp)
+
+private theorem memoryWitness_verifier :
+    (fullRv64imEnsemble 3 memoryProgram).ensemble.verifier = .empty FGL unit :=
+  (fullRv64imSoundEnsemble 3 memoryProgram).verifier_empty
+
+private theorem memoryWitness_mutable_tables_empty (table : Table FGL)
+    (hmem : table ∈ memoryWitness.allTables)
+    (hcomp : table.component = ZiskFv.AirsClean.Mem.componentWithDualMemBus) :
+    table.table = [] := by
+  rw [EnsembleWitness.allTables, List.mem_cons] at hmem
+  rcases hmem with hv | ht
+  · exfalso
+    rw [hv, EnsembleWitness.verifierTable_component] at hcomp
+    have hvnil :=
+      ZiskFv.AirsClean.FullEnsemble.verifierTable_interactionsWith_memBus_nil 3 memoryProgram
+    rw [hcomp,
+      ZiskFv.AirsClean.Mem.componentWithDualMemBus_interactionsWith_memBus] at hvnil
+    exact absurd hvnil (by simp)
+  · simp only [memoryWitness, EnsembleWitness.ofRows_tables, List.mem_ofFn] at ht
+    obtain ⟨i, rfl⟩ := ht
+    simp [EnsembleWitness.tableAt, Table.table]
+    split <;> rfl
+
+private theorem memoryWitness_not_mutableMemPresent :
+    ¬ MutableMemPresent memoryWitness := by
+  intro hpresent
+  obtain ⟨table, hmem, hcomp, hlen⟩ := hpresent
+  have htable := memoryWitness_mutable_tables_empty table hmem hcomp
+  exact absurd hlen (by simp [htable])
+
+private theorem memoryWitness_constraints : memoryWitness.Constraints := by
+  refine memoryWitness.constraints_of_tables memoryWitness_verifier ?_
+  intro t ht
+  simp only [memoryWitness, EnsembleWitness.ofRows_tables, List.mem_ofFn] at ht
+  obtain ⟨i, rfl⟩ := ht
+  simp [Air.Flat.Table.Constraints, EnsembleWitness.tableAt, Table.table]
+  split <;> simp
+
+private theorem memoryWitness_balanced : memoryWitness.BalancedChannels := by
+  refine memoryWitness.balancedChannels_of_tables memoryWitness_verifier ?_
+  intro channel _
+  have hnil : memoryWitness.tables.flatMap (·.interactionsWith channel) = [] := by
+    rw [List.flatMap_eq_nil_iff]
+    intro t ht
+    simp only [memoryWitness, EnsembleWitness.ofRows_tables, List.mem_ofFn] at ht
+    obtain ⟨i, rfl⟩ := ht
+    simp [Air.Flat.Table.interactionsWith, EnsembleWitness.tableAt, Table.table]
+    split <;> simp
+  rw [hnil]
+  exact balancedInteractions_of_present (Or.symm (Nat.eq_zero_or_pos _)) []
+    (by simp) (by simp)
+
+private theorem memoryWitness_transitions : memoryWitness.TransitionConstraints := by
+  intro table hmem
+  rw [Table.TransitionConstraints]
+  intro index
+  rw [EnsembleWitness.allTables, List.mem_cons] at hmem
+  rcases hmem with hverifier | htable
+  · subst table
+    simp [EnsembleWitness.verifierTable]
+  · simp only [memoryWitness, EnsembleWitness.ofRows_tables, List.mem_ofFn] at htable
+    obtain ⟨i, rfl⟩ := htable
+    change Fin 0 at index
+    exact Fin.elim0 index
+
+private theorem memoryWitness_cyclic :
+    memoryWitness.CyclicSuccessorTransitionConstraints := by
+  intro table hmem
+  rw [Table.CyclicSuccessorTransitionConstraints]
+  intro index
+  rw [EnsembleWitness.allTables, List.mem_cons] at hmem
+  rcases hmem with hverifier | htable
+  · subst table
+    simp [EnsembleWitness.verifierTable]
+  · simp only [memoryWitness, EnsembleWitness.ofRows_tables, List.mem_ofFn] at htable
+    obtain ⟨i, rfl⟩ := htable
+    change Fin 0 at index
+    exact Fin.elim0 index
+
+def memoryAcceptedTrace : AcceptedZiskTrace 0 where
+  programLength := 3
+  program := memoryProgram
+  witness := memoryWitness
+  constraints_hold := memoryWitness_constraints
+  channels_balanced := memoryWitness_balanced
+  mem_replay_table := fun h => absurd h memoryWitness_not_mutableMemPresent
+  mem_replay_source_covers := fun h => absurd h memoryWitness_not_mutableMemPresent
+  transitions_hold := memoryWitness_transitions
+  cyclic_successor_transitions_hold := memoryWitness_cyclic
+  main_height := by intro table _ _ i; exact i.elim0
+
+def memoryAddr : Fin memoryAcceptedTrace.programLength → FGL
+  | ⟨0, _⟩ => 0
+  | ⟨1, _⟩ => 4
+  | ⟨2, _⟩ => 8
+
+def memoryRawProgram : Fin memoryAcceptedTrace.programLength → BitVec 32
+  | ⟨0, _⟩ => ZiskFv.Completeness.Rv64imShapes.rawSType 0 2 1 3
+  | ⟨1, _⟩ => ZiskFv.Completeness.Rv64imShapes.rawIType 0 1 3 3 0x03
+  | ⟨2, _⟩ => ZiskFv.Completeness.Rv64imShapes.rawIType 4088 1 3 4 0x03
+
+private def operandFields (before after : zisk_inst_builder.ZiskInstBuilder) : Prop :=
+  after.i.a_src = before.i.a_src
+    ∧ after.i.a_use_sp_imm1 = before.i.a_use_sp_imm1
+    ∧ after.i.a_offset_imm0 = before.i.a_offset_imm0
+    ∧ after.i.b_src = before.i.b_src
+    ∧ after.i.b_use_sp_imm1 = before.i.b_use_sp_imm1
+    ∧ after.i.b_offset_imm0 = before.i.b_offset_imm0
+
+private theorem operandFields_trans {a b c : zisk_inst_builder.ZiskInstBuilder}
+    (hab : operandFields a b) (hbc : operandFields b c) : operandFields a c := by
+  rcases hab with ⟨ha1, ha2, ha3, hb1, hb2, hb3⟩
+  rcases hbc with ⟨ha1', ha2', ha3', hb1', hb2', hb3'⟩
+  exact ⟨ha1'.trans ha1, ha2'.trans ha2, ha3'.trans ha3,
+    hb1'.trans hb1, hb2'.trans hb2, hb3'.trans hb3⟩
+
+private theorem operandFields_op_zisk (self z : zisk_inst_builder.ZiskInstBuilder)
+    (op : zisk_ops.ZiskOp) (h : self.op_zisk op = ok z) : operandFields self z := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.op_zisk,
+    zisk_inst_builder.ZiskInstBuilder.set_runtime_op_fields,
+    core.convert.IntoFrom.into,
+    zisk_inst.ZiskOperationType.Insts.CoreConvertFromOpType.from, Bind.bind] at h
+  obtain ⟨ot, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨b, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨cval, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨self1, hself1, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨zot, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨i1, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨mval, _, h4⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hself1
+  rw [Result.ok.injEq] at h h4
+  subst h
+  subst h4
+  exact ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+
+private theorem operandFields_ind_width (self z : zisk_inst_builder.ZiskInstBuilder)
+    (w : Std.U64) (h : self.ind_width w = ok z) : operandFields self z := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.ind_width] at h
+  split at h <;>
+    first
+    | (rw [Result.ok.injEq] at h; subst z;
+       exact ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩)
+    | simp at h
+
+private theorem operandFields_store_ind (self z : zisk_inst_builder.ZiskInstBuilder)
+    (off : Std.I64) (usp : Bool) (h : self.store_ind off usp = ok z) :
+    operandFields self z := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.store_ind] at h
+  rw [Result.ok.injEq] at h
+  subst z
+  exact ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+
+private theorem operandFields_j (self z : zisk_inst_builder.ZiskInstBuilder)
+    (j1 j2 : Std.I64) (h : self.j j1 j2 = ok z) : operandFields self z := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.j, bind_ok, Bind.bind] at h
+  rw [Result.ok.injEq] at h
+  subst z
+  exact ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+
+private theorem operandFields_build (self z : zisk_inst_builder.ZiskInstBuilder)
+    (h : self.build = ok z) : operandFields self z := by
+  rw [ZiskFv.Compliance.Extraction.build_eq self z h]
+  exact ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+
+private theorem op_zisk_copyb_precompiled (self z : zisk_inst_builder.ZiskInstBuilder)
+    (h : self.op_zisk zisk_ops.ZiskOp.CopyB = ok z) : z.i.is_precompiled = false := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.op_zisk,
+    zisk_inst_builder.ZiskInstBuilder.set_runtime_op_fields,
+    zisk_ops.ZiskOp.op_type, zisk_ops.ZiskOp.code, zisk_ops.ZiskOp.is_m32,
+    zisk_ops.ZiskOp.input_size, core.convert.IntoFrom.into,
+    zisk_inst.ZiskOperationType.Insts.CoreConvertFromOpType.from, Bind.bind] at h
+  simp only [bind_ok, Bind.bind] at h
+  rw [Result.ok.injEq] at h
+  subst z
+  norm_num [memoryLdZeroRow, romMessageOfRaw]
+
+private theorem precompiled_pres_ind_width (self z : zisk_inst_builder.ZiskInstBuilder)
+    (w : Std.U64) (h : self.ind_width w = ok z) :
+    z.i.is_precompiled = self.i.is_precompiled := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.ind_width] at h
+  split at h <;>
+    first
+    | (rw [Result.ok.injEq] at h; subst z; rfl)
+    | simp at h
+
+private theorem precompiled_pres_store_ind (self z : zisk_inst_builder.ZiskInstBuilder)
+    (off : Std.I64) (usp : Bool) (h : self.store_ind off usp = ok z) :
+    z.i.is_precompiled = self.i.is_precompiled := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.store_ind] at h
+  rw [Result.ok.injEq] at h
+  subst z
+  norm_num [memoryLdNegativeRow, romMessageOfRaw]
+
+private theorem precompiled_pres_j (self z : zisk_inst_builder.ZiskInstBuilder)
+    (j1 j2 : Std.I64) (h : self.j j1 j2 = ok z) :
+    z.i.is_precompiled = self.i.is_precompiled := by
+  simp only [zisk_inst_builder.ZiskInstBuilder.j, Bind.bind] at h
+  rw [Result.ok.injEq] at h
+  subst z
+  rfl
+
+theorem memorySdRow_eq_romMessageOfRaw :
+    memorySdRow =
+      romMessageOfRaw 0 (ZiskFv.Completeness.Rv64imShapes.rawSType 0 2 1 3) := by
+  let raw := ZiskFv.Compliance.Decode.toU32
+    (ZiskFv.Completeness.Rv64imShapes.rawSType 0 2 1 3)
+  obtain ⟨decoded, hdecoded, hopd, hrs1b, hrs2b⟩ :=
+    decode_s_bounds raw aeneas_extract.rv64im_decode.RiscvOpcode.Sd
+  have hdec0 : aeneas_extract.rv64im_decode.decode_32_core raw = ok decoded := by
+    rw [show aeneas_extract.rv64im_decode.decode_32_core raw =
+        aeneas_extract.rv64im_decode.decode_s raw
+          aeneas_extract.rv64im_decode.RiscvOpcode.Sd by
+      simp only [raw, aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc,
+        Bind.bind, bind_ok, ZiskFv.Compliance.Decode.toU32_and127,
+        ZiskFv.Compliance.Decode.toU32_and7, ZiskFv.Compliance.Decode.toU32_shr12,
+        ZiskFv.Compliance.Decode.toU32_ofNat,
+        ZiskFv.Compliance.Decode.rawSType_opcode 0 2 1 3,
+        ZiskFv.Compliance.Decode.rawSType_funct3 0 2 1 3 (by norm_num)]
+      all_goals rfl]
+    exact hdecoded
+  have hraw : raw = 2142243#u32 := by rfl
+  rw [hraw] at hdecoded
+  rw [aeneas_extract.rv64im_decode.decode_s] at hdecoded
+  simp only [aeneas_extract.rv64im_decode.DecodedRv64im.new, lift, bind_ok, Bind.bind] at hdecoded
+  obtain ⟨funct3, hfunct3, hdecoded⟩ :=
+    ZiskFv.Compliance.Extraction.bind_eq_ok_imp hdecoded
+  obtain ⟨imm4, himm4, hdecoded⟩ :=
+    ZiskFv.Compliance.Extraction.bind_eq_ok_imp hdecoded
+  obtain ⟨rs1, hrs1, hdecoded⟩ :=
+    ZiskFv.Compliance.Extraction.bind_eq_ok_imp hdecoded
+  obtain ⟨rs2, hrs2, hdecoded⟩ :=
+    ZiskFv.Compliance.Extraction.bind_eq_ok_imp hdecoded
+  obtain ⟨imm11, himm11, hdecoded⟩ :=
+    ZiskFv.Compliance.Extraction.bind_eq_ok_imp hdecoded
+  obtain ⟨immHigh, himmHigh, hdecoded⟩ :=
+    ZiskFv.Compliance.Extraction.bind_eq_ok_imp hdecoded
+  obtain ⟨imm, himm, hdecoded⟩ :=
+    ZiskFv.Compliance.Extraction.bind_eq_ok_imp hdecoded
+  change ok 3#u32 = ok funct3 at hfunct3
+  change ok 0#u32 = ok imm4 at himm4
+  change ok 1#u32 = ok rs1 at hrs1
+  change ok 2#u32 = ok rs2 at hrs2
+  change ok 0#u32 = ok imm11 at himm11
+  simp only [Result.ok.injEq] at hfunct3 himm4 hrs1 hrs2 himm11
+  subst funct3
+  subst imm4
+  subst rs1
+  subst rs2
+  subst imm11
+  change ok 0#u32 = ok immHigh at himmHigh
+  simp only [Result.ok.injEq] at himmHigh
+  subst immHigh
+  change ok 0#i32 = ok imm at himm
+  simp only [Result.ok.injEq] at himm
+  subst imm
+  rw [Result.ok.injEq] at hdecoded
+  set input : riscv2zisk_single_row.Rv64imLoweringInput :=
+    { rom_address := 0#u64, rd := decoded.rd, rs1 := decoded.rs1,
+      rs2 := decoded.rs2, imm := decoded.imm } with hinput
+  obtain ⟨ctx, hctx⟩ :=
+    store_op_typed_ok { defCtx with extract_marker := () } input zisk_ops.ZiskOp.CopyB
+      8#u64 4#u64 (fun _ => ⟨_, rfl⟩) hrs1b hrs2b
+  obtain ⟨zib, hzib, hiw, hb, hstore, hstoreOffset, hj1, hj2, hsetPc, hstorePc,
+      hop, hm32, ot, hot, hext⟩ :=
+    store_op_typed_full_pins { defCtx with extract_marker := () } input
+      zisk_ops.ZiskOp.CopyB 8#u64 4#u64 8#u64 ctx ind_width_set8 hctx
+  have hctxFields := hctx
+  simp only [riscv2zisk_context.Riscv2ZiskContext.store_op_typed,
+    Bind.bind, bind_ok] at hctxFields
+  obtain ⟨ctxBase, hctxBase, hctxFields⟩ :=
+    ZiskFv.Compliance.Extraction.bind_eq_ok_imp hctxFields
+  rw [Result.ok.injEq] at hctxFields
+  subst ctx
+  simp only [riscv2zisk_context.Riscv2ZiskContext.store_op_with_reg_offset,
+    lift, Bind.bind, bind_ok] at hctxBase
+  obtain ⟨z0, hz0, hctxFields⟩ :=
+    ZiskFv.Compliance.Extraction.bind_eq_ok_imp hctxBase
+  obtain ⟨z1, hz1, hctxFields⟩ :=
+    ZiskFv.Compliance.Extraction.bind_eq_ok_imp hctxFields
+  obtain ⟨off, hoff, hctxFields⟩ :=
+    ZiskFv.Compliance.Extraction.bind_eq_ok_imp hctxFields
+  obtain ⟨z2, hz2, hctxFields⟩ :=
+    ZiskFv.Compliance.Extraction.bind_eq_ok_imp hctxFields
+  obtain ⟨z3, hz3, hctxFields⟩ :=
+    ZiskFv.Compliance.Extraction.bind_eq_ok_imp hctxFields
+  obtain ⟨z4, hz4, hctxFields⟩ :=
+    ZiskFv.Compliance.Extraction.bind_eq_ok_imp hctxFields
+  obtain ⟨z5, hz5, hctxFields⟩ :=
+    ZiskFv.Compliance.Extraction.bind_eq_ok_imp hctxFields
+  obtain ⟨z6, hz6, hctxFields⟩ :=
+    ZiskFv.Compliance.Extraction.bind_eq_ok_imp hctxFields
+  obtain ⟨z7, hz7, hctxFields⟩ :=
+    ZiskFv.Compliance.Extraction.bind_eq_ok_imp hctxFields
+  obtain ⟨ctx', hctxInsert, hctxFields⟩ :=
+    ZiskFv.Compliance.Extraction.bind_eq_ok_imp hctxFields
+  rw [Result.ok.injEq] at hctxFields
+  subst hctxFields
+  have hctxExtract : ctx'.extract_inst = some z7 :=
+    ZiskFv.Compliance.Extraction.insert_inst_extract _ _ _ _ hctxInsert
+  have hopFields : operandFields z2 z3 := operandFields_op_zisk z2 z3 _ hz3
+  have hiwFields : operandFields z3 z4 := operandFields_ind_width z3 z4 _ hz4
+  have hstoreFields : operandFields z4 z5 := operandFields_store_ind z4 z5 _ _ hz5
+  have hjFields : operandFields z5 z6 := operandFields_j z5 z6 _ _ hz6
+  have hbuildFields : operandFields z6 z7 := operandFields_build z6 z7 hz7
+  have hfinalFields : operandFields z2 z7 :=
+    operandFields_trans hopFields
+      (operandFields_trans hiwFields
+        (operandFields_trans hstoreFields (operandFields_trans hjFields hbuildFields)))
+  have hpre3 : z3.i.is_precompiled = false := op_zisk_copyb_precompiled z2 z3 hz3
+  have hpre4 : z4.i.is_precompiled = false :=
+    (precompiled_pres_ind_width z3 z4 _ hz4).trans hpre3
+  have hpre5 := precompiled_pres_store_ind z4 z5 _ _ hz5
+  have hpre6 := precompiled_pres_j z5 z6 _ _ hz6
+  have hpre7 : z7.i.is_precompiled = false := by
+    rw [(ZiskFv.Compliance.Extraction.build_eq z6 z7 hz7)]
+    exact hpre6.trans (hpre5.trans hpre4)
+  simp only [zisk_inst_builder.ZiskInstBuilder.new_for_rv64im_lowering,
+    zisk_inst_builder.ZiskInstBuilder.new, input, ← hdecoded, Result.ok.injEq] at hz0
+  have hz1Saved := hz1
+  norm_num [input, ← hdecoded, zisk_inst_builder.ZiskInstBuilder.src_a_reg,
+    zisk_inst_builder.ZiskInstBuilder.src_a_imm, zisk_registers.REGS_IN_MAIN_FROM,
+    zisk_registers.REGS_IN_MAIN_TO, zisk_registers.REG_FIRST, mem.SYS_ADDR, mem.RAM_ADDR,
+    lift, Bind.bind, bind_ok] at hz1
+  subst z1
+  have hoffSaved := hoff
+  simp only [input, ← hdecoded] at hoffSaved
+  have hoffCalc : UScalar.cast UScalarTy.U64 2#u32 + 0#u64 = ok 2#u64 := by rfl
+  rw [hoffCalc] at hoffSaved
+  rw [Result.ok.injEq] at hoffSaved
+  subst off
+  norm_num [input, ← hdecoded] at hoff
+  have hz2Saved := hz2
+  norm_num [input, ← hdecoded, zisk_inst_builder.ZiskInstBuilder.src_b_reg,
+    zisk_inst_builder.ZiskInstBuilder.src_b_imm, zisk_registers.REGS_IN_MAIN_FROM,
+    zisk_registers.REGS_IN_MAIN_TO, zisk_registers.REG_FIRST, mem.SYS_ADDR, mem.RAM_ADDR,
+    lift, Bind.bind, bind_ok] at hz2Saved
+  subst z2
+  norm_num [input, ← hdecoded, zisk_inst_builder.ZiskInstBuilder.src_b_reg,
+    zisk_inst_builder.ZiskInstBuilder.src_b_imm, zisk_registers.REGS_IN_MAIN_FROM,
+    zisk_registers.REGS_IN_MAIN_TO, zisk_registers.REG_FIRST, mem.SYS_ADDR, mem.RAM_ADDR,
+    lift, Bind.bind, bind_ok] at hz2
+  have hzibEq : zib = z7 := by
+    rw [hctxExtract] at hzib
+    exact Option.some.inj hzib.symm
+  subst z7
+  obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
+  obtain ⟨row, hrow, haSrc, haUseSp, haOffset, hbSrc, hbUseSp, hbOffset, hrowWidth,
+      hrowOp, hrowStore, hrowStoreOffset, hrowJmp1, hrowJmp2, hrowSetPc, hrowStorePc,
+      hrowExternal, hrowM32⟩ := from_inst_full_fields zib.i
+  have hrowPrecompiled : row.is_precompiled = zib.i.is_precompiled := by
+    simp only [aeneas_extract.ZiskInstExtract.from_inst, lift, Bind.bind, bind_ok] at hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
+  rcases hfinalFields with ⟨haSrcFinal, haUseSpFinal, haOffsetFinal, hbSrcFinal,
+    hbUseSpFinal, hbOffsetFinal⟩
+  have hopVal : zib.i.op = 1#u8 := by
+    change ok 1#u8 = ok zib.i.op at hop
+    exact (Result.ok.inj hop).symm
+  have hm32Val : zib.i.m32 = false := by
+    change ok false = ok zib.i.m32 at hm32
+    exact (Result.ok.inj hm32).symm
+  have hotVal : ot = zisk_ops.OpType.Internal := by
+    change ok zisk_ops.OpType.Internal = ok ot at hot
+    exact (Result.ok.inj hot).symm
+  have hlower :
+      riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+          defCtx input riscv2zisk_single_row.Rv64imSingleRowOpcode.Sd false =
+        ok { ctx' with extract_marker := () } := by
+    rw [show riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        defCtx input riscv2zisk_single_row.Rv64imSingleRowOpcode.Sd false =
+      (do
+        let s ← riscv2zisk_context.Riscv2ZiskContext.store_op_typed
+          { defCtx with extract_marker := () } input zisk_ops.ZiskOp.CopyB 8#u64 4#u64
+        ok { s with extract_marker := () }) by rfl, hctx]
+    rfl
+  let ext : aeneas_extract.Rv64imTranspileExtract :=
+    { accepted := true, decode := dext, row := row }
+  have hextRaw : aeneas_extract.extract_transpile_rv64im_raw raw = ok ext := by
+    rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
+    simp only [bind_ok, Bind.bind, hdext, hopd]
+    simp only [defCtx] at hlower
+    simp only [aeneas_extract.lowering_opcode, riscv2zisk_single_row.Rv64imLoweringInput.new,
+      bind_ok, ← hinput, hlower, hctxExtract, core.option.Option.unwrap, Result.ofOption, hrow, ext]
+  rw [romMessageOfRaw]
+  change memorySdRow =
+    match aeneas_extract.extract_transpile_rv64im_raw raw with
+    | ok ext => romRowOf 0 ext.row
+    | _ => _
+  simp only [hextRaw]
+  rw [romRowOf_eq_serializeExtract]
+  simp only [memorySdRow, serializeExtract, romOpcode, romFlagBitsOfExtract,
+    ZiskFv.AirsClean.Main.packFlags, haSrc, haUseSp, haOffset, hbSrc, hbUseSp, hbOffset,
+    hrowWidth, hrowOp, hrowStore, hrowStoreOffset, hrowJmp1, hrowJmp2, hrowSetPc,
+    hrowStorePc, hrowExternal, hrowM32, hrowPrecompiled, hiw, hstore, hstoreOffset, hj1,
+    hj2, hsetPc,
+    hstorePc, hopVal, hm32Val, hotVal, hext, input, ← hdecoded, ext,
+    hpre7,
+    haSrcFinal, haUseSpFinal, haOffsetFinal, hbSrcFinal, hbUseSpFinal, hbOffsetFinal,
+    hz1Saved,
+    zisk_inst_builder.ZiskInstBuilder.src_a_reg,
+    zisk_inst_builder.ZiskInstBuilder.src_a_imm,
+    zisk_inst_builder.ZiskInstBuilder.src_b_reg,
+    zisk_inst_builder.ZiskInstBuilder.src_b_imm,
+    zisk_inst_builder.ZiskInstBuilder.op_zisk,
+    zisk_inst_builder.ZiskInstBuilder.ind_width,
+    zisk_inst_builder.ZiskInstBuilder.store_ind,
+    zisk_inst_builder.ZiskInstBuilder.j]
+  norm_num [input, ← hdecoded, zisk_inst_builder.ZiskInstBuilder.src_a_reg,
+    zisk_inst_builder.ZiskInstBuilder.src_a_imm,
+    zisk_inst_builder.ZiskInstBuilder.src_b_reg,
+    zisk_inst_builder.ZiskInstBuilder.src_b_imm, zisk_registers.REGS_IN_MAIN_FROM,
+    zisk_registers.REGS_IN_MAIN_TO, zisk_registers.REG_FIRST, mem.SYS_ADDR, mem.RAM_ADDR,
+    lift, Bind.bind, bind_ok] at hz1Saved ⊢
+  norm_num [signedOffset, sourceImmediate, ZiskFv.AirsClean.boolF,
+    zisk_inst.SRC_IMM, zisk_inst.SRC_MEM, zisk_inst.SRC_IND, zisk_inst.SRC_REG,
+    zisk_inst.STORE_MEM, zisk_inst.STORE_IND, zisk_inst.STORE_REG,
+    ZiskFv.Compliance.Extraction.cast_u32_u64_val] at *
+  constructor
+  · decide
+  constructor <;> decide
+
+#print axioms memorySdRow_eq_romMessageOfRaw
+
+theorem memoryLdZeroRow_eq_romMessageOfRaw :
+    memoryLdZeroRow =
+      romMessageOfRaw 4 (ZiskFv.Completeness.Rv64imShapes.rawIType 0 1 3 3 0x03) := by
+  let raw := ZiskFv.Compliance.Decode.toU32
+    (ZiskFv.Completeness.Rv64imShapes.rawIType 0 1 3 3 0x03)
+  obtain ⟨decoded, hdecoded, hopd, hrdb, hrs1b, _⟩ :=
+    decode_i_bounds raw aeneas_extract.rv64im_decode.RiscvOpcode.Ld false
+  have hdec0 : aeneas_extract.rv64im_decode.decode_32_core raw = ok decoded := by
+    rw [show aeneas_extract.rv64im_decode.decode_32_core raw =
+        aeneas_extract.rv64im_decode.decode_i raw
+          aeneas_extract.rv64im_decode.RiscvOpcode.Ld false by
+      simp only [raw, aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc,
+        Bind.bind, bind_ok, ZiskFv.Compliance.Decode.toU32_and127,
+        ZiskFv.Compliance.Decode.toU32_and7, ZiskFv.Compliance.Decode.toU32_shr12,
+        ZiskFv.Compliance.Decode.toU32_ofNat,
+        ZiskFv.Compliance.Decode.rawIType_opcode 0 1 3 3 0x03 (by norm_num),
+        ZiskFv.Compliance.Decode.rawIType_funct3 0 1 3 3 0x03 (by norm_num) (by norm_num)
+          (by norm_num)]
+      all_goals rfl]
+    exact hdecoded
+  obtain ⟨hrd, hrs1, himm⟩ :=
+    decode_i_rawIType_fields 0 1 3 3 0x03 (by norm_num) (by norm_num) (by norm_num)
+      (by norm_num) _ decoded hdecoded
+  have hrs1ne : decoded.rs1.val ≠ 0 := by
+    have hv : decoded.rs1.val = 1 := by
+      simpa only [UScalar.val, BitVec.toNat_ofNat] using congrArg BitVec.toNat hrs1
+    omega
+  have hrs1val : decoded.rs1.val = 1 := by
+    simpa only [UScalar.val, BitVec.toNat_ofNat] using congrArg BitVec.toNat hrs1
+  have hrdne : decoded.rd.val ≠ 0 := by
+    have hv : decoded.rd.val = 3 := by
+      simpa only [UScalar.val, BitVec.toNat_ofNat] using congrArg BitVec.toNat hrd
+    omega
+  have hrdval : decoded.rd.val = 3 := by
+    simpa only [UScalar.val, BitVec.toNat_ofNat] using congrArg BitVec.toNat hrd
+  set input : riscv2zisk_single_row.Rv64imLoweringInput :=
+    { rom_address := 0#u64, rd := decoded.rd, rs1 := decoded.rs1,
+      rs2 := decoded.rs2, imm := decoded.imm } with hinput
+  obtain ⟨ctx, hctx⟩ :=
+    load_op_typed_ok { defCtx with extract_marker := () } input zisk_ops.ZiskOp.CopyB
+      8#u64 4#u64 (fun _ => ⟨_, rfl⟩) (by rw [hinput]; exact hrs1b)
+      (by rw [hinput]; exact hrdb)
+  obtain ⟨zib, hzib, haSrc, haOff, haSp, hbSrc, hbOff, hstoreOff, hstore,
+      hstoreReg, hiw, hj1, hj2, hpre⟩ :=
+    ZiskFv.Compliance.RawProgramBinding.ld_op_typed_nonzero_rs1_full_pins
+      { defCtx with extract_marker := () } input
+      4#u64 8#u64 ctx (by rw [hinput]; exact hrdb) (by rw [hinput]; exact hrs1b)
+      (by rw [hinput]; exact hrs1ne) ind_width_set8 hctx
+  obtain ⟨zib', hzib', hop, hext, hm32, hsetPc, hstorePc⟩ :=
+    load_static_pins_of { defCtx with extract_marker := () } input zisk_ops.ZiskOp.CopyB
+      8#u64 4#u64 ctx 1#u8 false false zisk_ops.OpType.Internal rfl rfl rfl rfl hctx
+  have hz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
+  subst zib'
+  have haOffEq : zib.i.a_offset_imm0 = 1#u64 := by
+    apply UScalar.eq_of_val_eq
+    rw [haOff, hinput, hrs1val]
+    rfl
+  have hstoreOffEq : zib.i.store_offset = 3#i64 := by
+    apply IScalar.eq_of_val_eq
+    rw [hstoreOff, hinput, hrdval]
+    rfl
+  obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
+  obtain ⟨row, hrow, hrowASrc, hrowASp, hrowAOff, hrowBSrc, hrowBSp, hrowBOff,
+      hrowWidth, hrowOp, hrowStore, hrowStoreOff, hrowJ1, hrowJ2, hrowSetPc,
+      hrowStorePc, hrowExt, hrowM32⟩ := from_inst_full_fields zib.i
+  have hrowPre : row.is_precompiled = zib.i.is_precompiled := by
+    simp only [aeneas_extract.ZiskInstExtract.from_inst, lift, Bind.bind, bind_ok] at hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
+  have hlower :
+      riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+          defCtx input riscv2zisk_single_row.Rv64imSingleRowOpcode.Ld false =
+        ok { ctx with extract_marker := () } := by
+    rw [show riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        defCtx input riscv2zisk_single_row.Rv64imSingleRowOpcode.Ld false =
+      (do
+        let s ← riscv2zisk_context.Riscv2ZiskContext.load_op_typed
+          { defCtx with extract_marker := () } input zisk_ops.ZiskOp.CopyB 8#u64 4#u64
+        ok { s with extract_marker := () }) by rfl, hctx]
+    rfl
+  let ext : aeneas_extract.Rv64imTranspileExtract :=
+    { accepted := true, decode := dext, row := row }
+  have hextRaw : aeneas_extract.extract_transpile_rv64im_raw raw = ok ext := by
+    rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
+    simp only [bind_ok, Bind.bind, hdext, hopd]
+    simp only [defCtx] at hlower
+    simp only [aeneas_extract.lowering_opcode,
+      riscv2zisk_single_row.Rv64imLoweringInput.new, bind_ok, ← hinput, hlower, hzib,
+      core.option.Option.unwrap, Result.ofOption, hrow, ext]
+  rw [romMessageOfRaw]
+  change memoryLdZeroRow =
+    match aeneas_extract.extract_transpile_rv64im_raw raw with
+    | ok ext => romRowOf 4 ext.row
+    | _ => _
+  simp only [hextRaw, romRowOf_eq_serializeExtract, memoryLdZeroRow, serializeExtract,
+    romOpcode, romFlagBitsOfExtract, ZiskFv.AirsClean.Main.packFlags, hrowASrc, hrowASp,
+    hrowAOff, hrowBSrc, hrowBSp, hrowBOff, hrowWidth, hrowOp, hrowStore, hrowStoreOff,
+    hrowJ1, hrowJ2, hrowSetPc, hrowStorePc, hrowExt, hrowM32, haSrc, haOffEq, haSp,
+    hbSrc, hbOff, hstoreOffEq, hstoreReg hrdne, hiw, hj1, hj2, hpre, hrowPre, hop, hext,
+    hm32, hsetPc, hstorePc, input, ext]
+  norm_num [signedOffset, sourceImmediate, ZiskFv.AirsClean.boolF, zisk_inst.SRC_IMM,
+    zisk_inst.SRC_MEM, zisk_inst.SRC_IND, zisk_inst.SRC_REG, zisk_inst.STORE_MEM,
+    zisk_inst.STORE_IND, zisk_inst.STORE_REG, hrd, hrs1, himm]
+  constructor
+  · decide
+  constructor <;> decide
+
+theorem memoryLdNegativeRow_eq_romMessageOfRaw :
+    memoryLdNegativeRow =
+      romMessageOfRaw 8 (ZiskFv.Completeness.Rv64imShapes.rawIType 4088 1 3 4 0x03) := by
+  let raw := ZiskFv.Compliance.Decode.toU32
+    (ZiskFv.Completeness.Rv64imShapes.rawIType 4088 1 3 4 0x03)
+  obtain ⟨decoded, hdecoded, hopd, hrdb, hrs1b, _⟩ :=
+    decode_i_bounds raw aeneas_extract.rv64im_decode.RiscvOpcode.Ld false
+  have hdec0 : aeneas_extract.rv64im_decode.decode_32_core raw = ok decoded := by
+    rw [show aeneas_extract.rv64im_decode.decode_32_core raw =
+        aeneas_extract.rv64im_decode.decode_i raw
+          aeneas_extract.rv64im_decode.RiscvOpcode.Ld false by
+      simp only [raw, aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc,
+        Bind.bind, bind_ok, ZiskFv.Compliance.Decode.toU32_and127,
+        ZiskFv.Compliance.Decode.toU32_and7, ZiskFv.Compliance.Decode.toU32_shr12,
+        ZiskFv.Compliance.Decode.toU32_ofNat,
+        ZiskFv.Compliance.Decode.rawIType_opcode 4088 1 3 4 0x03 (by norm_num),
+        ZiskFv.Compliance.Decode.rawIType_funct3 4088 1 3 4 0x03 (by norm_num)
+          (by norm_num) (by norm_num)]
+      all_goals rfl]
+    exact hdecoded
+  obtain ⟨hrd, hrs1, himm⟩ :=
+    decode_i_rawIType_fields 4088 1 3 4 0x03 (by norm_num) (by norm_num)
+      (by norm_num) (by norm_num) _ decoded hdecoded
+  have hrs1val : decoded.rs1.val = 1 := by
+    simpa only [UScalar.val, BitVec.toNat_ofNat] using congrArg BitVec.toNat hrs1
+  have hrs1ne : decoded.rs1.val ≠ 0 := by omega
+  have hrdval : decoded.rd.val = 4 := by
+    simpa only [UScalar.val, BitVec.toNat_ofNat] using congrArg BitVec.toNat hrd
+  have hrdne : decoded.rd.val ≠ 0 := by omega
+  set input : riscv2zisk_single_row.Rv64imLoweringInput :=
+    { rom_address := 0#u64, rd := decoded.rd, rs1 := decoded.rs1,
+      rs2 := decoded.rs2, imm := decoded.imm } with hinput
+  obtain ⟨ctx, hctx⟩ :=
+    load_op_typed_ok { defCtx with extract_marker := () } input zisk_ops.ZiskOp.CopyB
+      8#u64 4#u64 (fun _ => ⟨_, rfl⟩) (by rw [hinput]; exact hrs1b)
+      (by rw [hinput]; exact hrdb)
+  obtain ⟨zib, hzib, haSrc, haOff, haSp, hbSrc, hbOff, hstoreOff, hstore,
+      hstoreReg, hiw, hj1, hj2, hpre⟩ :=
+    ZiskFv.Compliance.RawProgramBinding.ld_op_typed_nonzero_rs1_full_pins
+      { defCtx with extract_marker := () } input 4#u64 8#u64 ctx
+      (by rw [hinput]; exact hrdb) (by rw [hinput]; exact hrs1b)
+      (by rw [hinput]; exact hrs1ne) ind_width_set8 hctx
+  obtain ⟨zib', hzib', hop, hext, hm32, hsetPc, hstorePc⟩ :=
+    load_static_pins_of { defCtx with extract_marker := () } input zisk_ops.ZiskOp.CopyB
+      8#u64 4#u64 ctx 1#u8 false false zisk_ops.OpType.Internal rfl rfl rfl rfl hctx
+  have hz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
+  subst zib'
+  have haOffEq : zib.i.a_offset_imm0 = 1#u64 := by
+    apply UScalar.eq_of_val_eq
+    rw [haOff, hinput, hrs1val]
+    rfl
+  have hstoreOffEq : zib.i.store_offset = 4#i64 := by
+    apply IScalar.eq_of_val_eq
+    rw [hstoreOff, hinput, hrdval]
+    rfl
+  obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
+  obtain ⟨row, hrow, hrowASrc, hrowASp, hrowAOff, hrowBSrc, hrowBSp, hrowBOff,
+      hrowWidth, hrowOp, hrowStore, hrowStoreOff, hrowJ1, hrowJ2, hrowSetPc,
+      hrowStorePc, hrowExt, hrowM32⟩ := from_inst_full_fields zib.i
+  have hrowPre : row.is_precompiled = zib.i.is_precompiled := by
+    simp only [aeneas_extract.ZiskInstExtract.from_inst, lift, Bind.bind, bind_ok] at hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
+  have hlower :
+      riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+          defCtx input riscv2zisk_single_row.Rv64imSingleRowOpcode.Ld false =
+        ok { ctx with extract_marker := () } := by
+    rw [show riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        defCtx input riscv2zisk_single_row.Rv64imSingleRowOpcode.Ld false =
+      (do
+        let s ← riscv2zisk_context.Riscv2ZiskContext.load_op_typed
+          { defCtx with extract_marker := () } input zisk_ops.ZiskOp.CopyB 8#u64 4#u64
+        ok { s with extract_marker := () }) by rfl, hctx]
+    rfl
+  let ext : aeneas_extract.Rv64imTranspileExtract :=
+    { accepted := true, decode := dext, row := row }
+  have hextRaw : aeneas_extract.extract_transpile_rv64im_raw raw = ok ext := by
+    rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
+    simp only [bind_ok, Bind.bind, hdext, hopd]
+    simp only [defCtx] at hlower
+    simp only [aeneas_extract.lowering_opcode,
+      riscv2zisk_single_row.Rv64imLoweringInput.new, bind_ok, ← hinput, hlower, hzib,
+      core.option.Option.unwrap, Result.ofOption, hrow, ext]
+  rw [romMessageOfRaw]
+  change memoryLdNegativeRow =
+    match aeneas_extract.extract_transpile_rv64im_raw raw with
+    | ok ext => romRowOf 8 ext.row
+    | _ => _
+  simp only [hextRaw, romRowOf_eq_serializeExtract, memoryLdNegativeRow, serializeExtract,
+    romOpcode, romFlagBitsOfExtract, ZiskFv.AirsClean.Main.packFlags, hrowASrc, hrowASp,
+    hrowAOff, hrowBSrc, hrowBSp, hrowBOff, hrowWidth, hrowOp, hrowStore, hrowStoreOff,
+    hrowJ1, hrowJ2, hrowSetPc, hrowStorePc, hrowExt, hrowM32, haSrc, haOffEq, haSp,
+    hbSrc, hbOff, hstoreOffEq, hstoreReg hrdne, hiw, hj1, hj2, hpre, hrowPre, hop, hext,
+    hm32, hsetPc, hstorePc, input, ext]
+  norm_num [signedOffset, sourceImmediate, ZiskFv.AirsClean.boolF, zisk_inst.SRC_IMM,
+    zisk_inst.SRC_MEM, zisk_inst.SRC_IND, zisk_inst.SRC_REG, zisk_inst.STORE_MEM,
+    zisk_inst.STORE_IND, zisk_inst.STORE_REG, hrd, hrs1, himm]
+  constructor
+  · decide
+  constructor <;> decide
+
+theorem memoryProgramBinding :
+    ProgramBinding memoryAcceptedTrace memoryAddr memoryRawProgram := by
+  constructor
+  · decide
+  · intro k
+    fin_cases k
+    · simp only [memoryAcceptedTrace, memoryProgram, memoryAddr, memoryRawProgram]
+      exact memorySdRow_eq_romMessageOfRaw
+    · simp only [memoryAcceptedTrace, memoryProgram, memoryAddr, memoryRawProgram]
+      exact memoryLdZeroRow_eq_romMessageOfRaw
+    · simp only [memoryAcceptedTrace, memoryProgram, memoryAddr, memoryRawProgram]
+      exact memoryLdNegativeRow_eq_romMessageOfRaw
+
+#print axioms memoryProgramBinding
+
+end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBitfields.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBitfields.lean
@@ -1,0 +1,250 @@
+import ZiskFv.Compliance.AeneasBridgeTrust.Decode.Leaves
+import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.Helpers
+import ZiskFv.Completeness.Rv64im.Shapes
+
+open Aeneas Aeneas.Std Result zisk_core
+open aeneas_extract.rv64im_decode
+open ZiskFv.Compliance.Extraction (bind_eq_ok_imp)
+open ZiskFv.Compliance.Decode (toU32)
+open ZiskFv.Completeness.Rv64imShapes (rawIType rawOfNat32)
+
+attribute [local step] IScalar.sub_bv_spec I32.sub_bv_spec
+
+private theorem mask12_toInt_bounds (v : BitVec 32) :
+    0 ≤ (v &&& 4095#32).toInt ∧ (v &&& 4095#32).toInt ≤ 4095 := by
+  have h : (v &&& 4095#32).toNat ≤ 4095 := by
+    rw [BitVec.toNat_and]
+    exact le_trans Nat.and_le_right (by norm_num)
+  rw [BitVec.toInt]
+  rw [if_pos (by
+    have h' : v.toNat &&& 4095 ≤ 4095 := Nat.and_le_right
+    norm_num
+    omega)]
+  omega
+
+private theorem signExtend12_of_sign (v : BitVec 32)
+    (h : (v &&& 4095#32)[11] = true) :
+    (v &&& 4095#32) - 4096#32 = BitVec.signExtend 32 (v.truncate 12) := by
+  apply BitVec.eq_of_toInt_eq
+  rw [BitVec.toInt_sub, BitVec.toInt_signExtend_of_le (by omega)]
+  have hn : (v &&& 4095#32).toNat ≤ 4095 := by
+    rw [BitVec.toNat_and]
+    exact le_trans Nat.and_le_right (by norm_num)
+  have hlo : 2048 ≤ (v &&& 4095#32).toNat := by
+    by_contra hnlt
+    have ht := Nat.testBit_lt_two_pow
+      (show (v &&& 4095#32).toNat < 2 ^ 11 by omega)
+    have hb : (v &&& 4095#32).toNat.testBit 11 = true := by
+      change (v &&& 4095#32)[11] = true
+      exact h
+    rw [ht] at hb
+    contradiction
+  have htrunc : (v.truncate 12).toNat = (v &&& 4095#32).toNat := by
+    rw [BitVec.toNat_setWidth, BitVec.toNat_and]
+    calc
+      v.toNat % 2 ^ 12 = v.toNat &&& (2 ^ 12 - 1) :=
+        (Nat.and_two_pow_sub_one_eq_mod v.toNat 12).symm
+      _ = v.toNat &&& 4095 := by norm_num
+  have htruncInt : (v.truncate 12).toInt =
+      (v &&& 4095#32).toNat - 4096 := by
+    rw [BitVec.toInt, htrunc]
+    rw [if_neg (by omega)]
+    norm_num
+  have hxInt : (v &&& 4095#32).toInt = (v &&& 4095#32).toNat := by
+    rw [BitVec.toInt, if_pos (by
+      have hn' : v.toNat &&& 4095 ≤ 4095 := Nat.and_le_right
+      norm_num
+      omega)]
+  have h4096 : (4096#32).toInt = 4096 := by decide
+  rw [htruncInt, hxInt, h4096]
+  norm_num [Int.bmod]
+  have hn' : v.toNat &&& 4095 ≤ 4095 := Nat.and_le_right
+  have hlo' : 2048 ≤ v.toNat &&& 4095 := by
+    simpa [BitVec.toNat_and] using hlo
+  have hmod : ((v.toNat &&& 4095 : Nat) - 4096 : Int) % 4294967296 =
+      (v.toNat &&& 4095 : Nat) - 4096 + 4294967296 := by
+    rw [Int.emod_eq_add_self_emod]
+    apply Int.emod_eq_of_lt <;> omega
+  rw [hmod]
+  rw [if_neg (by omega)]
+  omega
+
+private theorem signExtend12_of_not_sign (v : BitVec 32)
+    (h : (v &&& 4095#32)[11] = false) :
+    v &&& 4095#32 = BitVec.signExtend 32 (v.truncate 12) := by
+  symm
+  apply BitVec.eq_of_getLsbD_eq
+  intro i
+  by_cases hi : i < 32
+  · interval_cases i <;>
+      simp [BitVec.getElem_signExtend,
+        BitVec.getElem_setWidth, BitVec.msb_setWidth] at h ⊢ <;> assumption
+  · simp [BitVec.getLsbD_signExtend, hi]
+
+private theorem signext_mask12 (v : BitVec 32) :
+    signext ⟨v &&& 4095#32⟩ 12#u32
+      ⦃ r => r.bv = BitVec.signExtend 32 (v.truncate 12) ⦄ := by
+  rw [signext]
+  step*
+  all_goals
+    have hi : i = 11#u32 := UScalar.eq_imp _ _ (by simpa using i_post1)
+    subst i
+    have hs : sign_bit = 2048#u32 :=
+      UScalar.eq_imp _ _ (by
+        norm_num [sign_bit_post1, U32.size_eq, Nat.shiftLeft_eq])
+    subst sign_bit
+    have hm0 : max_value = 4096#u32 :=
+      UScalar.eq_imp _ _ (by
+        norm_num [max_value_post1, U32.size_eq, Nat.shiftLeft_eq])
+    subst max_value
+    have hs_bv : (2048#u32).bv = 2048#32 := rfl
+    have hm_bv : (4096#u32).bv = 4096#32 := rfl
+    rw [hs_bv, hm_bv] at *
+    clear i_post1 i_post2 sign_bit_post1 sign_bit_post2 max_value_post1 max_value_post2
+  · -- signed-subtraction lower bound
+    clear i1_post1 i1_post2
+    rw [i2_post, i3_post]
+    change I32.min ≤ (v &&& 4095#32).toInt - (4096#32).toInt
+    have hv := (mask12_toInt_bounds v).1
+    have h4096 : (4096#32).toInt = 4096 := by decide
+    rw [h4096]
+    have hmin : I32.min = -2147483648 := by
+      norm_num [I32.min, I32.numBits_eq]
+    rw [hmin]
+    omega
+  · -- signed-subtraction upper bound
+    clear i1_post1 i1_post2
+    rw [i2_post, i3_post]
+    change (v &&& 4095#32).toInt - (4096#32).toInt ≤ I32.max
+    have hv := (mask12_toInt_bounds v).2
+    have h4096 : (4096#32).toInt = 4096 := by decide
+    rw [h4096]
+    have hmax : I32.max = 2147483647 := by
+      norm_num [I32.max, I32.numBits_eq]
+    rw [hmax]
+    omega
+  · -- negative immediate
+    calc
+      r.bv = i2.bv - i3.bv := r_post2
+      _ = (v &&& 4095#32) - 4096#32 := by rw [i2_post, i3_post]; rfl
+      _ = BitVec.signExtend 32 (v.truncate 12) := by
+        have hi1 := i1_post2
+        change i1.bv = 2048#32 &&& (v &&& 4095#32) at hi1
+        have hne : (i1 != 0#u32) = true := by assumption
+        have hsign : (v &&& 4095#32)[11] = true := by
+          simp at hne
+          change i1.bv.toNat ≠ 0 at hne
+          by_contra hb
+          have hz : 2048#32 &&& (v &&& 4095#32) = 0#32 := by
+            apply BitVec.eq_of_getLsbD_eq
+            intro k
+            by_cases hk : k < 32
+            · interval_cases k <;> simp_all
+            · simp [BitVec.getLsbD, hk]
+          rw [hi1, hz] at hne
+          exact hne rfl
+        exact signExtend12_of_sign v hsign
+  · -- nonnegative immediate
+    change v &&& 4095#32 = BitVec.signExtend 32 (v.truncate 12)
+    have hi1 := i1_post2
+    change i1.bv = 2048#32 &&& (v &&& 4095#32) at hi1
+    have hne : ¬(i1 != 0#u32) = true := by assumption
+    have hsign : (v &&& 4095#32)[11] = false := by
+      simp at hne
+      change i1.bv.toNat = 0 at hne
+      have hi1zero : i1.bv = 0#32 := BitVec.eq_of_toNat_eq hne
+      rw [hi1] at hi1zero
+      have hzbit := congrArg (fun x : BitVec 32 => x[11]) hi1zero
+      simpa using hzbit
+    exact signExtend12_of_not_sign v hsign
+
+private theorem rawIType_imm_bits
+    (imm rs1 funct3 rd opcode : Nat)
+    (hrs1 : rs1 < 32) (hfunct3 : funct3 < 8)
+    (hrd : rd < 32) (hopcode : opcode < 128) :
+    (((toU32 (rawIType imm rs1 funct3 rd opcode) &&& 4293918720#u32).bv >>> 20).truncate 12) =
+      BitVec.ofNat 12 imm := by
+  apply BitVec.eq_of_getLsbD_eq
+  intro i
+  by_cases hi : i < 12
+  · simp only [BitVec.getLsbD_setWidth, BitVec.getLsbD_ushiftRight,
+      BitVec.getLsbD_ofNat]
+    rw [decide_eq_true (by omega)]
+    simp only [toU32, rawIType, rawOfNat32]
+    simp only [Bool.true_and]
+    intro _
+    rw [show
+      ((⟨BitVec.ofNat 32
+          (((imm % 4096) <<< 20) ||| (rs1 <<< 15) |||
+            (funct3 <<< 12) ||| (rd <<< 7) ||| opcode)⟩ : Std.U32) &&&
+        4293918720#u32).bv =
+      BitVec.ofNat 32
+          (((imm % 4096) <<< 20) ||| (rs1 <<< 15) |||
+            (funct3 <<< 12) ||| (rd <<< 7) ||| opcode) &&&
+        4293918720#32 from rfl]
+    change
+      ((BitVec.ofNat 32
+          (((imm % 4096) <<< 20) ||| (rs1 <<< 15) |||
+            (funct3 <<< 12) ||| (rd <<< 7) ||| opcode) &&&
+        4293918720#32).getLsbD (20 + i)) = imm.testBit i
+    simp only [BitVec.getLsbD_and, BitVec.getLsbD_ofNat, Nat.testBit_or]
+    have himmMod : (imm % 4096).testBit i = imm.testBit i := by
+      rw [show (4096 : Nat) = 2 ^ 12 by norm_num, Nat.testBit_mod_two_pow]
+      simp [hi]
+    have hrs1' : rs1.testBit (20 + i - 15) = false :=
+      ZiskFv.Compliance.Decode.tbf (show rs1 < 2 ^ 5 by omega) (by omega)
+    have hfunct3' : funct3.testBit (20 + i - 12) = false :=
+      ZiskFv.Compliance.Decode.tbf (show funct3 < 2 ^ 3 by omega) (by omega)
+    have hrd' : rd.testBit (20 + i - 7) = false :=
+      ZiskFv.Compliance.Decode.tbf (show rd < 2 ^ 5 by omega) (by omega)
+    have hopcode' : opcode.testBit (20 + i) = false :=
+      ZiskFv.Compliance.Decode.tbf (show opcode < 2 ^ 7 by omega) (by omega)
+    have hmaskbit : Nat.testBit 4293918720 (20 + i) = true := by
+      interval_cases i <;> decide
+    simp [Nat.testBit_shiftLeft, hrs1', hfunct3', hrd',
+      hopcode', hmaskbit, himmMod, show 20 + i < 32 by omega,
+      show 20 + i - 20 = i by omega]
+  · simp [BitVec.getLsbD, hi]
+
+private theorem upper12_shift_mask (v : BitVec 32) :
+    ((v &&& 4293918720#32) >>> 20) &&& 4095#32 =
+      (v &&& 4293918720#32) >>> 20 := by
+  apply BitVec.eq_of_getLsbD_eq
+  intro i
+  by_cases hi : i < 32
+  · interval_cases i <;> simp
+  · simp [BitVec.getLsbD, hi]
+
+theorem decode_i_rawIType_imm
+    (imm rs1 funct3 rd opcode : Nat)
+    (hrs1 : rs1 < 32) (hfunct3 : funct3 < 8)
+    (hrd : rd < 32) (hopcode : opcode < 128)
+    (rop : RiscvOpcode) (d : DecodedRv64im)
+    (hd : decode_i (toU32 (rawIType imm rs1 funct3 rd opcode))
+      rop false = ok d) :
+    d.imm.bv = BitVec.signExtend 32 (BitVec.ofNat 12 imm) := by
+  simp only [decode_i, DecodedRv64im.new, lift, bind_ok, Bind.bind] at hd
+  obtain ⟨_i1, _, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨_i3, _, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨_i5, _, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨i7, hi7, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨i8, hi8, hd⟩ := bind_eq_ok_imp hd
+  rw [if_neg (by decide), Result.ok.injEq] at hd
+  rw [← hd]
+  have hi7bv :
+      i7.bv =
+        (toU32 (rawIType imm rs1 funct3 rd opcode) &&& 4293918720#u32).bv >>> 20 := by
+    rw [show ((toU32 (rawIType imm rs1 funct3 rd opcode) &&& 4293918720#u32) >>> 20#i32 :
+        Result Std.U32) =
+        ok ⟨(toU32 (rawIType imm rs1 funct3 rd opcode) &&& 4293918720#u32).bv >>> 20⟩ from rfl,
+      Result.ok.injEq] at hi7
+    exact (congrArg UScalar.bv hi7).symm
+  have hmask : i7.bv &&& 4095#32 = i7.bv := by
+    rw [hi7bv]
+    exact upper12_shift_mask _
+  have himm := signext_mask12 i7.bv
+  rw [hmask] at himm
+  rw [hi8] at himm
+  rw [himm, ← rawIType_imm_bits imm rs1 funct3 rd opcode hrs1 hfunct3 hrd hopcode]
+  congr 1
+  exact congrArg (BitVec.truncate 12) hi7bv

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBitfields.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBitfields.lean
@@ -265,6 +265,47 @@ private theorem and_shr_field (x : BitVec 32) (k w : Nat) (hk : k + w ≤ 32) :
       ZiskFv.Compliance.Decode.tbf (Nat.sub_lt (Nat.two_pow_pos w) (by omega)) hi]
     simp
 
+private theorem rawIType_rd_bits (imm rs1 funct3 rd opcode : Nat)
+    (hrd : rd < 32) (hopcode : opcode < 128) :
+    ((rawIType imm rs1 funct3 rd opcode &&& 3968#32) >>> 7) = BitVec.ofNat 32 rd := by
+  rw [show (3968 : Nat) = (2 ^ 5 - 1) <<< 7 by decide,
+    and_shr_field _ 7 5 (by norm_num)]
+  simp only [rawIType, rawOfNat32]
+  refine ZiskFv.Compliance.Decode.ofNat32_shift_mask_eq _ 7 5 rd hrd (by norm_num) ?_
+  intro i hi
+  simp only [Nat.testBit_or, Nat.testBit_shiftLeft]
+  have e20 : ¬(20 ≤ 7 + i) := by omega
+  have e15 : ¬(15 ≤ 7 + i) := by omega
+  have e12 : ¬(12 ≤ 7 + i) := by omega
+  have e7 : 7 ≤ 7 + i := by omega
+  have hop' : opcode.testBit (7 + i) = false :=
+    ZiskFv.Compliance.Decode.tbf (show opcode < 2 ^ 7 by omega) (by omega)
+  simp [e20, e15, e12, e7, hop', show 7 + i - 7 = i by omega]
+
+private theorem rawIType_rs1_bits (imm rs1 funct3 rd opcode : Nat)
+    (hrs1 : rs1 < 32) (hfunct3 : funct3 < 8)
+    (hrd : rd < 32) (hopcode : opcode < 128) :
+    ((rawIType imm rs1 funct3 rd opcode &&& 1015808#32) >>> 15) =
+      BitVec.ofNat 32 rs1 := by
+  rw [show (1015808 : Nat) = (2 ^ 5 - 1) <<< 15 by decide,
+    and_shr_field _ 15 5 (by norm_num)]
+  simp only [rawIType, rawOfNat32]
+  refine ZiskFv.Compliance.Decode.ofNat32_shift_mask_eq _ 15 5 rs1 hrs1 (by norm_num) ?_
+  intro i hi
+  simp only [Nat.testBit_or, Nat.testBit_shiftLeft]
+  have e20 : ¬(20 ≤ 15 + i) := by omega
+  have e15 : 15 ≤ 15 + i := by omega
+  have e12 : 12 ≤ 15 + i := by omega
+  have e7 : 7 ≤ 15 + i := by omega
+  have hf3' : funct3.testBit (15 + i - 12) = false :=
+    ZiskFv.Compliance.Decode.tbf (show funct3 < 2 ^ 3 by omega) (by omega)
+  have hrd' : rd.testBit (15 + i - 7) = false :=
+    ZiskFv.Compliance.Decode.tbf (show rd < 2 ^ 5 by omega) (by omega)
+  have hop' : opcode.testBit (15 + i) = false :=
+    ZiskFv.Compliance.Decode.tbf (show opcode < 2 ^ 7 by omega) (by omega)
+  simp [e20, e15, e12, e7, hf3', hrd', hop',
+    show 15 + i - 15 = i by omega]
+
 private theorem rawSType_rs1_bits (imm rs2 rs1 funct3 : Nat)
     (hrs1 : rs1 < 32) (hfunct3 : funct3 < 8) :
     ((rawSType imm rs2 rs1 funct3 &&& 1015808#32) >>> 15) = BitVec.ofNat 32 rs1 := by
@@ -486,3 +527,51 @@ theorem decode_s_rawSType_fields
       BitVec.signExtend 64 (BitVec.ofNat 12 imm)
     rw [hs, signExtend64_signExtend32, hcombined,
       rawSType_imm_bits imm rs2 rs1 funct3 hrs2 hrs1 hfunct3]
+
+/-- `decode_i ... false` recovers both register fields and the signed 12-bit
+    immediate from an honestly bounded symbolic I-type instruction word. -/
+theorem decode_i_rawIType_fields
+    (imm rs1 funct3 rd opcode : Nat)
+    (hrs1 : rs1 < 32) (hfunct3 : funct3 < 8)
+    (hrd : rd < 32) (hopcode : opcode < 128)
+    (rop : RiscvOpcode) (d : DecodedRv64im)
+    (hd : decode_i (toU32 (rawIType imm rs1 funct3 rd opcode))
+      rop false = ok d) :
+    d.rd.bv = BitVec.ofNat 32 rd ∧
+      d.rs1.bv = BitVec.ofNat 32 rs1 ∧
+      (IScalar.hcast UScalarTy.U64 d.imm).bv =
+        BitVec.signExtend 64 (BitVec.ofNat 12 imm) := by
+  have hdimm := decode_i_rawIType_imm imm rs1 funct3 rd opcode
+    hrs1 hfunct3 hrd hopcode rop d hd
+  simp only [decode_i, DecodedRv64im.new, lift, bind_ok, Bind.bind] at hd
+  obtain ⟨_i1, _, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨i3, hi3, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨i5, hi5, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨_i7, _, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨i8, _hi8, hd⟩ := bind_eq_ok_imp hd
+  rw [if_neg (by decide), Result.ok.injEq] at hd
+  rw [← hd]
+  have hi3bv : i3.bv =
+      (toU32 (rawIType imm rs1 funct3 rd opcode) &&& 3968#u32).bv >>> 7 := by
+    rw [show ((toU32 (rawIType imm rs1 funct3 rd opcode) &&& 3968#u32) >>> 7#i32 :
+      Result Std.U32) =
+        ok ⟨(toU32 (rawIType imm rs1 funct3 rd opcode) &&& 3968#u32).bv >>> 7⟩ from rfl,
+      Result.ok.injEq] at hi3
+    exact (congrArg UScalar.bv hi3).symm
+  have hi5bv : i5.bv =
+      (toU32 (rawIType imm rs1 funct3 rd opcode) &&& 1015808#u32).bv >>> 15 := by
+    rw [show ((toU32 (rawIType imm rs1 funct3 rd opcode) &&& 1015808#u32) >>> 15#i32 :
+      Result Std.U32) =
+        ok ⟨(toU32 (rawIType imm rs1 funct3 rd opcode) &&& 1015808#u32).bv >>> 15⟩ from rfl,
+      Result.ok.injEq] at hi5
+    exact (congrArg UScalar.bv hi5).symm
+  refine ⟨?_, ?_, ?_⟩
+  · change i3.bv = BitVec.ofNat 32 rd
+    rw [hi3bv]
+    exact rawIType_rd_bits imm rs1 funct3 rd opcode hrd hopcode
+  · change i5.bv = BitVec.ofNat 32 rs1
+    rw [hi5bv]
+    exact rawIType_rs1_bits imm rs1 funct3 rd opcode hrs1 hfunct3 hrd hopcode
+  · change BitVec.signExtend 64 i8.bv =
+      BitVec.signExtend 64 (BitVec.ofNat 12 imm)
+    rw [show i8.bv = d.imm.bv by rw [← hd], hdimm, signExtend64_signExtend32]

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBitfields.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBitfields.lean
@@ -6,7 +6,7 @@ open Aeneas Aeneas.Std Result zisk_core
 open aeneas_extract.rv64im_decode
 open ZiskFv.Compliance.Extraction (bind_eq_ok_imp)
 open ZiskFv.Compliance.Decode (toU32)
-open ZiskFv.Completeness.Rv64imShapes (rawIType rawOfNat32)
+open ZiskFv.Completeness.Rv64imShapes (rawIType rawSType rawOfNat32)
 
 attribute [local step] IScalar.sub_bv_spec I32.sub_bv_spec
 
@@ -248,3 +248,241 @@ theorem decode_i_rawIType_imm
   rw [himm, ← rawIType_imm_bits imm rs1 funct3 rd opcode hrs1 hfunct3 hrd hopcode]
   congr 1
   exact congrArg (BitVec.truncate 12) hi7bv
+
+private theorem and_shr_field (x : BitVec 32) (k w : Nat) (hk : k + w ≤ 32) :
+    (x &&& BitVec.ofNat 32 ((2 ^ w - 1) <<< k)) >>> k =
+      (x >>> k) &&& BitVec.ofNat 32 (2 ^ w - 1) := by
+  apply BitVec.eq_of_getLsbD_eq
+  intro i
+  simp only [BitVec.getLsbD_ushiftRight, BitVec.getLsbD_and, BitVec.getLsbD_ofNat,
+    Nat.testBit_shiftLeft]
+  rcases Nat.lt_or_ge i w with hi | hi
+  · rw [decide_eq_true (by omega), decide_eq_true (by omega)]
+    intro _
+    simp [show i < 32 by omega, show k + i - k = i by omega]
+  · rw [ZiskFv.Compliance.Decode.tbf (Nat.sub_lt (Nat.two_pow_pos w) (by omega))
+        (show w ≤ k + i - k by omega),
+      ZiskFv.Compliance.Decode.tbf (Nat.sub_lt (Nat.two_pow_pos w) (by omega)) hi]
+    simp
+
+private theorem rawSType_rs1_bits (imm rs2 rs1 funct3 : Nat)
+    (hrs1 : rs1 < 32) (hfunct3 : funct3 < 8) :
+    ((rawSType imm rs2 rs1 funct3 &&& 1015808#32) >>> 15) = BitVec.ofNat 32 rs1 := by
+  rw [show (1015808 : Nat) = (2 ^ 5 - 1) <<< 15 by decide,
+    and_shr_field _ 15 5 (by norm_num)]
+  simp only [rawSType, rawOfNat32]
+  refine ZiskFv.Compliance.Decode.ofNat32_shift_mask_eq _ 15 5 rs1 hrs1 (by norm_num) ?_
+  intro i hi
+  simp only [Nat.testBit_or, Nat.testBit_shiftLeft]
+  have e25 : ¬(25 ≤ 15 + i) := by omega
+  have e20 : ¬(20 ≤ 15 + i) := by omega
+  have e15 : 15 ≤ 15 + i := by omega
+  have e12 : 12 ≤ 15 + i := by omega
+  have e7 : 7 ≤ 15 + i := by omega
+  have hf3' : funct3.testBit (15 + i - 12) = false :=
+    ZiskFv.Compliance.Decode.tbf (show funct3 < 2 ^ 3 by omega) (by omega)
+  have himm' : Nat.testBit 31 (15 + i - 7) = false :=
+    ZiskFv.Compliance.Decode.tbf (show (31 : Nat) < 2 ^ 5 by norm_num) (by omega)
+  have hop' : Nat.testBit 35 (15 + i) = false := by
+    exact ZiskFv.Compliance.Decode.tbf (show 35 < 2 ^ 6 by norm_num) (by omega)
+  simp [e25, e20, e15, e12, e7, hf3', himm', hop',
+    show 15 + i - 15 = i by omega]
+
+private theorem rawSType_rs2_bits (imm rs2 rs1 funct3 : Nat)
+    (hrs2 : rs2 < 32) (hrs1 : rs1 < 32) (hfunct3 : funct3 < 8) :
+    ((rawSType imm rs2 rs1 funct3 &&& 32505856#32) >>> 20) = BitVec.ofNat 32 rs2 := by
+  rw [show (32505856 : Nat) = (2 ^ 5 - 1) <<< 20 by decide,
+    and_shr_field _ 20 5 (by norm_num)]
+  simp only [rawSType, rawOfNat32]
+  refine ZiskFv.Compliance.Decode.ofNat32_shift_mask_eq _ 20 5 rs2 hrs2 (by norm_num) ?_
+  intro i hi
+  simp only [Nat.testBit_or, Nat.testBit_shiftLeft]
+  have e25 : ¬(25 ≤ 20 + i) := by omega
+  have e20 : 20 ≤ 20 + i := by omega
+  have e15 : 15 ≤ 20 + i := by omega
+  have e12 : 12 ≤ 20 + i := by omega
+  have e7 : 7 ≤ 20 + i := by omega
+  have hrs1' : rs1.testBit (20 + i - 15) = false :=
+    ZiskFv.Compliance.Decode.tbf (show rs1 < 2 ^ 5 by omega) (by omega)
+  have hf3' : funct3.testBit (20 + i - 12) = false :=
+    ZiskFv.Compliance.Decode.tbf (show funct3 < 2 ^ 3 by omega) (by omega)
+  have himm' : Nat.testBit 31 (20 + i - 7) = false :=
+    ZiskFv.Compliance.Decode.tbf (show (31 : Nat) < 2 ^ 5 by norm_num) (by omega)
+  have hop' : Nat.testBit 35 (20 + i) = false := by
+    exact ZiskFv.Compliance.Decode.tbf (show 35 < 2 ^ 6 by norm_num) (by omega)
+  simp [e25, e20, e15, e12, e7, hrs1', hf3', himm', hop',
+    show 20 + i - 20 = i by omega]
+
+private theorem rawSType_imm_lo (imm rs2 rs1 funct3 : Nat) :
+    (rawSType imm rs2 rs1 funct3 &&& 3968#32) >>> 7 =
+      BitVec.ofNat 32 (imm % 4096 &&& 31) := by
+  rw [show (3968 : Nat) = (2 ^ 5 - 1) <<< 7 by decide,
+    and_shr_field _ 7 5 (by norm_num)]
+  simp only [rawSType, rawOfNat32]
+  refine ZiskFv.Compliance.Decode.ofNat32_shift_mask_eq _ 7 5
+    (imm % 4096 &&& 31) (lt_of_le_of_lt Nat.and_le_right (by norm_num)) (by norm_num) ?_
+  intro i hi
+  have e25 : ¬(25 ≤ 7 + i) := by omega
+  have e20 : ¬(20 ≤ 7 + i) := by omega
+  have e15 : ¬(15 ≤ 7 + i) := by omega
+  have e12 : ¬(12 ≤ 7 + i) := by omega
+  have e7 : 7 ≤ 7 + i := by omega
+  have hop' : Nat.testBit 35 (7 + i) = false :=
+    ZiskFv.Compliance.Decode.tbf (show 35 < 2 ^ 6 by norm_num) (by omega)
+  simp [Nat.testBit_or, Nat.testBit_shiftLeft, e25, e20, e15, e12, e7, hop',
+    show 7 + i - 7 = i by omega]
+
+private theorem rawSType_imm_hi (imm rs2 rs1 funct3 : Nat)
+    (hrs2 : rs2 < 32) (hrs1 : rs1 < 32) (hfunct3 : funct3 < 8) :
+    (rawSType imm rs2 rs1 funct3 &&& 4261412864#32) >>> 25 =
+      BitVec.ofNat 32 ((imm % 4096) >>> 5) := by
+  rw [show (4261412864 : Nat) = (2 ^ 7 - 1) <<< 25 by decide,
+    and_shr_field _ 25 7 (by norm_num)]
+  simp only [rawSType, rawOfNat32]
+  refine ZiskFv.Compliance.Decode.ofNat32_shift_mask_eq _ 25 7
+    ((imm % 4096) >>> 5) (by
+      rw [Nat.shiftRight_eq_div_pow]
+      have h := Nat.mod_lt imm (by norm_num : 0 < 4096)
+      norm_num
+      omega)
+    (by norm_num) ?_
+  intro i hi
+  have e25 : 25 ≤ 25 + i := by omega
+  have e20 : 20 ≤ 25 + i := by omega
+  have e15 : 15 ≤ 25 + i := by omega
+  have e12 : 12 ≤ 25 + i := by omega
+  have e7 : 7 ≤ 25 + i := by omega
+  have hrs2' : rs2.testBit (25 + i - 20) = false :=
+    ZiskFv.Compliance.Decode.tbf (show rs2 < 2 ^ 5 by omega) (by omega)
+  have hrs1' : rs1.testBit (25 + i - 15) = false :=
+    ZiskFv.Compliance.Decode.tbf (show rs1 < 2 ^ 5 by omega) (by omega)
+  have hf3' : funct3.testBit (25 + i - 12) = false :=
+    ZiskFv.Compliance.Decode.tbf (show funct3 < 2 ^ 3 by omega) (by omega)
+  have himmlo' : Nat.testBit 31 (25 + i - 7) = false :=
+    ZiskFv.Compliance.Decode.tbf (show 31 < 2 ^ 5 by norm_num) (by omega)
+  have hop' : Nat.testBit 35 (25 + i) = false :=
+    ZiskFv.Compliance.Decode.tbf (show 35 < 2 ^ 6 by norm_num) (by omega)
+  simp [Nat.testBit_or, Nat.testBit_shiftLeft, e25, e20, e15, e12, e7,
+    hrs2', hrs1', hf3', himmlo', hop', show 25 + i - 25 = i by omega]
+
+private theorem rawSType_imm_bits (imm rs2 rs1 funct3 : Nat)
+    (hrs2 : rs2 < 32) (hrs1 : rs1 < 32) (hfunct3 : funct3 < 8) :
+    (((((rawSType imm rs2 rs1 funct3 &&& 4261412864#32) >>> 25) <<< 5) |||
+        ((rawSType imm rs2 rs1 funct3 &&& 3968#32) >>> 7)).truncate 12) =
+      BitVec.ofNat 12 imm := by
+  rw [rawSType_imm_hi imm rs2 rs1 funct3 hrs2 hrs1 hfunct3,
+    rawSType_imm_lo imm rs2 rs1 funct3]
+  have himmLt : imm % 4096 < 4096 := Nat.mod_lt _ (by norm_num)
+  have hhiLt : (imm % 4096) >>> 5 < 4096 := by
+    rw [Nat.shiftRight_eq_div_pow]
+    omega
+  have hshiftLt : ((imm % 4096) >>> 5) <<< 5 < 4096 := by
+    rw [Nat.shiftRight_eq_div_pow, Nat.shiftLeft_eq]
+    norm_num
+    omega
+  apply BitVec.eq_of_getLsbD_eq
+  intro i
+  by_cases hi : i < 12
+  · interval_cases i <;>
+      simp [BitVec.getLsbD, Nat.testBit_shiftLeft, Nat.testBit_shiftRight,
+        Nat.mod_eq_of_lt himmLt, Nat.mod_eq_of_lt hhiLt, Nat.mod_eq_of_lt hshiftLt,
+        show (4096 : Nat) = 2 ^ 12 by norm_num] <;>
+      norm_num [Nat.testBit] <;> aesop
+  · simp [BitVec.getLsbD, hi]
+
+private theorem rawSType_assembled_mask (v : BitVec 32) :
+    (((((v &&& 4261412864#32) >>> 25) <<< 5) |||
+        ((v &&& 3968#32) >>> 7)) &&& 4095#32) =
+      ((((v &&& 4261412864#32) >>> 25) <<< 5) |||
+        ((v &&& 3968#32) >>> 7)) := by
+  apply BitVec.eq_of_getLsbD_eq
+  intro i
+  by_cases hi : i < 32
+  · interval_cases i <;> simp
+  · simp [BitVec.getLsbD, hi]
+
+private theorem signExtend64_signExtend32 (v : BitVec 12) :
+    BitVec.signExtend 64 (BitVec.signExtend 32 v) = BitVec.signExtend 64 v := by
+  apply BitVec.eq_of_getLsbD_eq
+  intro k
+  by_cases hk : k < 64
+  · interval_cases k <;>
+      simp [BitVec.getElem_signExtend,
+        BitVec.msb_signExtend]
+  · simp [BitVec.getLsbD_signExtend, hk]
+
+/-- `decode_s` recovers both source-register fields and the signed 12-bit
+    immediate from an honestly bounded symbolic S-type instruction word. -/
+theorem decode_s_rawSType_fields
+    (imm rs2 rs1 funct3 : Nat)
+    (hrs2 : rs2 < 32) (hrs1 : rs1 < 32) (hfunct3 : funct3 < 8)
+    (rop : RiscvOpcode) (d : DecodedRv64im)
+    (hd : decode_s (toU32 (rawSType imm rs2 rs1 funct3)) rop = ok d) :
+    d.rs1.bv = BitVec.ofNat 32 rs1 ∧
+      d.rs2.bv = BitVec.ofNat 32 rs2 ∧
+      (IScalar.hcast UScalarTy.U64 d.imm).bv =
+        BitVec.signExtend 64 (BitVec.ofNat 12 imm) := by
+  simp only [decode_s, DecodedRv64im.new, lift, bind_ok, Bind.bind] at hd
+  obtain ⟨_i1, _, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨imm4, himm4, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨i4, hi4, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨i6, hi6, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨imm11, himm11, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨i8, hi8, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨i9, hi9, hd⟩ := bind_eq_ok_imp hd
+  rw [Result.ok.injEq] at hd
+  rw [← hd]
+  have hi4bv : i4.bv =
+      (toU32 (rawSType imm rs2 rs1 funct3) &&& 1015808#u32).bv >>> 15 := by
+    rw [show ((toU32 (rawSType imm rs2 rs1 funct3) &&& 1015808#u32) >>> 15#i32 :
+      Result Std.U32) =
+        ok ⟨(toU32 (rawSType imm rs2 rs1 funct3) &&& 1015808#u32).bv >>> 15⟩ from rfl,
+      Result.ok.injEq] at hi4
+    exact (congrArg UScalar.bv hi4).symm
+  have hi6bv : i6.bv =
+      (toU32 (rawSType imm rs2 rs1 funct3) &&& 32505856#u32).bv >>> 20 := by
+    rw [show ((toU32 (rawSType imm rs2 rs1 funct3) &&& 32505856#u32) >>> 20#i32 :
+      Result Std.U32) =
+        ok ⟨(toU32 (rawSType imm rs2 rs1 funct3) &&& 32505856#u32).bv >>> 20⟩ from rfl,
+      Result.ok.injEq] at hi6
+    exact (congrArg UScalar.bv hi6).symm
+  refine ⟨?_, ?_, ?_⟩
+  · change i4.bv = BitVec.ofNat 32 rs1
+    rw [hi4bv]
+    exact rawSType_rs1_bits imm rs2 rs1 funct3 hrs1 hfunct3
+  · change i6.bv = BitVec.ofNat 32 rs2
+    rw [hi6bv]
+    exact rawSType_rs2_bits imm rs2 rs1 funct3 hrs2 hrs1 hfunct3
+  · have himm4bv : imm4.bv =
+        (toU32 (rawSType imm rs2 rs1 funct3) &&& 3968#u32).bv >>> 7 := by
+      rw [show ((toU32 (rawSType imm rs2 rs1 funct3) &&& 3968#u32) >>> 7#i32 :
+        Result Std.U32) =
+          ok ⟨(toU32 (rawSType imm rs2 rs1 funct3) &&& 3968#u32).bv >>> 7⟩ from rfl,
+        Result.ok.injEq] at himm4
+      exact (congrArg UScalar.bv himm4).symm
+    have himm11bv : imm11.bv =
+        (toU32 (rawSType imm rs2 rs1 funct3) &&& 4261412864#u32).bv >>> 25 := by
+      rw [show ((toU32 (rawSType imm rs2 rs1 funct3) &&& 4261412864#u32) >>> 25#i32 :
+        Result Std.U32) =
+          ok ⟨(toU32 (rawSType imm rs2 rs1 funct3) &&& 4261412864#u32).bv >>> 25⟩ from rfl,
+        Result.ok.injEq] at himm11
+      exact (congrArg UScalar.bv himm11).symm
+    have hi8bv : i8.bv = imm11.bv <<< 5 := by
+      rw [show (imm11 <<< 5#i32 : Result Std.U32) = ok ⟨imm11.bv <<< 5⟩ from rfl,
+        Result.ok.injEq] at hi8
+      exact (congrArg UScalar.bv hi8).symm
+    have hcombined : (i8 ||| imm4).bv =
+        ((((rawSType imm rs2 rs1 funct3 &&& 4261412864#32) >>> 25) <<< 5) |||
+          ((rawSType imm rs2 rs1 funct3 &&& 3968#32) >>> 7)) := by
+      change i8.bv ||| imm4.bv = _
+      rw [hi8bv, himm11bv, himm4bv]
+      rfl
+    have hmask : (i8 ||| imm4).bv &&& 4095#32 = (i8 ||| imm4).bv := by
+      rw [hcombined]
+      exact rawSType_assembled_mask _
+    have hs := signext_mask12 (i8 ||| imm4).bv
+    rw [hmask, hi9] at hs
+    change BitVec.signExtend 64 i9.bv =
+      BitVec.signExtend 64 (BitVec.ofNat 12 imm)
+    rw [hs, signExtend64_signExtend32, hcombined,
+      rawSType_imm_bits imm rs2 rs1 funct3 hrs2 hrs1 hfunct3]

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBitfields.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBitfields.lean
@@ -158,6 +158,150 @@ private theorem signext_mask12 (v : BitVec 32) :
       simpa using hzbit
     exact signExtend12_of_not_sign v hsign
 
+private theorem mask21_toInt_bounds (v : BitVec 32) :
+    0 ≤ (v &&& 2097151#32).toInt ∧ (v &&& 2097151#32).toInt ≤ 2097151 := by
+  have h : (v &&& 2097151#32).toNat ≤ 2097151 := by
+    rw [BitVec.toNat_and]
+    exact le_trans Nat.and_le_right (by norm_num)
+  rw [BitVec.toInt]
+  rw [if_pos (by
+    have h' : v.toNat &&& 2097151 ≤ 2097151 := Nat.and_le_right
+    norm_num
+    omega)]
+  omega
+
+private theorem signExtend21_of_sign (v : BitVec 32)
+    (h : (v &&& 2097151#32)[20] = true) :
+    (v &&& 2097151#32) - 2097152#32 =
+      BitVec.signExtend 32 (v.truncate 21) := by
+  apply BitVec.eq_of_toInt_eq
+  rw [BitVec.toInt_sub, BitVec.toInt_signExtend_of_le (by omega)]
+  have hn : (v &&& 2097151#32).toNat ≤ 2097151 := by
+    rw [BitVec.toNat_and]
+    exact le_trans Nat.and_le_right (by norm_num)
+  have hlo : 1048576 ≤ (v &&& 2097151#32).toNat := by
+    by_contra hnlt
+    have ht := Nat.testBit_lt_two_pow
+      (show (v &&& 2097151#32).toNat < 2 ^ 20 by omega)
+    have hb : (v &&& 2097151#32).toNat.testBit 20 = true := by
+      change (v &&& 2097151#32)[20] = true
+      exact h
+    rw [ht] at hb
+    contradiction
+  have htrunc : (v.truncate 21).toNat = (v &&& 2097151#32).toNat := by
+    rw [BitVec.toNat_setWidth, BitVec.toNat_and]
+    calc
+      v.toNat % 2 ^ 21 = v.toNat &&& (2 ^ 21 - 1) :=
+        (Nat.and_two_pow_sub_one_eq_mod v.toNat 21).symm
+      _ = v.toNat &&& 2097151 := by norm_num
+  have htruncInt : (v.truncate 21).toInt =
+      (v &&& 2097151#32).toNat - 2097152 := by
+    rw [BitVec.toInt, htrunc]
+    rw [if_neg (by omega)]
+    norm_num
+  have hxInt : (v &&& 2097151#32).toInt = (v &&& 2097151#32).toNat := by
+    rw [BitVec.toInt, if_pos (by
+      have hn' : v.toNat &&& 2097151 ≤ 2097151 := Nat.and_le_right
+      norm_num
+      omega)]
+  have hmax : (2097152#32).toInt = 2097152 := by decide
+  rw [htruncInt, hxInt, hmax]
+  norm_num [Int.bmod]
+  have hn' : v.toNat &&& 2097151 ≤ 2097151 := Nat.and_le_right
+  have hlo' : 1048576 ≤ v.toNat &&& 2097151 := by
+    simpa [BitVec.toNat_and] using hlo
+  have hmod : ((v.toNat &&& 2097151 : Nat) - 2097152 : Int) % 4294967296 =
+      (v.toNat &&& 2097151 : Nat) - 2097152 + 4294967296 := by
+    rw [Int.emod_eq_add_self_emod]
+    apply Int.emod_eq_of_lt <;> omega
+  rw [hmod, if_neg (by omega)]
+  omega
+
+private theorem signExtend21_of_not_sign (v : BitVec 32)
+    (h : (v &&& 2097151#32)[20] = false) :
+    v &&& 2097151#32 = BitVec.signExtend 32 (v.truncate 21) := by
+  symm
+  apply BitVec.eq_of_getLsbD_eq
+  intro i
+  by_cases hi : i < 32
+  · interval_cases i <;>
+      simp [BitVec.getElem_signExtend,
+        BitVec.getElem_setWidth, BitVec.msb_setWidth] at h ⊢ <;> assumption
+  · simp [BitVec.getLsbD_signExtend, hi]
+
+private theorem signext_mask21 (v : BitVec 32) :
+    signext ⟨v &&& 2097151#32⟩ 21#u32
+      ⦃ r => r.bv = BitVec.signExtend 32 (v.truncate 21) ⦄ := by
+  rw [signext]
+  step*
+  all_goals
+    have hi : i = 20#u32 := UScalar.eq_imp _ _ (by simpa using i_post1)
+    subst i
+    have hs : sign_bit = 1048576#u32 :=
+      UScalar.eq_imp _ _ (by
+        norm_num [sign_bit_post1, U32.size_eq, Nat.shiftLeft_eq])
+    subst sign_bit
+    have hm0 : max_value = 2097152#u32 :=
+      UScalar.eq_imp _ _ (by
+        norm_num [max_value_post1, U32.size_eq, Nat.shiftLeft_eq])
+    subst max_value
+    have hs_bv : (1048576#u32).bv = 1048576#32 := rfl
+    have hm_bv : (2097152#u32).bv = 2097152#32 := rfl
+    rw [hs_bv, hm_bv] at *
+    clear i_post1 i_post2 sign_bit_post1 sign_bit_post2 max_value_post1 max_value_post2
+  · clear i1_post1 i1_post2
+    rw [i2_post, i3_post]
+    change I32.min ≤ (v &&& 2097151#32).toInt - (2097152#32).toInt
+    have hv := (mask21_toInt_bounds v).1
+    have hmax : (2097152#32).toInt = 2097152 := by decide
+    rw [hmax]
+    have hmin : I32.min = -2147483648 := by
+      norm_num [I32.min, I32.numBits_eq]
+    rw [hmin]
+    omega
+  · clear i1_post1 i1_post2
+    rw [i2_post, i3_post]
+    change (v &&& 2097151#32).toInt - (2097152#32).toInt ≤ I32.max
+    have hv := (mask21_toInt_bounds v).2
+    have hmaxv : (2097152#32).toInt = 2097152 := by decide
+    rw [hmaxv]
+    have hmax : I32.max = 2147483647 := by
+      norm_num [I32.max, I32.numBits_eq]
+    rw [hmax]
+    omega
+  · calc
+      r.bv = i2.bv - i3.bv := r_post2
+      _ = (v &&& 2097151#32) - 2097152#32 := by rw [i2_post, i3_post]; rfl
+      _ = BitVec.signExtend 32 (v.truncate 21) := by
+        apply signExtend21_of_sign
+        have hi1 := i1_post2
+        change i1.bv = 1048576#32 &&& (v &&& 2097151#32) at hi1
+        have hne : (i1 != 0#u32) = true := by assumption
+        simp at hne
+        change i1.bv.toNat ≠ 0 at hne
+        by_contra hb
+        have hz : 1048576#32 &&& (v &&& 2097151#32) = 0#32 := by
+          apply BitVec.eq_of_getLsbD_eq
+          intro k
+          by_cases hk : k < 32
+          · interval_cases k <;> simp_all
+          · simp [BitVec.getLsbD, hk]
+        rw [hi1, hz] at hne
+        exact hne rfl
+  · change v &&& 2097151#32 = BitVec.signExtend 32 (v.truncate 21)
+    have hi1 := i1_post2
+    change i1.bv = 1048576#32 &&& (v &&& 2097151#32) at hi1
+    have hne : ¬(i1 != 0#u32) = true := by assumption
+    simp at hne
+    change i1.bv.toNat = 0 at hne
+    have hi1zero : i1.bv = 0#32 := BitVec.eq_of_toNat_eq hne
+    rw [hi1] at hi1zero
+    have hzbit := congrArg (fun x : BitVec 32 => x[20]) hi1zero
+    have hsign : (v &&& 2097151#32)[20] = false := by simpa using hzbit
+    exact signExtend21_of_not_sign v hsign
+
+#print axioms signext_mask21
+
 private theorem rawIType_imm_bits
     (imm rs1 funct3 rd opcode : Nat)
     (hrs1 : rs1 < 32) (hfunct3 : funct3 < 8)

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBitfields.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBitfields.lean
@@ -6,7 +6,7 @@ open Aeneas Aeneas.Std Result zisk_core
 open aeneas_extract.rv64im_decode
 open ZiskFv.Compliance.Extraction (bind_eq_ok_imp)
 open ZiskFv.Compliance.Decode (toU32)
-open ZiskFv.Completeness.Rv64imShapes (rawIType rawSType rawOfNat32)
+open ZiskFv.Completeness.Rv64imShapes (rawIType rawSType rawBType rawOfNat32)
 
 attribute [local step] IScalar.sub_bv_spec I32.sub_bv_spec
 
@@ -428,7 +428,7 @@ private theorem rawSType_imm_bits (imm rs2 rs1 funct3 : Nat)
       simp [BitVec.getLsbD, Nat.testBit_shiftLeft, Nat.testBit_shiftRight,
         Nat.mod_eq_of_lt himmLt, Nat.mod_eq_of_lt hhiLt, Nat.mod_eq_of_lt hshiftLt,
         show (4096 : Nat) = 2 ^ 12 by norm_num] <;>
-      norm_num [Nat.testBit] <;> aesop
+      first | rfl | (norm_num [Nat.testBit] <;> aesop)
   · simp [BitVec.getLsbD, hi]
 
 private theorem rawSType_assembled_mask (v : BitVec 32) :
@@ -575,3 +575,530 @@ theorem decode_i_rawIType_fields
   · change BitVec.signExtend 64 i8.bv =
       BitVec.signExtend 64 (BitVec.ofNat 12 imm)
     rw [show i8.bv = d.imm.bv by rw [← hd], hdimm, signExtend64_signExtend32]
+
+private theorem rawBType_imm12 (imm rs2 rs1 funct3 : Nat)
+    (hrs2 : rs2 < 32) (hrs1 : rs1 < 32) (hfunct3 : funct3 < 8) (himm : imm < 8192) :
+    (rawBType imm rs2 rs1 funct3 &&& 2147483648#32) >>> 31 =
+      BitVec.ofNat 32 ((imm >>> 12) &&& 1) := by
+  rw [show (2147483648 : Nat) = (2 ^ 1 - 1) <<< 31 by decide,
+    and_shr_field _ 31 1 (by norm_num)]
+  simp only [rawBType, rawOfNat32, Nat.mod_eq_of_lt himm]
+  refine ZiskFv.Compliance.Decode.ofNat32_shift_mask_eq _ 31 1
+    ((imm >>> 12) &&& 1) (lt_of_le_of_lt Nat.and_le_right (by norm_num))
+    (by norm_num) ?_
+  intro i hi
+  have e31 : 31 ≤ 31 + i := by omega
+  have e25 : 25 ≤ 31 + i := by omega
+  have e20 : 20 ≤ 31 + i := by omega
+  have e15 : 15 ≤ 31 + i := by omega
+  have e12 : 12 ≤ 31 + i := by omega
+  have e8 : 8 ≤ 31 + i := by omega
+  have e7 : 7 ≤ 31 + i := by omega
+  have himm10 : ((imm >>> 5) &&& 63).testBit (31 + i - 25) = false :=
+    ZiskFv.Compliance.Decode.tbf
+      (lt_of_le_of_lt Nat.and_le_right (by norm_num : 63 < 2 ^ 6)) (by omega)
+  have hrs2' : rs2.testBit (31 + i - 20) = false :=
+    ZiskFv.Compliance.Decode.tbf (show rs2 < 2 ^ 5 by omega) (by omega)
+  have hrs1' : rs1.testBit (31 + i - 15) = false :=
+    ZiskFv.Compliance.Decode.tbf (show rs1 < 2 ^ 5 by omega) (by omega)
+  have hf3' : funct3.testBit (31 + i - 12) = false :=
+    ZiskFv.Compliance.Decode.tbf (show funct3 < 2 ^ 3 by omega) (by omega)
+  have himm4 : ((imm >>> 1) &&& 15).testBit (31 + i - 8) = false :=
+    ZiskFv.Compliance.Decode.tbf
+      (lt_of_le_of_lt Nat.and_le_right (by norm_num : 15 < 2 ^ 4)) (by omega)
+  have himm11 : (imm >>> 11 % 2).testBit (31 + i - 7) = false :=
+    ZiskFv.Compliance.Decode.tbf
+      (show imm >>> 11 % 2 < 2 ^ 1 from Nat.mod_lt _ (by norm_num)) (by omega)
+  have hop' : Nat.testBit 99 (31 + i) = false :=
+    ZiskFv.Compliance.Decode.tbf (show 99 < 2 ^ 7 by norm_num) (by omega)
+  simp [Nat.testBit_or, Nat.testBit_shiftLeft, e31, e25, e20, e15, e12, e8, e7,
+    himm10, hrs2', hrs1', hf3', himm4, himm11, hop',
+    show 31 + i - 31 = i by omega]
+
+private theorem rawBType_imm11 (imm rs2 rs1 funct3 : Nat) (himm : imm < 8192) :
+    (rawBType imm rs2 rs1 funct3 &&& 128#32) >>> 7 =
+      BitVec.ofNat 32 ((imm >>> 11) &&& 1) := by
+  rw [show (128 : Nat) = (2 ^ 1 - 1) <<< 7 by decide,
+    and_shr_field _ 7 1 (by norm_num)]
+  simp only [rawBType, rawOfNat32, Nat.mod_eq_of_lt himm]
+  refine ZiskFv.Compliance.Decode.ofNat32_shift_mask_eq _ 7 1
+    ((imm >>> 11) &&& 1) (lt_of_le_of_lt Nat.and_le_right (by norm_num))
+    (by norm_num) ?_
+  intro i hi
+  have e31 : ¬(31 ≤ 7 + i) := by omega
+  have e25 : ¬(25 ≤ 7 + i) := by omega
+  have e20 : ¬(20 ≤ 7 + i) := by omega
+  have e15 : ¬(15 ≤ 7 + i) := by omega
+  have e12 : ¬(12 ≤ 7 + i) := by omega
+  have e8 : ¬(8 ≤ 7 + i) := by omega
+  have e7 : 7 ≤ 7 + i := by omega
+  have hop' : Nat.testBit 99 (7 + i) = false :=
+    ZiskFv.Compliance.Decode.tbf (show 99 < 2 ^ 7 by norm_num) (by omega)
+  simp [Nat.testBit_or, Nat.testBit_shiftLeft, e31, e25, e20, e15, e12, e8, e7,
+    hop', show 7 + i - 7 = i by omega]
+
+private theorem rawBType_imm10_5 (imm rs2 rs1 funct3 : Nat)
+    (hrs2 : rs2 < 32) (hrs1 : rs1 < 32) (hfunct3 : funct3 < 8) (himm : imm < 8192) :
+    (rawBType imm rs2 rs1 funct3 &&& 2113929216#32) >>> 25 =
+      BitVec.ofNat 32 ((imm >>> 5) &&& 63) := by
+  rw [show (2113929216 : Nat) = (2 ^ 6 - 1) <<< 25 by decide,
+    and_shr_field _ 25 6 (by norm_num)]
+  simp only [rawBType, rawOfNat32, Nat.mod_eq_of_lt himm]
+  refine ZiskFv.Compliance.Decode.ofNat32_shift_mask_eq _ 25 6
+    ((imm >>> 5) &&& 63) (lt_of_le_of_lt Nat.and_le_right (by norm_num))
+    (by norm_num) ?_
+  intro i hi
+  have e31 : ¬(31 ≤ 25 + i) := by omega
+  have e25 : 25 ≤ 25 + i := by omega
+  have e20 : 20 ≤ 25 + i := by omega
+  have e15 : 15 ≤ 25 + i := by omega
+  have e12 : 12 ≤ 25 + i := by omega
+  have e8 : 8 ≤ 25 + i := by omega
+  have e7 : 7 ≤ 25 + i := by omega
+  have hrs2' : rs2.testBit (25 + i - 20) = false :=
+    ZiskFv.Compliance.Decode.tbf (show rs2 < 2 ^ 5 by omega) (by omega)
+  have hrs1' : rs1.testBit (25 + i - 15) = false :=
+    ZiskFv.Compliance.Decode.tbf (show rs1 < 2 ^ 5 by omega) (by omega)
+  have hf3' : funct3.testBit (25 + i - 12) = false :=
+    ZiskFv.Compliance.Decode.tbf (show funct3 < 2 ^ 3 by omega) (by omega)
+  have himm4 : ((imm >>> 1) &&& 15).testBit (25 + i - 8) = false :=
+    ZiskFv.Compliance.Decode.tbf
+      (lt_of_le_of_lt Nat.and_le_right (by norm_num : 15 < 2 ^ 4)) (by omega)
+  have himm11 : (imm >>> 11 % 2).testBit (25 + i - 7) = false :=
+    ZiskFv.Compliance.Decode.tbf
+      (show imm >>> 11 % 2 < 2 ^ 1 from Nat.mod_lt _ (by norm_num)) (by omega)
+  have hop' : Nat.testBit 99 (25 + i) = false :=
+    ZiskFv.Compliance.Decode.tbf (show 99 < 2 ^ 7 by norm_num) (by omega)
+  simp [Nat.testBit_or, Nat.testBit_shiftLeft, e31, e25, e20, e15, e12, e8, e7,
+    hrs2', hrs1', hf3', himm4, himm11, hop',
+    show 25 + i - 25 = i by omega]
+
+private theorem rawBType_imm4_1 (imm rs2 rs1 funct3 : Nat) (himm : imm < 8192) :
+    (rawBType imm rs2 rs1 funct3 &&& 3840#32) >>> 8 =
+      BitVec.ofNat 32 ((imm >>> 1) &&& 15) := by
+  rw [show (3840 : Nat) = (2 ^ 4 - 1) <<< 8 by decide,
+    and_shr_field _ 8 4 (by norm_num)]
+  simp only [rawBType, rawOfNat32, Nat.mod_eq_of_lt himm]
+  refine ZiskFv.Compliance.Decode.ofNat32_shift_mask_eq _ 8 4
+    ((imm >>> 1) &&& 15) (lt_of_le_of_lt Nat.and_le_right (by norm_num))
+    (by norm_num) ?_
+  intro i hi
+  have e31 : ¬(31 ≤ 8 + i) := by omega
+  have e25 : ¬(25 ≤ 8 + i) := by omega
+  have e20 : ¬(20 ≤ 8 + i) := by omega
+  have e15 : ¬(15 ≤ 8 + i) := by omega
+  have e12 : ¬(12 ≤ 8 + i) := by omega
+  have e8 : 8 ≤ 8 + i := by omega
+  have e7 : 7 ≤ 8 + i := by omega
+  have himm11 : (imm >>> 11 % 2).testBit (8 + i - 7) = false :=
+    ZiskFv.Compliance.Decode.tbf
+      (show imm >>> 11 % 2 < 2 ^ 1 from Nat.mod_lt _ (by norm_num)) (by omega)
+  have hop' : Nat.testBit 99 (8 + i) = false :=
+    ZiskFv.Compliance.Decode.tbf (show 99 < 2 ^ 7 by norm_num) (by omega)
+  simp [Nat.testBit_or, Nat.testBit_shiftLeft, e31, e25, e20, e15, e12, e8, e7,
+    himm11, hop', show 8 + i - 8 = i by omega]
+
+private theorem rawBType_imm_bits (imm rs2 rs1 funct3 : Nat)
+    (hrs2 : rs2 < 32) (hrs1 : rs1 < 32) (hfunct3 : funct3 < 8)
+    (himmLt : imm < 8192) (halign : imm % 2 = 0) :
+    (((((rawBType imm rs2 rs1 funct3 &&& 2147483648#32) >>> 31) <<< 12) |||
+        (((rawBType imm rs2 rs1 funct3 &&& 128#32) >>> 7) <<< 11) |||
+        (((rawBType imm rs2 rs1 funct3 &&& 2113929216#32) >>> 25) <<< 5) |||
+        (((rawBType imm rs2 rs1 funct3 &&& 3840#32) >>> 8) <<< 1)).truncate 13) =
+      BitVec.ofNat 13 imm := by
+  rw [rawBType_imm12 imm rs2 rs1 funct3 hrs2 hrs1 hfunct3 himmLt,
+    rawBType_imm11 imm rs2 rs1 funct3 himmLt,
+    rawBType_imm10_5 imm rs2 rs1 funct3 hrs2 hrs1 hfunct3 himmLt,
+    rawBType_imm4_1 imm rs2 rs1 funct3 himmLt]
+  have hshr12 : imm >>> 12 < 8192 := by
+    rw [Nat.shiftRight_eq_div_pow]
+    omega
+  have hshr11 : imm >>> 11 < 8192 := by
+    rw [Nat.shiftRight_eq_div_pow]
+    omega
+  have hshr5 : imm >>> 5 < 8192 := by
+    rw [Nat.shiftRight_eq_div_pow]
+    omega
+  have hshr1 : imm >>> 1 < 8192 := by
+    rw [Nat.shiftRight_eq_div_pow]
+    omega
+  have h12 : ((imm >>> 12) % 2) <<< 12 < 8192 := by
+    rw [Nat.shiftLeft_eq]
+    have h := Nat.mod_lt (imm >>> 12) (by norm_num : 0 < 2)
+    norm_num
+    omega
+  have hp12 : (imm >>> 12) % 2 < 8192 :=
+    lt_trans (Nat.mod_lt _ (by norm_num)) (by norm_num)
+  have hp11 : (imm >>> 11) % 2 < 8192 :=
+    lt_trans (Nat.mod_lt _ (by norm_num)) (by norm_num)
+  have ha10 : ((imm >>> 5) &&& 63) < 8192 :=
+    lt_of_le_of_lt Nat.and_le_right (by norm_num)
+  have ha4 : ((imm >>> 1) &&& 15) < 8192 :=
+    lt_of_le_of_lt Nat.and_le_right (by norm_num)
+  have h11 : ((imm >>> 11) % 2) <<< 11 < 8192 := by
+    rw [Nat.shiftLeft_eq]
+    have h := Nat.mod_lt (imm >>> 11) (by norm_num : 0 < 2)
+    norm_num
+    omega
+  have h10 : ((imm >>> 5) &&& 63) <<< 5 < 8192 := by
+    rw [Nat.shiftLeft_eq]
+    have h : ((imm >>> 5) &&& 63) ≤ 63 := Nat.and_le_right
+    norm_num
+    omega
+  have h4 : ((imm >>> 1) &&& 15) <<< 1 < 8192 := by
+    rw [Nat.shiftLeft_eq]
+    have h : ((imm >>> 1) &&& 15) ≤ 15 := Nat.and_le_right
+    norm_num
+    omega
+  apply BitVec.eq_of_getLsbD_eq
+  intro i
+  by_cases hi : i < 13
+  · interval_cases i <;>
+      simp only [BitVec.getLsbD] <;>
+      simp [Nat.testBit_shiftLeft, Nat.testBit_shiftRight,
+        Nat.testBit_mod_two_pow, Nat.mod_eq_of_lt himmLt, Nat.mod_eq_of_lt hshr12,
+        Nat.mod_eq_of_lt hshr11, Nat.mod_eq_of_lt hshr5, Nat.mod_eq_of_lt hshr1,
+        Nat.mod_eq_of_lt hp12, Nat.mod_eq_of_lt hp11, Nat.mod_eq_of_lt ha10,
+        Nat.mod_eq_of_lt ha4,
+        Nat.mod_eq_of_lt h12, Nat.mod_eq_of_lt h11, Nat.mod_eq_of_lt h10,
+        Nat.mod_eq_of_lt h4, show (8192 : Nat) = 2 ^ 13 by norm_num] <;>
+      norm_num [Nat.testBit] at halign ⊢ <;> aesop <;>
+      simp [Nat.shiftRight_eq_div_pow] at *
+  · simp [BitVec.getLsbD, hi]
+
+private theorem rawBType_assembled_mask (v : BitVec 32) :
+    (((((v &&& 2147483648#32) >>> 31) <<< 12) |||
+        (((v &&& 128#32) >>> 7) <<< 11) |||
+        (((v &&& 2113929216#32) >>> 25) <<< 5) |||
+        (((v &&& 3840#32) >>> 8) <<< 1)) &&& 8191#32) =
+      ((((v &&& 2147483648#32) >>> 31) <<< 12) |||
+        (((v &&& 128#32) >>> 7) <<< 11) |||
+        (((v &&& 2113929216#32) >>> 25) <<< 5) |||
+        (((v &&& 3840#32) >>> 8) <<< 1)) := by
+  apply BitVec.eq_of_getLsbD_eq
+  intro i
+  by_cases hi : i < 32
+  · interval_cases i <;> simp
+  · simp [BitVec.getLsbD, hi]
+
+private theorem eq_setWidth_truncate13_of_mask (v : BitVec 32)
+    (hmask : v &&& 8191#32 = v) :
+    v = (v.truncate 13).setWidth 32 := by
+  have hv : v.toNat = v.toNat &&& 8191 := by
+    have h := congrArg BitVec.toNat hmask
+    simpa [BitVec.toNat_and] using h.symm
+  have hvlt : v.toNat < 8192 := by
+    rw [hv]
+    exact lt_of_le_of_lt Nat.and_le_right (by norm_num)
+  have hv32 : v.toNat < 2 ^ 32 := v.isLt
+  have hv32' : v.toNat < 4294967296 := by simpa using hv32
+  apply BitVec.eq_of_getLsbD_eq
+  intro i
+  by_cases hi32 : i < 32
+  · simp [BitVec.getLsbD, hi32, Nat.mod_eq_of_lt hvlt,
+      Nat.mod_eq_of_lt hv32']
+  · simp [BitVec.getLsbD, hi32]
+
+private theorem rawBType_rs1_bits (imm rs2 rs1 funct3 : Nat)
+    (hrs1 : rs1 < 32) (hfunct3 : funct3 < 8) :
+    (rawBType imm rs2 rs1 funct3 &&& 1015808#32) >>> 15 = BitVec.ofNat 32 rs1 := by
+  rw [show (1015808 : Nat) = (2 ^ 5 - 1) <<< 15 by decide,
+    and_shr_field _ 15 5 (by norm_num)]
+  simp only [rawBType, rawOfNat32]
+  refine ZiskFv.Compliance.Decode.ofNat32_shift_mask_eq _ 15 5 rs1 hrs1 (by norm_num) ?_
+  intro i hi
+  simp only [Nat.testBit_or, Nat.testBit_shiftLeft]
+  have e31 : ¬(31 ≤ 15 + i) := by omega
+  have e25 : ¬(25 ≤ 15 + i) := by omega
+  have e20 : ¬(20 ≤ 15 + i) := by omega
+  have e15 : 15 ≤ 15 + i := by omega
+  have e12 : 12 ≤ 15 + i := by omega
+  have e8 : 8 ≤ 15 + i := by omega
+  have e7 : 7 ≤ 15 + i := by omega
+  have hf3' : funct3.testBit (15 + i - 12) = false :=
+    ZiskFv.Compliance.Decode.tbf (show funct3 < 2 ^ 3 by omega) (by omega)
+  have himm4 : Nat.testBit 15 (15 + i - 8) = false :=
+    ZiskFv.Compliance.Decode.tbf (show 15 < 2 ^ 4 by norm_num) (by omega)
+  have himm11 : ((imm % 8192) >>> 11 % 2).testBit (15 + i - 7) = false :=
+    ZiskFv.Compliance.Decode.tbf
+      (show (imm % 8192) >>> 11 % 2 < 2 ^ 1 from Nat.mod_lt _ (by norm_num)) (by omega)
+  have hop' : Nat.testBit 99 (15 + i) = false :=
+    ZiskFv.Compliance.Decode.tbf (show 99 < 2 ^ 7 by norm_num) (by omega)
+  simp [e31, e25, e20, e15, e12, e8, e7, hf3', himm4, himm11, hop',
+    show 15 + i - 15 = i by omega]
+
+private theorem rawBType_rs2_bits (imm rs2 rs1 funct3 : Nat)
+    (hrs2 : rs2 < 32) (hrs1 : rs1 < 32) (hfunct3 : funct3 < 8) :
+    (rawBType imm rs2 rs1 funct3 &&& 32505856#32) >>> 20 = BitVec.ofNat 32 rs2 := by
+  rw [show (32505856 : Nat) = (2 ^ 5 - 1) <<< 20 by decide,
+    and_shr_field _ 20 5 (by norm_num)]
+  simp only [rawBType, rawOfNat32]
+  refine ZiskFv.Compliance.Decode.ofNat32_shift_mask_eq _ 20 5 rs2 hrs2 (by norm_num) ?_
+  intro i hi
+  simp only [Nat.testBit_or, Nat.testBit_shiftLeft]
+  have e31 : ¬(31 ≤ 20 + i) := by omega
+  have e25 : ¬(25 ≤ 20 + i) := by omega
+  have e20 : 20 ≤ 20 + i := by omega
+  have e15 : 15 ≤ 20 + i := by omega
+  have e12 : 12 ≤ 20 + i := by omega
+  have e8 : 8 ≤ 20 + i := by omega
+  have e7 : 7 ≤ 20 + i := by omega
+  have hrs1' : rs1.testBit (20 + i - 15) = false :=
+    ZiskFv.Compliance.Decode.tbf (show rs1 < 2 ^ 5 by omega) (by omega)
+  have hf3' : funct3.testBit (20 + i - 12) = false :=
+    ZiskFv.Compliance.Decode.tbf (show funct3 < 2 ^ 3 by omega) (by omega)
+  have himm4 : Nat.testBit 15 (20 + i - 8) = false :=
+    ZiskFv.Compliance.Decode.tbf (show 15 < 2 ^ 4 by norm_num) (by omega)
+  have himm11 : ((imm % 8192) >>> 11 % 2).testBit (20 + i - 7) = false :=
+    ZiskFv.Compliance.Decode.tbf
+      (show (imm % 8192) >>> 11 % 2 < 2 ^ 1 from Nat.mod_lt _ (by norm_num)) (by omega)
+  have hop' : Nat.testBit 99 (20 + i) = false :=
+    ZiskFv.Compliance.Decode.tbf (show 99 < 2 ^ 7 by norm_num) (by omega)
+  simp [e31, e25, e20, e15, e12, e8, e7, hrs1', hf3', himm4, himm11, hop',
+    show 20 + i - 20 = i by omega]
+
+private theorem signExtend13_of_sign (v : BitVec 13) (h : v[12] = true) :
+    v.setWidth 32 - 8192#32 = BitVec.signExtend 32 v := by
+  apply BitVec.eq_of_toInt_eq
+  rw [BitVec.toInt_sub, BitVec.toInt_signExtend_of_le (by omega)]
+  have hlo : 4096 ≤ v.toNat := by
+    by_contra hn
+    have ht := Nat.testBit_lt_two_pow (show v.toNat < 2 ^ 12 by omega)
+    have hb : v.toNat.testBit 12 = true := by
+      change v[12] = true
+      exact h
+    rw [ht] at hb
+    contradiction
+  have hvInt : v.toInt = v.toNat - 8192 := by
+    rw [BitVec.toInt, if_neg (by omega)]
+    norm_num
+  have hsetInt : (v.setWidth 32).toInt = v.toNat := by
+    rw [BitVec.toInt]
+    have hnat : (v.setWidth 32).toNat = v.toNat := by
+      rw [BitVec.toNat_setWidth, Nat.mod_eq_of_lt (lt_trans v.isLt (by norm_num))]
+    rw [hnat, if_pos (by have hv := v.isLt; norm_num at hv ⊢; omega)]
+  have h8192 : (8192#32).toInt = 8192 := by decide
+  rw [hvInt, hsetInt, h8192]
+  norm_num [Int.bmod]
+  have hmod : ((v.toNat : Int) - 8192) % 4294967296 =
+      (v.toNat : Int) - 8192 + 4294967296 := by
+    rw [Int.emod_eq_add_self_emod]
+    apply Int.emod_eq_of_lt <;> omega
+  rw [hmod, if_neg (by omega)]
+  omega
+
+private theorem signExtend13_of_not_sign (v : BitVec 13) (h : v[12] = false) :
+    v.setWidth 32 = BitVec.signExtend 32 v := by
+  symm
+  apply BitVec.eq_of_getLsbD_eq
+  intro i
+  by_cases hi : i < 32
+  · interval_cases i <;>
+      simp [BitVec.getElem_signExtend, BitVec.getElem_setWidth,
+        BitVec.msb_setWidth] at h ⊢ <;> assumption
+  · simp [BitVec.getLsbD_signExtend, hi]
+
+private theorem signext13 (v : BitVec 13) :
+    signext ⟨v.setWidth 32⟩ 13#u32
+      ⦃r => r.bv = BitVec.signExtend 32 v⦄ := by
+  rw [signext]
+  step*
+  all_goals
+    have hi : i = 12#u32 := UScalar.eq_imp _ _ (by simpa using i_post1)
+    subst i
+    have hs : sign_bit = 4096#u32 :=
+      UScalar.eq_imp _ _ (by
+        norm_num [sign_bit_post1, U32.size_eq, Nat.shiftLeft_eq])
+    subst sign_bit
+    have hm : max_value = 8192#u32 :=
+      UScalar.eq_imp _ _ (by
+        norm_num [max_value_post1, U32.size_eq, Nat.shiftLeft_eq])
+    subst max_value
+    clear i_post1 i_post2 sign_bit_post1 sign_bit_post2 max_value_post1 max_value_post2
+  · clear i1_post1 i1_post2
+    rw [i2_post, i3_post]
+    change I32.min ≤ (v.setWidth 32).toInt - (8192#32).toInt
+    have hmin : I32.min = -2147483648 := by
+      norm_num [I32.min, I32.numBits_eq]
+    have hset : (v.setWidth 32).toInt = v.toNat := by
+      rw [BitVec.toInt]
+      have hnat : (v.setWidth 32).toNat = v.toNat := by
+        rw [BitVec.toNat_setWidth, Nat.mod_eq_of_lt (lt_trans v.isLt (by norm_num))]
+      rw [hnat, if_pos (by have hv := v.isLt; norm_num at hv ⊢; omega)]
+    have h8192 : (8192#32).toInt = 8192 := by decide
+    rw [hmin, hset, h8192]
+    omega
+  · clear i1_post1 i1_post2
+    rw [i2_post, i3_post]
+    change (v.setWidth 32).toInt - (8192#32).toInt ≤ I32.max
+    have hmax : I32.max = 2147483647 := by
+      norm_num [I32.max, I32.numBits_eq]
+    have hset : (v.setWidth 32).toInt = v.toNat := by
+      rw [BitVec.toInt]
+      have hnat : (v.setWidth 32).toNat = v.toNat := by
+        rw [BitVec.toNat_setWidth, Nat.mod_eq_of_lt (lt_trans v.isLt (by norm_num))]
+      rw [hnat, if_pos (by have hv := v.isLt; norm_num at hv ⊢; omega)]
+    have h8192 : (8192#32).toInt = 8192 := by decide
+    rw [hmax, hset, h8192]
+    omega
+  · calc
+      r.bv = i2.bv - i3.bv := r_post2
+      _ = v.setWidth 32 - 8192#32 := by rw [i2_post, i3_post]; rfl
+      _ = BitVec.signExtend 32 v := by
+        apply signExtend13_of_sign
+        have hi1 := i1_post2
+        change i1.bv = 4096#32 &&& v.setWidth 32 at hi1
+        have hne : (i1 != 0#u32) = true := by assumption
+        simp at hne
+        change i1.bv.toNat ≠ 0 at hne
+        by_contra hb
+        have hz : 4096#32 &&& v.setWidth 32 = 0#32 := by
+          apply BitVec.eq_of_getLsbD_eq
+          intro k
+          by_cases hk : k < 32
+          · interval_cases k <;> simp_all
+          · simp [BitVec.getLsbD, hk]
+        rw [hi1, hz] at hne
+        exact hne rfl
+  · change v.setWidth 32 = BitVec.signExtend 32 v
+    apply signExtend13_of_not_sign
+    have hi1 := i1_post2
+    change i1.bv = 4096#32 &&& v.setWidth 32 at hi1
+    have hne : ¬(i1 != 0#u32) = true := by assumption
+    simp at hne
+    change i1.bv.toNat = 0 at hne
+    have hi1zero : i1.bv = 0#32 := BitVec.eq_of_toNat_eq hne
+    rw [hi1] at hi1zero
+    have hzbit := congrArg (fun x : BitVec 32 => x[12]) hi1zero
+    simpa using hzbit
+
+/-- `decode_b` recovers both source-register fields and the signed, aligned
+    13-bit branch immediate from an honestly bounded symbolic B-type word. -/
+theorem decode_b_rawBType_fields
+    (imm rs2 rs1 funct3 : Nat)
+    (hrs2 : rs2 < 32) (hrs1 : rs1 < 32) (hfunct3 : funct3 < 8)
+    (himmLt : imm < 8192) (halign : imm % 2 = 0)
+    (rop : RiscvOpcode) (d : DecodedRv64im)
+    (hd : decode_b (toU32 (rawBType imm rs2 rs1 funct3)) rop = ok d) :
+    d.rs1.bv = BitVec.ofNat 32 rs1 ∧
+      d.rs2.bv = BitVec.ofNat 32 rs2 ∧
+      (IScalar.hcast UScalarTy.U64 d.imm).bv =
+        BitVec.signExtend 64 (BitVec.ofNat 13 imm) := by
+  simp only [decode_b, DecodedRv64im.new, lift, bind_ok, Bind.bind] at hd
+  obtain ⟨_i1, _, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨imm11, himm11, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨imm4_1, himm4_1, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨i5, hi5, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨i7, hi7, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨imm10_5, himm10_5, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨imm12, himm12, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨i10, hi10, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨i11, hi11, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨i13, hi13, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨i15, hi15, hd⟩ := bind_eq_ok_imp hd
+  obtain ⟨i17, hi17, hd⟩ := bind_eq_ok_imp hd
+  rw [Result.ok.injEq] at hd
+  rw [← hd]
+  have hi5bv : i5.bv =
+      (toU32 (rawBType imm rs2 rs1 funct3) &&& 1015808#u32).bv >>> 15 := by
+    rw [show ((toU32 (rawBType imm rs2 rs1 funct3) &&& 1015808#u32) >>> 15#i32 :
+      Result Std.U32) =
+        ok ⟨(toU32 (rawBType imm rs2 rs1 funct3) &&& 1015808#u32).bv >>> 15⟩ from rfl,
+      Result.ok.injEq] at hi5
+    exact (congrArg UScalar.bv hi5).symm
+  have hi7bv : i7.bv =
+      (toU32 (rawBType imm rs2 rs1 funct3) &&& 32505856#u32).bv >>> 20 := by
+    rw [show ((toU32 (rawBType imm rs2 rs1 funct3) &&& 32505856#u32) >>> 20#i32 :
+      Result Std.U32) =
+        ok ⟨(toU32 (rawBType imm rs2 rs1 funct3) &&& 32505856#u32).bv >>> 20⟩ from rfl,
+      Result.ok.injEq] at hi7
+    exact (congrArg UScalar.bv hi7).symm
+  refine ⟨?_, ?_, ?_⟩
+  · change i5.bv = BitVec.ofNat 32 rs1
+    rw [hi5bv]
+    exact rawBType_rs1_bits imm rs2 rs1 funct3 hrs1 hfunct3
+  · change i7.bv = BitVec.ofNat 32 rs2
+    rw [hi7bv]
+    exact rawBType_rs2_bits imm rs2 rs1 funct3 hrs2 hrs1 hfunct3
+  · have himm11bv : imm11.bv =
+        (toU32 (rawBType imm rs2 rs1 funct3) &&& 128#u32).bv >>> 7 := by
+      rw [show ((toU32 (rawBType imm rs2 rs1 funct3) &&& 128#u32) >>> 7#i32 :
+        Result Std.U32) =
+          ok ⟨(toU32 (rawBType imm rs2 rs1 funct3) &&& 128#u32).bv >>> 7⟩ from rfl,
+        Result.ok.injEq] at himm11
+      exact (congrArg UScalar.bv himm11).symm
+    have himm4bv : imm4_1.bv =
+        (toU32 (rawBType imm rs2 rs1 funct3) &&& 3840#u32).bv >>> 8 := by
+      rw [show ((toU32 (rawBType imm rs2 rs1 funct3) &&& 3840#u32) >>> 8#i32 :
+        Result Std.U32) =
+          ok ⟨(toU32 (rawBType imm rs2 rs1 funct3) &&& 3840#u32).bv >>> 8⟩ from rfl,
+        Result.ok.injEq] at himm4_1
+      exact (congrArg UScalar.bv himm4_1).symm
+    have himm10bv : imm10_5.bv =
+        (toU32 (rawBType imm rs2 rs1 funct3) &&& 2113929216#u32).bv >>> 25 := by
+      rw [show ((toU32 (rawBType imm rs2 rs1 funct3) &&& 2113929216#u32) >>> 25#i32 :
+        Result Std.U32) =
+          ok ⟨(toU32 (rawBType imm rs2 rs1 funct3) &&& 2113929216#u32).bv >>> 25⟩ from rfl,
+        Result.ok.injEq] at himm10_5
+      exact (congrArg UScalar.bv himm10_5).symm
+    have himm12bv : imm12.bv =
+        (toU32 (rawBType imm rs2 rs1 funct3) &&& 2147483648#u32).bv >>> 31 := by
+      rw [show ((toU32 (rawBType imm rs2 rs1 funct3) &&& 2147483648#u32) >>> 31#i32 :
+        Result Std.U32) =
+          ok ⟨(toU32 (rawBType imm rs2 rs1 funct3) &&& 2147483648#u32).bv >>> 31⟩ from rfl,
+        Result.ok.injEq] at himm12
+      exact (congrArg UScalar.bv himm12).symm
+    have hi10bv : i10.bv = imm12.bv <<< 12 := by
+      rw [show (imm12 <<< 12#i32 : Result Std.U32) = ok ⟨imm12.bv <<< 12⟩ from rfl,
+        Result.ok.injEq] at hi10
+      exact (congrArg UScalar.bv hi10).symm
+    have hi11bv : i11.bv = imm11.bv <<< 11 := by
+      rw [show (imm11 <<< 11#i32 : Result Std.U32) = ok ⟨imm11.bv <<< 11⟩ from rfl,
+        Result.ok.injEq] at hi11
+      exact (congrArg UScalar.bv hi11).symm
+    have hi13bv : i13.bv = imm10_5.bv <<< 5 := by
+      rw [show (imm10_5 <<< 5#i32 : Result Std.U32) = ok ⟨imm10_5.bv <<< 5⟩ from rfl,
+        Result.ok.injEq] at hi13
+      exact (congrArg UScalar.bv hi13).symm
+    have hi15bv : i15.bv = imm4_1.bv <<< 1 := by
+      rw [show (imm4_1 <<< 1#i32 : Result Std.U32) = ok ⟨imm4_1.bv <<< 1⟩ from rfl,
+        Result.ok.injEq] at hi15
+      exact (congrArg UScalar.bv hi15).symm
+    have hcombined : (i10 ||| i11 ||| i13 ||| i15).bv =
+        ((((rawBType imm rs2 rs1 funct3 &&& 2147483648#32) >>> 31) <<< 12) |||
+          (((rawBType imm rs2 rs1 funct3 &&& 128#32) >>> 7) <<< 11) |||
+          (((rawBType imm rs2 rs1 funct3 &&& 2113929216#32) >>> 25) <<< 5) |||
+          (((rawBType imm rs2 rs1 funct3 &&& 3840#32) >>> 8) <<< 1)) := by
+      change i10.bv ||| i11.bv ||| i13.bv ||| i15.bv = _
+      rw [hi10bv, hi11bv, hi13bv, hi15bv, himm12bv, himm11bv, himm10bv, himm4bv]
+      rfl
+    have himmbits := rawBType_imm_bits imm rs2 rs1 funct3
+      hrs2 hrs1 hfunct3 himmLt halign
+    have hinput : (i10 ||| i11 ||| i13 ||| i15).bv =
+        (BitVec.ofNat 13 imm).setWidth 32 := by
+      calc
+        (i10 ||| i11 ||| i13 ||| i15).bv =
+            ((i10 ||| i11 ||| i13 ||| i15).bv.truncate 13).setWidth 32 := by
+          apply eq_setWidth_truncate13_of_mask
+          rw [hcombined]
+          exact rawBType_assembled_mask _
+        _ = (BitVec.ofNat 13 imm).setWidth 32 := by
+          rw [show (i10 ||| i11 ||| i13 ||| i15).bv.truncate 13 =
+            BitVec.ofNat 13 imm by rw [hcombined]; exact himmbits]
+    have hs := signext13 (BitVec.ofNat 13 imm)
+    rw [← hinput] at hs
+    rw [hi17] at hs
+    have hi17' : i17.bv = BitVec.signExtend 32 (BitVec.ofNat 13 imm) := hs
+    change BitVec.signExtend 64 i17.bv =
+      BitVec.signExtend 64 (BitVec.ofNat 13 imm)
+    rw [hi17']
+    apply BitVec.eq_of_getLsbD_eq
+    intro k
+    by_cases hk : k < 64
+    · interval_cases k <;>
+        simp [BitVec.getElem_signExtend, BitVec.msb_signExtend]
+    · simp [BitVec.getLsbD_signExtend, hk]
+
+section AxiomAudit
+#print axioms decode_b_rawBType_fields
+end AxiomAudit

--- a/trust/consistency/root_soundness_instantiation_rawprogram_memory.lean
+++ b/trust/consistency/root_soundness_instantiation_rawprogram_memory.lean
@@ -1,0 +1,5 @@
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingMemoryNonvacuity
+
+#print axioms ZiskFv.Compliance.RawProgramBinding.memoryProgramBinding
+#print axioms ZiskFv.Compliance.RawProgramBinding.memorySdRow_eq_romMessageOfRaw
+#print axioms ZiskFv.Compliance.RawProgramBinding.memoryLdNegativeRow_eq_romMessageOfRaw


### PR DESCRIPTION
Part 3 of the Phase 9 stack for #61. Base: `phase9-2-initial-decoders`.

## Summary

- Proves complete production row pins for loads and stores.
- Adds kernel proofs for raw I-, S-, branch-, and JAL-format field decoding.
- Retargets immediate, conditional CopyB, store, and LUI constructors using those exact fields.
- Lands the non-vacuity hard gate: an independently written accepted program containing SD, LD,
  and negative-offset LD is exactly the production serialization.
- Records the concrete negative branch/JAL serialization mismatches that forced the later signed
  interface correction instead of narrowing the accepted raw words.

No nonnegative-offset, nonzero-register, or alignment restriction is introduced.

## Stack

1. `phase9-1-raw-binding`
2. `phase9-2-initial-decoders`
3. **This PR**
4. `phase9-4-expanded-layout`
5. `phase9-5-architectural-decoders`
6. `phase9-6-root-endpoint`

## Verification

Focused family builds, the semantic non-vacuity probe, and standard-only closure audits passed.
The complete stack's full gates are recorded on PR 6.
