### PR TITLE
#61 Phase 9.6: export raw-program root soundness

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,20 @@
 [Sail RISC-V specification](https://github.com/riscv/sail-riscv), restricted
 to RV64IM.
 
-The current verification claim is:
+The headline trace-level soundness theorem is:
 
 ```lean
-ZiskFv.Compliance.zisk_riscv_compliant_program_bus
+ZiskFv.Compliance.root_soundness
 ```
 
-That theorem dispatches all 63 covered RV64IM opcode surfaces through
-`ZiskFv/Compliance/Wrappers/<Op>.lean` to the canonical `equiv_<OP>` theorem
-for each instruction. `lake build` typechecking is the formal check.
+It proves the Sail/RISC-V step corresponding to every accepted modeled ZisK
+step, indexed by the checked committed-program decode. The additive
+`ZiskFv.Compliance.root_soundness_rawProgram` endpoint constructs those 63
+decode-family bundles from raw RV64IM words, the production Aeneas lowering,
+and an exact raw-word-to-ROM-row binding before applying the same theorem.
+`ZiskFv.Compliance.zisk_riscv_compliant_program_bus` is the older global
+channel-balance theorem retained for trace-level consumers. `lake build`
+typechecking is the formal check.
 
 ## Trust Boundary
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,22 @@ The headline trace-level soundness theorem is:
 ZiskFv.Compliance.root_soundness
 ```
 
-It proves the Sail/RISC-V step corresponding to every accepted modeled ZisK
-step, indexed by the checked committed-program decode. The additive
-`ZiskFv.Compliance.root_soundness_rawProgram` endpoint constructs those 63
-decode-family bundles from raw RV64IM words, the production Aeneas lowering,
-and an exact raw-word-to-ROM-row binding before applying the same theorem.
+It is the single audit entrypoint: the entire compliance statement is reachable
+from it. It proves the Sail/RISC-V step corresponding to every accepted modeled
+ZisK step, taking the raw RV64IM program image plus an exact binding of that
+image to the committed ROM, and constructing all 63 decode-family bundles from
+the raw words through the production Aeneas lowering.
+
+`ZiskFv.Compliance.stepSound_of_programDecodes` is the interior layer it calls,
+indexed by the checked committed-program decode; the six concrete trace
+instantiations target that layer directly.
 `ZiskFv.Compliance.zisk_riscv_compliant_program_bus` is the older global
 channel-balance theorem retained for trace-level consumers. `lake build`
 typechecking is the formal check.
+
+The root's `programBinding` and `rawProgramDecodes` premises do not yet have
+in-tree witnesses — see
+[#320](https://github.com/eth-act/zisk-fv/issues/320).
 
 ## Trust Boundary
 

--- a/ZiskFv/Compliance/AddAddiSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/AddAddiSpinRootSoundness.lean
@@ -4,10 +4,10 @@ import ZiskFv.Soundness
 set_option maxRecDepth 10000
 
 /-!
-# Concrete `root_soundness` instantiation for the ADD/ADDI/spin trace (#220)
+# Concrete `stepSound_of_programDecodes` instantiation for the ADD/ADDI/spin trace (#220)
 
 This file binds the heterogeneous accepted Zisk trace to a three-state Sail trace and applies the
-public `root_soundness` theorem at all three executed rows.
+public `stepSound_of_programDecodes` theorem at all three executed rows.
 -/
 
 open Goldilocks
@@ -494,7 +494,7 @@ theorem addAddiSpinRootSoundness :
         (addAddiSpinZiskStep i)
         (rowDecode_of_programDecode addAddiSpinAcceptedTrace i
           (addAddiSpinProgramDecodes i)) :=
-  root_soundness 3 addAddiSpinAcceptedTrace addAddiSpinSailTrace addAddiSpinZiskStep
+  stepSound_of_programDecodes 3 addAddiSpinAcceptedTrace addAddiSpinSailTrace addAddiSpinZiskStep
     addAddiSpinProgramDecodes addAddiSpinInputsAgree addAddiSpinBootSeed
     addAddiSpinOutsideDefectRegion
 

--- a/ZiskFv/Compliance/AddAddiSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/AddAddiSpinRootSoundness.lean
@@ -458,10 +458,15 @@ def addAddiSpinAddiOutsideDefectRegion :
 def addAddiSpinJalOutsideDefectRegion :
     RowOutsideDefectRegion addAddiSpinAcceptedTrace addAddiSpinJalIndex
       (addAddiSpinZiskStep addAddiSpinJalIndex) where
-  h_no_fgl_wrap := by
+  h_target_nonneg := by
     unfold mainPcVal
     rw [addAddiSpinMainPc_jal]
-    change 8 + (BitVec.signExtend 64 (0#21)).toNat < GL_prime
+    change 0 ≤ (8 : Int) + (BitVec.signExtend 64 (0#21)).toInt
+    simp
+  h_target_lt := by
+    unfold mainPcVal
+    rw [addAddiSpinMainPc_jal]
+    change (8 : Int) + (BitVec.signExtend 64 (0#21)).toInt < GL_prime
     simp
   h_pc_bound := by
     unfold MainSequentialPcDomain mainPcVal

--- a/ZiskFv/Compliance/AddSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/AddSpinRootSoundness.lean
@@ -338,10 +338,15 @@ def addSpinAddOutsideDefectRegion :
 def addSpinJalOutsideDefectRegion :
     RowOutsideDefectRegion addSpinAcceptedTrace addSpinJalIndex
       (addSpinZiskStep addSpinJalIndex) where
-  h_no_fgl_wrap := by
+  h_target_nonneg := by
     unfold mainPcVal
     rw [addSpinMainPc_jal]
-    change 4 + (BitVec.signExtend 64 (0#21)).toNat < GL_prime
+    change 0 ≤ (4 : Int) + (BitVec.signExtend 64 (0#21)).toInt
+    simp
+  h_target_lt := by
+    unfold mainPcVal
+    rw [addSpinMainPc_jal]
+    change (4 : Int) + (BitVec.signExtend 64 (0#21)).toInt < GL_prime
     simp
   h_pc_bound := by
     unfold MainSequentialPcDomain mainPcVal

--- a/ZiskFv/Compliance/AddSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/AddSpinRootSoundness.lean
@@ -4,9 +4,9 @@ import ZiskFv.Soundness
 set_option maxRecDepth 10000
 
 /-!
-# Concrete `root_soundness` instantiation for the ADD + spin-loop trace (#220)
+# Concrete `stepSound_of_programDecodes` instantiation for the ADD + spin-loop trace (#220)
 
-This file applies the public `root_soundness` theorem to the concrete
+This file applies the public `stepSound_of_programDecodes` theorem to the concrete
 `addSpinAcceptedTrace` witness from `AddSpinWitness.lean`.
 -/
 
@@ -370,7 +370,7 @@ theorem addSpinRootSoundness :
     ∀ i : Fin 2, StepSound addSpinAcceptedTrace addSpinSailTrace i
       (addSpinZiskStep i)
       (rowDecode_of_programDecode addSpinAcceptedTrace i (addSpinProgramDecodes i)) :=
-  root_soundness 2 addSpinAcceptedTrace addSpinSailTrace addSpinZiskStep
+  stepSound_of_programDecodes 2 addSpinAcceptedTrace addSpinSailTrace addSpinZiskStep
     addSpinProgramDecodes addSpinInputsAgree addSpinBootSeed addSpinOutsideDefectRegion
 
 theorem addSpinAddStepSound :
@@ -597,7 +597,7 @@ theorem addPaddedRootSoundness :
     ∀ i : Fin 1, StepSound addPaddedAcceptedTrace addPaddedSailTrace i
       (addPaddedZiskStep i)
       (rowDecode_of_programDecode addPaddedAcceptedTrace i (addPaddedProgramDecodes i)) :=
-  root_soundness 1 addPaddedAcceptedTrace addPaddedSailTrace addPaddedZiskStep
+  stepSound_of_programDecodes 1 addPaddedAcceptedTrace addPaddedSailTrace addPaddedZiskStep
     addPaddedProgramDecodes addPaddedInputsAgree addPaddedBootSeed addPaddedOutsideDefectRegion
 
 theorem addPaddedAddStepSound :

--- a/ZiskFv/Compliance/AeneasBridgeTrust/Extraction.lean
+++ b/ZiskFv/Compliance/AeneasBridgeTrust/Extraction.lean
@@ -64,3 +64,4 @@ import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.Precompiled
 import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.Dispatch
 import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.DynamicFields
 import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.Totality
+import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.JalrRows

--- a/ZiskFv/Compliance/AeneasBridgeTrust/Extraction/JalrRows.lean
+++ b/ZiskFv/Compliance/AeneasBridgeTrust/Extraction/JalrRows.lean
@@ -1,0 +1,471 @@
+import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.Totality
+import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.ControlUType
+import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.DynamicFields
+
+open Aeneas Aeneas.Std Result zisk_core
+
+set_option linter.unusedSimpArgs false
+set_option linter.unusedTactic false
+set_option linter.unreachableTactic false
+
+namespace ZiskFv.Compliance.Extraction
+
+/-!
+# Production JALR expanded-row pins
+
+These predicates expose the complete decode-facing row shape emitted by the
+Aeneas-extracted production JALR lowerer.  In particular, the unaligned arm
+retains the first ADD row instead of projecting immediately to the terminal AND.
+-/
+
+def JalrRegisterOrX0SourcePins (i : riscv2zisk_single_row.Rv64imLoweringInput)
+    (row : zisk_inst.ZiskInst) : Prop :=
+  (i.rs1 = 0#u32 ∧ row.b_src = zisk_inst.SRC_IMM ∧
+      row.b_use_sp_imm1 = 0#u64 ∧ row.b_offset_imm0 = 0#u64) ∨
+  (i.rs1 ≠ 0#u32 ∧ row.b_src = zisk_inst.SRC_REG ∧
+      row.b_use_sp_imm1 = 0#u64 ∧ row.b_offset_imm0 = UScalar.cast UScalarTy.U64 i.rs1)
+
+def JalrDestinationPins (i : riscv2zisk_single_row.Rv64imLoweringInput)
+    (row : zisk_inst.ZiskInst) : Prop :=
+  (i.rd = 0#u32 ∧ row.store = 0#u64 ∧ row.store_offset = 0#i64 ∧
+      row.store_use_sp = false ∧ row.store_pc = false) ∨
+  (i.rd ≠ 0#u32 ∧ row.store = zisk_inst.STORE_REG ∧
+      row.store_offset = UScalar.hcast IScalarTy.I64 i.rd ∧
+      row.store_use_sp = false ∧ row.store_pc = true)
+
+def JalrAlignedRowPins (i : riscv2zisk_single_row.Rv64imLoweringInput)
+    (row : zisk_inst.ZiskInst) : Prop :=
+  row.op = 14#u8 ∧ row.jmp_offset2 = 4#i64 ∧
+  JalrDestinationPins i row ∧ JalrRegisterOrX0SourcePins i row ∧
+  row.is_external_op = true ∧ row.m32 = false ∧ row.set_pc = true
+
+def JalrUnalignedFirstRowPins (i : riscv2zisk_single_row.Rv64imLoweringInput)
+    (row : aeneas_extract.ZiskInstExtract) : Prop :=
+  row.op = 10#u8 ∧ row.jmp_offset1 = 1#i64 ∧ row.jmp_offset2 = 1#i64 ∧
+  row.a_src = zisk_inst.SRC_IMM ∧
+  row.a_use_sp_imm1.val = (IScalar.hcast UScalarTy.U64 i.imm).val / 2 ^ 32 ∧
+  row.a_offset_imm0.val = (IScalar.hcast UScalarTy.U64 i.imm).val % 2 ^ 32 ∧
+  JalrRegisterOrX0SourcePins i {
+    paddr := row.paddr, store_pc := row.store_pc, store_use_sp := row.store_use_sp,
+    store := row.store, store_offset := row.store_offset, set_pc := row.set_pc,
+    is_precompiled := row.is_precompiled, ind_width := row.ind_width, «end» := row.end,
+    a_src := row.a_src, a_use_sp_imm1 := row.a_use_sp_imm1, a_offset_imm0 := row.a_offset_imm0,
+    b_src := row.b_src, b_use_sp_imm1 := row.b_use_sp_imm1, b_offset_imm0 := row.b_offset_imm0,
+    jmp_offset1 := row.jmp_offset1, jmp_offset2 := row.jmp_offset2,
+    is_external_op := row.is_external_op, op := row.op,
+    op_type := zisk_inst.ZiskOperationType.None, m32 := row.m32,
+    input_size := row.input_size, sorted_pc_list_index := row.sorted_pc_list_index } ∧
+  row.is_external_op = true ∧ row.m32 = false ∧ row.set_pc = false ∧ row.store_pc = false
+
+def JalrUnalignedSuccessorRowPins (i : riscv2zisk_single_row.Rv64imLoweringInput)
+    (row : zisk_inst.ZiskInst) : Prop :=
+  row.op = 14#u8 ∧ row.jmp_offset1 = 0#i64 ∧ row.jmp_offset2 = 3#i64 ∧
+  JalrDestinationPins i row ∧ row.b_src = zisk_inst.SRC_C ∧
+  row.b_use_sp_imm1 = 0#u64 ∧ row.b_offset_imm0 = 0#u64 ∧
+  row.is_external_op = true ∧ row.m32 = false ∧ row.set_pc = true
+
+private theorem jalr_cast_rs1_zero_iff (x : Std.U32) :
+    UScalar.cast UScalarTy.U64 x = 0#u64 ↔ x = 0#u32 := by
+  constructor
+  · intro h
+    apply UScalar.eq_of_val_eq
+    have hv := congrArg UScalar.val h
+    simpa [cast_u32_u64_val] using hv
+  · rintro rfl
+    decide
+
+private theorem jalr_hcast_rd_zero_iff (x : Std.U32) :
+    (UScalar.hcast IScalarTy.I64 x : Std.I64) = 0#i64 ↔ x = 0#u32 := by
+  constructor
+  · intro h
+    apply UScalar.eq_of_val_eq
+    have hv := congrArg IScalar.val h
+    simpa [hcast_u32_i64_val] using hv
+  · rintro rfl
+    exact hcast_rd0
+
+private theorem jalr_hcast_four :
+    (UScalar.hcast IScalarTy.I64 4#u64 : Std.I64) = 4#i64 := by decide
+
+private theorem jalr_src_reg_ne_imm :
+    zisk_inst.SRC_REG ≠ zisk_inst.SRC_IMM := by
+  unfold zisk_inst.SRC_REG zisk_inst.SRC_IMM
+  decide
+
+private theorem jalr_zero_u64 :
+    (0#64#uscalar : Std.U64) = 0#u64 := by decide
+
+private theorem jalr_high_limb (x : Std.U64) :
+    (⟨x.bv >>> 32⟩ : Std.U64).val = x.val / 2 ^ 32 := by
+  change (x.bv >>> 32).toNat = x.bv.toNat / 2 ^ 32
+  rw [BitVec.toNat_ushiftRight, Nat.shiftRight_eq_div_pow]
+
+private theorem jalr_low_limb (x : Std.U64) :
+    (x &&& 4294967295#u64).val = x.val % 2 ^ 32 := by
+  change (x.bv &&& (BitVec.ofNat 64 4294967295)).toNat =
+    x.bv.toNat % 2 ^ 32
+  rw [BitVec.toNat_and, BitVec.toNat_ofNat]
+  have h := Nat.and_two_pow_sub_one_eq_mod x.bv.toNat 32
+  norm_num at h ⊢
+  exact h
+
+private theorem jalr_low_nat (n : Nat) :
+    n &&& 4294967295 = n % 4294967296 := by
+  have h := Nat.and_two_pow_sub_one_eq_mod n 32
+  norm_num at h ⊢
+  exact h
+
+private theorem src_b_reg_false_main_pins
+    (self z : zisk_inst_builder.ZiskInstBuilder) (reg : Std.U64)
+    (hlt : reg.val < 32)
+    (h : self.src_b_reg reg false = ok z) :
+    (reg = 0#u64 ∧ z.i.b_src = zisk_inst.SRC_IMM ∧
+        z.i.b_use_sp_imm1 = 0#u64 ∧ z.i.b_offset_imm0 = 0#u64) ∨
+    (reg ≠ 0#u64 ∧ z.i.b_src = zisk_inst.SRC_REG ∧
+        z.i.b_use_sp_imm1 = 0#u64 ∧ z.i.b_offset_imm0 = reg) := by
+  have hnotAbove : ¬ 31 < reg.val := by omega
+  have haboveFalse (habove : 31 < reg.val) : False := hnotAbove habove
+  have hregFrom :
+      (UScalar.cast UScalarTy.U64 zisk_registers.REGS_IN_MAIN_FROM).val = 1 := by
+    simp [zisk_registers.REGS_IN_MAIN_FROM, UScalar.cast,
+      UScalarTy.USize.numBits_eq]
+    cases System.Platform.numBits_eq <;> simp_all <;> decide
+  have hregTo :
+      (UScalar.cast UScalarTy.U64 zisk_registers.REGS_IN_MAIN_TO).val = 31 := by
+    simp [zisk_registers.REGS_IN_MAIN_TO, UScalar.cast,
+      UScalarTy.USize.numBits_eq]
+    cases System.Platform.numBits_eq <;> simp_all <;> decide
+  simp only [zisk_inst_builder.ZiskInstBuilder.src_b_reg,
+    zisk_inst_builder.ZiskInstBuilder.src_b_imm,
+    zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO,
+    HShiftRight.hShiftRight, UScalar.shiftRight_IScalar, UScalar.shiftRight,
+    lift, bind_ok, Bind.bind] at h
+  split_ifs at h with hzero hbelow habove huse <;>
+    (try exact (haboveFalse habove).elim) <;>
+    (try rw [Result.ok.injEq] at h) <;>
+    (try subst z) <;>
+    (try cases h) <;>
+    simp_all [hregFrom, hregTo, hnotAbove, haboveFalse] <;>
+      (try have : False := (not_lt_of_ge hnotAbove) (by assumption); contradiction) <;>
+      try decide <;> try scalar_tac <;> try omega
+
+set_option maxHeartbeats 8000000 in
+theorem jalr_production_expanded_row_pins
+    (i : riscv2zisk_single_row.Rv64imLoweringInput)
+    (ctx : riscv2zisk_context.Riscv2ZiskContext)
+    (hrdlt : i.rd.val < 32)
+    (hrs1 : i.rs1.val < 32)
+    (h : riscv2zisk_context.Riscv2ZiskContext.jalr
+      { defCtx with extract_marker := () } i 4#u64 = ok ctx) :
+    (i.imm % 4#i32 = ok 0#i32 ∧ ctx.extract_first_inst = none ∧
+        ∃ row, ctx.extract_inst = some row ∧ JalrAlignedRowPins i row.i) ∨
+    (∃ rem, i.imm % 4#i32 = ok rem ∧ rem ≠ 0#i32 ∧
+      ∃ first last, ctx.extract_first_inst = some first ∧ ctx.extract_inst = some last ∧
+        JalrUnalignedFirstRowPins i first ∧ JalrUnalignedSuccessorRowPins i last.i) := by
+  have hregFrom :
+      (UScalar.hcast IScalarTy.I64 zisk_registers.REGS_IN_MAIN_FROM : Std.I64).val = 1 := by
+    simp [zisk_registers.REGS_IN_MAIN_FROM, UScalar.hcast, UScalarTy.USize.numBits_eq]
+    cases System.Platform.numBits_eq <;> simp_all <;> decide
+  have hregTo :
+      (UScalar.hcast IScalarTy.I64 zisk_registers.REGS_IN_MAIN_TO : Std.I64).val = 31 := by
+    simp [zisk_registers.REGS_IN_MAIN_TO, UScalar.hcast, UScalarTy.USize.numBits_eq]
+    cases System.Platform.numBits_eq <;> simp_all <;> decide
+  have hregFromU :
+      (UScalar.cast UScalarTy.U64 zisk_registers.REGS_IN_MAIN_FROM).val = 1 := by
+    simp [zisk_registers.REGS_IN_MAIN_FROM, UScalar.cast,
+      UScalarTy.USize.numBits_eq]
+    cases System.Platform.numBits_eq <;> simp_all <;> decide
+  have hregToU :
+      (UScalar.cast UScalarTy.U64 zisk_registers.REGS_IN_MAIN_TO).val = 31 := by
+    simp [zisk_registers.REGS_IN_MAIN_TO, UScalar.cast,
+      UScalarTy.USize.numBits_eq]
+    cases System.Platform.numBits_eq <;> simp_all <;> decide
+  have hrdcast := hcast_u32_i64_val i.rd
+  have hrs1cast := cast_u32_u64_val i.rs1
+  have hrdnonneg : 0 ≤ (UScalar.hcast IScalarTy.I64 i.rd : Std.I64).val := by
+    rw [hrdcast]
+    omega
+  have hrdle : (UScalar.hcast IScalarTy.I64 i.rd : Std.I64).val ≤ 31 := by
+    rw [hrdcast]
+    omega
+  have hrs1le : (UScalar.cast UScalarTy.U64 i.rs1).val ≤ 31 := by
+    rw [hrs1cast]
+    omega
+  have hrdpos (hne : i.rd ≠ 0#u32) :
+      1 ≤ (UScalar.hcast IScalarTy.I64 i.rd : Std.I64).val := by
+    have hcastne : (UScalar.hcast IScalarTy.I64 i.rd : Std.I64) ≠ 0#i64 :=
+      mt (jalr_hcast_rd_zero_iff i.rd).mp hne
+    have hvalne : (UScalar.hcast IScalarTy.I64 i.rd : Std.I64).val ≠ 0 := by
+      intro hv
+      apply hcastne
+      apply IScalar.eq_of_val_eq
+      simpa using hv
+    omega
+  have hrs1pos (hne : i.rs1 ≠ 0#u32) :
+      1 ≤ (UScalar.cast UScalarTy.U64 i.rs1).val := by
+    have hcastne : UScalar.cast UScalarTy.U64 i.rs1 ≠ 0#u64 :=
+      mt (jalr_cast_rs1_zero_iff i.rs1).mp hne
+    have hvalne : (UScalar.cast UScalarTy.U64 i.rs1).val ≠ 0 := by
+      intro hv
+      apply hcastne
+      apply UScalar.eq_of_val_eq
+      simpa using hv
+    omega
+  have hrdnotAbove :
+      ¬ (UScalar.hcast IScalarTy.I64 i.rd : Std.I64) >
+        UScalar.hcast IScalarTy.I64 zisk_registers.REGS_IN_MAIN_TO := by
+    intro habove
+    scalar_tac
+  have hrs1notAbove :
+      ¬ UScalar.cast UScalarTy.U64 i.rs1 >
+        UScalar.cast UScalarTy.U64 zisk_registers.REGS_IN_MAIN_TO := by
+    intro habove
+    scalar_tac
+  have hrdnotBelow (hne : i.rd ≠ 0#u32) :
+      ¬ (UScalar.hcast IScalarTy.I64 i.rd : Std.I64) <
+        UScalar.hcast IScalarTy.I64 zisk_registers.REGS_IN_MAIN_FROM := by
+    intro hbelow
+    have hpos := hrdpos hne
+    scalar_tac
+  have hrs1notBelow (hne : i.rs1 ≠ 0#u32) :
+      ¬ UScalar.cast UScalarTy.U64 i.rs1 <
+        UScalar.cast UScalarTy.U64 zisk_registers.REGS_IN_MAIN_FROM := by
+    intro hbelow
+    have hpos := hrs1pos hne
+    scalar_tac
+  rw [riscv2zisk_context.Riscv2ZiskContext.jalr] at h
+  obtain ⟨rem, hrem, h⟩ := bind_eq_ok_imp h
+  simp only [hrem, bind_ok, Bind.bind] at h
+  by_cases haligned : rem = 0#i32
+  · rw [if_pos haligned] at h
+    simp only [lift, bind_ok, Bind.bind] at h
+    obtain ⟨z0, hz0, h⟩ := bind_eq_ok_imp h
+    obtain ⟨z1, hz1, h⟩ := bind_eq_ok_imp h
+    obtain ⟨z2, hz2, h⟩ := bind_eq_ok_imp h
+    obtain ⟨z3, hz3, h⟩ := bind_eq_ok_imp h
+    obtain ⟨z4, hz4, h⟩ := bind_eq_ok_imp h
+    obtain ⟨z5, hz5, h⟩ := bind_eq_ok_imp h
+    obtain ⟨z6, hz6, h⟩ := bind_eq_ok_imp h
+    obtain ⟨z7, hz7, h⟩ := bind_eq_ok_imp h
+    obtain ⟨s1, hs1, h⟩ := bind_eq_ok_imp h
+    have hz76 := build_eq _ _ hz7
+    rw [Result.ok.injEq] at h
+    subst ctx
+    left
+    refine ⟨haligned ▸ hrem, ?_, z7, ?_, ?_⟩
+    · simp only [riscv2zisk_context.Riscv2ZiskContext.insert_inst, bind_ok,
+        Bind.bind] at hs1
+      rw [Result.ok.injEq] at hs1
+      subst s1
+      rfl
+    · exact insert_inst_extract _ _ _ _ hs1
+    · subst z7
+      simp only [JalrAlignedRowPins, JalrDestinationPins, JalrRegisterOrX0SourcePins,
+        hz0, hz1, hz2, hz3, hz4, hz5, hz6,
+        zisk_inst_builder.ZiskInstBuilder.new_for_rv64im_lowering,
+        zisk_inst_builder.ZiskInstBuilder.new,
+        zisk_inst_builder.ZiskInstBuilder.Insts.CoreDefaultDefault.default,
+        zisk_inst.ZiskInst.Insts.CoreDefaultDefault.default,
+        zisk_inst_builder.ZiskInstBuilder.src_a_imm,
+        zisk_inst_builder.ZiskInstBuilder.src_b_reg,
+        zisk_inst_builder.ZiskInstBuilder.src_b_imm,
+        zisk_inst_builder.ZiskInstBuilder.op_zisk,
+        zisk_inst_builder.ZiskInstBuilder.set_runtime_op_fields,
+        zisk_inst_builder.ZiskInstBuilder.store_pc_reg,
+        zisk_inst_builder.ZiskInstBuilder.store_reg,
+        zisk_inst_builder.ZiskInstBuilder.set_pc,
+        zisk_inst_builder.ZiskInstBuilder.j,
+        zisk_inst_builder.ZiskInstBuilder.build,
+        riscv2zisk_context.Riscv2ZiskContext.jalr.JALR_MASK,
+        zisk_ops.ZiskOp.op_type, zisk_ops.ZiskOp.code, zisk_ops.ZiskOp.input_size,
+        zisk_ops.ZiskOp.is_m32, core.convert.IntoFrom.into,
+        zisk_inst.ZiskOperationType.Insts.CoreConvertFromOpType.from,
+        IScalar.cast, reduceIte,
+        HShiftRight.hShiftRight, UScalar.shiftRight_IScalar, UScalar.shiftRight,
+        lift, bind_ok, Bind.bind] at hz0 hz1 hz2 hz3 hz4 hz5 hz6 ⊢
+      split_ifs at hz0 hz1 hz2 hz3 hz4 hz5 hz6 ⊢ <;>
+        by_cases hrd0 : i.rd = 0#u32 <;>
+        by_cases hrs10 : i.rs1 = 0#u32 <;>
+        (try have hrdpos' := hrdpos hrd0) <;>
+        (try have hrs1pos' := hrs1pos hrs10) <;>
+        (try have hrdnotBelow' := hrdnotBelow hrd0) <;>
+        (try have hrs1notBelow' := hrs1notBelow hrs10) <;>
+        (try have hrdcast0 := (jalr_hcast_rd_zero_iff i.rd).mpr hrd0) <;>
+        (try have hrs1cast0 := (jalr_cast_rs1_zero_iff i.rs1).mpr hrs10) <;>
+        (try have hrdzero' : i.rd = 0#u32 :=
+          (jalr_hcast_rd_zero_iff i.rd).mp (by assumption)) <;>
+        (try have hrs1zero' : i.rs1 = 0#u32 :=
+          (jalr_cast_rs1_zero_iff i.rs1).mp (by assumption)) <;>
+        (try rw [Result.ok.injEq] at hz0) <;>
+        (try rw [Result.ok.injEq] at hz1) <;>
+        (try rw [Result.ok.injEq] at hz2) <;>
+        (try rw [Result.ok.injEq] at hz3) <;>
+        (try rw [Result.ok.injEq] at hz4) <;>
+        (try rw [Result.ok.injEq] at hz5) <;>
+        (try rw [Result.ok.injEq] at hz6) <;>
+        (try cases hz6) <;> (try cases hz5) <;> (try cases hz4) <;>
+        (try cases hz3) <;> (try cases hz2) <;> (try cases hz1) <;>
+        (try cases hz0) <;>
+        simp [cast_u32_u64_val, hcast_u32_i64_val,
+          hrd0, hrs10, hcast_rd0, hcast_rd_ne_zero,
+          jalr_cast_rs1_zero_iff, jalr_hcast_rd_zero_iff,
+          jalr_hcast_four, jalr_src_reg_ne_imm, jalr_zero_u64,
+          zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO,
+          hregFrom, hregTo,
+          one_i64_val_not_lt_regs_from_set_width,
+          regs_to_set_width_val_not_lt_one_i64] <;>
+        (try have : False := (not_lt_of_ge hrs1le) (by assumption); contradiction) <;>
+        (try have : False := (not_lt_of_ge hrdle) (by assumption); contradiction) <;>
+        (try have : False := (not_lt_of_ge hrs1pos') (by assumption); contradiction) <;>
+        (try have : False := (not_lt_of_ge hrdpos') (by assumption); contradiction) <;>
+        try contradiction <;>
+        (try apply UScalar.eq_of_val_eq; decide) <;>
+        try rfl <;> try decide <;> try norm_num [zisk_inst.STORE_REG] <;>
+        try scalar_tac <;> omega
+  · rw [if_neg haligned] at h
+    simp only [lift, bind_ok, Bind.bind] at h
+    obtain ⟨z0, hz0, h⟩ := bind_eq_ok_imp h
+    obtain ⟨z1, hz1, h⟩ := bind_eq_ok_imp h
+    obtain ⟨z2, hz2, h⟩ := bind_eq_ok_imp h
+    obtain ⟨z3, hz3, h⟩ := bind_eq_ok_imp h
+    obtain ⟨z4, hz4, h⟩ := bind_eq_ok_imp h
+    obtain ⟨z5, hz5, h⟩ := bind_eq_ok_imp h
+    have hz54 := build_eq _ _ hz5
+    obtain ⟨s1, hs1, h⟩ := bind_eq_ok_imp h
+    obtain ⟨roma, hroma, h⟩ := bind_eq_ok_imp h
+    obtain ⟨z6, hz6, h⟩ := bind_eq_ok_imp h
+    obtain ⟨z7, hz7, h⟩ := bind_eq_ok_imp h
+    obtain ⟨z8, hz8, h⟩ := bind_eq_ok_imp h
+    obtain ⟨z9, hz9, h⟩ := bind_eq_ok_imp h
+    obtain ⟨z10, hz10, h⟩ := bind_eq_ok_imp h
+    obtain ⟨z11, hz11, h⟩ := bind_eq_ok_imp h
+    obtain ⟨three, hthree, h⟩ := bind_eq_ok_imp h
+    have hthree3 : three = 3#i64 := by
+      have hh :
+          (UScalar.hcast IScalarTy.I64 4#u64 : Std.I64) - 1#i64 = ok 3#i64 := by
+        rfl
+      rw [hh] at hthree
+      exact Result.ok.inj hthree.symm
+    obtain ⟨z12, hz12, h⟩ := bind_eq_ok_imp h
+    obtain ⟨z13, hz13, h⟩ := bind_eq_ok_imp h
+    have hz1312 := build_eq _ _ hz13
+    obtain ⟨s2, hs2, h⟩ := bind_eq_ok_imp h
+    rw [Result.ok.injEq] at h
+    subst ctx
+    let first : aeneas_extract.ZiskInstExtract :=
+      { paddr := z5.i.paddr, store_pc := z5.i.store_pc,
+        store_use_sp := z5.i.store_use_sp, store := z5.i.store,
+        store_offset := z5.i.store_offset, set_pc := z5.i.set_pc,
+        is_precompiled := z5.i.is_precompiled, ind_width := z5.i.ind_width,
+        «end» := z5.i.end, a_src := z5.i.a_src,
+        a_use_sp_imm1 := z5.i.a_use_sp_imm1,
+        a_offset_imm0 := z5.i.a_offset_imm0, b_src := z5.i.b_src,
+        b_use_sp_imm1 := z5.i.b_use_sp_imm1,
+        b_offset_imm0 := z5.i.b_offset_imm0,
+        jmp_offset1 := z5.i.jmp_offset1, jmp_offset2 := z5.i.jmp_offset2,
+        is_external_op := z5.i.is_external_op, op := z5.i.op,
+        op_type_id := UScalar.cast UScalarTy.U32 (read_discriminant z5.i.op_type),
+        m32 := z5.i.m32, input_size := z5.i.input_size,
+        sorted_pc_list_index := z5.i.sorted_pc_list_index }
+    right
+    refine ⟨rem, hrem, haligned, ?_⟩
+    refine ⟨first, z13, ?_, insert_inst_extract _ _ _ _ hs2, ?_, ?_⟩
+    · simp only [riscv2zisk_context.Riscv2ZiskContext.insert_inst, bind_ok,
+        Bind.bind] at hs1 hs2
+      rw [Result.ok.injEq] at hs1 hs2
+      subst s1
+      subst s2
+      rfl
+    · simp only [first]
+      subst z5
+      simp only [JalrUnalignedFirstRowPins, JalrRegisterOrX0SourcePins,
+        hz0, hz1, hz2, hz3, hz4,
+        zisk_inst_builder.ZiskInstBuilder.new_for_rv64im_lowering,
+        zisk_inst_builder.ZiskInstBuilder.new,
+        zisk_inst_builder.ZiskInstBuilder.Insts.CoreDefaultDefault.default,
+        zisk_inst.ZiskInst.Insts.CoreDefaultDefault.default,
+        zisk_inst_builder.ZiskInstBuilder.src_a_imm,
+        zisk_inst_builder.ZiskInstBuilder.src_b_reg,
+        zisk_inst_builder.ZiskInstBuilder.src_b_imm,
+        zisk_inst_builder.ZiskInstBuilder.op_zisk,
+        zisk_inst_builder.ZiskInstBuilder.set_runtime_op_fields,
+        zisk_inst_builder.ZiskInstBuilder.j,
+        zisk_inst_builder.ZiskInstBuilder.build,
+        zisk_ops.ZiskOp.op_type, zisk_ops.ZiskOp.code, zisk_ops.ZiskOp.input_size,
+        zisk_ops.ZiskOp.is_m32, core.convert.IntoFrom.into,
+        zisk_inst.ZiskOperationType.Insts.CoreConvertFromOpType.from,
+        HShiftRight.hShiftRight, UScalar.shiftRight_IScalar, UScalar.shiftRight,
+        lift, bind_ok, Bind.bind] at *
+      rw [Result.ok.injEq] at hz4
+      subst z4
+      rw [Result.ok.injEq] at hz3
+      subst z3
+      split_ifs at * <;>
+        (try contradiction) <;>
+        (try rw [Result.ok.injEq] at hz2) <;>
+        (try cases hz2) <;>
+        (try rw [Result.ok.injEq] at hz1) <;>
+        (try cases hz1) <;>
+        (try rw [Result.ok.injEq] at hz0) <;>
+        (try cases hz0) <;>
+        (try subst z0) <;> (try subst z1) <;> (try subst z2) <;>
+        (try subst z3) <;> (try subst z4) <;> (try subst z5) <;>
+        simp_all [cast_u32_u64_val, hcast_u32_i64_val,
+          jalr_cast_rs1_zero_iff, jalr_src_reg_ne_imm, jalr_zero_u64,
+          jalr_high_limb, jalr_low_limb, jalr_low_nat,
+          zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO,
+          hregFrom, hregTo,
+          one_i64_val_not_lt_regs_from_set_width,
+          regs_to_set_width_val_not_lt_one_i64,
+          Nat.mod_eq_of_lt, BitVec.toNat_ushiftRight,
+          Nat.shiftRight_eq_div_pow] <;> try decide <;> omega
+    · subst z13
+      simp only [JalrUnalignedSuccessorRowPins, JalrDestinationPins,
+        hz6, hz7, hz8, hz9, hz10, hz11,
+        hthree, hz12,
+        zisk_inst_builder.ZiskInstBuilder.new,
+        zisk_inst_builder.ZiskInstBuilder.Insts.CoreDefaultDefault.default,
+        zisk_inst.ZiskInst.Insts.CoreDefaultDefault.default,
+        zisk_inst_builder.ZiskInstBuilder.src_a_imm,
+        zisk_inst_builder.ZiskInstBuilder.src_b_lastc,
+        zisk_inst_builder.ZiskInstBuilder.op_zisk,
+        zisk_inst_builder.ZiskInstBuilder.set_runtime_op_fields,
+        zisk_inst_builder.ZiskInstBuilder.store_pc_reg,
+        zisk_inst_builder.ZiskInstBuilder.store_reg,
+        zisk_inst_builder.ZiskInstBuilder.set_pc,
+        zisk_inst_builder.ZiskInstBuilder.j,
+        zisk_inst_builder.ZiskInstBuilder.build,
+        riscv2zisk_context.Riscv2ZiskContext.jalr.JALR_MASK,
+        zisk_ops.ZiskOp.op_type, zisk_ops.ZiskOp.code, zisk_ops.ZiskOp.input_size,
+        zisk_ops.ZiskOp.is_m32, core.convert.IntoFrom.into,
+        zisk_inst.ZiskOperationType.Insts.CoreConvertFromOpType.from,
+        HShiftRight.hShiftRight, UScalar.shiftRight_IScalar, UScalar.shiftRight,
+        lift, bind_ok, Bind.bind] at *
+      rw [Result.ok.injEq] at hz12
+      subst z12
+      rw [Result.ok.injEq] at hz11
+      subst z11
+      rw [Result.ok.injEq] at hz9
+      subst z9
+      rw [Result.ok.injEq] at hz8
+      subst z8
+      split_ifs at * <;>
+        (try contradiction) <;>
+        (try have hrdzero' : i.rd = 0#u32 :=
+          (jalr_hcast_rd_zero_iff i.rd).mp (by assumption)) <;>
+        (try rw [Result.ok.injEq] at hz6) <;>
+        (try cases hz6) <;>
+        (try rw [Result.ok.injEq] at hz7) <;>
+        (try cases hz7) <;>
+        (try rw [Result.ok.injEq] at hz10) <;>
+        (try subst z6) <;> (try subst z7) <;> (try subst z8) <;>
+        (try subst z9) <;> (try subst z10) <;> (try subst z11) <;>
+        (try subst z12) <;> (try subst z13) <;>
+        simp_all [cast_u32_u64_val, hcast_u32_i64_val,
+          hthree3, jalr_hcast_rd_zero_iff, hcast_rd0,
+          zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO,
+          hregFrom, hregTo,
+          one_i64_val_not_lt_regs_from_set_width,
+          regs_to_set_width_val_not_lt_one_i64] <;> try decide <;> omega
+
+end ZiskFv.Compliance.Extraction

--- a/ZiskFv/Compliance/AeneasBridgeTrust/Extraction/JalrRows.lean
+++ b/ZiskFv/Compliance/AeneasBridgeTrust/Extraction/JalrRows.lean
@@ -35,7 +35,8 @@ def JalrDestinationPins (i : riscv2zisk_single_row.Rv64imLoweringInput)
 
 def JalrAlignedRowPins (i : riscv2zisk_single_row.Rv64imLoweringInput)
     (row : zisk_inst.ZiskInst) : Prop :=
-  row.op = 14#u8 ∧ row.jmp_offset2 = 4#i64 ∧
+  row.op = 14#u8 ∧ row.jmp_offset1 = IScalar.cast IScalarTy.I64 i.imm ∧
+  row.jmp_offset2 = 4#i64 ∧
   JalrDestinationPins i row ∧ JalrRegisterOrX0SourcePins i row ∧
   row.is_external_op = true ∧ row.m32 = false ∧ row.set_pc = true
 

--- a/ZiskFv/Compliance/DivSpinRootSoundness/DefectExclusions.lean
+++ b/ZiskFv/Compliance/DivSpinRootSoundness/DefectExclusions.lean
@@ -81,10 +81,15 @@ def divSpinDivOutsideDefectRegion :
 def divSpinJalOutsideDefectRegion :
     RowOutsideDefectRegion divSpinAcceptedTrace divSpinJalIndex
       (divSpinZiskStep divSpinJalIndex) where
-  h_no_fgl_wrap := by
+  h_target_nonneg := by
     unfold mainPcVal
     rw [divSpinMainPc]
-    change 12 + (BitVec.signExtend 64 (0#21)).toNat < GL_prime
+    change 0 ≤ (12 : Int) + (BitVec.signExtend 64 (0#21)).toInt
+    simp
+  h_target_lt := by
+    unfold mainPcVal
+    rw [divSpinMainPc]
+    change (12 : Int) + (BitVec.signExtend 64 (0#21)).toInt < GL_prime
     simp
   h_pc_bound := by
     unfold MainSequentialPcDomain mainPcVal

--- a/ZiskFv/Compliance/DivSpinRootSoundness/Final.lean
+++ b/ZiskFv/Compliance/DivSpinRootSoundness/Final.lean
@@ -9,7 +9,7 @@ theorem divSpinRootSoundness :
     ∀ i : Fin 4,
       StepSound divSpinAcceptedTrace divSpinSailTrace i (divSpinZiskStep i)
         (rowDecode_of_programDecode divSpinAcceptedTrace i (divSpinProgramDecodes i)) :=
-  root_soundness 4 divSpinAcceptedTrace divSpinSailTrace divSpinZiskStep
+  stepSound_of_programDecodes 4 divSpinAcceptedTrace divSpinSailTrace divSpinZiskStep
     divSpinProgramDecodes divSpinInputsAgree divSpinBootSeed
     divSpinOutsideDefectRegion
 

--- a/ZiskFv/Compliance/DivSpinRootSoundness/State.lean
+++ b/ZiskFv/Compliance/DivSpinRootSoundness/State.lean
@@ -6,7 +6,7 @@ set_option maxHeartbeats 8000000
 set_option Elab.async false
 
 /-!
-# Concrete `root_soundness` instantiation for signed DIV
+# Concrete `stepSound_of_programDecodes` instantiation for signed DIV
 
 The four executed rows initialize x1 and x2, compute `6 / 2 = 3`, and finish
 at the self-looping JAL.  The DIV input is reconstructed from the accepted

--- a/ZiskFv/Compliance/EnsembleWitnessBuilder.lean
+++ b/ZiskFv/Compliance/EnsembleWitnessBuilder.lean
@@ -8,7 +8,7 @@ from a position-indexed row assignment, together with a lemma-driven
 `BalancedInteractions` combinator and the generic verifier-empty reductions of
 `Constraints` / `BalancedChannels` to per-`tables` obligations.
 
-This is the foundation for instantiating `ZiskFv.Compliance.root_soundness` on a
+This is the foundation for instantiating `ZiskFv.Compliance.stepSound_of_programDecodes` on a
 concrete accepted trace (eth-act/zisk-fv#217, feeding #218/#219). Nothing here is
 ZisK-specific: everything is stated over an abstract `Air.Flat.Ensemble`.
 

--- a/ZiskFv/Compliance/JalrSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/JalrSpinRootSoundness.lean
@@ -251,13 +251,14 @@ def jalrProgramDecode :
           jalrAcceptedTrace.program jalrAcceptedTrace.mainTable 2).core.c_1 = 0
         rw [mainRawAt_finish]
         rfl
-      h_offset_bridge := by
-        simp [jalrIndex, jalrClaim, jalrAndProgramRow, jalrAndBits,
-          ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
-          jalrAndRowTemplate, ZiskFv.AirsClean.Main.mainRomRowOf]
       h_offset_even := by simp [jalrClaim]
-      h_no_fgl_wrap := by
-        norm_num [jalrIndex, jalrAndProgramRow, jalrAndBits,
+      h_target_nonneg := by
+        norm_num [jalrIndex, jalrClaim, jalrAndProgramRow, jalrAndBits,
+          ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
+          jalrAndRowWithLast, jalrAndRowTemplate,
+          ZiskFv.AirsClean.Main.mainRomRowOf]
+      h_target_lt := by
+        norm_num [jalrIndex, jalrClaim, jalrAndProgramRow, jalrAndBits,
           ZiskFv.AirsClean.FullEnsemble.mainOfTable, jalrAndRow,
           jalrAndRowWithLast, jalrAndRowTemplate,
           ZiskFv.AirsClean.Main.mainRomRowOf]
@@ -266,6 +267,7 @@ def jalrProgramDecode :
       h_add_m32 := rfl
       h_add_set_pc := rfl
       h_add_a_src_imm := rfl
+      h_add_b_src_imm := rfl
       h_add_b_src_reg := rfl
       andBits := jalrAndBits
       h_and_ieo := rfl

--- a/ZiskFv/Compliance/JalrSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/JalrSpinRootSoundness.lean
@@ -4,7 +4,7 @@ import ZiskFv.Soundness
 set_option maxRecDepth 10000
 
 /-!
-# Concrete `root_soundness` instantiation for unaligned JALR lowering
+# Concrete `stepSound_of_programDecodes` instantiation for unaligned JALR lowering
 
 The architectural trace executes `ADDI x1,x0,2`, then `JALR x2,2(x1)`.
 The JALR is represented by adjacent physical Main rows `ADD; AND`; the
@@ -495,7 +495,7 @@ theorem jalrSpinRootSoundness :
     ∀ i : Fin 2,
       StepSound jalrAcceptedTrace sailTrace i (jalrSpinZiskStep i)
         (rowDecode_of_programDecode jalrAcceptedTrace i (programDecodes i)) :=
-  root_soundness 2 jalrAcceptedTrace sailTrace jalrSpinZiskStep
+  stepSound_of_programDecodes 2 jalrAcceptedTrace sailTrace jalrSpinZiskStep
     programDecodes inputsAgree bootSeed outsideDefectRegion
 
 theorem jalrStepSound :

--- a/ZiskFv/Compliance/Pilot/JalrNextPC.lean
+++ b/ZiskFv/Compliance/Pilot/JalrNextPC.lean
@@ -1,5 +1,6 @@
 import ZiskFv.Compliance.Pilot.SubNextPC
 import ZiskFv.EquivCore.And
+import ZiskFv.Bits.PackedBitVec.WidePCNoWrap
 
 /-!
 # Pilot next-PC discharge for JALR (#100): the masked AND jump target
@@ -205,12 +206,15 @@ theorem jalr_setpc_nextPC_discharged
     (hc6 : row.cBytes.free_in_c_6.val < 256) (hc7 : row.cBytes.free_in_c_7.val < 256)
     (h_c1_zero : (mainOfTable trace.program trace.mainTable).c_1 i.val = 0)
     (h_offset_bridge :
-      ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val).val
-        = offset_bv.toNat)
+      (mainOfTable trace.program trace.mainTable).jmp_offset1 i.val =
+        (offset_bv.toInt : FGL))
     (h_offset_even : offset_bv &&& 1#64 = 0#64)
-    (h_no_fgl_wrap :
-      ((mainOfTable trace.program trace.mainTable).c_0 i.val).val
-        + ((mainOfTable trace.program trace.mainTable).jmp_offset1 i.val).val < GL_prime) :
+    (h_target_nonneg :
+      0 ≤ (((mainOfTable trace.program trace.mainTable).c_0 i.val).val : Int)
+        + offset_bv.toInt)
+    (h_target_lt :
+      (((mainOfTable trace.program trace.mainTable).c_0 i.val).val : Int)
+        + offset_bv.toInt < GL_prime) :
     (register_type_pc_equiv ▸
         (BitVec.ofNat 64 ((execRowAt trace i)[1]!.pc).val))
       = 0xFFFFFFFFFFFFFFFE#64 &&& (operand + offset_bv) := by
@@ -219,9 +223,29 @@ theorem jalr_setpc_nextPC_discharged
         = (0xFFFFFFFFFFFFFFFE#64 &&& operand).toNat :=
     jalr_c0_val_eq_masked_operand row _ _ operand h_matches h_match_clo h_match_chi
       h_a_mask h_b_operand hc0 hc1 hc2 hc3 hc4 hc5 hc6 hc7 h_c1_zero
+  have h_target_nonneg' :
+      0 ≤ (((0xFFFFFFFFFFFFFFFE#64 &&& operand).toNat : Int)
+        + offset_bv.toInt) := by
+    rw [← h_c0]
+    exact h_target_nonneg
+  have h_target_lt' :
+      (((0xFFFFFFFFFFFFFFFE#64 &&& operand).toNat : Int)
+        + offset_bv.toInt) < GL_prime := by
+    rw [← h_c0]
+    exact h_target_lt
   rw [setpc_path_nextPC_discharged_at trace i h_idx h_set_pc h_flag,
-      ofNat_fgl_pc_plus_offset_eq _ _ (0xFFFFFFFFFFFFFFFE#64 &&& operand) offset_bv
-        h_c0 h_offset_bridge h_no_fgl_wrap,
-      masked_add_offset_even operand offset_bv h_offset_even]
+      h_offset_bridge,
+      ZiskFv.PackedBitVec.WidePCNoWrap.fgl_pc_plus_signed_offset_val _
+        (0xFFFFFFFFFFFFFFFE#64 &&& operand) offset_bv
+        h_c0 h_target_nonneg' h_target_lt']
+  calc
+    BitVec.ofNat 64
+        ((0xFFFFFFFFFFFFFFFE#64 &&& operand) + offset_bv).toNat =
+        (0xFFFFFFFFFFFFFFFE#64 &&& operand) + offset_bv := by
+          simpa using
+            (BitVec.ofNat_toNat 64
+              ((0xFFFFFFFFFFFFFFFE#64 &&& operand) + offset_bv))
+    _ = 0xFFFFFFFFFFFFFFFE#64 &&& (operand + offset_bv) :=
+      masked_add_offset_even operand offset_bv h_offset_even
 
 end ZiskFv.Compliance.Pilot

--- a/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
@@ -4,7 +4,7 @@ import ZiskFv.Soundness
 set_option maxRecDepth 10000
 
 /-!
-# Concrete `root_soundness` instantiation for the SD/LD spin trace (#221)
+# Concrete `stepSound_of_programDecodes` instantiation for the SD/LD spin trace (#221)
 
 The seven executed rows initialize x1 and x2, store 42 to `0xA0000008`,
 load it into x3, and finish at the self-looping JAL.
@@ -1021,7 +1021,7 @@ theorem sdLdRootSoundness :
     ∀ i : Fin 7, StepSound sdLdAcceptedTrace sdLdSailTrace i
       (sdLdZiskStep i)
       (rowDecode_of_programDecode sdLdAcceptedTrace i (sdLdProgramDecodes i)) :=
-  root_soundness 7 sdLdAcceptedTrace sdLdSailTrace sdLdZiskStep
+  stepSound_of_programDecodes 7 sdLdAcceptedTrace sdLdSailTrace sdLdZiskStep
     sdLdProgramDecodes sdLdInputsAgree sdLdBootSeed sdLdOutsideDefectRegion
 
 theorem sdLdAddiA0StepSound :

--- a/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
@@ -984,10 +984,15 @@ def sdLdLdOutsideDefectRegion :
 def sdLdJalOutsideDefectRegion :
     RowOutsideDefectRegion sdLdAcceptedTrace sdLdJalIndex
       (sdLdZiskStep sdLdJalIndex) where
-  h_no_fgl_wrap := by
+  h_target_nonneg := by
     unfold mainPcVal
     rw [sdLdMainPc]
-    change 24 + (BitVec.signExtend 64 (0#21)).toNat < GL_prime
+    change 0 ≤ (24 : Int) + (BitVec.signExtend 64 (0#21)).toInt
+    simp
+  h_target_lt := by
+    unfold mainPcVal
+    rw [sdLdMainPc]
+    change (24 : Int) + (BitVec.signExtend 64 (0#21)).toInt < GL_prime
     simp
   h_pc_bound := by
     unfold MainSequentialPcDomain mainPcVal

--- a/ZiskFv/Compliance/TraceLevelExport.lean
+++ b/ZiskFv/Compliance/TraceLevelExport.lean
@@ -16,7 +16,7 @@ import ZiskFv.Compliance.TraceLevelExport.BootSegmentMemorySeedWitness
 
 This is the achievable closure of #61.  It exports the per-opcode
 `construction_<op>_sound` theorems to a single trace-level statement
-(`root_soundness`, in `ZiskFv/Soundness.lean`) in the channel-balance form:
+(`stepSound_of_programDecodes`, in `ZiskFv/Soundness.lean`) in the channel-balance form:
 given an accepted full-ensemble trace and a program binding, with each row's
 residual split three ways — `ziskStep i : ZiskStep` (which op decoded + its
 `Claim_<op>`), `rowDecodes i : RowDecode` (the circuit-checkable `Decode_<op>`),

--- a/ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/Dispatcher.lean
@@ -1636,7 +1636,7 @@ theorem stepSound_of_evidence (ziskTrace : AcceptedZiskTrace numInstructions) (s
             rw [h_offset, ia.h_input_imm, h_rs1]
           · obtain ⟨h_adj, h_offset, h_add_op, h_add_active, h_add_m32,
                 _h_start_flag, _h_start_set_pc, _h_start_jmp2, h_start_a,
-                _h_start_b_reg, h_finish_b_imm, h_finish_b_mem,
+                _h_start_b_imm, _h_start_b_reg, h_finish_b_imm, h_finish_b_mem,
                 h_finish_b_ind, h_finish_b_reg⟩ := h_unaligned
             have h_add := main_add_packed_result_at ziskTrace rd.rows.start
               h_add_active h_add_op h_add_m32
@@ -1701,7 +1701,7 @@ theorem stepSound_of_evidence (ziskTrace : AcceptedZiskTrace numInstructions) (s
             h_matches h_match_clo h_match_chi h_a_mask h_b_operand
             hc0 hc1 hc2 hc3 hc4 hc5 hc6 hc7
             rd.h_c1_zero rd.h_offset_bridge
-            rd.h_offset_even rd.h_no_fgl_wrap
+            rd.h_offset_even rd.h_target_nonneg rd.h_target_lt
         exact jalr_nextPC_matches_of_target
           (register_type_pc_equiv ▸
             BitVec.ofNat 64 ((Pilot.execRowAt ziskTrace finish)[1]!.pc).val)
@@ -1710,27 +1710,6 @@ theorem stepSound_of_evidence (ziskTrace : AcceptedZiskTrace numInstructions) (s
           (ia.jalr_input.rs1_val
             + BitVec.signExtend 64 ia.jalr_input.imm)
           h_exec hoo
-      let promises : ZiskFv.EquivCore.Promises.JumpPromises
-          state ia.jalr_input.PC ia.jalr_input.rd ia.misa_val
-          (PureSpec.execute_JALR_pure ia.jalr_input).success
-          (PureSpec.execute_JALR_pure ia.jalr_input).nextPC
-          c.rd (Pilot.execRowAt ziskTrace finish) e_rd nextPC_val :=
-        { input_rd_eq := ia.h_input_rd
-          input_pc_eq := ia.h_input_pc
-          input_misa_eq := ia.h_input_misa
-          misa_c_zero := ia.h_misa_c
-          -- exec artifacts: now `rfl` (`Pilot.execRowOf` is a concrete two-entry list).
-          exec_len := by rfl
-          e0_mult := by rfl
-          e1_mult := by rfl
-          nextPC_matches := h_nextPC_disch
-          rd_mult := by rfl
-          rd_as := by rfl
-          success := ia.h_success
-          nextPC_option := h_nextPC_option
-          rd_idx := ia.h_input_rd.trans
-            (eRdAt_rd_idx_of_decode (trace := ziskTrace) (i := finish)
-              (rd := c.rd) rd.h_store_ind rd.h_store_offset) }
       have h_link_bridge :
           (m.pc finish.val + m.jmp_offset2 finish.val).val =
             (ia.jalr_input.PC + 4#64).toNat := by
@@ -1785,14 +1764,78 @@ theorem stepSound_of_evidence (ziskTrace : AcceptedZiskTrace numInstructions) (s
           exact jalr_link_bridge_scalar (m.pc rd.rows.start.val)
             (m.pc finish.val) (m.jmp_offset2 finish.val) ia.jalr_input.PC
             h_total h_start_pc h_domain.h_pc_bound
-      exact ZiskFv.Compliance.equiv_JALR
-        state ia.jalr_input c.imm c.rs1 c.rd
-        ia.misa_val ia.mseccfg (Pilot.execRowAt ziskTrace finish)
-        e_rd nextPC_val m r next_pc store_pc_mem pins rd.h_flag
-        rd.h_m32 rd.h_set_pc rd.h_store_pc h_jalr_subset
-        promises ia.h_input_imm ia.h_input_rs1
-        ia.h_cur_privilege ia.h_mseccfg h_link_bridge
-        h_domain.h_pc_bound h_domain.h_pc_offset_lt_2_32
+      by_cases h_rd_zero : (regidx_to_fin c.rd).val = 0
+      · let promises : ZiskFv.EquivCore.Promises.JumpNoMemPromises
+            state ia.jalr_input.PC ia.jalr_input.rd ia.misa_val
+            (PureSpec.execute_JALR_pure ia.jalr_input).success
+            (PureSpec.execute_JALR_pure ia.jalr_input).nextPC
+            c.rd (Pilot.execRowAt ziskTrace finish) nextPC_val :=
+          { input_rd_eq := ia.h_input_rd
+            input_rd_zero := by
+              rw [ia.h_input_rd]
+              exact Fin.ext h_rd_zero
+            input_pc_eq := ia.h_input_pc
+            input_misa_eq := ia.h_input_misa
+            misa_c_zero := ia.h_misa_c
+            exec_len := by rfl
+            e0_mult := by rfl
+            e1_mult := by rfl
+            nextPC_matches := h_nextPC_disch
+            success := ia.h_success
+            nextPC_option := h_nextPC_option }
+        have h_store_offset_zero :
+            (mainRowWithRomAt ziskTrace finish).rom.store_offset =
+              Transpiler.ind (regidx_to_fin c.rd) := by
+          simpa [h_rd_zero, Transpiler.ind] using rd.h_store_offset
+        have h_rd_idx :
+            ia.jalr_input.rd = Transpiler.wrap_to_regidx e_rd.ptr :=
+          ia.h_input_rd.trans
+            (eRdAt_rd_idx_of_decode (trace := ziskTrace) (i := finish)
+              (rd := c.rd) rd.h_store_ind h_store_offset_zero)
+        have h_e_rd_idx_zero :
+            Transpiler.wrap_to_regidx e_rd.ptr = 0 := by
+          rw [← h_rd_idx]
+          exact promises.input_rd_zero
+        exact ZiskFv.Compliance.equiv_JALR_x0_no_memory
+          state ia.jalr_input c.imm c.rs1 c.rd ia.misa_val ia.mseccfg
+          (Pilot.execRowAt ziskTrace finish) e_rd nextPC_val promises
+          (by rfl) (by rfl) h_e_rd_idx_zero
+          ia.h_input_imm ia.h_input_rs1 ia.h_cur_privilege ia.h_mseccfg
+      · have h_store_offset :
+            (mainRowWithRomAt ziskTrace finish).rom.store_offset =
+              Transpiler.ind (regidx_to_fin c.rd) := by
+          simpa [h_rd_zero] using rd.h_store_offset
+        let promises : ZiskFv.EquivCore.Promises.JumpPromises
+            state ia.jalr_input.PC ia.jalr_input.rd ia.misa_val
+            (PureSpec.execute_JALR_pure ia.jalr_input).success
+            (PureSpec.execute_JALR_pure ia.jalr_input).nextPC
+            c.rd (Pilot.execRowAt ziskTrace finish) e_rd nextPC_val :=
+          { input_rd_eq := ia.h_input_rd
+            input_pc_eq := ia.h_input_pc
+            input_misa_eq := ia.h_input_misa
+            misa_c_zero := ia.h_misa_c
+            exec_len := by rfl
+            e0_mult := by rfl
+            e1_mult := by rfl
+            nextPC_matches := h_nextPC_disch
+            rd_mult := by rfl
+            rd_as := by rfl
+            success := ia.h_success
+            nextPC_option := h_nextPC_option
+            rd_idx := ia.h_input_rd.trans
+              (eRdAt_rd_idx_of_decode (trace := ziskTrace) (i := finish)
+                (rd := c.rd) rd.h_store_ind h_store_offset) }
+        have h_store_pc_one : m.store_pc r = 1 := by
+          rw [rd.h_store_pc]
+          simp [h_rd_zero, ZiskFv.AirsClean.boolF]
+        exact ZiskFv.Compliance.equiv_JALR
+          state ia.jalr_input c.imm c.rs1 c.rd
+          ia.misa_val ia.mseccfg (Pilot.execRowAt ziskTrace finish)
+          e_rd nextPC_val m r next_pc store_pc_mem pins rd.h_flag
+          rd.h_m32 rd.h_set_pc h_store_pc_one h_jalr_subset
+          promises ia.h_input_imm ia.h_input_rs1
+          ia.h_cur_privilege ia.h_mseccfg h_link_bridge
+          h_domain.h_pc_bound h_domain.h_pc_offset_lt_2_32
 
   | sb c => exact stepStrong_sb ziskTrace sailTrace i (toRowData_sb c rd ia) memEv hAvoidKnownBugs
   | sh c => exact stepStrong_sh ziskTrace sailTrace i (toRowData_sh c rd ia) memEv hAvoidKnownBugs

--- a/ZiskFv/Compliance/TraceLevelExport/EnvOf.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/EnvOf.lean
@@ -126,7 +126,7 @@ noncomputable def mulEnvOf
     `False` and the FENCE defect predicate's negation is `True`, while the
     arith-mul defect predicate is exactly the two exceptional product-sign shapes
     that `h_not_forge` rules out.  Hence the threaded obligation is SATISFIABLE for
-    the concrete `RowData_mul` witness, so the `.mul` arm of `root_soundness`
+    the concrete `RowData_mul` witness, so the `.mul` arm of `stepSound_of_programDecodes`
     does not rely on a contradictory binder.  The full trace-local
     `RowOutsideDefectRegion` premise is stronger: it requires this forge
     negation for every arith witness row whose operation-bus entry, including

--- a/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
@@ -6,7 +6,7 @@ import ZiskFv.Compliance.TraceLevelExport.RomDecodeBindingOps
 # Committed-program row-decode dispatch (issue #159, BLOCK 1 wiring, IN PLACE)
 
 This module wires block 1's per-op `Decode_<op>_of_program`
-(`RomDecodeBinding`/`RomDecodeBindingOps`) into the headline `root_soundness`
+(`RomDecodeBinding`/`RomDecodeBindingOps`) into the headline `stepSound_of_programDecodes`
 endpoint (`ZiskFv/Soundness.lean`) by repackaging, per row, exactly the inputs
 those derivations consume that are NOT themselves derivable:
 
@@ -21,7 +21,7 @@ those derivations consume that are NOT themselves derivable:
 `ProgramDecode ziskTrace i zs` is the 63-arm dispatch (mirroring `RowDecode` in
 `Dispatcher.lean`) to the per-op bundle `ProgramDecode_<op>`.
 `rowDecode_of_programDecode` rebuilds block 1's `RowDecode` for one row by
-applying the matching `Decode_<op>_of_program`, so `root_soundness` can take the
+applying the matching `Decode_<op>_of_program`, so `stepSound_of_programDecodes` can take the
 committed-program decode bundle and DERIVE the witness-row decode columns.
 
 The ROM-backed decode columns (`op` / flags / `jmp_offset` / `ind_width`) are no
@@ -1914,7 +1914,7 @@ noncomputable def rowDecode_of_programDecode (ziskTrace : AcceptedZiskTrace numI
   | fence c => exact RomDecodeBinding.Decode_fence_of_program ziskTrace i c pd.h_idx pd.h_fm_zero pd.h_rs_x0 pd.h_rd_x0 pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_prog
 
 /-- Lift `rowDecode_of_programDecode` over every instruction: given a per-row
-    `ProgramDecode`, produce the full `rowDecodes` family `root_soundness`
+    `ProgramDecode`, produce the full `rowDecodes` family `stepSound_of_programDecodes`
     consumes. -/
 noncomputable def rowDecodes_of_programDecodes (ziskTrace : AcceptedZiskTrace numInstructions)
     (ziskStep : ∀ i : Fin numInstructions, ZiskStep ziskTrace i)

--- a/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/ProgramDecode.lean
@@ -1255,27 +1255,30 @@ structure ProgramDecode_jalr_aligned {numInstructions : Nat}
   h_c1_zero :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_1
       i.val = 0
-  h_offset_bridge :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-        i.val).val = c.offset_bv.toNat
   h_offset_even :
     c.offset_bv &&& 1#64 = 0#64
-  h_no_fgl_wrap :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_0 i.val).val
-      + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-          i.val).val < GL_prime
+  h_target_nonneg :
+    0 ≤ (((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_0
+      i.val).val : Int) + c.offset_bv.toInt
+  h_target_lt :
+    (((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_0
+      i.val).val : Int) + c.offset_bv.toInt < GL_prime
   bits : RomFlagBits
   h_bits_ieo : bits.is_external_op = true
   h_bits_m32 : bits.m32 = false
   h_bits_set_pc : bits.set_pc = true
-  h_bits_store_pc : bits.store_pc = true
+  h_bits_store_pc :
+    bits.store_pc = decide ((regidx_to_fin c.rd).val ≠ 0)
   h_bits_store_ind : bits.store_ind = false
   h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_AND
+        ∧ (trace.program j).jmp_offset1 = ((BitVec.signExtend 64 c.imm).toInt : FGL)
         ∧ (trace.program j).jmp_offset2 = 4
-        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
+        ∧ (trace.program j).store_offset =
+            (if (regidx_to_fin c.rd).val = 0 then 0
+             else Transpiler.ind (regidx_to_fin c.rd))
         ∧ (trace.program j).flags = packFlags bits
 
 /-- Per-row committed-program decode bundle for the UNALIGNED `jalr` lowering:
@@ -1308,27 +1311,29 @@ structure ProgramDecode_jalr_unaligned {numInstructions : Nat}
   h_c1_zero :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_1
       (i.val + 1) = 0
-  h_offset_bridge :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-        (i.val + 1)).val = c.offset_bv.toNat
   h_offset_even :
     c.offset_bv &&& 1#64 = 0#64
-  h_no_fgl_wrap :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_0
-        (i.val + 1)).val
-      + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-          (i.val + 1)).val < GL_prime
+  h_target_nonneg :
+    0 ≤ (((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_0
+      (i.val + 1)).val : Int) + c.offset_bv.toInt
+  h_target_lt :
+    (((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_0
+      (i.val + 1)).val : Int) + c.offset_bv.toInt < GL_prime
   addBits : RomFlagBits
   h_add_ieo : addBits.is_external_op = true
   h_add_m32 : addBits.m32 = false
   h_add_set_pc : addBits.set_pc = false
   h_add_a_src_imm : addBits.a_src_imm = true
-  h_add_b_src_reg : addBits.b_src_reg = true
+  h_add_b_src_imm :
+    addBits.b_src_imm = decide ((regidx_to_fin c.rs1).val = 0)
+  h_add_b_src_reg :
+    addBits.b_src_reg = decide ((regidx_to_fin c.rs1).val ≠ 0)
   andBits : RomFlagBits
   h_and_ieo : andBits.is_external_op = true
   h_and_m32 : andBits.m32 = false
   h_and_set_pc : andBits.set_pc = true
-  h_and_store_pc : andBits.store_pc = true
+  h_and_store_pc :
+    andBits.store_pc = decide ((regidx_to_fin c.rd).val ≠ 0)
   h_and_store_ind : andBits.store_ind = false
   h_and_b_src_imm : andBits.b_src_imm = false
   h_and_b_src_mem : andBits.b_src_mem = false
@@ -1348,8 +1353,11 @@ structure ProgramDecode_jalr_unaligned {numInstructions : Nat}
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc (i.val + 1) →
           (trace.program j).op = ZiskFv.Trusted.OP_AND
+        ∧ (trace.program j).jmp_offset1 = 0
         ∧ (trace.program j).jmp_offset2 = 3
-        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
+        ∧ (trace.program j).store_offset =
+            (if (regidx_to_fin c.rd).val = 0 then 0
+             else Transpiler.ind (regidx_to_fin c.rd))
         ∧ (trace.program j).flags = packFlags andBits
 
 /-- Per-row committed-program decode bundle for `jalr`.
@@ -1857,15 +1865,15 @@ noncomputable def rowDecode_of_programDecode (ziskTrace : AcceptedZiskTrace numI
       match pd with
       | .aligned p =>
           exact RomDecodeBinding.Decode_jalr_of_program ziskTrace i c p.h_offset_aligned
-            p.h_idx p.h_flag p.h_a_mask_lo p.h_a_mask_hi p.h_c1_zero p.h_offset_bridge
-            p.h_offset_even p.h_no_fgl_wrap p.bits p.h_bits_ieo p.h_bits_m32
+            p.h_idx p.h_flag p.h_a_mask_lo p.h_a_mask_hi p.h_c1_zero
+            p.h_offset_even p.h_target_nonneg p.h_target_lt p.bits p.h_bits_ieo p.h_bits_m32
             p.h_bits_set_pc p.h_bits_store_pc p.h_bits_store_ind p.h_prog
       | .unaligned p =>
           exact RomDecodeBinding.Decode_jalr_unaligned_of_program ziskTrace i c
             p.h_idx2 p.h_offset_zero p.h_flag_add p.h_flag p.h_a_mask_lo p.h_a_mask_hi
-            p.h_c1_zero p.h_offset_bridge p.h_offset_even p.h_no_fgl_wrap
+            p.h_c1_zero p.h_offset_even p.h_target_nonneg p.h_target_lt
             p.addBits p.h_add_ieo p.h_add_m32 p.h_add_set_pc p.h_add_a_src_imm
-            p.h_add_b_src_reg p.andBits p.h_and_ieo p.h_and_m32 p.h_and_set_pc
+            p.h_add_b_src_imm p.h_add_b_src_reg p.andBits p.h_and_ieo p.h_and_m32 p.h_and_set_pc
             p.h_and_store_pc p.h_and_store_ind p.h_and_b_src_imm p.h_and_b_src_mem
             p.h_and_b_src_ind p.h_and_b_src_reg p.h_prog_add p.h_prog_and
   | sb c => exact RomDecodeBinding.Decode_sb_of_program ziskTrace i c pd.h_idx pd.bits pd.h_bits_ieo pd.h_bits_set_pc pd.h_bits_store_pc pd.h_bits_store_ind pd.h_prog

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingControl.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingControl.lean
@@ -1,25 +1,26 @@
 import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingRegister
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBitfields
 
 /-!
 # Raw-program decode bridge — branch + control family (issue #159, BLOCK 3)
 
 Mirrors the register / immediate / load-store bridges
 (`RawProgramBinding{Register,Immediate,LoadStore}`) for the six RV64I branches
-(BEQ/BNE/BLT/BGE/BLTU/BGEU) and the five control ops (LUI/AUIPC/JAL/JALR/FENCE),
-with the raw word's register / immediate fields SYMBOLIC.
+(BEQ/BNE/BLT/BGE/BLTU/BGEU) and the non-JALR control ops
+(LUI/AUIPC/JAL/FENCE), with symbolic raw-word register and immediate fields.
 
   * BRANCHES (B-type word `rawBType`, `decode_b`) lower through
     `create_branch_op_typed`.  `neg` flips the two `j` offsets: the CONSTANT
     fall-through slot is `jmp_offset2` for the `neg = false` ops (BEQ/BLT/BLTU)
-    and `jmp_offset1` for the `neg = true` ops (BNE/BGE/BGEU).  The imm-target
-    slot is OUT of decode scope and not a decode pin (skipped).
+    and `jmp_offset1` for the `neg = true` ops (BNE/BGE/BGEU); the other slot
+    is the signed decoded branch target.
   * LUI / AUIPC (U-type word `rawUType`, `decode_u`) lower through `lui` /
     `auipc`.  AUIPC's `store_pc = true` needs `rd ≠ 0` (the nop-guard disproof,
-    matching `auipc_static_pins_full`); the decode-relevant constant slot is
-    `jmp_offset1 = 4` (jmp_offset2 carries the imm target, skipped).
+    matching `auipc_static_pins_full`); `jmp_offset1 = 4` and `jmp_offset2`
+    carries the signed decoded immediate.
   * JAL (J-type word `rawJType`, `decode_j`) lowers through `jal`; `store_pc =
-    true` needs `rd ≠ 0`.  The constant slot is `jmp_offset2 = 4` (jmp_offset1
-    carries the imm target, skipped).
+    true` needs `rd ≠ 0`.  `jmp_offset2 = 4` and `jmp_offset1` carries the
+    signed decoded immediate.
   * JALR (I-type word `rawIType … 0x67`, `decode_i … false`) lowers through
     `jalr`, whose `i.imm % 4` TWO-ROW split makes `jmp_offset` a per-row
     disjunction; `Decode_jalr_of_program` pins NO jmp_offset, so the bridge
@@ -36,8 +37,9 @@ For each op `<op>` this module retains:
   * `<op>_decode_fields_of_binding` — the committed message's decode fields,
     from its raw word + the op-agnostic `romMessageOfRaw` binding.
 
-The historical `Decode_<op>_from_rawProgram` endpoints and `RawDecode_<op>`
-bundles targeted a retired decode interface and are deliberately not restored.
+The raw bundles feed architectural `ProgramDecode_<op>` constructors through
+`ProgramRowsBinding` and `RawAtProgramStart`; JALR remains in its dedicated
+two-row binding module.
 
 Sound: NO native_decide / bv_decide / new axiom / `sorry`; kernel-only closure
 (`propext` / `Classical.choice` / `Quot.sound`).
@@ -60,6 +62,8 @@ open aeneas_extract (extract_transpile_rv64im_raw)
 
 set_option maxHeartbeats 4000000
 set_option linter.unusedSimpArgs false
+
+attribute [local step] IScalar.sub_bv_spec I32.sub_bv_spec
 
 private theorem hcast4' : (UScalar.hcast IScalarTy.I64 4#u64 : Std.I64).val = (4 : Int) := by decide
 
@@ -165,6 +169,44 @@ private theorem auipc_store_jmp_pins
   subst h
   exact ⟨_, rfl, by simpa using hso, by simpa using hsi, rfl⟩
 
+private theorem jal_store_pins
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (instSize : Std.U64)
+    (ctx : riscv2zisk_context.Riscv2ZiskContext)
+    (hrd : i.rd.val < 32)
+    (h : riscv2zisk_context.Riscv2ZiskContext.jal self i instSize = ok ctx) :
+    ∃ zib, ctx.extract_inst = some zib ∧
+      zib.i.store_offset.val = i.rd.val ∧ zib.i.store ≠ zisk_inst.STORE_IND := by
+  simp only [
+    riscv2zisk_context.Riscv2ZiskContext.jal,
+    zisk_inst_builder.ZiskInstBuilder.new_for_rv64im_lowering,
+    zisk_inst_builder.ZiskInstBuilder.new,
+    zisk_inst_builder.ZiskInstBuilder.Insts.CoreDefaultDefault.default,
+    zisk_inst.ZiskInst.Insts.CoreDefaultDefault.default,
+    zisk_inst_builder.ZiskInstBuilder.src_a_imm,
+    zisk_inst_builder.ZiskInstBuilder.src_b_imm,
+    zisk_inst_builder.ZiskInstBuilder.op_zisk,
+    zisk_ops.ZiskOp.op_type, zisk_ops.ZiskOp.code,
+    zisk_ops.ZiskOp.input_size, zisk_ops.ZiskOp.is_m32,
+    core.convert.IntoFrom.into,
+    zisk_inst.ZiskOperationType.Insts.CoreConvertFromOpType.from,
+    zisk_inst_builder.ZiskInstBuilder.set_runtime_op_fields,
+    zisk_inst_builder.ZiskInstBuilder.store_pc_reg,
+    zisk_inst_builder.ZiskInstBuilder.j,
+    zisk_inst_builder.ZiskInstBuilder.build,
+    riscv2zisk_context.Riscv2ZiskContext.insert_inst,
+    lift, reduceIte,
+    HShiftRight.hShiftRight, UScalar.shiftRight_IScalar, UScalar.shiftRight,
+    ZiskFv.Compliance.Extraction.i32_32_nonnegative,
+    ZiskFv.Compliance.Extraction.i32_32_toNat_lt_u64_numBits,
+    bind_ok, Bind.bind] at h
+  obtain ⟨zib, hstore, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨hso, hsi⟩ :=
+    store_reg_raw_index_pins_any _ _ i.rd hrd true (by rfl) (by rfl) hstore
+  rw [Result.ok.injEq] at h
+  subst h
+  exact ⟨_, rfl, by simpa using hso, by simpa using hsi⟩
+
 /-! ## Decoder `rd`-field recovery (`[7,11]` bits) and the symbolic `rd ≠ 0`
 derivations, for the AUIPC / JAL / JALR `store_pc = true` nop-guard.  All
 kernel-sound (`ofNat32_shift_mask_eq`, no native_decide). -/
@@ -267,33 +309,6 @@ private theorem decode_u_rawUType_imm
            simp)
   · simp [BitVec.getLsbD, hk]
 
-/-- Kernel counterexample to the current AUIPC committed-program interface for
-    the smallest negative U-immediate (`0x80000 << 12`).  Production embeds the
-    signed offset in FGL, while `ProgramDecode_auipc` asks for its unsigned
-    64-bit value. -/
-theorem auipc_negative_rom_target_mismatch :
-    ((((BitVec.signExtend 64 ((524288#20) ++ (0#12))).toInt : Int) : FGL).val) ≠
-      (BitVec.signExtend 64 ((524288#20) ++ (0#12))).toNat := by
-  decide
-
-/-- Representative backward-branch counterexample to all six current branch
-    committed-program interfaces.  The aligned immediate `4096#13` denotes
-    `-4096`; production embeds that signed offset in FGL, while the interfaces
-    ask for its unsigned 64-bit value. -/
-theorem branch_negative_rom_target_mismatch :
-    ((((BitVec.signExtend 64 (4096#13)).toInt : Int) : FGL).val) ≠
-      (BitVec.signExtend 64 (4096#13)).toNat := by
-  decide
-
-/-- Representative backward-JAL counterexample to the current committed-program
-    interface.  The aligned immediate `1048576#21` denotes `-1048576`;
-    production embeds that signed offset in FGL, while `ProgramDecode_jal`
-    asks for its unsigned 64-bit value. -/
-theorem jal_negative_rom_target_mismatch :
-    ((((BitVec.signExtend 64 (1048576#21)).toInt : Int) : FGL).val) ≠
-      (BitVec.signExtend 64 (1048576#21)).toNat := by
-  decide
-
 private theorem rawJType_rd (imm rd : Nat) (hrd : rd < 32) :
     ((ZiskFv.Completeness.Rv64imShapes.rawJType imm rd) &&& 3968#32) >>> 7 = BitVec.ofNat 32 rd := by
   rw [and3968_shr7]
@@ -371,6 +386,47 @@ theorem op_flags_of_binding
 fall-through jump slot is `jmp_offset2` for `neg = false`, `jmp_offset1` for
 `neg = true`. -/
 
+private theorem branch_dynamic_pins
+    (self : riscv2zisk_context.Riscv2ZiskContext)
+    (i : riscv2zisk_single_row.Rv64imLoweringInput) (op : zisk_ops.ZiskOp)
+    (neg : Bool) (instSize : Std.U64)
+    (ctx : riscv2zisk_context.Riscv2ZiskContext)
+    (h : riscv2zisk_context.Riscv2ZiskContext.create_branch_op_typed
+      self i op neg instSize = ok ctx) :
+    ∃ zib, ctx.extract_inst = some zib ∧
+      (neg = false →
+        zib.i.jmp_offset1 = IScalar.cast IScalarTy.I64 i.imm ∧
+        zib.i.jmp_offset2 = UScalar.hcast IScalarTy.I64 instSize) ∧
+      (neg = true →
+        zib.i.jmp_offset1 = UScalar.hcast IScalarTy.I64 instSize ∧
+        zib.i.jmp_offset2 = IScalar.cast IScalarTy.I64 i.imm) := by
+  simp only [riscv2zisk_context.Riscv2ZiskContext.create_branch_op_typed,
+    lift, Bind.bind, bind_ok] at h
+  obtain ⟨zib0, h0, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨zib1, h1, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨zib2, h2, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨zib3, h3, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨zib4, h4, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨zib5, h5, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  obtain ⟨s1, h6, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  rw [Result.ok.injEq] at h
+  subst h
+  have hb := ZiskFv.Compliance.Extraction.build_eq _ _ h5
+  split_ifs at h4 with hcond
+  · obtain ⟨hj1, hj2⟩ := ZiskFv.Compliance.Extraction.j_jmp _ _ _ _ h4
+    refine ⟨zib5, ZiskFv.Compliance.Extraction.insert_inst_extract _ _ _ _ h6, ?_, ?_⟩
+    · intro hf
+      rw [hcond] at hf
+      contradiction
+    · intro _
+      constructor <;> rw [hb] <;> assumption
+  · obtain ⟨hj1, hj2⟩ := ZiskFv.Compliance.Extraction.j_jmp _ _ _ _ h4
+    refine ⟨zib5, ZiskFv.Compliance.Extraction.insert_inst_extract _ _ _ _ h6, ?_, ?_⟩
+    · intro _
+      constructor <;> rw [hb] <;> assumption
+    · intro ht
+      exact absurd ht hcond
+
 theorem transpile_branch_of
     (raw : Std.U32) (rop : RiscvOpcode) (srop : riscv2zisk_single_row.Rv64imSingleRowOpcode)
     (op : zisk_ops.ZiskOp) (neg : Bool) (opc : Std.U8)
@@ -389,7 +445,10 @@ theorem transpile_branch_of
       ∧ ext.row.op = opc ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
       ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
       ∧ (neg = false → ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64)
-      ∧ (neg = true  → ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64) := by
+      ∧ (neg = true  → ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64)
+      ∧ ∃ d, decode_b raw rop = ok d
+        ∧ (neg = false → ext.row.jmp_offset1 = IScalar.cast IScalarTy.I64 d.imm)
+        ∧ (neg = true → ext.row.jmp_offset2 = IScalar.cast IScalarTy.I64 d.imm) := by
   obtain ⟨decoded, hdecoded, hopd, hrs1b, hrs2b⟩ := decode_b_bounds raw rop
   have hdec0 : aeneas_extract.rv64im_decode.decode_32_core raw = ok decoded := hdec.trans hdecoded
   set input : riscv2zisk_single_row.Rv64imLoweringInput :=
@@ -401,7 +460,7 @@ theorem transpile_branch_of
     ZiskFv.Compliance.Extraction.branch_static_pins_of { defCtx with extract_marker := () }
       input op neg 4#u64 ctx0 opc hcode hm32 hot hctx0
   obtain ⟨zib', hzib', hjf, hjt⟩ :=
-    ZiskFv.Compliance.Extraction.create_branch_op_typed_dynamic_pins
+    branch_dynamic_pins
       { defCtx with extract_marker := () } input op neg 4#u64 ctx0 hctx0
   have hzz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
   rw [hzz] at hjf hjt
@@ -409,7 +468,7 @@ theorem transpile_branch_of
   obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, _⟩ := from_inst_ok zib.i
   have hlower : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input srop false
       = ok { ctx0 with extract_marker := () } := by rw [harm defCtx input, hctx0]; rfl
-  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
     simp only [bind_ok, Bind.bind, hdext, hopd, hlowop]
     simp only [defCtx] at hlower
@@ -420,8 +479,15 @@ theorem transpile_branch_of
   · show row.m32 = false; rw [hrm32]; exact hm322
   · show row.set_pc = false; rw [hrsp]; exact hsp2
   · show row.store_pc = false; rw [hrstp]; exact hstp2
-  · intro hf; show row.jmp_offset2 = _; rw [hrj2]; exact hjf hf
-  · intro ht; show row.jmp_offset1 = _; rw [hrj1]; exact hjt ht
+  · intro hf; show row.jmp_offset2 = _; rw [hrj2]; exact (hjf hf).2
+  · intro ht; show row.jmp_offset1 = _; rw [hrj1]; exact (hjt ht).1
+  · refine ⟨decoded, hdecoded, ?_, ?_⟩
+    · intro hf
+      show row.jmp_offset1 = _
+      rw [hrj1, (hjf hf).1, hinput]
+    · intro ht
+      show row.jmp_offset2 = _
+      rw [hrj2, (hjt ht).2, hinput]
 
 /-! ## Branch decode-field bridges (one constant jump slot, op, flags). -/
 
@@ -502,7 +568,11 @@ local macro "branch_false_op" nm:ident "," f3:term "," rop:term "," srop:term ",
             (toU32 (ZiskFv.Completeness.Rv64imShapes.rawBType imm rs2 rs1 $f3)) = ok ext
           ∧ ext.row.op = $opU8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
           ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
-          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+          ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+          ∧ ∃ d, decode_b
+              (toU32 (ZiskFv.Completeness.Rv64imShapes.rawBType imm rs2 rs1 $f3))
+                $rop = ok d
+            ∧ ext.row.jmp_offset1 = IScalar.cast IScalarTy.I64 d.imm := by
       have hdec : aeneas_extract.rv64im_decode.decode_32_core
             (toU32 (ZiskFv.Completeness.Rv64imShapes.rawBType imm rs2 rs1 $f3))
           = aeneas_extract.rv64im_decode.decode_b
@@ -513,9 +583,9 @@ local macro "branch_false_op" nm:ident "," f3:term "," rop:term "," srop:term ",
           ZiskFv.Compliance.Decode.rawBType_opcode imm rs2 rs1 $f3,
           ZiskFv.Compliance.Decode.rawBType_funct3 imm rs2 rs1 $f3 (by norm_num)]
         all_goals rfl
-      obtain ⟨ext, hok, hop, hieo, hm32, hsp, hstp, hjf, _⟩ :=
+      obtain ⟨ext, hok, hop, hieo, hm32, hsp, hstp, hjf, _, d, hd, htarget, _⟩ :=
         transpile_branch_of _ $rop $srop $op false $opU8 hdec rfl (by intro self input; rfl) rfl rfl rfl
-      exact ⟨ext, hok, hop, hieo, hm32, hsp, hstp, hjf rfl⟩)
+      exact ⟨ext, hok, hop, hieo, hm32, hsp, hstp, hjf rfl, d, hd, htarget rfl⟩)
   let t2 ← `(theorem $dfName (rs1 rs2 imm : Nat) (hrs1 : rs1 < 32) (hrs2 : rs2 < 32)
         (line : FGL) (msg : ZiskRomMessage FGL)
         (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawBType imm rs2 rs1 $f3)) :
@@ -525,7 +595,8 @@ local macro "branch_false_op" nm:ident "," f3:term "," rop:term "," srop:term ",
               ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
               ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
               ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
-      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj2⟩ := $tName rs1 rs2 imm hrs1 hrs2
+      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj2, _⟩ :=
+        $tName rs1 rs2 imm hrs1 hrs2
       obtain ⟨ho, hjo2, hf⟩ :=
         branch_decode_fields_false line msg _ $opU8 $opc ext
           (by simp [romOpcode, $opc:term]) hok hop hj2 hbind
@@ -543,7 +614,11 @@ local macro "branch_true_op" nm:ident "," f3:term "," rop:term "," srop:term ","
             (toU32 (ZiskFv.Completeness.Rv64imShapes.rawBType imm rs2 rs1 $f3)) = ok ext
           ∧ ext.row.op = $opU8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
           ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
-          ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64 := by
+          ∧ ext.row.jmp_offset1 = UScalar.hcast IScalarTy.I64 4#u64
+          ∧ ∃ d, decode_b
+              (toU32 (ZiskFv.Completeness.Rv64imShapes.rawBType imm rs2 rs1 $f3))
+                $rop = ok d
+            ∧ ext.row.jmp_offset2 = IScalar.cast IScalarTy.I64 d.imm := by
       have hdec : aeneas_extract.rv64im_decode.decode_32_core
             (toU32 (ZiskFv.Completeness.Rv64imShapes.rawBType imm rs2 rs1 $f3))
           = aeneas_extract.rv64im_decode.decode_b
@@ -554,9 +629,9 @@ local macro "branch_true_op" nm:ident "," f3:term "," rop:term "," srop:term ","
           ZiskFv.Compliance.Decode.rawBType_opcode imm rs2 rs1 $f3,
           ZiskFv.Compliance.Decode.rawBType_funct3 imm rs2 rs1 $f3 (by norm_num)]
         all_goals rfl
-      obtain ⟨ext, hok, hop, hieo, hm32, hsp, hstp, _, hjt⟩ :=
+      obtain ⟨ext, hok, hop, hieo, hm32, hsp, hstp, _, hjt, d, hd, _, htarget⟩ :=
         transpile_branch_of _ $rop $srop $op true $opU8 hdec rfl (by intro self input; rfl) rfl rfl rfl
-      exact ⟨ext, hok, hop, hieo, hm32, hsp, hstp, hjt rfl⟩)
+      exact ⟨ext, hok, hop, hieo, hm32, hsp, hstp, hjt rfl, d, hd, htarget rfl⟩)
   let t2 ← `(theorem $dfName (rs1 rs2 imm : Nat) (hrs1 : rs1 < 32) (hrs2 : rs2 < 32)
         (line : FGL) (msg : ZiskRomMessage FGL)
         (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawBType imm rs2 rs1 $f3)) :
@@ -566,7 +641,8 @@ local macro "branch_true_op" nm:ident "," f3:term "," rop:term "," srop:term ","
               ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
               ∧ ext.row.set_pc = false ∧ ext.row.store_pc = false
               ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
-      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1⟩ := $tName rs1 rs2 imm hrs1 hrs2
+      obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj1, _⟩ :=
+        $tName rs1 rs2 imm hrs1 hrs2
       obtain ⟨ho, hjo1, hf⟩ :=
         branch_decode_fields_true line msg _ $opU8 $opc ext
           (by simp [romOpcode, $opc:term]) hok hop hj1 hbind
@@ -822,7 +898,13 @@ theorem transpile_jal (rd imm : Nat) (hrd : rd < 32) (hrd0 : rd ≠ 0) :
     ∃ ext, extract_transpile_rv64im_raw (toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd)) = ok ext
       ∧ ext.row.op = 0#u8 ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
       ∧ ext.row.set_pc = false ∧ ext.row.store_pc = true
-      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64 := by
+      ∧ ext.row.jmp_offset2 = UScalar.hcast IScalarTy.I64 4#u64
+      ∧ ext.row.store_offset.val = rd
+      ∧ ext.row.store ≠ zisk_inst.STORE_IND
+      ∧ ∃ d, decode_j
+          (toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd))
+            RiscvOpcode.Jal = ok d
+        ∧ ext.row.jmp_offset1 = IScalar.cast IScalarTy.I64 d.imm := by
   have hdec : aeneas_extract.rv64im_decode.decode_32_core
         (toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd))
       = aeneas_extract.rv64im_decode.decode_j
@@ -847,10 +929,15 @@ theorem transpile_jal (rd imm : Nat) (hrd : rd < 32) (hrd0 : rd ≠ 0) :
   obtain ⟨ctx0, hctx0⟩ := jal_ok { defCtx with extract_marker := () } input 4#u64 (by rw [hinput]; exact hrdb)
   obtain ⟨zib, hzib, hop2, hext2, hm322, hsp2, hstp2cond⟩ :=
     ZiskFv.Compliance.Extraction.jal_static_pins { defCtx with extract_marker := () } input 4#u64 ctx0 hctx0
-  obtain ⟨zib', hzib', _, hj2⟩ :=
+  obtain ⟨zib', hzib', hj1, hj2⟩ :=
     ZiskFv.Compliance.Extraction.jal_dynamic_pins { defCtx with extract_marker := () } input 4#u64 ctx0 hctx0
   have hzz : zib' = zib := Option.some.inj (hzib'.symm.trans hzib)
-  rw [hzz] at hj2
+  rw [hzz] at hj1 hj2
+  obtain ⟨zibS, hzibS, hstoreOffset, hstoreInd⟩ :=
+    jal_store_pins { defCtx with extract_marker := () } input 4#u64 ctx0
+      (by rw [hinput]; exact hrdb) hctx0
+  have hzzS : zibS = zib := Option.some.inj (hzibS.symm.trans hzib)
+  rw [hzzS] at hstoreOffset hstoreInd
   obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
   obtain ⟨row, hrow, hrop, hrext, hrm32, hrsp, hrstp, hrj1, hrj2, _⟩ := from_inst_ok zib.i
   have harm : riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input defCtx input
@@ -862,7 +949,19 @@ theorem transpile_jal (rd imm : Nat) (hrd : rd < 32) (hrd0 : rd ≠ 0) :
     rw [harm, hctx0]; rfl
   have hlowop : aeneas_extract.lowering_opcode RiscvOpcode.Jal
       = ok (some riscv2zisk_single_row.Rv64imSingleRowOpcode.Jal) := rfl
-  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  have hrStoreOffset : row.store_offset = zib.i.store_offset := by
+    rw [aeneas_extract.ZiskInstExtract.from_inst] at hrow
+    obtain ⟨i2, hi2, hrow⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
+  have hrStore : row.store = zib.i.store := by
+    rw [aeneas_extract.ZiskInstExtract.from_inst] at hrow
+    obtain ⟨i2, hi2, hrow⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hrow
+    rw [Result.ok.injEq] at hrow
+    subst row
+    rfl
+  refine ⟨{ accepted := true, decode := dext, row := row }, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
     simp only [bind_ok, Bind.bind, hdext, hopd, hlowop]
     simp only [defCtx] at hlower
@@ -874,21 +973,51 @@ theorem transpile_jal (rd imm : Nat) (hrd : rd < 32) (hrd0 : rd ≠ 0) :
   · show row.set_pc = false; rw [hrsp]; exact hsp2
   · show row.store_pc = true; rw [hrstp]; exact hstp2cond (by rw [hinput] at hrd_ne ⊢; exact hrd_ne)
   · show row.jmp_offset2 = _; rw [hrj2]; exact hj2
+  · show row.store_offset.val = rd
+    rw [hrStoreOffset, hstoreOffset, hinput]
+    exact_mod_cast (show decoded.rd.val = rd by
+      change decoded.rd.bv.toNat = rd
+      rw [hrdbv]
+      change (((ZiskFv.Completeness.Rv64imShapes.rawJType imm rd) &&&
+        3968#32) >>> 7).toNat = rd
+      rw [rawJType_rd imm rd hrd, BitVec.toNat_ofNat]
+      omega)
+  · show row.store ≠ zisk_inst.STORE_IND
+    rw [hrStore]
+    exact hstoreInd
+  · refine ⟨decoded, hdecoded, ?_⟩
+    show row.jmp_offset1 = _
+    rw [hrj1, hj1, hinput]
 
 theorem jal_decode_fields_of_binding (rd imm : Nat) (hrd : rd < 32) (hrd0 : rd ≠ 0)
     (line : FGL) (msg : ZiskRomMessage FGL)
     (hbind : msg = romMessageOfRaw line (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd)) :
-    msg.op = OP_FLAG ∧ msg.jmp_offset2 = 4
+    msg.op = OP_FLAG ∧ msg.jmp_offset2 = 4 ∧ msg.store_offset = (rd : FGL)
       ∧ ∃ ext, extract_transpile_rv64im_raw
             (toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd)) = ok ext
           ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false
           ∧ ext.row.set_pc = false ∧ ext.row.store_pc = true
           ∧ msg.flags = packFlags (romFlagBitsOfExtract ext.row) := by
-  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj2⟩ := transpile_jal rd imm hrd hrd0
-  obtain ⟨ho, hjo2, hf⟩ :=
-    branch_decode_fields_false line msg _ 0#u8 OP_FLAG ext
-      (by simp [romOpcode, OP_FLAG]) hok hop hj2 hbind
-  exact ⟨ho, hjo2, ext, hok, hieo, hm32, hsetpc, hstorepc, hf⟩
+  obtain ⟨ext, hok, hop, hieo, hm32, hsetpc, hstorepc, hj2, hso, hsi, _⟩ :=
+    transpile_jal rd imm hrd hrd0
+  have hmsg : msg = serializeExtract line ext.row := by
+    rw [hbind, romMessageOfRaw, hok]
+    exact romRowOf_eq_serializeExtract line ext.row
+  refine ⟨?_, ?_, ?_, ext, hok, hieo, hm32, hsetpc, hstorepc, ?_⟩
+  · rw [hmsg]
+    show romOpcode ext.row.op = OP_FLAG
+    rw [hop]
+    simp [romOpcode, OP_FLAG]
+  · rw [hmsg]
+    show (ext.row.jmp_offset2.val : FGL) = 4
+    rw [hj2]
+    norm_num [hcast4']
+  · rw [hmsg]
+    show (ext.row.store_offset.val : FGL) = (rd : FGL)
+    rw [hso]
+    norm_num
+  · rw [hmsg]
+    rfl
 
 /-! ## JALR (I-type word `… 0x67`, `decode_i … false` → `jalr` → `OP_AND`,
 `set_pc = true`, `store_pc = true`).  The `i.imm % 4` TWO-ROW split is handled in
@@ -1052,10 +1181,28 @@ theorem fence_decode_fields_of_binding
 
 /-! ## Current `ProgramDecode` retarget: U-type controls and FENCE. -/
 
-structure RawProgramDecode_lui {n : Nat}
+private theorem primary_row_non_jalr_control {n rawLength : Nat}
+    {trace : ZiskFv.Compliance.AcceptedZiskTrace n}
+    {start : Fin rawLength → Fin trace.programLength}
+    {addr : Fin rawLength → FGL} {rawProgram : Fin rawLength → BitVec 32}
+    {j : Fin trace.programLength} {line : FGL} {raw : BitVec 32}
+    (hbind : ProgramRowsBinding trace start addr rawProgram)
+    (hlookup : RawAtProgramStart start addr rawProgram j line raw)
+    (ext : zisk_core.aeneas_extract.Rv64imTranspileExtract)
+    (hok : extract_transpile_rv64im_raw (toU32 raw) = ok ext)
+    (hnon : (toU32 raw &&& 127#u32) ≠ 103#u32) :
+    trace.program j = romMessageOfRaw line raw := by
+  calc
+    trace.program j = (romMessagesOfRaw line raw).1 :=
+      primary_row_of_programRowsBinding hbind hlookup
+    _ = romMessageOfRaw line raw :=
+      romMessagesOfRaw_fst_of_non_jalr line raw ext hok hnon
+
+structure RawProgramDecode_lui {n rawLength : Nat}
     (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
     (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_lui trace i)
-    (rawProgram : Fin trace.programLength → BitVec 32) where
+    (start : Fin rawLength → Fin trace.programLength)
+    (addr : Fin rawLength → FGL) (rawProgram : Fin rawLength → BitVec 32) where
   h_idx : i.val + 1 < trace.mainTable.table.length
   h_imm_lo_nat :
     ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).b_0 i.val).val
@@ -1066,16 +1213,18 @@ structure RawProgramDecode_lui {n : Nat}
   hLine : ∀ j : Fin trace.programLength,
     (trace.program j).line =
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
-      rawProgram j = ZiskFv.Completeness.Rv64imShapes.rawUType
-        (c.imm ++ (0 : BitVec 12)).toNat (regidx_to_fin c.rd).val 0x37
+      RawAtProgramStart start addr rawProgram j (trace.program j).line
+        (ZiskFv.Completeness.Rv64imShapes.rawUType
+          (c.imm ++ (0 : BitVec 12)).toNat (regidx_to_fin c.rd).val 0x37)
 
-noncomputable def ProgramDecode_lui_from_rawProgram {n : Nat}
+noncomputable def ProgramDecode_lui_from_rawProgram {n rawLength : Nat}
     (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
     (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_lui trace i)
-    (addr : Fin trace.programLength → FGL)
-    (rawProgram : Fin trace.programLength → BitVec 32)
-    (hbind : ProgramBinding trace addr rawProgram)
-    (rawDecode : RawProgramDecode_lui trace i c rawProgram) :
+    (start : Fin rawLength → Fin trace.programLength)
+    (addr : Fin rawLength → FGL)
+    (rawProgram : Fin rawLength → BitVec 32)
+    (hbind : ProgramRowsBinding trace start addr rawProgram)
+    (rawDecode : RawProgramDecode_lui trace i c start addr rawProgram) :
     ZiskFv.Compliance.RomDecodeBinding.ProgramDecode_lui trace i c := by
   let rd := (regidx_to_fin c.rd).val
   let imm := (c.imm ++ (0 : BitVec 12)).toNat
@@ -1096,14 +1245,18 @@ noncomputable def ProgramDecode_lui_from_rawProgram {n : Nat}
         exact decide_eq_false hsi
       h_prog := by
         intro j hline
-        have hbk : trace.program j = romMessageOfRaw (addr j)
+        obtain ⟨k, hstart, haddr, hraw⟩ := rawDecode.hLine j hline
+        have hbk : trace.program j = romMessageOfRaw (addr k)
             (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x37) := by
-          exact (hbind.2 j).trans
-            (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+          apply primary_row_non_jalr_control hbind ⟨k, hstart, rfl, hraw⟩ ext
+          · simpa only [imm, rd, ext] using hok
+          · rw [ZiskFv.Compliance.Decode.toU32_and127,
+              ZiskFv.Compliance.Decode.rawUType_opcode imm rd 0x37 (by norm_num)]
+            decide
         obtain ⟨ho, hjo1, hjo2, hs, ext', hok', hieo', hm32', hsetpc',
             hstorepc', hf⟩ :=
           lui_decode_fields_of_binding rd imm (regidx_to_fin c.rd).isLt
-            (addr j) (trace.program j) hbk
+            (addr k) (trace.program j) hbk
         have hext : ext' = ext :=
           Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
         subst ext'
@@ -1114,13 +1267,555 @@ noncomputable def ProgramDecode_lui_from_rawProgram {n : Nat}
         change (regidx_to_fin c.rd).val % GL_prime = (regidx_to_fin c.rd).val
         exact Nat.mod_eq_of_lt (lt_trans (regidx_to_fin c.rd).isLt (by norm_num)) }
 
+private theorem control_rom_offset (imm : BitVec w) (d : DecodedRv64im)
+    (hdimm : (IScalar.hcast UScalarTy.U64 d.imm).bv = BitVec.signExtend 64 imm) :
+    ((IScalar.cast IScalarTy.I64 d.imm).val : FGL) =
+      ((BitVec.signExtend 64 imm).toInt : FGL) := by
+  congr 1
+  change (BitVec.signExtend 64 d.imm.bv).toInt = _
+  rw [show BitVec.signExtend 64 d.imm.bv = BitVec.signExtend 64 imm by
+    simpa only using hdimm]
+
+private theorem signExtend21_of_sign_control (v : BitVec 21) (h : v[20] = true) :
+    v.setWidth 32 - 2097152#32 = BitVec.signExtend 32 v := by
+  apply BitVec.eq_of_toInt_eq
+  rw [BitVec.toInt_sub, BitVec.toInt_signExtend_of_le (by omega)]
+  have hlo : 1048576 ≤ v.toNat := by
+    by_contra hnlt
+    have ht := Nat.testBit_lt_two_pow (show v.toNat < 2 ^ 20 by omega)
+    have hb : v.toNat.testBit 20 = true := by
+      change v[20] = true
+      exact h
+    rw [ht] at hb
+    contradiction
+  have hsetInt : (v.setWidth 32).toInt = v.toNat := by
+    rw [BitVec.toInt]
+    have hnat : (v.setWidth 32).toNat = v.toNat := by
+      rw [BitVec.toNat_setWidth, Nat.mod_eq_of_lt (lt_trans v.isLt (by norm_num))]
+    rw [hnat, if_pos (by have hv := v.isLt; norm_num at hv ⊢; omega)]
+  have hvInt : v.toInt = (v.toNat : Int) - 2097152 := by
+    rw [BitVec.toInt, if_neg (by omega)]
+    norm_num
+  have hmax : (2097152#32).toInt = 2097152 := by decide
+  rw [hvInt, hsetInt, hmax]
+  norm_num [Int.bmod]
+  have hmod : ((v.toNat : Int) - 2097152) % 4294967296 =
+      (v.toNat : Int) - 2097152 + 4294967296 := by
+    rw [Int.emod_eq_add_self_emod]
+    apply Int.emod_eq_of_lt <;> have hv := v.isLt <;> omega
+  rw [hmod, if_neg (by have hv := v.isLt; omega)]
+  omega
+
+private theorem signExtend21_of_not_sign_control (v : BitVec 21) (h : v[20] = false) :
+    v.setWidth 32 = BitVec.signExtend 32 v := by
+  symm
+  apply BitVec.eq_of_getLsbD_eq
+  intro i
+  by_cases hi : i < 32
+  · interval_cases i <;>
+      simp [BitVec.getElem_signExtend, BitVec.getElem_setWidth,
+        BitVec.msb_setWidth] at h ⊢ <;> assumption
+  · simp [BitVec.getLsbD_signExtend, hi]
+
+private theorem signext21_control (v : BitVec 21) :
+    signext ⟨v.setWidth 32⟩ 21#u32
+      ⦃r => r.bv = BitVec.signExtend 32 v⦄ := by
+  rw [signext]
+  step*
+  all_goals
+    have hi : i = 20#u32 := UScalar.eq_imp _ _ (by simpa using i_post1)
+    subst i
+    have hs : sign_bit = 1048576#u32 :=
+      UScalar.eq_imp _ _ (by
+        norm_num [sign_bit_post1, U32.size_eq, Nat.shiftLeft_eq])
+    subst sign_bit
+    have hm : max_value = 2097152#u32 :=
+      UScalar.eq_imp _ _ (by
+        norm_num [max_value_post1, U32.size_eq, Nat.shiftLeft_eq])
+    subst max_value
+    clear i_post1 i_post2 sign_bit_post1 sign_bit_post2 max_value_post1 max_value_post2
+  · clear i1_post1 i1_post2
+    rw [i2_post, i3_post]
+    change I32.min ≤ (v.setWidth 32).toInt - (2097152#32).toInt
+    have hmin : I32.min = -2147483648 := by
+      norm_num [I32.min, I32.numBits_eq]
+    have hset : (v.setWidth 32).toInt = v.toNat := by
+      rw [BitVec.toInt]
+      have hnat : (v.setWidth 32).toNat = v.toNat := by
+        rw [BitVec.toNat_setWidth, Nat.mod_eq_of_lt (lt_trans v.isLt (by norm_num))]
+      rw [hnat, if_pos (by have hv := v.isLt; norm_num at hv ⊢; omega)]
+    have hmax : (2097152#32).toInt = 2097152 := by decide
+    rw [hmin, hset, hmax]
+    omega
+  · clear i1_post1 i1_post2
+    rw [i2_post, i3_post]
+    change (v.setWidth 32).toInt - (2097152#32).toInt ≤ I32.max
+    have hmax : I32.max = 2147483647 := by
+      norm_num [I32.max, I32.numBits_eq]
+    have hset : (v.setWidth 32).toInt = v.toNat := by
+      rw [BitVec.toInt]
+      have hnat : (v.setWidth 32).toNat = v.toNat := by
+        rw [BitVec.toNat_setWidth, Nat.mod_eq_of_lt (lt_trans v.isLt (by norm_num))]
+      rw [hnat, if_pos (by have hv := v.isLt; norm_num at hv ⊢; omega)]
+    have hpow : (2097152#32).toInt = 2097152 := by decide
+    rw [hmax, hset, hpow]
+    omega
+  · calc
+      r.bv = i2.bv - i3.bv := r_post2
+      _ = v.setWidth 32 - 2097152#32 := by rw [i2_post, i3_post]; rfl
+      _ = BitVec.signExtend 32 v := by
+        apply signExtend21_of_sign_control
+        have hi1 := i1_post2
+        change i1.bv = 1048576#32 &&& v.setWidth 32 at hi1
+        have hne : (i1 != 0#u32) = true := by assumption
+        simp at hne
+        change i1.bv.toNat ≠ 0 at hne
+        by_contra hb
+        have hz : 1048576#32 &&& v.setWidth 32 = 0#32 := by
+          apply BitVec.eq_of_getLsbD_eq
+          intro k
+          by_cases hk : k < 32
+          · interval_cases k <;> simp_all
+          · simp [BitVec.getLsbD, hk]
+        rw [hi1, hz] at hne
+        exact hne rfl
+  · change v.setWidth 32 = BitVec.signExtend 32 v
+    apply signExtend21_of_not_sign_control
+    have hi1 := i1_post2
+    change i1.bv = 1048576#32 &&& v.setWidth 32 at hi1
+    have hne : ¬(i1 != 0#u32) = true := by assumption
+    simp at hne
+    change i1.bv.toNat = 0 at hne
+    have hi1zero : i1.bv = 0#32 := BitVec.eq_of_toNat_eq hne
+    rw [hi1] at hi1zero
+    have hzbit := congrArg (fun x : BitVec 32 => x[20]) hi1zero
+    simpa using hzbit
+
+private theorem rawJType_imm_bits (imm rd : Nat) (hrd : rd < 32)
+    (himm : imm < 2097152) (halign : imm % 2 = 0) :
+    let assembled :=
+      ((((ZiskFv.Completeness.Rv64imShapes.rawJType imm rd &&&
+          2147483648#32) >>> 31) <<< 20) |||
+        (((ZiskFv.Completeness.Rv64imShapes.rawJType imm rd &&&
+          1044480#32) >>> 12) <<< 12) |||
+        (((ZiskFv.Completeness.Rv64imShapes.rawJType imm rd &&&
+          1048576#32) >>> 20) <<< 11) |||
+        (((ZiskFv.Completeness.Rv64imShapes.rawJType imm rd &&&
+          2145386496#32) >>> 21) <<< 1))
+    assembled.truncate 21 = BitVec.ofNat 21 imm := by
+  have hbit0 : imm.testBit 0 = false := by
+    rw [Nat.testBit_zero]
+    simp [halign]
+  have hrdBit (k : Nat) (hk : 5 ≤ k) : rd.testBit k = false :=
+    ZiskFv.Compliance.Decode.tbf (show rd < 2 ^ 5 by omega) hk
+  have hdiv (s k : Nat) :
+      (imm / 2 ^ s).testBit k = imm.testBit (s + k) := by
+    rw [← Nat.shiftRight_eq_div_pow, Nat.testBit_shiftRight]
+  have hdiv2 (k : Nat) :
+      (imm / 2).testBit k = imm.testBit (k + 1) := by
+    simpa [Nat.add_comm] using hdiv 1 k
+  have himmhalf : imm = imm / 2 * 2 := by omega
+  have htest (k : Nat) :
+      imm.testBit k = ((1 ≤ k) && (imm / 2).testBit (k - 1)) := by
+    rw [himmhalf]
+    simpa using Nat.testBit_mul_two_pow (imm / 2) k 1
+  apply BitVec.eq_of_getLsbD_eq
+  intro k
+  by_cases hk : k < 21
+  · interval_cases k <;>
+      simp only [ZiskFv.Completeness.Rv64imShapes.rawJType,
+        ZiskFv.Completeness.Rv64imShapes.rawOfNat32,
+        BitVec.truncate, BitVec.getLsbD_setWidth,
+        BitVec.getLsbD_ushiftRight, BitVec.getLsbD_shiftLeft,
+        BitVec.getLsbD_and, BitVec.getLsbD_or, BitVec.getLsbD_ofNat,
+        Nat.testBit_or, Nat.testBit_shiftLeft, Nat.testBit_shiftRight,
+        Nat.testBit_and, Nat.testBit_mod_two_pow] <;>
+      simp [Nat.mod_eq_of_lt himm, halign, hbit0, hrdBit, htest] <;>
+      norm_num [Nat.testBit] <;>
+      simp
+  · simp [BitVec.getLsbD, hk]
+
+private theorem decode_j_rawJType_imm
+    (imm rd : Nat) (hrd : rd < 32) (himm : imm < 2097152)
+    (halign : imm % 2 = 0) (d : DecodedRv64im)
+    (hd : decode_j (toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd))
+      RiscvOpcode.Jal = ok d) :
+    (IScalar.hcast UScalarTy.U64 d.imm).bv =
+      BitVec.signExtend 64 (BitVec.ofNat 21 imm) := by
+  simp only [decode_j, DecodedRv64im.new, lift, bind_ok, Bind.bind] at hd
+  obtain ⟨_rd, _, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+  obtain ⟨imm20, himm20, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+  obtain ⟨imm10_1, himm10, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+  obtain ⟨imm11, himm11, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+  obtain ⟨imm19_12, himm19, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+  obtain ⟨i6, hi6, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+  obtain ⟨i7, hi7, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+  obtain ⟨i9, hi9, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+  obtain ⟨i11, hi11, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+  obtain ⟨i13, hi13, hd⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hd
+  rw [Result.ok.injEq] at hd
+  rw [← hd]
+  have himm20bv : imm20.bv =
+      (toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd) &&&
+        2147483648#u32).bv >>> 31 := by
+    rw [show ((toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd) &&&
+      2147483648#u32) >>> 31#i32 : Result Std.U32) =
+        ok ⟨(toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd) &&&
+          2147483648#u32).bv >>> 31⟩ from rfl, Result.ok.injEq] at himm20
+    exact (congrArg UScalar.bv himm20).symm
+  have himm10bv : imm10_1.bv =
+      (toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd) &&&
+        2145386496#u32).bv >>> 21 := by
+    rw [show ((toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd) &&&
+      2145386496#u32) >>> 21#i32 : Result Std.U32) =
+        ok ⟨(toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd) &&&
+          2145386496#u32).bv >>> 21⟩ from rfl, Result.ok.injEq] at himm10
+    exact (congrArg UScalar.bv himm10).symm
+  have himm11bv : imm11.bv =
+      (toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd) &&&
+        1048576#u32).bv >>> 20 := by
+    rw [show ((toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd) &&&
+      1048576#u32) >>> 20#i32 : Result Std.U32) =
+        ok ⟨(toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd) &&&
+          1048576#u32).bv >>> 20⟩ from rfl, Result.ok.injEq] at himm11
+    exact (congrArg UScalar.bv himm11).symm
+  have himm19bv : imm19_12.bv =
+      (toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd) &&&
+        1044480#u32).bv >>> 12 := by
+    rw [show ((toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd) &&&
+      1044480#u32) >>> 12#i32 : Result Std.U32) =
+        ok ⟨(toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd) &&&
+          1044480#u32).bv >>> 12⟩ from rfl, Result.ok.injEq] at himm19
+    exact (congrArg UScalar.bv himm19).symm
+  have hi6bv : i6.bv = imm20.bv <<< 20 := by
+    rw [show (imm20 <<< 20#i32 : Result Std.U32) =
+      ok ⟨imm20.bv <<< 20⟩ from rfl, Result.ok.injEq] at hi6
+    exact (congrArg UScalar.bv hi6).symm
+  have hi7bv : i7.bv = imm19_12.bv <<< 12 := by
+    rw [show (imm19_12 <<< 12#i32 : Result Std.U32) =
+      ok ⟨imm19_12.bv <<< 12⟩ from rfl, Result.ok.injEq] at hi7
+    exact (congrArg UScalar.bv hi7).symm
+  have hi9bv : i9.bv = imm11.bv <<< 11 := by
+    rw [show (imm11 <<< 11#i32 : Result Std.U32) =
+      ok ⟨imm11.bv <<< 11⟩ from rfl, Result.ok.injEq] at hi9
+    exact (congrArg UScalar.bv hi9).symm
+  have hi11bv : i11.bv = imm10_1.bv <<< 1 := by
+    rw [show (imm10_1 <<< 1#i32 : Result Std.U32) =
+      ok ⟨imm10_1.bv <<< 1⟩ from rfl, Result.ok.injEq] at hi11
+    exact (congrArg UScalar.bv hi11).symm
+  have hi12bv : (i6 ||| i7 ||| i9 ||| i11).bv =
+      (imm20.bv <<< 20) ||| (imm19_12.bv <<< 12) |||
+        (imm11.bv <<< 11) ||| (imm10_1.bv <<< 1) := by
+    change i6.bv ||| i7.bv ||| i9.bv ||| i11.bv = _
+    rw [hi6bv, hi7bv, hi9bv, hi11bv]
+  have hassembled : (i6 ||| i7 ||| i9 ||| i11).bv.truncate 21 =
+      BitVec.ofNat 21 imm := by
+    rw [hi12bv, himm20bv, himm19bv, himm11bv, himm10bv]
+    exact rawJType_imm_bits imm rd hrd himm halign
+  have hwidth : (i6 ||| i7 ||| i9 ||| i11).bv =
+      (BitVec.ofNat 21 imm).setWidth 32 := by
+    apply BitVec.eq_of_getLsbD_eq
+    intro k
+    by_cases hk : k < 21
+    · have hg := congrArg (fun x : BitVec 21 => x.getLsbD k) hassembled
+      simpa [BitVec.getLsbD_setWidth, hk, show k < 32 by omega] using hg
+    · by_cases hk32 : k < 32
+      · interval_cases k <;>
+          simp [hi12bv, himm20bv, himm19bv, himm11bv, himm10bv,
+            BitVec.getLsbD_ushiftRight, BitVec.getLsbD_shiftLeft,
+            BitVec.getLsbD_and]
+      · simp [BitVec.getLsbD, hk32]
+  have hs := signext21_control (BitVec.ofNat 21 imm)
+  rw [← hwidth] at hs
+  rw [hi13] at hs
+  have hi13bv : i13.bv = BitVec.signExtend 32 (BitVec.ofNat 21 imm) := hs
+  change BitVec.signExtend 64 i13.bv =
+    BitVec.signExtend 64 (BitVec.ofNat 21 imm)
+  rw [hi13bv]
+  apply BitVec.eq_of_getLsbD_eq
+  intro k
+  by_cases hk : k < 64
+  · interval_cases k <;>
+      simp [BitVec.getElem_signExtend, BitVec.msb_signExtend]
+  · simp [BitVec.getLsbD_signExtend, hk]
+
+/-! ## Branch-family `ProgramDecode` bundles. -/
+
+local macro "branch_program_decode" nm:ident "," f3:term "," rop:term ","
+    neg:term : command => do
+  let s := nm.getId.toString
+  let rawName := Lean.mkIdent (Lean.Name.mkSimple ("RawProgramDecode_" ++ s))
+  let ctorName := Lean.mkIdent (Lean.Name.mkSimple ("ProgramDecode_" ++ s ++ "_from_rawProgram"))
+  let transpileName := Lean.mkIdent (Lean.Name.mkSimple ("transpile_" ++ s))
+  let fieldsName := Lean.mkIdent (Lean.Name.mkSimple (s ++ "_decode_fields_of_binding"))
+  let claimName := Lean.mkIdent ((`ZiskFv.Compliance).str ("Claim_" ++ s))
+  let programName :=
+    Lean.mkIdent ((`ZiskFv.Compliance.RomDecodeBinding).str ("ProgramDecode_" ++ s))
+  let t1 ← `(structure $rawName {n rawLength : Nat}
+      (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+      (i : Fin trace.numInstructions) (c : $claimName trace i)
+      (start : Fin rawLength → Fin trace.programLength)
+      (addr : Fin rawLength → FGL) (rawProgram : Fin rawLength → BitVec 32) where
+    h_idx : i.val + 1 < trace.mainTable.table.length
+    h_imm_aligned : c.imm.toNat % 2 = 0
+    hLine : ∀ j : Fin trace.programLength,
+      (trace.program j).line =
+          (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
+        RawAtProgramStart start addr rawProgram j (trace.program j).line
+          (ZiskFv.Completeness.Rv64imShapes.rawBType c.imm.toNat
+            (regidx_to_fin c.r2).val (regidx_to_fin c.r1).val $f3))
+  let t2 ← `(noncomputable def $ctorName {n rawLength : Nat}
+      (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+      (i : Fin trace.numInstructions) (c : $claimName trace i)
+      (start : Fin rawLength → Fin trace.programLength)
+      (addr : Fin rawLength → FGL)
+      (rawProgram : Fin rawLength → BitVec 32)
+      (hbind : ProgramRowsBinding trace start addr rawProgram)
+      (rawDecode : $rawName trace i c start addr rawProgram) :
+      $programName trace i c := by
+    let rs1 := (regidx_to_fin c.r1).val
+    let rs2 := (regidx_to_fin c.r2).val
+    let imm := c.imm.toNat
+    let ext := ($transpileName rs1 rs2 imm (regidx_to_fin c.r1).isLt
+      (regidx_to_fin c.r2).isLt).choose
+    obtain ⟨hok, hop, hieo, hm32, hsetpc, hstorepc, hconst, hdyn⟩ :=
+      ($transpileName rs1 rs2 imm (regidx_to_fin c.r1).isLt
+        (regidx_to_fin c.r2).isLt).choose_spec
+    let d := hdyn.choose
+    have hd := hdyn.choose_spec.1
+    have htarget := hdyn.choose_spec.2
+    have hdimm : (IScalar.hcast UScalarTy.U64 d.imm).bv =
+        BitVec.signExtend 64 c.imm := by
+      have hfields := decode_b_rawBType_fields
+        imm rs2 rs1 $f3 (regidx_to_fin c.r2).isLt (regidx_to_fin c.r1).isLt
+        (by norm_num)
+        (by simpa only [imm] using
+          (Aeneas.SimpScalar.BitVec.toNat_lt_two_pow c.imm 13 (by omega)))
+        rawDecode.h_imm_aligned
+        $rop d hd
+      simpa only [imm, BitVec.ofNat_toNat] using hfields.2.2
+    refine
+      { h_idx := rawDecode.h_idx
+        bits := romFlagBitsOfExtract ext.row
+        h_bits_ieo := by simpa only [ext, romFlagBitsOfExtract] using hieo
+        h_bits_m32 := by simpa only [ext, romFlagBitsOfExtract] using hm32
+        h_bits_set_pc := by simpa only [ext, romFlagBitsOfExtract] using hsetpc
+        h_bits_store_pc := by simpa only [ext, romFlagBitsOfExtract] using hstorepc
+        h_prog := by
+          intro j hline
+          obtain ⟨k, hstart, haddr, hraw⟩ := rawDecode.hLine j hline
+          have hbk : trace.program j =
+              romMessageOfRaw (addr k)
+                (ZiskFv.Completeness.Rv64imShapes.rawBType imm rs2 rs1 $f3) := by
+            apply primary_row_non_jalr_control hbind ⟨k, hstart, rfl, hraw⟩ ext
+            · simpa only [imm, rs1, rs2, ext] using hok
+            · rw [ZiskFv.Compliance.Decode.toU32_and127,
+                ZiskFv.Compliance.Decode.rawBType_opcode]
+              decide
+          obtain ⟨ho, hconstant, ext', hok', _hieo', _hm32', _hsetpc',
+              _hstorepc', hf⟩ :=
+            $fieldsName rs1 rs2 imm (regidx_to_fin c.r1).isLt
+              (regidx_to_fin c.r2).isLt (addr k) (trace.program j) hbk
+          have hext : ext' = ext :=
+            Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
+          subst ext'
+          have htargetF :
+              ((IScalar.cast IScalarTy.I64 d.imm).val : FGL) =
+                ((BitVec.signExtend 64 c.imm).toInt : FGL) :=
+            control_rom_offset c.imm d hdimm
+          first
+          | exact ⟨ho, by
+              rw [hbk, romMessageOfRaw, hok]
+              simp only [romRowOf_eq_serializeExtract, serializeExtract]
+              rw [htarget, htargetF], hconstant, hf⟩
+          | exact ⟨ho, hconstant, by
+              rw [hbk, romMessageOfRaw, hok]
+              simp only [romRowOf_eq_serializeExtract, serializeExtract]
+              rw [htarget, htargetF], hf⟩ })
+  return ⟨Lean.mkNullNode #[t1, t2]⟩
+
+branch_program_decode beq, 0, RiscvOpcode.Beq, false
+branch_program_decode bne, 1, RiscvOpcode.Bne, true
+branch_program_decode blt, 4, RiscvOpcode.Blt, false
+branch_program_decode bge, 5, RiscvOpcode.Bge, true
+branch_program_decode bltu, 6, RiscvOpcode.Bltu, false
+branch_program_decode bgeu, 7, RiscvOpcode.Bgeu, true
+
+structure RawProgramDecode_auipc {n rawLength : Nat}
+    (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_auipc trace i)
+    (start : Fin rawLength → Fin trace.programLength)
+    (addr : Fin rawLength → FGL) (rawProgram : Fin rawLength → BitVec 32) where
+  h_idx : i.val + 1 < trace.mainTable.table.length
+  h_rd_ne_zero : (regidx_to_fin c.rd).val ≠ 0
+  hLine : ∀ j : Fin trace.programLength,
+    (trace.program j).line =
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
+      RawAtProgramStart start addr rawProgram j (trace.program j).line
+        (ZiskFv.Completeness.Rv64imShapes.rawUType
+          (c.imm ++ (0 : BitVec 12)).toNat (regidx_to_fin c.rd).val 0x17)
+
+noncomputable def ProgramDecode_auipc_from_rawProgram {n rawLength : Nat}
+    (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_auipc trace i)
+    (start : Fin rawLength → Fin trace.programLength)
+    (addr : Fin rawLength → FGL)
+    (rawProgram : Fin rawLength → BitVec 32)
+    (hbind : ProgramRowsBinding trace start addr rawProgram)
+    (rawDecode : RawProgramDecode_auipc trace i c start addr rawProgram) :
+    ZiskFv.Compliance.RomDecodeBinding.ProgramDecode_auipc trace i c := by
+  let rd := (regidx_to_fin c.rd).val
+  let imm := (c.imm ++ (0 : BitVec 12)).toNat
+  let ext := (transpile_auipc rd imm (regidx_to_fin c.rd).isLt
+    rawDecode.h_rd_ne_zero).choose
+  obtain ⟨hok, hop, hieo, hm32, hsetpc, hstorepc, hconstant, hstoreOffset,
+      hstoreInd, hdyn⟩ :=
+    (transpile_auipc rd imm (regidx_to_fin c.rd).isLt
+      rawDecode.h_rd_ne_zero).choose_spec
+  let d := hdyn.choose
+  have hd := hdyn.choose_spec.1
+  have htarget := hdyn.choose_spec.2
+  have hdimm : (IScalar.hcast UScalarTy.U64 d.imm).bv =
+      BitVec.signExtend 64 (c.imm ++ (0 : BitVec 12)) :=
+    decode_u_rawUType_imm (c.imm) rd 0x17 (regidx_to_fin c.rd).isLt
+      (by norm_num) RiscvOpcode.Auipc d hd
+  refine
+    { h_idx := rawDecode.h_idx
+      bits := romFlagBitsOfExtract ext.row
+      h_bits_ieo := by simpa only [ext, romFlagBitsOfExtract] using hieo
+      h_bits_m32 := by simpa only [ext, romFlagBitsOfExtract] using hm32
+      h_bits_set_pc := by simpa only [ext, romFlagBitsOfExtract] using hsetpc
+      h_bits_store_pc := by simpa only [ext, romFlagBitsOfExtract] using hstorepc
+      h_bits_store_ind := by
+        simp only [romFlagBitsOfExtract]
+        exact decide_eq_false hstoreInd
+      h_prog := by
+        intro j hline
+        obtain ⟨k, hstart, haddr, hraw⟩ := rawDecode.hLine j hline
+        have hbk : trace.program j =
+            romMessageOfRaw (addr k)
+              (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x17) := by
+          apply primary_row_non_jalr_control hbind ⟨k, hstart, rfl, hraw⟩ ext
+          · simpa only [imm, rd, ext] using hok
+          · rw [ZiskFv.Compliance.Decode.toU32_and127,
+              ZiskFv.Compliance.Decode.rawUType_opcode imm rd 0x17 (by norm_num)]
+            decide
+        obtain ⟨ho, hjo1, hso, ext', hok', _hieo', _hm32', _hsetpc',
+            _hstorepc', hf⟩ :=
+          auipc_decode_fields_of_binding rd imm (regidx_to_fin c.rd).isLt
+            rawDecode.h_rd_ne_zero (addr k) (trace.program j) hbk
+        have hext : ext' = ext :=
+          Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
+        subst ext'
+        have htargetF :
+            ((IScalar.cast IScalarTy.I64 d.imm).val : FGL) =
+              ((BitVec.signExtend 64 (c.imm ++ (0 : BitVec 12))).toInt : FGL) :=
+          control_rom_offset (c.imm ++ (0 : BitVec 12)) d hdimm
+        refine ⟨ho, hjo1, ?_, ?_, hf⟩
+        · rw [hbk, romMessageOfRaw, hok]
+          simp only [romRowOf_eq_serializeExtract, serializeExtract]
+          rw [htarget, htargetF]
+        · rw [hso]
+          simp only [rd, Transpiler.ind]
+          apply Fin.ext
+          change (regidx_to_fin c.rd).val % GL_prime = (regidx_to_fin c.rd).val
+          exact Nat.mod_eq_of_lt
+            (lt_trans (regidx_to_fin c.rd).isLt (by norm_num)) }
+
+structure RawProgramDecode_jal {n rawLength : Nat}
+    (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_jal trace i)
+    (start : Fin rawLength → Fin trace.programLength)
+    (addr : Fin rawLength → FGL) (rawProgram : Fin rawLength → BitVec 32) where
+  h_idx : i.val + 1 < trace.mainTable.table.length
+  h_rd_ne_zero : (regidx_to_fin c.rd).val ≠ 0
+  h_imm_aligned : c.imm.toNat % 2 = 0
+  hLine : ∀ j : Fin trace.programLength,
+    (trace.program j).line =
+        (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
+      RawAtProgramStart start addr rawProgram j (trace.program j).line
+        (ZiskFv.Completeness.Rv64imShapes.rawJType
+          c.imm.toNat (regidx_to_fin c.rd).val)
+
+noncomputable def ProgramDecode_jal_from_rawProgram {n rawLength : Nat}
+    (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_jal trace i)
+    (start : Fin rawLength → Fin trace.programLength)
+    (addr : Fin rawLength → FGL)
+    (rawProgram : Fin rawLength → BitVec 32)
+    (hbind : ProgramRowsBinding trace start addr rawProgram)
+    (rawDecode : RawProgramDecode_jal trace i c start addr rawProgram) :
+    ZiskFv.Compliance.RomDecodeBinding.ProgramDecode_jal trace i c := by
+  let rd := (regidx_to_fin c.rd).val
+  let imm := c.imm.toNat
+  let ext := (transpile_jal rd imm (regidx_to_fin c.rd).isLt
+    rawDecode.h_rd_ne_zero).choose
+  obtain ⟨hok, hop, hieo, hm32, hsetpc, hstorepc, hconstant, hstoreOffset,
+      hstoreInd, hdyn⟩ :=
+    (transpile_jal rd imm (regidx_to_fin c.rd).isLt
+      rawDecode.h_rd_ne_zero).choose_spec
+  let d := hdyn.choose
+  have hd := hdyn.choose_spec.1
+  have htarget := hdyn.choose_spec.2
+  have hdimm : (IScalar.hcast UScalarTy.U64 d.imm).bv =
+      BitVec.signExtend 64 c.imm := by
+    simpa only [imm, BitVec.ofNat_toNat] using
+      decode_j_rawJType_imm imm rd (regidx_to_fin c.rd).isLt
+        (by
+          simpa only [imm] using
+            (Aeneas.SimpScalar.BitVec.toNat_lt_two_pow c.imm 21 (by omega)))
+        rawDecode.h_imm_aligned d hd
+  refine
+    { h_idx := rawDecode.h_idx
+      bits := romFlagBitsOfExtract ext.row
+      h_bits_ieo := by simpa only [ext, romFlagBitsOfExtract] using hieo
+      h_bits_m32 := by simpa only [ext, romFlagBitsOfExtract] using hm32
+      h_bits_set_pc := by simpa only [ext, romFlagBitsOfExtract] using hsetpc
+      h_bits_store_pc := by simpa only [ext, romFlagBitsOfExtract] using hstorepc
+      h_bits_store_ind := by
+        simp only [romFlagBitsOfExtract]
+        exact decide_eq_false hstoreInd
+      h_prog := by
+        intro j hline
+        obtain ⟨k, hstart, haddr, hraw⟩ := rawDecode.hLine j hline
+        have hbk : trace.program j =
+            romMessageOfRaw (addr k)
+              (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd) := by
+          apply primary_row_non_jalr_control hbind ⟨k, hstart, rfl, hraw⟩ ext
+          · simpa only [imm, rd, ext] using hok
+          · rw [ZiskFv.Compliance.Decode.toU32_and127,
+              ZiskFv.Compliance.Decode.rawJType_opcode]
+            decide
+        obtain ⟨ho, hjo2, hso, ext', hok', _hieo', _hm32', _hsetpc',
+            _hstorepc', hf⟩ :=
+          jal_decode_fields_of_binding rd imm (regidx_to_fin c.rd).isLt
+            rawDecode.h_rd_ne_zero (addr k) (trace.program j) hbk
+        have hext : ext' = ext :=
+          Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
+        subst ext'
+        have htargetF :
+            ((IScalar.cast IScalarTy.I64 d.imm).val : FGL) =
+              ((BitVec.signExtend 64 c.imm).toInt : FGL) :=
+          control_rom_offset c.imm d hdimm
+        refine ⟨ho, ?_, hjo2, ?_, hf⟩
+        · rw [hbk, romMessageOfRaw, hok]
+          simp only [romRowOf_eq_serializeExtract, serializeExtract]
+          rw [htarget, htargetF]
+        · rw [hso]
+          simp only [rd, Transpiler.ind]
+          apply Fin.ext
+          change (regidx_to_fin c.rd).val % GL_prime = (regidx_to_fin c.rd).val
+          exact Nat.mod_eq_of_lt
+            (lt_trans (regidx_to_fin c.rd).isLt (by norm_num)) }
+
 /-- Raw-program evidence for one supported FENCE step.  Only the claim-side
     defect witnesses and the Main-row bound remain caller supplied; all
     committed-ROM fields are recovered from the raw word. -/
-structure RawProgramDecode_fence {n : Nat}
+structure RawProgramDecode_fence {n rawLength : Nat}
     (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
     (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_fence trace i)
-    (rawProgram : Fin trace.programLength → BitVec 32) where
+    (start : Fin rawLength → Fin trace.programLength)
+    (addr : Fin rawLength → FGL) (rawProgram : Fin rawLength → BitVec 32) where
   h_idx : i.val + 1 < trace.mainTable.table.length
   h_fm_zero : c.fm = 0#4
   h_rs_x0 : ZiskFv.Compliance.Defects.IsX0Reg c.rs
@@ -1128,18 +1823,20 @@ structure RawProgramDecode_fence {n : Nat}
   hLine : ∀ j : Fin trace.programLength,
     (trace.program j).line =
         (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).pc i.val →
-      rawProgram j =
-        ZiskFv.Completeness.Rv64imShapes.rawSupportedFence c.fenceP.toNat c.fenceS.toNat
+      RawAtProgramStart start addr rawProgram j (trace.program j).line
+        (ZiskFv.Completeness.Rv64imShapes.rawSupportedFence
+          c.fenceP.toNat c.fenceS.toNat)
 
 /-- Rebuild the current committed-program FENCE bundle from the raw program and
     the op-agnostic production-lowering certificate. -/
-noncomputable def ProgramDecode_fence_from_rawProgram {n : Nat}
+noncomputable def ProgramDecode_fence_from_rawProgram {n rawLength : Nat}
     (trace : ZiskFv.Compliance.AcceptedZiskTrace n)
     (i : Fin trace.numInstructions) (c : ZiskFv.Compliance.Claim_fence trace i)
-    (addr : Fin trace.programLength → FGL)
-    (rawProgram : Fin trace.programLength → BitVec 32)
-    (hbind : ProgramBinding trace addr rawProgram)
-    (rawDecode : RawProgramDecode_fence trace i c rawProgram) :
+    (start : Fin rawLength → Fin trace.programLength)
+    (addr : Fin rawLength → FGL)
+    (rawProgram : Fin rawLength → BitVec 32)
+    (hbind : ProgramRowsBinding trace start addr rawProgram)
+    (rawDecode : RawProgramDecode_fence trace i c start addr rawProgram) :
     ZiskFv.Compliance.RomDecodeBinding.ProgramDecode_fence trace i c := by
   let pred := c.fenceP.toNat
   let succ := c.fenceS.toNat
@@ -1164,34 +1861,34 @@ noncomputable def ProgramDecode_fence_from_rawProgram {n : Nat}
   · simpa only [ext, romFlagBitsOfExtract] using hieo
   · simpa only [ext, romFlagBitsOfExtract] using hsetpc
   · intro j hline
+    obtain ⟨k, hstart, haddr, hraw⟩ := rawDecode.hLine j hline
     have hbk : trace.program j =
-        romMessageOfRaw (addr j)
+        romMessageOfRaw (addr k)
           (ZiskFv.Completeness.Rv64imShapes.rawSupportedFence pred succ) := by
-      exact (hbind.2 j).trans
-        (congrArg (romMessageOfRaw (addr j)) (rawDecode.hLine j hline))
+      apply primary_row_non_jalr_control hbind ⟨k, hstart, rfl, hraw⟩ ext
+      · simpa only [pred, succ, ext] using hok
+      · rw [ZiskFv.Compliance.Decode.toU32_and127,
+          ZiskFv.Compliance.Decode.rawSupportedFence_opcode]
+        decide
     obtain ⟨ho, hjo1, hjo2, ext', hok', _hieo', _hm32', _hsetpc',
         _hstorepc', hf⟩ :=
       fence_decode_fields_of_binding pred succ hp hs
-        (addr j) (trace.program j) hbk
+        (addr k) (trace.program j) hbk
     have hext : ext' = ext := Result.ok.inj (hok'.symm.trans (by simpa only [ext] using hok))
     subst ext'
     exact ⟨ho, hjo1, hjo2, hf⟩
 
 section AxiomAudit
-#print axioms transpile_lui
-#print axioms transpile_auipc
-#print axioms auipc_negative_rom_target_mismatch
-#print axioms branch_negative_rom_target_mismatch
-#print axioms jal_negative_rom_target_mismatch
-#print axioms transpile_jal
-#print axioms transpile_jalr
-#print axioms jalr_decode_fields_of_binding
-#print axioms transpile_fence
-#print axioms fence_decode_fields_of_binding
+#print axioms ProgramDecode_beq_from_rawProgram
+#print axioms ProgramDecode_bne_from_rawProgram
+#print axioms ProgramDecode_blt_from_rawProgram
+#print axioms ProgramDecode_bge_from_rawProgram
+#print axioms ProgramDecode_bltu_from_rawProgram
+#print axioms ProgramDecode_bgeu_from_rawProgram
 #print axioms ProgramDecode_lui_from_rawProgram
+#print axioms ProgramDecode_auipc_from_rawProgram
+#print axioms ProgramDecode_jal_from_rawProgram
 #print axioms ProgramDecode_fence_from_rawProgram
-#print axioms transpile_beq
-#print axioms beq_decode_fields_of_binding
 end AxiomAudit
 
 end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingJalr.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingJalr.lean
@@ -1,0 +1,835 @@
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingControl
+import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.JalrRows
+
+namespace ZiskFv.Compliance.RawProgramBinding
+
+open ZiskFv.Compliance
+open ZiskFv.Compliance.RomDecodeBinding
+open ZiskFv.AirsClean.FullEnsemble (mainOfTable)
+open Aeneas Aeneas.Std Result zisk_core
+open ZiskFv.Compliance.Extraction
+
+set_option maxHeartbeats 800000
+
+private theorem from_inst_store_use_sp
+    (zi : zisk_inst.ZiskInst) (e : aeneas_extract.ZiskInstExtract)
+    (h : aeneas_extract.ZiskInstExtract.from_inst zi = .ok e) :
+    e.store_use_sp = zi.store_use_sp := by
+  unfold aeneas_extract.ZiskInstExtract.from_inst at h
+  obtain ⟨_, _, h⟩ := bind_eq_ok_imp h
+  rw [Result.ok.injEq] at h
+  subst e
+  rfl
+
+private theorem signExtend64_signExtend32 (v : BitVec 12) :
+    BitVec.signExtend 64 (BitVec.signExtend 32 v) = BitVec.signExtend 64 v := by
+  apply BitVec.eq_of_getLsbD_eq
+  intro k
+  by_cases hk : k < 64
+  · interval_cases k <;>
+      simp [BitVec.getLsbD_signExtend, BitVec.getElem_signExtend,
+        BitVec.msb_signExtend]
+  · simp [BitVec.getLsbD_signExtend, hk]
+
+private theorem jalr_signExtend64_signExtend32 (v : BitVec 12) :
+    BitVec.signExtend 64 (BitVec.signExtend 32 v) = BitVec.signExtend 64 v := by
+  apply BitVec.eq_of_getLsbD_eq
+  intro k
+  by_cases hk : k < 64
+  · interval_cases k <;>
+      simp [BitVec.getLsbD_signExtend, BitVec.getElem_signExtend,
+        BitVec.msb_signExtend]
+  · simp [BitVec.getLsbD_signExtend, hk]
+
+private theorem jalr_immediate_rom_value
+    (imm : BitVec 12) (d : riscv2zisk_single_row.Rv64imLoweringInput)
+    (hdimm : d.imm.bv = BitVec.signExtend 32 imm)
+    (row : aeneas_extract.ZiskInstExtract)
+    (hsrc : row.a_src = zisk_inst.SRC_IMM)
+    (hhi : row.a_use_sp_imm1.val =
+      (IScalar.hcast UScalarTy.U64 d.imm).val / 4294967296)
+    (hlo : row.a_offset_imm0.val =
+      (IScalar.hcast UScalarTy.U64 d.imm).val % 4294967296) :
+    BitVec.signExtend 64 imm =
+      BitVec.ofNat 64
+        ((romRowOf (0 : FGL) row).a_offset_imm0.val +
+          (romRowOf (0 : FGL) row).a_imm1.val * 4294967296) := by
+  have hv :
+      (IScalar.hcast UScalarTy.U64 d.imm).val =
+        (BitVec.signExtend 64 imm).toNat := by
+    change (BitVec.signExtend 64 d.imm.bv).toNat =
+      (BitVec.signExtend 64 imm).toNat
+    rw [hdimm, jalr_signExtend64_signExtend32]
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_ofNat]
+  simp only [romRowOf, sourceImmediate, hsrc, if_pos, UScalar.val]
+  have hloBound : row.a_offset_imm0.bv.toNat < 2 ^ 32 := by
+    rw [show row.a_offset_imm0.bv.toNat =
+      (IScalar.hcast UScalarTy.U64 d.imm).val % 4294967296 by
+        simpa only [UScalar.val] using hlo]
+    exact Nat.mod_lt _ (by norm_num)
+  have hsigned : (signedOffset row.a_offset_imm0).val =
+      row.a_offset_imm0.bv.toNat := by
+    have hnonneg : 2 * row.a_offset_imm0.val < 18446744073709551616 := by
+      change 2 * row.a_offset_imm0.bv.toNat < 18446744073709551616
+      norm_num at hloBound ⊢
+      omega
+    have hsignedF : signedOffset row.a_offset_imm0 =
+        (row.a_offset_imm0.bv.toNat : FGL) := by
+      simp [signedOffset, BitVec.toInt, if_pos hnonneg]
+    rw [hsignedF]
+    exact Nat.mod_eq_of_lt (lt_trans hloBound (by norm_num))
+  rw [hsigned]
+  have hhi' : row.a_use_sp_imm1.bv.toNat =
+      (IScalar.hcast UScalarTy.U64 d.imm).val / 4294967296 := by
+    simpa only [UScalar.val] using hhi
+  have hlo' : row.a_offset_imm0.bv.toNat =
+      (IScalar.hcast UScalarTy.U64 d.imm).val % 4294967296 := by
+    simpa only [UScalar.val] using hlo
+  rw [hhi', hlo', hv]
+  have hhigh :
+      (((BitVec.signExtend 64 imm).toNat / 4294967296 : Nat) : FGL).val =
+        (BitVec.signExtend 64 imm).toNat / 4294967296 := by
+    exact Nat.mod_eq_of_lt (by
+      have := (BitVec.signExtend 64 imm).isLt
+      norm_num at this ⊢
+      exact Nat.div_lt_of_lt_mul (by omega))
+  rw [hhigh]
+  rw [Nat.mod_add_div']
+  exact (Nat.mod_eq_of_lt (BitVec.isLt _)).symm
+
+private theorem jalr_raw_rows
+    (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) :
+    ∃ (rows : aeneas_extract.Rv64imTranspileRowsExtract)
+        (input : riscv2zisk_single_row.Rv64imLoweringInput),
+      aeneas_extract.extract_transpile_rv64im_rows_raw
+          (ZiskFv.Compliance.Decode.toU32
+            (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 0 rd 0x67)) =
+        .ok rows ∧
+      input.rd.val = rd ∧ input.rs1.val = rs1 ∧
+      input.imm.bv = BitVec.signExtend 32 (BitVec.ofNat 12 imm) ∧
+      ((rows.row_count = 1#u32 ∧
+          ZiskFv.Compliance.Extraction.JalrAlignedRowPins input
+            { paddr := rows.last_row.paddr, store_pc := rows.last_row.store_pc,
+              store_use_sp := rows.last_row.store_use_sp, store := rows.last_row.store,
+              store_offset := rows.last_row.store_offset, set_pc := rows.last_row.set_pc,
+              is_precompiled := rows.last_row.is_precompiled,
+              ind_width := rows.last_row.ind_width, «end» := rows.last_row.end,
+              a_src := rows.last_row.a_src, a_use_sp_imm1 := rows.last_row.a_use_sp_imm1,
+              a_offset_imm0 := rows.last_row.a_offset_imm0, b_src := rows.last_row.b_src,
+              b_use_sp_imm1 := rows.last_row.b_use_sp_imm1,
+              b_offset_imm0 := rows.last_row.b_offset_imm0,
+              jmp_offset1 := rows.last_row.jmp_offset1,
+              jmp_offset2 := rows.last_row.jmp_offset2,
+              is_external_op := rows.last_row.is_external_op, op := rows.last_row.op,
+              op_type := zisk_inst.ZiskOperationType.None, m32 := rows.last_row.m32,
+              input_size := rows.last_row.input_size,
+              sorted_pc_list_index := rows.last_row.sorted_pc_list_index }) ∨
+        (rows.row_count = 2#u32 ∧
+          ZiskFv.Compliance.Extraction.JalrUnalignedFirstRowPins input rows.first_row ∧
+          ZiskFv.Compliance.Extraction.JalrUnalignedSuccessorRowPins input
+            { paddr := rows.last_row.paddr, store_pc := rows.last_row.store_pc,
+              store_use_sp := rows.last_row.store_use_sp, store := rows.last_row.store,
+              store_offset := rows.last_row.store_offset, set_pc := rows.last_row.set_pc,
+              is_precompiled := rows.last_row.is_precompiled,
+              ind_width := rows.last_row.ind_width, «end» := rows.last_row.end,
+              a_src := rows.last_row.a_src, a_use_sp_imm1 := rows.last_row.a_use_sp_imm1,
+              a_offset_imm0 := rows.last_row.a_offset_imm0, b_src := rows.last_row.b_src,
+              b_use_sp_imm1 := rows.last_row.b_use_sp_imm1,
+              b_offset_imm0 := rows.last_row.b_offset_imm0,
+              jmp_offset1 := rows.last_row.jmp_offset1,
+              jmp_offset2 := rows.last_row.jmp_offset2,
+              is_external_op := rows.last_row.is_external_op, op := rows.last_row.op,
+              op_type := zisk_inst.ZiskOperationType.None, m32 := rows.last_row.m32,
+              input_size := rows.last_row.input_size,
+              sorted_pc_list_index := rows.last_row.sorted_pc_list_index })) := by
+  let raw := ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 0 rd 0x67
+  have hdec : aeneas_extract.rv64im_decode.decode_32_core
+        (ZiskFv.Compliance.Decode.toU32 raw) =
+      aeneas_extract.rv64im_decode.decode_i
+        (ZiskFv.Compliance.Decode.toU32 raw)
+          aeneas_extract.rv64im_decode.RiscvOpcode.Jalr false := by
+    simp only [raw, aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc,
+      Bind.bind, bind_ok, ZiskFv.Compliance.Decode.toU32_and127,
+      ZiskFv.Compliance.Decode.toU32_ofNat,
+      ZiskFv.Compliance.Decode.rawIType_opcode imm rs1 0 rd 0x67 (by norm_num)]
+    all_goals rfl
+  obtain ⟨decoded, hdecoded, hopd, hrdb, hrs1b, _⟩ :=
+    decode_i_bounds (ZiskFv.Compliance.Decode.toU32 raw)
+      aeneas_extract.rv64im_decode.RiscvOpcode.Jalr false
+  have hdec0 : aeneas_extract.rv64im_decode.decode_32_core
+      (ZiskFv.Compliance.Decode.toU32 raw) = .ok decoded := hdec.trans hdecoded
+  let input : riscv2zisk_single_row.Rv64imLoweringInput :=
+    { rom_address := 0#u64, rd := decoded.rd, rs1 := decoded.rs1,
+      rs2 := decoded.rs2, imm := decoded.imm }
+  obtain ⟨ctx, hctx⟩ := jalr_ok { defCtx with extract_marker := () } input
+    (by simpa only [input] using hrs1b) (by simpa only [input] using hrdb) rfl
+  have hpins := jalr_production_expanded_row_pins input ctx
+    (by simpa only [input] using hrdb) (by simpa only [input] using hrs1b) hctx
+  obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
+  have hdext' := hdext
+  unfold aeneas_extract.decode_extract_from_decoded at hdext'
+  obtain ⟨_, _, hdext'⟩ := bind_eq_ok_imp hdext'
+  obtain ⟨_, _, hdext'⟩ := bind_eq_ok_imp hdext'
+  obtain ⟨_, _, hdext'⟩ := bind_eq_ok_imp hdext'
+  rw [Result.ok.injEq] at hdext'
+  have hdextimm : dext.imm = decoded.imm := by rw [← hdext']
+  have hdextrd : dext.rd = decoded.rd := by rw [← hdext']
+  have hdextrs1 : dext.rs1 = decoded.rs1 := by rw [← hdext']
+  have hdextrs2 : dext.rs2 = decoded.rs2 := by rw [← hdext']
+  obtain ⟨hrdbv, hrs1bv, himm64⟩ :=
+    decode_i_rawIType_fields imm rs1 0 rd 0x67 hrs1 (by norm_num) hrd
+      (by norm_num) aeneas_extract.rv64im_decode.RiscvOpcode.Jalr decoded
+      (by simpa only [raw] using hdecoded)
+  have hrdval : input.rd.val = rd := by
+    change decoded.rd.bv.toNat = rd
+    rw [hrdbv]
+    simp [BitVec.toNat_ofNat]
+    omega
+  have hrs1val : input.rs1.val = rs1 := by
+    change decoded.rs1.bv.toNat = rs1
+    rw [hrs1bv]
+    simp [BitVec.toNat_ofNat]
+    omega
+  have himm : input.imm.bv = BitVec.signExtend 32 (BitVec.ofNat 12 imm) := by
+    simp only [input]
+    exact decode_i_rawIType_imm imm rs1 0 rd 0x67 hrs1 (by norm_num) hrd
+      (by norm_num) aeneas_extract.rv64im_decode.RiscvOpcode.Jalr decoded
+        (by simpa only [raw] using hdecoded)
+  have hlower :
+      riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+          defCtx input riscv2zisk_single_row.Rv64imSingleRowOpcode.Jalr false =
+        .ok { ctx with extract_marker := () } := by
+    change (do
+      let s ← riscv2zisk_context.Riscv2ZiskContext.jalr
+        { defCtx with extract_marker := () } input 4#u64
+      .ok { s with extract_marker := () }) = _
+    rw [hctx]
+    rfl
+  rcases hpins with haligned | hunaligned
+  · obtain ⟨hrem, hfirst, last, hlast, hpins⟩ := haligned
+    obtain ⟨lastRow, hfrom, haSrc, haHi, haLo, hbSrc, hbHi, hbLo, hwidth,
+      hop, hstore, hstoreOffset, hj1, hj2, hsetpc, hstorepc, hieo, hm32⟩ :=
+      from_inst_full_fields last.i
+    have hstoreUseSp := from_inst_store_use_sp last.i lastRow hfrom
+    let terminal : aeneas_extract.Rv64imTranspileExtract :=
+      { accepted := true, decode := dext, row := lastRow }
+    have hterminal :
+        aeneas_extract.extract_transpile_rv64im_raw
+            (ZiskFv.Compliance.Decode.toU32 raw) = .ok terminal := by
+      rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
+      simp only [bind_ok, Bind.bind, hdext, hopd]
+      change (do
+        let input' ← riscv2zisk_single_row.Rv64imLoweringInput.new 0#u64
+          decoded.rd decoded.rs1 decoded.rs2 decoded.imm
+        let ctx' ←
+          riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+            defCtx input' riscv2zisk_single_row.Rv64imSingleRowOpcode.Jalr false
+        let zib ← core.option.Option.unwrap ctx'.extract_inst
+        let row ← aeneas_extract.ZiskInstExtract.from_inst zib.i
+        .ok ({ accepted := true, decode := dext, row := row } :
+          aeneas_extract.Rv64imTranspileExtract)) = _
+      simp only [riscv2zisk_single_row.Rv64imLoweringInput.new, bind_ok]
+      change (do
+        let ctx' ←
+          riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+            defCtx input riscv2zisk_single_row.Rv64imSingleRowOpcode.Jalr false
+        let zib ← core.option.Option.unwrap ctx'.extract_inst
+        let row ← aeneas_extract.ZiskInstExtract.from_inst zib.i
+        .ok ({ accepted := true, decode := dext, row := row } :
+          aeneas_extract.Rv64imTranspileExtract)) = _
+      rw [hlower]
+      simp only [Bind.bind]
+      simp only [hlast, core.option.Option.unwrap, Result.ofOption, bind_ok]
+      rw [hfrom]
+      rfl
+    let rows : aeneas_extract.Rv64imTranspileRowsExtract :=
+      { accepted := true, decode := dext, row_count := 1#u32,
+        first_row := lastRow, last_row := lastRow }
+    refine ⟨rows, input, ?_, hrdval, hrs1val, himm, Or.inl ⟨rfl, ?_⟩⟩
+    · unfold aeneas_extract.extract_transpile_rv64im_rows_raw
+      rw [hterminal]
+      simp only [ZiskFv.Compliance.Decode.toU32_and127,
+        ZiskFv.Compliance.Decode.rawIType_opcode imm rs1 0 rd 0x67 (by norm_num)]
+      norm_num [terminal, rows, raw, input, hdextimm, hrem, lift, Bind.bind,
+        ZiskFv.Compliance.Decode.toU32_and127,
+        ZiskFv.Compliance.Decode.rawIType_opcode]
+    · unfold JalrAlignedRowPins JalrDestinationPins
+        JalrRegisterOrX0SourcePins at hpins ⊢
+      simpa [rows, hbSrc, hbHi, hbLo, hop, hstore, hstoreOffset, hstoreUseSp,
+        hj1, hj2, hsetpc, hstorepc, hieo, hm32] using hpins
+  · obtain ⟨rem, hrem, hrem0, first, last, hfirst, hlast, hfirstPins,
+      hlastPins⟩ := hunaligned
+    obtain ⟨lastRow, hfrom, haSrc, haHi, haLo, hbSrc, hbHi, hbLo, hwidth,
+      hop, hstore, hstoreOffset, hj1, hj2, hsetpc, hstorepc, hieo, hm32⟩ :=
+      from_inst_full_fields last.i
+    have hstoreUseSp := from_inst_store_use_sp last.i lastRow hfrom
+    let terminal : aeneas_extract.Rv64imTranspileExtract :=
+      { accepted := true, decode := dext, row := lastRow }
+    have hterminal :
+        aeneas_extract.extract_transpile_rv64im_raw
+            (ZiskFv.Compliance.Decode.toU32 raw) = .ok terminal := by
+      rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
+      simp only [bind_ok, Bind.bind, hdext, hopd]
+      change (do
+        let input' ← riscv2zisk_single_row.Rv64imLoweringInput.new 0#u64
+          decoded.rd decoded.rs1 decoded.rs2 decoded.imm
+        let ctx' ←
+          riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+            defCtx input' riscv2zisk_single_row.Rv64imSingleRowOpcode.Jalr false
+        let zib ← core.option.Option.unwrap ctx'.extract_inst
+        let row ← aeneas_extract.ZiskInstExtract.from_inst zib.i
+        .ok ({ accepted := true, decode := dext, row := row } :
+          aeneas_extract.Rv64imTranspileExtract)) = _
+      simp only [riscv2zisk_single_row.Rv64imLoweringInput.new, bind_ok]
+      change (do
+        let ctx' ←
+          riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+            defCtx input riscv2zisk_single_row.Rv64imSingleRowOpcode.Jalr false
+        let zib ← core.option.Option.unwrap ctx'.extract_inst
+        let row ← aeneas_extract.ZiskInstExtract.from_inst zib.i
+        .ok ({ accepted := true, decode := dext, row := row } :
+          aeneas_extract.Rv64imTranspileExtract)) = _
+      rw [hlower]
+      simp only [Bind.bind]
+      simp only [hlast, core.option.Option.unwrap, Result.ofOption, bind_ok]
+      rw [hfrom]
+      rfl
+    let rows : aeneas_extract.Rv64imTranspileRowsExtract :=
+      { accepted := true, decode := dext, row_count := 2#u32,
+        first_row := first, last_row := lastRow }
+    refine ⟨rows, input, ?_, hrdval, hrs1val, himm,
+      Or.inr ⟨rfl, hfirstPins, ?_⟩⟩
+    · unfold aeneas_extract.extract_transpile_rv64im_rows_raw
+      rw [hterminal]
+      simp only [ZiskFv.Compliance.Decode.toU32_and127,
+        ZiskFv.Compliance.Decode.rawIType_opcode imm rs1 0 rd 0x67 (by norm_num)]
+      have hremval : rem.val ≠ 0 := by
+        intro hz
+        apply hrem0
+        apply IScalar.eq_of_val_eq
+        simpa using hz
+      have hinputNew :
+          riscv2zisk_single_row.Rv64imLoweringInput.new 0#u64 decoded.rd
+              decoded.rs1 decoded.rs2 decoded.imm = .ok input := rfl
+      have hremDecoded :
+          (decoded.imm % 4#i32 : Result Std.I32) = Result.ok rem := by
+        simpa only [input] using hrem
+      norm_num [terminal, raw, hdextrd, hdextrs1, hdextrs2, hdextimm, hrem,
+        hremDecoded, hremval, lift, Bind.bind, hinputNew, hlower, hfirst, rows,
+        core.option.Option.unwrap, Result.ofOption]
+      rw [if_pos (by decide)]
+      simp only [defCtx] at hlower
+      rw [hlower]
+      simp [Bind.bind, hfirst, rows]
+    · unfold JalrUnalignedSuccessorRowPins JalrDestinationPins at hlastPins ⊢
+      simpa [rows, hbSrc, hbHi, hbLo, hop, hstore, hstoreOffset, hstoreUseSp,
+        hj1, hj2, hsetpc, hstorepc, hieo, hm32] using hlastPins
+
+/-- A data-carrying certificate for the row count selected by the production
+    extractor. Keeping the extracted rows as data permits elimination into the
+    `ProgramDecode_jalr` bundle while the equalities remain proof fields. -/
+structure JalrRawRowsCertificate (raw : BitVec 32) (count : Std.U32) : Type where
+  rows : aeneas_extract.Rv64imTranspileRowsExtract
+  h_extract :
+    aeneas_extract.extract_transpile_rv64im_rows_raw
+        (ZiskFv.Compliance.Decode.toU32 raw) = .ok rows
+  h_count : rows.row_count = count
+
+set_option maxHeartbeats 800000 in
+/-- Raw-program evidence for JALR's production-selected one- or two-row
+    lowering. The two constructors carry exactly the Main/ROM correspondences
+    consumed by their matching committed-program decode bundle. -/
+structure RawProgramDecodeJalrAligned {n rawLength : Nat}
+    (trace : AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions)
+    (c : Claim_jalr trace i)
+    (start : Fin rawLength → Fin trace.programLength)
+    (addr : Fin rawLength → FGL)
+    (rawProgram : Fin rawLength → BitVec 32) : Type where
+  raw : BitVec 32
+  h_raw : raw = ZiskFv.Completeness.Rv64imShapes.rawIType c.imm.toNat
+    (regidx_to_fin c.rs1).val 0 (regidx_to_fin c.rd).val 0x67
+  h_rows : JalrRawRowsCertificate raw 1#u32
+  h_offset_aligned : c.offset_bv = BitVec.signExtend 64 c.imm
+  h_idx : i.val + 1 < trace.mainTable.table.length
+  h_flag : (mainOfTable trace.program trace.mainTable).flag i.val = 0
+  h_a_mask_lo : (mainOfTable trace.program trace.mainTable).a_0 i.val = 4294967294
+  h_a_mask_hi : (mainOfTable trace.program trace.mainTable).a_1 i.val = 4294967295
+  h_c1_zero : (mainOfTable trace.program trace.mainTable).c_1 i.val = 0
+  h_offset_even : c.offset_bv &&& 1#64 = 0#64
+  h_target_nonneg :
+    0 ≤ (((mainOfTable trace.program trace.mainTable).c_0 i.val).val : Int) +
+      c.offset_bv.toInt
+  h_target_lt :
+    (((mainOfTable trace.program trace.mainTable).c_0 i.val).val : Int) +
+      c.offset_bv.toInt < GL_prime
+  hLine : ∀ j : Fin trace.programLength,
+    (trace.program j).line = (mainOfTable trace.program trace.mainTable).pc i.val →
+      ∃ k : Fin rawLength,
+        start k = j ∧ addr k = (trace.program j).line ∧
+          rawProgram k = raw
+
+set_option maxHeartbeats 800000 in
+structure RawProgramDecodeJalrUnaligned {n rawLength : Nat}
+    (trace : AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions)
+    (c : Claim_jalr trace i)
+    (start : Fin rawLength → Fin trace.programLength)
+    (addr : Fin rawLength → FGL)
+    (rawProgram : Fin rawLength → BitVec 32) : Type where
+  raw : BitVec 32
+  h_raw : raw = ZiskFv.Completeness.Rv64imShapes.rawIType c.imm.toNat
+    (regidx_to_fin c.rs1).val 0 (regidx_to_fin c.rd).val 0x67
+  h_rows : JalrRawRowsCertificate raw 2#u32
+  h_offset_zero : c.offset_bv = 0#64
+  h_idx2 : i.val + 2 < trace.mainTable.table.length
+  h_flag_add : (mainOfTable trace.program trace.mainTable).flag i.val = 0
+  h_flag : (mainOfTable trace.program trace.mainTable).flag (i.val + 1) = 0
+  h_a_mask_lo :
+    (mainOfTable trace.program trace.mainTable).a_0 (i.val + 1) = 4294967294
+  h_a_mask_hi :
+    (mainOfTable trace.program trace.mainTable).a_1 (i.val + 1) = 4294967295
+  h_c1_zero : (mainOfTable trace.program trace.mainTable).c_1 (i.val + 1) = 0
+  h_offset_even : c.offset_bv &&& 1#64 = 0#64
+  h_target_nonneg :
+    0 ≤ (((mainOfTable trace.program trace.mainTable).c_0 (i.val + 1)).val : Int) +
+      c.offset_bv.toInt
+  h_target_lt :
+    (((mainOfTable trace.program trace.mainTable).c_0 (i.val + 1)).val : Int) +
+      c.offset_bv.toInt < GL_prime
+  hLineAdd : ∀ j : Fin trace.programLength,
+    (trace.program j).line = (mainOfTable trace.program trace.mainTable).pc i.val →
+      ∃ k : Fin rawLength,
+        start k = j ∧ addr k = (trace.program j).line ∧
+          rawProgram k = raw
+  hLineAnd : ∀ j : Fin trace.programLength,
+    (trace.program j).line =
+        (mainOfTable trace.program trace.mainTable).pc (i.val + 1) →
+      ∃ k : Fin rawLength,
+        j.val = (start k).val + 1 ∧
+          addr k + 1 = (trace.program j).line ∧
+            rawProgram k = raw
+
+inductive RawProgramDecode_jalr {n rawLength : Nat}
+    (trace : AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions)
+    (c : Claim_jalr trace i)
+    (start : Fin rawLength → Fin trace.programLength)
+    (addr : Fin rawLength → FGL)
+    (rawProgram : Fin rawLength → BitVec 32) : Type where
+  | aligned (evidence : RawProgramDecodeJalrAligned trace i c start addr rawProgram)
+  | unaligned (evidence : RawProgramDecodeJalrUnaligned trace i c start addr rawProgram)
+
+set_option maxHeartbeats 8000000 in
+noncomputable def ProgramDecode_jalr_from_rawProgram {n rawLength : Nat}
+    (trace : AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions)
+    (c : Claim_jalr trace i)
+    (start : Fin rawLength → Fin trace.programLength)
+    (addr : Fin rawLength → FGL)
+    (rawProgram : Fin rawLength → BitVec 32)
+    (hbind : ProgramRowsBinding trace start addr rawProgram)
+    (rawDecode : RawProgramDecode_jalr trace i c start addr rawProgram) :
+    ProgramDecode_jalr trace i c := by
+  let rd := (regidx_to_fin c.rd).val
+  let rs1 := (regidx_to_fin c.rs1).val
+  let imm := c.imm.toNat
+  let hex := jalr_raw_rows rd rs1 imm (regidx_to_fin c.rd).isLt
+    (regidx_to_fin c.rs1).isLt
+  let rows := Classical.choose hex
+  let hexInput := Classical.choose_spec hex
+  let input := Classical.choose hexInput
+  have hspec := Classical.choose_spec hexInput
+  have hrows := hspec.1
+  have hrd := hspec.2.1
+  have hrs1 := hspec.2.2.1
+  have himm := hspec.2.2.2.1
+  have hmode := hspec.2.2.2.2
+  change input.rd.val = (regidx_to_fin c.rd).val at hrd
+  change input.rs1.val = (regidx_to_fin c.rs1).val at hrs1
+  change input.imm.bv = BitVec.signExtend 32 (BitVec.ofNat 12 imm) at himm
+  have himmC : input.imm.bv = BitVec.signExtend 32 c.imm := by
+    simpa [imm] using himm
+  have himmInt :
+      input.imm.val = (BitVec.signExtend 64 c.imm).toInt := by
+    rw [show input.imm.val = input.imm.bv.toInt by rfl, himm]
+    have himmBv : BitVec.ofNat 12 imm = c.imm := by simp [imm]
+    rw [himmBv]
+    rw [BitVec.toInt_signExtend, BitVec.toInt_signExtend]
+    norm_num
+  cases rawDecode with
+  | aligned evidence =>
+      obtain ⟨raw, hrawEncoded, hcert, hOffset, hidx, hflag, haLo, haHi, hc1,
+        heven, hnonneg, hlt, hLine⟩ := evidence
+      subst raw
+      obtain ⟨certRows, hcertRows, hcount⟩ := hcert
+      have hcertEq : certRows = rows :=
+        Result.ok.inj (hcertRows.symm.trans (by simpa only [rd, rs1, imm] using hrows))
+      have hcount' : rows.row_count = 1#u32 := by
+        rw [← hcertEq]
+        exact hcount
+      have hpins : JalrAlignedRowPins input
+          { paddr := rows.last_row.paddr, store_pc := rows.last_row.store_pc,
+            store_use_sp := rows.last_row.store_use_sp, store := rows.last_row.store,
+            store_offset := rows.last_row.store_offset, set_pc := rows.last_row.set_pc,
+            is_precompiled := rows.last_row.is_precompiled,
+            ind_width := rows.last_row.ind_width, «end» := rows.last_row.end,
+            a_src := rows.last_row.a_src, a_use_sp_imm1 := rows.last_row.a_use_sp_imm1,
+            a_offset_imm0 := rows.last_row.a_offset_imm0, b_src := rows.last_row.b_src,
+            b_use_sp_imm1 := rows.last_row.b_use_sp_imm1,
+            b_offset_imm0 := rows.last_row.b_offset_imm0,
+            jmp_offset1 := rows.last_row.jmp_offset1,
+            jmp_offset2 := rows.last_row.jmp_offset2,
+            is_external_op := rows.last_row.is_external_op, op := rows.last_row.op,
+            op_type := zisk_inst.ZiskOperationType.None, m32 := rows.last_row.m32,
+            input_size := rows.last_row.input_size,
+            sorted_pc_list_index := rows.last_row.sorted_pc_list_index } := by
+        rcases hmode with ⟨_, hpins⟩ | ⟨hcountTwo, _, _⟩
+        · exact hpins
+        · rw [hcount'] at hcountTwo
+          norm_num at hcountTwo
+      let bits := romFlagBitsOfExtract rows.last_row
+      unfold JalrAlignedRowPins at hpins
+      rcases hpins with ⟨hop, hj1, hj2, hdest, hsrc, hieo, hm32, hsetpc⟩
+      simp only at hop hj1 hj2 hdest hsrc hieo hm32 hsetpc
+      refine .aligned
+          { h_offset_aligned := hOffset
+            h_idx := hidx
+            h_flag := hflag
+            h_a_mask_lo := haLo
+            h_a_mask_hi := haHi
+            h_c1_zero := hc1
+            h_offset_even := heven
+            h_target_nonneg := hnonneg
+            h_target_lt := hlt
+            bits := bits
+            h_bits_ieo := ?_
+            h_bits_m32 := ?_
+            h_bits_set_pc := ?_
+            h_bits_store_pc := ?_
+            h_bits_store_ind := ?_
+            h_prog := ?_ }
+      · exact hieo
+      · exact hm32
+      · exact hsetpc
+      · unfold JalrDestinationPins at hdest
+        rcases hdest with hzero | hnonzero
+        · change input.rd = 0#u32 ∧ rows.last_row.store = 0#u64 ∧
+              rows.last_row.store_offset = 0#i64 ∧ rows.last_row.store_use_sp = false ∧
+              rows.last_row.store_pc = false at hzero
+          have hrdZero : (regidx_to_fin c.rd).val = 0 := by
+            rw [← show input.rd.val = (regidx_to_fin c.rd).val by simpa [rd] using hrd]
+            exact congrArg UScalar.val hzero.1
+          simp [bits, romFlagBitsOfExtract, hzero.2.2.2.2, hrdZero]
+        · change input.rd ≠ 0#u32 ∧ rows.last_row.store = zisk_inst.STORE_REG ∧
+              rows.last_row.store_offset = UScalar.hcast IScalarTy.I64 input.rd ∧
+              rows.last_row.store_use_sp = false ∧ rows.last_row.store_pc = true at hnonzero
+          have hrdNonzero : (regidx_to_fin c.rd).val ≠ 0 := by
+            intro hz
+            apply hnonzero.1
+            apply UScalar.eq_of_val_eq
+            simpa [rd, hz] using hrd.symm
+          simp [bits, romFlagBitsOfExtract, hnonzero.2.2.2.2, hrdNonzero]
+      · unfold JalrDestinationPins at hdest
+        rcases hdest with hzero | hnonzero
+        · change input.rd = 0#u32 ∧ rows.last_row.store = 0#u64 ∧
+              rows.last_row.store_offset = 0#i64 ∧ rows.last_row.store_use_sp = false ∧
+              rows.last_row.store_pc = false at hzero
+          exact decide_eq_false (by
+            rw [hzero.2.1]
+            simp [zisk_inst.STORE_IND])
+        · change input.rd ≠ 0#u32 ∧ rows.last_row.store = zisk_inst.STORE_REG ∧
+              rows.last_row.store_offset = UScalar.hcast IScalarTy.I64 input.rd ∧
+              rows.last_row.store_use_sp = false ∧ rows.last_row.store_pc = true at hnonzero
+          exact decide_eq_false (by
+            rw [hnonzero.2.1]
+            simp [zisk_inst.STORE_REG, zisk_inst.STORE_IND])
+      · intro j hline
+        obtain ⟨k, hk, haddr, hraw⟩ := hLine j hline
+        have hprimary := primary_row_of_programRowsBinding hbind
+          ⟨k, hk, haddr, hraw⟩
+        have hmsg : trace.program j = romRowOf (addr k) rows.last_row := by
+          rw [hprimary]
+          unfold romMessagesOfRaw
+          rw [show aeneas_extract.extract_transpile_rv64im_rows_raw
+              (ZiskFv.Compliance.Decode.toU32
+                (ZiskFv.Completeness.Rv64imShapes.rawIType c.imm.toNat
+                  (regidx_to_fin c.rs1).val 0 (regidx_to_fin c.rd).val 0x67)) =
+                .ok rows by simpa only [rd, rs1, imm] using hrows]
+          simp [hcount', haddr]
+        unfold JalrDestinationPins at hdest
+        rcases hdest with hzero | hnonzero
+        · have hrdZero : (regidx_to_fin c.rd).val = 0 := by
+            rw [← hrd]
+            exact congrArg UScalar.val hzero.1
+          have hstoreZero := congrArg IScalar.val hzero.2.2.1
+          simp [hmsg, romRowOf, hop, hj1, hj2, hzero, bits, hrdZero,
+            himmInt, hstoreZero]
+        · have hrdNonzero : (regidx_to_fin c.rd).val ≠ 0 := by
+            intro hzero
+            apply hnonzero.1
+            apply UScalar.eq_of_val_eq
+            simpa [hzero] using hrd.symm
+          have hstoreVal := congrArg IScalar.val hnonzero.2.2.1
+          have hstoreOffset :
+              ((rows.last_row.store_offset.val : Int) : FGL) =
+                Transpiler.ind (regidx_to_fin c.rd) := by
+            have hrdPrime : (regidx_to_fin c.rd).val < GL_prime :=
+              lt_trans (regidx_to_fin c.rd).isLt (by norm_num)
+            apply Fin.ext
+            simp [hstoreVal, hcast_u32_i64_val, hrd, Transpiler.ind, hrdPrime]
+          simp [hmsg, romRowOf, hop, hj1, hj2, hnonzero, bits, hrdNonzero,
+            hrd, himmInt, hstoreOffset]
+  | unaligned evidence =>
+      obtain ⟨raw, hrawEncoded, hcert, hOffset, hidx, hflagAdd, hflag, haLo, haHi,
+        hc1, heven, hnonneg, hlt, hLineAdd, hLineAnd⟩ := evidence
+      subst raw
+      obtain ⟨certRows, hcertRows, hcount⟩ := hcert
+      have hcertEq : certRows = rows :=
+        Result.ok.inj (hcertRows.symm.trans (by simpa only [rd, rs1, imm] using hrows))
+      have hcount' : rows.row_count = 2#u32 := by
+        rw [← hcertEq]
+        exact hcount
+      have hpins : JalrUnalignedFirstRowPins input rows.first_row ∧
+          JalrUnalignedSuccessorRowPins input
+            { paddr := rows.last_row.paddr, store_pc := rows.last_row.store_pc,
+              store_use_sp := rows.last_row.store_use_sp, store := rows.last_row.store,
+              store_offset := rows.last_row.store_offset, set_pc := rows.last_row.set_pc,
+              is_precompiled := rows.last_row.is_precompiled,
+              ind_width := rows.last_row.ind_width, «end» := rows.last_row.end,
+              a_src := rows.last_row.a_src, a_use_sp_imm1 := rows.last_row.a_use_sp_imm1,
+              a_offset_imm0 := rows.last_row.a_offset_imm0, b_src := rows.last_row.b_src,
+              b_use_sp_imm1 := rows.last_row.b_use_sp_imm1,
+              b_offset_imm0 := rows.last_row.b_offset_imm0,
+              jmp_offset1 := rows.last_row.jmp_offset1,
+              jmp_offset2 := rows.last_row.jmp_offset2,
+              is_external_op := rows.last_row.is_external_op, op := rows.last_row.op,
+              op_type := zisk_inst.ZiskOperationType.None, m32 := rows.last_row.m32,
+              input_size := rows.last_row.input_size,
+              sorted_pc_list_index := rows.last_row.sorted_pc_list_index } := by
+        rcases hmode with ⟨hcountOne, _⟩ | ⟨_, hfirst, hlast⟩
+        · rw [hcount'] at hcountOne
+          norm_num at hcountOne
+        · exact ⟨hfirst, hlast⟩
+      let addBits := romFlagBitsOfExtract rows.first_row
+      let andBits := romFlagBitsOfExtract rows.last_row
+      unfold JalrUnalignedFirstRowPins JalrUnalignedSuccessorRowPins at hpins
+      rcases hpins with
+        ⟨⟨haddOp, haddJ1, haddJ2, haddASrc, haddHi, haddLo, haddSrc, haddIeo,
+            haddM32, haddSetPc, haddStorePc⟩,
+          ⟨handOp, handJ1, handJ2, handDest, handBSrc, handBUse, handBOffset,
+            handIeo, handM32, handSetPc⟩⟩
+      change rows.first_row.op = 10#u8 at haddOp
+      change rows.first_row.jmp_offset1 = 1#i64 at haddJ1
+      change rows.first_row.jmp_offset2 = 1#i64 at haddJ2
+      change rows.first_row.a_src = zisk_inst.SRC_IMM at haddASrc
+      change rows.first_row.a_use_sp_imm1.val =
+        (IScalar.hcast UScalarTy.U64 input.imm).val / 2 ^ 32 at haddHi
+      change rows.first_row.a_offset_imm0.val =
+        (IScalar.hcast UScalarTy.U64 input.imm).val % 2 ^ 32 at haddLo
+      change rows.last_row.op = 14#u8 at handOp
+      change rows.last_row.jmp_offset1 = 0#i64 at handJ1
+      change rows.last_row.jmp_offset2 = 3#i64 at handJ2
+      change rows.last_row.b_src = zisk_inst.SRC_C at handBSrc
+      refine .unaligned
+        { h_offset_zero := hOffset
+          h_idx2 := hidx
+          h_flag_add := hflagAdd
+          h_flag := hflag
+          h_a_mask_lo := haLo
+          h_a_mask_hi := haHi
+          h_c1_zero := hc1
+          h_offset_even := heven
+          h_target_nonneg := hnonneg
+          h_target_lt := hlt
+          addBits := addBits
+          h_add_ieo := by
+            exact haddIeo
+          h_add_m32 := by
+            exact haddM32
+          h_add_set_pc := by
+            exact haddSetPc
+          h_add_a_src_imm := by
+            exact decide_eq_true haddASrc
+          h_add_b_src_imm := by
+            change decide (rows.first_row.b_src = zisk_inst.SRC_IMM) =
+              decide ((regidx_to_fin c.rs1).val = 0)
+            unfold JalrRegisterOrX0SourcePins at haddSrc
+            rcases haddSrc with hz | hn
+            · change input.rs1 = 0#u32 ∧ rows.first_row.b_src = zisk_inst.SRC_IMM ∧
+                  rows.first_row.b_use_sp_imm1 = 0#u64 ∧
+                  rows.first_row.b_offset_imm0 = 0#u64 at hz
+              have hrs1Zero : (regidx_to_fin c.rs1).val = 0 := by
+                rw [← show input.rs1.val = (regidx_to_fin c.rs1).val by
+                  simpa [rs1] using hrs1]
+                exact congrArg UScalar.val hz.1
+              rw [decide_eq_true hrs1Zero]
+              exact decide_eq_true hz.2.1
+            · change input.rs1 ≠ 0#u32 ∧ rows.first_row.b_src = zisk_inst.SRC_REG ∧
+                  rows.first_row.b_use_sp_imm1 = 0#u64 ∧
+                  rows.first_row.b_offset_imm0 = UScalar.cast UScalarTy.U64 input.rs1 at hn
+              have hrs1Nonzero : (regidx_to_fin c.rs1).val ≠ 0 := by
+                intro hzero
+                apply hn.1
+                apply UScalar.eq_of_val_eq
+                simpa [rs1, hzero] using hrs1.symm
+              rw [decide_eq_false hrs1Nonzero]
+              exact decide_eq_false (by
+                rw [hn.2.1]
+                simp [zisk_inst.SRC_REG, zisk_inst.SRC_IMM])
+          h_add_b_src_reg := by
+            change decide (rows.first_row.b_src = zisk_inst.SRC_REG) =
+              decide ((regidx_to_fin c.rs1).val ≠ 0)
+            unfold JalrRegisterOrX0SourcePins at haddSrc
+            rcases haddSrc with hz | hn
+            · change input.rs1 = 0#u32 ∧ rows.first_row.b_src = zisk_inst.SRC_IMM ∧
+                  rows.first_row.b_use_sp_imm1 = 0#u64 ∧
+                  rows.first_row.b_offset_imm0 = 0#u64 at hz
+              have hrs1Zero : (regidx_to_fin c.rs1).val = 0 := by
+                rw [← show input.rs1.val = (regidx_to_fin c.rs1).val by
+                  simpa [rs1] using hrs1]
+                exact congrArg UScalar.val hz.1
+              have hnot : ¬((regidx_to_fin c.rs1).val ≠ 0) := by
+                intro hne
+                exact hne hrs1Zero
+              rw [decide_eq_false hnot]
+              exact decide_eq_false (by
+                intro heq
+                have hbad := hz.2.1.symm.trans heq
+                simpa [zisk_inst.SRC_IMM, zisk_inst.SRC_REG] using hbad)
+            · change input.rs1 ≠ 0#u32 ∧ rows.first_row.b_src = zisk_inst.SRC_REG ∧
+                  rows.first_row.b_use_sp_imm1 = 0#u64 ∧
+                  rows.first_row.b_offset_imm0 = UScalar.cast UScalarTy.U64 input.rs1 at hn
+              have hrs1Nonzero : (regidx_to_fin c.rs1).val ≠ 0 := by
+                intro hzero
+                apply hn.1
+                apply UScalar.eq_of_val_eq
+                simpa [rs1, hzero] using hrs1.symm
+              rw [decide_eq_true hrs1Nonzero]
+              exact decide_eq_true hn.2.1
+          andBits := andBits
+          h_and_ieo := by
+            exact handIeo
+          h_and_m32 := by
+            exact handM32
+          h_and_set_pc := by
+            exact handSetPc
+          h_and_store_pc := by
+            change rows.last_row.store_pc =
+              decide ((regidx_to_fin c.rd).val ≠ 0)
+            unfold JalrDestinationPins at handDest
+            rcases handDest with hz | hn
+            · change input.rd = 0#u32 ∧ rows.last_row.store = 0#u64 ∧
+                  rows.last_row.store_offset = 0#i64 ∧
+                  rows.last_row.store_use_sp = false ∧ rows.last_row.store_pc = false at hz
+              have hrdZero : (regidx_to_fin c.rd).val = 0 := by
+                rw [← hrd]
+                exact congrArg UScalar.val hz.1
+              simp [hz.2.2.2.2, hrdZero]
+            · change input.rd ≠ 0#u32 ∧ rows.last_row.store = zisk_inst.STORE_REG ∧
+                  rows.last_row.store_offset = UScalar.hcast IScalarTy.I64 input.rd ∧
+                  rows.last_row.store_use_sp = false ∧ rows.last_row.store_pc = true at hn
+              have hrdNonzero : (regidx_to_fin c.rd).val ≠ 0 := by
+                intro hzero
+                apply hn.1
+                apply UScalar.eq_of_val_eq
+                simpa [hzero] using hrd.symm
+              simp [hn.2.2.2.2, hrdNonzero]
+          h_and_store_ind := by
+            unfold JalrDestinationPins at handDest
+            rcases handDest with hz | hn
+            · change input.rd = 0#u32 ∧ rows.last_row.store = 0#u64 ∧
+                  rows.last_row.store_offset = 0#i64 ∧
+                  rows.last_row.store_use_sp = false ∧ rows.last_row.store_pc = false at hz
+              exact decide_eq_false (by
+                rw [hz.2.1]
+                simp [zisk_inst.STORE_IND])
+            · change input.rd ≠ 0#u32 ∧ rows.last_row.store = zisk_inst.STORE_REG ∧
+                  rows.last_row.store_offset = UScalar.hcast IScalarTy.I64 input.rd ∧
+                  rows.last_row.store_use_sp = false ∧ rows.last_row.store_pc = true at hn
+              exact decide_eq_false (by
+                rw [hn.2.1]
+                simp [zisk_inst.STORE_REG, zisk_inst.STORE_IND])
+          h_and_b_src_imm := by
+            simp [andBits, romFlagBitsOfExtract, handBSrc, zisk_inst.SRC_C,
+              zisk_inst.SRC_IMM]
+          h_and_b_src_mem := by
+            simp [andBits, romFlagBitsOfExtract, handBSrc, zisk_inst.SRC_C,
+              zisk_inst.SRC_MEM]
+          h_and_b_src_ind := by
+            simp [andBits, romFlagBitsOfExtract, handBSrc, zisk_inst.SRC_C,
+              zisk_inst.SRC_IND]
+          h_and_b_src_reg := by
+            simp [andBits, romFlagBitsOfExtract, handBSrc, zisk_inst.SRC_C,
+              zisk_inst.SRC_REG]
+          h_prog_add := by
+            intro j hline
+            obtain ⟨k, hk, haddr, hraw⟩ := hLineAdd j hline
+            have hprimary := primary_row_of_programRowsBinding hbind
+              ⟨k, hk, haddr, hraw⟩
+            have hmsg : trace.program j = romRowOf (addr k) rows.first_row := by
+              rw [hprimary]
+              unfold romMessagesOfRaw
+              rw [show aeneas_extract.extract_transpile_rv64im_rows_raw
+                  (ZiskFv.Compliance.Decode.toU32
+                    (ZiskFv.Completeness.Rv64imShapes.rawIType c.imm.toNat
+                      (regidx_to_fin c.rs1).val 0 (regidx_to_fin c.rd).val 0x67)) =
+                    .ok rows by simpa only [rd, rs1, imm] using hrows]
+              simp [hcount']
+              rw [← haddr]
+            have himmRow := jalr_immediate_rom_value c.imm input himmC
+              rows.first_row haddASrc haddHi haddLo
+            simp [hmsg, romRowOf, haddOp, haddJ2, haddASrc, haddHi, haddLo,
+              addBits, himm, himmRow]
+          h_prog_and := by
+            intro j hline
+            obtain ⟨k, hj, haddr, hraw⟩ := hLineAnd j hline
+            have hprimary : RawAtProgramStart start addr rawProgram (start k) (addr k)
+                (rawProgram k) := ⟨k, rfl, rfl, rfl⟩
+            have hsecond : (romMessagesOfRaw (addr k) (rawProgram k)).2 =
+                some (romRowOf (addr k + 1) rows.last_row) := by
+              rw [hraw]
+              unfold romMessagesOfRaw
+              rw [show aeneas_extract.extract_transpile_rv64im_rows_raw
+                  (ZiskFv.Compliance.Decode.toU32
+                    (ZiskFv.Completeness.Rv64imShapes.rawIType c.imm.toNat
+                      (regidx_to_fin c.rs1).val 0 (regidx_to_fin c.rd).val 0x67)) =
+                    .ok rows by simpa only [rd, rs1, imm] using hrows]
+              simp [hcount']
+            obtain ⟨hsucc, hmsg⟩ :=
+              successor_row_of_programRowsBinding hbind hprimary hsecond
+            have hjEq : j = ⟨(start k).val + 1, hsucc⟩ := Fin.ext hj
+            subst j
+            unfold JalrDestinationPins at handDest
+            rcases handDest with hz | hn
+            · change input.rd = 0#u32 ∧ rows.last_row.store = 0#u64 ∧
+                  rows.last_row.store_offset = 0#i64 ∧
+                  rows.last_row.store_use_sp = false ∧ rows.last_row.store_pc = false at hz
+              have hrdZero : (regidx_to_fin c.rd).val = 0 := by
+                rw [← hrd]
+                exact congrArg UScalar.val hz.1
+              have hstoreZero := congrArg IScalar.val hz.2.2.1
+              simp [hmsg, romRowOf, handOp, handJ1, handJ2,
+                hz, andBits, hrdZero, hstoreZero]
+            · change input.rd ≠ 0#u32 ∧ rows.last_row.store = zisk_inst.STORE_REG ∧
+                  rows.last_row.store_offset = UScalar.hcast IScalarTy.I64 input.rd ∧
+                  rows.last_row.store_use_sp = false ∧ rows.last_row.store_pc = true at hn
+              have hrdNonzero : (regidx_to_fin c.rd).val ≠ 0 := by
+                intro hzero
+                apply hn.1
+                apply UScalar.eq_of_val_eq
+                simpa [hzero] using hrd.symm
+              have hstoreVal := congrArg IScalar.val hn.2.2.1
+              have hstoreOffset :
+                  ((rows.last_row.store_offset.val : Int) : FGL) =
+                    Transpiler.ind (regidx_to_fin c.rd) := by
+                have hrdPrime : (regidx_to_fin c.rd).val < GL_prime :=
+                  lt_trans (regidx_to_fin c.rd).isLt (by norm_num)
+                apply Fin.ext
+                simp [hstoreVal, hcast_u32_i64_val, hrd, Transpiler.ind, hrdPrime]
+              simp [hmsg, romRowOf, handOp, handJ1, handJ2,
+                hn, andBits, hrdNonzero, hstoreOffset]
+              simpa only [hstoreVal] using hstoreOffset }
+
+end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramDecode.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramDecode.lean
@@ -1,0 +1,165 @@
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingRegister
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingImmediate
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingCopyb
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingMext
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingLoadStore
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingControl
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingJalr
+
+namespace ZiskFv.Compliance
+
+open RawProgramBinding
+
+/-- Raw-word evidence for the production lowering of the opcode selected by one
+    execution step. Control-flow evidence also sees the architectural-to-physical
+    start map because those constructors state their lookup directly. -/
+def RawProgramDecode {n rawLength : Nat}
+    (trace : AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions)
+    (zs : ZiskStep trace i)
+    (start : Fin rawLength → Fin trace.programLength)
+    (addr : Fin rawLength → FGL)
+    (rawProgram : Fin rawLength → BitVec 32) : Type 1 :=
+  match zs with
+  | .sub c => ULift.{1} (PLift (RawProgramDecode_sub trace i c addr rawProgram))
+  | .and c => ULift.{1} (PLift (RawProgramDecode_and trace i c addr rawProgram))
+  | .or c => ULift.{1} (PLift (RawProgramDecode_or trace i c addr rawProgram))
+  | .xor c => ULift.{1} (PLift (RawProgramDecode_xor trace i c addr rawProgram))
+  | .slt c => ULift.{1} (PLift (RawProgramDecode_slt trace i c addr rawProgram))
+  | .sltu c => ULift.{1} (PLift (RawProgramDecode_sltu trace i c addr rawProgram))
+  | .andi c => ULift.{1} (PLift (RawProgramDecode_andi trace i c addr rawProgram))
+  | .ori c => ULift.{1} (PLift (RawProgramDecode_ori trace i c addr rawProgram))
+  | .xori c => ULift.{1} (PLift (RawProgramDecode_xori trace i c addr rawProgram))
+  | .slti c => ULift.{1} (PLift (RawProgramDecode_slti trace i c addr rawProgram))
+  | .sltiu c => ULift.{1} (PLift (RawProgramDecode_sltiu trace i c addr rawProgram))
+  | .sll c => ULift.{1} (PLift (RawProgramDecode_sll trace i c addr rawProgram))
+  | .srl c => ULift.{1} (PLift (RawProgramDecode_srl trace i c addr rawProgram))
+  | .sra c => ULift.{1} (PLift (RawProgramDecode_sra trace i c addr rawProgram))
+  | .slli c => ULift.{1} (PLift (RawProgramDecode_slli trace i c addr rawProgram))
+  | .srli c => ULift.{1} (PLift (RawProgramDecode_srli trace i c addr rawProgram))
+  | .srai c => ULift.{1} (PLift (RawProgramDecode_srai trace i c addr rawProgram))
+  | .add c => ULift.{1} (PLift (RawProgramDecode_add trace i c addr rawProgram))
+  | .addi c => ULift.{1} (PLift (RawProgramDecode_addi trace i c addr rawProgram))
+  | .subw c => ULift.{1} (PLift (RawProgramDecode_subw trace i c addr rawProgram))
+  | .addw c => ULift.{1} (PLift (RawProgramDecode_addw trace i c addr rawProgram))
+  | .addiw c => ULift.{1} (PLift (RawProgramDecode_addiw trace i c addr rawProgram))
+  | .sllw c => ULift.{1} (PLift (RawProgramDecode_sllw trace i c addr rawProgram))
+  | .srlw c => ULift.{1} (PLift (RawProgramDecode_srlw trace i c addr rawProgram))
+  | .sraw c => ULift.{1} (PLift (RawProgramDecode_sraw trace i c addr rawProgram))
+  | .slliw c => ULift.{1} (PLift (RawProgramDecode_slliw trace i c addr rawProgram))
+  | .srliw c => ULift.{1} (PLift (RawProgramDecode_srliw trace i c addr rawProgram))
+  | .sraiw c => ULift.{1} (PLift (RawProgramDecode_sraiw trace i c addr rawProgram))
+  | .mul c => ULift.{1} (PLift (RawProgramDecode_mul trace i c addr rawProgram))
+  | .mulh c => ULift.{1} (PLift (RawProgramDecode_mulh trace i c addr rawProgram))
+  | .mulhsu c => ULift.{1} (PLift (RawProgramDecode_mulhsu trace i c addr rawProgram))
+  | .mulw c => ULift.{1} (PLift (RawProgramDecode_mulw trace i c addr rawProgram))
+  | .mulhu c => ULift.{1} (PLift (RawProgramDecode_mulhu trace i c addr rawProgram))
+  | .div c => ULift.{1} (PLift (RawProgramDecode_div trace i c addr rawProgram))
+  | .rem c => ULift.{1} (PLift (RawProgramDecode_rem trace i c addr rawProgram))
+  | .divw c => ULift.{1} (PLift (RawProgramDecode_divw trace i c addr rawProgram))
+  | .remw c => ULift.{1} (PLift (RawProgramDecode_remw trace i c addr rawProgram))
+  | .divu c => ULift.{1} (PLift (RawProgramDecode_divu trace i c addr rawProgram))
+  | .divuw c => ULift.{1} (PLift (RawProgramDecode_divuw trace i c addr rawProgram))
+  | .remu c => ULift.{1} (PLift (RawProgramDecode_remu trace i c addr rawProgram))
+  | .remuw c => ULift.{1} (PLift (RawProgramDecode_remuw trace i c addr rawProgram))
+  | .beq c => ULift.{1} (PLift (RawProgramDecode_beq trace i c start addr rawProgram))
+  | .bne c => ULift.{1} (PLift (RawProgramDecode_bne trace i c start addr rawProgram))
+  | .blt c => ULift.{1} (PLift (RawProgramDecode_blt trace i c start addr rawProgram))
+  | .bge c => ULift.{1} (PLift (RawProgramDecode_bge trace i c start addr rawProgram))
+  | .bltu c => ULift.{1} (PLift (RawProgramDecode_bltu trace i c start addr rawProgram))
+  | .bgeu c => ULift.{1} (PLift (RawProgramDecode_bgeu trace i c start addr rawProgram))
+  | .lui c => ULift.{1} (PLift (RawProgramDecode_lui trace i c start addr rawProgram))
+  | .auipc c => ULift.{1} (PLift (RawProgramDecode_auipc trace i c start addr rawProgram))
+  | .jal c => ULift.{1} (PLift (RawProgramDecode_jal trace i c start addr rawProgram))
+  | .jalr c => ULift.{1} (PLift (RawProgramDecode_jalr trace i c start addr rawProgram))
+  | .sb c => ULift.{1} (PLift (RawProgramDecode_sb trace i c addr rawProgram))
+  | .sh c => ULift.{1} (PLift (RawProgramDecode_sh trace i c addr rawProgram))
+  | .sw c => ULift.{1} (PLift (RawProgramDecode_sw trace i c addr rawProgram))
+  | .sd c => ULift.{1} (PLift (RawProgramDecode_sd trace i c addr rawProgram))
+  | .ld c => ULift.{1} (PLift (RawProgramDecode_ld trace i c addr rawProgram))
+  | .lbu c => ULift.{1} (PLift (RawProgramDecode_lbu trace i c addr rawProgram))
+  | .lhu c => ULift.{1} (PLift (RawProgramDecode_lhu trace i c addr rawProgram))
+  | .lwu c => ULift.{1} (PLift (RawProgramDecode_lwu trace i c addr rawProgram))
+  | .lb c => ULift.{1} (PLift (RawProgramDecode_lb trace i c addr rawProgram))
+  | .lh c => ULift.{1} (PLift (RawProgramDecode_lh trace i c addr rawProgram))
+  | .lw c => ULift.{1} (PLift (RawProgramDecode_lw trace i c addr rawProgram))
+  | .fence c => ULift.{1} (PLift (RawProgramDecode_fence trace i c start addr rawProgram))
+
+/-- Construct the committed-program decode bundle directly from raw-word
+    evidence and the single production-lowering certificate. -/
+noncomputable def programDecode_of_rawProgramDecode {n rawLength : Nat}
+    (trace : AcceptedZiskTrace n)
+    (i : Fin trace.numInstructions)
+    (zs : ZiskStep trace i)
+    (start : Fin rawLength → Fin trace.programLength)
+    (addr : Fin rawLength → FGL)
+    (rawProgram : Fin rawLength → BitVec 32)
+    (hbind : ProgramRowsBinding trace start addr rawProgram)
+    (rawDecode : RawProgramDecode trace i zs start addr rawProgram) :
+    ProgramDecode trace i zs := by
+  cases zs with
+  | sub c => exact ProgramDecode_sub_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | and c => exact ProgramDecode_and_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | or c => exact ProgramDecode_or_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | xor c => exact ProgramDecode_xor_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | slt c => exact ProgramDecode_slt_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | sltu c => exact ProgramDecode_sltu_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | andi c => exact ProgramDecode_andi_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | ori c => exact ProgramDecode_ori_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | xori c => exact ProgramDecode_xori_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | slti c => exact ProgramDecode_slti_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | sltiu c => exact ProgramDecode_sltiu_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | sll c => exact ProgramDecode_sll_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | srl c => exact ProgramDecode_srl_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | sra c => exact ProgramDecode_sra_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | slli c => exact ProgramDecode_slli_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | srli c => exact ProgramDecode_srli_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | srai c => exact ProgramDecode_srai_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | add c => exact ProgramDecode_add_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | addi c => exact ProgramDecode_addi_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | subw c => exact ProgramDecode_subw_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | addw c => exact ProgramDecode_addw_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | addiw c => exact ProgramDecode_addiw_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | sllw c => exact ProgramDecode_sllw_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | srlw c => exact ProgramDecode_srlw_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | sraw c => exact ProgramDecode_sraw_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | slliw c => exact ProgramDecode_slliw_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | srliw c => exact ProgramDecode_srliw_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | sraiw c => exact ProgramDecode_sraiw_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | mul c => exact ProgramDecode_mul_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | mulh c => exact ProgramDecode_mulh_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | mulhsu c => exact ProgramDecode_mulhsu_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | mulw c => exact ProgramDecode_mulw_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | mulhu c => exact ProgramDecode_mulhu_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | div c => exact ProgramDecode_div_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | rem c => exact ProgramDecode_rem_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | divw c => exact ProgramDecode_divw_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | remw c => exact ProgramDecode_remw_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | divu c => exact ProgramDecode_divu_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | divuw c => exact ProgramDecode_divuw_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | remu c => exact ProgramDecode_remu_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | remuw c => exact ProgramDecode_remuw_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | beq c => exact ProgramDecode_beq_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | bne c => exact ProgramDecode_bne_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | blt c => exact ProgramDecode_blt_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | bge c => exact ProgramDecode_bge_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | bltu c => exact ProgramDecode_bltu_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | bgeu c => exact ProgramDecode_bgeu_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | lui c => exact ProgramDecode_lui_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | auipc c => exact ProgramDecode_auipc_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | jal c => exact ProgramDecode_jal_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | jalr c => exact ProgramDecode_jalr_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | sb c => exact ProgramDecode_sb_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | sh c => exact ProgramDecode_sh_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | sw c => exact ProgramDecode_sw_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | sd c => exact ProgramDecode_sd_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | ld c => exact ProgramDecode_ld_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | lbu c => exact ProgramDecode_lbu_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | lhu c => exact ProgramDecode_lhu_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | lwu c => exact ProgramDecode_lwu_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | lb c => exact ProgramDecode_lb_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | lh c => exact ProgramDecode_lh_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | lw c => exact ProgramDecode_lw_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+  | fence c => exact ProgramDecode_fence_from_rawProgram trace i c start addr rawProgram hbind rawDecode.down.down
+
+end ZiskFv.Compliance

--- a/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
@@ -4316,54 +4316,75 @@ def Decode_jalr_of_program
     (h_c1_zero :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_1
       i.val = 0)
-    (h_offset_bridge :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-        i.val).val = c.offset_bv.toNat)
     (h_offset_even :
     c.offset_bv &&& 1#64 = 0#64)
-    (h_no_fgl_wrap :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_0 i.val).val
-      + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-          i.val).val < GL_prime)
+    (h_target_nonneg :
+      0 ≤ (((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_0
+        i.val).val : Int) + c.offset_bv.toInt)
+    (h_target_lt :
+      (((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_0
+        i.val).val : Int) + c.offset_bv.toInt < GL_prime)
     (bits : RomFlagBits)
     (h_bits_ieo : bits.is_external_op = true)
     (h_bits_m32 : bits.m32 = false)
     (h_bits_set_pc : bits.set_pc = true)
-    (h_bits_store_pc : bits.store_pc = true)
+    (h_bits_store_pc :
+      bits.store_pc = decide ((regidx_to_fin c.rd).val ≠ 0))
     (h_bits_store_ind : bits.store_ind = false)
     (h_prog : ∀ j : Fin trace.programLength,
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc i.val →
           (trace.program j).op = ZiskFv.Trusted.OP_AND
+        ∧ (trace.program j).jmp_offset1 = ((BitVec.signExtend 64 c.imm).toInt : FGL)
         ∧ (trace.program j).jmp_offset2 = 4
-        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
+        ∧ (trace.program j).store_offset =
+            (if (regidx_to_fin c.rd).val = 0 then 0
+             else Transpiler.ind (regidx_to_fin c.rd))
         ∧ (trace.program j).flags = packFlags bits) :
     Decode_jalr trace i c := by
   have h_lt : i.val < trace.mainTable.table.length := trace.mainTable_index i
   let physical : Fin trace.mainTable.table.length := ⟨i.val, h_lt⟩
-  let rows : JalrLoweringRows trace i c.imm c.offset_bv :=
+  let rows : JalrLoweringRows trace i c.imm c.rs1 c.offset_bv :=
     { start := physical
       finish := physical
       architectural_start := rfl
       finish_has_successor := h_idx
       lowering := Or.inl ⟨rfl, h_offset_aligned⟩ }
-  have h_dest := mainLuiDestinationFacts_of_program trace i h_lt bits c.rd h_bits_store_ind
-    (fun j hline => by
-      obtain ⟨_hpo, _hpj2, hpso, hpf⟩ := h_prog j hline
-      exact ⟨hpso, hpf⟩)
+  have h_dest :
+      (mainRowWithRomLui trace i).rom.store_ind = 0 ∧
+      (mainRowWithRomLui trace i).rom.store_offset =
+        (if (regidx_to_fin c.rd).val = 0 then 0
+         else Transpiler.ind (regidx_to_fin c.rd)) := by
+    obtain ⟨j, hline, _hop, _hiw, _hj1, _hj2, hflags⟩ :=
+      mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_hpo, _hpj1, _hpj2, hpso, hpf⟩ := h_prog j hline
+    obtain ⟨p_store_ind, _, _⟩ :=
+      mainSelectorColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
+    refine ⟨by
+      simpa [mainRowWithRomLui, h_bits_store_ind, ZiskFv.AirsClean.boolF_false]
+        using p_store_ind, ?_⟩
+    obtain ⟨j, hline, hstore⟩ := mainStoreOffset_at_eq_program trace ⟨i.val, h_lt⟩
+    obtain ⟨_, _, _, hpso, _⟩ := h_prog j hline
+    simpa [mainRowWithRomLui] using hstore.symm.trans hpso
   have key :
       (mainOfTable trace.program trace.mainTable).op i.val = ZiskFv.Trusted.OP_AND ∧
       (mainOfTable trace.program trace.mainTable).is_external_op i.val = 1 ∧
       (mainOfTable trace.program trace.mainTable).m32 i.val = 0 ∧
       (mainOfTable trace.program trace.mainTable).set_pc i.val = 1 ∧
-      (mainOfTable trace.program trace.mainTable).store_pc i.val = 1 ∧
+      (mainOfTable trace.program trace.mainTable).store_pc i.val =
+        ZiskFv.AirsClean.boolF (decide ((regidx_to_fin c.rd).val ≠ 0)) ∧
+      (mainOfTable trace.program trace.mainTable).jmp_offset1 i.val =
+        ((BitVec.signExtend 64 c.imm).toInt : FGL) ∧
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 4 := by
-    obtain ⟨j, hline, hop, _, _, hjmp2, hflags⟩ :=
+    obtain ⟨j, hline, hop, _, hj1, hjmp2, hflags⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt⟩
-    obtain ⟨hpo, hpj2, _hpso, hpf⟩ := h_prog j hline
+    obtain ⟨hpo, hpj1, hpj2, _hpso, hpf⟩ := h_prog j hline
     obtain ⟨p_ieo, p_m32, p_set_pc, p_store_pc⟩ :=
       mainFlagColumns_of_packFlags trace i h_lt bits (hflags.symm.trans hpf)
-    exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true], by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false], by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_true], by rw [p_store_pc, h_bits_store_pc, ZiskFv.AirsClean.boolF_true], hjmp2.symm.trans hpj2⟩
+    exact ⟨hop.symm.trans hpo, by rw [p_ieo, h_bits_ieo, ZiskFv.AirsClean.boolF_true],
+      by rw [p_m32, h_bits_m32, ZiskFv.AirsClean.boolF_false],
+      by rw [p_set_pc, h_bits_set_pc, ZiskFv.AirsClean.boolF_true],
+      by rw [p_store_pc, h_bits_store_pc], hj1.symm.trans hpj1, hjmp2.symm.trans hpj2⟩
   exact
     { rows := rows
       h_main_op := key.1
@@ -4378,10 +4399,11 @@ def Decode_jalr_of_program
       h_a_mask_lo := h_a_mask_lo
       h_a_mask_hi := h_a_mask_hi
       h_c1_zero := h_c1_zero
-      h_jmp2 := Or.inl ⟨rfl, key.2.2.2.2.2⟩
-      h_offset_bridge := h_offset_bridge
+      h_jmp2 := Or.inl ⟨rfl, key.2.2.2.2.2.2⟩
+      h_offset_bridge := by rw [key.2.2.2.2.2.1, h_offset_aligned]
       h_offset_even := h_offset_even
-      h_no_fgl_wrap := h_no_fgl_wrap }
+      h_target_nonneg := h_target_nonneg
+      h_target_lt := h_target_lt }
 
 /-- `Decode_jalr` for the UNALIGNED lowering, rebuilt from the committed program
     via the ROM lookup at BOTH physical rows the lowering occupies.
@@ -4422,25 +4444,28 @@ def Decode_jalr_unaligned_of_program
     (mainOfTable trace.program trace.mainTable).a_1 (i.val + 1) = 4294967295)
     (h_c1_zero :
     (mainOfTable trace.program trace.mainTable).c_1 (i.val + 1) = 0)
-    (h_offset_bridge :
-    ((mainOfTable trace.program trace.mainTable).jmp_offset1 (i.val + 1)).val
-      = c.offset_bv.toNat)
     (h_offset_even : c.offset_bv &&& 1#64 = 0#64)
-    (h_no_fgl_wrap :
-    ((mainOfTable trace.program trace.mainTable).c_0 (i.val + 1)).val
-      + ((mainOfTable trace.program trace.mainTable).jmp_offset1 (i.val + 1)).val
-        < GL_prime)
+    (h_target_nonneg :
+      0 ≤ (((mainOfTable trace.program trace.mainTable).c_0
+        (i.val + 1)).val : Int) + c.offset_bv.toInt)
+    (h_target_lt :
+      (((mainOfTable trace.program trace.mainTable).c_0
+        (i.val + 1)).val : Int) + c.offset_bv.toInt < GL_prime)
     (addBits : RomFlagBits)
     (h_add_ieo : addBits.is_external_op = true)
     (h_add_m32 : addBits.m32 = false)
     (h_add_set_pc : addBits.set_pc = false)
     (h_add_a_src_imm : addBits.a_src_imm = true)
-    (h_add_b_src_reg : addBits.b_src_reg = true)
+    (h_add_b_src_imm :
+      addBits.b_src_imm = decide ((regidx_to_fin c.rs1).val = 0))
+    (h_add_b_src_reg :
+      addBits.b_src_reg = decide ((regidx_to_fin c.rs1).val ≠ 0))
     (andBits : RomFlagBits)
     (h_and_ieo : andBits.is_external_op = true)
     (h_and_m32 : andBits.m32 = false)
     (h_and_set_pc : andBits.set_pc = true)
-    (h_and_store_pc : andBits.store_pc = true)
+    (h_and_store_pc :
+      andBits.store_pc = decide ((regidx_to_fin c.rd).val ≠ 0))
     (h_and_store_ind : andBits.store_ind = false)
     (h_and_b_src_imm : andBits.b_src_imm = false)
     (h_and_b_src_mem : andBits.b_src_mem = false)
@@ -4460,8 +4485,11 @@ def Decode_jalr_unaligned_of_program
         (trace.program j).line
             = (mainOfTable trace.program trace.mainTable).pc (i.val + 1) →
           (trace.program j).op = ZiskFv.Trusted.OP_AND
+        ∧ (trace.program j).jmp_offset1 = 0
         ∧ (trace.program j).jmp_offset2 = 3
-        ∧ (trace.program j).store_offset = Transpiler.ind (regidx_to_fin c.rd)
+        ∧ (trace.program j).store_offset =
+            (if (regidx_to_fin c.rd).val = 0 then 0
+             else Transpiler.ind (regidx_to_fin c.rd))
         ∧ (trace.program j).flags = packFlags andBits) :
     Decode_jalr trace i c := by
   have h_lt_start : i.val < trace.mainTable.table.length := trace.mainTable_index i
@@ -4476,7 +4504,10 @@ def Decode_jalr_unaligned_of_program
       (mainOfTable trace.program trace.mainTable).m32 i.val = 0 ∧
       (mainOfTable trace.program trace.mainTable).set_pc i.val = 0 ∧
       (mainOfTable trace.program trace.mainTable).jmp_offset2 i.val = 1 ∧
-      (mainRowWithRomAt trace ⟨i.val, h_lt_start⟩).rom.b_src_reg = 1 := by
+      (mainRowWithRomAt trace ⟨i.val, h_lt_start⟩).rom.b_src_imm =
+        ZiskFv.AirsClean.boolF (decide ((regidx_to_fin c.rs1).val = 0)) ∧
+      (mainRowWithRomAt trace ⟨i.val, h_lt_start⟩).rom.b_src_reg =
+        ZiskFv.AirsClean.boolF (decide ((regidx_to_fin c.rs1).val ≠ 0)) := by
     obtain ⟨ja, hlinea, hopa, _, _, hjmp2a, hflagsa⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val, h_lt_start⟩
     obtain ⟨hpoa, hpj2a, _, hpfa⟩ := h_prog_add ja hlinea
@@ -4485,12 +4516,15 @@ def Decode_jalr_unaligned_of_program
       mainFlagColumns_of_packFlags_at trace ⟨i.val, h_lt_start⟩ addBits hroma
     obtain ⟨_, _, _, _, pa_b_src_reg, _⟩ :=
       mainMemorySelectorColumns_of_packFlags_at trace ⟨i.val, h_lt_start⟩ addBits hroma
+    have pa_b_src_imm :=
+      mainBSourceImmColumn_of_packFlags_at trace ⟨i.val, h_lt_start⟩ addBits hroma
     exact ⟨hopa.symm.trans hpoa,
       by rw [pa_ieo, h_add_ieo, ZiskFv.AirsClean.boolF_true],
       by rw [pa_m32, h_add_m32, ZiskFv.AirsClean.boolF_false],
       by rw [pa_set_pc, h_add_set_pc, ZiskFv.AirsClean.boolF_false],
       hjmp2a.symm.trans hpj2a,
-      by rw [pa_b_src_reg, h_add_b_src_reg, ZiskFv.AirsClean.boolF_true]⟩
+      by rw [pa_b_src_imm, h_add_b_src_imm],
+      by rw [pa_b_src_reg, h_add_b_src_reg]⟩
   -- The ADD row's `a` lane carries the committed immediate: `a_src_imm = 1`
   -- turns `SourceSpec` into `a_0 = a_offset_imm0`, `a_1 = a_imm1`, and the ROM
   -- message ties both limbs to the committed program entry.
@@ -4535,7 +4569,9 @@ def Decode_jalr_unaligned_of_program
       (mainOfTable trace.program trace.mainTable).is_external_op (i.val + 1) = 1 ∧
       (mainOfTable trace.program trace.mainTable).m32 (i.val + 1) = 0 ∧
       (mainOfTable trace.program trace.mainTable).set_pc (i.val + 1) = 1 ∧
-      (mainOfTable trace.program trace.mainTable).store_pc (i.val + 1) = 1 ∧
+      (mainOfTable trace.program trace.mainTable).store_pc (i.val + 1) =
+        ZiskFv.AirsClean.boolF (decide ((regidx_to_fin c.rd).val ≠ 0)) ∧
+      (mainOfTable trace.program trace.mainTable).jmp_offset1 (i.val + 1) = 0 ∧
       (mainOfTable trace.program trace.mainTable).jmp_offset2 (i.val + 1) = 3 ∧
       (mainRowWithRomAt trace ⟨i.val + 1, h_lt_finish⟩).rom.b_src_imm = 0 ∧
       (mainRowWithRomAt trace ⟨i.val + 1, h_lt_finish⟩).rom.b_src_mem = 0 ∧
@@ -4543,10 +4579,11 @@ def Decode_jalr_unaligned_of_program
       (mainRowWithRomAt trace ⟨i.val + 1, h_lt_finish⟩).rom.b_src_reg = 0 ∧
       (mainRowWithRomAt trace ⟨i.val + 1, h_lt_finish⟩).rom.store_ind = 0 ∧
       (mainRowWithRomAt trace ⟨i.val + 1, h_lt_finish⟩).rom.store_offset
-        = Transpiler.ind (regidx_to_fin c.rd) := by
-    obtain ⟨jb, hlineb, hopb, _, _, hjmp2b, hflagsb⟩ :=
+        = (if (regidx_to_fin c.rd).val = 0 then 0 else
+            Transpiler.ind (regidx_to_fin c.rd)) := by
+    obtain ⟨jb, hlineb, hopb, _, hjmp1b, hjmp2b, hflagsb⟩ :=
       mainRomColumns_at_eq_program trace ⟨i.val + 1, h_lt_finish⟩
-    obtain ⟨hpob, hpj2b, _, hpfb⟩ := h_prog_and jb hlineb
+    obtain ⟨hpob, hpj1b, hpj2b, _, hpfb⟩ := h_prog_and jb hlineb
     have hromb := hflagsb.symm.trans hpfb
     obtain ⟨pb_ieo, pb_m32, pb_set_pc, pb_store_pc⟩ :=
       mainFlagColumns_of_packFlags_at trace ⟨i.val + 1, h_lt_finish⟩ andBits hromb
@@ -4554,16 +4591,26 @@ def Decode_jalr_unaligned_of_program
       mainMemorySelectorColumns_of_packFlags_at trace ⟨i.val + 1, h_lt_finish⟩ andBits hromb
     have pb_b_imm :=
       mainBSourceImmColumn_of_packFlags_at trace ⟨i.val + 1, h_lt_finish⟩ andBits hromb
-    have h_dest := mainDestinationFacts_of_program_at trace ⟨i.val + 1, h_lt_finish⟩
-      andBits c.rd h_and_store_ind
-      (fun j hline => by
-        obtain ⟨_, _, hpso, hpf⟩ := h_prog_and j hline
-        exact ⟨hpso, hpf⟩)
+    have h_dest :
+        (mainRowWithRomAt trace ⟨i.val + 1, h_lt_finish⟩).rom.store_ind = 0 ∧
+        (mainRowWithRomAt trace ⟨i.val + 1, h_lt_finish⟩).rom.store_offset =
+          (if (regidx_to_fin c.rd).val = 0 then 0 else
+            Transpiler.ind (regidx_to_fin c.rd)) := by
+      obtain ⟨_, _, p_store_ind, _, _, _⟩ :=
+        mainMemorySelectorColumns_of_packFlags_at trace ⟨i.val + 1, h_lt_finish⟩
+          andBits hromb
+      refine ⟨by
+        simpa [h_and_store_ind, ZiskFv.AirsClean.boolF_false] using p_store_ind, ?_⟩
+      obtain ⟨j, hline, hstore⟩ :=
+        mainStoreOffset_at_eq_program trace ⟨i.val + 1, h_lt_finish⟩
+      obtain ⟨_, _, _, hpso, _⟩ := h_prog_and j hline
+      simpa [mainRowWithRomAt] using hstore.symm.trans hpso
     exact ⟨hopb.symm.trans hpob,
       by rw [pb_ieo, h_and_ieo, ZiskFv.AirsClean.boolF_true],
       by rw [pb_m32, h_and_m32, ZiskFv.AirsClean.boolF_false],
       by rw [pb_set_pc, h_and_set_pc, ZiskFv.AirsClean.boolF_true],
-      by rw [pb_store_pc, h_and_store_pc, ZiskFv.AirsClean.boolF_true],
+      by rw [pb_store_pc, h_and_store_pc],
+      hjmp1b.symm.trans hpj1b,
       hjmp2b.symm.trans hpj2b,
       by rw [pb_b_imm, h_and_b_src_imm, ZiskFv.AirsClean.boolF_false],
       by rw [pb_b_mem, h_and_b_src_mem, ZiskFv.AirsClean.boolF_false],
@@ -4577,25 +4624,29 @@ def Decode_jalr_unaligned_of_program
           architectural_start := rfl
           finish_has_successor := by simpa using h_idx2
           lowering := Or.inr ⟨rfl, h_offset_zero, keyAdd.1, keyAdd.2.1, keyAdd.2.2.1,
-            h_flag_add, keyAdd.2.2.2.1, keyAdd.2.2.2.2.1, h_a_lane, keyAdd.2.2.2.2.2,
-            keyAnd.2.2.2.2.2.2.1, keyAnd.2.2.2.2.2.2.2.1,
-            keyAnd.2.2.2.2.2.2.2.2.1, keyAnd.2.2.2.2.2.2.2.2.2.1⟩ }
+            h_flag_add, keyAdd.2.2.2.1, keyAdd.2.2.2.2.1, h_a_lane,
+            keyAdd.2.2.2.2.2.1, keyAdd.2.2.2.2.2.2,
+            keyAnd.2.2.2.2.2.2.2.1, keyAnd.2.2.2.2.2.2.2.2.1,
+            keyAnd.2.2.2.2.2.2.2.2.2.1, keyAnd.2.2.2.2.2.2.2.2.2.2.1⟩ }
       h_main_op := keyAnd.1
       h_main_active := keyAnd.2.1
       h_flag := h_flag
       h_m32 := keyAnd.2.2.1
       h_set_pc := keyAnd.2.2.2.1
       h_store_pc := keyAnd.2.2.2.2.1
-      h_store_ind := keyAnd.2.2.2.2.2.2.2.2.2.2.1
-      h_store_offset := keyAnd.2.2.2.2.2.2.2.2.2.2.2
+      h_store_ind := keyAnd.2.2.2.2.2.2.2.2.2.2.2.1
+      h_store_offset := keyAnd.2.2.2.2.2.2.2.2.2.2.2.2
       h_idx := by simpa using h_idx2
       h_a_mask_lo := h_a_mask_lo
       h_a_mask_hi := h_a_mask_hi
       h_c1_zero := h_c1_zero
-      h_jmp2 := Or.inr ⟨rfl, keyAnd.2.2.2.2.2.1⟩
-      h_offset_bridge := h_offset_bridge
+      h_jmp2 := Or.inr ⟨rfl, keyAnd.2.2.2.2.2.2.1⟩
+      h_offset_bridge := by
+        rw [keyAnd.2.2.2.2.2.1, h_offset_zero]
+        norm_num
       h_offset_even := h_offset_even
-      h_no_fgl_wrap := h_no_fgl_wrap }
+      h_target_nonneg := h_target_nonneg
+      h_target_lt := h_target_lt }
 
 
 /-! ## Family: FENCE -/

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
@@ -673,6 +673,7 @@ structure JalrLoweringRows
     (trace : AcceptedZiskTrace numInstructions)
     (i : Fin trace.numInstructions)
     (imm : BitVec 12)
+    (rs1 : regidx)
     (offset_bv : BitVec 64) where
   start : Fin trace.mainTable.table.length
   finish : Fin trace.mainTable.table.length
@@ -694,7 +695,10 @@ structure JalrLoweringRows
           (((mainOfTable trace.program trace.mainTable).a_0 start.val).val
             + ((mainOfTable trace.program trace.mainTable).a_1 start.val).val * 4294967296)
           = BitVec.signExtend 64 imm
-      ∧ (mainRowWithRomAt trace start).rom.b_src_reg = 1
+      ∧ (mainRowWithRomAt trace start).rom.b_src_imm =
+          ZiskFv.AirsClean.boolF (decide ((regidx_to_fin rs1).val = 0))
+      ∧ (mainRowWithRomAt trace start).rom.b_src_reg =
+          ZiskFv.AirsClean.boolF (decide ((regidx_to_fin rs1).val ≠ 0))
       ∧ (mainRowWithRomAt trace finish).rom.b_src_imm = 0
       ∧ (mainRowWithRomAt trace finish).rom.b_src_mem = 0
       ∧ (mainRowWithRomAt trace finish).rom.b_src_ind = 0
@@ -710,7 +714,7 @@ structure Claim_jalr (trace : AcceptedZiskTrace numInstructions) (i : Fin trace.
 
 structure Decode_jalr (trace : AcceptedZiskTrace numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_jalr trace i) : Type where
-  rows : JalrLoweringRows trace i c.imm c.offset_bv
+  rows : JalrLoweringRows trace i c.imm c.rs1 c.offset_bv
   h_main_op :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).op
       rows.finish.val = ZiskFv.Trusted.OP_AND
@@ -728,12 +732,13 @@ structure Decode_jalr (trace : AcceptedZiskTrace numInstructions)
       rows.finish.val = 1
   h_store_pc :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).store_pc
-      rows.finish.val = 1
+      rows.finish.val =
+        ZiskFv.AirsClean.boolF (decide ((regidx_to_fin c.rd).val ≠ 0))
   h_store_ind :
     (mainRowWithRomAt trace rows.finish).rom.store_ind = 0
   h_store_offset :
     (mainRowWithRomAt trace rows.finish).rom.store_offset =
-      Transpiler.ind (regidx_to_fin c.rd)
+      if (regidx_to_fin c.rd).val = 0 then 0 else Transpiler.ind (regidx_to_fin c.rd)
   -- #100 next-PC transition inputs (replace the exec artifacts; the next-PC
   -- residual is now DERIVED via `jalr_setpc_nextPC_discharged`). All are
   -- same-world circuit / decode / ROM pins (no Sail-binding dependency).
@@ -765,14 +770,15 @@ structure Decode_jalr (trace : AcceptedZiskTrace numInstructions)
   --     (aligned `imm % 4 == 0` ⇒ `offset_bv` even; trivial for unaligned
   --     `offset_bv = 0`) + the field-level no-FGL-wrap bound.
   h_offset_bridge :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-        rows.finish.val).val = c.offset_bv.toNat
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
+      rows.finish.val = (c.offset_bv.toInt : FGL)
   h_offset_even : c.offset_bv &&& 1#64 = 0#64
-  h_no_fgl_wrap :
-    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_0
-        rows.finish.val).val
-      + ((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).jmp_offset1
-          rows.finish.val).val < GL_prime
+  h_target_nonneg :
+    0 ≤ (((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_0
+      rows.finish.val).val : Int) + c.offset_bv.toInt
+  h_target_lt :
+    (((ZiskFv.AirsClean.FullEnsemble.mainOfTable trace.program trace.mainTable).c_0
+      rows.finish.val).val : Int) + c.offset_bv.toInt < GL_prime
 
 structure Inputs_jalr (trace : AcceptedZiskTrace numInstructions) (binding : SailTrace trace.numInstructions)
     (i : Fin trace.numInstructions) (c : Claim_jalr trace i) : Type where

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataSplit.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataSplit.lean
@@ -3,7 +3,7 @@ import ZiskFv.Compliance.TraceLevelExport.RowDataArithMem
 import ZiskFv.Compliance.TraceLevelExport.RowDataControl
 
 /-!
-# Per-op claim / decode / inputs split (root_soundness 3-way refactor)
+# Per-op claim / decode / inputs split (stepSound_of_programDecodes 3-way refactor)
 
 For each RV64IM op, the per-row residual is declared ONCE as a 3-way split —
 `Claim_<op>` (ziskStep claim), `Decode_<op>` (rowDecodes), `Inputs_<op>`

--- a/ZiskFv/Compliance/Wrappers/Jalr.lean
+++ b/ZiskFv/Compliance/Wrappers/Jalr.lean
@@ -21,6 +21,41 @@ open Goldilocks
 open ZiskFv.Trusted
 open ZiskFv.Airs.Main
 
+/-- Compliance wrapper for production JALR with `rd = x0`. -/
+lemma equiv_JALR_x0_no_memory
+    (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
+    (jalr_input : PureSpec.JalrInput)
+    (imm : BitVec 12)
+    (rs1 rd : regidx)
+    (misa_val : RegisterType Register.misa)
+    (mseccfg : RegisterType Register.mseccfg)
+    (exec_row : List (Interaction.ExecutionBusEntry FGL))
+    (e_rd : Interaction.MemoryBusEntry FGL)
+    (nextPC_val : BitVec 64)
+    (promises : ZiskFv.EquivCore.Promises.JumpNoMemPromises
+        state jalr_input.PC jalr_input.rd misa_val
+        (PureSpec.execute_JALR_pure jalr_input).success
+        (PureSpec.execute_JALR_pure jalr_input).nextPC
+        rd exec_row nextPC_val)
+    (h_e_rd_mult : e_rd.multiplicity = 1)
+    (h_e_rd_as : e_rd.as.val = 1)
+    (h_e_rd_idx_zero : Transpiler.wrap_to_regidx e_rd.ptr = 0)
+    (h_input_imm : jalr_input.imm = imm)
+    (h_input_rs1 : read_xreg (regidx_to_fin rs1) state
+      = EStateM.Result.ok jalr_input.rs1_val state)
+    (h_cur_privilege : Sail.readReg Register.cur_privilege state
+      = EStateM.Result.ok Privilege.Machine state)
+    (h_mseccfg : Sail.readReg Register.mseccfg state
+      = EStateM.Result.ok mseccfg state) :
+    (do
+        Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
+        LeanRV64D.Functions.execute (instruction.JALR (imm, rs1, rd))) state
+      = (bus_effect exec_row [e_rd] state).2 :=
+  ZiskFv.EquivCore.Jalr.equiv_JALR_x0_no_memory
+    state jalr_input imm rs1 rd misa_val mseccfg exec_row e_rd nextPC_val
+    promises h_e_rd_mult h_e_rd_as h_e_rd_idx_zero
+    h_input_imm h_input_rs1 h_cur_privilege h_mseccfg
+
 
 /-- **Compatibility wrapper for `equiv_JALR`.** Derives `h_circuit` from
     explicit Main-row pins and delegates to canonical `equiv_JALR`. -/

--- a/ZiskFv/EquivCore/Jalr.lean
+++ b/ZiskFv/EquivCore/Jalr.lean
@@ -105,6 +105,66 @@ lemma equiv_JALR_sail
     h_input_imm h_input_rd h_input_rs1 h_input_pc h_input_misa h_misa_c
     h_cur_privilege h_mseccfg
 
+/-- JALR `rd = x0` shape. Production lowering suppresses the register write.
+    The legacy selected-entry adapter still carries multiplicity one, but its
+    x0 pointer makes the write semantically inert. -/
+lemma equiv_JALR_x0_no_memory
+    (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
+    (jalr_input : PureSpec.JalrInput)
+    (imm : BitVec 12)
+    (rs1 rd : regidx)
+    (misa_val : RegisterType Register.misa)
+    (mseccfg : RegisterType Register.mseccfg)
+    (exec_row : List (Interaction.ExecutionBusEntry FGL))
+    (e_rd : Interaction.MemoryBusEntry FGL)
+    (nextPC_val : BitVec 64)
+    (promises : ZiskFv.EquivCore.Promises.JumpNoMemPromises
+        state jalr_input.PC jalr_input.rd misa_val
+        (PureSpec.execute_JALR_pure jalr_input).success
+        (PureSpec.execute_JALR_pure jalr_input).nextPC
+        rd exec_row nextPC_val)
+    (h_e_rd_mult : e_rd.multiplicity = 1)
+    (h_e_rd_as : e_rd.as.val = 1)
+    (h_e_rd_idx_zero : Transpiler.wrap_to_regidx e_rd.ptr = 0)
+    (h_input_imm : jalr_input.imm = imm)
+    (h_input_rs1 : read_xreg (regidx_to_fin rs1) state
+      = EStateM.Result.ok jalr_input.rs1_val state)
+    (h_cur_privilege : Sail.readReg Register.cur_privilege state
+      = EStateM.Result.ok Privilege.Machine state)
+    (h_mseccfg : Sail.readReg Register.mseccfg state
+      = EStateM.Result.ok mseccfg state) :
+    (do
+        Sail.writeReg Register.nextPC (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
+        LeanRV64D.Functions.execute (instruction.JALR (imm, rs1, rd))) state
+      = (bus_effect exec_row [e_rd] state).2 := by
+  obtain ⟨h_input_rd, h_input_rd_zero, h_input_pc, h_input_misa, h_misa_c,
+          h_exec_len, h_e0_mult, h_e1_mult, h_nextPC_matches,
+          h_success, h_nextPC_option⟩ := promises
+  rw [equiv_JALR_sail state jalr_input imm rs1 rd misa_val mseccfg
+        h_input_imm h_input_rd h_input_rs1 h_input_pc h_input_misa h_misa_c
+        h_cur_privilege h_mseccfg]
+  symm
+  have h_bus_zero :
+      (bus_effect exec_row [e_rd] state).2 =
+        (bus_effect exec_row [] state).2 := by
+    have h_one_ne_neg_one : (1 : FGL) ≠ -1 := by decide
+    simp [bus_effect, h_exec_len, h_e_rd_mult, h_e_rd_as,
+      h_e_rd_idx_zero, h_one_ne_neg_one]
+  rw [h_bus_zero]
+  rw [ZiskFv.Airs.Bus.BusEmission.bus_effect_matches_sail_jump_no_memory
+        state exec_row nextPC_val false
+        (PureSpec.execute_JALR_pure jalr_input).success
+        jalr_input.PC
+        (0xFFFFFFFFFFFFFFFE &&&
+          (jalr_input.rs1_val + BitVec.signExtend 64 jalr_input.imm))
+        h_exec_len h_e0_mult h_e1_mult h_nextPC_matches
+        (by rfl) h_success]
+  simp only [h_nextPC_option]
+  have h_rd_none :
+      (PureSpec.execute_JALR_pure jalr_input).rd = none := by
+    simp [PureSpec.execute_JALR_pure, h_input_rd_zero]
+  simp [h_rd_none, h_success]
+
 /-- **Canonical equivalence.** Sail's `execute_instruction` on an RV64
     JALR equals the state computed by applying `bus_effect` to the
     circuit's execution and memory bus rows.

--- a/ZiskFv/Soundness.lean
+++ b/ZiskFv/Soundness.lean
@@ -5,16 +5,25 @@ import ZiskFv.Compliance.TraceLevelExport.RawProgramDecode
 /-!
 # Root soundness
 
-The headline soundness statement of the project, factored out of the
-trace-level export development for visibility. It sits parallel to
-`ZiskFv.Compliance` and re-exports the single endpoint theorem.
+The headline soundness statement of the project, factored out of the trace-level
+export development for visibility. It sits parallel to `ZiskFv.Compliance`.
+
+`root_soundness` is the single audit entrypoint: the entire compliance statement
+is reachable from it. `stepSound_of_programDecodes` is the interior layer it
+calls, kept as a separate declaration because the six concrete trace
+instantiations target it directly.
 -/
 
 namespace ZiskFv.Compliance
 
-/-- ** The top-level global soundness theorem: given a satisfying assignment of circuits
-    that does not involve any explicitly enumerated bugs, the zisk machine state transition
-    agrees with the Sail machine state transition.
+/-- Soundness for every executed step, indexed by the COMMITTED-program decode
+    family: given a satisfying assignment of circuits that does not involve any
+    explicitly enumerated bugs, the zisk machine state transition agrees with the
+    Sail machine state transition.
+
+    This is the interior layer of the audit tree, not the entrypoint. The public
+    endpoint is `root_soundness` below, which CONSTRUCTS `programDecodes` from raw
+    RV64IM words through the production lowerer instead of taking it as a premise.
 
     An AcceptedZiskTrace is a set of constraints, and a witness that satisfies those constraints and the
     channel balancing constraint enfoced in the proving system through a lookup argument.
@@ -52,7 +61,7 @@ namespace ZiskFv.Compliance
     (`= state_effect_via_channels …`). The per-row `OpEnvelope` is constructed
     from the trace inside each `stepStrong_<op>` — nothing is caller-supplied
     beyond the trace itself. -/
-theorem root_soundness
+theorem stepSound_of_programDecodes
     (numInstructions : Nat)
     (ziskTrace : AcceptedZiskTrace numInstructions)
     (sailTrace : SailTrace numInstructions)
@@ -70,11 +79,36 @@ theorem root_soundness
       (rowDecode_of_programDecode ziskTrace i (programDecodes i)) (inputsAgree i)
       (memEvidence_of_bootSeed bootSeed i) (hAvoidKnownBugs i)
 
-/-- Additive raw-program endpoint. A single production-lowering binding and
-    per-instruction raw decode evidence construct the committed-program decode
-    family consumed by `root_soundness`; the existing headline theorem and
-    `AcceptedZiskTrace` remain unchanged. -/
-theorem root_soundness_rawProgram
+/-- **The root soundness theorem — the entrypoint for an audit of this project's
+    soundness claim.** The entire compliance statement is reachable from here:
+    every premise below is either discharged inside this theorem or is a named
+    trust premise documented in `trust/trusted-base.md`.
+
+    Given an accepted ZisK trace, the raw RV64IM program image, and an exact
+    binding of that image to the committed ROM, every executed step's ZisK state
+    transition agrees with the Sail/RISC-V transition.
+
+    The per-instruction decode family consumed by `stepSound_of_programDecodes` is
+    CONSTRUCTED here (`programDecode_of_rawProgramDecode`, 63 arms) by running the
+    Aeneas-extracted production lowerer on the raw word, rather than being supplied
+    by the caller. `programBinding` states that the committed ROM holds exactly the
+    serialized lowering of `rawProgram` — gap-free, in program order, with two-row
+    (unaligned JALR) expansions occupying adjacent physical slots.
+
+    Residual boundaries, all named in `trust/trusted-base.md`: the layout maps
+    `start` / `addr` are caller-supplied (their meaning is that architectural word
+    `k` sits at the location assigned to `k`, not that the map came from a
+    particular linker image); grounding the same word in Sail's `ext_decode` is
+    #172; and identifying `rawProgram` with the intended compiled binary is the
+    external compile/commitment boundary.
+
+    NON-VACUITY (#320): `programBinding` and `rawProgramDecodes` do not yet have
+    in-tree witnesses. The six concrete instantiations (`addSpin`, `addAddiSpin`,
+    `divSpin`, `jalrSpin`, `sdLdSpin`, degenerate) discharge the premises this
+    theorem SHARES with `stepSound_of_programDecodes` — `ziskTrace`, `ziskStep`,
+    `inputsAgree`, `bootSeed`, `hAvoidKnownBugs` — but they satisfy `ProgramDecode`
+    directly and so provide no evidence for those two. -/
+theorem root_soundness
     (numInstructions rawLength : Nat)
     (ziskTrace : AcceptedZiskTrace numInstructions)
     (sailTrace : SailTrace numInstructions)
@@ -96,7 +130,7 @@ theorem root_soundness_rawProgram
         (rowDecode_of_programDecode ziskTrace i
           (programDecode_of_rawProgramDecode ziskTrace i (ziskStep i)
             start addr rawProgram programBinding (rawProgramDecodes i))) :=
-  root_soundness numInstructions ziskTrace sailTrace ziskStep
+  stepSound_of_programDecodes numInstructions ziskTrace sailTrace ziskStep
     (fun i => programDecode_of_rawProgramDecode ziskTrace i (ziskStep i)
       start addr rawProgram programBinding (rawProgramDecodes i))
     inputsAgree bootSeed hAvoidKnownBugs

--- a/ZiskFv/Soundness.lean
+++ b/ZiskFv/Soundness.lean
@@ -1,5 +1,6 @@
 import ZiskFv.Compliance.TraceLevelExport
 import ZiskFv.Compliance.TraceLevelExport.ProgramDecode
+import ZiskFv.Compliance.TraceLevelExport.RawProgramDecode
 
 /-!
 # Root soundness
@@ -68,5 +69,36 @@ theorem root_soundness
     stepSound_of_evidence ziskTrace sailTrace i (ziskStep i)
       (rowDecode_of_programDecode ziskTrace i (programDecodes i)) (inputsAgree i)
       (memEvidence_of_bootSeed bootSeed i) (hAvoidKnownBugs i)
+
+/-- Additive raw-program endpoint. A single production-lowering binding and
+    per-instruction raw decode evidence construct the committed-program decode
+    family consumed by `root_soundness`; the existing headline theorem and
+    `AcceptedZiskTrace` remain unchanged. -/
+theorem root_soundness_rawProgram
+    (numInstructions rawLength : Nat)
+    (ziskTrace : AcceptedZiskTrace numInstructions)
+    (sailTrace : SailTrace numInstructions)
+    (ziskStep : ∀ i : Fin numInstructions, ZiskStep ziskTrace i)
+    (start : Fin rawLength → Fin ziskTrace.programLength)
+    (addr : Fin rawLength → FGL)
+    (rawProgram : Fin rawLength → BitVec 32)
+    (programBinding : RawProgramBinding.ProgramRowsBinding
+      ziskTrace start addr rawProgram)
+    (rawProgramDecodes : ∀ i : Fin numInstructions,
+      RawProgramDecode ziskTrace i (ziskStep i) start addr rawProgram)
+    (inputsAgree : ∀ i : Fin numInstructions,
+      InputsAgree ziskTrace sailTrace i (ziskStep i))
+    (bootSeed : BootSegmentMemorySeed ziskTrace sailTrace ziskStep)
+    (hAvoidKnownBugs : ∀ i : Fin numInstructions,
+      RowOutsideDefectRegion ziskTrace i (ziskStep i)) :
+    ∀ i : Fin numInstructions,
+      StepSound ziskTrace sailTrace i (ziskStep i)
+        (rowDecode_of_programDecode ziskTrace i
+          (programDecode_of_rawProgramDecode ziskTrace i (ziskStep i)
+            start addr rawProgram programBinding (rawProgramDecodes i))) :=
+  root_soundness numInstructions ziskTrace sailTrace ziskStep
+    (fun i => programDecode_of_rawProgramDecode ziskTrace i (ziskStep i)
+      start addr rawProgram programBinding (rawProgramDecodes i))
+    inputsAgree bootSeed hAvoidKnownBugs
 
 end ZiskFv.Compliance

--- a/bin/TrustGate/Main.lean
+++ b/bin/TrustGate/Main.lean
@@ -237,7 +237,13 @@ def cmdPrintGlobalBinders (env : Environment) (theoremName : Name) : IO UInt32 :
 /-- The strengthened trace-level export theorem (#61, channel-balance form).
 Audited by the strong-export closure + binder gates exactly as
 `zisk_riscv_compliant_program_bus` is audited by `check-closure-vs-baseline` /
-`check-global-theorem-binders`. -/
+`check-global-theorem-binders`.
+
+This Name deliberately tracks whatever is called `root_soundness`: the gate audits
+the project's audit entrypoint, so promoting a new outermost endpoint to that name
+retargets the binder/closure baselines onto it by construction. It now resolves to
+the raw-program root, whose binder list is the raw image plus its ROM binding
+rather than the caller-supplied `ProgramDecode` family. -/
 def strongExportTheorem : Name :=
   `ZiskFv.Compliance.root_soundness
 

--- a/scripts/aeneas-production-extract.sh
+++ b/scripts/aeneas-production-extract.sh
@@ -4148,6 +4148,7 @@ same shape before calling `lower_rv64im_single_row_input`. -/
 def emptyExtractContext : riscv2zisk_context.Riscv2ZiskContext :=
   {
     extract_inst := none,
+    extract_first_inst := none,
     extract_marker := (),
     input_precompile := none,
     output_precompile := none,
@@ -8318,7 +8319,7 @@ def lowerLuiRouteForReg (rd : Std.U32) (imm : Std.I32) : Bool :=
       (do
         let ctx ←
           riscv2zisk_context.Riscv2ZiskContext.lui
-            { extract_inst := none, extract_marker := (),
+            { extract_inst := none, extract_first_inst := none, extract_marker := (),
               input_precompile := none, output_precompile := none,
               input_precompile_reg := none, output_precompile_reg := none }
             { rom_address := 0#u64, rd := rd, rs1 := 0#u32,
@@ -8348,7 +8349,7 @@ def lowerAuipcRouteForReg (rd : Std.U32) (imm : Std.I32) : Bool :=
       (do
         let ctx ←
           riscv2zisk_context.Riscv2ZiskContext.auipc
-            { extract_inst := none, extract_marker := (),
+            { extract_inst := none, extract_first_inst := none, extract_marker := (),
               input_precompile := none, output_precompile := none,
               input_precompile_reg := none, output_precompile_reg := none }
             { rom_address := 0#u64, rd := rd, rs1 := 0#u32,
@@ -8377,7 +8378,7 @@ def lowerJalRouteForReg (rd : Std.U32) (imm : Std.I32) : Bool :=
       (do
         let ctx ←
           riscv2zisk_context.Riscv2ZiskContext.jal
-            { extract_inst := none, extract_marker := (),
+            { extract_inst := none, extract_first_inst := none, extract_marker := (),
               input_precompile := none, output_precompile := none,
               input_precompile_reg := none, output_precompile_reg := none }
             { rom_address := 0#u64, rd := rd, rs1 := 0#u32,

--- a/trust/README.md
+++ b/trust/README.md
@@ -80,9 +80,12 @@ axioms should not exist as source trust, and any future
 soundness closure; canonical active dispatch targets, public-looking
 `Equivalence.equiv_*` helper theorem surfaces, and route-named `OpEnvelope`
 variants are also checked.
-The intended public theorem API is `zisk_riscv_compliant_program_bus` plus the
-63 canonical `ZiskFv.Equivalence.<Op>.equiv_<OP>` theorems. Wrapper and
-EquivCore routes are implementation details.
+The headline public theorem API is `root_soundness`, with
+`root_soundness_rawProgram` as its additive raw-word/production-lowering entry
+point. `zisk_riscv_compliant_program_bus` remains the older global
+channel-balance theorem consumed by the trace-level export, and the 63
+canonical `ZiskFv.Equivalence.<Op>.equiv_<OP>` theorems remain the per-op
+semantic endpoints. Wrapper and EquivCore routes are implementation details.
 
 ## RV64IM Acceptance Completeness
 

--- a/trust/README.md
+++ b/trust/README.md
@@ -80,9 +80,11 @@ axioms should not exist as source trust, and any future
 soundness closure; canonical active dispatch targets, public-looking
 `Equivalence.equiv_*` helper theorem surfaces, and route-named `OpEnvelope`
 variants are also checked.
-The headline public theorem API is `root_soundness`, with
-`root_soundness_rawProgram` as its additive raw-word/production-lowering entry
-point. `zisk_riscv_compliant_program_bus` remains the older global
+The headline public theorem API is `root_soundness`, the raw-word /
+production-lowering audit entrypoint, with `stepSound_of_programDecodes` as the
+interior committed-program layer it calls. The strong-export binder and closure
+gates target `root_soundness` by name, so they audit whichever theorem holds the
+entrypoint role. `zisk_riscv_compliant_program_bus` remains the older global
 channel-balance theorem consumed by the trace-level export, and the 63
 canonical `ZiskFv.Equivalence.<Op>.equiv_<OP>` theorems remain the per-op
 semantic endpoints. Wrapper and EquivCore routes are implementation details.

--- a/trust/consistency/root_soundness_instantiation_degenerate.lean
+++ b/trust/consistency/root_soundness_instantiation_degenerate.lean
@@ -3,16 +3,16 @@ import ZiskFv.Compliance.EnsembleWitnessBuilder
 import ZiskFv.AirsClean.FullEnsemble.Balance.Classification
 
 /-!
-# Degenerate `root_soundness` instantiation (end-to-end integration witness, base case)
+# Degenerate `stepSound_of_programDecodes` instantiation (end-to-end integration witness, base case)
 
 The first concrete inhabitant of `ZiskFv.Compliance.AcceptedZiskTrace` fed through
-`ZiskFv.Compliance.root_soundness` (eth-act/zisk-fv#217, foundation of #74).
+`ZiskFv.Compliance.stepSound_of_programDecodes` (eth-act/zisk-fv#217, foundation of #74).
 
 This is the DEGENERATE base case: `numInstructions = 0`, every provider table empty.
 It exercises the whole witness-construction pipeline — the 11-table
 `EnsembleWitness` (`same_length`/`same_circuits`/`same_data`), `constraints_hold`,
     `transitions_hold`, and the first forward `BalancedChannels`
-proof — and applies `root_soundness` to the result. The `∀ i : Fin 0` conclusion
+proof — and applies `stepSound_of_programDecodes` to the result. The `∀ i : Fin 0` conclusion
 is vacuous, so this establishes only that the quantified-over trace object is
 INHABITED and accepted; the non-vacuous single-ADD instance is #219/#220. No new
 axioms, no `sorry`.
@@ -173,15 +173,15 @@ private def seed : BootSegmentMemorySeed trace sail step where
     exact absurd (by simp [AcceptedZiskTrace.numInstructions]) h_ne
   placement := fun i => i.elim0
 
-/-- `root_soundness` applied to a concrete (degenerate) accepted trace. The `Fin 0`
+/-- `stepSound_of_programDecodes` applied to a concrete (degenerate) accepted trace. The `Fin 0`
     conclusion is vacuous, but the term genuinely constructs an `AcceptedZiskTrace`
     and feeds it through the headline theorem — witnessing that the object
-    `root_soundness` quantifies over is inhabited and accepted. -/
+    `stepSound_of_programDecodes` quantifies over is inhabited and accepted. -/
 theorem root_soundness_instantiation_degenerate :
     ∀ i : Fin 0,
       StepSound trace sail i (step i)
         (rowDecode_of_programDecode trace i (decode i)) :=
-  root_soundness 0 trace sail step decode nofun seed nofun
+  stepSound_of_programDecodes 0 trace sail step decode nofun seed nofun
 
 #print axioms root_soundness_instantiation_degenerate
 

--- a/trust/consistency/root_soundness_instantiation_rawprogram_endpoint.lean
+++ b/trust/consistency/root_soundness_instantiation_rawprogram_endpoint.lean
@@ -1,4 +1,4 @@
 import ZiskFv.Soundness
 
-#print axioms ZiskFv.Compliance.root_soundness_rawProgram
+#print axioms ZiskFv.Compliance.root_soundness
 #print axioms ZiskFv.Compliance.programDecode_of_rawProgramDecode

--- a/trust/consistency/root_soundness_instantiation_rawprogram_endpoint.lean
+++ b/trust/consistency/root_soundness_instantiation_rawprogram_endpoint.lean
@@ -1,0 +1,4 @@
+import ZiskFv.Soundness
+
+#print axioms ZiskFv.Compliance.root_soundness_rawProgram
+#print axioms ZiskFv.Compliance.programDecode_of_rawProgramDecode

--- a/trust/envelope-burden-audit.md
+++ b/trust/envelope-burden-audit.md
@@ -75,7 +75,7 @@ note below.
 
 | Premise class | Current surface | Final trace-level role |
 |---------------|-----------------|------------------------|
-| Program binding and decode | `root_soundness_rawProgram` derives all 63 `ProgramDecode` bundles from raw-word fields plus exact production-lowered primary/successor ROM rows | `ProgramRowsBinding` retains the caller-supplied raw image and its `start`/`addr` layout map; Sail `ext_decode` grounding is #172 and binary identity is the compile/commitment boundary |
+| Program binding and decode | `root_soundness` derives all 63 `ProgramDecode` bundles from raw-word fields plus exact production-lowered primary/successor ROM rows | `ProgramRowsBinding` retains the caller-supplied raw image and its `start`/`addr` layout map; Sail `ext_decode` grounding is #172 and binary identity is the compile/commitment boundary |
 | Boot/profile state | `misa` C-bit facts, `cur_privilege = Machine`, `RISC_V_assumptions`, `ModeRegsFull`, PMA/mstatus/mseccfg values | Named initial-state/profile invariant; not 63 separate assumptions |
 | Aeneas lowering bridge | `env.aeneasBridgeTrust` in `Compliance.lean` | Named bridge premise until generated Aeneas Lean is imported by the main proof |
 | Load memory timeline | `env.memoryTimelineEvidence` for LD/LBU/LHU/LWU/LB/LH/LW routes | Named memory premise until #76 derives it from Mem AIR/replay |

--- a/trust/envelope-burden-audit.md
+++ b/trust/envelope-burden-audit.md
@@ -75,7 +75,7 @@ note below.
 
 | Premise class | Current surface | Final trace-level role |
 |---------------|-----------------|------------------------|
-| Program binding and decode | Pure input records, `r1`/`r2`/`rd`/`imm`/`shamt`/`fm`/`pred`/`succ`, opcode pins | Named `ProgramBinding`/decode premise; constructor projections should be generated |
+| Program binding and decode | `root_soundness_rawProgram` derives all 63 `ProgramDecode` bundles from raw-word fields plus exact production-lowered primary/successor ROM rows | `ProgramRowsBinding` retains the caller-supplied raw image and its `start`/`addr` layout map; Sail `ext_decode` grounding is #172 and binary identity is the compile/commitment boundary |
 | Boot/profile state | `misa` C-bit facts, `cur_privilege = Machine`, `RISC_V_assumptions`, `ModeRegsFull`, PMA/mstatus/mseccfg values | Named initial-state/profile invariant; not 63 separate assumptions |
 | Aeneas lowering bridge | `env.aeneasBridgeTrust` in `Compliance.lean` | Named bridge premise until generated Aeneas Lean is imported by the main proof |
 | Load memory timeline | `env.memoryTimelineEvidence` for LD/LBU/LHU/LWU/LB/LH/LW routes | Named memory premise until #76 derives it from Mem AIR/replay |

--- a/trust/generated/baseline-strong-export-binders.txt
+++ b/trust/generated/baseline-strong-export-binders.txt
@@ -1,9 +1,14 @@
 0 :: numInstructions :: Nat
-1 :: ziskTrace :: ZiskFv.Compliance.AcceptedZiskTrace numInstructions
-2 :: sailTrace :: ZiskFv.Compliance.SailTrace numInstructions
-3 :: ziskStep :: (i : Fin numInstructions) → ZiskFv.Compliance.ZiskStep ziskTrace i
-4 :: programDecodes :: (i : Fin numInstructions) → ZiskFv.Compliance.ProgramDecode ziskTrace i (ziskStep i)
-5 :: inputsAgree :: (i : Fin numInstructions) → ZiskFv.Compliance.InputsAgree ziskTrace sailTrace i (ziskStep i)
-6 :: bootSeed :: ZiskFv.Compliance.BootSegmentMemorySeed ziskTrace sailTrace ziskStep
-7 :: hAvoidKnownBugs :: ∀ (i : Fin numInstructions), ZiskFv.Compliance.RowOutsideDefectRegion ziskTrace i (ziskStep i)
-8 :: i :: Fin numInstructions
+1 :: rawLength :: Nat
+2 :: ziskTrace :: ZiskFv.Compliance.AcceptedZiskTrace numInstructions
+3 :: sailTrace :: ZiskFv.Compliance.SailTrace numInstructions
+4 :: ziskStep :: (i : Fin numInstructions) → ZiskFv.Compliance.ZiskStep ziskTrace i
+5 :: start :: Fin rawLength → Fin ziskTrace.programLength
+6 :: addr :: Fin rawLength → Fin 18446744069414584321
+7 :: rawProgram :: Fin rawLength → BitVec 32
+8 :: programBinding :: ZiskFv.Compliance.RawProgramBinding.ProgramRowsBinding ziskTrace start addr rawProgram
+9 :: rawProgramDecodes :: (i : Fin numInstructions) → ZiskFv.Compliance.RawProgramDecode ziskTrace i (ziskStep i) start addr rawProgram
+10 :: inputsAgree :: (i : Fin numInstructions) → ZiskFv.Compliance.InputsAgree ziskTrace sailTrace i (ziskStep i)
+11 :: bootSeed :: ZiskFv.Compliance.BootSegmentMemorySeed ziskTrace sailTrace ziskStep
+12 :: hAvoidKnownBugs :: ∀ (i : Fin numInstructions), ZiskFv.Compliance.RowOutsideDefectRegion ziskTrace i (ziskStep i)
+13 :: i :: Fin numInstructions

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -891,6 +891,37 @@ architectural index `i`. No binder is added — `programDecodes` was already a
 `root_soundness` binder — and `JalrLoweringRows.architectural_start` pins
 `start.val = i.val`; every other family still reads its effect at `i`.
 
+The additive `root_soundness_rawProgram` entry point replaces the caller's 63
+`ProgramDecode` bundles with a single exact `ProgramRowsBinding` and
+per-instruction `RawProgramDecode` evidence. Each arm checks the raw RV64IM
+shape, uses the Aeneas-extracted production lowerer, and constructs the same
+committed-program decode consumed by `root_soundness`; unaligned JALR uses the
+binding's primary and successor rows. This is a caller-trust reduction and does
+not alter `AcceptedZiskTrace`, the semantic conclusion, the known-defect
+boundary, or the project axiom closure.
+
+Three boundaries remain explicit. First, the layout functions (`start` and
+`addr`) are caller-supplied: their meaning is that architectural word `k` sits
+at the binary/ROM location assigned to `k`; the binding proves exact,
+gap-free lowered rows relative to that map, not that the map came from a
+particular linker image. Second, grounding the same word in Sail's
+`ext_decode` is #172 and is not claimed here. Third, identifying `rawProgram`
+with the intended compiled binary remains the external compile/commitment
+boundary. Non-vacuity is witnessed independently by
+`RawProgramBinding.memoryProgramBinding`, whose hand-written accepted ROM
+contains SD, LD, and a negative-offset LD and is proved equal to production
+serialization.
+
+Two extraction fidelity qualifications also remain visible. The Aeneas wrapper
+passes `rom_address := 0#u64`; this is sound for the exported fields because
+that value reaches only `paddr` and a discarded map key, but a production
+change that makes it affect another serialized field requires revisiting the
+proof. The Rust implementation has a
+`#[cfg(feature = "aeneas_extract")]` extraction path, so equivalence of that
+feature-selected path with the ordinary production build remains a reviewed
+source/configuration boundary and is cross-checked by the focused real
+`compute_trace_rom` test.
+
 **Within-segment boundary (explicit).** `mainTransition_to_next_pc`
 (`Compliance/MainTransition.lean`) requires `i + 1 < mainTable.table.length` — a
 *physical Main-row successor* must exist — surfaced as the per-opcode `h_idx`.

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -891,12 +891,18 @@ architectural index `i`. No binder is added — `programDecodes` was already a
 `root_soundness` binder — and `JalrLoweringRows.architectural_start` pins
 `start.val = i.val`; every other family still reads its effect at `i`.
 
-The additive `root_soundness_rawProgram` entry point replaces the caller's 63
+The `root_soundness` entry point replaces the caller's 63
 `ProgramDecode` bundles with a single exact `ProgramRowsBinding` and
 per-instruction `RawProgramDecode` evidence. Each arm checks the raw RV64IM
 shape, uses the Aeneas-extracted production lowerer, and constructs the same
-committed-program decode consumed by `root_soundness`; unaligned JALR uses the
-binding's primary and successor rows. This is a caller-trust reduction and does
+committed-program decode consumed by `stepSound_of_programDecodes`; unaligned
+JALR uses the binding's primary and successor rows. (This endpoint was
+introduced as `root_soundness_rawProgram`; it now holds the `root_soundness`
+name, and the theorem it calls — formerly `root_soundness` — is
+`stepSound_of_programDecodes`. The project keeps exactly one theorem named
+`root_soundness`, and it is the outermost node of the audit tree, so the
+strong-export binder and closure gates retarget onto it by construction.)
+This is a caller-trust reduction and does
 not alter `AcceptedZiskTrace`, the semantic conclusion, the known-defect
 boundary, or the project axiom closure.
 
@@ -907,10 +913,24 @@ gap-free lowered rows relative to that map, not that the map came from a
 particular linker image. Second, grounding the same word in Sail's
 `ext_decode` is #172 and is not claimed here. Third, identifying `rawProgram`
 with the intended compiled binary remains the external compile/commitment
-boundary. Non-vacuity is witnessed independently by
-`RawProgramBinding.memoryProgramBinding`, whose hand-written accepted ROM
-contains SD, LD, and a negative-offset LD and is proved equal to production
-serialization.
+boundary.
+
+**Non-vacuity of this endpoint is NOT yet witnessed (#320).** No theorem in the
+tree concludes `ProgramRowsBinding`, and there is no conversion lemma from the
+older `ProgramBinding`. `RawProgramBinding.memoryProgramBinding` — whose
+hand-written accepted ROM contains SD, LD, and a negative-offset LD and is
+proved equal to production serialization — inhabits `ProgramBinding`, which is
+the physically-indexed predecessor predicate and is not the premise this
+endpoint takes. The six concrete instantiations (`addSpin`, `addAddiSpin`,
+`divSpin`, `jalrSpin`, `sdLdSpin`, degenerate) discharge the premises
+`root_soundness` shares with `stepSound_of_programDecodes` — `ziskTrace`,
+`ziskStep`, `inputsAgree`, `bootSeed`, `hAvoidKnownBugs` — but they satisfy
+`ProgramDecode` directly, and `ProgramRowsBinding + RawProgramDecode ⟹
+ProgramDecode` does not run in the direction that would transfer that evidence.
+So the clauses carrying the binding's weight (4-alignment, `addr + 1 <
+GL_prime`, two-slot separation, and the surjectivity clause) and the two-row
+JALR expansion path are currently unexercised, and no gate detects this:
+`#print axioms` reports nothing about inhabitation.
 
 Two extraction fidelity qualifications also remain visible. The Aeneas wrapper
 passes `rom_address := 0#u64`; this is sound for the exported fields because
@@ -921,6 +941,16 @@ proof. The Rust implementation has a
 feature-selected path with the ordinary production build remains a reviewed
 source/configuration boundary and is cross-checked by the focused real
 `compute_trace_rom` test.
+
+One extraction-boundary allowlist was widened for this endpoint:
+`trust/scripts/check-aeneas-production-boundary.py` exempts
+`extract_transpile_rv64im_rows_raw` from the "no public extraction helpers
+outside the generated start surface" rule. It is the two-row sibling of the
+already-exempt `extract_transpile_rv64im_raw` family and carries the same
+reviewed status; it is recorded here because it is a widening of the extraction
+surface rather than a proof step. Countervailing, `ZiskFv.Compliance.RawProgramBinding`
+was added to `extractionNamespaces` in `bin/TrustGate/Main.lean`, putting the new
+module under the raw-closure regression gate.
 
 **Within-segment boundary (explicit).** `mainTransition_to_next_pc`
 (`Compliance/MainTransition.lean`) requires `i + 1 < mainTable.table.length` — a


### PR DESCRIPTION
Part 6 of the Phase 9 stack for #61. Base: `phase9-5-architectural-decoders`.

## Summary

- Adds all ten ordinary control constructors and the production-selected aligned/expanded JALR
  constructor.
- Corrects JALR signed offsets and exact `rs1=x0` / `rd=x0` source, destination, and link semantics
  through Dispatcher and StepStrong.
- Adds the 63-arm `RawProgramDecode` dispatcher and
  `ZiskFv.Compliance.root_soundness_rawProgram`.
- Keeps the existing headline `root_soundness` and `AcceptedZiskTrace` unchanged.
- Documents the three residual boundaries: caller-supplied layout, Sail raw-word grounding (#172),
  and compiled-binary identity.
- Repairs four concrete JAL range witnesses and the production-extraction harness fixtures exposed
  by the final full gates.

The constructor dispatcher has only
`{propext, Classical.choice, Quot.sound}` in its axiom closure. No project axiom, trust marker,
alignment restriction, nonnegative-offset restriction, or x0 exclusion is added.

## Stack

1. `phase9-1-raw-binding`
2. `phase9-2-initial-decoders`
3. `phase9-3-fidelity-nonvacuity`
4. `phase9-4-expanded-layout`
5. `phase9-5-architectural-decoders`
6. **This PR**

Review and merge the stack in order. GitHub will retarget each next PR automatically as its base
branch is merged.

## Verification

- `lake build`: 9,132 jobs passed.
- `trust/scripts/check-all.sh`: 18/18 passed; 702 reachable modules and 28 semantic probes.
- `trust/scripts/check-all-semantic.sh`: 19/19 passed; 2,964 raw extraction/decode declarations
  have standard-only closure.
- Focused production-extraction harness: 1,732 jobs passed; 70 production starts and
  206 declarations.
- `nix run .#test`: all eight stages passed, including flake reproducibility.
