### PR TITLE
#61 Phase 9.4: model signed and expanded control rows

### DIFF
--- a/ZiskFv/Bits/PackedBitVec/WidePCNoWrap.lean
+++ b/ZiskFv/Bits/PackedBitVec/WidePCNoWrap.lean
@@ -261,6 +261,50 @@ lemma fgl_pc_plus_offset_lo_of_bound
     (no_wrap_of_pc_offset_bound pc_fgl offset_fgl PC offset_bv
       h_pc_bridge h_offset_bridge h_pc_offset_bound)
 
+/-- A signed 64-bit offset is stored in production ROM as its integer cast to
+Goldilocks.  If the mathematical target stays in the field's canonical range,
+field addition agrees with 64-bit addition, including backward offsets. -/
+lemma fgl_pc_plus_signed_offset_val
+    (pc_fgl : FGL) (PC offset_bv : BitVec 64)
+    (h_pc_bridge : pc_fgl.val = PC.toNat)
+    (h_target_nonneg : 0 ≤ (PC.toNat : Int) + offset_bv.toInt)
+    (h_target_lt : (PC.toNat : Int) + offset_bv.toInt < GL_prime) :
+    (pc_fgl + (offset_bv.toInt : FGL)).val = (PC + offset_bv).toNat := by
+  have hpc_eq : pc_fgl = (PC.toNat : FGL) := by
+    apply Fin.ext
+    rw [Fin.val_natCast, Nat.mod_eq_of_lt (by omega)]
+    exact h_pc_bridge
+  rw [hpc_eq]
+  let r : Int := (PC.toNat : Int) + offset_bv.toInt
+  have hr0 : 0 ≤ r := by simpa [r] using h_target_nonneg
+  have hrp : r < (GL_prime : Int) := by
+    simpa [r] using h_target_lt
+  have hrnat : ((r : FGL).val) = r.toNat := by
+    rw [Fin.val_intCast]
+    exact congrArg Int.toNat (Int.emod_eq_of_lt hr0 hrp)
+  have hfield : (PC.toNat : FGL) + (offset_bv.toInt : FGL) = (r : FGL) := by
+    simp only [r]
+    push_cast
+    rfl
+  rw [hfield, hrnat, BitVec.toNat_add]
+  have hpc64 : PC.toNat < 2 ^ 64 := PC.isLt
+  simp only [r] at hr0 hrp
+  rw [BitVec.toInt_eq_toNat_cond] at hr0 hrp
+  split at hr0
+  · rename_i hoff
+    rw [if_pos hoff] at hrp
+    have hsum : PC.toNat + offset_bv.toNat < 2 ^ 64 := by omega
+    rw [Nat.mod_eq_of_lt hsum]
+    simp only [r, BitVec.toInt_eq_toNat_cond, if_pos hoff]
+    omega
+  · rename_i hoff
+    rw [if_neg hoff] at hrp
+    have hle : 2 ^ 64 ≤ PC.toNat + offset_bv.toNat := by omega
+    have hlt : PC.toNat + offset_bv.toNat - 2 ^ 64 < 2 ^ 64 := by omega
+    rw [Nat.mod_eq_sub_mod hle, Nat.mod_eq_of_lt hlt]
+    simp only [r, BitVec.toInt_eq_toNat_cond, if_neg hoff]
+    omega
+
 /-- **Hi-half lift specialised to small offset.**  Companion to
 `fgl_pc_plus_offset_lo_of_bound`. -/
 lemma fgl_pc_plus_offset_hi_of_bound

--- a/ZiskFv/Compliance/AeneasBridgeTrust/Base.lean
+++ b/ZiskFv/Compliance/AeneasBridgeTrust/Base.lean
@@ -68,11 +68,11 @@ def OpEnvelope.aeneasBridgeTrust : OpEnvelope state m r_main → Prop
       ∧ (m.b_0 r_main).val = (imm ++ (0 : BitVec 12)).toNat
       ∧ (m.b_1 r_main).val
           = (BitVec.signExtend 64 (imm ++ (0 : BitVec 12))).toNat / 4294967296
-  | .auipc auipc_input _ _ _ _ _ _ _ provenance _ _ _ _ _ _ _ =>
+  | .auipc auipc_input _ _ _ _ _ _ _ provenance _ _ _ _ _ _ _ _ =>
       Nonempty (MainRowProvenance m r_main)
       ∧ MainRowProvenance.AuipcRowMode provenance
-      ∧ (m.jmp_offset2 r_main).val
-          = (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
+      ∧ m.jmp_offset2 r_main
+          = ((BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt : FGL)
       ∧ (m.pc r_main).val = auipc_input.PC.toNat
   | .auipc_x0 .. =>
       True

--- a/ZiskFv/Compliance/AeneasBridgeTrust/ControlAndUType.lean
+++ b/ZiskFv/Compliance/AeneasBridgeTrust/ControlAndUType.lean
@@ -87,16 +87,17 @@ def OpEnvelope.auipcOfExtractedShape
     (h_set_pc : provenance.extractedRow.setPc = false)
     (h_store_pc : provenance.extractedRow.storePc = true)
     (h_auipc_subset : ZiskFv.Tactics.UTypeArchetype.auipc_subset_holds m r_main next_pc)
-    (h_offset_bridge : (m.jmp_offset2 r_main).val
-      = (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat)
+    (h_offset_bridge : m.jmp_offset2 r_main =
+      ((BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt : FGL))
     (h_pc_bridge : (m.pc r_main).val = auipc_input.PC.toNat)
     (promises : ZiskFv.EquivCore.Promises.UTypePromises
         state auipc_input.imm auipc_input.rd auipc_input.PC
         (PureSpec.execute_AUIPC_pure auipc_input).nextPC
         imm rd exec_row e_rd nextPC_val)
-    (h_no_wrap : auipc_input.PC.toNat
-      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
-        < GL_prime)
+    (h_target_nonneg : 0 ≤ (auipc_input.PC.toNat : Int)
+      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt)
+    (h_target_lt : (auipc_input.PC.toNat : Int)
+      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt < GL_prime)
     (h_pc_offset_lt_2_32 :
       (auipc_input.PC + BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
         < 4294967296) :
@@ -106,7 +107,7 @@ def OpEnvelope.auipcOfExtractedShape
     (MainRowProvenance.auipcRowMode_of_extracted_shape provenance
       h_op h_internal h_m32 h_set_pc h_store_pc)
     h_auipc_subset h_offset_bridge h_pc_bridge promises
-    h_no_wrap h_pc_offset_lt_2_32
+    h_target_nonneg h_target_lt h_pc_offset_lt_2_32
 
 /-- The AUIPC bridge predicate is derivable for the envelope constructed from
 extracted row-shape equalities and the remaining dynamic AUIPC facts. -/
@@ -124,16 +125,17 @@ theorem OpEnvelope.aeneasBridgeTrust_auipcOfExtractedShape
     (h_set_pc : provenance.extractedRow.setPc = false)
     (h_store_pc : provenance.extractedRow.storePc = true)
     (h_auipc_subset : ZiskFv.Tactics.UTypeArchetype.auipc_subset_holds m r_main next_pc)
-    (h_offset_bridge : (m.jmp_offset2 r_main).val
-      = (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat)
+    (h_offset_bridge : m.jmp_offset2 r_main =
+      ((BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt : FGL))
     (h_pc_bridge : (m.pc r_main).val = auipc_input.PC.toNat)
     (promises : ZiskFv.EquivCore.Promises.UTypePromises
         state auipc_input.imm auipc_input.rd auipc_input.PC
         (PureSpec.execute_AUIPC_pure auipc_input).nextPC
         imm rd exec_row e_rd nextPC_val)
-    (h_no_wrap : auipc_input.PC.toNat
-      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
-        < GL_prime)
+    (h_target_nonneg : 0 ≤ (auipc_input.PC.toNat : Int)
+      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt)
+    (h_target_lt : (auipc_input.PC.toNat : Int)
+      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt < GL_prime)
     (h_pc_offset_lt_2_32 :
       (auipc_input.PC + BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
         < 4294967296) :
@@ -143,7 +145,7 @@ theorem OpEnvelope.aeneasBridgeTrust_auipcOfExtractedShape
       store_pc_mem provenance
       h_op h_internal h_m32 h_set_pc h_store_pc
       h_auipc_subset h_offset_bridge h_pc_bridge promises
-      h_no_wrap h_pc_offset_lt_2_32).aeneasBridgeTrust := by
+      h_target_nonneg h_target_lt h_pc_offset_lt_2_32).aeneasBridgeTrust := by
   unfold OpEnvelope.auipcOfExtractedShape OpEnvelope.aeneasBridgeTrust
   exact ⟨⟨provenance⟩,
     MainRowProvenance.auipcRowMode_of_extracted_shape provenance

--- a/ZiskFv/Compliance/AeneasBridgeTrust/Extraction/Totality.lean
+++ b/ZiskFv/Compliance/AeneasBridgeTrust/Extraction/Totality.lean
@@ -782,7 +782,7 @@ theorem jalr_ok (self : riscv2zisk_context.Riscv2ZiskContext)
 
 /-- The default lowering context the transpile pipeline threads into the dispatcher. -/
 def defCtx : riscv2zisk_context.Riscv2ZiskContext :=
-  { extract_inst := none, extract_marker := (), input_precompile := none,
+  { extract_inst := none, extract_first_inst := none, extract_marker := (), input_precompile := none,
     output_precompile := none, input_precompile_reg := none, output_precompile_reg := none }
 
 /-! ## 9. Index-width totality — DISCHARGES the `hw` premise of §6.

--- a/ZiskFv/Compliance/AeneasBridgeTrust/Extraction/Totality.lean
+++ b/ZiskFv/Compliance/AeneasBridgeTrust/Extraction/Totality.lean
@@ -762,7 +762,20 @@ theorem jalr_ok (self : riscv2zisk_context.Riscv2ZiskContext)
     obtain ⟨z3, hz3⟩ := op_zisk_ok z2 zisk_ops.ZiskOp.Add
     obtain ⟨z4, hz4⟩ := j_ok z3 1#i64 1#i64
     obtain ⟨z5, hz5⟩ := build_ok z4
-    obtain ⟨s1, hs1⟩ := insert_inst_ok { self with extract_marker := () } i.rom_address z5
+    let first : aeneas_extract.ZiskInstExtract :=
+      { paddr := z5.i.paddr, store_pc := z5.i.store_pc, store_use_sp := z5.i.store_use_sp
+        store := z5.i.store, store_offset := z5.i.store_offset, set_pc := z5.i.set_pc
+        is_precompiled := z5.i.is_precompiled, ind_width := z5.i.ind_width, «end» := z5.i.end
+        a_src := z5.i.a_src, a_use_sp_imm1 := z5.i.a_use_sp_imm1
+        a_offset_imm0 := z5.i.a_offset_imm0, b_src := z5.i.b_src
+        b_use_sp_imm1 := z5.i.b_use_sp_imm1, b_offset_imm0 := z5.i.b_offset_imm0
+        jmp_offset1 := z5.i.jmp_offset1, jmp_offset2 := z5.i.jmp_offset2
+        is_external_op := z5.i.is_external_op, op := z5.i.op
+        op_type_id := UScalar.cast UScalarTy.U32 (read_discriminant z5.i.op_type)
+        m32 := z5.i.m32, input_size := z5.i.input_size
+        sorted_pc_list_index := z5.i.sorted_pc_list_index }
+    obtain ⟨s1, hs1⟩ := insert_inst_ok
+      { self with extract_first_inst := some first, extract_marker := () } i.rom_address z5
     obtain ⟨roma, hroma⟩ := add_one_at_zero_ok i.rom_address hrom
     obtain ⟨z6, hz6⟩ := new_raw_ok roma
     obtain ⟨z7, hz7⟩ := src_a_imm_ok z6 riscv2zisk_context.Riscv2ZiskContext.jalr.JALR_MASK
@@ -777,7 +790,7 @@ theorem jalr_ok (self : riscv2zisk_context.Riscv2ZiskContext)
     obtain ⟨z13, hz13⟩ := build_ok z12
     obtain ⟨s2, hs2⟩ := insert_inst_ok { s1 with extract_marker := () } roma z13
     refine ⟨{ s2 with extract_marker := () }, ?_⟩
-    simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hz5, hs1, hroma,
+    simp only [lift, Bind.bind, bind_ok, hz0, hz1, hz2, hz3, hz4, hz5, first, hs1, hroma,
       hz6, hz7, hz8, hz9, hz10, hz11, hsix, hz12, hz13, hs2]
 
 /-- The default lowering context the transpile pipeline threads into the dispatcher. -/

--- a/ZiskFv/Compliance/ConstructionAuipc.lean
+++ b/ZiskFv/Compliance/ConstructionAuipc.lean
@@ -104,9 +104,9 @@ theorem construction_auipc_sound_claimed_dead
     (h_input_rd : auipc_input.rd = regidx_to_fin rd)
     (h_input_pc : (binding i).regs.get? Register.PC = .some auipc_input.PC)
     (h_offset_bridge :
-      ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
-          i.val).val
-        = (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat)
+      (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
+          i.val = ((BitVec.signExtend 64
+            (auipc_input.imm ++ (0 : BitVec 12))).toInt : FGL))
     (h_pc_bridge :
       ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val).val
         = auipc_input.PC.toNat)
@@ -124,9 +124,10 @@ theorem construction_auipc_sound_claimed_dead
       auipc_input.rd =
         Transpiler.wrap_to_regidx (eRdLui trace i).ptr)
     -- (b) RANGE pins
-    (h_no_wrap : auipc_input.PC.toNat
-      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
-        < GL_prime)
+    (h_target_nonneg : 0 ≤ (auipc_input.PC.toNat : Int)
+      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt)
+    (h_target_lt : (auipc_input.PC.toNat : Int)
+      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt < GL_prime)
     (h_pc_offset_lt_2_32 :
       (auipc_input.PC + BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
         < 4294967296) :
@@ -189,6 +190,7 @@ theorem construction_auipc_sound_claimed_dead
   exact ZiskFv.EquivCore.Auipc.equiv_AUIPC state auipc_input imm rd
     execRow e_rd m i.val next_pc store_pc_mem
     (PureSpec.execute_AUIPC_pure auipc_input).nextPC
-    promises h_circuit h_offset_bridge h_pc_bridge h_no_wrap h_pc_offset_lt_2_32
+    promises h_circuit h_offset_bridge h_pc_bridge h_target_nonneg h_target_lt
+      h_pc_offset_lt_2_32
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/Dispatch/NoMemOrSimple.lean
+++ b/ZiskFv/Compliance/Dispatch/NoMemOrSimple.lean
@@ -34,7 +34,7 @@ def OpEnvelope.exec_eq_nomem
   | .lui _ imm rd _ exec_row e_rd _ _ _ _ _ _ _ =>
       execute_instruction (instruction.UTYPE (imm, rd, uop.LUI)) state
         = state_effect_via_channels ⟨exec_row, [e_rd]⟩ state
-  | .auipc _ imm rd exec_row e_rd _ _ _ _ _ _ _ _ _ _ _ =>
+  | .auipc _ imm rd exec_row e_rd _ _ _ _ _ _ _ _ _ _ _ _ =>
       execute_instruction (instruction.UTYPE (imm, rd, uop.AUIPC)) state
         = state_effect_via_channels ⟨exec_row, [e_rd]⟩ state
   | .auipc_x0 _ imm rd exec_row _ =>
@@ -59,14 +59,14 @@ theorem zisk_riscv_compliant_program_bus_nomem
   | auipc auipc_input imm rd exec_row e_rd nextPC_val next_pc
           store_pc_mem provenance row_mode h_auipc_subset
           h_offset_bridge h_pc_bridge
-          promises h_no_wrap h_pc_offset_lt_2_32 =>
+          promises h_target_nonneg h_target_lt h_pc_offset_lt_2_32 =>
     simp only [OpEnvelope.exec_eq_nomem]
     exact ZiskFv.Equivalence.Auipc.equiv_AUIPC state auipc_input imm rd
       m r_main next_pc
       (ZiskFv.Equivalence.Auipc.AuipcRoute.rdWrite exec_row e_rd nextPC_val
         next_pc store_pc_mem provenance row_mode
         h_auipc_subset h_offset_bridge h_pc_bridge
-        promises h_no_wrap h_pc_offset_lt_2_32)
+        promises h_target_nonneg h_target_lt h_pc_offset_lt_2_32)
   | auipc_x0 auipc_input imm rd exec_row promises =>
     simp only [OpEnvelope.exec_eq_nomem]
     exact ZiskFv.Equivalence.Auipc.equiv_AUIPC state auipc_input imm rd

--- a/ZiskFv/Compliance/OpEnvelope.lean
+++ b/ZiskFv/Compliance/OpEnvelope.lean
@@ -329,16 +329,17 @@ inductive OpEnvelope
     (provenance : ZiskFv.Compliance.MainRowProvenance m r_main)
     (row_mode : ZiskFv.Compliance.MainRowProvenance.AuipcRowMode provenance)
     (h_auipc_subset : auipc_subset_holds m r_main next_pc)
-    (h_offset_bridge : (m.jmp_offset2 r_main).val
-      = (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat)
+    (h_offset_bridge : m.jmp_offset2 r_main =
+      ((BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt : FGL))
     (h_pc_bridge : (m.pc r_main).val = auipc_input.PC.toNat)
     (promises : ZiskFv.EquivCore.Promises.UTypePromises
         state auipc_input.imm auipc_input.rd auipc_input.PC
         (PureSpec.execute_AUIPC_pure auipc_input).nextPC
         imm rd exec_row e_rd nextPC_val)
-    (h_no_wrap : auipc_input.PC.toNat
-      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
-        < GL_prime)
+    (h_target_nonneg : 0 ≤ (auipc_input.PC.toNat : Int)
+      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt)
+    (h_target_lt : (auipc_input.PC.toNat : Int)
+      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt < GL_prime)
     (h_pc_offset_lt_2_32 :
       (auipc_input.PC + BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
         < 4294967296) : OpEnvelope state m r_main

--- a/ZiskFv/Compliance/Pilot/BranchNextPC.lean
+++ b/ZiskFv/Compliance/Pilot/BranchNextPC.lean
@@ -1,4 +1,5 @@
 import ZiskFv.Compliance.Pilot.SubNextPC
+import ZiskFv.Bits.PackedBitVec.WidePCNoWrap
 
 /-!
 # Branch next-PC discharge mechanism (#100 / #101, conditional branches)
@@ -37,6 +38,7 @@ namespace ZiskFv.Compliance.Pilot
 
 open ZiskFv.AirsClean.FullEnsemble (mainOfTable)
 open ZiskFv.Airs.Main (pc_handshake_branch)
+open ZiskFv.PackedBitVec.WidePCNoWrap
 open Interaction
 
 /-- **General BRANCH-PATH next-PC discharge (#100/#101).** For a branch
@@ -112,14 +114,12 @@ theorem branch_nextPC_flag1_taken
     (h_jmp2 :
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4)
     (h_off_bridge :
-      ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val).val
-        = offset_bv.toNat)
+      (mainOfTable trace.program trace.mainTable).jmp_offset1 i.val
+        = (offset_bv.toInt : FGL))
     (h_pc_bridge :
       ((mainOfTable trace.program trace.mainTable).pc i.val).val = PC.toNat)
-    (h_no_wrap :
-      ((mainOfTable trace.program trace.mainTable).pc i.val).val
-        + ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val).val
-        < GL_prime)
+    (h_target_nonneg : 0 ≤ (PC.toNat : Int) + offset_bv.toInt)
+    (h_target_lt : (PC.toNat : Int) + offset_bv.toInt < GL_prime)
     (h_pc_bound : PC.toNat < 18446744069414584321 - 4) :
     (register_type_pc_equiv ▸
         (BitVec.ofNat 64 ((execRowOf trace i)[1]!.pc).val))
@@ -131,7 +131,10 @@ theorem branch_nextPC_flag1_taken
   | true =>
     simp only [reduceIte]
     rw [show (pc + 4 + (1 : FGL) * (j1 - 4)) = pc + j1 from by ring]
-    exact ofNat_fgl_pc_plus_offset_eq pc j1 PC offset_bv h_pc_bridge h_off_bridge h_no_wrap
+    rw [h_off_bridge]
+    rw [fgl_pc_plus_signed_offset_val
+      pc PC offset_bv h_pc_bridge h_target_nonneg h_target_lt]
+    simpa using BitVec.ofNat_toNat 64 (PC + offset_bv)
   | false =>
     simp only [Bool.false_eq_true, if_false]
     rw [show (pc + 4 + (0 : FGL) * (j1 - 4)) = pc + 4 from by ring]
@@ -157,14 +160,12 @@ theorem branch_nextPC_flag0_taken
     (h_jmp1 :
       (mainOfTable trace.program trace.mainTable).jmp_offset1 i.val = 4)
     (h_off_bridge :
-      ((mainOfTable trace.program trace.mainTable).jmp_offset2 i.val).val
-        = offset_bv.toNat)
+      (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val
+        = (offset_bv.toInt : FGL))
     (h_pc_bridge :
       ((mainOfTable trace.program trace.mainTable).pc i.val).val = PC.toNat)
-    (h_no_wrap :
-      ((mainOfTable trace.program trace.mainTable).pc i.val).val
-        + ((mainOfTable trace.program trace.mainTable).jmp_offset2 i.val).val
-        < GL_prime)
+    (h_target_nonneg : 0 ≤ (PC.toNat : Int) + offset_bv.toInt)
+    (h_target_lt : (PC.toNat : Int) + offset_bv.toInt < GL_prime)
     (h_pc_bound : PC.toNat < 18446744069414584321 - 4) :
     (register_type_pc_equiv ▸
         (BitVec.ofNat 64 ((execRowOf trace i)[1]!.pc).val))
@@ -180,6 +181,9 @@ theorem branch_nextPC_flag0_taken
   | false =>
     simp only [Bool.false_eq_true, if_false]
     rw [show (pc + j2 + (0 : FGL) * (4 - j2)) = pc + j2 from by ring]
-    exact ofNat_fgl_pc_plus_offset_eq pc j2 PC offset_bv h_pc_bridge h_off_bridge h_no_wrap
+    rw [h_off_bridge]
+    rw [fgl_pc_plus_signed_offset_val
+      pc PC offset_bv h_pc_bridge h_target_nonneg h_target_lt]
+    simpa using BitVec.ofNat_toNat 64 (PC + offset_bv)
 
 end ZiskFv.Compliance.Pilot

--- a/ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean
@@ -314,23 +314,30 @@ def MainSequentialPcDomain (ziskTrace : AcceptedZiskTrace numInstructions)
   mainPcVal ziskTrace i < GL_prime - 4
 
 def MainBranchRangeDomain (ziskTrace : AcceptedZiskTrace numInstructions)
-    (i : Fin ziskTrace.numInstructions) (takenOffset : FGL) : Prop :=
-  mainPcVal ziskTrace i + takenOffset.val < GL_prime ∧
+    (i : Fin ziskTrace.numInstructions) (takenOffset : BitVec 64) : Prop :=
+  0 ≤ (mainPcVal ziskTrace i : Int) + takenOffset.toInt ∧
+    (mainPcVal ziskTrace i : Int) + takenOffset.toInt < GL_prime ∧
     MainSequentialPcDomain ziskTrace i
 
 structure MainAuipcRangeDomain (ziskTrace : AcceptedZiskTrace numInstructions)
     (i : Fin ziskTrace.numInstructions) (imm : BitVec 20) : Prop where
   h_pc_bound : MainSequentialPcDomain ziskTrace i
-  h_no_wrap :
-    mainPcVal ziskTrace i + (BitVec.signExtend 64 (imm ++ (0 : BitVec 12))).toNat
-      < GL_prime
+  h_target_nonneg :
+    0 ≤ (mainPcVal ziskTrace i : Int)
+      + (BitVec.signExtend 64 (imm ++ (0 : BitVec 12))).toInt
+  h_target_lt :
+    (mainPcVal ziskTrace i : Int)
+      + (BitVec.signExtend 64 (imm ++ (0 : BitVec 12))).toInt < GL_prime
   h_pc_offset_lt_2_32 :
     ∀ pc : BitVec 64, mainPcVal ziskTrace i = pc.toNat →
       (pc + BitVec.signExtend 64 (imm ++ (0 : BitVec 12))).toNat < 4294967296
 
 structure MainJalRangeDomain (ziskTrace : AcceptedZiskTrace numInstructions)
     (i : Fin ziskTrace.numInstructions) (imm : BitVec 21) : Prop where
-  h_no_fgl_wrap : mainPcVal ziskTrace i + (BitVec.signExtend 64 imm).toNat < GL_prime
+  h_target_nonneg :
+    0 ≤ (mainPcVal ziskTrace i : Int) + (BitVec.signExtend 64 imm).toInt
+  h_target_lt :
+    (mainPcVal ziskTrace i : Int) + (BitVec.signExtend 64 imm).toInt < GL_prime
   h_pc_bound : MainSequentialPcDomain ziskTrace i
   h_pc_offset_lt_2_32 :
     ∀ pc : BitVec 64, mainPcVal ziskTrace i = pc.toNat →
@@ -355,13 +362,14 @@ theorem sequentialPcDomain_of_main
 
 theorem branchRangeDomain_of_main
     {ziskTrace : AcceptedZiskTrace numInstructions}
-    {i : Fin ziskTrace.numInstructions} {pc : BitVec 64} {takenOffset : FGL}
+    {i : Fin ziskTrace.numInstructions} {pc takenOffset : BitVec 64}
     (h_bridge : mainPcVal ziskTrace i = pc.toNat)
     (h_domain : MainBranchRangeDomain ziskTrace i takenOffset) :
     BranchRangeDomain ziskTrace i pc takenOffset := by
-  constructor
-  · simpa [BranchRangeDomain, MainBranchRangeDomain, mainPcVal] using h_domain.1
-  · simpa [SequentialPcDomain] using sequentialPcDomain_of_main h_bridge h_domain.2
+  unfold BranchRangeDomain
+  unfold MainBranchRangeDomain MainSequentialPcDomain at h_domain
+  rw [h_bridge] at h_domain
+  exact h_domain
 
 theorem auipcRangeDomain_of_main
     {ziskTrace : AcceptedZiskTrace numInstructions}
@@ -372,9 +380,12 @@ theorem auipcRangeDomain_of_main
     (h_domain : MainAuipcRangeDomain ziskTrace i imm) :
     AuipcRangeDomain auipc_input where
   h_pc_bound := sequentialPcDomain_of_main h_bridge h_domain.h_pc_bound
-  h_no_wrap := by
+  h_target_nonneg := by
     rw [h_input_imm, ← h_bridge]
-    exact h_domain.h_no_wrap
+    exact h_domain.h_target_nonneg
+  h_target_lt := by
+    rw [h_input_imm, ← h_bridge]
+    exact h_domain.h_target_lt
   h_pc_offset_lt_2_32 := by
     simpa [h_input_imm] using h_domain.h_pc_offset_lt_2_32 auipc_input.PC h_bridge
 
@@ -386,9 +397,12 @@ theorem jalRangeDomain_of_main
     (h_bridge : mainPcVal ziskTrace i = jal_input.PC.toNat)
     (h_domain : MainJalRangeDomain ziskTrace i imm) :
     JalRangeDomain jal_input where
-  h_no_fgl_wrap := by
+  h_target_nonneg := by
     rw [h_input_imm, ← h_bridge]
-    exact h_domain.h_no_fgl_wrap
+    exact h_domain.h_target_nonneg
+  h_target_lt := by
+    rw [h_input_imm, ← h_bridge]
+    exact h_domain.h_target_lt
   h_pc_bound := sequentialPcDomain_of_main h_bridge h_domain.h_pc_bound
   h_pc_offset_lt_2_32 := h_domain.h_pc_offset_lt_2_32 jal_input.PC h_bridge
 
@@ -513,24 +527,24 @@ def RowOutsideDefectRegion (ziskTrace : AcceptedZiskTrace numInstructions)
   | .slliw c => SequentialPcDomain c.slliw_input.PC
   | .srliw c => SequentialPcDomain c.srliw_input.PC
   | .sraiw c => SequentialPcDomain c.sraiw_input.PC
-  | .beq _ =>
+  | .beq c =>
       MainBranchRangeDomain ziskTrace i
-        ((mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset1 i.val)
-  | .bne _ =>
+        (BitVec.signExtend 64 c.imm)
+  | .bne c =>
       MainBranchRangeDomain ziskTrace i
-        ((mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset2 i.val)
-  | .blt _ =>
+        (BitVec.signExtend 64 c.imm)
+  | .blt c =>
       MainBranchRangeDomain ziskTrace i
-        ((mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset1 i.val)
-  | .bge _ =>
+        (BitVec.signExtend 64 c.imm)
+  | .bge c =>
       MainBranchRangeDomain ziskTrace i
-        ((mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset2 i.val)
-  | .bltu _ =>
+        (BitVec.signExtend 64 c.imm)
+  | .bltu c =>
       MainBranchRangeDomain ziskTrace i
-        ((mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset1 i.val)
-  | .bgeu _ =>
+        (BitVec.signExtend 64 c.imm)
+  | .bgeu c =>
       MainBranchRangeDomain ziskTrace i
-        ((mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset2 i.val)
+        (BitVec.signExtend 64 c.imm)
   | .auipc c => MainAuipcRangeDomain ziskTrace i c.imm
   | .jal c => MainJalRangeDomain ziskTrace i c.imm
   | .jalr _ => MainJalrRangeDomain ziskTrace i
@@ -1402,22 +1416,46 @@ theorem stepSound_of_evidence (ziskTrace : AcceptedZiskTrace numInstructions) (s
         (sequentialPcDomain_of_main ia.h_pc_bridge hAvoidKnownBugs)
   | beq c =>
       exact stepStrong_beq ziskTrace sailTrace i (toRowData_beq c rd ia)
-        (branchRangeDomain_of_main ia.h_pc_bridge hAvoidKnownBugs)
+        (by
+          change BranchRangeDomain ziskTrace i ia.beq_input.PC
+            (BitVec.signExtend 64 ia.beq_input.imm)
+          simpa [ia.h_input_imm] using
+            branchRangeDomain_of_main ia.h_pc_bridge hAvoidKnownBugs)
   | bne c =>
       exact stepStrong_bne ziskTrace sailTrace i (toRowData_bne c rd ia)
-        (branchRangeDomain_of_main ia.h_pc_bridge hAvoidKnownBugs)
+        (by
+          change BranchRangeDomain ziskTrace i ia.bne_input.PC
+            (BitVec.signExtend 64 ia.bne_input.imm)
+          simpa [ia.h_input_imm] using
+            branchRangeDomain_of_main ia.h_pc_bridge hAvoidKnownBugs)
   | blt c =>
       exact stepStrong_blt ziskTrace sailTrace i (toRowData_blt c rd ia)
-        (branchRangeDomain_of_main ia.h_pc_bridge hAvoidKnownBugs)
+        (by
+          change BranchRangeDomain ziskTrace i ia.blt_input.PC
+            (BitVec.signExtend 64 ia.blt_input.imm)
+          simpa [ia.h_input_imm] using
+            branchRangeDomain_of_main ia.h_pc_bridge hAvoidKnownBugs)
   | bge c =>
       exact stepStrong_bge ziskTrace sailTrace i (toRowData_bge c rd ia)
-        (branchRangeDomain_of_main ia.h_pc_bridge hAvoidKnownBugs)
+        (by
+          change BranchRangeDomain ziskTrace i ia.bge_input.PC
+            (BitVec.signExtend 64 ia.bge_input.imm)
+          simpa [ia.h_input_imm] using
+            branchRangeDomain_of_main ia.h_pc_bridge hAvoidKnownBugs)
   | bltu c =>
       exact stepStrong_bltu ziskTrace sailTrace i (toRowData_bltu c rd ia)
-        (branchRangeDomain_of_main ia.h_pc_bridge hAvoidKnownBugs)
+        (by
+          change BranchRangeDomain ziskTrace i ia.bltu_input.PC
+            (BitVec.signExtend 64 ia.bltu_input.imm)
+          simpa [ia.h_input_imm] using
+            branchRangeDomain_of_main ia.h_pc_bridge hAvoidKnownBugs)
   | bgeu c =>
       exact stepStrong_bgeu ziskTrace sailTrace i (toRowData_bgeu c rd ia)
-        (branchRangeDomain_of_main ia.h_pc_bridge hAvoidKnownBugs)
+        (by
+          change BranchRangeDomain ziskTrace i ia.bgeu_input.PC
+            (BitVec.signExtend 64 ia.bgeu_input.imm)
+          simpa [ia.h_input_imm] using
+            branchRangeDomain_of_main ia.h_pc_bridge hAvoidKnownBugs)
   | lui c =>
       exact stepStrong_lui ziskTrace sailTrace i (toRowData_lui c rd ia)
         (sequentialPcDomain_of_main ia.h_pc_bridge hAvoidKnownBugs)
@@ -1433,15 +1471,9 @@ theorem stepSound_of_evidence (ziskTrace : AcceptedZiskTrace numInstructions) (s
           (PureSpec.execute_JAL_pure ia.jal_input).nextPC = .some nextPC_val :=
         PureSpec.execute_JAL_pure_succ_nextPC ia.jal_input ia.h_success
       have h_offset_bridge :
-          ((mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset1 i.val).val =
-            (BitVec.signExtend 64 ia.jal_input.imm).toNat := by
+          (mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset1 i.val =
+            ((BitVec.signExtend 64 ia.jal_input.imm).toInt : FGL) := by
         simpa [ia.h_input_imm] using rd.h_jmp_offset1_imm
-      have h_no_wrap_fgl :
-          ((mainOfTable ziskTrace.program ziskTrace.mainTable).pc i.val).val
-            + ((mainOfTable ziskTrace.program ziskTrace.mainTable).jmp_offset1 i.val).val
-              < GL_prime := by
-        rw [ia.h_pc_bridge, h_offset_bridge]
-        exact h_domain.h_no_fgl_wrap
       have h_spec := mainSpec_at ziskTrace sailTrace i
       have h_subset := ZiskFv.AirsClean.Main.add_subset_holds_of_spec_rowAt
         (mainOfTable ziskTrace.program ziskTrace.mainTable) i.val h_spec
@@ -1457,7 +1489,7 @@ theorem stepSound_of_evidence (ziskTrace : AcceptedZiskTrace numInstructions) (s
             = nextPC_val := by
         simpa [nextPC_val] using jal_nextPC_matches_of_physical ziskTrace i
           ia.jal_input.PC ia.jal_input.imm rd.h_idx rd.h_set_pc h_flag
-          ia.h_pc_bridge h_offset_bridge h_no_wrap_fgl
+          ia.h_pc_bridge h_offset_bridge h_domain.h_target_nonneg h_domain.h_target_lt
       have h_not_throws :
           (PureSpec.execute_JAL_pure ia.jal_input).throws = false :=
         PureSpec.execute_JAL_pure_succ_throws ia.jal_input ia.h_success

--- a/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
@@ -1056,7 +1056,7 @@ structure ProgramDecode_beq {numInstructions : Nat}
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_EQ
-        ∧ ((trace.program j).jmp_offset1).val = (BitVec.signExtend 64 c.imm).toNat
+        ∧ (trace.program j).jmp_offset1 = ((BitVec.signExtend 64 c.imm).toInt : FGL)
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).flags = packFlags bits
 
@@ -1077,7 +1077,7 @@ structure ProgramDecode_bne {numInstructions : Nat}
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_EQ
         ∧ (trace.program j).jmp_offset1 = 4
-        ∧ ((trace.program j).jmp_offset2).val = (BitVec.signExtend 64 c.imm).toNat
+        ∧ (trace.program j).jmp_offset2 = ((BitVec.signExtend 64 c.imm).toInt : FGL)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `blt`: exactly the inputs
@@ -1096,7 +1096,7 @@ structure ProgramDecode_blt {numInstructions : Nat}
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LT
-        ∧ ((trace.program j).jmp_offset1).val = (BitVec.signExtend 64 c.imm).toNat
+        ∧ (trace.program j).jmp_offset1 = ((BitVec.signExtend 64 c.imm).toInt : FGL)
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).flags = packFlags bits
 
@@ -1117,7 +1117,7 @@ structure ProgramDecode_bge {numInstructions : Nat}
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LT
         ∧ (trace.program j).jmp_offset1 = 4
-        ∧ ((trace.program j).jmp_offset2).val = (BitVec.signExtend 64 c.imm).toNat
+        ∧ (trace.program j).jmp_offset2 = ((BitVec.signExtend 64 c.imm).toInt : FGL)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `bltu`: exactly the inputs
@@ -1136,7 +1136,7 @@ structure ProgramDecode_bltu {numInstructions : Nat}
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LTU
-        ∧ ((trace.program j).jmp_offset1).val = (BitVec.signExtend 64 c.imm).toNat
+        ∧ (trace.program j).jmp_offset1 = ((BitVec.signExtend 64 c.imm).toInt : FGL)
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).flags = packFlags bits
 
@@ -1157,7 +1157,7 @@ structure ProgramDecode_bgeu {numInstructions : Nat}
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LTU
         ∧ (trace.program j).jmp_offset1 = 4
-        ∧ ((trace.program j).jmp_offset2).val = (BitVec.signExtend 64 c.imm).toNat
+        ∧ (trace.program j).jmp_offset2 = ((BitVec.signExtend 64 c.imm).toInt : FGL)
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for `lui`: exactly the inputs
@@ -1206,8 +1206,8 @@ structure ProgramDecode_auipc {numInstructions : Nat}
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_FLAG
         ∧ (trace.program j).jmp_offset1 = 4
-        ∧ ((trace.program j).jmp_offset2).val =
-          (BitVec.signExtend 64 (c.imm ++ (0 : BitVec 12))).toNat
+        ∧ (trace.program j).jmp_offset2 =
+          ((BitVec.signExtend 64 (c.imm ++ (0 : BitVec 12))).toInt : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits
 
@@ -1228,7 +1228,7 @@ structure ProgramDecode_jal {numInstructions : Nat}
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_FLAG
-        ∧ ((trace.program j).jmp_offset1).val = (BitVec.signExtend 64 c.imm).toNat
+        ∧ (trace.program j).jmp_offset1 = ((BitVec.signExtend 64 c.imm).toInt : FGL)
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits
@@ -1489,7 +1489,7 @@ structure ProgramDecode_ld {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (8 : FGL)
         ∧ (trace.program j).b_offset_imm0 =
-            ((BitVec.signExtend 64 c.ld_input.imm).toNat : FGL)
+            ((BitVec.signExtend 64 c.ld_input.imm).toInt : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.ld_input.rd)
         ∧ (trace.program j).flags = packFlags bits
 
@@ -1515,7 +1515,7 @@ structure ProgramDecode_lbu {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (1 : FGL)
         ∧ (trace.program j).b_offset_imm0 =
-            ((BitVec.signExtend 64 c.lbu_input.imm).toNat : FGL)
+            ((BitVec.signExtend 64 c.lbu_input.imm).toInt : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lbu_input.rd)
         ∧ (trace.program j).flags = packFlags bits
 
@@ -1541,7 +1541,7 @@ structure ProgramDecode_lhu {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (2 : FGL)
         ∧ (trace.program j).b_offset_imm0 =
-            ((BitVec.signExtend 64 c.lhu_input.imm).toNat : FGL)
+            ((BitVec.signExtend 64 c.lhu_input.imm).toInt : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lhu_input.rd)
         ∧ (trace.program j).flags = packFlags bits
 
@@ -1567,7 +1567,7 @@ structure ProgramDecode_lwu {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (4 : FGL)
         ∧ (trace.program j).b_offset_imm0 =
-            ((BitVec.signExtend 64 c.lwu_input.imm).toNat : FGL)
+            ((BitVec.signExtend 64 c.lwu_input.imm).toInt : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lwu_input.rd)
         ∧ (trace.program j).flags = packFlags bits
 
@@ -1609,7 +1609,7 @@ structure ProgramDecode_lb {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (1 : FGL)
         ∧ (trace.program j).b_offset_imm0 =
-            ((BitVec.signExtend 64 c.lb_input.imm).toNat : FGL)
+            ((BitVec.signExtend 64 c.lb_input.imm).toInt : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lb_input.rd)
         ∧ (trace.program j).flags = packFlags bits
 
@@ -1651,7 +1651,7 @@ structure ProgramDecode_lh {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (2 : FGL)
         ∧ (trace.program j).b_offset_imm0 =
-            ((BitVec.signExtend 64 c.lh_input.imm).toNat : FGL)
+            ((BitVec.signExtend 64 c.lh_input.imm).toInt : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lh_input.rd)
         ∧ (trace.program j).flags = packFlags bits
 
@@ -1693,7 +1693,7 @@ structure ProgramDecode_lw {numInstructions : Nat}
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (4 : FGL)
         ∧ (trace.program j).b_offset_imm0 =
-            ((BitVec.signExtend 64 c.lw_input.imm).toNat : FGL)
+            ((BitVec.signExtend 64 c.lw_input.imm).toInt : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lw_input.rd)
         ∧ (trace.program j).flags = packFlags bits
 

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBinding.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBinding.lean
@@ -127,6 +127,20 @@ noncomputable def romMessageOfRaw (line : FGL) (raw : BitVec 32) : ZiskRomMessag
            b_imm1 := 0, ind_width := 0, op := 0, store_offset := 0,
            jmp_offset1 := 0, jmp_offset2 := 0, flags := 0 }
 
+/-- The complete production lowering of one raw word. Most words have one row;
+    an unaligned JALR has its intermediate ADD row followed by its terminal AND
+    row. The existing `romMessageOfRaw` remains the terminal-row projection. -/
+noncomputable def romMessagesOfRaw (line : FGL) (raw : BitVec 32) :
+    ZiskRomMessage FGL × Option (ZiskRomMessage FGL) :=
+  match zisk_core.aeneas_extract.extract_transpile_rv64im_rows_raw
+      (ZiskFv.Compliance.Decode.toU32 raw) with
+  | .ok ext =>
+      if ext.row_count = 2#u32 then
+        (romRowOf line ext.first_row, some (romRowOf (line + 1) ext.last_row))
+      else
+        (romRowOf line ext.last_row, none)
+  | _ => (romMessageOfRaw line raw, none)
+
 /-- Op-agnostic ROM-image binding (a verifier-attached certificate, NOT an axiom):
     the committed ROM holds exactly the serialized lowering of the raw program. -/
 def ProgramBinding {n : Nat} (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
@@ -135,5 +149,167 @@ def ProgramBinding {n : Nat} (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
   (∀ k k' : Fin trace.programLength, k < k' → (addr k).val < (addr k').val) ∧
   ∀ k : Fin trace.programLength, trace.program k = romMessageOfRaw (addr k) (rawProgram k)
 
+/-- Additive program-image binding for production lowerings with one or two rows.
+    `start` embeds architectural raw-word indices into physical ROM indices.
+    The separation condition prevents a two-row lowering from overlapping the
+    next word. Existing one-word/one-row clients keep using `ProgramBinding`. -/
+def ProgramRowsBinding {n rawLength : Nat}
+    (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+    (start : Fin rawLength → Fin trace.programLength)
+    (addr : Fin rawLength → FGL)
+    (rawProgram : Fin rawLength → BitVec 32) : Prop :=
+  (∀ k k' : Fin rawLength, k < k' →
+      (start k).val < (start k').val ∧ (addr k).val < (addr k').val) ∧
+  (∀ k : Fin rawLength, (addr k).val % 4 = 0) ∧
+  (∀ k : Fin rawLength, (addr k).val + 1 < GL_prime) ∧
+  (∀ k k' : Fin rawLength, k < k' →
+      match (romMessagesOfRaw (addr k) (rawProgram k)).2 with
+      | none => (start k).val + 1 ≤ (start k').val
+      | some _ => (start k).val + 2 ≤ (start k').val) ∧
+  (∀ k : Fin rawLength,
+      let rows := romMessagesOfRaw (addr k) (rawProgram k)
+      trace.program (start k) = rows.1 ∧
+        match rows.2 with
+        | none => True
+        | some row =>
+            ∃ h : (start k).val + 1 < trace.programLength,
+              trace.program ⟨(start k).val + 1, h⟩ = row) ∧
+  ∀ j : Fin trace.programLength,
+    ∃ k : Fin rawLength,
+      j = start k ∨
+        ∃ row : ZiskRomMessage FGL,
+          (romMessagesOfRaw (addr k) (rawProgram k)).2 = some row ∧
+            j.val = (start k).val + 1
+
+/-- Faithful architectural lookup at the first physical row of a lowered word.
+    Unlike a physical-indexed raw array, this never duplicates an instruction
+    word to account for expansion rows. -/
+def RawAtProgramStart {programLength rawLength : Nat}
+    (start : Fin rawLength → Fin programLength)
+    (addr : Fin rawLength → FGL)
+    (rawProgram : Fin rawLength → BitVec 32)
+    (j : Fin programLength) (line : FGL) (raw : BitVec 32) : Prop :=
+  ∃ k : Fin rawLength, start k = j ∧ addr k = line ∧ rawProgram k = raw
+
+theorem romMessagesOfRaw_first_line (line : FGL) (raw : BitVec 32) :
+    (romMessagesOfRaw line raw).1.line = line := by
+  unfold romMessagesOfRaw
+  split
+  · split <;> rfl
+  · unfold romMessageOfRaw
+    split <;> rfl
+
+theorem romMessagesOfRaw_second_line {line : FGL} {raw : BitVec 32}
+    {row : ZiskRomMessage FGL}
+    (hsecond : (romMessagesOfRaw line raw).2 = some row) :
+    row.line = line + 1 := by
+  unfold romMessagesOfRaw at hsecond
+  split at hsecond
+  · split at hsecond
+    · simp only [Option.some.injEq] at hsecond
+      rw [← hsecond]
+      rfl
+    · simp at hsecond
+  · simp at hsecond
+
+/-- Reuse bridge for the existing one-row opcode proofs: architectural lookup
+    plus `ProgramRowsBinding` gives the same primary-row equality those proofs
+    previously obtained from a physical-indexed `ProgramBinding`. -/
+theorem primary_row_of_programRowsBinding {n rawLength : Nat}
+    {trace : ZiskFv.Compliance.AcceptedZiskTrace n}
+    {start : Fin rawLength → Fin trace.programLength}
+    {addr : Fin rawLength → FGL}
+    {rawProgram : Fin rawLength → BitVec 32}
+    {j : Fin trace.programLength} {line : FGL} {raw : BitVec 32}
+    (hbind : ProgramRowsBinding trace start addr rawProgram)
+    (hlookup : RawAtProgramStart start addr rawProgram j line raw) :
+    trace.program j = (romMessagesOfRaw line raw).1 := by
+  obtain ⟨_, _, _, _, hrows, _⟩ := hbind
+  obtain ⟨k, rfl, rfl, rfl⟩ := hlookup
+  exact (hrows k).1
+
+/-- Expansion bridge: when the lowering exposes a second row, the committed
+    physical successor is exactly that row. This is the JALR ADD-to-AND join. -/
+theorem successor_row_of_programRowsBinding {n rawLength : Nat}
+    {trace : ZiskFv.Compliance.AcceptedZiskTrace n}
+    {start : Fin rawLength → Fin trace.programLength}
+    {addr : Fin rawLength → FGL}
+    {rawProgram : Fin rawLength → BitVec 32}
+    {j : Fin trace.programLength} {line : FGL} {raw : BitVec 32}
+    (hbind : ProgramRowsBinding trace start addr rawProgram)
+    (hlookup : RawAtProgramStart start addr rawProgram j line raw)
+    {row : ZiskRomMessage FGL}
+    (hsecond : (romMessagesOfRaw line raw).2 = some row) :
+    ∃ h : j.val + 1 < trace.programLength,
+      trace.program ⟨j.val + 1, h⟩ = row := by
+  obtain ⟨_, _, _, _, hrows, _⟩ := hbind
+  obtain ⟨k, rfl, rfl, rfl⟩ := hlookup
+  simpa [hsecond] using (hrows k).2
+
+/-- Exact physical-row coverage: every committed row is either an
+    architectural word's primary lowering row or that word's present expansion
+    successor. In particular there are no unbound gap rows. -/
+theorem physical_row_of_programRowsBinding {n rawLength : Nat}
+    {trace : ZiskFv.Compliance.AcceptedZiskTrace n}
+    {start : Fin rawLength → Fin trace.programLength}
+    {addr : Fin rawLength → FGL}
+    {rawProgram : Fin rawLength → BitVec 32}
+    (hbind : ProgramRowsBinding trace start addr rawProgram)
+    (j : Fin trace.programLength) :
+    ∃ k : Fin rawLength,
+      (j = start k ∧
+        trace.program j = (romMessagesOfRaw (addr k) (rawProgram k)).1) ∨
+      ∃ row : ZiskRomMessage FGL,
+        (romMessagesOfRaw (addr k) (rawProgram k)).2 = some row ∧
+          j.val = (start k).val + 1 ∧ trace.program j = row := by
+  obtain ⟨_, _, _, _, hrows, hcover⟩ := hbind
+  obtain ⟨k, hj | ⟨row, hsecond, hj⟩⟩ := hcover j
+  · exact ⟨k, Or.inl ⟨hj, hj ▸ (hrows k).1⟩⟩
+  · obtain ⟨hnext, hrow⟩ := by
+      simpa [hsecond] using (hrows k).2
+    have hfin : j = ⟨(start k).val + 1, hnext⟩ := Fin.ext hj
+    exact ⟨k, Or.inr ⟨row, hsecond, hj, hfin ▸ hrow⟩⟩
+
+/-- Legacy one-row adapter. Exact physical coverage, four-byte architectural
+    alignment, and successor no-wrap imply that any row whose committed line
+    is an architectural address is that word's primary row, never an expansion
+    successor. -/
+theorem primary_row_at_architectural_line {n rawLength : Nat}
+    {trace : ZiskFv.Compliance.AcceptedZiskTrace n}
+    {start : Fin rawLength → Fin trace.programLength}
+    {addr : Fin rawLength → FGL}
+    {rawProgram : Fin rawLength → BitVec 32}
+    (hbind : ProgramRowsBinding trace start addr rawProgram)
+    (j : Fin trace.programLength) (k₀ : Fin rawLength)
+    (hline : (trace.program j).line = addr k₀) :
+    j = start k₀ ∧
+      trace.program j = (romMessagesOfRaw (addr k₀) (rawProgram k₀)).1 := by
+  have hbind' := hbind
+  obtain ⟨horder, halign, hnowrap, _, _, _⟩ := hbind
+  obtain ⟨k, ⟨hj, hrow⟩ | ⟨row, hsecond, _, hrow⟩⟩ :=
+    physical_row_of_programRowsBinding hbind' j
+  · have ha : addr k = addr k₀ := by
+      have := hline
+      rw [hrow, romMessagesOfRaw_first_line] at this
+      exact this
+    have hk : k = k₀ := by
+      by_contra hne
+      rcases lt_or_gt_of_ne hne with hlt | hgt
+      · have := (horder k k₀ hlt).2
+        rw [ha] at this
+        omega
+      · have := (horder k₀ k hgt).2
+        rw [ha] at this
+        omega
+    subst k
+    exact ⟨hj, hrow⟩
+  · have hrowline := romMessagesOfRaw_second_line hsecond
+    have heq : addr k + 1 = addr k₀ := by
+      rw [← hrowline, ← hline, hrow]
+    have heqv := congrArg Fin.val heq
+    simp [Fin.add_def, Nat.mod_eq_of_lt (hnowrap k)] at heqv
+    have hkmod := halign k
+    have hk₀mod := halign k₀
+    omega
 
 end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
@@ -2941,7 +2941,7 @@ def Decode_ld_of_program
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (8 : FGL)
         ∧ (trace.program j).b_offset_imm0 =
-            ((BitVec.signExtend 64 c.ld_input.imm).toNat : FGL)
+            ((BitVec.signExtend 64 c.ld_input.imm).toInt : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.ld_input.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_ld trace i c := by
@@ -2986,7 +2986,7 @@ def Decode_ld_of_program
     simpa [mainRowWithRomLd] using hstore.symm.trans hpso
   have h_b_offset_imm0 :
       (mainRowWithRomLd trace i).rom.b_offset_imm0 =
-        ((BitVec.signExtend 64 c.ld_input.imm).toNat : FGL) := by
+        ((BitVec.signExtend 64 c.ld_input.imm).toInt : FGL) := by
     obtain ⟨j, hline, hboff⟩ := mainBOffsetImm0_at_eq_program trace ⟨i.val, h_lt⟩
     obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpbo, _hpso, _hpf⟩ := h_prog j hline
     simpa [mainRowWithRomLd] using hboff.symm.trans hpbo
@@ -3029,7 +3029,7 @@ def Decode_lbu_of_program
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (1 : FGL)
         ∧ (trace.program j).b_offset_imm0 =
-            ((BitVec.signExtend 64 c.lbu_input.imm).toNat : FGL)
+            ((BitVec.signExtend 64 c.lbu_input.imm).toInt : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lbu_input.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_lbu trace i c := by
@@ -3059,7 +3059,7 @@ def Decode_lbu_of_program
         exact hpf)
   have h_b_offset_imm0 :
       (mainRowWithRomLd trace i).rom.b_offset_imm0 =
-        ((BitVec.signExtend 64 c.lbu_input.imm).toNat : FGL) := by
+        ((BitVec.signExtend 64 c.lbu_input.imm).toInt : FGL) := by
     obtain ⟨j, hline, hboff⟩ := mainBOffsetImm0_at_eq_program trace ⟨i.val, h_lt⟩
     obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpbo, _hpso, _hpf⟩ := h_prog j hline
     simpa [mainRowWithRomLd] using hboff.symm.trans hpbo
@@ -3102,7 +3102,7 @@ def Decode_lhu_of_program
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (2 : FGL)
         ∧ (trace.program j).b_offset_imm0 =
-            ((BitVec.signExtend 64 c.lhu_input.imm).toNat : FGL)
+            ((BitVec.signExtend 64 c.lhu_input.imm).toInt : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lhu_input.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_lhu trace i c := by
@@ -3132,7 +3132,7 @@ def Decode_lhu_of_program
         exact hpf)
   have h_b_offset_imm0 :
       (mainRowWithRomLd trace i).rom.b_offset_imm0 =
-        ((BitVec.signExtend 64 c.lhu_input.imm).toNat : FGL) := by
+        ((BitVec.signExtend 64 c.lhu_input.imm).toInt : FGL) := by
     obtain ⟨j, hline, hboff⟩ := mainBOffsetImm0_at_eq_program trace ⟨i.val, h_lt⟩
     obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpbo, _hpso, _hpf⟩ := h_prog j hline
     simpa [mainRowWithRomLd] using hboff.symm.trans hpbo
@@ -3175,7 +3175,7 @@ def Decode_lwu_of_program
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (4 : FGL)
         ∧ (trace.program j).b_offset_imm0 =
-            ((BitVec.signExtend 64 c.lwu_input.imm).toNat : FGL)
+            ((BitVec.signExtend 64 c.lwu_input.imm).toInt : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lwu_input.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_lwu trace i c := by
@@ -3205,7 +3205,7 @@ def Decode_lwu_of_program
         exact hpf)
   have h_b_offset_imm0 :
       (mainRowWithRomLd trace i).rom.b_offset_imm0 =
-        ((BitVec.signExtend 64 c.lwu_input.imm).toNat : FGL) := by
+        ((BitVec.signExtend 64 c.lwu_input.imm).toInt : FGL) := by
     obtain ⟨j, hline, hboff⟩ := mainBOffsetImm0_at_eq_program trace ⟨i.val, h_lt⟩
     obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpbo, _hpso, _hpf⟩ := h_prog j hline
     simpa [mainRowWithRomLd] using hboff.symm.trans hpbo
@@ -3264,7 +3264,7 @@ def Decode_lb_of_program
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (1 : FGL)
         ∧ (trace.program j).b_offset_imm0 =
-            ((BitVec.signExtend 64 c.lb_input.imm).toNat : FGL)
+            ((BitVec.signExtend 64 c.lb_input.imm).toInt : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lb_input.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_lb trace i c := by
@@ -3294,7 +3294,7 @@ def Decode_lb_of_program
         exact hpf)
   have h_b_offset_imm0 :
       (mainRowWithRomLd trace i).rom.b_offset_imm0 =
-        ((BitVec.signExtend 64 c.lb_input.imm).toNat : FGL) := by
+        ((BitVec.signExtend 64 c.lb_input.imm).toInt : FGL) := by
     obtain ⟨j, hline, hboff⟩ := mainBOffsetImm0_at_eq_program trace ⟨i.val, h_lt⟩
     obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpbo, _hpso, _hpf⟩ := h_prog j hline
     simpa [mainRowWithRomLd] using hboff.symm.trans hpbo
@@ -3359,7 +3359,7 @@ def Decode_lh_of_program
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (2 : FGL)
         ∧ (trace.program j).b_offset_imm0 =
-            ((BitVec.signExtend 64 c.lh_input.imm).toNat : FGL)
+            ((BitVec.signExtend 64 c.lh_input.imm).toInt : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lh_input.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_lh trace i c := by
@@ -3389,7 +3389,7 @@ def Decode_lh_of_program
         exact hpf)
   have h_b_offset_imm0 :
       (mainRowWithRomLd trace i).rom.b_offset_imm0 =
-        ((BitVec.signExtend 64 c.lh_input.imm).toNat : FGL) := by
+        ((BitVec.signExtend 64 c.lh_input.imm).toInt : FGL) := by
     obtain ⟨j, hline, hboff⟩ := mainBOffsetImm0_at_eq_program trace ⟨i.val, h_lt⟩
     obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpbo, _hpso, _hpf⟩ := h_prog j hline
     simpa [mainRowWithRomLd] using hboff.symm.trans hpbo
@@ -3454,7 +3454,7 @@ def Decode_lw_of_program
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).ind_width = (4 : FGL)
         ∧ (trace.program j).b_offset_imm0 =
-            ((BitVec.signExtend 64 c.lw_input.imm).toNat : FGL)
+            ((BitVec.signExtend 64 c.lw_input.imm).toInt : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lw_input.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_lw trace i c := by
@@ -3484,7 +3484,7 @@ def Decode_lw_of_program
         exact hpf)
   have h_b_offset_imm0 :
       (mainRowWithRomLd trace i).rom.b_offset_imm0 =
-        ((BitVec.signExtend 64 c.lw_input.imm).toNat : FGL) := by
+        ((BitVec.signExtend 64 c.lw_input.imm).toInt : FGL) := by
     obtain ⟨j, hline, hboff⟩ := mainBOffsetImm0_at_eq_program trace ⟨i.val, h_lt⟩
     obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, hpbo, _hpso, _hpf⟩ := h_prog j hline
     simpa [mainRowWithRomLd] using hboff.symm.trans hpbo
@@ -3855,8 +3855,8 @@ def Decode_auipc_of_program
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_FLAG
         ∧ (trace.program j).jmp_offset1 = 4
-        ∧ ((trace.program j).jmp_offset2).val =
-          (BitVec.signExtend 64 (c.imm ++ (0 : BitVec 12))).toNat
+        ∧ (trace.program j).jmp_offset2 =
+          ((BitVec.signExtend 64 (c.imm ++ (0 : BitVec 12))).toInt : FGL)
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_auipc trace i c := by
@@ -3879,8 +3879,8 @@ def Decode_auipc_of_program
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_true], hj1.symm.trans hpj0⟩
   have h_jmp_offset2_imm :
-      ((mainOfTable trace.program trace.mainTable).jmp_offset2 i.val).val =
-        (BitVec.signExtend 64 (c.imm ++ (0 : BitVec 12))).toNat := by
+      (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val =
+        ((BitVec.signExtend 64 (c.imm ++ (0 : BitVec 12))).toInt : FGL) := by
     obtain ⟨j, hline, _hop, _, _, hj2, _hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
     obtain ⟨_hpo, _hpj0, hpj2_imm, _hpso, _hpf⟩ := h_prog j hline
@@ -3918,7 +3918,7 @@ def Decode_beq_of_program
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_EQ
-        ∧ ((trace.program j).jmp_offset1).val = (BitVec.signExtend 64 c.imm).toNat
+        ∧ (trace.program j).jmp_offset1 = ((BitVec.signExtend 64 c.imm).toInt : FGL)
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_beq trace i c := by
@@ -3937,8 +3937,8 @@ def Decode_beq_of_program
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj2.symm.trans hpj0⟩
   have h_jmp_offset1_imm :
-      ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val).val =
-        (BitVec.signExtend 64 c.imm).toNat := by
+      (mainOfTable trace.program trace.mainTable).jmp_offset1 i.val =
+        ((BitVec.signExtend 64 c.imm).toInt : FGL) := by
     obtain ⟨j, hline, _hop, _, hj1, _, _hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
     obtain ⟨_hpo, hpj1_imm, _hpj0, _hpf⟩ := h_prog j hline
@@ -3972,7 +3972,7 @@ def Decode_bne_of_program
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_EQ
         ∧ (trace.program j).jmp_offset1 = 4
-        ∧ ((trace.program j).jmp_offset2).val = (BitVec.signExtend 64 c.imm).toNat
+        ∧ (trace.program j).jmp_offset2 = ((BitVec.signExtend 64 c.imm).toInt : FGL)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_bne trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -3990,8 +3990,8 @@ def Decode_bne_of_program
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0⟩
   have h_jmp_offset2_imm :
-      ((mainOfTable trace.program trace.mainTable).jmp_offset2 i.val).val =
-        (BitVec.signExtend 64 c.imm).toNat := by
+      (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val =
+        ((BitVec.signExtend 64 c.imm).toInt : FGL) := by
     obtain ⟨j, hline, _hop, _, _, hj2, _hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
     obtain ⟨_hpo, _hpj0, hpj2_imm, _hpf⟩ := h_prog j hline
@@ -4024,7 +4024,7 @@ def Decode_blt_of_program
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LT
-        ∧ ((trace.program j).jmp_offset1).val = (BitVec.signExtend 64 c.imm).toNat
+        ∧ (trace.program j).jmp_offset1 = ((BitVec.signExtend 64 c.imm).toInt : FGL)
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_blt trace i c := by
@@ -4043,8 +4043,8 @@ def Decode_blt_of_program
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj2.symm.trans hpj0⟩
   have h_jmp_offset1_imm :
-      ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val).val =
-        (BitVec.signExtend 64 c.imm).toNat := by
+      (mainOfTable trace.program trace.mainTable).jmp_offset1 i.val =
+        ((BitVec.signExtend 64 c.imm).toInt : FGL) := by
     obtain ⟨j, hline, _hop, _, hj1, _, _hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
     obtain ⟨_hpo, hpj1_imm, _hpj0, _hpf⟩ := h_prog j hline
@@ -4078,7 +4078,7 @@ def Decode_bge_of_program
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LT
         ∧ (trace.program j).jmp_offset1 = 4
-        ∧ ((trace.program j).jmp_offset2).val = (BitVec.signExtend 64 c.imm).toNat
+        ∧ (trace.program j).jmp_offset2 = ((BitVec.signExtend 64 c.imm).toInt : FGL)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_bge trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -4096,8 +4096,8 @@ def Decode_bge_of_program
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0⟩
   have h_jmp_offset2_imm :
-      ((mainOfTable trace.program trace.mainTable).jmp_offset2 i.val).val =
-        (BitVec.signExtend 64 c.imm).toNat := by
+      (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val =
+        ((BitVec.signExtend 64 c.imm).toInt : FGL) := by
     obtain ⟨j, hline, _hop, _, _, hj2, _hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
     obtain ⟨_hpo, _hpj0, hpj2_imm, _hpf⟩ := h_prog j hline
@@ -4130,7 +4130,7 @@ def Decode_bltu_of_program
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LTU
-        ∧ ((trace.program j).jmp_offset1).val = (BitVec.signExtend 64 c.imm).toNat
+        ∧ (trace.program j).jmp_offset1 = ((BitVec.signExtend 64 c.imm).toInt : FGL)
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_bltu trace i c := by
@@ -4149,8 +4149,8 @@ def Decode_bltu_of_program
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj2.symm.trans hpj0⟩
   have h_jmp_offset1_imm :
-      ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val).val =
-        (BitVec.signExtend 64 c.imm).toNat := by
+      (mainOfTable trace.program trace.mainTable).jmp_offset1 i.val =
+        ((BitVec.signExtend 64 c.imm).toInt : FGL) := by
     obtain ⟨j, hline, _hop, _, hj1, _, _hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
     obtain ⟨_hpo, hpj1_imm, _hpj0, _hpf⟩ := h_prog j hline
@@ -4184,7 +4184,7 @@ def Decode_bgeu_of_program
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_LTU
         ∧ (trace.program j).jmp_offset1 = 4
-        ∧ ((trace.program j).jmp_offset2).val = (BitVec.signExtend 64 c.imm).toNat
+        ∧ (trace.program j).jmp_offset2 = ((BitVec.signExtend 64 c.imm).toInt : FGL)
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_bgeu trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -4202,8 +4202,8 @@ def Decode_bgeu_of_program
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_false], hj1.symm.trans hpj0⟩
   have h_jmp_offset2_imm :
-      ((mainOfTable trace.program trace.mainTable).jmp_offset2 i.val).val =
-        (BitVec.signExtend 64 c.imm).toNat := by
+      (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val =
+        ((BitVec.signExtend 64 c.imm).toInt : FGL) := by
     obtain ⟨j, hline, _hop, _, _, hj2, _hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
     obtain ⟨_hpo, _hpj0, hpj2_imm, _hpf⟩ := h_prog j hline
@@ -4240,7 +4240,7 @@ def Decode_jal_of_program
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_FLAG
-        ∧ ((trace.program j).jmp_offset1).val = (BitVec.signExtend 64 c.imm).toNat
+        ∧ (trace.program j).jmp_offset1 = ((BitVec.signExtend 64 c.imm).toInt : FGL)
         ∧ (trace.program j).jmp_offset2 = 4
         ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
         ∧ (trace.program j).flags = packFlags bits) :
@@ -4264,8 +4264,8 @@ def Decode_jal_of_program
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_false], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_false], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_true], hj2.symm.trans hpj0⟩
   have h_jmp_offset1_imm :
-      ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val).val =
-        (BitVec.signExtend 64 c.imm).toNat := by
+      (mainOfTable trace.program trace.mainTable).jmp_offset1 i.val =
+        ((BitVec.signExtend 64 c.imm).toInt : FGL) := by
     obtain ⟨j, hline, _hop, _, hj1, _, _hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
     obtain ⟨_hpo, hpj1_imm, _hpj0, _hpso, _hpf⟩ := h_prog j hline

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
@@ -50,9 +50,10 @@ agreement. Keeping them separate from `Inputs_auipc` leaves the input record foc
 value agreement while preserving the same AUIPC range obligations at the theorem boundary. -/
 structure AuipcRangeDomain (auipc_input : PureSpec.AuipcInput) : Prop where
   h_pc_bound : auipc_input.PC.toNat < GL_prime - 4
-  h_no_wrap : auipc_input.PC.toNat
-    + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
-      < GL_prime
+  h_target_nonneg : 0 ≤ (auipc_input.PC.toNat : Int)
+    + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt
+  h_target_lt : (auipc_input.PC.toNat : Int)
+    + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt < GL_prime
   h_pc_offset_lt_2_32 :
     (auipc_input.PC + BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
       < 4294967296

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
@@ -651,8 +651,8 @@ structure Decode_auipc (trace : AcceptedZiskTrace numInstructions)
       Transpiler.ind (regidx_to_fin c.rd)
   h_jmp_offset2_imm :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
-        i.val).val
-      = (BitVec.signExtend 64 (c.imm ++ (0 : BitVec 12))).toNat
+        i.val)
+      = ((BitVec.signExtend 64 (c.imm ++ (0 : BitVec 12))).toInt : FGL)
   -- #100 next-PC transition inputs (replace the exec artifacts; AUIPC already
   -- carries h_set_pc above): the next row exists, plus the AUIPC FLAG-row jmp
   -- pin `jmp_offset1 = 4` and committed-program `jmp_offset2 = signExtend imm`
@@ -2347,7 +2347,7 @@ structure Decode_ld (trace : AcceptedZiskTrace numInstructions)
     (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.ld_input.rd)
   h_b_offset_imm0 :
     (mainRowWithRomLd trace i).rom.b_offset_imm0 =
-      ((BitVec.signExtend 64 c.ld_input.imm).toNat : FGL)
+      ((BitVec.signExtend 64 c.ld_input.imm).toInt : FGL)
 
 structure Inputs_ld (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_ld trace i) : Type where
@@ -2426,7 +2426,7 @@ structure Decode_lbu (trace : AcceptedZiskTrace numInstructions)
     (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lbu_input.rd)
   h_b_offset_imm0 :
     (mainRowWithRomLd trace i).rom.b_offset_imm0 =
-      ((BitVec.signExtend 64 c.lbu_input.imm).toNat : FGL)
+      ((BitVec.signExtend 64 c.lbu_input.imm).toInt : FGL)
 
 structure Inputs_lbu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lbu trace i) : Type where
@@ -2508,7 +2508,7 @@ structure Decode_lhu (trace : AcceptedZiskTrace numInstructions)
     (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lhu_input.rd)
   h_b_offset_imm0 :
     (mainRowWithRomLd trace i).rom.b_offset_imm0 =
-      ((BitVec.signExtend 64 c.lhu_input.imm).toNat : FGL)
+      ((BitVec.signExtend 64 c.lhu_input.imm).toInt : FGL)
 
 structure Inputs_lhu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lhu trace i) : Type where
@@ -2590,7 +2590,7 @@ structure Decode_lwu (trace : AcceptedZiskTrace numInstructions)
     (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lwu_input.rd)
   h_b_offset_imm0 :
     (mainRowWithRomLd trace i).rom.b_offset_imm0 =
-      ((BitVec.signExtend 64 c.lwu_input.imm).toNat : FGL)
+      ((BitVec.signExtend 64 c.lwu_input.imm).toInt : FGL)
 
 structure Inputs_lwu (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lwu trace i) : Type where
@@ -2683,7 +2683,7 @@ structure Decode_lb (trace : AcceptedZiskTrace numInstructions)
     (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lb_input.rd)
   h_b_offset_imm0 :
     (mainRowWithRomLd trace i).rom.b_offset_imm0 =
-      ((BitVec.signExtend 64 c.lb_input.imm).toNat : FGL)
+      ((BitVec.signExtend 64 c.lb_input.imm).toInt : FGL)
 
 structure Inputs_lb (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lb trace i) : Type where
@@ -2773,7 +2773,7 @@ structure Decode_lh (trace : AcceptedZiskTrace numInstructions)
     (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lh_input.rd)
   h_b_offset_imm0 :
     (mainRowWithRomLd trace i).rom.b_offset_imm0 =
-      ((BitVec.signExtend 64 c.lh_input.imm).toNat : FGL)
+      ((BitVec.signExtend 64 c.lh_input.imm).toInt : FGL)
 
 structure Inputs_lh (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lh trace i) : Type where
@@ -2863,7 +2863,7 @@ structure Decode_lw (trace : AcceptedZiskTrace numInstructions)
     (mainRowWithRomLd trace i).rom.store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 c.lw_input.rd)
   h_b_offset_imm0 :
     (mainRowWithRomLd trace i).rom.b_offset_imm0 =
-      ((BitVec.signExtend 64 c.lw_input.imm).toNat : FGL)
+      ((BitVec.signExtend 64 c.lw_input.imm).toInt : FGL)
 
 structure Inputs_lw (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_lw trace i) : Type where

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
@@ -47,8 +47,9 @@ This is not a decoded placement fact: it is the explicit soundness-domain condit
 branch next-PC cast. Keeping it separate from `Inputs_<branch>` leaves those input records focused
 on Sail/ZisK state and value agreement. -/
 def BranchRangeDomain (trace : AcceptedZiskTrace numInstructions)
-    (i : Fin trace.numInstructions) (pc : BitVec 64) (takenOffset : FGL) : Prop :=
-  ((mainOfTable trace.program trace.mainTable).pc i.val).val + takenOffset.val < GL_prime
+    (i : Fin trace.numInstructions) (pc takenOffset : BitVec 64) : Prop :=
+  0 ≤ (pc.toNat : Int) + takenOffset.toInt
+    ∧ (pc.toNat : Int) + takenOffset.toInt < GL_prime
     ∧ pc.toNat < GL_prime - 4
 
 /-- JAL theorem-domain range assumptions.
@@ -56,7 +57,10 @@ def BranchRangeDomain (trace : AcceptedZiskTrace numInstructions)
 These preserve the old JAL target no-wrap, PC-bound, and 32-bit next-PC obligations at the explicit
 soundness theorem boundary instead of mixing them into `Inputs_jal` state/value agreement. -/
 structure JalRangeDomain (jal_input : PureSpec.JalInput) : Prop where
-  h_no_fgl_wrap : jal_input.PC.toNat + (BitVec.signExtend 64 jal_input.imm).toNat < GL_prime
+  h_target_nonneg :
+    0 ≤ (jal_input.PC.toNat : Int) + (BitVec.signExtend 64 jal_input.imm).toInt
+  h_target_lt :
+    (jal_input.PC.toNat : Int) + (BitVec.signExtend 64 jal_input.imm).toInt < GL_prime
   h_pc_bound : jal_input.PC.toNat < GL_prime - 4
   h_pc_offset_lt_2_32 : (jal_input.PC + 4#64).toNat < 4294967296
 
@@ -94,9 +98,8 @@ structure Decode_beq (trace : AcceptedZiskTrace numInstructions)
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
       i.val = 4
   h_jmp_offset1_imm :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-        i.val).val
-      = (BitVec.signExtend 64 c.imm).toNat
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
+      i.val = ((BitVec.signExtend 64 c.imm).toInt : FGL)
   -- #100: taken on flag=1 (`r1 == r2`); `jmp_offset2 = 4` fall-through.
   h_idx : i.val + 1 < trace.mainTable.table.length
 
@@ -182,9 +185,8 @@ structure Decode_bne (trace : AcceptedZiskTrace numInstructions)
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
       i.val = 4
   h_jmp_offset2_imm :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
-        i.val).val
-      = (BitVec.signExtend 64 c.imm).toNat
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
+      i.val = ((BitVec.signExtend 64 c.imm).toInt : FGL)
   -- #100: `neg` polarity (taken on flag=0, `r1 ≠ r2`); the taken offset rides on
   -- `jmp_offset2`, `jmp_offset1 = 4` is the fall-through side.
   h_idx : i.val + 1 < trace.mainTable.table.length
@@ -271,9 +273,8 @@ structure Decode_blt (trace : AcceptedZiskTrace numInstructions)
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
       i.val = 4
   h_jmp_offset1_imm :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-        i.val).val
-      = (BitVec.signExtend 64 c.imm).toNat
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
+      i.val = ((BitVec.signExtend 64 c.imm).toInt : FGL)
   -- #100: taken on flag=1 (signed `r1 <s r2`); `jmp_offset2 = 4` fall-through.
   h_idx : i.val + 1 < trace.mainTable.table.length
 
@@ -359,9 +360,8 @@ structure Decode_bge (trace : AcceptedZiskTrace numInstructions)
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
       i.val = 4
   h_jmp_offset2_imm :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
-        i.val).val
-      = (BitVec.signExtend 64 c.imm).toNat
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
+      i.val = ((BitVec.signExtend 64 c.imm).toInt : FGL)
   -- #100: `neg` polarity (taken on flag=0, signed `r1 ≥s r2`); the taken offset
   -- rides on `jmp_offset2`, `jmp_offset1 = 4` is the fall-through side.
   h_idx : i.val + 1 < trace.mainTable.table.length
@@ -448,9 +448,8 @@ structure Decode_bltu (trace : AcceptedZiskTrace numInstructions)
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
       i.val = 4
   h_jmp_offset1_imm :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-        i.val).val
-      = (BitVec.signExtend 64 c.imm).toNat
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
+      i.val = ((BitVec.signExtend 64 c.imm).toInt : FGL)
   -- #100 next-PC transition input (replaces the exec artifacts): the next row
   -- exists. The taken-offset pin (`jmp_offset1 = signExtend imm`) is decoded from
   -- the committed program; `flag = comparison` is DERIVED in `stepStrong_bltu`
@@ -540,9 +539,8 @@ structure Decode_bgeu (trace : AcceptedZiskTrace numInstructions)
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
       i.val = 4
   h_jmp_offset2_imm :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
-        i.val).val
-      = (BitVec.signExtend 64 c.imm).toNat
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
+      i.val = ((BitVec.signExtend 64 c.imm).toInt : FGL)
   -- #100 next-PC transition input (replaces the exec artifacts): the next row
   -- exists. BGEU is the `create_branch_op`-`neg` polarity (taken on `flag = 0`):
   -- the taken offset rides on `jmp_offset2`; `jmp_offset1 = 4` is the fall-through
@@ -632,9 +630,8 @@ structure Decode_jal (trace : AcceptedZiskTrace numInstructions)
     (mainRowWithRomLui trace i).rom.store_offset =
       Transpiler.ind (regidx_to_fin c.rd)
   h_jmp_offset1_imm :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-        i.val).val
-      = (BitVec.signExtend 64 c.imm).toNat
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
+      i.val = ((BitVec.signExtend 64 c.imm).toInt : FGL)
   h_jmp2 :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset2
       i.val = 4

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongControlStore.lean
@@ -456,17 +456,18 @@ theorem jal_nextPC_matches_of_physical
     (h_pc_bridge :
       ((mainOfTable trace.program trace.mainTable).pc i.val).val = pc.toNat)
     (h_offset_bridge :
-      ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val).val =
-        (BitVec.signExtend 64 imm).toNat)
-    (h_no_wrap :
-      ((mainOfTable trace.program trace.mainTable).pc i.val).val
-        + ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val).val < GL_prime) :
+      (mainOfTable trace.program trace.mainTable).jmp_offset1 i.val =
+        ((BitVec.signExtend 64 imm).toInt : FGL))
+    (h_target_nonneg : 0 ≤ (pc.toNat : Int) + (BitVec.signExtend 64 imm).toInt)
+    (h_target_lt : (pc.toNat : Int) + (BitVec.signExtend 64 imm).toInt < GL_prime) :
     (register_type_pc_equiv ▸
         (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
       = pc + BitVec.signExtend 64 imm := by
   rw [Pilot.flag_path_nextPC_discharged trace i h_idx h_set_pc h_flag]
-  exact Pilot.ofNat_fgl_pc_plus_offset_eq _ _ pc (BitVec.signExtend 64 imm)
-    h_pc_bridge h_offset_bridge h_no_wrap
+  rw [h_offset_bridge]
+  rw [ZiskFv.PackedBitVec.WidePCNoWrap.fgl_pc_plus_signed_offset_val
+    _ pc (BitVec.signExtend 64 imm) h_pc_bridge h_target_nonneg h_target_lt]
+  simpa using BitVec.ofNat_toNat 64 (pc + BitVec.signExtend 64 imm)
 
 /-! ## Strengthened control-flow + U-type arms (branches, JAL/JALR, LUI/AUIPC)
 
@@ -795,7 +796,7 @@ theorem stepStrong_beq
     (d : RowData_beq trace binding i)
     (h_domain :
       BranchRangeDomain trace i d.toInputs.beq_input.PC
-        ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val)) :
+        (BitVec.signExtend 64 d.toInputs.beq_input.imm)) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BEQ)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨Pilot.execRowOf trace i, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -830,14 +831,14 @@ theorem stepStrong_beq
             d.toInputs.h_a_lo_t d.toInputs.h_a_hi_t d.toInputs.h_b_lo_t d.toInputs.h_b_hi_t
             d.toInputs.h_input_r1 d.toInputs.h_input_r2
         have h_off_bridge :
-            (m.jmp_offset1 i.val).val =
-              (BitVec.signExtend 64 d.toInputs.beq_input.imm).toNat := by
+            m.jmp_offset1 i.val =
+              ((BitVec.signExtend 64 d.toInputs.beq_input.imm).toInt : FGL) := by
           simpa [hm, d.toInputs.h_input_imm] using d.toDecode.h_jmp_offset1_imm
         have h_cast := Pilot.branch_nextPC_flag1_taken trace i
           (d.toInputs.beq_input.r1_val == d.toInputs.beq_input.r2_val)
           d.toInputs.beq_input.PC (BitVec.signExtend 64 d.toInputs.beq_input.imm)
           d.toDecode.h_idx d.toDecode.h_set_pc h_flag d.toDecode.h_jmp_offset2
-          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2
+          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2.1 h_domain.2.2
         show (register_type_pc_equiv ▸
             (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
           = (PureSpec.execute_BEQ_pure d.toInputs.beq_input).nextPC
@@ -862,7 +863,7 @@ theorem stepStrong_bne
     (d : RowData_bne trace binding i)
     (h_domain :
       BranchRangeDomain trace i d.toInputs.bne_input.PC
-        ((mainOfTable trace.program trace.mainTable).jmp_offset2 i.val)) :
+        (BitVec.signExtend 64 d.toInputs.bne_input.imm)) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BNE)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨Pilot.execRowOf trace i, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -897,14 +898,14 @@ theorem stepStrong_bne
             d.toInputs.h_a_lo_t d.toInputs.h_a_hi_t d.toInputs.h_b_lo_t d.toInputs.h_b_hi_t
             d.toInputs.h_input_r1 d.toInputs.h_input_r2
         have h_off_bridge :
-            (m.jmp_offset2 i.val).val =
-              (BitVec.signExtend 64 d.toInputs.bne_input.imm).toNat := by
+            m.jmp_offset2 i.val =
+              ((BitVec.signExtend 64 d.toInputs.bne_input.imm).toInt : FGL) := by
           simpa [hm, d.toInputs.h_input_imm] using d.toDecode.h_jmp_offset2_imm
         have h_cast := Pilot.branch_nextPC_flag0_taken trace i
           (d.toInputs.bne_input.r1_val == d.toInputs.bne_input.r2_val)
           d.toInputs.bne_input.PC (BitVec.signExtend 64 d.toInputs.bne_input.imm)
           d.toDecode.h_idx d.toDecode.h_set_pc h_flag d.toDecode.h_jmp_offset1
-          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2
+          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2.1 h_domain.2.2
         show (register_type_pc_equiv ▸
             (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
           = (PureSpec.execute_BNE_pure d.toInputs.bne_input).nextPC
@@ -929,7 +930,7 @@ theorem stepStrong_blt
     (d : RowData_blt trace binding i)
     (h_domain :
       BranchRangeDomain trace i d.toInputs.blt_input.PC
-        ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val)) :
+        (BitVec.signExtend 64 d.toInputs.blt_input.imm)) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BLT)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨Pilot.execRowOf trace i, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -964,14 +965,14 @@ theorem stepStrong_blt
             d.toInputs.h_a_lo_t d.toInputs.h_a_hi_t d.toInputs.h_b_lo_t d.toInputs.h_b_hi_t
             d.toInputs.h_input_r1 d.toInputs.h_input_r2
         have h_off_bridge :
-            (m.jmp_offset1 i.val).val =
-              (BitVec.signExtend 64 d.toInputs.blt_input.imm).toNat := by
+            m.jmp_offset1 i.val =
+              ((BitVec.signExtend 64 d.toInputs.blt_input.imm).toInt : FGL) := by
           simpa [hm, d.toInputs.h_input_imm] using d.toDecode.h_jmp_offset1_imm
         have h_cast := Pilot.branch_nextPC_flag1_taken trace i
           (BitVec.slt d.toInputs.blt_input.r1_val d.toInputs.blt_input.r2_val)
           d.toInputs.blt_input.PC (BitVec.signExtend 64 d.toInputs.blt_input.imm)
           d.toDecode.h_idx d.toDecode.h_set_pc h_flag d.toDecode.h_jmp_offset2
-          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2
+          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2.1 h_domain.2.2
         show (register_type_pc_equiv ▸
             (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
           = (PureSpec.execute_BLT_pure d.toInputs.blt_input).nextPC
@@ -996,7 +997,7 @@ theorem stepStrong_bge
     (d : RowData_bge trace binding i)
     (h_domain :
       BranchRangeDomain trace i d.toInputs.bge_input.PC
-        ((mainOfTable trace.program trace.mainTable).jmp_offset2 i.val)) :
+        (BitVec.signExtend 64 d.toInputs.bge_input.imm)) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BGE)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨Pilot.execRowOf trace i, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -1031,14 +1032,14 @@ theorem stepStrong_bge
             d.toInputs.h_a_lo_t d.toInputs.h_a_hi_t d.toInputs.h_b_lo_t d.toInputs.h_b_hi_t
             d.toInputs.h_input_r1 d.toInputs.h_input_r2
         have h_off_bridge :
-            (m.jmp_offset2 i.val).val =
-              (BitVec.signExtend 64 d.toInputs.bge_input.imm).toNat := by
+            m.jmp_offset2 i.val =
+              ((BitVec.signExtend 64 d.toInputs.bge_input.imm).toInt : FGL) := by
           simpa [hm, d.toInputs.h_input_imm] using d.toDecode.h_jmp_offset2_imm
         have h_cast := Pilot.branch_nextPC_flag0_taken trace i
           (BitVec.slt d.toInputs.bge_input.r1_val d.toInputs.bge_input.r2_val)
           d.toInputs.bge_input.PC (BitVec.signExtend 64 d.toInputs.bge_input.imm)
           d.toDecode.h_idx d.toDecode.h_set_pc h_flag d.toDecode.h_jmp_offset1
-          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2
+          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2.1 h_domain.2.2
         show (register_type_pc_equiv ▸
             (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
           = (PureSpec.execute_BGE_pure d.toInputs.bge_input).nextPC
@@ -1063,7 +1064,7 @@ theorem stepStrong_bltu
     (d : RowData_bltu trace binding i)
     (h_domain :
       BranchRangeDomain trace i d.toInputs.bltu_input.PC
-        ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val)) :
+        (BitVec.signExtend 64 d.toInputs.bltu_input.imm)) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BLTU)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨Pilot.execRowOf trace i, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -1101,14 +1102,14 @@ theorem stepStrong_bltu
             d.toInputs.h_a_lo_t d.toInputs.h_a_hi_t d.toInputs.h_b_lo_t d.toInputs.h_b_hi_t
             d.toInputs.h_input_r1 d.toInputs.h_input_r2
         have h_off_bridge :
-            (m.jmp_offset1 i.val).val =
-              (BitVec.signExtend 64 d.toInputs.bltu_input.imm).toNat := by
+            m.jmp_offset1 i.val =
+              ((BitVec.signExtend 64 d.toInputs.bltu_input.imm).toInt : FGL) := by
           simpa [hm, d.toInputs.h_input_imm] using d.toDecode.h_jmp_offset1_imm
         have h_cast := Pilot.branch_nextPC_flag1_taken trace i
           (BitVec.ult d.toInputs.bltu_input.r1_val d.toInputs.bltu_input.r2_val)
           d.toInputs.bltu_input.PC (BitVec.signExtend 64 d.toInputs.bltu_input.imm)
           d.toDecode.h_idx d.toDecode.h_set_pc h_flag d.toDecode.h_jmp_offset2
-          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2
+          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2.1 h_domain.2.2
         show (register_type_pc_equiv ▸
             (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
           = (PureSpec.execute_BLTU_pure d.toInputs.bltu_input).nextPC
@@ -1133,7 +1134,7 @@ theorem stepStrong_bgeu
     (d : RowData_bgeu trace binding i)
     (h_domain :
       BranchRangeDomain trace i d.toInputs.bgeu_input.PC
-        ((mainOfTable trace.program trace.mainTable).jmp_offset2 i.val)) :
+        (BitVec.signExtend 64 d.toInputs.bgeu_input.imm)) :
     execute_instruction (instruction.BTYPE (d.toClaim.imm, d.toClaim.r2, d.toClaim.r1, bop.BGEU)) (binding i)
       = ZiskFv.Channels.state_effect_via_channels ⟨Pilot.execRowOf trace i, []⟩ (binding i) := by
   set m := ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable with hm
@@ -1171,14 +1172,14 @@ theorem stepStrong_bgeu
             d.toInputs.h_a_lo_t d.toInputs.h_a_hi_t d.toInputs.h_b_lo_t d.toInputs.h_b_hi_t
             d.toInputs.h_input_r1 d.toInputs.h_input_r2
         have h_off_bridge :
-            (m.jmp_offset2 i.val).val =
-              (BitVec.signExtend 64 d.toInputs.bgeu_input.imm).toNat := by
+            m.jmp_offset2 i.val =
+              ((BitVec.signExtend 64 d.toInputs.bgeu_input.imm).toInt : FGL) := by
           simpa [hm, d.toInputs.h_input_imm] using d.toDecode.h_jmp_offset2_imm
         have h_cast := Pilot.branch_nextPC_flag0_taken trace i
           (BitVec.ult d.toInputs.bgeu_input.r1_val d.toInputs.bgeu_input.r2_val)
           d.toInputs.bgeu_input.PC (BitVec.signExtend 64 d.toInputs.bgeu_input.imm)
           d.toDecode.h_idx d.toDecode.h_set_pc h_flag d.toDecode.h_jmp_offset1
-          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2
+          h_off_bridge d.toInputs.h_pc_bridge h_domain.1 h_domain.2.1 h_domain.2.2
         show (register_type_pc_equiv ▸
             (BitVec.ofNat 64 ((Pilot.execRowOf trace i)[1]!.pc).val))
           = (PureSpec.execute_BGEU_pure d.toInputs.bgeu_input).nextPC
@@ -1342,8 +1343,9 @@ theorem stepStrong_auipc
   let row_mode : ZiskFv.Compliance.MainRowProvenance.AuipcRowMode provenance :=
     { op_eq := rfl, internal_eq := rfl, m32_eq := rfl, set_pc_eq := rfl, store_pc_eq := rfl }
   have h_offset_bridge :
-      (m.jmp_offset2 i.val).val =
-        (BitVec.signExtend 64 (d.toInputs.auipc_input.imm ++ (0 : BitVec 12))).toNat := by
+      m.jmp_offset2 i.val =
+        ((BitVec.signExtend 64
+          (d.toInputs.auipc_input.imm ++ (0 : BitVec 12))).toInt : FGL) := by
     simpa [hm, d.toInputs.h_input_imm] using d.toDecode.h_jmp_offset2_imm
   have h_row_core :
       (mainRowWithRomLui trace i).core =
@@ -1385,7 +1387,7 @@ theorem stepStrong_auipc
     OpEnvelope.auipc d.toInputs.auipc_input d.toClaim.imm d.toClaim.rd (Pilot.execRowOf trace i) e_rd
       (PureSpec.execute_AUIPC_pure d.toInputs.auipc_input).nextPC next_pc store_pc_mem
       provenance row_mode h_auipc_subset h_offset_bridge d.toInputs.h_pc_bridge promises
-      h_domain.h_no_wrap h_domain.h_pc_offset_lt_2_32
+      h_domain.h_target_nonneg h_domain.h_target_lt h_domain.h_pc_offset_lt_2_32
   have h_bridge : env.aeneasBridgeTrust :=
     ⟨⟨provenance⟩, row_mode, h_offset_bridge, d.toInputs.h_pc_bridge⟩
   have h_mem : env.memoryTimelineConstructionEvidence := by trivial

--- a/ZiskFv/Compliance/TraceLevelExport/StepStrongLoadMext.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/StepStrongLoadMext.lean
@@ -103,7 +103,7 @@ theorem load_addr_arith_of_decode
     {r1_val : BitVec 64}
     (h_b_offset_imm0 :
       (mainRowWithRomLd trace i).rom.b_offset_imm0 =
-        ((BitVec.signExtend 64 imm).toNat : FGL))
+        ((BitVec.signExtend 64 imm).toInt : FGL))
     (h_a0_value : (mainRowWithRomLd trace i).core.a_0 = lane_lo r1_val)
     (h_addr_bound :
       r1_val.toNat + (BitVec.signExtend 64 imm).toNat < ZiskPhysicalAddressSpaceSize) :
@@ -117,7 +117,11 @@ theorem load_addr_arith_of_decode
   have h_r1_lt_gl : r1_val.toNat < GL_prime := by omega
   have h_imm_lt_gl : (BitVec.signExtend 64 imm).toNat < GL_prime := by omega
   have h_sum_lt_gl : r1_val.toNat + (BitVec.signExtend 64 imm).toNat < GL_prime := by omega
+  have h_imm_toInt :
+      (BitVec.signExtend 64 imm).toInt = (BitVec.signExtend 64 imm).toNat := by
+    rw [BitVec.toInt, if_pos (by omega)]
   rw [h_b_offset_imm0, h_a0_value]
+  rw [h_imm_toInt]
   change ((((BitVec.signExtend 64 imm).toNat : FGL) + lane_lo r1_val : FGL).val) =
     r1_val.toNat + (BitVec.signExtend 64 imm).toNat
   rw [Fin.val_add, Fin.val_natCast]
@@ -142,7 +146,7 @@ theorem load_addr1_of_decode
     (h_b_src_ind : (mainRowWithRomLd trace i).rom.b_src_ind = 1)
     (h_b_offset_imm0 :
       (mainRowWithRomLd trace i).rom.b_offset_imm0 =
-        ((BitVec.signExtend 64 imm).toNat : FGL))
+        ((BitVec.signExtend 64 imm).toInt : FGL))
     (h_a0_value : (mainRowWithRomLd trace i).core.a_0 = lane_lo r1_val)
     (h_addr_bound :
       r1_val.toNat + (BitVec.signExtend 64 imm).toNat < ZiskPhysicalAddressSpaceSize) :

--- a/ZiskFv/Compliance/Wrappers/Auipc.lean
+++ b/ZiskFv/Compliance/Wrappers/Auipc.lean
@@ -60,17 +60,18 @@ lemma equiv_AUIPC_of_main_pins
     (h_set_pc : m.set_pc r_main = 0)
     (h_store_pc : m.store_pc r_main = 1)
     (h_auipc_subset : auipc_subset_holds m r_main next_pc)
-    (h_offset_bridge : (m.jmp_offset2 r_main).val
-      = (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat)
+    (h_offset_bridge : m.jmp_offset2 r_main =
+      ((BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt : FGL))
     (h_pc_bridge : (m.pc r_main).val = auipc_input.PC.toNat)
     -- Structural `UTypePromises` bundle.
     (promises : ZiskFv.EquivCore.Promises.UTypePromises
         state auipc_input.imm auipc_input.rd auipc_input.PC
         (PureSpec.execute_AUIPC_pure auipc_input).nextPC
         imm rd exec_row e_rd nextPC_val)
-    (h_no_wrap : auipc_input.PC.toNat
-      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
-        < GL_prime)
+    (h_target_nonneg : 0 ≤ (auipc_input.PC.toNat : Int)
+      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt)
+    (h_target_lt : (auipc_input.PC.toNat : Int)
+      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt < GL_prime)
     (h_pc_offset_lt_2_32 :
       (auipc_input.PC + BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
         < 4294967296) :
@@ -82,7 +83,8 @@ lemma equiv_AUIPC_of_main_pins
       h_m32 h_set_pc h_store_pc h_auipc_subset
   ZiskFv.EquivCore.Auipc.equiv_AUIPC state auipc_input imm rd
     exec_row e_rd m r_main next_pc store_pc_mem nextPC_val
-    promises h_circuit h_offset_bridge h_pc_bridge h_no_wrap h_pc_offset_lt_2_32
+    promises h_circuit h_offset_bridge h_pc_bridge h_target_nonneg h_target_lt
+      h_pc_offset_lt_2_32
 
 /-- Row-provenance wrapper for `equiv_AUIPC`. The mode pins come from a
     selected production-extracted row shape. The PC/offset dynamic facts are
@@ -100,16 +102,17 @@ lemma equiv_AUIPC
     (provenance : ZiskFv.Compliance.MainRowProvenance m r_main)
     (row_mode : ZiskFv.Compliance.MainRowProvenance.AuipcRowMode provenance)
     (h_auipc_subset : auipc_subset_holds m r_main next_pc)
-    (h_offset_bridge : (m.jmp_offset2 r_main).val
-      = (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat)
+    (h_offset_bridge : m.jmp_offset2 r_main =
+      ((BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt : FGL))
     (h_pc_bridge : (m.pc r_main).val = auipc_input.PC.toNat)
     (promises : ZiskFv.EquivCore.Promises.UTypePromises
         state auipc_input.imm auipc_input.rd auipc_input.PC
         (PureSpec.execute_AUIPC_pure auipc_input).nextPC
         imm rd exec_row e_rd nextPC_val)
-    (h_no_wrap : auipc_input.PC.toNat
-      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
-        < GL_prime)
+    (h_target_nonneg : 0 ≤ (auipc_input.PC.toNat : Int)
+      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt)
+    (h_target_lt : (auipc_input.PC.toNat : Int)
+      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt < GL_prime)
     (h_pc_offset_lt_2_32 :
       (auipc_input.PC + BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
         < 4294967296) :
@@ -120,6 +123,7 @@ lemma equiv_AUIPC
       m r_main next_pc provenance row_mode h_auipc_subset
   exact ZiskFv.EquivCore.Auipc.equiv_AUIPC state auipc_input imm rd
     exec_row e_rd m r_main next_pc store_pc_mem nextPC_val
-    promises h_circuit h_offset_bridge h_pc_bridge h_no_wrap h_pc_offset_lt_2_32
+    promises h_circuit h_offset_bridge h_pc_bridge h_target_nonneg h_target_lt
+      h_pc_offset_lt_2_32
 
 end ZiskFv.Compliance

--- a/ZiskFv/EquivCore/Auipc.lean
+++ b/ZiskFv/EquivCore/Auipc.lean
@@ -137,12 +137,13 @@ lemma equiv_AUIPC
     -- Discharge parameters
     (h_circuit :
       ZiskFv.Tactics.UTypeArchetype.auipc_archetype_circuit_holds m r_main next_pc)
-    (h_offset_bridge : (m.jmp_offset2 r_main).val
-      = (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat)
+    (h_offset_bridge : m.jmp_offset2 r_main =
+      ((BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt : FGL))
     (h_pc_bridge : (m.pc r_main).val = auipc_input.PC.toNat)
-    (h_no_wrap : auipc_input.PC.toNat
-      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
-        < GL_prime)
+    (h_target_nonneg : 0 ≤ (auipc_input.PC.toNat : Int)
+      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt)
+    (h_target_lt : (auipc_input.PC.toNat : Int)
+      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt < GL_prime)
     (h_pc_offset_lt_2_32 :
       (auipc_input.PC + BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
         < 4294967296)
@@ -159,28 +160,11 @@ lemma equiv_AUIPC
   -- 32-bit result bound, avoiding the legacy range bus.
   have h_lo_bound :
       (m.pc r_main + m.jmp_offset2 r_main : FGL).val < 4294967296 := by
-    have h_no_wrap_fgl :
-        (m.pc r_main).val + (m.jmp_offset2 r_main).val < GL_prime := by
-      rw [h_pc_bridge, h_offset_bridge]
-      exact h_no_wrap
-    have h_fgl_val :
-        (m.pc r_main + m.jmp_offset2 r_main : FGL).val =
-          auipc_input.PC.toNat
-            + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat := by
-      rw [Fin.val_add, Nat.mod_eq_of_lt h_no_wrap_fgl, h_pc_bridge, h_offset_bridge]
-    have h_bv_add :
-        (auipc_input.PC + BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat =
-          auipc_input.PC.toNat
-            + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat := by
-      rw [BitVec.toNat_add]
-      have h_lt_64 :
-          auipc_input.PC.toNat
-            + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
-              < 18446744073709551616 := by
-        have h_gl_lt : GL_prime < 18446744073709551616 := by decide
-        omega
-      rw [Nat.mod_eq_of_lt h_lt_64]
-    rw [h_fgl_val, ← h_bv_add]
+    rw [h_offset_bridge]
+    rw [ZiskFv.PackedBitVec.WidePCNoWrap.fgl_pc_plus_signed_offset_val
+      (m.pc r_main) auipc_input.PC
+      (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12)))
+      h_pc_bridge h_target_nonneg h_target_lt]
     exact h_pc_offset_lt_2_32
   have h_rd_val :
       U64.toBV #v[(byteAt e_rd 0 : BitVec 8), (byteAt e_rd 1 : BitVec 8),
@@ -202,7 +186,7 @@ lemma equiv_AUIPC
     exact ZiskFv.EquivCore.WriteValueProofs.JumpUType.h_rd_val_jut_auipc
       auipc_input.PC auipc_input.imm m r_main next_pc e_rd
       h_circuit h_offset_bridge h_pc_bridge h_lane_lo h_lane_hi
-      h_no_wrap h_lo_bound h_pc_offset_lt_2_32
+      h_target_nonneg h_target_lt h_lo_bound h_pc_offset_lt_2_32
       hb0 hb1 hb2 hb3 hb4 hb5 hb6 hb7
   rw [equiv_AUIPC_sail state auipc_input imm rd
         h_input_imm h_input_rd h_input_pc]

--- a/ZiskFv/EquivCore/WriteValueProofs/JumpUType.lean
+++ b/ZiskFv/EquivCore/WriteValueProofs/JumpUType.lean
@@ -461,16 +461,17 @@ lemma h_rd_val_jut_auipc
     -- CIRCUIT-CONSTRAINT
     (h_circuit : auipc_archetype_circuit_holds m r_main next_pc)
     -- TRANSPILE-BRIDGE: jmp_offset2 lifts to (sext (imm ++ 0#12)).toNat
-    (h_offset_bridge : (m.jmp_offset2 r_main).val
-      = (BitVec.signExtend 64 (imm ++ (0 : BitVec 12))).toNat)
+    (h_offset_bridge : m.jmp_offset2 r_main =
+      ((BitVec.signExtend 64 (imm ++ (0 : BitVec 12))).toInt : FGL))
     (h_pc_bridge : (m.pc r_main).val = PC.toNat)
     -- LANE-MATCH (lo + hi)
     (h_lane_lo : store_pc_lanes_match_lo m r_main e2)
     (h_lane_hi : store_pc_lanes_match_hi m r_main e2)
     -- RANGE: no-wrap PC+offset bound + lo-half FGL bound + 32-bit bound
-    (h_no_wrap :
-      PC.toNat + (BitVec.signExtend 64 (imm ++ (0 : BitVec 12))).toNat
-        < GL_prime)
+    (h_target_nonneg :
+      0 ≤ (PC.toNat : Int) + (BitVec.signExtend 64 (imm ++ (0 : BitVec 12))).toInt)
+    (h_target_lt :
+      (PC.toNat : Int) + (BitVec.signExtend 64 (imm ++ (0 : BitVec 12))).toInt < GL_prime)
     (h_lo_bound : (m.pc r_main + m.jmp_offset2 r_main : FGL).val < 4294967296)
     (h_pc_offset_lt_2_32 :
       (PC + BitVec.signExtend 64 (imm ++ (0 : BitVec 12))).toNat < 4294967296)
@@ -488,7 +489,7 @@ lemma h_rd_val_jut_auipc
   set offset_bv : BitVec 64 := BitVec.signExtend 64 (imm ++ (0 : BitVec 12)) with h_offset_def
   have h_lo_val : (memory_entry_lo e2).val = (PC + offset_bv).toNat % 4294967296 :=
     auipc_store_value_lo_bv m r_main next_pc PC offset_bv e2
-      h_circuit h_lane_lo h_pc_bridge h_offset_bridge h_no_wrap h_lo_bound
+      h_circuit h_lane_lo h_pc_bridge h_offset_bridge h_target_nonneg h_target_lt h_lo_bound
   have h_hi_val : (memory_entry_hi e2).val = (PC + offset_bv).toNat / 4294967296 :=
     auipc_store_value_hi_bv m r_main next_pc PC offset_bv e2
       h_circuit h_lane_hi h_pc_offset_lt_2_32

--- a/ZiskFv/Equivalence/Auipc.lean
+++ b/ZiskFv/Equivalence/Auipc.lean
@@ -47,16 +47,17 @@ inductive AuipcRoute
     (provenance : ZiskFv.Compliance.MainRowProvenance m r_main)
     (row_mode : ZiskFv.Compliance.MainRowProvenance.AuipcRowMode provenance)
     (h_auipc_subset : auipc_subset_holds m r_main next_pc)
-    (h_offset_bridge : (m.jmp_offset2 r_main).val
-      = (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat)
+    (h_offset_bridge : m.jmp_offset2 r_main =
+      ((BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt : FGL))
     (h_pc_bridge : (m.pc r_main).val = auipc_input.PC.toNat)
     (promises : ZiskFv.EquivCore.Promises.UTypePromises
         state auipc_input.imm auipc_input.rd auipc_input.PC
         (PureSpec.execute_AUIPC_pure auipc_input).nextPC
         imm rd exec_row e_rd nextPC_val)
-    (h_no_wrap : auipc_input.PC.toNat
-      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
-        < GL_prime)
+    (h_target_nonneg : 0 ≤ (auipc_input.PC.toNat : Int)
+      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt)
+    (h_target_lt : (auipc_input.PC.toNat : Int)
+      + (BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toInt < GL_prime)
     (h_pc_offset_lt_2_32 :
       (auipc_input.PC + BitVec.signExtend 64 (auipc_input.imm ++ (0 : BitVec 12))).toNat
         < 4294967296) :
@@ -98,14 +99,15 @@ theorem equiv_AUIPC
   cases route with
   | rdWrite exec_row e_rd nextPC_val route_next_pc store_pc_mem provenance
       row_mode h_auipc_subset h_offset_bridge h_pc_bridge promises
-      h_no_wrap h_pc_offset_lt_2_32 =>
+      h_target_nonneg h_target_lt h_pc_offset_lt_2_32 =>
     change execute_instruction (instruction.UTYPE (imm, rd, uop.AUIPC)) state
       = state_effect_via_channels ⟨exec_row, [e_rd]⟩ state
     rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
     exact ZiskFv.Compliance.equiv_AUIPC
       state auipc_input imm rd exec_row e_rd nextPC_val m r_main route_next_pc
       store_pc_mem provenance row_mode h_auipc_subset
-      h_offset_bridge h_pc_bridge promises h_no_wrap h_pc_offset_lt_2_32
+      h_offset_bridge h_pc_bridge promises h_target_nonneg h_target_lt
+      h_pc_offset_lt_2_32
   | x0NoMemory exec_row promises =>
     change execute_instruction (instruction.UTYPE (imm, rd, uop.AUIPC)) state
       = state_effect_via_channels ⟨exec_row, []⟩ state

--- a/ZiskFv/ZiskCircuit/AddUpperImmediatePC.lean
+++ b/ZiskFv/ZiskCircuit/AddUpperImmediatePC.lean
@@ -120,8 +120,9 @@ lemma auipc_store_value_lo_bv
     (h_circuit : auipc_archetype_circuit_holds m r_main next_pc)
     (h_lane_lo : store_pc_lanes_match_lo m r_main e)
     (h_pc_bridge : (m.pc r_main).val = PC.toNat)
-    (h_offset_bridge : (m.jmp_offset2 r_main).val = offset_bv.toNat)
-    (h_no_wrap : PC.toNat + offset_bv.toNat < GL_prime)
+    (h_offset_bridge : m.jmp_offset2 r_main = (offset_bv.toInt : FGL))
+    (h_target_nonneg : 0 ≤ (PC.toNat : Int) + offset_bv.toInt)
+    (h_target_lt : (PC.toNat : Int) + offset_bv.toInt < GL_prime)
     (h_lo_bound : (m.pc r_main + m.jmp_offset2 r_main : FGL).val
                     < 4294967296) :
     (memory_entry_lo e).val = (PC + offset_bv).toNat % 4294967296 := by
@@ -131,14 +132,11 @@ lemma auipc_store_value_lo_bv
   rw [h_sv] at h_lane_lo
   -- `h_lane_lo : memory_entry_lo e = m.pc r_main + m.jmp_offset2 r_main`
   rw [h_lane_lo]
-  -- Apply S2's strict-form lo lemma with the AUIPC offset.
-  have h_no_wrap_fgl :
-      (m.pc r_main).val + (m.jmp_offset2 r_main).val < GL_prime := by
-    rw [h_pc_bridge, h_offset_bridge]
-    exact h_no_wrap
-  exact fgl_pc_plus_offset_val_eq_lo_strict
-    (m.pc r_main) (m.jmp_offset2 r_main) PC offset_bv
-    h_pc_bridge h_offset_bridge h_no_wrap_fgl h_lo_bound
+  have hval := fgl_pc_plus_signed_offset_val
+    (m.pc r_main) PC offset_bv h_pc_bridge h_target_nonneg h_target_lt
+  rw [h_offset_bridge] at h_lo_bound
+  rw [hval] at h_lo_bound
+  rw [h_offset_bridge, hval, Nat.mod_eq_of_lt h_lo_bound]
 
 /-- **AUIPC rd-write hi half (BitVec form).** Under AUIPC's
     `store_pc = 1` mode, the PIL `(1 - store_pc) * c_1` collapses to

--- a/trust/aeneas/ProductionM2.lean
+++ b/trust/aeneas/ProductionM2.lean
@@ -959,8 +959,18 @@ structure aeneas_extract.Rv64imTranspileExtract where
   decode : aeneas_extract.Rv64imDecodeExtract
   row : aeneas_extract.ZiskInstExtract
 
+/-- [zisk_core::aeneas_extract::Rv64imTranspileRowsExtract]
+    Source: 'core/src/aeneas_extract.rs', lines 64:0-70:1
+    Visibility: public -/
+structure aeneas_extract.Rv64imTranspileRowsExtract where
+  accepted : Bool
+  decode : aeneas_extract.Rv64imDecodeExtract
+  row_count : Std.U32
+  first_row : aeneas_extract.ZiskInstExtract
+  last_row : aeneas_extract.ZiskInstExtract
+
 /-- [zisk_core::aeneas_extract::opcode_id]:
-    Source: 'core/src/aeneas_extract.rs', lines 63:0-131:1 -/
+    Source: 'core/src/aeneas_extract.rs', lines 72:0-140:1 -/
 def aeneas_extract.opcode_id
   (opcode : aeneas_extract.rv64im_decode.RiscvOpcode) : Result Std.U32 := do
   match opcode with
@@ -1031,7 +1041,7 @@ def aeneas_extract.opcode_id
   | aeneas_extract.rv64im_decode.RiscvOpcode.Unsupported => ok 1001#u32
 
 /-- [zisk_core::aeneas_extract::format_id]:
-    Source: 'core/src/aeneas_extract.rs', lines 133:0-145:1 -/
+    Source: 'core/src/aeneas_extract.rs', lines 142:0-154:1 -/
 def aeneas_extract.format_id
   (format : aeneas_extract.rv64im_decode.RiscvFormat) : Result Std.U32 := do
   match format with
@@ -1046,7 +1056,7 @@ def aeneas_extract.format_id
   | aeneas_extract.rv64im_decode.RiscvFormat.Unsupported => ok 1001#u32
 
 /-- [zisk_core::aeneas_extract::decode_extract_from_decoded]:
-    Source: 'core/src/aeneas_extract.rs', lines 147:0-161:1 -/
+    Source: 'core/src/aeneas_extract.rs', lines 156:0-170:1 -/
 def aeneas_extract.decode_extract_from_decoded
   (decoded : aeneas_extract.rv64im_decode.DecodedRv64im) :
   Result aeneas_extract.Rv64imDecodeExtract
@@ -1140,7 +1150,7 @@ inductive riscv2zisk_single_row.Rv64imSingleRowOpcode where
 | Sd : riscv2zisk_single_row.Rv64imSingleRowOpcode
 
 /-- [zisk_core::aeneas_extract::lowering_opcode]:
-    Source: 'core/src/aeneas_extract.rs', lines 163:0-230:1 -/
+    Source: 'core/src/aeneas_extract.rs', lines 172:0-239:1 -/
 def aeneas_extract.lowering_opcode
   (opcode : aeneas_extract.rv64im_decode.RiscvOpcode) :
   Result (Option riscv2zisk_single_row.Rv64imSingleRowOpcode)
@@ -1328,7 +1338,7 @@ structure zisk_inst.ZiskInst where
   sorted_pc_list_index : Std.Usize
 
 /-- [zisk_core::aeneas_extract::{zisk_core::aeneas_extract::ZiskInstExtract}::from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 233:4-259:5
+    Source: 'core/src/aeneas_extract.rs', lines 242:4-268:5
     Visibility: public -/
 def aeneas_extract.ZiskInstExtract.from_inst
   (i : zisk_inst.ZiskInst) : Result aeneas_extract.ZiskInstExtract := do
@@ -2177,10 +2187,11 @@ def zisk_inst_builder.ZiskInstBuilder.new_for_rv64im_lowering
   zisk_inst_builder.ZiskInstBuilder.new i.rom_address
 
 /-- [zisk_core::riscv2zisk_context::Riscv2ZiskContext]
-    Source: 'core/src/riscv2zisk_context.rs', lines 82:0-97:1
+    Source: 'core/src/riscv2zisk_context.rs', lines 84:0-101:1
     Visibility: public -/
 structure riscv2zisk_context.Riscv2ZiskContext where
   extract_inst : Option zisk_inst_builder.ZiskInstBuilder
+  extract_first_inst : Option aeneas_extract.ZiskInstExtract
   extract_marker : core.marker.PhantomData Unit
   input_precompile : Option Std.U32
   output_precompile : Option Std.U32
@@ -2188,7 +2199,7 @@ structure riscv2zisk_context.Riscv2ZiskContext where
   output_precompile_reg : Option Std.U32
 
 /-- [zisk_core::riscv2zisk_context::{zisk_core::riscv2zisk_context::Riscv2ZiskContext<0>}::insert_inst]:
-    Source: 'core/src/riscv2zisk_context.rs', lines 106:4-108:5 -/
+    Source: 'core/src/riscv2zisk_context.rs', lines 110:4-112:5 -/
 def riscv2zisk_context.Riscv2ZiskContext.insert_inst
   (self : riscv2zisk_context.Riscv2ZiskContext) (_rom_address : Std.U64)
   (zib : zisk_inst_builder.ZiskInstBuilder) :
@@ -2197,7 +2208,7 @@ def riscv2zisk_context.Riscv2ZiskContext.insert_inst
   ok { self with extract_inst := (some zib), extract_marker := () }
 
 /-- [zisk_core::riscv2zisk_context::{zisk_core::riscv2zisk_context::Riscv2ZiskContext<0>}::jal]:
-    Source: 'core/src/riscv2zisk_context.rs', lines 1418:4-1440:5
+    Source: 'core/src/riscv2zisk_context.rs', lines 1450:4-1472:5
     Visibility: public -/
 def riscv2zisk_context.Riscv2ZiskContext.jal
   (self : riscv2zisk_context.Riscv2ZiskContext)
@@ -2340,13 +2351,13 @@ def zisk_inst_builder.ZiskInstBuilder.src_b_reg
             }
 
 /-- [zisk_core::riscv2zisk_context::{zisk_core::riscv2zisk_context::Riscv2ZiskContext<0>}::jalr::JALR_MASK]
-    Source: 'core/src/riscv2zisk_context.rs', lines 1346:8-1346:50 -/
+    Source: 'core/src/riscv2zisk_context.rs', lines 1350:8-1350:50 -/
 @[global_simps, irreducible]
 def riscv2zisk_context.Riscv2ZiskContext.jalr.JALR_MASK : Std.U64 :=
   18446744073709551614#u64
 
 /-- [zisk_core::riscv2zisk_context::{zisk_core::riscv2zisk_context::Riscv2ZiskContext<0>}::jalr]:
-    Source: 'core/src/riscv2zisk_context.rs', lines 1315:4-1413:5
+    Source: 'core/src/riscv2zisk_context.rs', lines 1319:4-1445:5
     Visibility: public -/
 def riscv2zisk_context.Riscv2ZiskContext.jalr
   (self : riscv2zisk_context.Riscv2ZiskContext)
@@ -2385,9 +2396,42 @@ def riscv2zisk_context.Riscv2ZiskContext.jalr
       zisk_inst_builder.ZiskInstBuilder.op_zisk zib2 zisk_ops.ZiskOp.Add
     let zib4 ← zisk_inst_builder.ZiskInstBuilder.j zib3 1#i64 1#i64
     let zib5 ← zisk_inst_builder.ZiskInstBuilder.build zib4
+    let i4 := read_discriminant zib5.i.op_type
+    let i5 ← lift (UScalar.cast .U32 i4)
     let self1 ←
       riscv2zisk_context.Riscv2ZiskContext.insert_inst
-        { self with extract_marker := () } i.rom_address zib5
+        {
+          self
+            with
+            extract_first_inst :=
+              (some
+                {
+                  paddr := zib5.i.paddr,
+                  store_pc := zib5.i.store_pc,
+                  store_use_sp := zib5.i.store_use_sp,
+                  store := zib5.i.store,
+                  store_offset := zib5.i.store_offset,
+                  set_pc := zib5.i.set_pc,
+                  is_precompiled := zib5.i.is_precompiled,
+                  ind_width := zib5.i.ind_width,
+                  «end» := zib5.i.«end»,
+                  a_src := zib5.i.a_src,
+                  a_use_sp_imm1 := zib5.i.a_use_sp_imm1,
+                  a_offset_imm0 := zib5.i.a_offset_imm0,
+                  b_src := zib5.i.b_src,
+                  b_use_sp_imm1 := zib5.i.b_use_sp_imm1,
+                  b_offset_imm0 := zib5.i.b_offset_imm0,
+                  jmp_offset1 := zib5.i.jmp_offset1,
+                  jmp_offset2 := zib5.i.jmp_offset2,
+                  is_external_op := zib5.i.is_external_op,
+                  op := zib5.i.op,
+                  op_type_id := i5,
+                  m32 := zib5.i.m32,
+                  input_size := zib5.i.input_size,
+                  sorted_pc_list_index := zib5.i.sorted_pc_list_index
+                }),
+            extract_marker := ()
+        } i.rom_address zib5
     let rom_address ← i.rom_address + 1#u64
     let zib6 ← zisk_inst_builder.ZiskInstBuilder.new rom_address
     let zib7 ←
@@ -2396,12 +2440,12 @@ def riscv2zisk_context.Riscv2ZiskContext.jalr
     let zib8 ← zisk_inst_builder.ZiskInstBuilder.src_b_lastc zib7
     let zib9 ←
       zisk_inst_builder.ZiskInstBuilder.op_zisk zib8 zisk_ops.ZiskOp.And
-    let i4 ← lift (UScalar.hcast .I64 i.rd)
-    let zib10 ← zisk_inst_builder.ZiskInstBuilder.store_pc_reg zib9 i4 false
+    let i6 ← lift (UScalar.hcast .I64 i.rd)
+    let zib10 ← zisk_inst_builder.ZiskInstBuilder.store_pc_reg zib9 i6 false
     let zib11 ← zisk_inst_builder.ZiskInstBuilder.set_pc zib10
-    let i5 ← lift (UScalar.hcast .I64 inst_size)
-    let i6 ← i5 - 1#i64
-    let zib12 ← zisk_inst_builder.ZiskInstBuilder.j zib11 0#i64 i6
+    let i7 ← lift (UScalar.hcast .I64 inst_size)
+    let i8 ← i7 - 1#i64
+    let zib12 ← zisk_inst_builder.ZiskInstBuilder.j zib11 0#i64 i8
     let zib13 ← zisk_inst_builder.ZiskInstBuilder.build zib12
     let self2 ←
       riscv2zisk_context.Riscv2ZiskContext.insert_inst
@@ -2409,7 +2453,7 @@ def riscv2zisk_context.Riscv2ZiskContext.jalr
     ok { self2 with extract_marker := () }
 
 /-- [zisk_core::riscv2zisk_context::{zisk_core::riscv2zisk_context::Riscv2ZiskContext<0>}::lui]:
-    Source: 'core/src/riscv2zisk_context.rs', lines 1288:4-1310:5
+    Source: 'core/src/riscv2zisk_context.rs', lines 1292:4-1314:5
     Visibility: public -/
 def riscv2zisk_context.Riscv2ZiskContext.lui
   (self : riscv2zisk_context.Riscv2ZiskContext)
@@ -2434,7 +2478,7 @@ def riscv2zisk_context.Riscv2ZiskContext.lui
   ok { self1 with extract_marker := () }
 
 /-- [zisk_core::riscv2zisk_context::{zisk_core::riscv2zisk_context::Riscv2ZiskContext<0>}::auipc]:
-    Source: 'core/src/riscv2zisk_context.rs', lines 1176:4-1196:5
+    Source: 'core/src/riscv2zisk_context.rs', lines 1180:4-1200:5
     Visibility: public -/
 def riscv2zisk_context.Riscv2ZiskContext.auipc
   (self : riscv2zisk_context.Riscv2ZiskContext)
@@ -2457,7 +2501,7 @@ def riscv2zisk_context.Riscv2ZiskContext.auipc
   ok { self1 with extract_marker := () }
 
 /-- [zisk_core::riscv2zisk_context::{zisk_core::riscv2zisk_context::Riscv2ZiskContext<0>}::copyb]:
-    Source: 'core/src/riscv2zisk_context.rs', lines 1155:4-1171:5
+    Source: 'core/src/riscv2zisk_context.rs', lines 1159:4-1175:5
     Visibility: public -/
 def riscv2zisk_context.Riscv2ZiskContext.copyb
   (self : riscv2zisk_context.Riscv2ZiskContext)
@@ -2562,7 +2606,7 @@ def zisk_inst_builder.ZiskInstBuilder.src_a_reg
             }
 
 /-- [zisk_core::riscv2zisk_context::{zisk_core::riscv2zisk_context::Riscv2ZiskContext<0>}::immediate_op_or_x0_copyb_typed]:
-    Source: 'core/src/riscv2zisk_context.rs', lines 1125:4-1153:5
+    Source: 'core/src/riscv2zisk_context.rs', lines 1129:4-1157:5
     Visibility: public -/
 def riscv2zisk_context.Riscv2ZiskContext.immediate_op_or_x0_copyb_typed
   (self : riscv2zisk_context.Riscv2ZiskContext)
@@ -2591,7 +2635,7 @@ def riscv2zisk_context.Riscv2ZiskContext.immediate_op_or_x0_copyb_typed
   ok { self1 with extract_marker := () }
 
 /-- [zisk_core::riscv2zisk_context::{zisk_core::riscv2zisk_context::Riscv2ZiskContext<0>}::immediate_op_typed]:
-    Source: 'core/src/riscv2zisk_context.rs', lines 1076:4-1089:5
+    Source: 'core/src/riscv2zisk_context.rs', lines 1080:4-1093:5
     Visibility: public -/
 def riscv2zisk_context.Riscv2ZiskContext.immediate_op_typed
   (self : riscv2zisk_context.Riscv2ZiskContext)
@@ -2657,7 +2701,7 @@ def zisk_inst_builder.ZiskInstBuilder.store_ind
     }
 
 /-- [zisk_core::riscv2zisk_context::{zisk_core::riscv2zisk_context::Riscv2ZiskContext<0>}::store_op_with_reg_offset]:
-    Source: 'core/src/riscv2zisk_context.rs', lines 1028:4-1049:5
+    Source: 'core/src/riscv2zisk_context.rs', lines 1032:4-1053:5
     Visibility: public -/
 def riscv2zisk_context.Riscv2ZiskContext.store_op_with_reg_offset
   (self : riscv2zisk_context.Riscv2ZiskContext)
@@ -2685,7 +2729,7 @@ def riscv2zisk_context.Riscv2ZiskContext.store_op_with_reg_offset
   ok { self1 with extract_marker := () }
 
 /-- [zisk_core::riscv2zisk_context::{zisk_core::riscv2zisk_context::Riscv2ZiskContext<0>}::store_op_typed]:
-    Source: 'core/src/riscv2zisk_context.rs', lines 1024:4-1026:5
+    Source: 'core/src/riscv2zisk_context.rs', lines 1028:4-1030:5
     Visibility: public -/
 def riscv2zisk_context.Riscv2ZiskContext.store_op_typed
   (self : riscv2zisk_context.Riscv2ZiskContext)
@@ -2738,7 +2782,7 @@ def zisk_inst_builder.ZiskInstBuilder.src_b_ind
       }
 
 /-- [zisk_core::riscv2zisk_context::{zisk_core::riscv2zisk_context::Riscv2ZiskContext<0>}::load_op_with_reg_offset]:
-    Source: 'core/src/riscv2zisk_context.rs', lines 969:4-990:5
+    Source: 'core/src/riscv2zisk_context.rs', lines 973:4-994:5
     Visibility: public -/
 def riscv2zisk_context.Riscv2ZiskContext.load_op_with_reg_offset
   (self : riscv2zisk_context.Riscv2ZiskContext)
@@ -2766,7 +2810,7 @@ def riscv2zisk_context.Riscv2ZiskContext.load_op_with_reg_offset
   ok { self1 with extract_marker := () }
 
 /-- [zisk_core::riscv2zisk_context::{zisk_core::riscv2zisk_context::Riscv2ZiskContext<0>}::load_op_typed]:
-    Source: 'core/src/riscv2zisk_context.rs', lines 965:4-967:5
+    Source: 'core/src/riscv2zisk_context.rs', lines 969:4-971:5
     Visibility: public -/
 def riscv2zisk_context.Riscv2ZiskContext.load_op_typed
   (self : riscv2zisk_context.Riscv2ZiskContext)
@@ -2780,7 +2824,7 @@ def riscv2zisk_context.Riscv2ZiskContext.load_op_typed
   ok { self1 with extract_marker := () }
 
 /-- [zisk_core::riscv2zisk_context::{zisk_core::riscv2zisk_context::Riscv2ZiskContext<0>}::nop]:
-    Source: 'core/src/riscv2zisk_context.rs', lines 896:4-916:5
+    Source: 'core/src/riscv2zisk_context.rs', lines 900:4-920:5
     Visibility: public -/
 def riscv2zisk_context.Riscv2ZiskContext.nop
   (self : riscv2zisk_context.Riscv2ZiskContext)
@@ -2802,7 +2846,7 @@ def riscv2zisk_context.Riscv2ZiskContext.nop
   ok { self1 with extract_marker := () }
 
 /-- [zisk_core::riscv2zisk_context::{zisk_core::riscv2zisk_context::Riscv2ZiskContext<0>}::hint]:
-    Source: 'core/src/riscv2zisk_context.rs', lines 880:4-892:5
+    Source: 'core/src/riscv2zisk_context.rs', lines 884:4-896:5
     Visibility: public -/
 def riscv2zisk_context.Riscv2ZiskContext.hint
   (self : riscv2zisk_context.Riscv2ZiskContext)
@@ -2826,7 +2870,7 @@ def riscv2zisk_context.Riscv2ZiskContext.hint
   ok { self1 with extract_marker := () }
 
 /-- [zisk_core::riscv2zisk_context::{zisk_core::riscv2zisk_context::Riscv2ZiskContext<0>}::create_branch_op_typed]:
-    Source: 'core/src/riscv2zisk_context.rs', lines 854:4-876:5
+    Source: 'core/src/riscv2zisk_context.rs', lines 858:4-880:5
     Visibility: public -/
 def riscv2zisk_context.Riscv2ZiskContext.create_branch_op_typed
   (self : riscv2zisk_context.Riscv2ZiskContext)
@@ -2859,7 +2903,7 @@ def riscv2zisk_context.Riscv2ZiskContext.create_branch_op_typed
   ok { self1 with extract_marker := () }
 
 /-- [zisk_core::riscv2zisk_context::{zisk_core::riscv2zisk_context::Riscv2ZiskContext<0>}::create_precompiled_op_typed]:
-    Source: 'core/src/riscv2zisk_context.rs', lines 730:4-760:5
+    Source: 'core/src/riscv2zisk_context.rs', lines 734:4-764:5
     Visibility: public -/
 def riscv2zisk_context.Riscv2ZiskContext.create_precompiled_op_typed
   (self : riscv2zisk_context.Riscv2ZiskContext)
@@ -2884,7 +2928,7 @@ def riscv2zisk_context.Riscv2ZiskContext.create_precompiled_op_typed
   ok { self1 with extract_marker := () }
 
 /-- [zisk_core::riscv2zisk_context::{zisk_core::riscv2zisk_context::Riscv2ZiskContext<0>}::create_register_op_typed]:
-    Source: 'core/src/riscv2zisk_context.rs', lines 680:4-698:5
+    Source: 'core/src/riscv2zisk_context.rs', lines 684:4-702:5
     Visibility: public -/
 def riscv2zisk_context.Riscv2ZiskContext.create_register_op_typed
   (self : riscv2zisk_context.Riscv2ZiskContext)
@@ -3495,7 +3539,7 @@ def riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
   ok { self1 with extract_marker := () }
 
 /-- [zisk_core::aeneas_extract::extract_lui_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 308:0-312:1
+    Source: 'core/src/aeneas_extract.rs', lines 318:0-322:1
     Visibility: public -/
 def aeneas_extract.extract_lui_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3507,6 +3551,7 @@ def aeneas_extract.extract_lui_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -3517,7 +3562,7 @@ def aeneas_extract.extract_lui_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_auipc_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 314:0-318:1
+    Source: 'core/src/aeneas_extract.rs', lines 324:0-328:1
     Visibility: public -/
 def aeneas_extract.extract_auipc_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3529,6 +3574,7 @@ def aeneas_extract.extract_auipc_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -3539,7 +3585,7 @@ def aeneas_extract.extract_auipc_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_jal_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 320:0-324:1
+    Source: 'core/src/aeneas_extract.rs', lines 330:0-334:1
     Visibility: public -/
 def aeneas_extract.extract_jal_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3551,6 +3597,7 @@ def aeneas_extract.extract_jal_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -3561,7 +3608,7 @@ def aeneas_extract.extract_jal_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_jalr_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 326:0-330:1
+    Source: 'core/src/aeneas_extract.rs', lines 336:0-340:1
     Visibility: public -/
 def aeneas_extract.extract_jalr_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3573,6 +3620,7 @@ def aeneas_extract.extract_jalr_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -3583,7 +3631,7 @@ def aeneas_extract.extract_jalr_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_fence_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 332:0-336:1
+    Source: 'core/src/aeneas_extract.rs', lines 342:0-346:1
     Visibility: public -/
 def aeneas_extract.extract_fence_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3595,6 +3643,7 @@ def aeneas_extract.extract_fence_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -3605,7 +3654,7 @@ def aeneas_extract.extract_fence_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_fence_accepts_raw_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 338:0-341:1
+    Source: 'core/src/aeneas_extract.rs', lines 348:0-351:1
     Visibility: public -/
 def aeneas_extract.extract_fence_accepts_raw_inst
   (raw1 : Std.U32) : Result Bool := do
@@ -3614,7 +3663,7 @@ def aeneas_extract.extract_fence_accepts_raw_inst
     fence.kind aeneas_extract.fence_decode.FenceDecodeKind.Fence
 
 /-- [zisk_core::aeneas_extract::extract_decode_rv64im_raw]:
-    Source: 'core/src/aeneas_extract.rs', lines 343:0-345:1
+    Source: 'core/src/aeneas_extract.rs', lines 353:0-355:1
     Visibility: public -/
 def aeneas_extract.extract_decode_rv64im_raw
   (raw1 : Std.U32) : Result aeneas_extract.Rv64imDecodeExtract := do
@@ -3622,7 +3671,7 @@ def aeneas_extract.extract_decode_rv64im_raw
   aeneas_extract.decode_extract_from_decoded dri
 
 /-- [zisk_core::aeneas_extract::extract_rv64im_opcode_supported]:
-    Source: 'core/src/aeneas_extract.rs', lines 347:0-349:1
+    Source: 'core/src/aeneas_extract.rs', lines 357:0-359:1
     Visibility: public -/
 def aeneas_extract.extract_rv64im_opcode_supported
   (raw1 : Std.U32) : Result Bool := do
@@ -3640,7 +3689,7 @@ def riscv2zisk_single_row.Rv64imLoweringInput.new
   ok { rom_address, rd, rs1, rs2, imm }
 
 /-- [zisk_core::aeneas_extract::extract_transpile_rv64im_raw]:
-    Source: 'core/src/aeneas_extract.rs', lines 351:0-365:1
+    Source: 'core/src/aeneas_extract.rs', lines 361:0-375:1
     Visibility: public -/
 def aeneas_extract.extract_transpile_rv64im_raw
   (raw1 : Std.U32) : Result aeneas_extract.Rv64imTranspileExtract := do
@@ -3659,6 +3708,7 @@ def aeneas_extract.extract_transpile_rv64im_raw
       riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
         {
           extract_inst := none,
+          extract_first_inst := none,
           extract_marker := (),
           input_precompile := none,
           output_precompile := none,
@@ -3669,8 +3719,56 @@ def aeneas_extract.extract_transpile_rv64im_raw
     let row ← aeneas_extract.ZiskInstExtract.from_inst zib.i
     ok { accepted := true, decode, row }
 
+/-- [zisk_core::aeneas_extract::extract_transpile_rv64im_rows_raw]:
+    Source: 'core/src/aeneas_extract.rs', lines 377:0-410:1
+    Visibility: public -/
+def aeneas_extract.extract_transpile_rv64im_rows_raw
+  (raw1 : Std.U32) : Result aeneas_extract.Rv64imTranspileRowsExtract := do
+  let decoded ← aeneas_extract.rv64im_decode.decode_32_core raw1
+  let decode ← aeneas_extract.decode_extract_from_decoded decoded
+  let o ← aeneas_extract.lowering_opcode decoded.opcode
+  match o with
+  | none =>
+    let zie ← aeneas_extract.ZiskInstExtract.Insts.CoreDefaultDefault.default
+    ok
+      {
+        accepted := false,
+        decode,
+        row_count := 0#u32,
+        first_row := zie,
+        last_row := zie
+      }
+  | some opcode =>
+    let input ←
+      riscv2zisk_single_row.Rv64imLoweringInput.new 0#u64 decoded.rd
+        decoded.rs1 decoded.rs2 decoded.imm
+    let ctx ←
+      riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+        {
+          extract_inst := none,
+          extract_first_inst := none,
+          extract_marker := (),
+          input_precompile := none,
+          output_precompile := none,
+          input_precompile_reg := none,
+          output_precompile_reg := none
+        } input opcode false
+    let zib ← core.option.Option.unwrap ctx.extract_inst
+    let last_row ← aeneas_extract.ZiskInstExtract.from_inst zib.i
+    let b := core.option.Option.is_some ctx.extract_first_inst
+    let row_count ← if b
+                      then ok 2#u32
+                      else ok 1#u32
+    match ctx.extract_first_inst with
+    | none =>
+      ok
+        { accepted := true, decode, row_count, first_row := last_row, last_row
+        }
+    | some first =>
+      ok { accepted := true, decode, row_count, first_row := first, last_row }
+
 /-- [zisk_core::aeneas_extract::extract_transpile_rv64im_accepted_raw]:
-    Source: 'core/src/aeneas_extract.rs', lines 367:0-370:1
+    Source: 'core/src/aeneas_extract.rs', lines 412:0-415:1
     Visibility: public -/
 def aeneas_extract.extract_transpile_rv64im_accepted_raw
   (raw1 : Std.U32) : Result Bool := do
@@ -3679,14 +3777,14 @@ def aeneas_extract.extract_transpile_rv64im_accepted_raw
   ok (core.option.Option.is_some o)
 
 /-- [zisk_core::aeneas_extract::extract_transpile_rv64im_materializes_raw]:
-    Source: 'core/src/aeneas_extract.rs', lines 372:0-374:1
+    Source: 'core/src/aeneas_extract.rs', lines 417:0-419:1
     Visibility: public -/
 def aeneas_extract.extract_transpile_rv64im_materializes_raw
   (raw1 : Std.U32) : Result Bool := do
   aeneas_extract.extract_transpile_rv64im_accepted_raw raw1
 
 /-- [zisk_core::aeneas_extract::extract_add_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_add_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3698,6 +3796,7 @@ def aeneas_extract.extract_add_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -3708,7 +3807,7 @@ def aeneas_extract.extract_add_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_addw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_addw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3720,6 +3819,7 @@ def aeneas_extract.extract_addw_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -3730,7 +3830,7 @@ def aeneas_extract.extract_addw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_and_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_and_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3742,6 +3842,7 @@ def aeneas_extract.extract_and_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -3752,7 +3853,7 @@ def aeneas_extract.extract_and_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_div_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_div_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3764,6 +3865,7 @@ def aeneas_extract.extract_div_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -3774,7 +3876,7 @@ def aeneas_extract.extract_div_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_divu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_divu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3786,6 +3888,7 @@ def aeneas_extract.extract_divu_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -3796,7 +3899,7 @@ def aeneas_extract.extract_divu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_divuw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_divuw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3808,6 +3911,7 @@ def aeneas_extract.extract_divuw_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -3818,7 +3922,7 @@ def aeneas_extract.extract_divuw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_divw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_divw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3830,6 +3934,7 @@ def aeneas_extract.extract_divw_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -3840,7 +3945,7 @@ def aeneas_extract.extract_divw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_mul_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_mul_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3852,6 +3957,7 @@ def aeneas_extract.extract_mul_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -3862,7 +3968,7 @@ def aeneas_extract.extract_mul_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_mulh_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_mulh_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3874,6 +3980,7 @@ def aeneas_extract.extract_mulh_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -3884,7 +3991,7 @@ def aeneas_extract.extract_mulh_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_mulhsu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_mulhsu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3896,6 +4003,7 @@ def aeneas_extract.extract_mulhsu_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -3906,7 +4014,7 @@ def aeneas_extract.extract_mulhsu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_mulhu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_mulhu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3918,6 +4026,7 @@ def aeneas_extract.extract_mulhu_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -3928,7 +4037,7 @@ def aeneas_extract.extract_mulhu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_mulw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_mulw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3940,6 +4049,7 @@ def aeneas_extract.extract_mulw_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -3950,7 +4060,7 @@ def aeneas_extract.extract_mulw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_or_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_or_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3962,6 +4072,7 @@ def aeneas_extract.extract_or_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -3972,7 +4083,7 @@ def aeneas_extract.extract_or_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_rem_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_rem_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3984,6 +4095,7 @@ def aeneas_extract.extract_rem_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -3994,7 +4106,7 @@ def aeneas_extract.extract_rem_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_remu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_remu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4006,6 +4118,7 @@ def aeneas_extract.extract_remu_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4016,7 +4129,7 @@ def aeneas_extract.extract_remu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_remuw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_remuw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4028,6 +4141,7 @@ def aeneas_extract.extract_remuw_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4038,7 +4152,7 @@ def aeneas_extract.extract_remuw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_remw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_remw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4050,6 +4164,7 @@ def aeneas_extract.extract_remw_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4060,7 +4175,7 @@ def aeneas_extract.extract_remw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sll_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_sll_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4072,6 +4187,7 @@ def aeneas_extract.extract_sll_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4082,7 +4198,7 @@ def aeneas_extract.extract_sll_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sllw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_sllw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4094,6 +4210,7 @@ def aeneas_extract.extract_sllw_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4104,7 +4221,7 @@ def aeneas_extract.extract_sllw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_slt_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_slt_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4116,6 +4233,7 @@ def aeneas_extract.extract_slt_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4126,7 +4244,7 @@ def aeneas_extract.extract_slt_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sltu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_sltu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4138,6 +4256,7 @@ def aeneas_extract.extract_sltu_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4148,7 +4267,7 @@ def aeneas_extract.extract_sltu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sra_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_sra_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4160,6 +4279,7 @@ def aeneas_extract.extract_sra_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4170,7 +4290,7 @@ def aeneas_extract.extract_sra_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sraw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_sraw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4182,6 +4302,7 @@ def aeneas_extract.extract_sraw_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4192,7 +4313,7 @@ def aeneas_extract.extract_sraw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_srl_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_srl_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4204,6 +4325,7 @@ def aeneas_extract.extract_srl_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4214,7 +4336,7 @@ def aeneas_extract.extract_srl_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_srlw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_srlw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4226,6 +4348,7 @@ def aeneas_extract.extract_srlw_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4236,7 +4359,7 @@ def aeneas_extract.extract_srlw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sub_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_sub_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4248,6 +4371,7 @@ def aeneas_extract.extract_sub_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4258,7 +4382,7 @@ def aeneas_extract.extract_sub_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_subw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_subw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4270,6 +4394,7 @@ def aeneas_extract.extract_subw_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4280,7 +4405,7 @@ def aeneas_extract.extract_subw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_xor_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 378:8-382:9
+    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
     Visibility: public -/
 def aeneas_extract.extract_xor_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4292,6 +4417,7 @@ def aeneas_extract.extract_xor_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4302,7 +4428,7 @@ def aeneas_extract.extract_xor_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_addiw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 388:8-392:9
+    Source: 'core/src/aeneas_extract.rs', lines 433:8-437:9
     Visibility: public -/
 def aeneas_extract.extract_addiw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4314,6 +4440,7 @@ def aeneas_extract.extract_addiw_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4324,7 +4451,7 @@ def aeneas_extract.extract_addiw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_andi_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 388:8-392:9
+    Source: 'core/src/aeneas_extract.rs', lines 433:8-437:9
     Visibility: public -/
 def aeneas_extract.extract_andi_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4336,6 +4463,7 @@ def aeneas_extract.extract_andi_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4346,7 +4474,7 @@ def aeneas_extract.extract_andi_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_slli_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 388:8-392:9
+    Source: 'core/src/aeneas_extract.rs', lines 433:8-437:9
     Visibility: public -/
 def aeneas_extract.extract_slli_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4358,6 +4486,7 @@ def aeneas_extract.extract_slli_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4368,7 +4497,7 @@ def aeneas_extract.extract_slli_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_slliw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 388:8-392:9
+    Source: 'core/src/aeneas_extract.rs', lines 433:8-437:9
     Visibility: public -/
 def aeneas_extract.extract_slliw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4380,6 +4509,7 @@ def aeneas_extract.extract_slliw_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4390,7 +4520,7 @@ def aeneas_extract.extract_slliw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_slti_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 388:8-392:9
+    Source: 'core/src/aeneas_extract.rs', lines 433:8-437:9
     Visibility: public -/
 def aeneas_extract.extract_slti_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4402,6 +4532,7 @@ def aeneas_extract.extract_slti_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4412,7 +4543,7 @@ def aeneas_extract.extract_slti_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sltiu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 388:8-392:9
+    Source: 'core/src/aeneas_extract.rs', lines 433:8-437:9
     Visibility: public -/
 def aeneas_extract.extract_sltiu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4424,6 +4555,7 @@ def aeneas_extract.extract_sltiu_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4434,7 +4566,7 @@ def aeneas_extract.extract_sltiu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_srai_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 388:8-392:9
+    Source: 'core/src/aeneas_extract.rs', lines 433:8-437:9
     Visibility: public -/
 def aeneas_extract.extract_srai_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4446,6 +4578,7 @@ def aeneas_extract.extract_srai_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4456,7 +4589,7 @@ def aeneas_extract.extract_srai_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sraiw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 388:8-392:9
+    Source: 'core/src/aeneas_extract.rs', lines 433:8-437:9
     Visibility: public -/
 def aeneas_extract.extract_sraiw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4468,6 +4601,7 @@ def aeneas_extract.extract_sraiw_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4478,7 +4612,7 @@ def aeneas_extract.extract_sraiw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_srli_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 388:8-392:9
+    Source: 'core/src/aeneas_extract.rs', lines 433:8-437:9
     Visibility: public -/
 def aeneas_extract.extract_srli_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4490,6 +4624,7 @@ def aeneas_extract.extract_srli_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4500,7 +4635,7 @@ def aeneas_extract.extract_srli_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_srliw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 388:8-392:9
+    Source: 'core/src/aeneas_extract.rs', lines 433:8-437:9
     Visibility: public -/
 def aeneas_extract.extract_srliw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4512,6 +4647,7 @@ def aeneas_extract.extract_srliw_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4522,7 +4658,7 @@ def aeneas_extract.extract_srliw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_addi_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 398:8-402:9
+    Source: 'core/src/aeneas_extract.rs', lines 443:8-447:9
     Visibility: public -/
 def aeneas_extract.extract_addi_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4534,6 +4670,7 @@ def aeneas_extract.extract_addi_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4544,7 +4681,7 @@ def aeneas_extract.extract_addi_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_ori_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 398:8-402:9
+    Source: 'core/src/aeneas_extract.rs', lines 443:8-447:9
     Visibility: public -/
 def aeneas_extract.extract_ori_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4556,6 +4693,7 @@ def aeneas_extract.extract_ori_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4566,7 +4704,7 @@ def aeneas_extract.extract_ori_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_xori_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 398:8-402:9
+    Source: 'core/src/aeneas_extract.rs', lines 443:8-447:9
     Visibility: public -/
 def aeneas_extract.extract_xori_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4578,6 +4716,7 @@ def aeneas_extract.extract_xori_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4588,7 +4727,7 @@ def aeneas_extract.extract_xori_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_beq_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 408:8-412:9
+    Source: 'core/src/aeneas_extract.rs', lines 453:8-457:9
     Visibility: public -/
 def aeneas_extract.extract_beq_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4600,6 +4739,7 @@ def aeneas_extract.extract_beq_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4610,7 +4750,7 @@ def aeneas_extract.extract_beq_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_bge_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 408:8-412:9
+    Source: 'core/src/aeneas_extract.rs', lines 453:8-457:9
     Visibility: public -/
 def aeneas_extract.extract_bge_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4622,6 +4762,7 @@ def aeneas_extract.extract_bge_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4632,7 +4773,7 @@ def aeneas_extract.extract_bge_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_bgeu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 408:8-412:9
+    Source: 'core/src/aeneas_extract.rs', lines 453:8-457:9
     Visibility: public -/
 def aeneas_extract.extract_bgeu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4644,6 +4785,7 @@ def aeneas_extract.extract_bgeu_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4654,7 +4796,7 @@ def aeneas_extract.extract_bgeu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_blt_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 408:8-412:9
+    Source: 'core/src/aeneas_extract.rs', lines 453:8-457:9
     Visibility: public -/
 def aeneas_extract.extract_blt_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4666,6 +4808,7 @@ def aeneas_extract.extract_blt_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4676,7 +4819,7 @@ def aeneas_extract.extract_blt_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_bltu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 408:8-412:9
+    Source: 'core/src/aeneas_extract.rs', lines 453:8-457:9
     Visibility: public -/
 def aeneas_extract.extract_bltu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4688,6 +4831,7 @@ def aeneas_extract.extract_bltu_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4698,7 +4842,7 @@ def aeneas_extract.extract_bltu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_bne_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 408:8-412:9
+    Source: 'core/src/aeneas_extract.rs', lines 453:8-457:9
     Visibility: public -/
 def aeneas_extract.extract_bne_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4710,6 +4854,7 @@ def aeneas_extract.extract_bne_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4720,7 +4865,7 @@ def aeneas_extract.extract_bne_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_lb_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 418:8-422:9
+    Source: 'core/src/aeneas_extract.rs', lines 463:8-467:9
     Visibility: public -/
 def aeneas_extract.extract_lb_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4732,6 +4877,7 @@ def aeneas_extract.extract_lb_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4742,7 +4888,7 @@ def aeneas_extract.extract_lb_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_lbu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 418:8-422:9
+    Source: 'core/src/aeneas_extract.rs', lines 463:8-467:9
     Visibility: public -/
 def aeneas_extract.extract_lbu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4754,6 +4900,7 @@ def aeneas_extract.extract_lbu_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4764,7 +4911,7 @@ def aeneas_extract.extract_lbu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_ld_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 418:8-422:9
+    Source: 'core/src/aeneas_extract.rs', lines 463:8-467:9
     Visibility: public -/
 def aeneas_extract.extract_ld_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4776,6 +4923,7 @@ def aeneas_extract.extract_ld_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4786,7 +4934,7 @@ def aeneas_extract.extract_ld_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_lh_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 418:8-422:9
+    Source: 'core/src/aeneas_extract.rs', lines 463:8-467:9
     Visibility: public -/
 def aeneas_extract.extract_lh_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4798,6 +4946,7 @@ def aeneas_extract.extract_lh_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4808,7 +4957,7 @@ def aeneas_extract.extract_lh_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_lhu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 418:8-422:9
+    Source: 'core/src/aeneas_extract.rs', lines 463:8-467:9
     Visibility: public -/
 def aeneas_extract.extract_lhu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4820,6 +4969,7 @@ def aeneas_extract.extract_lhu_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4830,7 +4980,7 @@ def aeneas_extract.extract_lhu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_lw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 418:8-422:9
+    Source: 'core/src/aeneas_extract.rs', lines 463:8-467:9
     Visibility: public -/
 def aeneas_extract.extract_lw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4842,6 +4992,7 @@ def aeneas_extract.extract_lw_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4852,7 +5003,7 @@ def aeneas_extract.extract_lw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_lwu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 418:8-422:9
+    Source: 'core/src/aeneas_extract.rs', lines 463:8-467:9
     Visibility: public -/
 def aeneas_extract.extract_lwu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4864,6 +5015,7 @@ def aeneas_extract.extract_lwu_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4874,7 +5026,7 @@ def aeneas_extract.extract_lwu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sb_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 428:8-432:9
+    Source: 'core/src/aeneas_extract.rs', lines 473:8-477:9
     Visibility: public -/
 def aeneas_extract.extract_sb_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4886,6 +5038,7 @@ def aeneas_extract.extract_sb_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4896,7 +5049,7 @@ def aeneas_extract.extract_sb_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sd_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 428:8-432:9
+    Source: 'core/src/aeneas_extract.rs', lines 473:8-477:9
     Visibility: public -/
 def aeneas_extract.extract_sd_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4908,6 +5061,7 @@ def aeneas_extract.extract_sd_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4918,7 +5072,7 @@ def aeneas_extract.extract_sd_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sh_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 428:8-432:9
+    Source: 'core/src/aeneas_extract.rs', lines 473:8-477:9
     Visibility: public -/
 def aeneas_extract.extract_sh_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4930,6 +5084,7 @@ def aeneas_extract.extract_sh_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,
@@ -4940,7 +5095,7 @@ def aeneas_extract.extract_sh_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 428:8-432:9
+    Source: 'core/src/aeneas_extract.rs', lines 473:8-477:9
     Visibility: public -/
 def aeneas_extract.extract_sw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4952,6 +5107,7 @@ def aeneas_extract.extract_sw_from_inst
     riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row
       {
         extract_inst := none,
+        extract_first_inst := none,
         extract_marker := (),
         input_precompile := none,
         output_precompile := none,

--- a/trust/aeneas/ProductionM2.lean
+++ b/trust/aeneas/ProductionM2.lean
@@ -3727,9 +3727,8 @@ def aeneas_extract.extract_transpile_rv64im_rows_raw
   let terminal ← aeneas_extract.extract_transpile_rv64im_raw raw1
   if terminal.accepted
   then
-    let i ←
-      aeneas_extract.opcode_id aeneas_extract.rv64im_decode.RiscvOpcode.Jalr
-    if terminal.decode.opcode_id = i
+    let i ← lift (raw1 &&& 127#u32)
+    if i = 103#u32
     then
       let i1 ← terminal.decode.imm % 4#i32
       if i1 != 0#i32

--- a/trust/aeneas/ProductionM2.lean
+++ b/trust/aeneas/ProductionM2.lean
@@ -3720,15 +3720,15 @@ def aeneas_extract.extract_transpile_rv64im_raw
     ok { accepted := true, decode, row }
 
 /-- [zisk_core::aeneas_extract::extract_transpile_rv64im_rows_raw]:
-    Source: 'core/src/aeneas_extract.rs', lines 377:0-421:1
+    Source: 'core/src/aeneas_extract.rs', lines 377:0-412:1
     Visibility: public -/
 def aeneas_extract.extract_transpile_rv64im_rows_raw
   (raw1 : Std.U32) : Result aeneas_extract.Rv64imTranspileRowsExtract := do
   let terminal ← aeneas_extract.extract_transpile_rv64im_raw raw1
-  if terminal.accepted
+  let i ← lift (raw1 &&& 127#u32)
+  if i = 103#u32
   then
-    let i ← lift (raw1 &&& 127#u32)
-    if i = 103#u32
+    if terminal.accepted
     then
       let i1 ← terminal.decode.imm % 4#i32
       if i1 != 0#i32
@@ -3769,25 +3769,24 @@ def aeneas_extract.extract_transpile_rv64im_rows_raw
     else
       ok
         {
-          accepted := true,
+          accepted := false,
           decode := terminal.decode,
           row_count := 1#u32,
           first_row := terminal.row,
           last_row := terminal.row
         }
   else
-    let zie ← aeneas_extract.ZiskInstExtract.Insts.CoreDefaultDefault.default
     ok
       {
-        accepted := false,
+        accepted := terminal.accepted,
         decode := terminal.decode,
-        row_count := 0#u32,
-        first_row := zie,
-        last_row := zie
+        row_count := 1#u32,
+        first_row := terminal.row,
+        last_row := terminal.row
       }
 
 /-- [zisk_core::aeneas_extract::extract_transpile_rv64im_accepted_raw]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:0-426:1
+    Source: 'core/src/aeneas_extract.rs', lines 414:0-417:1
     Visibility: public -/
 def aeneas_extract.extract_transpile_rv64im_accepted_raw
   (raw1 : Std.U32) : Result Bool := do
@@ -3796,14 +3795,14 @@ def aeneas_extract.extract_transpile_rv64im_accepted_raw
   ok (core.option.Option.is_some o)
 
 /-- [zisk_core::aeneas_extract::extract_transpile_rv64im_materializes_raw]:
-    Source: 'core/src/aeneas_extract.rs', lines 428:0-430:1
+    Source: 'core/src/aeneas_extract.rs', lines 419:0-421:1
     Visibility: public -/
 def aeneas_extract.extract_transpile_rv64im_materializes_raw
   (raw1 : Std.U32) : Result Bool := do
   aeneas_extract.extract_transpile_rv64im_accepted_raw raw1
 
 /-- [zisk_core::aeneas_extract::extract_add_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_add_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3826,7 +3825,7 @@ def aeneas_extract.extract_add_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_addw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_addw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3849,7 +3848,7 @@ def aeneas_extract.extract_addw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_and_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_and_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3872,7 +3871,7 @@ def aeneas_extract.extract_and_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_div_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_div_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3895,7 +3894,7 @@ def aeneas_extract.extract_div_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_divu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_divu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3918,7 +3917,7 @@ def aeneas_extract.extract_divu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_divuw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_divuw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3941,7 +3940,7 @@ def aeneas_extract.extract_divuw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_divw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_divw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3964,7 +3963,7 @@ def aeneas_extract.extract_divw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_mul_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_mul_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3987,7 +3986,7 @@ def aeneas_extract.extract_mul_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_mulh_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_mulh_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4010,7 +4009,7 @@ def aeneas_extract.extract_mulh_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_mulhsu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_mulhsu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4033,7 +4032,7 @@ def aeneas_extract.extract_mulhsu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_mulhu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_mulhu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4056,7 +4055,7 @@ def aeneas_extract.extract_mulhu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_mulw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_mulw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4079,7 +4078,7 @@ def aeneas_extract.extract_mulw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_or_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_or_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4102,7 +4101,7 @@ def aeneas_extract.extract_or_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_rem_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_rem_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4125,7 +4124,7 @@ def aeneas_extract.extract_rem_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_remu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_remu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4148,7 +4147,7 @@ def aeneas_extract.extract_remu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_remuw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_remuw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4171,7 +4170,7 @@ def aeneas_extract.extract_remuw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_remw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_remw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4194,7 +4193,7 @@ def aeneas_extract.extract_remw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sll_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_sll_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4217,7 +4216,7 @@ def aeneas_extract.extract_sll_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sllw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_sllw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4240,7 +4239,7 @@ def aeneas_extract.extract_sllw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_slt_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_slt_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4263,7 +4262,7 @@ def aeneas_extract.extract_slt_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sltu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_sltu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4286,7 +4285,7 @@ def aeneas_extract.extract_sltu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sra_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_sra_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4309,7 +4308,7 @@ def aeneas_extract.extract_sra_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sraw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_sraw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4332,7 +4331,7 @@ def aeneas_extract.extract_sraw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_srl_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_srl_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4355,7 +4354,7 @@ def aeneas_extract.extract_srl_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_srlw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_srlw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4378,7 +4377,7 @@ def aeneas_extract.extract_srlw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sub_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_sub_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4401,7 +4400,7 @@ def aeneas_extract.extract_sub_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_subw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_subw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4424,7 +4423,7 @@ def aeneas_extract.extract_subw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_xor_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
+    Source: 'core/src/aeneas_extract.rs', lines 425:8-429:9
     Visibility: public -/
 def aeneas_extract.extract_xor_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4447,7 +4446,7 @@ def aeneas_extract.extract_xor_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_addiw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 444:8-448:9
+    Source: 'core/src/aeneas_extract.rs', lines 435:8-439:9
     Visibility: public -/
 def aeneas_extract.extract_addiw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4470,7 +4469,7 @@ def aeneas_extract.extract_addiw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_andi_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 444:8-448:9
+    Source: 'core/src/aeneas_extract.rs', lines 435:8-439:9
     Visibility: public -/
 def aeneas_extract.extract_andi_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4493,7 +4492,7 @@ def aeneas_extract.extract_andi_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_slli_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 444:8-448:9
+    Source: 'core/src/aeneas_extract.rs', lines 435:8-439:9
     Visibility: public -/
 def aeneas_extract.extract_slli_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4516,7 +4515,7 @@ def aeneas_extract.extract_slli_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_slliw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 444:8-448:9
+    Source: 'core/src/aeneas_extract.rs', lines 435:8-439:9
     Visibility: public -/
 def aeneas_extract.extract_slliw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4539,7 +4538,7 @@ def aeneas_extract.extract_slliw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_slti_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 444:8-448:9
+    Source: 'core/src/aeneas_extract.rs', lines 435:8-439:9
     Visibility: public -/
 def aeneas_extract.extract_slti_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4562,7 +4561,7 @@ def aeneas_extract.extract_slti_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sltiu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 444:8-448:9
+    Source: 'core/src/aeneas_extract.rs', lines 435:8-439:9
     Visibility: public -/
 def aeneas_extract.extract_sltiu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4585,7 +4584,7 @@ def aeneas_extract.extract_sltiu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_srai_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 444:8-448:9
+    Source: 'core/src/aeneas_extract.rs', lines 435:8-439:9
     Visibility: public -/
 def aeneas_extract.extract_srai_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4608,7 +4607,7 @@ def aeneas_extract.extract_srai_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sraiw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 444:8-448:9
+    Source: 'core/src/aeneas_extract.rs', lines 435:8-439:9
     Visibility: public -/
 def aeneas_extract.extract_sraiw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4631,7 +4630,7 @@ def aeneas_extract.extract_sraiw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_srli_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 444:8-448:9
+    Source: 'core/src/aeneas_extract.rs', lines 435:8-439:9
     Visibility: public -/
 def aeneas_extract.extract_srli_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4654,7 +4653,7 @@ def aeneas_extract.extract_srli_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_srliw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 444:8-448:9
+    Source: 'core/src/aeneas_extract.rs', lines 435:8-439:9
     Visibility: public -/
 def aeneas_extract.extract_srliw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4677,7 +4676,7 @@ def aeneas_extract.extract_srliw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_addi_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 454:8-458:9
+    Source: 'core/src/aeneas_extract.rs', lines 445:8-449:9
     Visibility: public -/
 def aeneas_extract.extract_addi_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4700,7 +4699,7 @@ def aeneas_extract.extract_addi_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_ori_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 454:8-458:9
+    Source: 'core/src/aeneas_extract.rs', lines 445:8-449:9
     Visibility: public -/
 def aeneas_extract.extract_ori_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4723,7 +4722,7 @@ def aeneas_extract.extract_ori_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_xori_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 454:8-458:9
+    Source: 'core/src/aeneas_extract.rs', lines 445:8-449:9
     Visibility: public -/
 def aeneas_extract.extract_xori_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4746,7 +4745,7 @@ def aeneas_extract.extract_xori_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_beq_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 464:8-468:9
+    Source: 'core/src/aeneas_extract.rs', lines 455:8-459:9
     Visibility: public -/
 def aeneas_extract.extract_beq_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4769,7 +4768,7 @@ def aeneas_extract.extract_beq_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_bge_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 464:8-468:9
+    Source: 'core/src/aeneas_extract.rs', lines 455:8-459:9
     Visibility: public -/
 def aeneas_extract.extract_bge_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4792,7 +4791,7 @@ def aeneas_extract.extract_bge_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_bgeu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 464:8-468:9
+    Source: 'core/src/aeneas_extract.rs', lines 455:8-459:9
     Visibility: public -/
 def aeneas_extract.extract_bgeu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4815,7 +4814,7 @@ def aeneas_extract.extract_bgeu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_blt_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 464:8-468:9
+    Source: 'core/src/aeneas_extract.rs', lines 455:8-459:9
     Visibility: public -/
 def aeneas_extract.extract_blt_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4838,7 +4837,7 @@ def aeneas_extract.extract_blt_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_bltu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 464:8-468:9
+    Source: 'core/src/aeneas_extract.rs', lines 455:8-459:9
     Visibility: public -/
 def aeneas_extract.extract_bltu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4861,7 +4860,7 @@ def aeneas_extract.extract_bltu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_bne_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 464:8-468:9
+    Source: 'core/src/aeneas_extract.rs', lines 455:8-459:9
     Visibility: public -/
 def aeneas_extract.extract_bne_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4884,7 +4883,7 @@ def aeneas_extract.extract_bne_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_lb_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 474:8-478:9
+    Source: 'core/src/aeneas_extract.rs', lines 465:8-469:9
     Visibility: public -/
 def aeneas_extract.extract_lb_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4907,7 +4906,7 @@ def aeneas_extract.extract_lb_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_lbu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 474:8-478:9
+    Source: 'core/src/aeneas_extract.rs', lines 465:8-469:9
     Visibility: public -/
 def aeneas_extract.extract_lbu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4930,7 +4929,7 @@ def aeneas_extract.extract_lbu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_ld_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 474:8-478:9
+    Source: 'core/src/aeneas_extract.rs', lines 465:8-469:9
     Visibility: public -/
 def aeneas_extract.extract_ld_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4953,7 +4952,7 @@ def aeneas_extract.extract_ld_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_lh_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 474:8-478:9
+    Source: 'core/src/aeneas_extract.rs', lines 465:8-469:9
     Visibility: public -/
 def aeneas_extract.extract_lh_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4976,7 +4975,7 @@ def aeneas_extract.extract_lh_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_lhu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 474:8-478:9
+    Source: 'core/src/aeneas_extract.rs', lines 465:8-469:9
     Visibility: public -/
 def aeneas_extract.extract_lhu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4999,7 +4998,7 @@ def aeneas_extract.extract_lhu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_lw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 474:8-478:9
+    Source: 'core/src/aeneas_extract.rs', lines 465:8-469:9
     Visibility: public -/
 def aeneas_extract.extract_lw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -5022,7 +5021,7 @@ def aeneas_extract.extract_lw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_lwu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 474:8-478:9
+    Source: 'core/src/aeneas_extract.rs', lines 465:8-469:9
     Visibility: public -/
 def aeneas_extract.extract_lwu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -5045,7 +5044,7 @@ def aeneas_extract.extract_lwu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sb_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 484:8-488:9
+    Source: 'core/src/aeneas_extract.rs', lines 475:8-479:9
     Visibility: public -/
 def aeneas_extract.extract_sb_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -5068,7 +5067,7 @@ def aeneas_extract.extract_sb_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sd_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 484:8-488:9
+    Source: 'core/src/aeneas_extract.rs', lines 475:8-479:9
     Visibility: public -/
 def aeneas_extract.extract_sd_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -5091,7 +5090,7 @@ def aeneas_extract.extract_sd_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sh_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 484:8-488:9
+    Source: 'core/src/aeneas_extract.rs', lines 475:8-479:9
     Visibility: public -/
 def aeneas_extract.extract_sh_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -5114,7 +5113,7 @@ def aeneas_extract.extract_sh_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 484:8-488:9
+    Source: 'core/src/aeneas_extract.rs', lines 475:8-479:9
     Visibility: public -/
 def aeneas_extract.extract_sw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :

--- a/trust/aeneas/ProductionM2.lean
+++ b/trust/aeneas/ProductionM2.lean
@@ -3720,55 +3720,75 @@ def aeneas_extract.extract_transpile_rv64im_raw
     ok { accepted := true, decode, row }
 
 /-- [zisk_core::aeneas_extract::extract_transpile_rv64im_rows_raw]:
-    Source: 'core/src/aeneas_extract.rs', lines 377:0-410:1
+    Source: 'core/src/aeneas_extract.rs', lines 377:0-421:1
     Visibility: public -/
 def aeneas_extract.extract_transpile_rv64im_rows_raw
   (raw1 : Std.U32) : Result aeneas_extract.Rv64imTranspileRowsExtract := do
-  let decoded ← aeneas_extract.rv64im_decode.decode_32_core raw1
-  let decode ← aeneas_extract.decode_extract_from_decoded decoded
-  let o ← aeneas_extract.lowering_opcode decoded.opcode
-  match o with
-  | none =>
+  let terminal ← aeneas_extract.extract_transpile_rv64im_raw raw1
+  if terminal.accepted
+  then
+    let i ←
+      aeneas_extract.opcode_id aeneas_extract.rv64im_decode.RiscvOpcode.Jalr
+    if terminal.decode.opcode_id = i
+    then
+      let i1 ← terminal.decode.imm % 4#i32
+      if i1 != 0#i32
+      then
+        let input ←
+          riscv2zisk_single_row.Rv64imLoweringInput.new 0#u64
+            terminal.decode.rd terminal.decode.rs1 terminal.decode.rs2
+            terminal.decode.imm
+        let ctx ←
+          riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+            {
+              extract_inst := none,
+              extract_first_inst := none,
+              extract_marker := (),
+              input_precompile := none,
+              output_precompile := none,
+              input_precompile_reg := none,
+              output_precompile_reg := none
+            } input riscv2zisk_single_row.Rv64imSingleRowOpcode.Jalr false
+        let zie ← core.option.Option.unwrap ctx.extract_first_inst
+        ok
+          {
+            accepted := true,
+            decode := terminal.decode,
+            row_count := 2#u32,
+            first_row := zie,
+            last_row := terminal.row
+          }
+      else
+        ok
+          {
+            accepted := true,
+            decode := terminal.decode,
+            row_count := 1#u32,
+            first_row := terminal.row,
+            last_row := terminal.row
+          }
+    else
+      ok
+        {
+          accepted := true,
+          decode := terminal.decode,
+          row_count := 1#u32,
+          first_row := terminal.row,
+          last_row := terminal.row
+        }
+  else
     let zie ← aeneas_extract.ZiskInstExtract.Insts.CoreDefaultDefault.default
     ok
       {
         accepted := false,
-        decode,
+        decode := terminal.decode,
         row_count := 0#u32,
         first_row := zie,
         last_row := zie
       }
-  | some opcode =>
-    let input ←
-      riscv2zisk_single_row.Rv64imLoweringInput.new 0#u64 decoded.rd
-        decoded.rs1 decoded.rs2 decoded.imm
-    let ctx ←
-      riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
-        {
-          extract_inst := none,
-          extract_first_inst := none,
-          extract_marker := (),
-          input_precompile := none,
-          output_precompile := none,
-          input_precompile_reg := none,
-          output_precompile_reg := none
-        } input opcode false
-    let zib ← core.option.Option.unwrap ctx.extract_inst
-    let last_row ← aeneas_extract.ZiskInstExtract.from_inst zib.i
-    let b := core.option.Option.is_some ctx.extract_first_inst
-    let row_count ← if b
-                      then ok 2#u32
-                      else ok 1#u32
-    match ctx.extract_first_inst with
-    | none =>
-      ok
-        { accepted := true, decode, row_count, first_row := last_row, last_row
-        }
-    | some first =>
-      ok { accepted := true, decode, row_count, first_row := first, last_row }
 
 /-- [zisk_core::aeneas_extract::extract_transpile_rv64im_accepted_raw]:
-    Source: 'core/src/aeneas_extract.rs', lines 412:0-415:1
+    Source: 'core/src/aeneas_extract.rs', lines 423:0-426:1
     Visibility: public -/
 def aeneas_extract.extract_transpile_rv64im_accepted_raw
   (raw1 : Std.U32) : Result Bool := do
@@ -3777,14 +3797,14 @@ def aeneas_extract.extract_transpile_rv64im_accepted_raw
   ok (core.option.Option.is_some o)
 
 /-- [zisk_core::aeneas_extract::extract_transpile_rv64im_materializes_raw]:
-    Source: 'core/src/aeneas_extract.rs', lines 417:0-419:1
+    Source: 'core/src/aeneas_extract.rs', lines 428:0-430:1
     Visibility: public -/
 def aeneas_extract.extract_transpile_rv64im_materializes_raw
   (raw1 : Std.U32) : Result Bool := do
   aeneas_extract.extract_transpile_rv64im_accepted_raw raw1
 
 /-- [zisk_core::aeneas_extract::extract_add_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_add_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3807,7 +3827,7 @@ def aeneas_extract.extract_add_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_addw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_addw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3830,7 +3850,7 @@ def aeneas_extract.extract_addw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_and_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_and_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3853,7 +3873,7 @@ def aeneas_extract.extract_and_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_div_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_div_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3876,7 +3896,7 @@ def aeneas_extract.extract_div_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_divu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_divu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3899,7 +3919,7 @@ def aeneas_extract.extract_divu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_divuw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_divuw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3922,7 +3942,7 @@ def aeneas_extract.extract_divuw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_divw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_divw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3945,7 +3965,7 @@ def aeneas_extract.extract_divw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_mul_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_mul_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3968,7 +3988,7 @@ def aeneas_extract.extract_mul_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_mulh_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_mulh_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -3991,7 +4011,7 @@ def aeneas_extract.extract_mulh_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_mulhsu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_mulhsu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4014,7 +4034,7 @@ def aeneas_extract.extract_mulhsu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_mulhu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_mulhu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4037,7 +4057,7 @@ def aeneas_extract.extract_mulhu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_mulw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_mulw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4060,7 +4080,7 @@ def aeneas_extract.extract_mulw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_or_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_or_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4083,7 +4103,7 @@ def aeneas_extract.extract_or_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_rem_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_rem_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4106,7 +4126,7 @@ def aeneas_extract.extract_rem_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_remu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_remu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4129,7 +4149,7 @@ def aeneas_extract.extract_remu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_remuw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_remuw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4152,7 +4172,7 @@ def aeneas_extract.extract_remuw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_remw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_remw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4175,7 +4195,7 @@ def aeneas_extract.extract_remw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sll_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_sll_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4198,7 +4218,7 @@ def aeneas_extract.extract_sll_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sllw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_sllw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4221,7 +4241,7 @@ def aeneas_extract.extract_sllw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_slt_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_slt_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4244,7 +4264,7 @@ def aeneas_extract.extract_slt_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sltu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_sltu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4267,7 +4287,7 @@ def aeneas_extract.extract_sltu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sra_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_sra_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4290,7 +4310,7 @@ def aeneas_extract.extract_sra_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sraw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_sraw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4313,7 +4333,7 @@ def aeneas_extract.extract_sraw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_srl_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_srl_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4336,7 +4356,7 @@ def aeneas_extract.extract_srl_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_srlw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_srlw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4359,7 +4379,7 @@ def aeneas_extract.extract_srlw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sub_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_sub_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4382,7 +4402,7 @@ def aeneas_extract.extract_sub_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_subw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_subw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4405,7 +4425,7 @@ def aeneas_extract.extract_subw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_xor_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 423:8-427:9
+    Source: 'core/src/aeneas_extract.rs', lines 434:8-438:9
     Visibility: public -/
 def aeneas_extract.extract_xor_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4428,7 +4448,7 @@ def aeneas_extract.extract_xor_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_addiw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 433:8-437:9
+    Source: 'core/src/aeneas_extract.rs', lines 444:8-448:9
     Visibility: public -/
 def aeneas_extract.extract_addiw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4451,7 +4471,7 @@ def aeneas_extract.extract_addiw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_andi_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 433:8-437:9
+    Source: 'core/src/aeneas_extract.rs', lines 444:8-448:9
     Visibility: public -/
 def aeneas_extract.extract_andi_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4474,7 +4494,7 @@ def aeneas_extract.extract_andi_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_slli_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 433:8-437:9
+    Source: 'core/src/aeneas_extract.rs', lines 444:8-448:9
     Visibility: public -/
 def aeneas_extract.extract_slli_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4497,7 +4517,7 @@ def aeneas_extract.extract_slli_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_slliw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 433:8-437:9
+    Source: 'core/src/aeneas_extract.rs', lines 444:8-448:9
     Visibility: public -/
 def aeneas_extract.extract_slliw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4520,7 +4540,7 @@ def aeneas_extract.extract_slliw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_slti_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 433:8-437:9
+    Source: 'core/src/aeneas_extract.rs', lines 444:8-448:9
     Visibility: public -/
 def aeneas_extract.extract_slti_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4543,7 +4563,7 @@ def aeneas_extract.extract_slti_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sltiu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 433:8-437:9
+    Source: 'core/src/aeneas_extract.rs', lines 444:8-448:9
     Visibility: public -/
 def aeneas_extract.extract_sltiu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4566,7 +4586,7 @@ def aeneas_extract.extract_sltiu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_srai_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 433:8-437:9
+    Source: 'core/src/aeneas_extract.rs', lines 444:8-448:9
     Visibility: public -/
 def aeneas_extract.extract_srai_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4589,7 +4609,7 @@ def aeneas_extract.extract_srai_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sraiw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 433:8-437:9
+    Source: 'core/src/aeneas_extract.rs', lines 444:8-448:9
     Visibility: public -/
 def aeneas_extract.extract_sraiw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4612,7 +4632,7 @@ def aeneas_extract.extract_sraiw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_srli_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 433:8-437:9
+    Source: 'core/src/aeneas_extract.rs', lines 444:8-448:9
     Visibility: public -/
 def aeneas_extract.extract_srli_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4635,7 +4655,7 @@ def aeneas_extract.extract_srli_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_srliw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 433:8-437:9
+    Source: 'core/src/aeneas_extract.rs', lines 444:8-448:9
     Visibility: public -/
 def aeneas_extract.extract_srliw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4658,7 +4678,7 @@ def aeneas_extract.extract_srliw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_addi_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 443:8-447:9
+    Source: 'core/src/aeneas_extract.rs', lines 454:8-458:9
     Visibility: public -/
 def aeneas_extract.extract_addi_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4681,7 +4701,7 @@ def aeneas_extract.extract_addi_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_ori_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 443:8-447:9
+    Source: 'core/src/aeneas_extract.rs', lines 454:8-458:9
     Visibility: public -/
 def aeneas_extract.extract_ori_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4704,7 +4724,7 @@ def aeneas_extract.extract_ori_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_xori_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 443:8-447:9
+    Source: 'core/src/aeneas_extract.rs', lines 454:8-458:9
     Visibility: public -/
 def aeneas_extract.extract_xori_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4727,7 +4747,7 @@ def aeneas_extract.extract_xori_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_beq_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 453:8-457:9
+    Source: 'core/src/aeneas_extract.rs', lines 464:8-468:9
     Visibility: public -/
 def aeneas_extract.extract_beq_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4750,7 +4770,7 @@ def aeneas_extract.extract_beq_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_bge_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 453:8-457:9
+    Source: 'core/src/aeneas_extract.rs', lines 464:8-468:9
     Visibility: public -/
 def aeneas_extract.extract_bge_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4773,7 +4793,7 @@ def aeneas_extract.extract_bge_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_bgeu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 453:8-457:9
+    Source: 'core/src/aeneas_extract.rs', lines 464:8-468:9
     Visibility: public -/
 def aeneas_extract.extract_bgeu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4796,7 +4816,7 @@ def aeneas_extract.extract_bgeu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_blt_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 453:8-457:9
+    Source: 'core/src/aeneas_extract.rs', lines 464:8-468:9
     Visibility: public -/
 def aeneas_extract.extract_blt_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4819,7 +4839,7 @@ def aeneas_extract.extract_blt_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_bltu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 453:8-457:9
+    Source: 'core/src/aeneas_extract.rs', lines 464:8-468:9
     Visibility: public -/
 def aeneas_extract.extract_bltu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4842,7 +4862,7 @@ def aeneas_extract.extract_bltu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_bne_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 453:8-457:9
+    Source: 'core/src/aeneas_extract.rs', lines 464:8-468:9
     Visibility: public -/
 def aeneas_extract.extract_bne_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4865,7 +4885,7 @@ def aeneas_extract.extract_bne_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_lb_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 463:8-467:9
+    Source: 'core/src/aeneas_extract.rs', lines 474:8-478:9
     Visibility: public -/
 def aeneas_extract.extract_lb_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4888,7 +4908,7 @@ def aeneas_extract.extract_lb_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_lbu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 463:8-467:9
+    Source: 'core/src/aeneas_extract.rs', lines 474:8-478:9
     Visibility: public -/
 def aeneas_extract.extract_lbu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4911,7 +4931,7 @@ def aeneas_extract.extract_lbu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_ld_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 463:8-467:9
+    Source: 'core/src/aeneas_extract.rs', lines 474:8-478:9
     Visibility: public -/
 def aeneas_extract.extract_ld_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4934,7 +4954,7 @@ def aeneas_extract.extract_ld_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_lh_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 463:8-467:9
+    Source: 'core/src/aeneas_extract.rs', lines 474:8-478:9
     Visibility: public -/
 def aeneas_extract.extract_lh_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4957,7 +4977,7 @@ def aeneas_extract.extract_lh_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_lhu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 463:8-467:9
+    Source: 'core/src/aeneas_extract.rs', lines 474:8-478:9
     Visibility: public -/
 def aeneas_extract.extract_lhu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -4980,7 +5000,7 @@ def aeneas_extract.extract_lhu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_lw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 463:8-467:9
+    Source: 'core/src/aeneas_extract.rs', lines 474:8-478:9
     Visibility: public -/
 def aeneas_extract.extract_lw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -5003,7 +5023,7 @@ def aeneas_extract.extract_lw_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_lwu_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 463:8-467:9
+    Source: 'core/src/aeneas_extract.rs', lines 474:8-478:9
     Visibility: public -/
 def aeneas_extract.extract_lwu_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -5026,7 +5046,7 @@ def aeneas_extract.extract_lwu_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sb_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 473:8-477:9
+    Source: 'core/src/aeneas_extract.rs', lines 484:8-488:9
     Visibility: public -/
 def aeneas_extract.extract_sb_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -5049,7 +5069,7 @@ def aeneas_extract.extract_sb_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sd_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 473:8-477:9
+    Source: 'core/src/aeneas_extract.rs', lines 484:8-488:9
     Visibility: public -/
 def aeneas_extract.extract_sd_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -5072,7 +5092,7 @@ def aeneas_extract.extract_sd_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sh_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 473:8-477:9
+    Source: 'core/src/aeneas_extract.rs', lines 484:8-488:9
     Visibility: public -/
 def aeneas_extract.extract_sh_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :
@@ -5095,7 +5115,7 @@ def aeneas_extract.extract_sh_from_inst
   aeneas_extract.ZiskInstExtract.from_inst zib.i
 
 /-- [zisk_core::aeneas_extract::extract_sw_from_inst]:
-    Source: 'core/src/aeneas_extract.rs', lines 473:8-477:9
+    Source: 'core/src/aeneas_extract.rs', lines 484:8-488:9
     Visibility: public -/
 def aeneas_extract.extract_sw_from_inst
   (i : riscv.riscv_inst.RiscvInstruction) :

--- a/trust/scripts/check-aeneas-production-boundary.py
+++ b/trust/scripts/check-aeneas-production-boundary.py
@@ -88,6 +88,7 @@ non_start_extract_fns = sorted(
         "extract_decode_rv64im_raw",
         "extract_rv64im_opcode_supported",
         "extract_transpile_rv64im_raw",
+        "extract_transpile_rv64im_rows_raw",
         "extract_transpile_rv64im_accepted_raw",
         "extract_transpile_rv64im_materializes_raw",
     }


### PR DESCRIPTION
Part 4 of the Phase 9 stack for #61. Base: `phase9-3-fidelity-nonvacuity`.

## Summary

- Corrects load, branch, AUIPC, and JAL ROM/decode surfaces to use the production signed
  `Int → FGL` representation.
- Proves signed modular PC-offset arithmetic used by downstream control semantics.
- Extends the extracted production path for JALR's real one-or-two-row lowering.
- Introduces exact, gap-free `ProgramRowsBinding` with primary/successor eliminators.
- Proves aligned AND and unaligned ADD+AND row pins, including conditional x0 selectors.
- Repairs and verifies the expanded-JALR snapshot in the extraction-totality proof.

This is the architectural correction forced by the counterexamples in PR 3. It adds no alignment,
nonnegative-offset, `rs1 ≠ x0`, or `rd ≠ x0` premise.

## Stack

1. `phase9-1-raw-binding`
2. `phase9-2-initial-decoders`
3. `phase9-3-fidelity-nonvacuity`
4. **This PR**
5. `phase9-5-architectural-decoders`
6. `phase9-6-root-endpoint`

## Verification

Rust/Aeneas regeneration, boundary checks, focused Dispatcher/extraction builds, and standard-only
closure audits passed. The complete stack's full gates are recorded on PR 6.
