### PR TITLE
#61 Phase 9.5: migrate decoders to architectural row binding

### DIFF
--- a/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
@@ -1479,7 +1479,7 @@ structure ProgramDecode_ld {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_bits_store_reg : bits.store_reg = true
+  h_bits_store_reg : bits.store_reg = decide (c.ld_input.rd.toNat ≠ 0)
   h_bits_b_src_ind : bits.b_src_ind = true
   h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
@@ -1505,7 +1505,7 @@ structure ProgramDecode_lbu {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_bits_store_reg : bits.store_reg = true
+  h_bits_store_reg : bits.store_reg = decide (c.lbu_input.rd.toNat ≠ 0)
   h_bits_b_src_ind : bits.b_src_ind = true
   h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
@@ -1531,7 +1531,7 @@ structure ProgramDecode_lhu {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_bits_store_reg : bits.store_reg = true
+  h_bits_store_reg : bits.store_reg = decide (c.lhu_input.rd.toNat ≠ 0)
   h_bits_b_src_ind : bits.b_src_ind = true
   h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
@@ -1557,7 +1557,7 @@ structure ProgramDecode_lwu {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_bits_store_reg : bits.store_reg = true
+  h_bits_store_reg : bits.store_reg = decide (c.lwu_input.rd.toNat ≠ 0)
   h_bits_b_src_ind : bits.b_src_ind = true
   h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
@@ -1599,7 +1599,7 @@ structure ProgramDecode_lb {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_bits_store_reg : bits.store_reg = true
+  h_bits_store_reg : bits.store_reg = decide (c.lb_input.rd.toNat ≠ 0)
   h_bits_b_src_ind : bits.b_src_ind = true
   h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
@@ -1641,7 +1641,7 @@ structure ProgramDecode_lh {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_bits_store_reg : bits.store_reg = true
+  h_bits_store_reg : bits.store_reg = decide (c.lh_input.rd.toNat ≠ 0)
   h_bits_b_src_ind : bits.b_src_ind = true
   h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
@@ -1683,7 +1683,7 @@ structure ProgramDecode_lw {numInstructions : Nat}
   h_bits_set_pc : bits.set_pc = false
   h_bits_store_pc : bits.store_pc = false
   h_bits_store_ind : bits.store_ind = false
-  h_bits_store_reg : bits.store_reg = true
+  h_bits_store_reg : bits.store_reg = decide (c.lw_input.rd.toNat ≠ 0)
   h_bits_b_src_ind : bits.b_src_ind = true
   h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBinding.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBinding.lean
@@ -141,6 +141,19 @@ noncomputable def romMessagesOfRaw (line : FGL) (raw : BitVec 32) :
         (romRowOf line ext.last_row, none)
   | _ => (romMessageOfRaw line raw, none)
 
+/-- A successfully lowered non-JALR word has exactly one physical row, namely
+    the existing terminal-row projection. -/
+theorem romMessagesOfRaw_fst_of_non_jalr (line : FGL) (raw : BitVec 32)
+    (ext : aeneas_extract.Rv64imTranspileExtract)
+    (hok : aeneas_extract.extract_transpile_rv64im_raw
+      (ZiskFv.Compliance.Decode.toU32 raw) = .ok ext)
+    (hnon : (ZiskFv.Compliance.Decode.toU32 raw &&& 127#u32) ≠ 103#u32) :
+    (romMessagesOfRaw line raw).1 = romMessageOfRaw line raw := by
+  unfold romMessagesOfRaw romMessageOfRaw
+  rw [aeneas_extract.extract_transpile_rv64im_rows_raw, hok]
+  simp only [lift, Bind.bind, bind_ok, hnon, if_false]
+  norm_num [UScalar.val]
+
 /-- Op-agnostic ROM-image binding (a verifier-attached certificate, NOT an axiom):
     the committed ROM holds exactly the serialized lowering of the raw program. -/
 def ProgramBinding {n : Nat} (trace : ZiskFv.Compliance.AcceptedZiskTrace n)

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingCopyb.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingCopyb.lean
@@ -800,10 +800,10 @@ theorem or_decode_fields_of_binding (rd rs1 rs2 : Nat) (hrd : rd < 32) (hrs1 : r
   exact ⟨ho, hjo1, hjo2, hmso, ext, hok, hieo, hm32, hsetpc, hstorepc,
     hstoreInd, hf⟩
 
-structure RawProgramDecode_add {n : Nat}
+structure RawProgramDecode_add {n rawLength : Nat}
     (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
     (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_add trace i)
-    (rawProgram : Fin trace.programLength → BitVec 32) where
+    (addr : Fin rawLength → FGL) (rawProgram : Fin rawLength → BitVec 32) where
   h_idx : i.val + 1 < trace.mainTable.table.length
   hrd0 : (regidx_to_fin c.rd).val ≠ 0
   hrs10 : (regidx_to_fin c.r1).val ≠ 0
@@ -811,16 +811,19 @@ structure RawProgramDecode_add {n : Nat}
   hLine : ∀ j : Fin trace.programLength,
     (trace.program j).line =
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
-      rawProgram j = rawRType 0 (regidx_to_fin c.r2).val
-        (regidx_to_fin c.r1).val 0 (regidx_to_fin c.rd).val 0x33
+      ∃ k : Fin rawLength,
+        addr k = (trace.program j).line ∧
+          rawProgram k = rawRType 0 (regidx_to_fin c.r2).val
+            (regidx_to_fin c.r1).val 0 (regidx_to_fin c.rd).val 0x33
 
-noncomputable def ProgramDecode_add_from_rawProgram {n : Nat}
+noncomputable def ProgramDecode_add_from_rawProgram {n rawLength : Nat}
     (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
     (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_add trace i)
-    (addr : Fin trace.programLength → FGL)
-    (rawProgram : Fin trace.programLength → BitVec 32)
-    (hbind : ProgramBinding trace addr rawProgram)
-    (rawDecode : RawProgramDecode_add trace i c rawProgram) :
+    (start : Fin rawLength → Fin trace.programLength)
+    (addr : Fin rawLength → FGL)
+    (rawProgram : Fin rawLength → BitVec 32)
+    (hbind : ProgramRowsBinding trace start addr rawProgram)
+    (rawDecode : RawProgramDecode_add trace i c addr rawProgram) :
     ZiskFv.Compliance.RomDecodeBinding.ProgramDecode_add trace i c := by
   let rd := (regidx_to_fin c.rd).val
   let rs1 := (regidx_to_fin c.r1).val
@@ -844,14 +847,27 @@ noncomputable def ProgramDecode_add_from_rawProgram {n : Nat}
         exact decide_eq_false hstoreInd
       h_prog := ?_ }
   intro j hline
+  obtain ⟨k, haddr, hraw⟩ := rawDecode.hLine j hline
+  have hprimary := primary_row_at_architectural_line hbind j k haddr.symm
   have hbk : trace.program j =
-      romMessageOfRaw (addr j) (rawRType 0 rs2 rs1 0 rd 0x33) := by
-    exact (hbind.2 j).trans
-      (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+      romMessageOfRaw (addr k) (rawRType 0 rs2 rs1 0 rd 0x33) := by
+    have hok' : extract_transpile_rv64im_raw
+        (toU32 (rawRType 0 (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val 0
+          (regidx_to_fin c.rd).val 0x33)) = .ok ext := by
+      simpa only [rd, rs1, rs2, ext] using hok
+    have hnon :
+        (toU32 (rawRType 0 (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val 0
+          (regidx_to_fin c.rd).val 0x33) &&& 127#u32) ≠ 103#u32 := by
+      rw [ZiskFv.Compliance.Decode.toU32_and127,
+        ZiskFv.Compliance.Decode.rawRType_opcode]
+      all_goals decide
+    have hp := hprimary.2
+    rw [hraw, romMessagesOfRaw_fst_of_non_jalr _ _ ext hok' hnon] at hp
+    simpa only [rd, rs1, rs2] using hp
   obtain ⟨ho, hj1, hj2, hso, ext', hok', _, _, _, _, _, hf⟩ :=
     add_decode_fields_of_binding rd rs1 rs2 (regidx_to_fin c.rd).isLt
       (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt rawDecode.hrd0
-      rawDecode.hrs10 rawDecode.hrs20 (addr j) (trace.program j) hbk
+      rawDecode.hrs10 rawDecode.hrs20 (addr k) (trace.program j) hbk
   have hext : ext' = ext := Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
   subst ext'
   refine ⟨ho, hj1, hj2, ?_, hf⟩
@@ -861,26 +877,29 @@ noncomputable def ProgramDecode_add_from_rawProgram {n : Nat}
   change (regidx_to_fin c.rd).val % GL_prime = (regidx_to_fin c.rd).val
   exact Nat.mod_eq_of_lt (lt_trans (regidx_to_fin c.rd).isLt (by norm_num))
 
-structure RawProgramDecode_or {n : Nat}
+structure RawProgramDecode_or {n rawLength : Nat}
     (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
     (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_or trace i)
-    (rawProgram : Fin trace.programLength → BitVec 32) where
+    (addr : Fin rawLength → FGL) (rawProgram : Fin rawLength → BitVec 32) where
   h_idx : i.val + 1 < trace.mainTable.table.length
   hrs10 : (regidx_to_fin c.r1).val ≠ 0
   hrs20 : (regidx_to_fin c.r2).val ≠ 0
   hLine : ∀ j : Fin trace.programLength,
     (trace.program j).line =
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
-      rawProgram j = rawRType 0 (regidx_to_fin c.r2).val
-        (regidx_to_fin c.r1).val 6 (regidx_to_fin c.rd).val 0x33
+      ∃ k : Fin rawLength,
+        addr k = (trace.program j).line ∧
+          rawProgram k = rawRType 0 (regidx_to_fin c.r2).val
+            (regidx_to_fin c.r1).val 6 (regidx_to_fin c.rd).val 0x33
 
-noncomputable def ProgramDecode_or_from_rawProgram {n : Nat}
+noncomputable def ProgramDecode_or_from_rawProgram {n rawLength : Nat}
     (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
     (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_or trace i)
-    (addr : Fin trace.programLength → FGL)
-    (rawProgram : Fin trace.programLength → BitVec 32)
-    (hbind : ProgramBinding trace addr rawProgram)
-    (rawDecode : RawProgramDecode_or trace i c rawProgram) :
+    (start : Fin rawLength → Fin trace.programLength)
+    (addr : Fin rawLength → FGL)
+    (rawProgram : Fin rawLength → BitVec 32)
+    (hbind : ProgramRowsBinding trace start addr rawProgram)
+    (rawDecode : RawProgramDecode_or trace i c addr rawProgram) :
     ZiskFv.Compliance.RomDecodeBinding.ProgramDecode_or trace i c := by
   let rd := (regidx_to_fin c.rd).val
   let rs1 := (regidx_to_fin c.r1).val
@@ -904,14 +923,27 @@ noncomputable def ProgramDecode_or_from_rawProgram {n : Nat}
         exact decide_eq_false hstoreInd
       h_prog := ?_ }
   intro j hline
+  obtain ⟨k, haddr, hraw⟩ := rawDecode.hLine j hline
+  have hprimary := primary_row_at_architectural_line hbind j k haddr.symm
   have hbk : trace.program j =
-      romMessageOfRaw (addr j) (rawRType 0 rs2 rs1 6 rd 0x33) := by
-    exact (hbind.2 j).trans
-      (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+      romMessageOfRaw (addr k) (rawRType 0 rs2 rs1 6 rd 0x33) := by
+    have hok' : extract_transpile_rv64im_raw
+        (toU32 (rawRType 0 (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val 6
+          (regidx_to_fin c.rd).val 0x33)) = .ok ext := by
+      simpa only [rd, rs1, rs2, ext] using hok
+    have hnon :
+        (toU32 (rawRType 0 (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val 6
+          (regidx_to_fin c.rd).val 0x33) &&& 127#u32) ≠ 103#u32 := by
+      rw [ZiskFv.Compliance.Decode.toU32_and127,
+        ZiskFv.Compliance.Decode.rawRType_opcode]
+      all_goals decide
+    have hp := hprimary.2
+    rw [hraw, romMessagesOfRaw_fst_of_non_jalr _ _ ext hok' hnon] at hp
+    simpa only [rd, rs1, rs2] using hp
   obtain ⟨ho, hj1, hj2, hso, ext', hok', _, _, _, _, _, hf⟩ :=
     or_decode_fields_of_binding rd rs1 rs2 (regidx_to_fin c.rd).isLt
       (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt rawDecode.hrs10
-      rawDecode.hrs20 (addr j) (trace.program j) hbk
+      rawDecode.hrs20 (addr k) (trace.program j) hbk
   have hext : ext' = ext := Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
   subst ext'
   refine ⟨ho, hj1, hj2, ?_, hf⟩
@@ -1139,24 +1171,27 @@ local macro "copyb_imm_program_decode" nm:ident "," f3:term : command => do
   let claimName := Lean.mkIdent ((`ZiskFv.Compliance).str ("Claim_" ++ s))
   let programName :=
     Lean.mkIdent ((`ZiskFv.Compliance.RomDecodeBinding).str ("ProgramDecode_" ++ s))
-  let t1 ← `(structure $rawName {n : Nat}
+  let t1 ← `(structure $rawName {n rawLength : Nat}
       (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
       (i : Fin trace.numInstructions) (c : $claimName trace i)
-      (rawProgram : Fin trace.programLength → BitVec 32) where
+      (addr : Fin rawLength → FGL) (rawProgram : Fin rawLength → BitVec 32) where
     h_idx : i.val + 1 < trace.mainTable.table.length
     hrs10 : (regidx_to_fin c.r1).val ≠ 0
     hLine : ∀ j : Fin trace.programLength,
       (trace.program j).line =
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
-        rawProgram j = rawIType c.imm.toNat (regidx_to_fin c.r1).val $f3
-          (regidx_to_fin c.rd).val 0x13)
-  let t2 ← `(noncomputable def $ctorName {n : Nat}
+        ∃ k : Fin rawLength,
+          addr k = (trace.program j).line ∧
+            rawProgram k = rawIType c.imm.toNat (regidx_to_fin c.r1).val $f3
+              (regidx_to_fin c.rd).val 0x13)
+  let t2 ← `(noncomputable def $ctorName {n rawLength : Nat}
       (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
       (i : Fin trace.numInstructions) (c : $claimName trace i)
-      (addr : Fin trace.programLength → FGL)
-      (rawProgram : Fin trace.programLength → BitVec 32)
-      (hbind : ProgramBinding trace addr rawProgram)
-      (rawDecode : $rawName trace i c rawProgram) :
+      (start : Fin rawLength → Fin trace.programLength)
+      (addr : Fin rawLength → FGL)
+      (rawProgram : Fin rawLength → BitVec 32)
+      (hbind : ProgramRowsBinding trace start addr rawProgram)
+      (rawDecode : $rawName trace i c addr rawProgram) :
       $programName trace i c := by
     let rd := (regidx_to_fin c.rd).val
     let rs1 := (regidx_to_fin c.r1).val
@@ -1182,13 +1217,26 @@ local macro "copyb_imm_program_decode" nm:ident "," f3:term : command => do
           exact decide_eq_true hsrc
         h_prog := ?_ }
     intro j hline
+    obtain ⟨k, haddr, hraw⟩ := rawDecode.hLine j hline
+    have hprimary := primary_row_at_architectural_line hbind j k haddr.symm
     have hbk : trace.program j =
-        romMessageOfRaw (addr j) (rawIType imm rs1 $f3 rd 0x13) := by
-      exact (hbind.2 j).trans
-        (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+        romMessageOfRaw (addr k) (rawIType imm rs1 $f3 rd 0x13) := by
+      have hok' : extract_transpile_rv64im_raw
+          (toU32 (rawIType c.imm.toNat (regidx_to_fin c.r1).val $f3
+            (regidx_to_fin c.rd).val 0x13)) = .ok ext := by
+        simpa only [rd, rs1, imm, ext] using hok
+      have hnon :
+          (toU32 (rawIType c.imm.toNat (regidx_to_fin c.r1).val $f3
+            (regidx_to_fin c.rd).val 0x13) &&& 127#u32) ≠ 103#u32 := by
+        rw [ZiskFv.Compliance.Decode.toU32_and127,
+          ZiskFv.Compliance.Decode.rawIType_opcode]
+        all_goals decide
+      have hp := hprimary.2
+      rw [hraw, romMessagesOfRaw_fst_of_non_jalr _ _ ext hok' hnon] at hp
+      simpa only [rd, rs1, imm] using hp
     obtain ⟨ho, hj1, hj2, hso, ext', hok', _, _, _, _, _, _, himm, hf⟩ :=
       $fieldsName rd rs1 imm (regidx_to_fin c.rd).isLt
-        (regidx_to_fin c.r1).isLt rawDecode.hrs10 (addr j) (trace.program j) hbk
+        (regidx_to_fin c.r1).isLt rawDecode.hrs10 (addr k) (trace.program j) hbk
     have hext : ext' = ext :=
       Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
     subst ext'
@@ -1238,10 +1286,10 @@ private theorem decode_i_rawIType_imm_ne_zero
     (by norm_num) RiscvOpcode.Addi d hd, hz]
   rfl
 
-structure RawProgramDecode_addi {n : Nat}
+structure RawProgramDecode_addi {n rawLength : Nat}
     (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
     (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_addi trace i)
-    (rawProgram : Fin trace.programLength → BitVec 32) where
+    (addr : Fin rawLength → FGL) (rawProgram : Fin rawLength → BitVec 32) where
   h_idx : i.val + 1 < trace.mainTable.table.length
   hrd0 : (regidx_to_fin c.rd).val ≠ 0
   hrs10 : (regidx_to_fin c.r1).val ≠ 0
@@ -1249,16 +1297,19 @@ structure RawProgramDecode_addi {n : Nat}
   hLine : ∀ j : Fin trace.programLength,
     (trace.program j).line =
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
-      rawProgram j = rawIType c.imm.toNat (regidx_to_fin c.r1).val 0
-        (regidx_to_fin c.rd).val 0x13
+      ∃ k : Fin rawLength,
+        addr k = (trace.program j).line ∧
+          rawProgram k = rawIType c.imm.toNat (regidx_to_fin c.r1).val 0
+            (regidx_to_fin c.rd).val 0x13
 
-noncomputable def ProgramDecode_addi_from_rawProgram {n : Nat}
+noncomputable def ProgramDecode_addi_from_rawProgram {n rawLength : Nat}
     (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
     (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_addi trace i)
-    (addr : Fin trace.programLength → FGL)
-    (rawProgram : Fin trace.programLength → BitVec 32)
-    (hbind : ProgramBinding trace addr rawProgram)
-    (rawDecode : RawProgramDecode_addi trace i c rawProgram) :
+    (start : Fin rawLength → Fin trace.programLength)
+    (addr : Fin rawLength → FGL)
+    (rawProgram : Fin rawLength → BitVec 32)
+    (hbind : ProgramRowsBinding trace start addr rawProgram)
+    (rawDecode : RawProgramDecode_addi trace i c addr rawProgram) :
     ZiskFv.Compliance.RomDecodeBinding.ProgramDecode_addi trace i c := by
   let rd := (regidx_to_fin c.rd).val
   let rs1 := (regidx_to_fin c.r1).val
@@ -1290,14 +1341,27 @@ noncomputable def ProgramDecode_addi_from_rawProgram {n : Nat}
         exact decide_eq_true hsrc
       h_prog := ?_ }
   intro j hline
+  obtain ⟨k, haddr, hraw⟩ := rawDecode.hLine j hline
+  have hprimary := primary_row_at_architectural_line hbind j k haddr.symm
   have hbk : trace.program j =
-      romMessageOfRaw (addr j) (rawIType imm rs1 0 rd 0x13) := by
-    exact (hbind.2 j).trans
-      (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+      romMessageOfRaw (addr k) (rawIType imm rs1 0 rd 0x13) := by
+    have hok' : extract_transpile_rv64im_raw
+        (toU32 (rawIType c.imm.toNat (regidx_to_fin c.r1).val 0
+          (regidx_to_fin c.rd).val 0x13)) = .ok ext := by
+      simpa only [rd, rs1, imm, ext] using hok
+    have hnon :
+        (toU32 (rawIType c.imm.toNat (regidx_to_fin c.r1).val 0
+          (regidx_to_fin c.rd).val 0x13) &&& 127#u32) ≠ 103#u32 := by
+      rw [ZiskFv.Compliance.Decode.toU32_and127,
+        ZiskFv.Compliance.Decode.rawIType_opcode]
+      all_goals decide
+    have hp := hprimary.2
+    rw [hraw, romMessagesOfRaw_fst_of_non_jalr _ _ ext hok' hnon] at hp
+    simpa only [rd, rs1, imm] using hp
   obtain ⟨ho, hj1, hj2, hso, ext', hok', _, _, _, _, _, _, himmv, hf⟩ :=
     addi_decode_fields_of_binding rd rs1 imm (regidx_to_fin c.rd).isLt
       (regidx_to_fin c.r1).isLt rawDecode.hrd0 rawDecode.hrs10 himm
-      (addr j) (trace.program j) hbk
+      (addr k) (trace.program j) hbk
   have hext : ext' = ext :=
     Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
   subst ext'

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingImmediate.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingImmediate.lean
@@ -22,7 +22,7 @@ second operand is the unconditionally-total `src_b_imm`, so totality needs only
     generic `register_decode_fields_of_binding` is reused verbatim — it is op-shape
     agnostic).
   * `Decode_<op>_from_rawProgram` — rebuilds block-1's `Decode_<op>` from
-    `rawProgram` + `ProgramBinding` + the `<op>`-shaped raw-word hypothesis +
+    `rawProgram` + `ProgramRowsBinding` + the `<op>`-shaped raw-word hypothesis +
     `h_idx`, with NO per-op decode premise.
 
 Sound: NO native_decide / bv_decide / new axiom / `sorry`; kernel-only closure
@@ -670,10 +670,10 @@ local macro "shift_program_decode" nm:ident "," upper:term "," f3:term "," opw:t
   let fieldsName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
   let claimName := Lean.mkIdent ((`ZiskFv.Compliance).str ("Claim_" ++ s))
   let programName := Lean.mkIdent ((`ZiskFv.Compliance.RomDecodeBinding).str ("ProgramDecode_" ++ s))
-  let t1 ← `(structure $rawName {n : Nat}
+  let t1 ← `(structure $rawName {n rawLength : Nat}
       (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
       (i : Fin trace.numInstructions) (c : $claimName trace i)
-      (rawProgram : Fin trace.programLength → BitVec 32) where
+      (addr : Fin rawLength → FGL) (rawProgram : Fin rawLength → BitVec 32) where
     h_idx : i.val + 1 < trace.mainTable.table.length
     h_b_lo_t :
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).b_0 i.val =
@@ -681,17 +681,20 @@ local macro "shift_program_decode" nm:ident "," upper:term "," f3:term "," opw:t
     hLine : ∀ j : Fin trace.programLength,
       (trace.program j).line =
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
-        rawProgram j =
-          ZiskFv.Completeness.Rv64imShapes.rawIType
-            ($upper ||| c.shamt.toNat) (regidx_to_fin c.r1).val $f3
-            (regidx_to_fin c.rd).val $opw)
-  let t2 ← `(noncomputable def $ctorName {n : Nat}
+        ∃ k : Fin rawLength,
+          addr k = (trace.program j).line ∧
+            rawProgram k =
+              ZiskFv.Completeness.Rv64imShapes.rawIType
+                ($upper ||| c.shamt.toNat) (regidx_to_fin c.r1).val $f3
+                (regidx_to_fin c.rd).val $opw)
+  let t2 ← `(noncomputable def $ctorName {n rawLength : Nat}
       (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
       (i : Fin trace.numInstructions) (c : $claimName trace i)
-      (addr : Fin trace.programLength → FGL)
-      (rawProgram : Fin trace.programLength → BitVec 32)
-      (hbind : ProgramBinding trace addr rawProgram)
-      (rawDecode : $rawName trace i c rawProgram) :
+      (start : Fin rawLength → Fin trace.programLength)
+      (addr : Fin rawLength → FGL)
+      (rawProgram : Fin rawLength → BitVec 32)
+      (hbind : ProgramRowsBinding trace start addr rawProgram)
+      (rawDecode : $rawName trace i c addr rawProgram) :
       $programName trace i c := by
     let rd := (regidx_to_fin c.rd).val
     let rs1 := (regidx_to_fin c.r1).val
@@ -723,16 +726,33 @@ local macro "shift_program_decode" nm:ident "," upper:term "," f3:term "," opw:t
     · simp only [romFlagBitsOfExtract]
       exact decide_eq_false hstoreInd
     · intro j hline
+      obtain ⟨k, haddr, hraw⟩ := rawDecode.hLine j hline
+      have hprimary := primary_row_at_architectural_line hbind j k haddr.symm
       have hbk : trace.program j =
-          romMessageOfRaw (addr j)
+          romMessageOfRaw (addr k)
             (ZiskFv.Completeness.Rv64imShapes.rawIType
               ($upper ||| shamt) rs1 $f3 rd $opw) := by
-        exact (hbind.2 j).trans
-          (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+        have hok' : aeneas_extract.extract_transpile_rv64im_raw
+            (ZiskFv.Compliance.Decode.toU32
+              (ZiskFv.Completeness.Rv64imShapes.rawIType
+                ($upper ||| (c.shamt.toNat)) (regidx_to_fin c.r1).val $f3
+                (regidx_to_fin c.rd).val $opw)) = .ok ext := by
+          simpa only [rd, rs1, shamt, ext] using hok
+        have hnon :
+            (ZiskFv.Compliance.Decode.toU32
+                (ZiskFv.Completeness.Rv64imShapes.rawIType
+                  ($upper ||| (c.shamt.toNat)) (regidx_to_fin c.r1).val $f3
+                  (regidx_to_fin c.rd).val $opw) &&& 127#u32) ≠ 103#u32 := by
+          rw [ZiskFv.Compliance.Decode.toU32_and127,
+            ZiskFv.Compliance.Decode.rawIType_opcode]
+          all_goals decide
+        have hp := hprimary.2
+        rw [hraw, romMessagesOfRaw_fst_of_non_jalr _ _ ext hok' hnon] at hp
+        simpa only [rd, rs1, shamt] using hp
       obtain ⟨ho, hjo1, hjo2, hso, ext', hok', hieo', hm32', hsetpc',
           hstorepc', hf⟩ :=
         $fieldsName rd rs1 shamt (regidx_to_fin c.rd).isLt
-          (regidx_to_fin c.r1).isLt hsh (addr j) (trace.program j) hbk
+          (regidx_to_fin c.r1).isLt hsh (addr k) (trace.program j) hbk
       have hext : ext' = ext :=
         Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
       subst ext'
@@ -757,25 +777,28 @@ local macro "shiftw_program_decode" nm:ident "," upper:term "," f3:term ","
   let fieldsName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
   let claimName := Lean.mkIdent ((`ZiskFv.Compliance).str ("Claim_" ++ s))
   let programName := Lean.mkIdent ((`ZiskFv.Compliance.RomDecodeBinding).str ("ProgramDecode_" ++ s))
-  let t1 ← `(structure $rawName {n : Nat}
+  let t1 ← `(structure $rawName {n rawLength : Nat}
       (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
       (i : Fin trace.numInstructions) (c : $claimName trace i)
-      (rawProgram : Fin trace.programLength → BitVec 32) where
+      (addr : Fin rawLength → FGL) (rawProgram : Fin rawLength → BitVec 32) where
     h_idx : i.val + 1 < trace.mainTable.table.length
     hLine : ∀ j : Fin trace.programLength,
       (trace.program j).line =
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
-        rawProgram j =
-          ZiskFv.Completeness.Rv64imShapes.rawIType
-            ($upper ||| ($shget c).shamt.toNat) (regidx_to_fin c.r1).val $f3
-            (regidx_to_fin c.rd).val 0x1b)
-  let t2 ← `(noncomputable def $ctorName {n : Nat}
+        ∃ k : Fin rawLength,
+          addr k = (trace.program j).line ∧
+            rawProgram k =
+              ZiskFv.Completeness.Rv64imShapes.rawIType
+                ($upper ||| ($shget c).shamt.toNat) (regidx_to_fin c.r1).val $f3
+                (regidx_to_fin c.rd).val 0x1b)
+  let t2 ← `(noncomputable def $ctorName {n rawLength : Nat}
       (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
       (i : Fin trace.numInstructions) (c : $claimName trace i)
-      (addr : Fin trace.programLength → FGL)
-      (rawProgram : Fin trace.programLength → BitVec 32)
-      (hbind : ProgramBinding trace addr rawProgram)
-      (rawDecode : $rawName trace i c rawProgram) :
+      (start : Fin rawLength → Fin trace.programLength)
+      (addr : Fin rawLength → FGL)
+      (rawProgram : Fin rawLength → BitVec 32)
+      (hbind : ProgramRowsBinding trace start addr rawProgram)
+      (rawDecode : $rawName trace i c addr rawProgram) :
       $programName trace i c := by
     let rd := (regidx_to_fin c.rd).val
     let rs1 := (regidx_to_fin c.r1).val
@@ -798,16 +821,33 @@ local macro "shiftw_program_decode" nm:ident "," upper:term "," f3:term ","
           simp only [romFlagBitsOfExtract]; exact decide_eq_false hstoreInd
         h_prog := by
           intro j hline
+          obtain ⟨k, haddr, hraw⟩ := rawDecode.hLine j hline
+          have hprimary := primary_row_at_architectural_line hbind j k haddr.symm
           have hbk : trace.program j =
-              romMessageOfRaw (addr j)
+              romMessageOfRaw (addr k)
                 (ZiskFv.Completeness.Rv64imShapes.rawIType
                   ($upper ||| shamt) rs1 $f3 rd 0x1b) := by
-            exact (hbind.2 j).trans
-              (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+            have hok' : aeneas_extract.extract_transpile_rv64im_raw
+                (ZiskFv.Compliance.Decode.toU32
+                  (ZiskFv.Completeness.Rv64imShapes.rawIType
+                    ($upper ||| ($shget c).shamt.toNat) (regidx_to_fin c.r1).val $f3
+                    (regidx_to_fin c.rd).val 0x1b)) = .ok ext := by
+              simpa only [rd, rs1, shamt, ext] using hok
+            have hnon :
+                (ZiskFv.Compliance.Decode.toU32
+                    (ZiskFv.Completeness.Rv64imShapes.rawIType
+                      ($upper ||| ($shget c).shamt.toNat) (regidx_to_fin c.r1).val $f3
+                      (regidx_to_fin c.rd).val 0x1b) &&& 127#u32) ≠ 103#u32 := by
+              rw [ZiskFv.Compliance.Decode.toU32_and127,
+                ZiskFv.Compliance.Decode.rawIType_opcode]
+              all_goals decide
+            have hp := hprimary.2
+            rw [hraw, romMessagesOfRaw_fst_of_non_jalr _ _ ext hok' hnon] at hp
+            simpa only [rd, rs1, shamt] using hp
           obtain ⟨ho, hjo1, hjo2, hso, ext', hok', hieo', hm32', hsetpc',
               hstorepc', hf⟩ :=
             $fieldsName rd rs1 shamt (regidx_to_fin c.rd).isLt
-              (regidx_to_fin c.r1).isLt hsh (addr j) (trace.program j) hbk
+              (regidx_to_fin c.r1).isLt hsh (addr k) (trace.program j) hbk
           have hext : ext' = ext :=
             Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
           subst ext'
@@ -899,24 +939,27 @@ local macro "imm_program_decode" nm:ident "," f3:term "," opw:term ","
   let fieldsName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
   let claimName := Lean.mkIdent ((`ZiskFv.Compliance).str ("Claim_" ++ s))
   let programName := Lean.mkIdent ((`ZiskFv.Compliance.RomDecodeBinding).str ("ProgramDecode_" ++ s))
-  let t1 ← `(structure $rawName {n : Nat}
+  let t1 ← `(structure $rawName {n rawLength : Nat}
       (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
       (i : Fin trace.numInstructions) (c : $claimName trace i)
-      (rawProgram : Fin trace.programLength → BitVec 32) where
+      (addr : Fin rawLength → FGL) (rawProgram : Fin rawLength → BitVec 32) where
     h_idx : i.val + 1 < trace.mainTable.table.length
     hLine : ∀ j : Fin trace.programLength,
       (trace.program j).line =
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
-        rawProgram j =
-          ZiskFv.Completeness.Rv64imShapes.rawIType c.imm.toNat
-            (regidx_to_fin c.r1).val $f3 (regidx_to_fin c.rd).val $opw)
-  let t2 ← `(noncomputable def $ctorName {n : Nat}
+        ∃ k : Fin rawLength,
+          addr k = (trace.program j).line ∧
+            rawProgram k =
+              ZiskFv.Completeness.Rv64imShapes.rawIType c.imm.toNat
+                (regidx_to_fin c.r1).val $f3 (regidx_to_fin c.rd).val $opw)
+  let t2 ← `(noncomputable def $ctorName {n rawLength : Nat}
       (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
       (i : Fin trace.numInstructions) (c : $claimName trace i)
-      (addr : Fin trace.programLength → FGL)
-      (rawProgram : Fin trace.programLength → BitVec 32)
-      (hbind : ProgramBinding trace addr rawProgram)
-      (rawDecode : $rawName trace i c rawProgram) :
+      (start : Fin rawLength → Fin trace.programLength)
+      (addr : Fin rawLength → FGL)
+      (rawProgram : Fin rawLength → BitVec 32)
+      (hbind : ProgramRowsBinding trace start addr rawProgram)
+      (rawDecode : $rawName trace i c addr rawProgram) :
       $programName trace i c := by
     let rd := (regidx_to_fin c.rd).val
     let rs1 := (regidx_to_fin c.r1).val
@@ -948,15 +991,31 @@ local macro "imm_program_decode" nm:ident "," f3:term "," opw:term ","
           exact decide_eq_true hsrc
         h_prog := by
           intro j hline
+          obtain ⟨k, haddr, hraw⟩ := rawDecode.hLine j hline
+          have hprimary := primary_row_at_architectural_line hbind j k haddr.symm
           have hbk : trace.program j =
-              romMessageOfRaw (addr j)
+              romMessageOfRaw (addr k)
                 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 $f3 rd $opw) := by
-            exact (hbind.2 j).trans
-              (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+            have hok' : aeneas_extract.extract_transpile_rv64im_raw
+                (ZiskFv.Compliance.Decode.toU32
+                  (ZiskFv.Completeness.Rv64imShapes.rawIType c.imm.toNat
+                    (regidx_to_fin c.r1).val $f3 (regidx_to_fin c.rd).val $opw)) = .ok ext := by
+              simpa only [rd, rs1, imm, ext] using hok
+            have hnon :
+                (ZiskFv.Compliance.Decode.toU32
+                    (ZiskFv.Completeness.Rv64imShapes.rawIType c.imm.toNat
+                      (regidx_to_fin c.r1).val $f3
+                      (regidx_to_fin c.rd).val $opw) &&& 127#u32) ≠ 103#u32 := by
+              rw [ZiskFv.Compliance.Decode.toU32_and127,
+                ZiskFv.Compliance.Decode.rawIType_opcode]
+              all_goals decide
+            have hp := hprimary.2
+            rw [hraw, romMessagesOfRaw_fst_of_non_jalr _ _ ext hok' hnon] at hp
+            simpa only [rd, rs1, imm] using hp
           obtain ⟨ho, hjo1, hjo2, hso, ext', hok', hieo', hm32', hsetpc',
               hstorepc', hf⟩ :=
             $fieldsName rd rs1 imm (regidx_to_fin c.rd).isLt
-              (regidx_to_fin c.r1).isLt (addr j) (trace.program j) hbk
+              (regidx_to_fin c.r1).isLt (addr k) (trace.program j) hbk
           have hext : ext' = ext :=
             Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
           subst ext'
@@ -975,26 +1034,29 @@ imm_program_decode slti, 2, 0x13, RiscvOpcode.Slti
 imm_program_decode sltiu, 3, 0x13, RiscvOpcode.Sltiu
 imm_program_decode andi, 7, 0x13, RiscvOpcode.Andi
 
-structure RawProgramDecode_addiw {n : Nat}
+structure RawProgramDecode_addiw {n rawLength : Nat}
     (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
     (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_addiw trace i)
-    (rawProgram : Fin trace.programLength → BitVec 32) where
+    (addr : Fin rawLength → FGL) (rawProgram : Fin rawLength → BitVec 32) where
   h_idx : i.val + 1 < trace.mainTable.table.length
   h_rd_ne_zero : (regidx_to_fin c.rd).val ≠ 0
   hLine : ∀ j : Fin trace.programLength,
     (trace.program j).line =
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
-      rawProgram j =
-        ZiskFv.Completeness.Rv64imShapes.rawIType c.imm.toNat
-          (regidx_to_fin c.r1).val 0 (regidx_to_fin c.rd).val 0x1b
+      ∃ k : Fin rawLength,
+        addr k = (trace.program j).line ∧
+          rawProgram k =
+            ZiskFv.Completeness.Rv64imShapes.rawIType c.imm.toNat
+              (regidx_to_fin c.r1).val 0 (regidx_to_fin c.rd).val 0x1b
 
-noncomputable def ProgramDecode_addiw_from_rawProgram {n : Nat}
+noncomputable def ProgramDecode_addiw_from_rawProgram {n rawLength : Nat}
     (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
     (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_addiw trace i)
-    (addr : Fin trace.programLength → FGL)
-    (rawProgram : Fin trace.programLength → BitVec 32)
-    (hbind : ProgramBinding trace addr rawProgram)
-    (rawDecode : RawProgramDecode_addiw trace i c rawProgram) :
+    (start : Fin rawLength → Fin trace.programLength)
+    (addr : Fin rawLength → FGL)
+    (rawProgram : Fin rawLength → BitVec 32)
+    (hbind : ProgramRowsBinding trace start addr rawProgram)
+    (rawDecode : RawProgramDecode_addiw trace i c addr rawProgram) :
     ZiskFv.Compliance.RomDecodeBinding.ProgramDecode_addiw trace i c := by
   let rd := (regidx_to_fin c.rd).val
   let rs1 := (regidx_to_fin c.r1).val
@@ -1025,16 +1087,32 @@ noncomputable def ProgramDecode_addiw_from_rawProgram {n : Nat}
         simp only [romFlagBitsOfExtract]; exact decide_eq_true hsrc
       h_prog := by
         intro j hline
+        obtain ⟨k, haddr, hraw⟩ := rawDecode.hLine j hline
+        have hprimary := primary_row_at_architectural_line hbind j k haddr.symm
         have hbk : trace.program j =
-            romMessageOfRaw (addr j)
+            romMessageOfRaw (addr k)
               (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 0 rd 0x1b) := by
-          exact (hbind.2 j).trans
-            (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+          have hok' : aeneas_extract.extract_transpile_rv64im_raw
+              (ZiskFv.Compliance.Decode.toU32
+                (ZiskFv.Completeness.Rv64imShapes.rawIType c.imm.toNat
+                  (regidx_to_fin c.r1).val 0 (regidx_to_fin c.rd).val 0x1b)) = .ok ext := by
+            simpa only [rd, rs1, imm, ext] using hok
+          have hnon :
+              (ZiskFv.Compliance.Decode.toU32
+                  (ZiskFv.Completeness.Rv64imShapes.rawIType c.imm.toNat
+                    (regidx_to_fin c.r1).val 0
+                    (regidx_to_fin c.rd).val 0x1b) &&& 127#u32) ≠ 103#u32 := by
+            rw [ZiskFv.Compliance.Decode.toU32_and127,
+              ZiskFv.Compliance.Decode.rawIType_opcode]
+            all_goals decide
+          have hp := hprimary.2
+          rw [hraw, romMessagesOfRaw_fst_of_non_jalr _ _ ext hok' hnon] at hp
+          simpa only [rd, rs1, imm] using hp
         obtain ⟨ho, hjo1, hjo2, hso, ext', hok', hieo', hm32', hsetpc',
             hstorepc', hf⟩ :=
           addiw_decode_fields_of_binding rd rs1 imm (regidx_to_fin c.rd).isLt
             (regidx_to_fin c.r1).isLt rawDecode.h_rd_ne_zero
-            (addr j) (trace.program j) hbk
+            (addr k) (trace.program j) hbk
         have hext : ext' = ext :=
           Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
         subst ext'
@@ -1056,6 +1134,10 @@ section AxiomAudit
 #print axioms transpile_sraiw
 #print axioms transpile_addiw
 #print axioms ProgramDecode_slli_from_rawProgram
+#print axioms ProgramDecode_srli_from_rawProgram
+#print axioms ProgramDecode_srai_from_rawProgram
+#print axioms ProgramDecode_slliw_from_rawProgram
+#print axioms ProgramDecode_srliw_from_rawProgram
 #print axioms ProgramDecode_sraiw_from_rawProgram
 #print axioms ProgramDecode_slti_from_rawProgram
 #print axioms ProgramDecode_sltiu_from_rawProgram

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingLoadStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingLoadStore.lean
@@ -25,7 +25,7 @@ serializes it to `msg.ind_width = (N : FGL)`.  For each op `<op>`:
     incl. `ind_width`), derived from its raw word + the op-agnostic `romMessageOfRaw`
     binding.
   * `Decode_<op>_from_rawProgram` — rebuilds block-1's `Decode_<op>` from
-    `rawProgram` + `ProgramBinding` + the `<op>`-shaped raw-word hypothesis +
+    `rawProgram` + `ProgramRowsBinding` + the `<op>`-shaped raw-word hypothesis +
     `h_idx`, with NO per-op decode premise.  The SIGNEXTEND loads (LB/LH/LW) carry
     the genuine `BinaryExtension` operand-bus witnesses (`v`/`r_binary`/`offset`/
     `env`/`h_static`/`h_match`) that `Decode_<op>_of_program` requires — these are
@@ -113,6 +113,27 @@ theorem store_reg_i64_is_reg (self z : zisk_inst_builder.ZiskInstBuilder)
     | (exfalso; scalar_tac)
   all_goals exfalso; scalar_tac
 
+theorem store_reg_i64_selector_pin (self z : zisk_inst_builder.ZiskInstBuilder)
+    (rd : Std.I64) (hrd0 : 0 ≤ rd.val) (hrd : rd.val < 32)
+    (hzero : self.i.store = 0#u64)
+    (h : self.store_reg rd false false = ok z) :
+    z.i.store = if rd.val = 0 then 0#u64 else zisk_inst.STORE_REG := by
+  by_cases hz : rd.val = 0
+  · simp [hz]
+    simp only [zisk_inst_builder.ZiskInstBuilder.store_reg,
+      zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO,
+      zisk_registers.REG_FIRST, mem.SYS_ADDR, mem.RAM_ADDR,
+      lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
+    have e1 := ZiskFv.Compliance.Extraction.cast_one_i64
+    have e31 := ZiskFv.Compliance.Extraction.cast_31_i64
+    split_ifs at h <;>
+      first
+      | (rw [Result.ok.injEq] at h; subst z; exact hzero)
+      | (exfalso; scalar_tac)
+    all_goals exfalso; scalar_tac
+  · simp [hz]
+    exact store_reg_i64_is_reg self z rd hrd0 hrd hz h
+
 theorem load_op_typed_full_pins
     (self : riscv2zisk_context.Riscv2ZiskContext)
     (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp)
@@ -128,6 +149,7 @@ theorem load_op_typed_full_pins
       ∧ zib.i.store_offset.val = i.rd.val
       ∧ zib.i.store ≠ zisk_inst.STORE_IND
       ∧ (i.rd.val ≠ 0 → zib.i.store = zisk_inst.STORE_REG)
+      ∧ zib.i.store = (if i.rd.val = 0 then 0#u64 else zisk_inst.STORE_REG)
       ∧ zib.i.jmp_offset1 = UScalar.hcast IScalarTy.I64 inst_size
       ∧ zib.i.jmp_offset2 = UScalar.hcast IScalarTy.I64 inst_size := by
   simp only [riscv2zisk_context.Riscv2ZiskContext.load_op_typed,
@@ -174,6 +196,13 @@ theorem load_op_typed_full_pins
     (by rw [hiadd', hiaddval,
       ZiskFv.Compliance.Extraction.hcast_u32_i64_val]; exact_mod_cast hrd)
     hbase.1 hbase.2 h5
+  have hselector := store_reg_i64_selector_pin z4 z5 iadd
+    (by rw [hiadd', hiaddval,
+      ZiskFv.Compliance.Extraction.hcast_u32_i64_val]; omega)
+    (by rw [hiadd', hiaddval,
+      ZiskFv.Compliance.Extraction.hcast_u32_i64_val]; exact_mod_cast hrd)
+    hbase.2
+    h5
   obtain ⟨hjs, hjst⟩ := j_pres_store _ _ _ _ h6
   obtain ⟨hbs, hbo, _, _⟩ := src_b_ind_full_pins z2 z3 _ _ h3
   obtain ⟨hos, _, hol⟩ := op_zisk_pres_b z3 z4 op h4
@@ -187,7 +216,7 @@ theorem load_op_typed_full_pins
   have hiw6 := (ZiskFv.Compliance.Extraction.j_pres_data _ _ _ _ h6).1
   have hz := ZiskFv.Compliance.Extraction.build_eq _ _ h7
   refine ⟨z7, ZiskFv.Compliance.Extraction.insert_inst_extract _ _ _ _ h8,
-    ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+    ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · rw [hz, hiw6, hiw5, hiw4, hiw3, hiw2]
   · rw [hz, hjsb, hss, hos, hbs]
   · rw [hz, hjlb, hsl, hol, hbo]
@@ -205,6 +234,9 @@ theorem load_op_typed_full_pins
       (by rw [hiadd', hiaddval,
         ZiskFv.Compliance.Extraction.hcast_u32_i64_val]; exact_mod_cast hrdne)
       h5
+  · rw [hz, hjst, hselector, hiadd', hiaddval,
+      ZiskFv.Compliance.Extraction.hcast_u32_i64_val]
+    simp
   · rw [hz, hj1]
   · rw [hz, hj2]
 
@@ -342,11 +374,13 @@ theorem load_op_typed_nonzero_rs1_full_pins
       ∧ zib.i.store_offset.val = i.rd.val
       ∧ zib.i.store ≠ zisk_inst.STORE_IND
       ∧ (i.rd.val ≠ 0 → zib.i.store = zisk_inst.STORE_REG)
+      ∧ zib.i.store = (if i.rd.val = 0 then 0#u64 else zisk_inst.STORE_REG)
       ∧ zib.i.ind_width = wval
       ∧ zib.i.jmp_offset1 = UScalar.hcast IScalarTy.I64 inst_size
       ∧ zib.i.jmp_offset2 = UScalar.hcast IScalarTy.I64 inst_size
       ∧ zib.i.is_precompiled = false := by
-  obtain ⟨zib, hzib, hiw', hbSrc, hbOff, hstoreOff, hstore, hstoreReg, hj1, hj2⟩ :=
+  obtain ⟨zib, hzib, hiw', hbSrc, hbOff, hstoreOff, hstore, hstoreReg,
+      hstoreSelector, hj1, hj2⟩ :=
     load_op_typed_full_pins self i op w inst_size wval ctx hrd hiw h
   simp only [riscv2zisk_context.Riscv2ZiskContext.load_op_typed,
     Bind.bind, bind_ok] at h
@@ -384,7 +418,7 @@ theorem load_op_typed_nonzero_rs1_full_pins
   subst zib
   refine ⟨z7, ZiskFv.Compliance.Extraction.insert_inst_extract _ _ _ _ h8,
     haSrc7.trans haSrc, ?_, haSp7.trans haSp, hbSrc, hbOff, hstoreOff, hstore,
-    hstoreReg, hiw', hj1, hj2, ?_⟩
+    hstoreReg, hstoreSelector, hiw', hj1, hj2, ?_⟩
   · rw [haOff7]
     exact haOff
   · have hp45' : z5.i.is_precompiled = false := by
@@ -418,6 +452,7 @@ theorem ld_op_typed_nonzero_rs1_full_pins
       ∧ zib.i.store_offset.val = i.rd.val
       ∧ zib.i.store ≠ zisk_inst.STORE_IND
       ∧ (i.rd.val ≠ 0 → zib.i.store = zisk_inst.STORE_REG)
+      ∧ zib.i.store = (if i.rd.val = 0 then 0#u64 else zisk_inst.STORE_REG)
       ∧ zib.i.ind_width = wval
       ∧ zib.i.jmp_offset1 = UScalar.hcast IScalarTy.I64 inst_size
       ∧ zib.i.jmp_offset2 = UScalar.hcast IScalarTy.I64 inst_size
@@ -607,7 +642,8 @@ theorem transpile_load_of
         ∧ ext.row.b_offset_imm0 = IScalar.hcast UScalarTy.U64 d.imm
         ∧ ext.row.store_offset.val = d.rd.val
         ∧ ext.row.store ≠ zisk_inst.STORE_IND
-        ∧ (d.rd.val ≠ 0 → ext.row.store = zisk_inst.STORE_REG) := by
+        ∧ (d.rd.val ≠ 0 → ext.row.store = zisk_inst.STORE_REG)
+        ∧ ext.row.store = (if d.rd.val = 0 then 0#u64 else zisk_inst.STORE_REG) := by
   obtain ⟨decoded, hdecoded, hopd, hrdb, hrs1b, _⟩ := decode_i_bounds raw rop false
   have hdec0 : aeneas_extract.rv64im_decode.decode_32_core raw = ok decoded := hdec.trans hdecoded
   set input : riscv2zisk_single_row.Rv64imLoweringInput :=
@@ -623,11 +659,11 @@ theorem transpile_load_of
   have hzz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
   rw [hzz] at hiw' hj1 hj2
   obtain ⟨zib'', hzib'', hiw'', hbSrc, hbOff, hstoreOff, hstore, hstoreReg,
-      hj1', hj2'⟩ :=
+      hstoreSelector, hj1', hj2'⟩ :=
     load_op_typed_full_pins { defCtx with extract_marker := () } input zop W 4#u64
       wval ctx0 (by rw [hinput]; exact hrdb) hiw hctx0
   have hzz' : zib'' = zib := Option.some.inj (hzib''.symm.trans hzib)
-  rw [hzz'] at hbSrc hbOff hstoreOff hstore hstoreReg
+  rw [hzz'] at hbSrc hbOff hstoreOff hstore hstoreReg hstoreSelector
   obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
   obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, hriw⟩ := from_inst_ok zib.i
   have hrBSrc : row.b_src = zib.i.b_src := by
@@ -670,7 +706,7 @@ theorem transpile_load_of
   · show row.ind_width = wval; rw [hriw]; exact hiw'
   · show row.jmp_offset1 = _; rw [hrj1]; exact hj1
   · show row.jmp_offset2 = _; rw [hrj2]; exact hj2
-  · refine ⟨decoded, hdecoded, ?_, ?_, ?_, ?_, ?_⟩
+  · refine ⟨decoded, hdecoded, ?_, ?_, ?_, ?_, ?_, ?_⟩
     · rw [hrBSrc]; exact hbSrc
     · rw [hrBOff, hbOff, hinput]
     · rw [hrStoreOff, hstoreOff, hinput]
@@ -678,6 +714,7 @@ theorem transpile_load_of
     · intro hne
       rw [hrStore]
       exact hstoreReg (by rw [hinput]; exact hne)
+    · rw [hrStore, hstoreSelector, hinput]
 
 /-! ## Generic store-family transpile reduction (S-type word, `decode_s`). -/
 
@@ -789,7 +826,9 @@ local macro "load_copyb_op" nm:ident "," f3:term "," rop:term "," srop:term ","
             ∧ ext.row.b_offset_imm0 = IScalar.hcast UScalarTy.U64 d.imm
             ∧ ext.row.store_offset.val = d.rd.val
             ∧ ext.row.store ≠ zisk_inst.STORE_IND
-            ∧ (d.rd.val ≠ 0 → ext.row.store = zisk_inst.STORE_REG) := by
+            ∧ (d.rd.val ≠ 0 → ext.row.store = zisk_inst.STORE_REG)
+            ∧ ext.row.store =
+              (if d.rd.val = 0 then 0#u64 else zisk_inst.STORE_REG) := by
       refine transpile_load_of _ $rop $srop zisk_ops.ZiskOp.CopyB 1#u8 false false
         zisk_ops.OpType.Internal $width $width ?_ rfl (fun _ => ⟨_, rfl⟩) $iwlem
         (by intro self input; rfl) rfl rfl rfl rfl
@@ -952,7 +991,9 @@ local macro "load_sext_op" nm:ident "," f3:term "," rop:term "," srop:term ","
             ∧ ext.row.b_offset_imm0 = IScalar.hcast UScalarTy.U64 d.imm
             ∧ ext.row.store_offset.val = d.rd.val
             ∧ ext.row.store ≠ zisk_inst.STORE_IND
-            ∧ (d.rd.val ≠ 0 → ext.row.store = zisk_inst.STORE_REG) := by
+            ∧ (d.rd.val ≠ 0 → ext.row.store = zisk_inst.STORE_REG)
+            ∧ ext.row.store =
+              (if d.rd.val = 0 then 0#u64 else zisk_inst.STORE_REG) := by
       refine transpile_load_of _ $rop $srop $zop $opU8 $m32 true
         zisk_ops.OpType.BinaryE $width $width ?_ rfl (fun _ => ⟨_, rfl⟩) $iwlem
         (by intro self input; rfl) rfl rfl rfl rfl
@@ -984,6 +1025,259 @@ load_sext_op lb, 0, RiscvOpcode.Lb, riscv2zisk_single_row.Rv64imSingleRowOpcode.
 load_sext_op lh, 1, RiscvOpcode.Lh, riscv2zisk_single_row.Rv64imSingleRowOpcode.Lh, zisk_ops.ZiskOp.SignExtendH, 40#u8, false, 2#u64, (2 : FGL), ind_width_set2, OP_SIGNEXTEND_H
 load_sext_op lw, 2, RiscvOpcode.Lw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Lw, zisk_ops.ZiskOp.SignExtendW, 41#u8, true, 4#u64, (4 : FGL), ind_width_set4, OP_SIGNEXTEND_W
 
+/-! ## Current `ProgramDecode` retarget: load family. -/
+
+private theorem load_rom_offset (imm : BitVec 12) (d : DecodedRv64im)
+    (hdimm : (IScalar.hcast UScalarTy.U64 d.imm).bv = BitVec.signExtend 64 imm) :
+    signedOffset (IScalar.hcast UScalarTy.U64 d.imm) =
+      ((BitVec.signExtend 64 imm).toInt : FGL) := by
+  unfold signedOffset
+  exact congrArg (fun x : BitVec 64 => (x.toInt : FGL)) hdimm
+
+private theorem load_rom_store_offset (rd : BitVec 5) (d : DecodedRv64im)
+    (hrd : d.rd.bv = BitVec.ofNat 32 rd.toNat) :
+    (d.rd.val : FGL) = Transpiler.ind (Transpiler.regidxOfBitVec5 rd) := by
+  apply Fin.ext
+  change d.rd.val % GL_prime = rd.toNat
+  have hdval : d.rd.val = rd.toNat := by
+    change d.rd.bv.toNat = rd.toNat
+    rw [hrd, BitVec.toNat_ofNat]
+    exact Nat.mod_eq_of_lt (by omega)
+  rw [hdval]
+  exact Nat.mod_eq_of_lt (by omega)
+
+local macro "load_copyb_program_decode" nm:ident "," inp:term "," f3:term ","
+    rop:term : command => do
+  let s := nm.getId.toString
+  let rawName := Lean.mkIdent (Lean.Name.mkSimple ("RawProgramDecode_" ++ s))
+  let ctorName := Lean.mkIdent (Lean.Name.mkSimple ("ProgramDecode_" ++ s ++ "_from_rawProgram"))
+  let transpileName := Lean.mkIdent (Lean.Name.mkSimple ("transpile_" ++ s))
+  let fieldsName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
+  let claimName := Lean.mkIdent ((`ZiskFv.Compliance).str ("Claim_" ++ s))
+  let programName := Lean.mkIdent ((`ZiskFv.Compliance.RomDecodeBinding).str ("ProgramDecode_" ++ s))
+  let t1 ← `(structure $rawName {n rawLength : Nat}
+      (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+      (i : Fin trace.numInstructions) (c : $claimName trace i)
+      (addr : Fin rawLength → FGL) (rawProgram : Fin rawLength → BitVec 32) where
+    h_idx : i.val + 1 < trace.mainTable.table.length
+    hLine : ∀ j : Fin trace.programLength,
+      (trace.program j).line =
+          (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
+        ∃ k : Fin rawLength,
+          addr k = (trace.program j).line ∧
+            rawProgram k =
+              ZiskFv.Completeness.Rv64imShapes.rawIType ($inp c).imm.toNat
+                ($inp c).r1.toNat $f3 ($inp c).rd.toNat 0x03)
+  let t2 ← `(noncomputable def $ctorName {n rawLength : Nat}
+      (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+      (i : Fin trace.numInstructions) (c : $claimName trace i)
+      (start : Fin rawLength → Fin trace.programLength)
+      (addr : Fin rawLength → FGL)
+      (rawProgram : Fin rawLength → BitVec 32)
+      (hbind : ProgramRowsBinding trace start addr rawProgram)
+      (rawDecode : $rawName trace i c addr rawProgram) :
+      $programName trace i c := by
+    let rd := ($inp c).rd.toNat
+    let rs1 := ($inp c).r1.toNat
+    let imm := ($inp c).imm.toNat
+    let ext := ($transpileName rd rs1 imm ($inp c).rd.isLt ($inp c).r1.isLt).choose
+    obtain ⟨hok, hop, hieo, hm32, hsetpc, hstorepc, hiw, hj1, hj2, hrow⟩ :=
+      ($transpileName rd rs1 imm ($inp c).rd.isLt ($inp c).r1.isLt).choose_spec
+    let d := hrow.choose
+    obtain ⟨hdecode, hbSrc, hbOff, hstoreOff, hstoreInd, hstoreReg, hstoreSelector⟩ :=
+      hrow.choose_spec
+    have hdfields := decode_i_rawIType_fields imm rs1 $f3 rd 0x03
+      ($inp c).r1.isLt (by norm_num) ($inp c).rd.isLt (by norm_num) $rop d hdecode
+    have hdval : d.rd.val = ($inp c).rd.toNat := by
+      change d.rd.bv.toNat = ($inp c).rd.toNat
+      rw [hdfields.1, BitVec.toNat_ofNat]
+      exact Nat.mod_eq_of_lt (by omega)
+    have hdimm : (IScalar.hcast UScalarTy.U64 d.imm).bv =
+        BitVec.signExtend 64 ($inp c).imm := by
+      simpa only [imm, BitVec.ofNat_toNat] using hdfields.2.2
+    refine
+      { h_idx := rawDecode.h_idx
+        bits := romFlagBitsOfExtract ext.row
+        h_bits_ieo := by simpa only [ext, romFlagBitsOfExtract] using hieo
+        h_bits_set_pc := by simpa only [ext, romFlagBitsOfExtract] using hsetpc
+        h_bits_store_pc := by simpa only [ext, romFlagBitsOfExtract] using hstorepc
+        h_bits_store_ind := by
+          simp only [romFlagBitsOfExtract]
+          exact decide_eq_false hstoreInd
+        h_bits_store_reg := by
+          simp only [romFlagBitsOfExtract]
+          rw [hstoreSelector, hdval]
+          by_cases hrd : ($inp c).rd.toNat = 0
+          · simp [hrd, zisk_inst.STORE_REG]
+          · simp [hrd]
+        h_bits_b_src_ind := by
+          simp only [romFlagBitsOfExtract]
+          exact decide_eq_true hbSrc
+        h_prog := by
+          intro j hline
+          obtain ⟨k, haddr, hraw⟩ := rawDecode.hLine j hline
+          have hprimary := primary_row_at_architectural_line hbind j k haddr.symm
+          have hbk : trace.program j =
+              romMessageOfRaw (addr k)
+                (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 $f3 rd 0x03) := by
+            have hp := hprimary.2
+            rw [hraw, romMessagesOfRaw_fst_of_non_jalr _ _ ext
+              (by simpa only [rd, rs1, imm, ext] using hok)
+              (by
+                rw [ZiskFv.Compliance.Decode.toU32_and127,
+                  ZiskFv.Compliance.Decode.rawIType_opcode]
+                all_goals decide)] at hp
+            simpa only [rd, rs1, imm] using hp
+          obtain ⟨ho, hjo1, hjo2, hiwF, ext', hok', hieo', hm32', hsetpc',
+              hstorepc', hf⟩ :=
+            $fieldsName rd rs1 imm ($inp c).rd.isLt ($inp c).r1.isLt
+              (addr k) (trace.program j) hbk
+          have hext : ext' = ext :=
+            Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
+          subst ext'
+          refine ⟨ho, hjo1, hjo2, hiwF, ?_, ?_, hf⟩
+          · rw [hbk, romMessageOfRaw, hok]
+            show signedOffset ext.row.b_offset_imm0 =
+              ((BitVec.signExtend 64 ($inp c).imm).toInt : FGL)
+            rw [hbOff]
+            exact load_rom_offset ($inp c).imm d hdimm
+          · rw [hbk, romMessageOfRaw, hok]
+            show (ext.row.store_offset.val : FGL) =
+              Transpiler.ind (Transpiler.regidxOfBitVec5 ($inp c).rd)
+            rw [hstoreOff]
+            exact load_rom_store_offset ($inp c).rd d (by
+              simpa only [rd, BitVec.ofNat_toNat] using hdfields.1) })
+  return ⟨Lean.mkNullNode #[t1, t2]⟩
+
+load_copyb_program_decode ld, ZiskFv.Compliance.Claim_ld.ld_input, 3, RiscvOpcode.Ld
+load_copyb_program_decode lbu, ZiskFv.Compliance.Claim_lbu.lbu_input, 4, RiscvOpcode.Lbu
+load_copyb_program_decode lhu, ZiskFv.Compliance.Claim_lhu.lhu_input, 5, RiscvOpcode.Lhu
+load_copyb_program_decode lwu, ZiskFv.Compliance.Claim_lwu.lwu_input, 6, RiscvOpcode.Lwu
+
+local macro "load_sext_program_decode" nm:ident "," inp:term "," f3:term ","
+    rop:term : command => do
+  let s := nm.getId.toString
+  let rawName := Lean.mkIdent (Lean.Name.mkSimple ("RawProgramDecode_" ++ s))
+  let ctorName := Lean.mkIdent (Lean.Name.mkSimple ("ProgramDecode_" ++ s ++ "_from_rawProgram"))
+  let transpileName := Lean.mkIdent (Lean.Name.mkSimple ("transpile_" ++ s))
+  let fieldsName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
+  let claimName := Lean.mkIdent ((`ZiskFv.Compliance).str ("Claim_" ++ s))
+  let programName := Lean.mkIdent ((`ZiskFv.Compliance.RomDecodeBinding).str ("ProgramDecode_" ++ s))
+  let t1 ← `(structure $rawName {n rawLength : Nat}
+      (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+      (i : Fin trace.numInstructions) (c : $claimName trace i)
+      (addr : Fin rawLength → FGL) (rawProgram : Fin rawLength → BitVec 32) where
+    h_idx : i.val + 1 < trace.mainTable.table.length
+    v : ZiskFv.Airs.BinaryExtension.Valid_BinaryExtension FGL FGL
+    r_binary : ℕ
+    offset : ℕ
+    env : Environment FGL
+    h_static : ZiskFv.AirsClean.BinaryExtension.StaticLookupSoundness v
+    h_match :
+      ZiskFv.Airs.OperationBus.matches_entry
+        (ZiskFv.Airs.OperationBus.opBus_row_Main
+          (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable)
+          i.val)
+        (ZiskFv.Airs.OperationBus.opBus_row_BinaryExtension v r_binary)
+    hLine : ∀ j : Fin trace.programLength,
+      (trace.program j).line =
+          (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
+        ∃ k : Fin rawLength,
+          addr k = (trace.program j).line ∧
+            rawProgram k =
+              ZiskFv.Completeness.Rv64imShapes.rawIType ($inp c).imm.toNat
+                ($inp c).r1.toNat $f3 ($inp c).rd.toNat 0x03)
+  let t2 ← `(noncomputable def $ctorName {n rawLength : Nat}
+      (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+      (i : Fin trace.numInstructions) (c : $claimName trace i)
+      (start : Fin rawLength → Fin trace.programLength)
+      (addr : Fin rawLength → FGL)
+      (rawProgram : Fin rawLength → BitVec 32)
+      (hbind : ProgramRowsBinding trace start addr rawProgram)
+      (rawDecode : $rawName trace i c addr rawProgram) :
+      $programName trace i c := by
+    let rd := ($inp c).rd.toNat
+    let rs1 := ($inp c).r1.toNat
+    let imm := ($inp c).imm.toNat
+    let ext := ($transpileName rd rs1 imm ($inp c).rd.isLt ($inp c).r1.isLt).choose
+    obtain ⟨hok, hop, hieo, hm32, hsetpc, hstorepc, hiw, hj1, hj2, hrow⟩ :=
+      ($transpileName rd rs1 imm ($inp c).rd.isLt ($inp c).r1.isLt).choose_spec
+    let d := hrow.choose
+    obtain ⟨hdecode, hbSrc, hbOff, hstoreOff, hstoreInd, hstoreReg, hstoreSelector⟩ :=
+      hrow.choose_spec
+    have hdfields := decode_i_rawIType_fields imm rs1 $f3 rd 0x03
+      ($inp c).r1.isLt (by norm_num) ($inp c).rd.isLt (by norm_num) $rop d hdecode
+    have hdval : d.rd.val = ($inp c).rd.toNat := by
+      change d.rd.bv.toNat = ($inp c).rd.toNat
+      rw [hdfields.1, BitVec.toNat_ofNat]
+      exact Nat.mod_eq_of_lt (by omega)
+    have hdimm : (IScalar.hcast UScalarTy.U64 d.imm).bv =
+        BitVec.signExtend 64 ($inp c).imm := by
+      simpa only [imm, BitVec.ofNat_toNat] using hdfields.2.2
+    refine
+      { h_idx := rawDecode.h_idx
+        v := rawDecode.v
+        r_binary := rawDecode.r_binary
+        offset := rawDecode.offset
+        env := rawDecode.env
+        h_static := rawDecode.h_static
+        h_match := rawDecode.h_match
+        bits := romFlagBitsOfExtract ext.row
+        h_bits_ieo := by simpa only [ext, romFlagBitsOfExtract] using hieo
+        h_bits_set_pc := by simpa only [ext, romFlagBitsOfExtract] using hsetpc
+        h_bits_store_pc := by simpa only [ext, romFlagBitsOfExtract] using hstorepc
+        h_bits_store_ind := by
+          simp only [romFlagBitsOfExtract]
+          exact decide_eq_false hstoreInd
+        h_bits_store_reg := by
+          simp only [romFlagBitsOfExtract]
+          rw [hstoreSelector, hdval]
+          by_cases hrd : ($inp c).rd.toNat = 0
+          · simp [hrd, zisk_inst.STORE_REG]
+          · simp [hrd]
+        h_bits_b_src_ind := by
+          simp only [romFlagBitsOfExtract]
+          exact decide_eq_true hbSrc
+        h_prog := by
+          intro j hline
+          obtain ⟨k, haddr, hraw⟩ := rawDecode.hLine j hline
+          have hprimary := primary_row_at_architectural_line hbind j k haddr.symm
+          have hbk : trace.program j =
+              romMessageOfRaw (addr k)
+                (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 $f3 rd 0x03) := by
+            have hp := hprimary.2
+            rw [hraw, romMessagesOfRaw_fst_of_non_jalr _ _ ext
+              (by simpa only [rd, rs1, imm, ext] using hok)
+              (by
+                rw [ZiskFv.Compliance.Decode.toU32_and127,
+                  ZiskFv.Compliance.Decode.rawIType_opcode]
+                all_goals decide)] at hp
+            simpa only [rd, rs1, imm] using hp
+          obtain ⟨ho, hjo1, hjo2, hiwF, ext', hok', hieo', hm32', hsetpc',
+              hstorepc', hf⟩ :=
+            $fieldsName rd rs1 imm ($inp c).rd.isLt ($inp c).r1.isLt
+              (addr k) (trace.program j) hbk
+          have hext : ext' = ext :=
+            Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
+          subst ext'
+          refine ⟨ho, hjo1, hjo2, hiwF, ?_, ?_, hf⟩
+          · rw [hbk, romMessageOfRaw, hok]
+            show signedOffset ext.row.b_offset_imm0 =
+              ((BitVec.signExtend 64 ($inp c).imm).toInt : FGL)
+            rw [hbOff]
+            exact load_rom_offset ($inp c).imm d hdimm
+          · rw [hbk, romMessageOfRaw, hok]
+            show (ext.row.store_offset.val : FGL) =
+              Transpiler.ind (Transpiler.regidxOfBitVec5 ($inp c).rd)
+            rw [hstoreOff]
+            exact load_rom_store_offset ($inp c).rd d (by
+              simpa only [rd, BitVec.ofNat_toNat] using hdfields.1) })
+  return ⟨Lean.mkNullNode #[t1, t2]⟩
+
+load_sext_program_decode lb, ZiskFv.Compliance.Claim_lb.lb_input, 0, RiscvOpcode.Lb
+load_sext_program_decode lh, ZiskFv.Compliance.Claim_lh.lh_input, 1, RiscvOpcode.Lh
+load_sext_program_decode lw, ZiskFv.Compliance.Claim_lw.lw_input, 2, RiscvOpcode.Lw
+
 /-! ## Current `ProgramDecode` retarget: store family. -/
 
 private theorem store_rom_offset (imm : BitVec 12) (d : DecodedRv64im)
@@ -1005,24 +1299,27 @@ local macro "store_program_decode" nm:ident "," inp:term "," f3:term ","
   let claimName := Lean.mkIdent ((`ZiskFv.Compliance).str ("Claim_" ++ s))
   let programName := Lean.mkIdent ((`ZiskFv.Compliance.RomDecodeBinding).str ("ProgramDecode_" ++ s))
   let decodeFieldsName := Lean.mkIdent `decode_s_rawSType_fields
-  let t1 ← `(structure $rawName {n : Nat}
+  let t1 ← `(structure $rawName {n rawLength : Nat}
       (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
       (i : Fin trace.numInstructions) (c : $claimName trace i)
-      (rawProgram : Fin trace.programLength → BitVec 32) where
+      (addr : Fin rawLength → FGL) (rawProgram : Fin rawLength → BitVec 32) where
     h_idx : i.val + 1 < trace.mainTable.table.length
     hLine : ∀ j : Fin trace.programLength,
       (trace.program j).line =
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
-        rawProgram j =
-          ZiskFv.Completeness.Rv64imShapes.rawSType ($inp c).imm.toNat
-            ($inp c).r2.toNat ($inp c).r1.toNat $f3)
-  let t2 ← `(noncomputable def $ctorName {n : Nat}
+        ∃ k : Fin rawLength,
+          addr k = (trace.program j).line ∧
+            rawProgram k =
+              ZiskFv.Completeness.Rv64imShapes.rawSType ($inp c).imm.toNat
+                ($inp c).r2.toNat ($inp c).r1.toNat $f3)
+  let t2 ← `(noncomputable def $ctorName {n rawLength : Nat}
       (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
       (i : Fin trace.numInstructions) (c : $claimName trace i)
-      (addr : Fin trace.programLength → FGL)
-      (rawProgram : Fin trace.programLength → BitVec 32)
-      (hbind : ProgramBinding trace addr rawProgram)
-      (rawDecode : $rawName trace i c rawProgram) :
+      (start : Fin rawLength → Fin trace.programLength)
+      (addr : Fin rawLength → FGL)
+      (rawProgram : Fin rawLength → BitVec 32)
+      (hbind : ProgramRowsBinding trace start addr rawProgram)
+      (rawDecode : $rawName trace i c addr rawProgram) :
       $programName trace i c := by
     let rs1 := ($inp c).r1.toNat
     let rs2 := ($inp c).r2.toNat
@@ -1048,15 +1345,23 @@ local macro "store_program_decode" nm:ident "," inp:term "," f3:term ","
           exact decide_eq_true hstore
         h_prog := by
           intro j hline
+          obtain ⟨k, haddr, hraw⟩ := rawDecode.hLine j hline
+          have hprimary := primary_row_at_architectural_line hbind j k haddr.symm
           have hbk : trace.program j =
-              romMessageOfRaw (addr j)
+              romMessageOfRaw (addr k)
                 (ZiskFv.Completeness.Rv64imShapes.rawSType imm rs2 rs1 $f3) := by
-            exact (hbind.2 j).trans
-              (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+            have hp := hprimary.2
+            rw [hraw, romMessagesOfRaw_fst_of_non_jalr _ _ ext
+              (by simpa only [rs1, rs2, imm, ext] using hok)
+              (by
+                rw [ZiskFv.Compliance.Decode.toU32_and127,
+                  ZiskFv.Compliance.Decode.rawSType_opcode]
+                all_goals decide)] at hp
+            simpa only [rs1, rs2, imm] using hp
           obtain ⟨ho, hjo1, hjo2, hiwF, ext', hok', hieo', hm32', hsetpc',
               hstorepc', hf⟩ :=
             $fieldsName rs1 rs2 imm ($inp c).r1.isLt ($inp c).r2.isLt
-              (addr j) (trace.program j) hbk
+              (addr k) (trace.program j) hbk
           have hext : ext' = ext :=
             Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
           subst ext'
@@ -1072,25 +1377,28 @@ store_program_decode sb, ZiskFv.Compliance.Claim_sb.sb_input, 0, RiscvOpcode.Sb
 store_program_decode sh, ZiskFv.Compliance.Claim_sh.sh_input, 1, RiscvOpcode.Sh
 store_program_decode sw, ZiskFv.Compliance.Claim_sw.sw_input, 2, RiscvOpcode.Sw
 
-structure RawProgramDecode_sd {n : Nat}
+structure RawProgramDecode_sd {n rawLength : Nat}
     (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
     (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_sd trace i)
-    (rawProgram : Fin trace.programLength → BitVec 32) where
+    (addr : Fin rawLength → FGL) (rawProgram : Fin rawLength → BitVec 32) where
   h_idx : i.val + 1 < trace.mainTable.table.length
   hLine : ∀ j : Fin trace.programLength,
     (trace.program j).line =
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
-      rawProgram j =
-        ZiskFv.Completeness.Rv64imShapes.rawSType c.sd_input.imm.toNat
-          c.sd_input.r2.toNat c.sd_input.r1.toNat 3
+      ∃ k : Fin rawLength,
+        addr k = (trace.program j).line ∧
+          rawProgram k =
+            ZiskFv.Completeness.Rv64imShapes.rawSType c.sd_input.imm.toNat
+              c.sd_input.r2.toNat c.sd_input.r1.toNat 3
 
-noncomputable def ProgramDecode_sd_from_rawProgram {n : Nat}
+noncomputable def ProgramDecode_sd_from_rawProgram {n rawLength : Nat}
     (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
     (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_sd trace i)
-    (addr : Fin trace.programLength → FGL)
-    (rawProgram : Fin trace.programLength → BitVec 32)
-    (hbind : ProgramBinding trace addr rawProgram)
-    (rawDecode : RawProgramDecode_sd trace i c rawProgram) :
+    (start : Fin rawLength → Fin trace.programLength)
+    (addr : Fin rawLength → FGL)
+    (rawProgram : Fin rawLength → BitVec 32)
+    (hbind : ProgramRowsBinding trace start addr rawProgram)
+    (rawDecode : RawProgramDecode_sd trace i c addr rawProgram) :
     ZiskFv.Compliance.RomDecodeBinding.ProgramDecode_sd trace i c := by
   let rs1 := c.sd_input.r1.toNat
   let rs2 := c.sd_input.r2.toNat
@@ -1116,15 +1424,23 @@ noncomputable def ProgramDecode_sd_from_rawProgram {n : Nat}
         exact decide_eq_true hstore
       h_prog := by
         intro j hline
+        obtain ⟨k, haddr, hraw⟩ := rawDecode.hLine j hline
+        have hprimary := primary_row_at_architectural_line hbind j k haddr.symm
         have hbk : trace.program j =
-            romMessageOfRaw (addr j)
+            romMessageOfRaw (addr k)
               (ZiskFv.Completeness.Rv64imShapes.rawSType imm rs2 rs1 3) := by
-          exact (hbind.2 j).trans
-            (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+          have hp := hprimary.2
+          rw [hraw, romMessagesOfRaw_fst_of_non_jalr _ _ ext
+            (by simpa only [rs1, rs2, imm, ext] using hok)
+            (by
+              rw [ZiskFv.Compliance.Decode.toU32_and127,
+                ZiskFv.Compliance.Decode.rawSType_opcode]
+              all_goals decide)] at hp
+          simpa only [rs1, rs2, imm] using hp
         obtain ⟨ho, hjo1, hjo2, ext', hok', hieo', hm32', hsetpc',
             hstorepc', hf⟩ :=
           sd_decode_fields_of_binding rs1 rs2 imm c.sd_input.r1.isLt c.sd_input.r2.isLt
-            (addr j) (trace.program j) hbk
+            (addr k) (trace.program j) hbk
         have hext : ext' = ext :=
           Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
         subst ext'
@@ -1147,6 +1463,13 @@ section AxiomAudit
 #print axioms ProgramDecode_sh_from_rawProgram
 #print axioms ProgramDecode_sw_from_rawProgram
 #print axioms ProgramDecode_sd_from_rawProgram
+#print axioms ProgramDecode_ld_from_rawProgram
+#print axioms ProgramDecode_lbu_from_rawProgram
+#print axioms ProgramDecode_lhu_from_rawProgram
+#print axioms ProgramDecode_lwu_from_rawProgram
+#print axioms ProgramDecode_lb_from_rawProgram
+#print axioms ProgramDecode_lh_from_rawProgram
+#print axioms ProgramDecode_lw_from_rawProgram
 end AxiomAudit
 
 end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingMext.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingMext.lean
@@ -15,9 +15,9 @@ bridges therefore reuse the generic register lemmas verbatim:
     (`ZiskOp.code`/`is_m32`/`op_type`) and the decode classification by the
     `rawRType_{opcode,funct3,funct7}` masks (`funct7 = 1`).
   * `<op>_decode_fields_of_binding` — reuses `register_decode_fields_of_binding`.
-  * `Decode_<op>_from_rawProgram` — rebuilds block-1's `Decode_<op>_of_program`
-    from `rawProgram` + `ProgramBinding` + the `<op>`-shaped raw-word hypothesis
-    + `h_idx`, with NO per-op ROM decode premise.
+  * `ProgramDecode_<op>_from_rawProgram` — rebuilds the committed-program decode
+    bundle from `rawProgram` + `ProgramRowsBinding` + the `<op>`-shaped raw-word
+    hypothesis + `h_idx`, with NO per-op ROM decode premise.
 
 **Bespoke part.**  Unlike the base ALU ops, each M-ext `Decode_<op>_of_program`
 carries HETEROGENEOUS non-ROM operand/arith-side witnesses that are OUTSIDE the
@@ -211,10 +211,10 @@ local macro "mext_program_decode_ab" nm:ident "," f3:term "," opw:term : command
   let claimName := Lean.mkIdent ((`ZiskFv.Compliance).str ("Claim_" ++ s))
   let programName :=
     Lean.mkIdent ((`ZiskFv.Compliance.RomDecodeBinding).str ("ProgramDecode_" ++ s))
-  let t1 ← `(structure $rawName {n : Nat}
+  let t1 ← `(structure $rawName {n rawLength : Nat}
       (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
       (i : Fin trace.numInstructions) (c : $claimName trace i)
-      (rawProgram : Fin trace.programLength → BitVec 32) where
+      (addr : Fin rawLength → FGL) (rawProgram : Fin rawLength → BitVec 32) where
     h_idx : i.val + 1 < trace.mainTable.table.length
     arith_mem : ZiskFv.Compliance.ExternalArithMemoryWitness
       (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable) i.val
@@ -224,16 +224,19 @@ local macro "mext_program_decode_ab" nm:ident "," f3:term "," opw:term : command
     hLine : ∀ j : Fin trace.programLength,
       (trace.program j).line =
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
-        rawProgram j = ZiskFv.Completeness.Rv64imShapes.rawRType 1
-          (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val $f3
-          (regidx_to_fin c.rd).val $opw)
-  let t2 ← `(noncomputable def $ctorName {n : Nat}
+        ∃ k : Fin rawLength,
+          addr k = (trace.program j).line ∧
+            rawProgram k = ZiskFv.Completeness.Rv64imShapes.rawRType 1
+              (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val $f3
+              (regidx_to_fin c.rd).val $opw)
+  let t2 ← `(noncomputable def $ctorName {n rawLength : Nat}
       (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
       (i : Fin trace.numInstructions) (c : $claimName trace i)
-      (addr : Fin trace.programLength → FGL)
-      (rawProgram : Fin trace.programLength → BitVec 32)
-      (hbind : ProgramBinding trace addr rawProgram)
-      (rawDecode : $rawName trace i c rawProgram) :
+      (start : Fin rawLength → Fin trace.programLength)
+      (addr : Fin rawLength → FGL)
+      (rawProgram : Fin rawLength → BitVec 32)
+      (hbind : ProgramRowsBinding trace start addr rawProgram)
+      (rawDecode : $rawName trace i c addr rawProgram) :
       $programName trace i c := by
     let rd := (regidx_to_fin c.rd).val
     let rs1 := (regidx_to_fin c.r1).val
@@ -258,15 +261,32 @@ local macro "mext_program_decode_ab" nm:ident "," f3:term "," opw:term : command
           exact decide_eq_false hstoreInd
         h_prog := ?_ }
     intro j hline
-    have hbk : trace.program j = romMessageOfRaw (addr j)
+    obtain ⟨k, haddr, hraw⟩ := rawDecode.hLine j hline
+    have hprimary := primary_row_at_architectural_line hbind j k haddr.symm
+    have hbk : trace.program j = romMessageOfRaw (addr k)
         (ZiskFv.Completeness.Rv64imShapes.rawRType 1 rs2 rs1 $f3 rd $opw) := by
-      exact (hbind.2 j).trans
-        (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+      have hok' : aeneas_extract.extract_transpile_rv64im_raw
+          (ZiskFv.Compliance.Decode.toU32
+            (ZiskFv.Completeness.Rv64imShapes.rawRType 1
+              (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val $f3
+              (regidx_to_fin c.rd).val $opw)) = .ok ext := by
+        simpa only [rd, rs1, rs2, ext] using hok
+      have hnon :
+          (ZiskFv.Compliance.Decode.toU32
+              (ZiskFv.Completeness.Rv64imShapes.rawRType 1
+                (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val $f3
+                (regidx_to_fin c.rd).val $opw) &&& 127#u32) ≠ 103#u32 := by
+        rw [ZiskFv.Compliance.Decode.toU32_and127,
+          ZiskFv.Compliance.Decode.rawRType_opcode]
+        all_goals decide
+      have hp := hprimary.2
+      rw [hraw, romMessagesOfRaw_fst_of_non_jalr _ _ ext hok' hnon] at hp
+      simpa only [rd, rs1, rs2] using hp
     obtain ⟨ho, hjo1, hjo2, hso, ext', hok', hieo', hm32', hsetpc',
         hstorepc', hstoreInd', hf⟩ :=
       $fieldsName rd rs1 rs2 (regidx_to_fin c.rd).isLt
         (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt
-        (addr j) (trace.program j) hbk
+        (addr k) (trace.program j) hbk
     have hext : ext' = ext :=
       Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
     subst ext'
@@ -287,26 +307,29 @@ local macro "mext_program_decode_c" nm:ident "," f3:term "," opw:term : command 
   let claimName := Lean.mkIdent ((`ZiskFv.Compliance).str ("Claim_" ++ s))
   let programName :=
     Lean.mkIdent ((`ZiskFv.Compliance.RomDecodeBinding).str ("ProgramDecode_" ++ s))
-  let t1 ← `(structure $rawName {n : Nat}
+  let t1 ← `(structure $rawName {n rawLength : Nat}
       (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
       (i : Fin trace.numInstructions) (c : $claimName trace i)
-      (rawProgram : Fin trace.programLength → BitVec 32) where
+      (addr : Fin rawLength → FGL) (rawProgram : Fin rawLength → BitVec 32) where
     h_idx : i.val + 1 < trace.mainTable.table.length
     bounds : ZiskFv.Compliance.ByteBounds
       (ZiskFv.Compliance.busSub trace i (ZiskFv.Compliance.Pilot.execRowOf trace i)).e2
     hLine : ∀ j : Fin trace.programLength,
       (trace.program j).line =
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
-        rawProgram j = ZiskFv.Completeness.Rv64imShapes.rawRType 1
-          (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val $f3
-          (regidx_to_fin c.rd).val $opw)
-  let t2 ← `(noncomputable def $ctorName {n : Nat}
+        ∃ k : Fin rawLength,
+          addr k = (trace.program j).line ∧
+            rawProgram k = ZiskFv.Completeness.Rv64imShapes.rawRType 1
+              (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val $f3
+              (regidx_to_fin c.rd).val $opw)
+  let t2 ← `(noncomputable def $ctorName {n rawLength : Nat}
       (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
       (i : Fin trace.numInstructions) (c : $claimName trace i)
-      (addr : Fin trace.programLength → FGL)
-      (rawProgram : Fin trace.programLength → BitVec 32)
-      (hbind : ProgramBinding trace addr rawProgram)
-      (rawDecode : $rawName trace i c rawProgram) :
+      (start : Fin rawLength → Fin trace.programLength)
+      (addr : Fin rawLength → FGL)
+      (rawProgram : Fin rawLength → BitVec 32)
+      (hbind : ProgramRowsBinding trace start addr rawProgram)
+      (rawDecode : $rawName trace i c addr rawProgram) :
       $programName trace i c := by
     let rd := (regidx_to_fin c.rd).val
     let rs1 := (regidx_to_fin c.r1).val
@@ -330,15 +353,32 @@ local macro "mext_program_decode_c" nm:ident "," f3:term "," opw:term : command 
           exact decide_eq_false hstoreInd
         h_prog := ?_ }
     intro j hline
-    have hbk : trace.program j = romMessageOfRaw (addr j)
+    obtain ⟨k, haddr, hraw⟩ := rawDecode.hLine j hline
+    have hprimary := primary_row_at_architectural_line hbind j k haddr.symm
+    have hbk : trace.program j = romMessageOfRaw (addr k)
         (ZiskFv.Completeness.Rv64imShapes.rawRType 1 rs2 rs1 $f3 rd $opw) := by
-      exact (hbind.2 j).trans
-        (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+      have hok' : aeneas_extract.extract_transpile_rv64im_raw
+          (ZiskFv.Compliance.Decode.toU32
+            (ZiskFv.Completeness.Rv64imShapes.rawRType 1
+              (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val $f3
+              (regidx_to_fin c.rd).val $opw)) = .ok ext := by
+        simpa only [rd, rs1, rs2, ext] using hok
+      have hnon :
+          (ZiskFv.Compliance.Decode.toU32
+              (ZiskFv.Completeness.Rv64imShapes.rawRType 1
+                (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val $f3
+                (regidx_to_fin c.rd).val $opw) &&& 127#u32) ≠ 103#u32 := by
+        rw [ZiskFv.Compliance.Decode.toU32_and127,
+          ZiskFv.Compliance.Decode.rawRType_opcode]
+        all_goals decide
+      have hp := hprimary.2
+      rw [hraw, romMessagesOfRaw_fst_of_non_jalr _ _ ext hok' hnon] at hp
+      simpa only [rd, rs1, rs2] using hp
     obtain ⟨ho, hjo1, hjo2, hso, ext', hok', hieo', hm32', hsetpc',
         hstorepc', hstoreInd', hf⟩ :=
       $fieldsName rd rs1 rs2 (regidx_to_fin c.rd).isLt
         (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt
-        (addr j) (trace.program j) hbk
+        (addr k) (trace.program j) hbk
     have hext : ext' = ext :=
       Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
     subst ext'

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingRegister.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingRegister.lean
@@ -439,28 +439,30 @@ reg_op mulw, 1, 0, 0x3b, RiscvOpcode.Mulw, riscv2zisk_single_row.Rv64imSingleRow
 /-- Raw-program evidence for one SUB step. The raw word is stated directly in
     terms of the claim registers, so the destination-register pin required by
     `ProgramDecode_sub.h_prog` is not a separate caller premise. -/
-structure RawProgramDecode_sub {n : Nat}
+structure RawProgramDecode_sub {n rawLength : Nat}
     (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
     (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_sub trace i)
-    (rawProgram : Fin trace.programLength → BitVec 32) where
+    (addr : Fin rawLength → FGL) (rawProgram : Fin rawLength → BitVec 32) where
   h_idx : i.val + 1 < trace.mainTable.table.length
   hLine : ∀ j : Fin trace.programLength,
     (trace.program j).line =
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
-      rawProgram j =
-        ZiskFv.Completeness.Rv64imShapes.rawRType 32
-          (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val 0
-          (regidx_to_fin c.rd).val 0x33
+      ∃ k : Fin rawLength,
+        addr k = (trace.program j).line ∧
+          rawProgram k = ZiskFv.Completeness.Rv64imShapes.rawRType 32
+            (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val 0
+            (regidx_to_fin c.rd).val 0x33
 
 /-- Rebuild the current committed-program SUB bundle from the raw program and
     the op-agnostic production-lowering certificate. -/
-noncomputable def ProgramDecode_sub_from_rawProgram {n : Nat}
+noncomputable def ProgramDecode_sub_from_rawProgram {n rawLength : Nat}
     (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
     (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_sub trace i)
-    (addr : Fin trace.programLength → FGL)
-    (rawProgram : Fin trace.programLength → BitVec 32)
-    (hbind : ProgramBinding trace addr rawProgram)
-    (rawDecode : RawProgramDecode_sub trace i c rawProgram) :
+    (start : Fin rawLength → Fin trace.programLength)
+    (addr : Fin rawLength → FGL)
+    (rawProgram : Fin rawLength → BitVec 32)
+    (hbind : ProgramRowsBinding trace start addr rawProgram)
+    (rawDecode : RawProgramDecode_sub trace i c addr rawProgram) :
     ZiskFv.Compliance.RomDecodeBinding.ProgramDecode_sub trace i c := by
   let rd := (regidx_to_fin c.rd).val
   let rs1 := (regidx_to_fin c.r1).val
@@ -487,16 +489,33 @@ noncomputable def ProgramDecode_sub_from_rawProgram {n : Nat}
   · simp only [romFlagBitsOfExtract]
     exact decide_eq_false hstoreInd
   · intro j hline
+    obtain ⟨k, haddr, hraw⟩ := rawDecode.hLine j hline
+    have hprimary := primary_row_at_architectural_line hbind j k haddr.symm
     have hbk : trace.program j =
-        romMessageOfRaw (addr j)
+        romMessageOfRaw (addr k)
           (ZiskFv.Completeness.Rv64imShapes.rawRType 32 rs2 rs1 0 rd 0x33) := by
-      exact (hbind.2 j).trans
-        (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+      have hok' : aeneas_extract.extract_transpile_rv64im_raw
+          (ZiskFv.Compliance.Decode.toU32
+            (ZiskFv.Completeness.Rv64imShapes.rawRType 32
+              (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val 0
+              (regidx_to_fin c.rd).val 0x33)) = .ok ext := by
+        simpa only [rd, rs1, rs2, ext] using hok
+      have hnon :
+          (ZiskFv.Compliance.Decode.toU32
+              (ZiskFv.Completeness.Rv64imShapes.rawRType 32
+                (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val 0
+                (regidx_to_fin c.rd).val 0x33) &&& 127#u32) ≠ 103#u32 := by
+        rw [ZiskFv.Compliance.Decode.toU32_and127,
+          ZiskFv.Compliance.Decode.rawRType_opcode]
+        all_goals decide
+      have hp := hprimary.2
+      rw [hraw, romMessagesOfRaw_fst_of_non_jalr _ _ ext hok' hnon] at hp
+      simpa only [rd, rs1, rs2] using hp
     obtain ⟨ho, hjo1, hjo2, hso, ext', hok', hieo', hm32', hsetpc',
         hstorepc', hstoreInd', hf⟩ :=
       sub_decode_fields_of_binding rd rs1 rs2 (regidx_to_fin c.rd).isLt
         (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt
-        (addr j) (trace.program j) hbk
+        (addr k) (trace.program j) hbk
     have hext : ext' = ext := Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
     subst ext'
     refine ⟨ho, hjo1, hjo2, ?_, hf⟩
@@ -517,25 +536,28 @@ local macro "reg_program_decode" nm:ident "," f7:term "," f3:term "," opw:term :
   let claimName := Lean.mkIdent ((`ZiskFv.Compliance).str ("Claim_" ++ s))
   let programName :=
     Lean.mkIdent ((`ZiskFv.Compliance.RomDecodeBinding).str ("ProgramDecode_" ++ s))
-  let t1 ← `(structure $rawName {n : Nat}
+  let t1 ← `(structure $rawName {n rawLength : Nat}
       (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
       (i : Fin trace.numInstructions) (c : $claimName trace i)
-      (rawProgram : Fin trace.programLength → BitVec 32) where
+      (addr : Fin rawLength → FGL) (rawProgram : Fin rawLength → BitVec 32) where
     h_idx : i.val + 1 < trace.mainTable.table.length
     hLine : ∀ j : Fin trace.programLength,
       (trace.program j).line =
           (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
-        rawProgram j =
-          ZiskFv.Completeness.Rv64imShapes.rawRType $f7
-            (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val $f3
-            (regidx_to_fin c.rd).val $opw)
-  let t2 ← `(noncomputable def $ctorName {n : Nat}
+        ∃ k : Fin rawLength,
+          addr k = (trace.program j).line ∧
+            rawProgram k =
+              ZiskFv.Completeness.Rv64imShapes.rawRType $f7
+                (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val $f3
+                (regidx_to_fin c.rd).val $opw)
+  let t2 ← `(noncomputable def $ctorName {n rawLength : Nat}
       (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
       (i : Fin trace.numInstructions) (c : $claimName trace i)
-      (addr : Fin trace.programLength → FGL)
-      (rawProgram : Fin trace.programLength → BitVec 32)
-      (hbind : ProgramBinding trace addr rawProgram)
-      (rawDecode : $rawName trace i c rawProgram) :
+      (start : Fin rawLength → Fin trace.programLength)
+      (addr : Fin rawLength → FGL)
+      (rawProgram : Fin rawLength → BitVec 32)
+      (hbind : ProgramRowsBinding trace start addr rawProgram)
+      (rawDecode : $rawName trace i c addr rawProgram) :
       $programName trace i c := by
     let rd := (regidx_to_fin c.rd).val
     let rs1 := (regidx_to_fin c.r1).val
@@ -562,16 +584,33 @@ local macro "reg_program_decode" nm:ident "," f7:term "," f3:term "," opw:term :
     · simp only [romFlagBitsOfExtract]
       exact decide_eq_false hstoreInd
     · intro j hline
+      obtain ⟨k, haddr, hraw⟩ := rawDecode.hLine j hline
+      have hprimary := primary_row_at_architectural_line hbind j k haddr.symm
       have hbk : trace.program j =
-          romMessageOfRaw (addr j)
+          romMessageOfRaw (addr k)
             (ZiskFv.Completeness.Rv64imShapes.rawRType $f7 rs2 rs1 $f3 rd $opw) := by
-        exact (hbind.2 j).trans
-          (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+        have hok' : aeneas_extract.extract_transpile_rv64im_raw
+            (ZiskFv.Compliance.Decode.toU32
+              (ZiskFv.Completeness.Rv64imShapes.rawRType $f7
+                (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val $f3
+                (regidx_to_fin c.rd).val $opw)) = .ok ext := by
+          simpa only [rd, rs1, rs2, ext] using hok
+        have hnon :
+            (ZiskFv.Compliance.Decode.toU32
+                (ZiskFv.Completeness.Rv64imShapes.rawRType $f7
+                  (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val $f3
+                  (regidx_to_fin c.rd).val $opw) &&& 127#u32) ≠ 103#u32 := by
+          rw [ZiskFv.Compliance.Decode.toU32_and127,
+            ZiskFv.Compliance.Decode.rawRType_opcode]
+          all_goals decide
+        have hp := hprimary.2
+        rw [hraw, romMessagesOfRaw_fst_of_non_jalr _ _ ext hok' hnon] at hp
+        simpa only [rd, rs1, rs2] using hp
       obtain ⟨ho, hjo1, hjo2, hso, ext', hok', hieo', hm32', hsetpc',
           hstorepc', hstoreInd', hf⟩ :=
         $fieldsName rd rs1 rs2 (regidx_to_fin c.rd).isLt
           (regidx_to_fin c.r1).isLt (regidx_to_fin c.r2).isLt
-          (addr j) (trace.program j) hbk
+          (addr k) (trace.program j) hbk
       have hext : ext' = ext :=
         Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
       subst ext'

--- a/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
@@ -2865,14 +2865,14 @@ theorem mainLoadDestinationFacts_of_program
     (bits : RomFlagBits)
     (rd : BitVec 5)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_bits_store_reg : bits.store_reg = true)
+    (h_bits_store_reg : bits.store_reg = decide (rd.toNat ≠ 0))
     (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).store_offset = Transpiler.ind (Transpiler.regidxOfBitVec5 rd)
         ∧ (trace.program j).flags = packFlags bits) :
     (mainRowWithRomLd trace i).rom.store_ind = 0
-  ∧ (mainRowWithRomLd trace i).rom.store_reg = 1
+  ∧ (mainRowWithRomLd trace i).rom.store_reg = (if rd.toNat = 0 then 0 else 1)
   ∧ (mainRowWithRomLd trace i).rom.store_offset =
       Transpiler.ind (Transpiler.regidxOfBitVec5 rd) := by
   obtain ⟨j, hline, _hop, _hiw, _hj1, _hj2, hflags⟩ :=
@@ -2882,8 +2882,13 @@ theorem mainLoadDestinationFacts_of_program
     mainSelectorColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
   have h_store_ind : (mainRowWithRomLd trace i).rom.store_ind = 0 := by
     simpa [mainRowWithRomLd, h_bits_store_ind, ZiskFv.AirsClean.boolF_false] using p_store_ind
-  have h_store_reg : (mainRowWithRomLd trace i).rom.store_reg = 1 := by
-    simpa [mainRowWithRomLd, h_bits_store_reg, ZiskFv.AirsClean.boolF_true] using p_store_reg
+  have h_store_reg :
+      (mainRowWithRomLd trace i).rom.store_reg = (if rd.toNat = 0 then 0 else 1) := by
+    rw [p_store_reg, h_bits_store_reg]
+    by_cases hrd : rd.toNat = 0
+    · simp [hrd, ZiskFv.AirsClean.boolF_false]
+    · rw [show decide (rd.toNat ≠ 0) = true from decide_eq_true hrd]
+      simp [hrd, ZiskFv.AirsClean.boolF_true]
   have h_store_offset :
       (mainRowWithRomLd trace i).rom.store_offset =
         Transpiler.ind (Transpiler.regidxOfBitVec5 rd) := by
@@ -2931,7 +2936,7 @@ def Decode_ld_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_bits_store_reg : bits.store_reg = true)
+    (h_bits_store_reg : bits.store_reg = decide (c.ld_input.rd.toNat ≠ 0))
     (h_bits_b_src_ind : bits.b_src_ind = true)
     (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
@@ -2967,13 +2972,20 @@ def Decode_ld_of_program
     obtain ⟨p_store_ind, _, _p_store_reg⟩ :=
       mainSelectorColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
     simpa [mainRowWithRomLd, h_bits_store_ind, ZiskFv.AirsClean.boolF_false] using p_store_ind
-  have h_store_reg : (mainRowWithRomLd trace i).rom.store_reg = 1 := by
+  have h_store_reg : (mainRowWithRomLd trace i).rom.store_reg =
+      (if c.ld_input.rd.toNat = 0 then 0 else 1) := by
     obtain ⟨j, hline, _hop, _hiw, _hj1, _hj2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
     obtain ⟨_hpo, _hpj0, _hpj1, _hpiw, _hpbo, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨_p_store_ind, _, p_store_reg⟩ :=
       mainSelectorColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
-    simpa [mainRowWithRomLd, h_bits_store_reg, ZiskFv.AirsClean.boolF_true] using p_store_reg
+    rw [show (mainRowWithRomLd trace i).rom.store_reg =
+        ZiskFv.AirsClean.boolF bits.store_reg by simpa [mainRowWithRomLd] using p_store_reg,
+      h_bits_store_reg]
+    by_cases hrd : c.ld_input.rd.toNat = 0
+    · simp [hrd, ZiskFv.AirsClean.boolF_false]
+    · rw [show decide (c.ld_input.rd.toNat ≠ 0) = true from decide_eq_true hrd]
+      simp [hrd, ZiskFv.AirsClean.boolF_true]
   have h_b_src_ind : (mainRowWithRomLd trace i).rom.b_src_ind = 1 :=
     mainLoadBsrcInd_of_program trace i h_lt bits h_bits_b_src_ind
       (fun j hline => by
@@ -3019,7 +3031,7 @@ def Decode_lbu_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_bits_store_reg : bits.store_reg = true)
+    (h_bits_store_reg : bits.store_reg = decide (c.lbu_input.rd.toNat ≠ 0))
     (h_bits_b_src_ind : bits.b_src_ind = true)
     (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
@@ -3092,7 +3104,7 @@ def Decode_lhu_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_bits_store_reg : bits.store_reg = true)
+    (h_bits_store_reg : bits.store_reg = decide (c.lhu_input.rd.toNat ≠ 0))
     (h_bits_b_src_ind : bits.b_src_ind = true)
     (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
@@ -3165,7 +3177,7 @@ def Decode_lwu_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_bits_store_reg : bits.store_reg = true)
+    (h_bits_store_reg : bits.store_reg = decide (c.lwu_input.rd.toNat ≠ 0))
     (h_bits_b_src_ind : bits.b_src_ind = true)
     (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
@@ -3254,7 +3266,7 @@ def Decode_lb_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_bits_store_reg : bits.store_reg = true)
+    (h_bits_store_reg : bits.store_reg = decide (c.lb_input.rd.toNat ≠ 0))
     (h_bits_b_src_ind : bits.b_src_ind = true)
     (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
@@ -3349,7 +3361,7 @@ def Decode_lh_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_bits_store_reg : bits.store_reg = true)
+    (h_bits_store_reg : bits.store_reg = decide (c.lh_input.rd.toNat ≠ 0))
     (h_bits_b_src_ind : bits.b_src_ind = true)
     (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
@@ -3444,7 +3456,7 @@ def Decode_lw_of_program
     (h_bits_set_pc : bits.set_pc = false)
     (h_bits_store_pc : bits.store_pc = false)
     (h_bits_store_ind : bits.store_ind = false)
-    (h_bits_store_reg : bits.store_reg = true)
+    (h_bits_store_reg : bits.store_reg = decide (c.lw_input.rd.toNat ≠ 0))
     (h_bits_b_src_ind : bits.b_src_ind = true)
     (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataArithMem.lean
@@ -2341,7 +2341,8 @@ structure Decode_ld (trace : AcceptedZiskTrace numInstructions)
   h_store_ind :
     (mainRowWithRomLd trace i).rom.store_ind = 0
   h_store_reg :
-    (mainRowWithRomLd trace i).rom.store_reg = 1
+    (mainRowWithRomLd trace i).rom.store_reg =
+      if c.ld_input.rd.toNat = 0 then 0 else 1
   h_b_src_ind :
     (mainRowWithRomLd trace i).rom.b_src_ind = 1
   h_store_offset :
@@ -2420,7 +2421,8 @@ structure Decode_lbu (trace : AcceptedZiskTrace numInstructions)
   h_store_ind :
     (mainRowWithRomLd trace i).rom.store_ind = 0
   h_store_reg :
-    (mainRowWithRomLd trace i).rom.store_reg = 1
+    (mainRowWithRomLd trace i).rom.store_reg =
+      if c.lbu_input.rd.toNat = 0 then 0 else 1
   h_b_src_ind :
     (mainRowWithRomLd trace i).rom.b_src_ind = 1
   h_store_offset :
@@ -2502,7 +2504,8 @@ structure Decode_lhu (trace : AcceptedZiskTrace numInstructions)
   h_store_ind :
     (mainRowWithRomLd trace i).rom.store_ind = 0
   h_store_reg :
-    (mainRowWithRomLd trace i).rom.store_reg = 1
+    (mainRowWithRomLd trace i).rom.store_reg =
+      if c.lhu_input.rd.toNat = 0 then 0 else 1
   h_b_src_ind :
     (mainRowWithRomLd trace i).rom.b_src_ind = 1
   h_store_offset :
@@ -2584,7 +2587,8 @@ structure Decode_lwu (trace : AcceptedZiskTrace numInstructions)
   h_store_ind :
     (mainRowWithRomLd trace i).rom.store_ind = 0
   h_store_reg :
-    (mainRowWithRomLd trace i).rom.store_reg = 1
+    (mainRowWithRomLd trace i).rom.store_reg =
+      if c.lwu_input.rd.toNat = 0 then 0 else 1
   h_b_src_ind :
     (mainRowWithRomLd trace i).rom.b_src_ind = 1
   h_store_offset :
@@ -2677,7 +2681,8 @@ structure Decode_lb (trace : AcceptedZiskTrace numInstructions)
   h_store_ind :
     (mainRowWithRomLd trace i).rom.store_ind = 0
   h_store_reg :
-    (mainRowWithRomLd trace i).rom.store_reg = 1
+    (mainRowWithRomLd trace i).rom.store_reg =
+      if c.lb_input.rd.toNat = 0 then 0 else 1
   h_b_src_ind :
     (mainRowWithRomLd trace i).rom.b_src_ind = 1
   h_store_offset :
@@ -2767,7 +2772,8 @@ structure Decode_lh (trace : AcceptedZiskTrace numInstructions)
   h_store_ind :
     (mainRowWithRomLd trace i).rom.store_ind = 0
   h_store_reg :
-    (mainRowWithRomLd trace i).rom.store_reg = 1
+    (mainRowWithRomLd trace i).rom.store_reg =
+      if c.lh_input.rd.toNat = 0 then 0 else 1
   h_b_src_ind :
     (mainRowWithRomLd trace i).rom.b_src_ind = 1
   h_store_offset :
@@ -2857,7 +2863,8 @@ structure Decode_lw (trace : AcceptedZiskTrace numInstructions)
   h_store_ind :
     (mainRowWithRomLd trace i).rom.store_ind = 0
   h_store_reg :
-    (mainRowWithRomLd trace i).rom.store_reg = 1
+    (mainRowWithRomLd trace i).rom.store_reg =
+      if c.lw_input.rd.toNat = 0 then 0 else 1
   h_b_src_ind :
     (mainRowWithRomLd trace i).rom.b_src_ind = 1
   h_store_offset :


### PR DESCRIPTION
Part 5 of the Phase 9 stack for #61. Base: `phase9-4-expanded-layout`.

## Summary

- Migrates register, M-extension, immediate/shift, conditional CopyB, load, and store constructors
  from the retired one-row binding to architectural `ProgramRowsBinding`.
- Reuses the common primary-row projection for every non-JALR family.
- Preserves all genuine routing and arithmetic/memory witness conditions.
- Makes load destination storage exactly conditional on the decoded `rd`, including legal `rd=x0`.

After this PR, every non-control family consumes the same raw-word-to-production-row contract used
by the final endpoint.

## Stack

1. `phase9-1-raw-binding`
2. `phase9-2-initial-decoders`
3. `phase9-3-fidelity-nonvacuity`
4. `phase9-4-expanded-layout`
5. **This PR**
6. `phase9-6-root-endpoint`

## Verification

Focused builds for each migrated family and standard-only closure checks for every constructor
passed. The complete stack's full gates are recorded on PR 6.
