### PR TITLE
Pair every generated constraint against the mirrors that restate it

### DIFF
--- a/.github/workflows/proofs.yml
+++ b/.github/workflows/proofs.yml
@@ -256,7 +256,7 @@ jobs:
           # proof-memory fix, and matches nix/test.nix's default.
           LEAN_NUM_THREADS: "4"
           # The independent Aeneas production-extraction completeness check
-          # (step 4/9) is the single largest cost (~1.5h) and is unrelated to
+          # (step 5/10) is the single largest cost (~1.5h) and is unrelated to
           # the Lake proof graph. Run it in the parallel
           # aeneas-production-extraction job below instead of serializing it
           # ahead of `lake build`. Plain local `nix run .#test` is unaffected.
@@ -322,7 +322,7 @@ jobs:
 
   # ------------------------------------------------------------------
   # Aeneas RV-completeness extraction harness, run in PARALLEL with the
-  # Lake FV gate above. Previously this ran as step 4/9 of `nix run .#test`
+  # Lake FV gate above. Previously this ran as step 5/10 of `nix run .#test`
   # inside the lake-build job, serializing ~1.5h of generated-extraction
   # work ahead of the proof build. It is independent of the Lake proof
   # graph (the `aeneas-extraction-diff` job already guards the tracked

--- a/docs/extraction/extractor-notes.md
+++ b/docs/extraction/extractor-notes.md
@@ -456,13 +456,76 @@ directory: an AIR whose constraints all became `--skip-unsupported` stubs has no
 perfect ratio.
 
 Wiring: the tail of `nix run .#populate` (so drift fails where it is produced)
-and step 3/9 of `nix run .#test` (`check.py` plus the mutation selftest). Not in
+and step 3/10 of `nix run .#test` (`check.py` plus the mutation selftest). Not in
 `trust/scripts/check-all.sh`, whose CI job has no `build/` at all. Exit 1 is a
 mismatch or an uncovered constraint, exit 2 is a missing artifact; neither is a
 pass.
 
 `tools/pilout-roundtrip/README.md` carries the full argument, the two atom
 vocabularies, and the measured residual blind spots.
+
+## Mirror gate (`tools/mirror-roundtrip`, eth-act/zisk-fv#304)
+
+The round-trip gate above ends at `build/extraction/`. Nothing in its argument
+touches `ZiskFv/`, and no Lean under `ZiskFv/` imports a per-AIR
+`Extraction.<AIR>` module at all, so a constraint can round-trip perfectly and
+still be restated wrongly, partially, or not at all in the handwritten Lean the
+proof actually consumes. This gate closes that second direction for the
+polynomial content.
+
+How the two differ:
+
+| | round-trip gate (#303) | mirror gate (#304) |
+| - | - | - |
+| decides | `pilout` vs `build/extraction/` | `build/extraction/` vs `ZiskFv/AirsClean/**` |
+| both sides are | generated | one generated, one handwritten |
+| a failure means | the extractor dropped or distorted a constraint | a constraint has no mirror, or a mirror has no constraint |
+| its verdict is | `OK` at HEAD | `FAILED` at HEAD, and the failures are the finding |
+| the fix is | change the generator and rerun | proof work on a protected interface |
+
+It reuses `poly.py`, `check.to_poly`, `lean_parse.py`, `pilout_wire.py` and
+`pilout_atoms.py` from `tools/pilout-roundtrip` rather than forking them, so the
+two tools cannot disagree about what a column, an atom or a canonical form is.
+Per AIR it canonicalises the *comparable* generated constraints — the issue's
+rule: all of them minus every constraint reaching `Extraction.Circuit.challenge`
+or a stage-2 lane, 176 of the 355 — and the clauses of every inventoried mirror
+predicate, and pairs the two sets by canonical form rather than by index. The
+comparable rule is implemented twice, off the emitted Lean and off the pilout
+operands, and the two index sets must agree on every run.
+
+Five finding classes: `MATCHED`; `GAP`, a comparable constraint no mirror clause
+has the canonical form of; `STRENGTHENING`, a mirror clause no constraint has the
+form of — a *syntactic* class, so the report also runs a cofactor search and says
+when the clause is in fact implied by a constraint and therefore weaker rather
+than stronger; `RECLASSIFICATION`, a pairing that turns on a lane's kind;
+`UNBACKED`, an equation over a row field this AIR has no lane for, which has no
+canonical form to pair with and so is reported rather than compared.
+
+Besides the pairing, the run holds its own scope: `survey.CLASSIFICATION` against
+the declarations actually under the mirror root, every `NEAR_*`-classified
+declaration re-parsed and required to carry no comparable equation,
+`DECLARED_AIRS` through #303's own `_check_scope`, `lanes.gate_lane_map`, every
+resolved projection against the row record it claims to project, and a non-empty
+floor on both denominators. A scope that shrinks is the failure mode a
+declared-list scope has, and each of those is what makes one loud.
+
+Wiring: step 4/10 of `nix run .#test` (`check_mirrors.py` plus `acceptance.py`,
+the mutation suite that is the evidence the gate can fail and classify). Exit 1
+is a finding, exit 2 a missing artifact; neither is a pass. Deliberately NOT in
+`nix run .#populate`: populate materialises generated inputs, and this gate's
+failing side is handwritten source that populate neither writes nor reads, so a
+gap here is not extraction drift and re-running populate cannot change it.
+Deliberately not in `trust/scripts/check-all.sh` either, for #303's reason — that
+CI job has no `build/`.
+
+**This step fails at HEAD**, and that is the deliverable rather than a wiring
+bug: 35 comparable generated constraints have no mirror clause of their AIR.
+Those are findings for the owner. Mirrors and `Valid_<AIR>` validators are
+protected proof interfaces, so closing one is proof work — not something the tool
+may do, and not something to silence with a baseline here.
+
+`tools/mirror-roundtrip/README.md` carries the full argument, the declared
+exclusions with their citations, and the measured blind spots.
 
 ## Negative row rotations (Phase 2.5 D2)
 

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -131,7 +131,7 @@ writeShellApplication {
     }
 
     # 1. Tool unit tests.
-    run "1/9 cargo test" bash -c '
+    run "1/10 cargo test" bash -c '
       cargo test --manifest-path tools/pil-extract/Cargo.toml --quiet
     '
 
@@ -139,7 +139,7 @@ writeShellApplication {
     # `aeneas_extract` wrapper against `Riscv2ZiskContext::convert` for the
     # covered single-row opcode surface, preventing extraction shims from
     # drifting into a parallel Rust lowering path.
-    run "2/9 zisk-core aeneas_extract tests" bash -c '
+    run "2/10 zisk-core aeneas_extract tests" bash -c '
       cd zisk/core
       cargo test --lib --features aeneas_extract extraction_starts_match_production_convert_for_single_row_opcodes --quiet
     '
@@ -153,21 +153,44 @@ writeShellApplication {
     # trust/scripts/check-all.sh, whose CI job has no build/ at all.
     # `set -e` because `bash -c` otherwise reports only the last command's
     # status, which would let a failing check.py pass behind a green selftest.
-    run "3/9 pilout round trip" bash -c '
+    run "3/10 pilout round trip" bash -c '
       set -e
       python3 tools/pilout-roundtrip/check.py --quiet
       python3 tools/pilout-roundtrip/selftest.py > /dev/null
     '
 
-    # 4. Pinned Aeneas extraction harness. This stays outside the main Lean
+    # 4. Mirror round trip (eth-act/zisk-fv#304), the other direction of step 3.
+    # Step 3 decides that the extractor moved every pilout constraint into
+    # build/extraction/ unaltered; nothing in that argument touches ZiskFv/. This
+    # pairs each comparable generated constraint against the handwritten mirror
+    # clauses under ZiskFv/AirsClean/** that restate it, and reports the
+    # constraints no mirror models, the mirror clauses no constraint backs, and
+    # the pairings that turn on a lane's kind. acceptance.py is the evidence the
+    # gate can fail and classify: one mutation of a COPY of the mirrors per
+    # defect class, each required to move the report in exactly the predicted
+    # way. Python stdlib only, ~40 s together; reads ZiskFv/AirsClean/** source
+    # plus build/, and needs no Lean build.
+    #
+    # This step FAILS at HEAD, and that is the finding, not a wiring bug: 35
+    # comparable generated constraints have no mirror. Neither the failing
+    # findings nor a baseline of them may be silenced here -- mirrors are
+    # protected proof interfaces and closing a gap is proof work. `set -e` for
+    # the same reason as step 3.
+    run "4/10 mirror round trip" bash -c '
+      set -e
+      python3 tools/mirror-roundtrip/check_mirrors.py --quiet
+      python3 tools/mirror-roundtrip/acceptance.py > /dev/null
+    '
+
+    # 5. Pinned Aeneas extraction harness. This stays outside the main Lean
     # build and checks the production-backed extraction boundary. The canonical
     # ProductionM2 extraction is tracked under trust/aeneas/ and diff-checked by
     # CI; temporary generated harness files remain under build/.
-    run_unless_skipped ZISK_FV_TEST_SKIP_AENEAS "4/9 Aeneas production extraction harness" bash -c '
+    run_unless_skipped ZISK_FV_TEST_SKIP_AENEAS "5/10 Aeneas production extraction harness" bash -c '
       AENEAS_FLAKE="${aeneas}" AENEAS_CHECK_RV_COMPLETENESS=1 scripts/aeneas-production-extract.sh
     '
 
-    # 5. Lake build — the FV check. Every theorem typechecks. This is
+    # 6. Lake build — the FV check. Every theorem typechecks. This is
     # the load-bearing claim: if `lake build` is green, every per-opcode
     # equivalence theorem (Sail spec = ZisK circuit + bus model) holds.
     #
@@ -181,28 +204,28 @@ writeShellApplication {
     # when sd.lean's elaboration peaked at 42 GiB, before PR #4's
     # layered dsimp+rw refactor cut it to ~8 GiB PSS. Override with
     # LEAN_NUM_THREADS=N at call site for a different cap.
-    run "5/9 lake build" env LEAN_NUM_THREADS="''${LEAN_NUM_THREADS:-4}" lake build
+    run "6/10 lake build" env LEAN_NUM_THREADS="''${LEAN_NUM_THREADS:-4}" lake build
 
-    # 6. The generated extraction files are intentionally outside the main
+    # 7. The generated extraction files are intentionally outside the main
     # Lake library, but the Mem constraint source and generated-artifact
     # wrapper must stay synchronized with the current FV APIs. This runs after
     # `lake build` so clean CI runners have the imported `ZiskFv` oleans.
-    run "6/9 Mem generated artifact wrapper" mem_generated_artifact_wrapper
+    run "7/10 Mem generated artifact wrapper" mem_generated_artifact_wrapper
 
-    # 7. Trust gate (locality + baseline + forbidden tier1 params +
+    # 8. Trust gate (locality + baseline + forbidden tier1 params +
     # floors + zero-sorry + uniformity lint). See trust/README.md.
-    run "7/9 trust gate (V1 syntactic)" trust/scripts/check-all.sh
+    run "8/10 trust gate (V1 syntactic)" trust/scripts/check-all.sh
 
-    # 8. V2 trust-gate semantic checks. Walks the elaborated
+    # 9. V2 trust-gate semantic checks. Walks the elaborated
     # environment via `lake exe trust-gate`: per-theorem axiom-closure
     # baseline + binder-type forbidden-Names walk. Requires the lake
     # build above to have populated oleans.
-    run "8/9 trust gate (V2 semantic)" trust/scripts/check-all-semantic.sh
+    run "9/10 trust gate (V2 semantic)" trust/scripts/check-all-semantic.sh
 
-    # 9. Reproducibility check. The flake.lock pins every input
+    # 10. Reproducibility check. The flake.lock pins every input
     # (sail/sail-riscv/zisk/pil2-* sources, nixpkgs revision) by content
     # hash; `nix flake check` verifies the lock matches the flake.
-    run "9/9 flake repro" nix flake check --no-build
+    run "10/10 flake repro" nix flake check --no-build
 
     if [ $overall -eq 0 ]; then
       echo "================================"

--- a/tools/mirror-roundtrip/.gitignore
+++ b/tools/mirror-roundtrip/.gitignore
@@ -1,0 +1,3 @@
+# Bytecode caches from running the checker as a script.
+__pycache__/
+.ruff_cache/

--- a/tools/mirror-roundtrip/README.md
+++ b/tools/mirror-roundtrip/README.md
@@ -1,0 +1,501 @@
+# mirror-roundtrip: does a handwritten mirror back every generated constraint?
+
+Issue: eth-act/zisk-fv#304, blocked by #303. Python 3 standard library only; no
+Lean build, no network, and nothing under `ZiskFv/` is ever written.
+
+```bash
+python3 tools/mirror-roundtrip/check_mirrors.py          # the gate
+python3 tools/mirror-roundtrip/acceptance.py             # the test that the gate works
+python3 tools/mirror-roundtrip/survey.py                 # the mirror inventory
+python3 tools/mirror-roundtrip/mirror_parse.py           # the mirror parser
+python3 tools/mirror-roundtrip/lanes.py                  # pilout lanes <-> accessors
+```
+
+The first two are step 4/10 of `nix run .#test`. The gate FAILS at HEAD; see
+"Gate" below for why that is the deliverable rather than a wiring bug.
+
+## What this is
+
+`tools/pilout-roundtrip` (#303) decided one direction: every polynomial identity
+in `build/zisk.pilout` reaches `build/extraction/Extraction/<AIR>.lean` unaltered.
+Nothing in that argument touches `ZiskFv/`. The emitted per-AIR files are imported
+by no Lean under `ZiskFv/` at all, so a constraint can round-trip perfectly and
+still be restated wrongly, partially, or not at all in the handwritten Lean the
+proof actually consumes.
+
+This package closes the other direction for the polynomial content. Per AIR it
+canonicalises two sets into the same `poly.Poly` normal form #303 decides equality
+in, and pairs them set-to-set:
+
+| side | what it is |
+| ---- | ---------- |
+| GENERATED | the *comparable* constraints of `build/extraction/Extraction/<AIR>.lean` |
+| MIRROR | every clause of every inventoried mirror predicate under `ZiskFv/AirsClean/**` |
+
+*Comparable* is the issue's own rule: the AIR's constraints minus every one whose
+expression reaches `Extraction.Circuit.challenge` or a stage-2 lane
+`main c (id := 2)`. 176 of the 355 emitted constraints are comparable. The
+extractor's own single-field/two-field binder distinction is deliberately **not**
+used instead: it would drop nine more Main constraints -- `{0, 3, 4, 9, 10, 19,
+20, 21, 38}`, the ones reaching an `AirValue`/`AirGroupValue` but no challenge and
+no stage-2 lane -- and Main #3 and #9 are the flagship gap below. The rule is
+implemented twice, off the emitted Lean here and off the pilout operands in
+`survey.air_facts`, and the two index sets must agree on every run.
+
+### Files
+
+| file | what it owns |
+| ---- | ------------ |
+| `survey.py` | the declared mirror inventory (`CLASSIFICATION`), per-AIR comparable sets, reference counts |
+| `inventory.md` | the written inventory and findings F1-F10, regenerable from `survey.py` |
+| `lanes.py` | one AIR's lanes: `(stage, column)`, fixed, exposed, challenge, by lane and by name |
+| `mirror_parse.py` | mirror Lean source -> the shared expression AST, with declared field-to-lane resolution |
+| `check_mirrors.py` | the driver and gate: canonicalise, pair, classify, report |
+| `acceptance.py` | the test that the gate works: reproductions, mutations of a COPY, controls |
+| `README.md` | this file |
+
+`poly.py`, `check.py`, `lean_parse.py`, `lean_wiring.py`, `pilout_wire.py` and
+`pilout_atoms.py` are imported from `tools/pilout-roundtrip`, never forked, so the
+two tools cannot disagree about what a column, an atom or a canonical form is --
+and #303's `check._check_scope` and `poly._run_self_test` are called rather than
+reimplemented.
+
+## Why this is not what a weld already checks
+
+A weld -- `Valid_<AIR>` against the generated definitions, `link_*`, `template_*`,
+a `sourceBinding` discharged by `rfl` -- relates a mirror to the generated
+constraint it was welded *to*. That catches a mirror that disagrees with its own
+counterpart, and it is blind in both directions this tool covers:
+
+* a generated constraint that **no mirror models at all** is welded to nothing,
+  so no weld can notice its absence;
+* a mirror clause that **no generated constraint backs** is, in an
+  implication-only weld (`mirror -> generated`, the usual soundness direction),
+  just an extra hypothesis. It makes the implication *easier* to prove, so the
+  weld passes and looks stronger, which is exactly backwards.
+
+The second is the `Valid_<AIR>` strengthening AGENTS.md requires a source citation
+and a constructibility argument for. This tool finds candidates for that review
+mechanically instead of by reading.
+
+## The finding classes
+
+| class | meaning |
+| ----- | ------- |
+| `MATCHED` | canonical forms agree |
+| `GAP` | a comparable generated constraint no mirror clause has the canonical form of |
+| `STRENGTHENING` | a mirror clause no generated constraint has the canonical form of |
+| `RECLASSIFICATION` | the pairing turns on a lane's KIND: a fixed column modelled as a witness, or a stage-2 lane as stage-1 |
+| `UNBACKED` | a mirror equation over a row field this AIR has no lane for: it has no canonical form, so nothing can pair with it |
+
+`STRENGTHENING` is a **syntactic** class, and the distinction matters. "No
+generated constraint carries this canonical form" is not the same statement as
+"the mirror asserts more than the AIR": a clause that is a polynomial *multiple*
+of a generated constraint follows from it, so it is strictly weaker. Printing
+AGENTS.md's source-citation-and-constructibility demand on one of those sends a
+reviewer to argue for something that needs no argument, and buries a real extra
+hypothesis in the same pile. So every strengthening is put through a cofactor
+search first: for each comparable generated constraint of the AIR and each
+cofactor `c`, `c*a`, `c*(1-a)` over an atom `a` of both sides, does multiplying
+out reproduce the clause -- optionally after reducing `x*x = x` on the pair's
+fixed lanes, in which case the condition is printed rather than assumed. A hit
+withdraws the AGENTS.md line and says the clause is implied. A miss leaves it
+standing, and says the search is one atom wide so a miss is not evidence that no
+cofactor exists.
+
+Both of the two strengthenings at HEAD are hits: `sourceCCopyBetween#0` is
+`(1 - Main.SEGMENT_L1)` times generated `#4`, and `#1` is the same times `#10`,
+conditional on that fixed column being boolean. The mirror says as much in its
+own docstring (`ZiskFv/AirsClean/Main/Circuit.lean:715-720`) -- Clean's transition
+interface has no public-input surface, so the intrinsic transition states the
+within-segment equation and gates it. What survives is the `GAP` half: nothing
+restates `#4` or `#10` themselves.
+
+`UNBACKED` used to be a declared exclusion named `mirror_field_has_no_lane`, and
+that was wrong. It bucketed the clause out of the comparison on the FIELD, before
+pairing, so *any* clause mentioning one of four fields left the comparison
+whatever else it asserted -- contributing nothing to the failure count and showing
+up only as a line in the declaration table. An equation with no lane is not "not
+comparable"; it is an assertion nothing in the AIR's vocabulary can back. It is
+now a finding that fails the run and prints the clause verbatim. The per-field
+citations that justified the bucket are printed on each finding, as the reason
+the field has no lane rather than as a reason to stop looking. Note what the
+class does and does not claim: no generated constraint of the AIR can carry the
+clause, and the tool does *not* decide whether it is a definition of a PIL
+`const expr` the pilout inlines (and therefore never carries as a constraint) or
+a genuine extra hypothesis.
+
+Pairing is set-to-set, never positional: a mirror clause pairs with whichever
+generated constraint carries its canonical form, at any index. Both sides are
+grouped by canonical form first, so a form carried by two generated constraints
+(`Arith` #29 and #30 are one polynomial) or restated by two mirrors (a `Spec` and
+its `Valid_<AIR>` twin) is one finding naming all of them rather than an arbitrary
+choice of pair. Every such many-to-one is flagged `[many]` and counted, because
+that is where a double count would hide.
+
+`RECLASSIFICATION` is reached two ways, and both are the same fact:
+
+* **kind erasure** -- re-canonicalise with every atom's kind erased and its slot
+  kept. If the erased forms agree and the kind-preserving ones do not, the mirror
+  is pointing at the wrong kind of lane. Reporting that as a gap plus an unrelated
+  strengthening would bury the cause, so it is one finding naming both sides and
+  the atoms that differ.
+* **lane-kind change on resolution** -- the kind-preserving forms agree, but only
+  because a row-record projection resolved onto a lane that is not a stage-1
+  witness column. `MemAlignRow.preL1` is fixed column `MemAlign.L1`;
+  `MainRowWithRom.core.segment_l1` is fixed column `Main.SEGMENT_L1`. The
+  polynomial matches on the assumption that the field *is* that lane, which is a
+  weld this tool does not check, so counting it as a plain match would be the
+  quiet version of inventory finding F7.
+
+  This is recorded whether or not a declared `mirror_parse.FIELD_ALIASES` entry
+  produced it. Gating it on the alias table was a hole: `__L1__` is an
+  *unqualified* fixed-column name in all ten AIRs, so a field leaf spelling it
+  resolves onto a fixed lane through no declared table at all -- and in MemAlign
+  `__L1__` is fixed column 1 where `MemAlign.L1` is fixed column 0, so the
+  undeclared route reaches a different column than the declared one and used to
+  say nothing about it. `std_alpha` and `std_gamma` are unqualified challenge
+  names on the same footing. A projection with no declared alias is reported with
+  that fact as its citation.
+
+  The `MemAlign.preL1` entry's citation deserves reading. Unlike the two `Main`
+  entries, which cite a real weld (`mainFixedLayout` slot 17 to fixed column 0,
+  installed at `Main/Circuit.lean:953`), **MemAlign declares no `fixedColumns`
+  anywhere** -- only `Main` and `Mem` do. The field is declared at
+  `MemAlign/Row.lean:51` with nothing pinning it to a column. What the
+  correspondence rests on is the name, and the fact that fixed column 0 is read
+  by exactly one comparable constraint of the AIR. That the clause then matches
+  that constraint is not evidence for the alias -- the alias is what produces the
+  match -- which is exactly why this is a `RECLASSIFICATION` and not a pairing.
+
+Separately from the pairing, the run holds its own **scope**, because a scope
+taken from a declared list fails by shrinking. Each of the following is a
+failure, and each is held against something outside this package:
+
+* `survey.CLASSIFICATION` against the declarations actually under the mirror
+  root, in both directions. The mirror set is a declared list rather than a shape
+  heuristic (letting a mirror classify itself out of the audit would be worse),
+  and a new mirror predicate is added by writing a `def`, not by editing a list,
+  so an unclassified one is invisible to a declared scope unless something checks;
+* every `NEAR_*`-classified declaration under the root, re-parsed with the mirror
+  parser and required to carry no comparable polynomial equation. Moving one
+  entry from `MIRROR_VALIDATOR` to `NEAR_SEMANTIC` is a reclassification, not a
+  deletion, so the classification gate above stays green while a whole
+  `Valid_<AIR>` validator leaves the comparison. This screen has a disclosed
+  limit: at HEAD it reads 13 of the 64 near-misses and the parser refuses the
+  other 51, and for those "no equation found" means the parser could not read the
+  declaration;
+* `lanes.DECLARED_AIRS` through #303's own `check._check_scope`, against
+  `nix/extracted-lean.nix`, `LookupWiring.lean`'s `airStatus` manifest and the
+  emitted files;
+* `lanes.gate_lane_map`: the lane map closed in both directions, the emitted
+  header agreeing with the symbol reconstruction, every constraint atom resolving;
+* every resolved projection against the row record the definition claims to
+  project -- the totality audit of the field-to-lane map, which is the direct
+  analogue of auditing `h998ExprToField`'s arms against `MemAlignRow`;
+* a non-empty floor: every declared AIR present, and a non-zero comparable set on
+  both sides. `BinaryExtension` legitimately has zero comparable constraints, so
+  the floor is on the run and not per AIR;
+* `poly.py`'s self-test plus a screen of `canonical()` against random evaluation
+  on the operator shapes this tool emits. Both sides fold through one
+  `check.to_poly`, so a defect in the fold cancels rather than showing up as a
+  mismatch, and the same cancellation exists inside #303;
+* `MirrorDef.notes`, `MirrorDef.path_aliases` and `Delegation.row_order_mismatch`,
+  three signals `mirror_parse` computes. Nothing read them before, so writing
+  `f curr prev` for a delegate that binds `(prev, curr)` -- which `mirror_parse`
+  itself calls "a real defect and invisible to everything else here" -- changed
+  nothing in the report.
+
+Separately, and named by the issue as one of the four things to report, every
+mirror predicate that is **unreachable**: defined under the mirror root and
+referenced by nothing else in `ZiskFv/`, `trust/` or `Tests/`. A clause of one can
+be canonically perfect and constrain nothing, because no proof consumes it, so a
+match backed *only* by an unreachable mirror is reported as the hollow match it
+is. Reachability is measured on the declaration's NAME, so it says nothing about
+the equations: `RomBoolSpec`'s fourteen are asserted by `mainWithRom`
+(`ZiskFv/AirsClean/Main/Constraints.lean:247-261`) and restated inline by
+`romBoolSpec_of_mainWithRomAndMemBus_constraints`
+(`ZiskFv/AirsClean/Main/Circuit.lean:397`). An unreferenced predicate is a mirror
+nothing consumes, not a dead constraint.
+
+The NAME measurement has a consequence for *coverage* the run now names: the
+head-line discount is per name over every Prop-valued declaration, so for a name
+borne by several declarations the count can only reach zero if all of them die at
+once. **16 of the 40 inventoried mirrors share a name** (`Spec` x8,
+`constraints_at` x6, `FullSpec` x2), and a dead `Spec` among live ones counts as
+coverage with no hollow-match flag. The 16 are listed on every run.
+
+## Declared exclusions
+
+Three, all category-level, each with the citation that earns it, all printed on
+every run with the count and every clause each one took -- not truncated, because
+truncating what an exclusion swallowed is how it stops being auditable. Not one
+names an individual constraint index or an individual mirror clause: an allowlist
+keyed by index is how a gate gets tuned into silence, so there is not one here. If
+this list starts to grow past what a person will read, that is a finding to
+report, not a place to append.
+
+| key | side | rule | citation |
+| --- | ---- | ---- | -------- |
+| `challenge_or_stage2` | generated | a constraint reaching `Extraction.Circuit.challenge` or a stage-2 lane | the issue's own comparable rule. Stage-2 lanes and challenges are the prover's random-linear-combination machinery, which no row-local mirror restates. Implemented twice (emitted Lean, pilout operands) and required to agree per AIR |
+| `mirror_carrier_not_a_row` | mirror | an equation clause over a carrier that is not a row of the AIR | `mirror_parse.NON_ROW_CARRIERS`: honest-row builder inputs and a ROM bus message (`ZiskFv/AirsClean/Main/Circuit.lean:326-339`), and a component-owned fixed-column schema (`ZiskFv/AirsClean/Mem/GeneratedTransition.lean:251`). Inputs to a row, not slots of one, so they have no lane by construction |
+| `mirror_clause_not_an_equation` | mirror | a `.val` bound, or a delegation to another named `Prop` whose own clauses are compared elsewhere | this tool's declared scope is polynomial identities; a bound is not one (`survey.CLASSES NEAR_RANGE`). A delegation carries no equation of its own, and inlining it would double-count the delegate's clauses -- but only if something compares them |
+
+There used to be a fourth, `mirror_field_has_no_lane`; it is the `UNBACKED`
+finding class now, for the reason given above.
+
+The delegation entry's citation is the one worth watching, because it used to be
+false for a third of what it carried. `mirror_parse` marked a delegate "declared"
+if `survey.CLASSIFICATION` named it at **any** class, while `parse_mirror_file`
+only ever parses the `MIRROR_*` classes -- so the 9 delegations reaching a
+`NEAR_*`-classified delegate (`ArithTableSpec` x2, `IndexedRangeSpec` x2,
+`ChunkRangeSpec`, `CarryRangeSpec`, `RangeFacts`, `memRangeSidecarBridge`,
+`BinaryAdd.Spec`) were excluded on the grounds that the delegate "is itself
+inventoried and compared here", which was true of the first word and false of the
+second. The entry now covers a delegation exactly when the delegate is
+
+* `MIRROR_*`-class, so parsed and paired here; or
+* a declared out-of-root mirror (`survey.DELEGATED`), named but not compared, and
+  printed as an unverified claim on the gaps it touches; or
+* `NEAR_*`-classified **and** shown equation-free by the near-miss screen.
+
+Anything else is an undeclared delegation and a finding -- there is one at HEAD,
+`ZiskFv.Airs.Mem.permutation_every_row`. Each near-miss delegation is printed as
+`screened` or `unscreened` according to what the screen could actually read; at
+HEAD 1 of the 9 is screened and 8 are not, so for those 8 the exclusion's citation
+is honestly labelled uncorroborated rather than quietly assumed.
+
+## Reading the report
+
+* the scope declarations -- what fixes the two denominators, and what each is
+  held against;
+* the exclusion table, with every clause each entry carried and the near-miss
+  screen's verdict on each delegation it covers;
+* the per-AIR table: comparable generated, mirror clauses, matched, gap,
+  strengthening, reclassification, unbacked, unparsed, undeclared-unresolved, and
+  a TOTAL;
+* the pairings, `generated <- mirror clauses`, with `[many]` and
+  `[RECLASSIFICATION]` flags, and the measured redundancy: how many canonical
+  forms have more than one backing clause, how many clauses sit in one, and how
+  many of those forms are backed twice inside a single definition;
+* the checks: the two comparable-rule implementations agreeing, the
+  classification gate, the near-miss screen, the `DECLARED_AIRS` scope check, the
+  lane-map gate, projection totality, the non-empty floor, the canonicaliser
+  self-test, the reclassifier self-check, and any unparsed /
+  undeclared-unresolved / undeclared-delegation / definition-note / path-alias /
+  row-order line;
+* a detail block per finding: the generated index and its provenance comment, the
+  mirror definition with `file:line`, the verbatim clause text, and the canonical
+  symmetric difference truncated to ten monomials. A `GAP` also names the nearest
+  unmatched mirror clause by shared monomials -- a lead for the reader, never a
+  pairing -- and says so when the two differ only by a nonzero field scalar, which
+  is a presentation difference rather than a different constraint. A
+  `STRENGTHENING` carries either the cofactor that shows it is implied by a
+  generated constraint, or the AGENTS.md demand. An `UNBACKED` carries the
+  per-field citation for why the field has no lane;
+* the unreachable mirrors, the 16 whose name is shared, and any hollow matches.
+
+`--json PATH` writes the same content structurally, including each finding's
+route, scalar factor, lane-kind changes, implication and laneless projections,
+plus the scope-failure buckets and the near-miss screen's verdicts.
+
+Exit codes: `0` only when every comparable constraint matched, every mirror clause
+matched, nothing is unparsed or undeclared-unresolved, no scope check failed, and
+the run covered every declared AIR; `1` on any undeclared finding *or* on an
+`--air`-filtered run, which has gated nothing about the AIRs it skipped and so may
+not report success; `2` on usage or IO error. Exit 2 is not a pass -- absent
+artifacts get a loud line, and a missing mirror root says it is checked-in source
+rather than pointing the reader at `build/`. `lanes.py` and `mirror_parse.py`
+follow the same rule: a filtered run of either exits 1, because printing
+`PARTIAL` on stdout while exiting 0 is how a CI step goes quietly green over most
+of its scope.
+
+## Gate
+
+Step 4/10 of `nix run .#test`, next to #303's step 3/10, running
+`check_mirrors.py --quiet` and then `acceptance.py`. **It fails at HEAD**, and
+that is the deliverable: 35 comparable generated constraints have no mirror
+clause. Those are findings for the owner, and mirrors are protected proof
+interfaces -- closing one is proof work, not something this tool or its gate may
+do, and not something to silence with a baseline.
+
+Deliberately not in `nix run .#populate`, where #303's check does live. Populate
+materialises generated inputs, and its tail gates a property of the artifact it
+has just written, so extraction drift fails at the moment it is produced. This
+check's failing side is handwritten Lean under `ZiskFv/AirsClean/**`, which
+populate neither writes nor reads: a gap it reports is not extraction drift, is
+unchanged by re-running populate, and would make a bootstrap step fail for a
+reason the bootstrap did not cause and cannot fix. The direction populate *could*
+justify -- a regenerated pilout moving the generated side -- is caught by the next
+`nix run .#test`, which is also when a mirror edit needs checking.
+
+Deliberately not in `trust/scripts/check-all.sh`, for #303's reason: that CI job
+runs on a bare checkout with no `build/`.
+
+## Scope
+
+Polynomial identities over lane atoms, and nothing else. Out of scope, each by a
+declared rule rather than by omission: challenge-mixed and stage-2 constraints,
+`.val` bounds, lookups, permutations, channel balance, the *values* of fixed
+columns, and mirrors declared outside `ZiskFv/AirsClean/**`.
+
+The tool REPORTS. It never edits a mirror, a `Valid_<AIR>` validator or a row
+record -- those are protected proof interfaces under AGENTS.md, and a gap it finds
+is a finding to cite, not something to fix by editing the mirror and not something
+to make disappear by widening an exclusion.
+
+## Residual blind spots
+
+* **A match is canonical equality, not a proof of anything.** It says the mirror
+  clause and the generated constraint are the same polynomial. It does not say the
+  mirror is *used*, that its row record is welded to the trace, or that the
+  component asserts it. Reachability and the hollow-match report cover one corner
+  of that; the rest is what welds are for.
+* **The mirror side is only as complete as `survey.CLASSIFICATION`.** The scope is
+  a declared list, not a shape heuristic, because letting the mirror set be
+  discovered would let a mirror classify itself out of the audit. Both ways that
+  list goes stale are now gated by the run itself: a declaration with no entry, or
+  an entry naming a declaration that is gone, and separately a declaration moved
+  from a `MIRROR_*` class to a `NEAR_*` one while still carrying equations. The
+  residual is the near-miss screen's own reach: it can only read 13 of the 64
+  near-misses, so a mirror reclassified into a shape the parser refuses would be
+  screened as "no equation found" when the truth is "not read". The 51 refused are
+  named on every run.
+* **Out-of-root mirrors are named, not compared.** Mem's 15 remaining comparable
+  constraints are claimed by `ZiskFv.Airs.Mem.segmentResidualEveryRow`
+  (`ZiskFv/Airs/Mem.lean:296`), outside the mirror root. They are reported as gaps
+  *with the claim printed*, because this tool parsed nothing of that file: the
+  claim neither closes the gap nor is checked by it. Whether the gate's scope is
+  `AirsClean` only or "every polynomial mirror the AirsClean components reach" is
+  an owner decision.
+* **Kind erasure erases the kind at a fixed index.** A kind confusion that also
+  moves the index reads as a gap plus a strengthening. Relatedly, kind erasure is
+  decided only on the LEFTOVERS: a generated constraint that already has a correct
+  twin is not a candidate, so a *second*, kind-confused clause pointing at it is
+  reported as a plain strengthening with no kind pairing. The lane-kind change is
+  still printed on that finding -- the resolution-time record is not conditional
+  on pairing -- but the two sides are not brought together.
+* **The cofactor search is one atom wide.** It tries `c`, `c*a` and `c*(1-a)` and
+  verifies by multiplying out, so a hit is exact and a miss is not evidence that
+  no cofactor exists. A weakening by a cofactor of two or more atoms would still
+  be reported under the AGENTS.md banner. The conditional form -- reducing
+  `x*x = x` on the pair's fixed lanes -- prints its condition rather than assuming
+  it, because a fixed column's *values* are out of scope here.
+* **Matching is exact.** Two clauses related by a nonzero field scalar are the
+  same assertion but different canonical forms, so they classify as a gap plus a
+  strengthening; the detail block says when that is what happened, and the
+  classification is left alone deliberately -- softening the decision is how a
+  matcher starts accepting things nobody chose. No pair at HEAD is related this
+  way.
+* **`.val` bounds and field equations never pair.** `x.val < 2` and
+  `x * (1 - x) = 0` are equivalent facts over `FGL` but not the same term, which
+  is why four MemAlignByte booleans read as gaps (F2). That is a real difference in
+  where the obligation sits -- an `Assumptions` clause is a caller-supplied premise
+  where the generated constraint is an assertion -- but it is not a polynomial
+  disagreement.
+* **The circuit side is not compared.** The `assertZero` sequences in
+  `*/Constraints.lean` hold the same content in `Expression FGL` and are what the
+  components actually assert; `Mem/Constraints.lean:112` covers all 24 comparable
+  Mem constraints. Comparing those instead of the `Prop`s would change the
+  denominator, and no assumption is made either way here.
+
+## Known blind spots
+
+Measured, not reasoned about. `acceptance.py` is the test that this tool works.
+It reruns the four things the 2026-07-28 hand fan-out found, in one unfiltered
+run with nothing told to it about where to look, and then mutates a COPY of the
+mirrors one edit at a time and requires the reported findings to move in exactly
+the predicted way -- exactly the predicted findings appearing and exactly the
+predicted ones disappearing, since "it noticed" and "it noticed the right thing"
+are different claims.
+
+```bash
+python3 tools/mirror-roundtrip/acceptance.py    # the test that the gate works
+```
+
+Against the tree it was written for it reports 4 of the 4 hand findings
+reproduced as findings, 8 of 8 mutations classified exactly as predicted, 3 of 3
+neutral rewrites unmoved -- and the entries below, which are what it could not get
+the gate to report. No expectation was relaxed and no case was dropped to make the
+run green.
+
+Three adversarial audits ran against the first version of this tool on
+2026-07-29, and most of what follows is what survived them. What did not survive
+is fixed, not documented: the classification gate, the near-miss screen, the
+`DECLARED_AIRS` scope check, the lane-map gate, projection totality, the
+non-empty floor, the `UNBACKED` class, the split of unresolved reasons by the
+reason `mirror_parse` records, the delegation exclusion's corrected citation, the
+lane-kind record no longer being gated on the alias table, the consumption of
+`notes` / `path_aliases` / `row_order_mismatch`, the cofactor search, filtered
+runs of `lanes.py` and `mirror_parse.py` exiting 1, and the untruncated exclusion
+listing. `acceptance.py` gained `UNCLASSIFIED_PREDICATE_ADDED`,
+`LANELESS_CLAUSE_ADDED` and `FIXED_LEAF_UNDECLARED`, one per fatal defect the
+audits measured, plus the ability to assert a scope-check delta at all.
+
+### A constraint restated by two mirrors keeps its match when one is deleted
+
+48 of the 140 paired canonical forms are backed by more than one mirror clause --
+one generated constraint restated by both a `Spec` and its `Valid_<AIR>` twin --
+and 96 of the 190 comparable mirror clauses sit in such a form, so each of those
+96 can be deleted one at a time with no change to any count. For 1 of the 48
+forms both clauses live in a single definition, so even the definition count does
+not move. The run prints all of these numbers.
+
+Deleting one of the two clauses reports nothing at all: pairing is set-to-set, and
+the survivor still supplies the canonical form. `acceptance.py` measures this with
+`REDUNDANT_CLAUSE_DELETED` (`ZiskFv/AirsClean/Binary/Spec.lean` `Spec#1`, which
+`Valid_Binary.constraints_at#1` also carries); its predicted delta is empty and
+it passes by showing the loss is invisible, which is a measurement rather than
+coverage. A mirror can lose clauses to an edit and leave the gate exactly as red
+as it was, because nothing counts coverage per mirror definition -- only per
+canonical form.
+
+### A shared declaration name hides an unreachable mirror
+
+`unreachable_mirrors` subtracts a per-NAME head-line discount from a per-NAME
+reference count, so a name borne by several declarations only reaches zero if all
+of them die at once. 16 of the 40 inventoried mirrors share a name, and a dead
+`Spec` among live `Spec`s is counted as coverage with no hollow-match flag. The
+upper-bound property of a positive count was already documented; this consequence
+for coverage was not. The 16 are now listed on every run, but the measurement is
+still by name -- resolving constants would need Lean.
+
+### The near-miss screen reads 13 of 64
+
+The screen re-parses every `NEAR_*`-classified declaration under the mirror root
+and fails if one carries a comparable polynomial equation, which is what makes a
+`MIRROR_* -> NEAR_*` reclassification loud. At HEAD it reads 13 and the parser
+refuses 51 -- they are bus predicates, `.val` bounds and ℕ statements the mirror
+grammar does not accept. For those 51 the screen's answer means "not read", not
+"carries nothing", and the run says so and names them. The same limit is what
+leaves 8 of the 9 near-miss delegations labelled `unscreened`.
+
+### What the mutation suite itself does not reach
+
+The mutation cases edit `MIRROR` and `MIRROR_2ROW` predicates in MemAlign, Main
+and Binary. `MIRROR_ENV` adapters and `MIRROR_VALIDATOR` twins are exercised only
+through the baseline run. No case mutates the generated side, the pilout,
+`survey.CLASSIFICATION`, or an exclusion table, so an exclusion quietly grown by
+one entry is not something this suite would fail on -- the declaration table
+being printed in full on every run is what stands in for that.
+
+`NOOP_REORDER` is a weak control and the case says so in place: `signature()`
+deliberately drops the clause index, and the two conjuncts it swaps are
+structurally isomorphic booleans, so the only thing it can move is an ordering
+the key already ignores. It cannot fail unless the parser breaks outright. The
+claim that the decider is canonical form rather than text is carried by
+`NOOP_EQ_AS_ZERO`, which rewrites `a = b` into `a - b = 0` on a resolvable,
+matched clause.
+
+`RECLASSIFICATION_MEMALIGN_16` is declared-then-re-read rather than rediscovered:
+it fires because a human wrote the `FIELD_ALIASES` entry, and the data
+contribution is only that the polynomial then matches. The other three
+reproductions are derived from set-to-set canonical pairing with no per-index list
+anywhere in `check_mirrors.py`, and `FIXED_AS_WITNESS` does exercise the
+data-driven kind-erasure route.
+
+A staged copy must carry every root reachability is measured over (`ZiskFv`,
+`trust`, `Tests`), because `--airs-clean` redirects `survey.REPO_ROOT` and a
+partial copy would make a use in an unstaged directory look like no use at all --
+over-reporting unreachable mirrors. `check_mirrors.py` refuses such a copy with
+exit 2 rather than reporting from it.

--- a/tools/mirror-roundtrip/acceptance.py
+++ b/tools/mirror-roundtrip/acceptance.py
@@ -1,0 +1,1196 @@
+#!/usr/bin/env python3
+"""Acceptance test for `check_mirrors.py`: does the gate actually work?
+
+Issue: eth-act/zisk-fv#304. Python 3 standard library only.
+
+The 2026-07-28 hand fan-out found four things, one AIR at a time, none of them
+by a gate. #304 exists to make that mechanical, so the acceptance criterion is
+that `check_mirrors.py` rediscovers all four in one unfiltered run with nothing
+told to it about where to look. That is PART A.
+
+Four known cases cannot show the tool would catch a fifth, so PART B is the
+mutation half, in the style of `tools/pilout-roundtrip/selftest.py`: copy the
+mirrors into a temporary directory, apply exactly ONE edit to the copy, run the
+gate against the REAL pilout and the REAL extraction, and require the reported
+findings to move in exactly the predicted way -- not merely to move, because "it
+noticed" and "it noticed the right thing" are different claims.
+
+Why the verdict is a DELTA and not an exit code
+
+    `check_mirrors.py` already exits 1 at HEAD: 35 gaps, 2 strengthenings, 2
+    reclassifications. So an exit code cannot distinguish a mutated tree from an
+    untouched one, and a case asserting "it failed" would pass for a mutation
+    the gate never saw. Every mutation case here is therefore decided on the
+    SIGNATURE DELTA -- the multiset of failing-class findings, each keyed by
+    (class, air, route, generated indices, mirror definitions), differenced
+    against the baseline run. Exactly the predicted findings must appear and
+    exactly the predicted ones must disappear; anything else is a failure of the
+    case, in either direction.
+
+    Two invariants are asserted on every case as well: the comparable GENERATED
+    count per AIR never moves (these mutations touch only mirrors, so a generated
+    count that moved would mean the harness edited the wrong thing), and the
+    neutral controls must reproduce the baseline totals exactly.
+
+What each mutation emulates
+
+    CLAUSE_DELETED      a mirror clause that used to restate a constraint and no
+                        longer does                              -> GAP
+    CLAUSE_ADDED        a plausible-looking mirror conjunct the AIR does not
+                        carry                                    -> STRENGTHENING
+    PROJECTION_SWAPPED  a mirror reading the wrong row field: the polynomial is
+                        still well-formed and still looks like the constraint
+                                                    -> GAP + STRENGTHENING
+    ROW_DELTA_SHIFTED   the right fields at the wrong row offset, the defect the
+                        `h998ExprToField`-style maps are exposed to
+                                                    -> GAP + STRENGTHENING
+    FIXED_AS_WITNESS    a fixed column read as the witness column of the same
+                        index -- the `| _ => 0` fallback's failure mode
+                                                    -> RECLASSIFICATION, and
+                        specifically the kind-erasure route, NOT a gap plus an
+                        unrelated strengthening
+
+Measured limits
+
+    REDUNDANT_CLAUSE_DELETED  the same edit as CLAUSE_DELETED, but on a clause
+                        one of the 48 `[many]` pairings backs twice. Predicted
+                        delta: NOTHING. That case passing measures a limit of
+                        set-to-set pairing; it is not reassurance, it is printed
+                        under its own heading, and it is in README.md's known
+                        blind spots.
+
+Controls
+
+    NO_MUTATION         an untouched copy must reproduce the baseline findings
+                        exactly: no more, no fewer
+    NOOP_REORDER        the conjuncts of one mirror in a different order
+    NOOP_EQ_AS_ZERO     one clause written `a = b` rewritten as `a - b = 0`
+
+    Both neutral rewrites must stay MATCHED, because the decider is canonical
+    polynomial form and not text. A control that moves the verdict is a worse
+    finding than an uncaught mutation: it means the canonicaliser is wrong.
+
+Honesty
+
+    Any PART A case the tool does not reproduce, and any mutation it does not
+    catch, is a finding about the TOOL. It is printed under its own heading with
+    the reason it slips through, and it belongs in the "Known blind spots"
+    section of README.md. It does not get deleted and its expectation does not
+    get relaxed to match what the tool happens to do.
+
+    Nothing under `ZiskFv/` is written. Every mutation case works inside its own
+    directory under `tempfile.mkdtemp()`, and the digest of the real `ZiskFv/`
+    and `trust/` trees is taken before and after the run and compared.
+
+Exit codes
+
+    0  every acceptance case and every mutation case behaved as expected
+    1  one did not: an unreproduced hand finding, an uncaught mutation, a wrong
+       classification, or a neutral rewrite that moved the verdict
+    2  the harness itself is broken: a mutation anchor no longer occurs in the
+       mirrors, or the artifacts are absent. A stale anchor is not a finding
+       about the gate, so it must not read as one.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+CHECK_MIRRORS = HERE / "check_mirrors.py"
+
+DEFAULT_PILOUT = REPO_ROOT / "build" / "zisk.pilout"
+DEFAULT_EXTRACTION = REPO_ROOT / "build" / "extraction" / "Extraction"
+REAL_MIRROR = REPO_ROOT / "ZiskFv" / "AirsClean"
+
+# What a mutation case needs staged. `mirror_parse` and `survey` derive every
+# path from one `REPO_ROOT`, so a copy has to carry the whole of `ZiskFv/` (the
+# mirrors, plus the delegate targets outside `AirsClean/`) and `trust/`, which
+# `survey.reference_counts` scans for the reachability count.
+STAGED_ROOTS = ("ZiskFv", "trust")
+
+MATCHED = "MATCHED"
+GAP = "GAP"
+STRENGTHENING = "STRENGTHENING"
+RECLASSIFICATION = "RECLASSIFICATION"
+UNBACKED = "UNBACKED"
+
+EXIT_OK = 0
+EXIT_FAILED = 1
+EXIT_BROKEN = 2
+
+EVIDENCE_LINES = 8
+EVIDENCE_WIDTH = 116
+
+
+class HarnessError(Exception):
+    """The harness could not do its job, so it has no verdict to give.
+
+    Every anchor below is real text from the checked-in mirrors. If a mirror is
+    edited, an anchor stops matching, and that must stop this file rather than
+    silently skipping a defect class.
+    """
+
+
+# ------------------------------------------------------------------ running the gate
+
+
+@dataclass
+class ToolRun:
+    """One invocation of `check_mirrors.py`, kept whole."""
+
+    exit_code: int
+    text: str
+    payload: dict
+    stderr: str
+    seconds: float
+
+
+def run_tool(mirror_root: Path, json_path: Path) -> ToolRun:
+    """Run the gate against the REAL pilout and extraction, and a given mirror root.
+
+    The pilout and the extraction are the fixed side of the experiment: the
+    mirrors are what is under test, so nothing else may move.
+    """
+    started = time.time()
+    proc = subprocess.run(
+        [sys.executable, str(CHECK_MIRRORS),
+         "--pilout", str(DEFAULT_PILOUT),
+         "--extraction", str(DEFAULT_EXTRACTION),
+         "--airs-clean", str(mirror_root),
+         "--json", str(json_path)],
+        capture_output=True, text=True, check=False)
+    if not json_path.exists():
+        raise HarnessError(
+            f"check_mirrors.py wrote no JSON for {mirror_root}: exit "
+            f"{proc.returncode}, stderr {proc.stderr.strip()[:200]!r}")
+    return ToolRun(
+        exit_code=proc.returncode,
+        text=proc.stdout,
+        payload=json.loads(json_path.read_text()),
+        stderr=proc.stderr.strip(),
+        seconds=time.time() - started,
+    )
+
+
+# --------------------------------------------------------------- reading the report
+
+
+def blocks(text: str) -> list[str]:
+    """The report's blank-line-separated blocks, which is one finding each."""
+    return [chunk for chunk in text.split("\n\n") if chunk.strip()]
+
+
+def block_with(text: str, *needles: str) -> str:
+    """The first report block containing every needle, verbatim."""
+    for chunk in blocks(text):
+        if all(needle in chunk for needle in needles):
+            return chunk
+    return ""
+
+
+def lines_with(text: str, *needles: str) -> list[str]:
+    return [line for line in text.split("\n")
+            if all(needle in line for needle in needles)]
+
+
+def trim(chunk: str, limit: int = EVIDENCE_LINES) -> list[str]:
+    lines = [line[:EVIDENCE_WIDTH] for line in chunk.split("\n") if line.strip()]
+    if len(lines) <= limit:
+        return lines
+    return lines[:limit] + [f"    ... {len(lines) - limit} more line(s)"]
+
+
+def declared_exclusion_for(text: str, needle: str) -> list[str]:
+    """The declaration-table entry that swallowed a clause, with its citation.
+
+    A case can fail two ways: the tool missed the thing, or it found it and
+    filed it somewhere that is not a finding. The second is the more interesting
+    defect and the easier one to mistake for the first, so when a hand finding
+    does not arrive as a finding, the report quotes the exclusion that took it
+    instead of only saying it is absent.
+    """
+    lines = text.split("\n")
+    for i, line in enumerate(lines):
+        if "took" not in line or needle not in line:
+            continue
+        head = i
+        while head > 0 and not lines[head].lstrip().startswith("["):
+            head -= 1
+        return [entry for entry in lines[head:head + 3] + [line] if entry.strip()]
+    return []
+
+
+def cited_source(lines: list[str]) -> list[str]:
+    """The checked-in source line a `<path>.lean:<n>` citation points at.
+
+    Which conjunct a report names is only as good as what that conjunct says, so
+    the citation is followed rather than paraphrased.
+    """
+    for line in lines:
+        for token in line.replace("(", " ").replace(")", " ").split():
+            rel, _, number = token.rpartition(":")
+            if not rel.endswith(".lean") or not number.isdigit():
+                continue
+            path = REPO_ROOT / rel
+            if not path.is_file():
+                continue
+            source = path.read_text().split("\n")
+            index = int(number)
+            if 1 <= index <= len(source):
+                return [f"{rel}:{index}  {source[index - 1].strip()}"]
+    return []
+
+
+Signature = tuple
+
+
+def signature(finding: dict) -> Signature:
+    """One failing finding, keyed by what it names rather than by where it sits.
+
+    Mirror CLAUSE indices are deliberately not in the key: reordering the
+    conjuncts of a mirror renumbers them without changing a single polynomial,
+    and a control that reads as a change would be measuring the wrong thing.
+    Definition names and generated indices are what a finding actually names.
+    """
+    return (
+        finding["kind"], finding["air"], finding["route"],
+        tuple(sorted(g["index"] for g in finding["generated"])),
+        tuple(sorted({m["definition"] for m in finding["mirror"]})),
+    )
+
+
+def signatures(payload: dict) -> Counter:
+    return Counter(
+        signature(finding)
+        for air in payload["airs"] for finding in air["findings"]
+        if finding["kind"] != MATCHED
+    )
+
+
+def scope_signatures(payload: dict) -> Counter:
+    """One count per scope-failure bucket.
+
+    The findings a signature delta covers are the pairing outcomes. The checks
+    that hold the RUN'S OWN SCOPE -- the classification gate, the near-miss
+    screen, `DECLARED_AIRS`, the lane map, projection totality, the non-empty
+    floor -- produce no finding, so a mutation that defeats one of them moved
+    nothing this suite compared. They are compared here, by bucket.
+    """
+    return Counter(
+        bucket
+        for bucket, messages in payload.get("scope_failures", {}).items()
+        for _ in messages)
+
+
+def totals(payload: dict) -> dict:
+    """Per-AIR counts, for the invariants a signature delta does not cover."""
+    return {
+        air["air"]: (
+            air["generated_comparable"], air["mirror_comparable"],
+            sum(len(f["generated"]) for f in air["findings"] if f["kind"] == MATCHED),
+        )
+        for air in payload["airs"]
+    }
+
+
+def fmt_signature(sig: Signature) -> str:
+    kind, air, route, indices, defs = sig
+    parts = [f"{kind} {air}"]
+    if indices:
+        parts.append(" ".join(f"#{i}" for i in indices))
+    if defs:
+        parts.append(" ".join(defs))
+    if route:
+        parts.append(f"[{route}]")
+    return "  ".join(parts)
+
+
+def fmt_delta(delta: Counter) -> str:
+    if not delta:
+        return "(nothing)"
+    return "; ".join(
+        f"{count}x {fmt_signature(sig)}" if count > 1 else fmt_signature(sig)
+        for sig, count in sorted(delta.items(), key=lambda kv: fmt_signature(kv[0]))
+    )
+
+
+def fmt_signed(added: Counter, removed: Counter) -> str:
+    """A delta with its direction on the front, because both directions matter."""
+    parts = ([f"+{fmt_signature(sig)}" for sig in sorted(added.elements(),
+                                                         key=fmt_signature)]
+             + [f"-{fmt_signature(sig)}" for sig in sorted(removed.elements(),
+                                                           key=fmt_signature)])
+    return "; ".join(parts) if parts else "(nothing)"
+
+
+def gap(air: str, *indices: int) -> Signature:
+    return (GAP, air, "", tuple(sorted(indices)), ())
+
+
+def strengthening(air: str, *definitions: str) -> Signature:
+    return (STRENGTHENING, air, "", (), tuple(sorted(definitions)))
+
+
+def unbacked(air: str, *definitions: str) -> Signature:
+    return (UNBACKED, air, "", (), tuple(sorted(definitions)))
+
+
+def reclassification(air: str, route: str, index: int, *definitions: str) -> Signature:
+    return (RECLASSIFICATION, air, route, (index,), tuple(sorted(definitions)))
+
+
+# ------------------------------------------------- PART A: the four hand findings
+
+
+@dataclass(frozen=True)
+class Reproduction:
+    """One thing the 2026-07-28 hand fan-out found, and the class it must arrive as."""
+
+    name: str
+    expect_class: str
+    names: str
+    hand_finding: str
+    locate: Callable[[dict], list[dict]]
+    evidence: Callable[[str], list[str]]
+    # How many findings of the class must name it. Asserting only that at least
+    # one exists lets a case pass while the tool also emits findings nobody
+    # predicted onto the same target -- "it noticed" is not "it noticed exactly
+    # this".
+    expect_count: int = 1
+    # What to grep the declaration table for when the case fails, so the report
+    # can say whether the tool missed the thing or filed it as an exclusion.
+    needle: str = ""
+
+
+def findings_of(payload: dict, kind: str, air: str | None = None) -> list[dict]:
+    return [
+        finding
+        for entry in payload["airs"] for finding in entry["findings"]
+        if finding["kind"] == kind and (air is None or finding["air"] == air)
+    ]
+
+
+def gap_on(payload: dict, air: str, index: int) -> list[dict]:
+    return [f for f in findings_of(payload, GAP, air)
+            if any(g["index"] == index for g in f["generated"])]
+
+
+def strengthening_naming(payload: dict, definition: str) -> list[dict]:
+    return [f for f in findings_of(payload, STRENGTHENING)
+            if any(m["definition"] == definition for m in f["mirror"])]
+
+
+def unbacked_naming(payload: dict, definition: str) -> list[dict]:
+    return [f for f in findings_of(payload, UNBACKED)
+            if any(m["definition"] == definition for m in f["mirror"])]
+
+
+def reclassification_on(payload: dict, air: str, index: int) -> list[dict]:
+    return [f for f in findings_of(payload, RECLASSIFICATION, air)
+            if any(g["index"] == index for g in f["generated"])]
+
+
+def unreachable_named(payload: dict, name: str) -> list[dict]:
+    return [entry for entry in payload["unreachable"] if entry["name"] == name]
+
+
+REPRODUCTIONS: tuple[Reproduction, ...] = (
+    Reproduction(
+        name="GAP_MAIN_A_SIDE_C_COPY",
+        expect_class=GAP,
+        names="Main #3 and Main #9",
+        hand_finding="the a-side C-copy at main.pil:385 has no mirror counterpart "
+                     "anywhere; sourceCCopyBetween (ZiskFv/AirsClean/Main/"
+                     "Circuit.lean:721) models only the b-side",
+        locate=lambda p: gap_on(p, "Main", 3) + gap_on(p, "Main", 9),
+        expect_count=2,
+        evidence=lambda t: (trim(block_with(t, "GAP  Main #3"), 7)
+                            + [""] + trim(block_with(t, "GAP  Main #9"), 5)),
+    ),
+    Reproduction(
+        # The hand finding's word was "strengthening". The class it arrives as is
+        # UNBACKED, and that is the more careful of the two claims: the conjunct
+        # projects `delta_pc`, which this AIR has no lane for, so the tool can say
+        # no generated constraint carries it and CANNOT say the mirror asserts
+        # more -- the comparison has no canonical form to compare. The expectation
+        # names the class the tool actually owes, not a stronger one it would have
+        # to invent. It was previously not reported as any finding at all.
+        name="UNBACKED_MEMALIGN_CYCLIC",
+        expect_class=UNBACKED,
+        names="cyclicSuccessorTransitionRows",
+        hand_finding="cyclicSuccessorTransitionRows (ZiskFv/AirsClean/MemAlign/"
+                     "Circuit.lean:255) carries a conjunct with no F-only "
+                     "generated counterpart: a mirror asserting more than the AIR",
+        locate=lambda p: unbacked_naming(p, "cyclicSuccessorTransitionRows"),
+        # The issue does not say which conjunct, so nothing here assumes one.
+        # Whatever the tool names -- as a finding or as an exclusion -- is
+        # quoted, and the citation on it is followed back to the source line.
+        evidence=lambda t: (
+            [line for line in lines_with(t, "cyclicSuccessorTransitionRows")
+             if "<-" not in line]
+            + declared_exclusion_for(t, "cyclicSuccessorTransitionRows")
+            + cited_source(lines_with(t, "cyclicSuccessorTransitionRows"))),
+        needle="cyclicSuccessorTransitionRows",
+    ),
+    Reproduction(
+        name="RECLASSIFICATION_MEMALIGN_16",
+        expect_class=RECLASSIFICATION,
+        names="MemAlign #16",
+        hand_finding="MemAlign constraint_16 (mem_align.pil:121, MemAlign.L1*pc) "
+                     "involves a column the AIR declares FIXED and the mirror "
+                     "treats as a witness",
+        locate=lambda p: reclassification_on(p, "MemAlign", 16),
+        evidence=lambda t: trim(block_with(t, "RECLASSIFICATION  MemAlign #16")),
+    ),
+    Reproduction(
+        name="UNREACHABLE_ROMBOOLSPEC",
+        expect_class="UNREACHABLE",
+        names="RomBoolSpec",
+        hand_finding="RomBoolSpec (ZiskFv/AirsClean/Main/Circuit.lean:346), a "
+                     "published 14-conjunct mirror predicate with no consumers "
+                     "anywhere",
+        locate=lambda p: unreachable_named(p, "RomBoolSpec"),
+        evidence=lambda t: trim(block_with(t, "unreachable mirrors"), 8),
+    ),
+)
+
+
+@dataclass
+class ReproResult:
+    case: Reproduction
+    found: list = field(default_factory=list)
+    actual: str = ""
+    evidence: list[str] = field(default_factory=list)
+    where_instead: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return len(self.found) == self.case.expect_count
+
+
+def locate_elsewhere(case: Reproduction, run: ToolRun) -> list[str]:
+    """Where the tool DID put a case it failed to report as the expected class.
+
+    Empty means the tool never mentions it at all, which is the worse of the two
+    ways a case can fail and reads differently in the report.
+    """
+    if not case.needle:
+        return []
+    took = [line.strip() for line in run.text.split("\n")
+            if case.needle in line and "took" in line]
+    return took + cited_source(took)
+
+
+def evaluate_reproductions(run: ToolRun) -> list[ReproResult]:
+    results = []
+    for case in REPRODUCTIONS:
+        result = ReproResult(case=case)
+        result.found = case.locate(run.payload)
+        if result.found:
+            result.actual = f"{case.expect_class} x{len(result.found)}"
+            if len(result.found) != case.expect_count:
+                result.actual += (f" -- expected exactly {case.expect_count}, so "
+                                  f"the tool named this target more or fewer "
+                                  f"times than predicted")
+        else:
+            result.actual = "(no finding of this class names it)"
+            result.where_instead = locate_elsewhere(case, run)
+        result.evidence = [line for line in case.evidence(run.text) if line is not None]
+        results.append(result)
+    return results
+
+
+# ------------------------------------------------------------ mutation primitives
+#
+# Every anchor is a whole stripped source line of a checked-in mirror, and every
+# one must occur EXACTLY once in its file. An anchor that stops being unique is
+# a broken harness, not a finding: two identical conjuncts would make "the
+# clause this case deletes" ambiguous.
+
+Applied = tuple[list[str], str, str]
+Mutator = Callable[[list[str]], Applied]
+
+
+def locate_line(lines: list[str], anchor: str) -> int:
+    hits = [i for i, line in enumerate(lines) if line.strip() == anchor]
+    if len(hits) != 1:
+        raise HarnessError(
+            f"anchor occurs {len(hits)} time(s), need exactly 1: {anchor!r}")
+    return hits[0]
+
+
+def indent_of(line: str) -> str:
+    return line[:len(line) - len(line.lstrip())]
+
+
+def drop_line(anchor: str) -> Mutator:
+    def apply(lines: list[str]) -> Applied:
+        i = locate_line(lines, anchor)
+        return lines[:i] + lines[i + 1:], anchor, "(clause deleted)"
+    return apply
+
+
+def add_line_after(anchor: str, clause: str) -> Mutator:
+    def apply(lines: list[str]) -> Applied:
+        i = locate_line(lines, anchor)
+        new = indent_of(lines[i]) + clause
+        return lines[:i + 1] + [new] + lines[i + 1:], "(no such clause)", clause
+    return apply
+
+
+def rewrite_line(anchor: str, clause: str) -> Mutator:
+    def apply(lines: list[str]) -> Applied:
+        i = locate_line(lines, anchor)
+        lines[i] = indent_of(lines[i]) + clause
+        return lines, anchor, clause
+    return apply
+
+
+def replace_in_line(anchor: str, old: str, new: str, occurrence: int = 1) -> Mutator:
+    def apply(lines: list[str]) -> Applied:
+        i = locate_line(lines, anchor)
+        line = lines[i]
+        if line.count(old) < occurrence:
+            raise HarnessError(
+                f"{anchor!r} contains {line.count(old)} occurrence(s) of {old!r}, "
+                f"need occurrence {occurrence}")
+        pos = -1
+        for _ in range(occurrence):
+            pos = line.index(old, pos + 1)
+        lines[i] = line[:pos] + new + line[pos + len(old):]
+        return lines, anchor, lines[i].strip()
+    return apply
+
+
+def swap_lines(first: str, second: str) -> Mutator:
+    def apply(lines: list[str]) -> Applied:
+        i, j = locate_line(lines, first), locate_line(lines, second)
+        lines[i], lines[j] = lines[j], lines[i]
+        return lines, f"{first} / {second}", f"{second} / {first}"
+    return apply
+
+
+def append_declaration(head: str, body: list[str]) -> Mutator:
+    """Add a whole new top-level declaration at the end of a file.
+
+    This is the shape of the defect the classification gate exists for: a new
+    mirror predicate arrives as a `def`, and no list a reviewer watches changes.
+    """
+    def apply(lines: list[str]) -> Applied:
+        if any(line.strip().startswith(head.split("(")[0].strip())
+               for line in lines):
+            raise HarnessError(f"a declaration named in {head!r} already exists")
+        new = lines + [""] + [head] + body + [""]
+        return new, "(no such declaration)", head
+    return apply
+
+
+def no_mutation(lines: list[str]) -> Applied:
+    return lines, "(nothing)", "(nothing)"
+
+
+# ------------------------------------------------------------------- the mutations
+#
+# Targets are fixed, real mirror clauses, so a run is reproducible.
+#
+#   ZiskFv/AirsClean/MemAlign/Spec.lean       `Spec`, 16 conjuncts, all paired
+#     #0   row.wr * (1 - row.wr) = 0                     <- MemAlign #25
+#     #11  row.sel_7 * (1 - row.sel_7) = 0               <- MemAlign #24
+#     #12  row.preL1 * row.pc = 0                        <- MemAlign #16, by alias
+#   ZiskFv/AirsClean/MemAlign/Circuit.lean    `transitionRows`, a two-row mirror
+#     #1   (previous.reg_0 - current.reg_0) * ...        <- MemAlign #1
+#   ZiskFv/AirsClean/Main/Spec.lean           `AddressSpec`
+#     #1   row.rom.addr1 = ...                           <- Main #1, in `a = b` form
+#
+# `MemAlign.addr` is witness column 0 of the AIR and `MemAlign.L1` is fixed
+# column 0, which is what makes FIXED_AS_WITNESS a same-index kind swap and not
+# a change of slot.
+
+MEMALIGN_SPEC = "ZiskFv/AirsClean/MemAlign/Spec.lean"
+MEMALIGN_CIRCUIT = "ZiskFv/AirsClean/MemAlign/Circuit.lean"
+MAIN_SPEC = "ZiskFv/AirsClean/Main/Spec.lean"
+BINARY_SPEC = "ZiskFv/AirsClean/Binary/Spec.lean"
+
+SEL_6 = "∧ row.sel_6 * (1 - row.sel_6) = 0"
+SEL_7 = "∧ row.sel_7 * (1 - row.sel_7) = 0"
+WR_BOOL = "row.wr * (1 - row.wr) = 0"
+PRE_L1 = "∧ row.preL1 * row.pc = 0"
+SEL_PROVE = "∧ row.sel_prove * (row.sel_up_to_down + row.sel_down_to_up) = 0"
+REG_0_DOWN = ("∧ (previous.reg_0 - current.reg_0) * current.sel_0 "
+              "* current.sel_down_to_up = 0")
+ADDR1 = "∧ row.rom.addr1 = row.rom.b_offset_imm0 + row.rom.b_src_ind * row.core.a_0"
+CARRY_7_BOOL = "∧ row.chain.carry_7 * (1 - row.chain.carry_7) = 0"
+
+
+@dataclass(frozen=True)
+class Mutation:
+    name: str
+    lean_file: str
+    target: str
+    intent: str
+    apply: Mutator
+    added: tuple[Signature, ...] = ()
+    removed: tuple[Signature, ...] = ()
+    # Scope-failure buckets this mutation must add at least one entry to. A
+    # mutation that defeats a scope check produces no finding at all, so its
+    # prediction lives here rather than in `added`.
+    scope_added: tuple[str, ...] = ()
+    control: bool = False
+    # Set when the predicted delta is EMPTY because the gate cannot see this
+    # defect, not because there is nothing to see. Such a case passing is a
+    # measurement of a limit, never reassurance, and the report says so.
+    blind_spot: str = ""
+
+
+MUTATIONS: tuple[Mutation, ...] = (
+    Mutation(
+        name="NO_MUTATION",
+        lean_file="(control)", target="(control)",
+        intent="an untouched copy must reproduce the baseline findings exactly",
+        apply=no_mutation,
+        control=True,
+    ),
+    Mutation(
+        name="CLAUSE_DELETED",
+        lean_file=MEMALIGN_SPEC, target="Spec#11, the sel_7 boolean",
+        intent="a mirror clause that used to restate a constraint and no longer does",
+        # MemAlign #24 was backed by this clause alone, so it loses its only
+        # mirror. Nothing else moves: no clause is added, so no strengthening.
+        apply=drop_line(SEL_7),
+        added=(gap("MemAlign", 24),),
+    ),
+    Mutation(
+        name="CLAUSE_ADDED",
+        lean_file=MEMALIGN_SPEC, target="Spec, one extra conjunct",
+        intent="a plausible-looking lane-disjointness clause the AIR does not carry",
+        # The shape a reviewer would wave through: two selector columns asserted
+        # mutually exclusive. No generated constraint has that canonical form.
+        apply=add_line_after(SEL_PROVE, "∧ row.sel_0 * row.sel_1 = 0"),
+        added=(strengthening("MemAlign", "Spec"),),
+    ),
+    Mutation(
+        name="PROJECTION_SWAPPED",
+        lean_file=MEMALIGN_SPEC, target="Spec#0, wr -> reset on one side",
+        intent="a mirror reading the wrong row field: still well-formed, still "
+               "looks like the constraint it is not",
+        apply=replace_in_line(WR_BOOL, "row.wr", "row.reset", occurrence=2),
+        added=(gap("MemAlign", 25), strengthening("MemAlign", "Spec")),
+    ),
+    Mutation(
+        name="ROW_DELTA_SHIFTED",
+        lean_file=MEMALIGN_CIRCUIT, target="transitionRows#1, current -> previous",
+        intent="the right fields at the wrong row offset",
+        # Lane-kind erasure keeps the row delta, so this must NOT read as a
+        # reclassification: a shifted row is a different assertion, not a
+        # differently-kinded one.
+        apply=replace_in_line(REG_0_DOWN, "current.sel_0", "previous.sel_0"),
+        added=(gap("MemAlign", 1), strengthening("MemAlign", "transitionRows")),
+    ),
+    Mutation(
+        name="FIXED_AS_WITNESS",
+        lean_file=MEMALIGN_SPEC, target="Spec#12, preL1 -> addr",
+        intent="a fixed column read as the witness column of the same index -- "
+               "what a `| _ => 0` fallback in a field-to-column map does",
+        # `preL1` is fixed column 0, `addr` is witness column 0. The claim is
+        # that this arrives as RECLASSIFICATION by the kind-erasure route, and
+        # that the declared-alias reclassification it replaces goes away -- not
+        # as a gap plus an unrelated strengthening.
+        apply=replace_in_line(PRE_L1, "row.preL1", "row.addr"),
+        added=(reclassification("MemAlign", "kind erasure", 16, "Spec"),),
+        removed=(reclassification("MemAlign", "declared lane-kind alias", 16, "Spec"),),
+    ),
+    Mutation(
+        name="REDUNDANT_CLAUSE_DELETED",
+        lean_file=BINARY_SPEC, target="Spec#1, the carry_7 boolean",
+        intent="a mirror clause that stopped restating a constraint a SECOND "
+               "mirror also restates",
+        # Binary #1 is carried by both `Spec#1` and `Valid_Binary.constraints_at#1`
+        # -- one of the 48 `[many]` pairings. Pairing is set-to-set by design, so
+        # the surviving clause still supplies the canonical form and the gate has
+        # nothing to report. The predicted delta is therefore empty, and that is
+        # a limit being measured rather than a defect class being covered.
+        apply=drop_line(CARRY_7_BOOL),
+        blind_spot="a constraint restated by two mirrors keeps its match when "
+                   "one of them is deleted; set-to-set pairing cannot see the "
+                   "loss, and no per-mirror coverage count exists to see it "
+                   "either",
+    ),
+    Mutation(
+        name="UNCLASSIFIED_PREDICATE_ADDED",
+        lean_file=MEMALIGN_SPEC, target="a new two-clause `def` nobody classified",
+        intent="a whole new mirror predicate, added the way one is really added: "
+               "by writing a `def`, not by editing any list",
+        # Neither clause is a MemAlign constraint. The mirror scope is a declared
+        # table, so an unclassified predicate is compared by nothing; the
+        # classification gate is what makes that loud instead of silent.
+        apply=append_declaration(
+            "def SmuggledSpec (row : MemAlignRow FGL) : Prop :=",
+            ["  row.sel_0 * row.sel_1 = 0",
+             "  ∧ row.wr * row.reset = 0"]),
+        scope_added=("classification_coverage",),
+    ),
+    Mutation(
+        name="LANELESS_CLAUSE_ADDED",
+        lean_file=MEMALIGN_SPEC, target="Spec, one extra conjunct over delta_pc",
+        intent="an unbacked assertion routed through the one field this AIR has "
+               "no lane for",
+        # `delta_pc` is hint #998's payload slot. Any clause naming it used to
+        # leave the compared set before pairing, whatever else it said, and
+        # contributed nothing to the failure count.
+        apply=add_line_after(
+            PRE_L1, "∧ row.delta_pc * (row.addr + row.wr * 12345) = 0"),
+        added=(unbacked("MemAlign", "Spec"),),
+    ),
+    Mutation(
+        name="FIXED_LEAF_UNDECLARED",
+        lean_file=MEMALIGN_SPEC, target="Spec#12, preL1 -> __L1__",
+        intent="a row field spelling a fixed-column name directly, with no "
+               "declared alias and no such field on the row record",
+        # `__L1__` is an unqualified fixed-column name in all ten AIRs, and in
+        # MemAlign it is fixed column 1 where `MemAlign.L1` is fixed column 0. So
+        # this reaches a DIFFERENT fixed column through no declared table at all.
+        # Two checks must move: the projection audit (MemAlignRow has no such
+        # field) and the pairing (#16 loses its backer).
+        apply=replace_in_line(PRE_L1, "row.preL1", "row.__L1__"),
+        added=(gap("MemAlign", 16), strengthening("MemAlign", "Spec")),
+        removed=(reclassification("MemAlign", "declared lane-kind alias", 16,
+                                  "Spec"),),
+        scope_added=("projection_totality",),
+    ),
+    Mutation(
+        name="NOOP_REORDER",
+        lean_file=MEMALIGN_SPEC, target="Spec#10 <-> Spec#11",
+        intent="control: the same conjuncts in a different order",
+        # A WEAK control, and worth saying so. `signature()` deliberately drops
+        # the clause index, and these two conjuncts are structurally isomorphic
+        # booleans, so the only thing this swap can move is a clause index and an
+        # ordering the key already ignores. It cannot fail unless the parser
+        # breaks outright. The claim that the decider is canonical form and not
+        # text is carried by NOOP_EQ_AS_ZERO, which rewrites `a = b` into
+        # `a - b = 0` on a resolvable, matched clause.
+        apply=swap_lines(SEL_6, SEL_7),
+        control=True,
+    ),
+    Mutation(
+        name="NOOP_EQ_AS_ZERO",
+        lean_file=MAIN_SPEC, target="AddressSpec#1, a = b -> a - b = 0",
+        intent="control: one clause restated in the other equation form",
+        apply=rewrite_line(
+            ADDR1,
+            "∧ row.rom.addr1 - (row.rom.b_offset_imm0 + row.rom.b_src_ind "
+            "* row.core.a_0) = 0"),
+        control=True,
+    ),
+)
+
+
+# --------------------------------------------------------------- running one case
+
+
+@dataclass
+class CaseResult:
+    mutation: Mutation
+    before: str = ""
+    after: str = ""
+    exit_code: int | None = None
+    added: Counter = field(default_factory=Counter)
+    removed: Counter = field(default_factory=Counter)
+    scope_added: Counter = field(default_factory=Counter)
+    totals_moved: list[str] = field(default_factory=list)
+    summary: str = ""
+    evidence: list[str] = field(default_factory=list)
+    problems: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.problems
+
+    @property
+    def uncaught(self) -> bool:
+        """A mutation the gate was supposed to notice and did not notice at all."""
+        return (bool(self.mutation.added or self.mutation.removed
+                     or self.mutation.scope_added)
+                and not self.added and not self.removed and not self.scope_added)
+
+    @property
+    def blind(self) -> bool:
+        """A case that passed by measuring a limit rather than by catching one."""
+        return bool(self.mutation.blind_spot) and self.ok
+
+
+def stage(work_dir: Path) -> Path:
+    """One pristine copy of everything a mirror-side run reads."""
+    base = work_dir / "_pristine"
+    base.mkdir()
+    for root in STAGED_ROOTS:
+        source = REPO_ROOT / root
+        if not source.is_dir():
+            raise HarnessError(f"nothing to stage at {source}")
+        shutil.copytree(source, base / root)
+    return base
+
+
+def evidence_for(sig: Signature, text: str) -> list[str]:
+    """The gate's own words about one predicted finding."""
+    kind, air, _route, indices, defs = sig
+    if kind == GAP and indices:
+        return trim(block_with(text, f"GAP  {air} #{indices[0]}"), 6)
+    if kind == RECLASSIFICATION and indices:
+        return trim(block_with(text, f"RECLASSIFICATION  {air} #{indices[0]}"), 6)
+    if kind == STRENGTHENING and defs:
+        return trim(block_with(text, f"STRENGTHENING  {air}", defs[0]), 6)
+    if kind == UNBACKED and defs:
+        return trim(block_with(text, f"UNBACKED  {air}", defs[0]), 6)
+    return []
+
+
+def run_case(mutation: Mutation, base: Path, work_dir: Path,
+             baseline: ToolRun) -> CaseResult:
+    case_dir = work_dir / mutation.name
+    shutil.copytree(base, case_dir)
+    result = CaseResult(mutation=mutation)
+
+    if mutation.apply is not no_mutation:
+        path = case_dir / mutation.lean_file
+        if not path.is_file():
+            raise HarnessError(f"{mutation.name}: no {mutation.lean_file} staged")
+        original = path.read_text().split("\n")
+        mutated, result.before, result.after = mutation.apply(list(original))
+        if mutated == original:
+            raise HarnessError(f"{mutation.name}: the mutation changed nothing")
+        path.write_text("\n".join(mutated))
+    else:
+        _, result.before, result.after = mutation.apply([])
+
+    run = run_tool(case_dir / "ZiskFv" / "AirsClean",
+                   work_dir / f"{mutation.name}.json")
+    result.exit_code = run.exit_code
+    result.summary = next(
+        (line for line in reversed(run.text.strip().split("\n")) if line.strip()),
+        "(no output)")
+
+    observed = signatures(run.payload)
+    result.added = observed - signatures(baseline.payload)
+    result.removed = signatures(baseline.payload) - observed
+
+    expected_added = Counter(mutation.added)
+    expected_removed = Counter(mutation.removed)
+    if result.added != expected_added:
+        result.problems.append(
+            f"expected to ADD {fmt_delta(expected_added)}; "
+            f"tool added {fmt_delta(result.added)}")
+    if result.removed != expected_removed:
+        result.problems.append(
+            f"expected to REMOVE {fmt_delta(expected_removed)}; "
+            f"tool removed {fmt_delta(result.removed)}")
+
+    result.scope_added = scope_signatures(run.payload) - scope_signatures(
+        baseline.payload)
+    missed = [bucket for bucket in mutation.scope_added
+              if not result.scope_added.get(bucket)]
+    if missed:
+        result.problems.append(
+            f"expected new scope failure(s) in {', '.join(missed)}; the run's "
+            f"scope buckets moved by {fmt_delta(result.scope_added) or '(nothing)'}")
+    unexpected = [bucket for bucket in result.scope_added
+                  if bucket not in mutation.scope_added]
+    if unexpected:
+        result.problems.append(
+            f"unpredicted new scope failure(s) in {', '.join(sorted(unexpected))}")
+
+    # Invariants no signature delta covers.
+    base_totals, case_totals = totals(baseline.payload), totals(run.payload)
+    for air, (generated, mirror, matched) in sorted(base_totals.items()):
+        got = case_totals.get(air)
+        if got is None:
+            result.problems.append(f"{air} left the run entirely")
+            continue
+        if got[0] != generated:
+            result.problems.append(
+                f"{air}: comparable GENERATED moved {generated} -> {got[0]}; "
+                f"these mutations touch only mirrors, so it must not")
+        if got[1:] != (mirror, matched):
+            result.totals_moved.append(
+                f"{air} mirror {mirror}->{got[1]} matched {matched}->{got[2]}")
+    if mutation.control and result.totals_moved:
+        result.problems.append(
+            f"a neutral rewrite moved the totals: {'; '.join(result.totals_moved)}")
+    if run.exit_code != baseline.exit_code:
+        result.problems.append(
+            f"exit code moved {baseline.exit_code} -> {run.exit_code}; the gate "
+            f"is already failing at HEAD, so it should not")
+
+    for sig in mutation.added:
+        result.evidence.extend(evidence_for(sig, run.text))
+    return result
+
+
+# ------------------------------------------------------------------------ reporting
+
+
+_TABLE = "{:<26} {:<46} {:>4} {:<50} {:<7}"
+
+
+def print_repro(results: list[ReproResult], run: ToolRun) -> None:
+    print("PART A -- REPRODUCTION")
+    print("  One unfiltered run of the gate, told nothing about where to look. Each")
+    print("  case asserts a finding of the right CLASS naming the right generated")
+    print("  index or mirror definition.")
+    print()
+    for result in results:
+        case = result.case
+        print(f"{case.name}  [{'ok' if result.ok else 'FAILED'}]")
+        print(f"  hand finding  {case.hand_finding}")
+        print(f"  expected      a {case.expect_class} finding naming {case.names}")
+        print(f"  actual        {result.actual}")
+        if result.where_instead:
+            print("  filed instead as, verbatim:")
+            for line in result.where_instead[:4]:
+                print(f"    {line[:EVIDENCE_WIDTH]}")
+        if result.evidence:
+            print("  the tool's own text, verbatim:")
+            for line in result.evidence[:EVIDENCE_LINES + 12]:
+                print(f"    {line[:EVIDENCE_WIDTH]}" if line else "")
+        print()
+    print(f"  gate summary line: {run.text.strip().split(chr(10))[-1]}")
+    print()
+
+
+def print_mutation_table(results: list[CaseResult]) -> None:
+    header = _TABLE.format("mutation", "expected delta", "exit", "observed delta",
+                           "verdict")
+    print(header)
+    print("-" * len(header))
+    for result in results:
+        scope = "; ".join(f"+scope:{b}" for b in result.mutation.scope_added)
+        expected = "; ".join(part for part in (
+            fmt_signed(Counter(result.mutation.added),
+                       Counter(result.mutation.removed)).replace("(nothing)", ""),
+            scope) if part)
+        observed = "; ".join(part for part in (
+            fmt_signed(result.added, result.removed).replace("(nothing)", ""),
+            "; ".join(f"+scope:{b}" for b in sorted(result.scope_added))) if part)
+        print(_TABLE.format(
+            result.mutation.name,
+            (expected or "(nothing)")[:46]
+            if not (result.mutation.control or result.mutation.blind_spot)
+            else "(nothing: control)" if result.mutation.control
+            else "(nothing: known blind spot)",
+            "-" if result.exit_code is None else result.exit_code,
+            (observed or "(nothing)")[:50],
+            ("blind" if result.blind else "ok") if result.ok else "FAILED",
+        ))
+    print("-" * len(header))
+    print("  delta is against the baseline run; `+` findings and `-` findings are")
+    print("  both asserted, so a mutation that adds the right finding while quietly")
+    print("  dropping another one still fails.")
+    print()
+
+
+def print_mutation_details(results: list[CaseResult]) -> None:
+    print("WHAT EACH CASE CHANGED, AND WHAT THE GATE SAID")
+    print()
+    for result in results:
+        mutation = result.mutation
+        print(f"{mutation.name}  [{mutation.lean_file} {mutation.target}]")
+        print(f"  intent     {mutation.intent}")
+        print(f"  before     {result.before[:EVIDENCE_WIDTH]}")
+        print(f"  after      {result.after[:EVIDENCE_WIDTH]}")
+        print(f"  added      {fmt_delta(result.added)}")
+        print(f"  removed    {fmt_delta(result.removed)}")
+        if result.scope_added:
+            print(f"  scope      new failure(s) in "
+                  f"{', '.join(f'{b} x{n}' for b, n in sorted(result.scope_added.items()))}")
+        if result.totals_moved:
+            print(f"  totals     {'; '.join(result.totals_moved)}")
+        if mutation.blind_spot:
+            print(f"  BLIND SPOT {mutation.blind_spot}")
+        print(f"  exit       {result.exit_code}")
+        print(f"  summary    {result.summary[:EVIDENCE_WIDTH]}")
+        for line in result.evidence[:EVIDENCE_LINES]:
+            print(f"  evidence   {line.strip()[:EVIDENCE_WIDTH]}" if line else "")
+        for problem in result.problems:
+            print(f"  PROBLEM    {problem}")
+        print()
+
+
+def print_findings(repro: list[ReproResult], cases: list[CaseResult]) -> None:
+    unreproduced = [r for r in repro if not r.ok]
+    uncaught = [c for c in cases if c.uncaught]
+    misclassified = [c for c in cases if c.problems and not c.uncaught
+                     and not c.mutation.control and not c.mutation.blind_spot]
+    controls_broken = [c for c in cases if c.problems and c.mutation.control]
+
+    if unreproduced:
+        print(f"HAND FINDINGS THE TOOL DID NOT REPRODUCE AS A FINDING "
+              f"({len(unreproduced)}) -- BLIND SPOTS OF THE GATE:")
+        for result in unreproduced:
+            print(f"  {result.case.name}: expected a {result.case.expect_class} "
+                  f"naming {result.case.names}")
+            print(f"    hand finding  {result.case.hand_finding}")
+            print(f"    got instead   {result.actual}")
+            for line in result.where_instead[:3]:
+                print(f"    verbatim      {line[:EVIDENCE_WIDTH]}")
+        print("  These belong in the 'Known blind spots' section of README.md.")
+        print()
+
+    if uncaught:
+        print(f"UNCAUGHT MUTATIONS ({len(uncaught)}) -- BLIND SPOTS OF THE GATE:")
+        for result in uncaught:
+            print(f"  {result.mutation.name} [{result.mutation.lean_file} "
+                  f"{result.mutation.target}]: {result.mutation.intent}")
+            print(f"    changed  {result.before[:100]}")
+            print(f"    into     {result.after[:100]}")
+            print("    and the gate reported no new and no missing finding")
+        print("  These belong in the 'Known blind spots' section of README.md.")
+        print()
+
+    measured = [c for c in cases if c.blind]
+    if measured:
+        print(f"MEASURED BLIND SPOTS ({len(measured)}) -- CASES THAT PASSED BY "
+              f"SHOWING THE GATE CANNOT SEE THE DEFECT:")
+        for result in measured:
+            print(f"  {result.mutation.name} [{result.mutation.lean_file} "
+                  f"{result.mutation.target}]: {result.mutation.intent}")
+            print(f"    changed  {result.before[:100]}")
+            print(f"    into     {result.after[:100]}")
+            print(f"    why      {result.mutation.blind_spot}")
+        print("  A pass here is a measurement, not coverage. These belong in the")
+        print("  'Known blind spots' section of README.md.")
+        print()
+
+    if controls_broken:
+        print(f"NEUTRAL REWRITES THAT MOVED THE VERDICT ({len(controls_broken)}) -- "
+              f"THE CANONICALISER IS WRONG:")
+        for result in controls_broken:
+            for problem in result.problems:
+                print(f"  {result.mutation.name}: {problem}")
+        print()
+
+    if misclassified:
+        print(f"MUTATIONS THE GATE NOTICED BUT CLASSIFIED UNEXPECTEDLY "
+              f"({len(misclassified)}):")
+        for result in misclassified:
+            for problem in result.problems:
+                print(f"  {result.mutation.name}: {problem}")
+        print()
+
+
+# ---------------------------------------------------------------------- the driver
+
+
+def digest_tree() -> str:
+    """Content digest of everything a case stages, to prove it was never written."""
+    digest = hashlib.sha256()
+    for root in STAGED_ROOTS:
+        for path in sorted((REPO_ROOT / root).rglob("*")):
+            if not path.is_file():
+                continue
+            digest.update(str(path.relative_to(REPO_ROOT)).encode())
+            digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def main(argv: list[str]) -> int:
+    if argv[1:]:
+        print(__doc__.strip().split("\n")[0], file=sys.stderr)
+        print("usage: acceptance.py", file=sys.stderr)
+        return EXIT_BROKEN
+    for path in (CHECK_MIRRORS, DEFAULT_PILOUT, DEFAULT_EXTRACTION, REAL_MIRROR):
+        if not path.exists():
+            print(f"acceptance: missing {path}", file=sys.stderr)
+            print("ARTIFACTS ABSENT -- this is not a pass", file=sys.stderr)
+            return EXIT_BROKEN
+
+    started = time.time()
+    print("mirror-roundtrip acceptance: the gate must find what the hand fan-out "
+          "found, and a fifth thing it has never been shown")
+    print(f"  check       {CHECK_MIRRORS}")
+    print(f"  pilout      {DEFAULT_PILOUT}")
+    print(f"  extraction  {DEFAULT_EXTRACTION}")
+    print(f"  mirrors     {REAL_MIRROR}  (copied for every mutation, never written)")
+    print()
+
+    before = digest_tree()
+    work_dir = Path(tempfile.mkdtemp(prefix="mirror-roundtrip-acceptance-"))
+    try:
+        baseline = run_tool(REAL_MIRROR, work_dir / "_baseline.json")
+        repro = evaluate_reproductions(baseline)
+        print_repro(repro, baseline)
+
+        base = stage(work_dir)
+        print("PART B -- MUTATION")
+        print(f"  {len(MUTATIONS)} case(s); one edit each to a copy of "
+              f"{'/, '.join(STAGED_ROOTS)}/ under {work_dir}")
+        print("  The gate already exits 1 at HEAD, so the verdict is the signature")
+        print("  delta against the baseline run, never the exit code.")
+        print()
+        with concurrent.futures.ThreadPoolExecutor(
+                max_workers=min(8, len(MUTATIONS))) as pool:
+            futures = [pool.submit(run_case, mutation, base, work_dir, baseline)
+                       for mutation in MUTATIONS]
+            cases = [future.result() for future in futures]
+    finally:
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+    after = digest_tree()
+    print_mutation_table(cases)
+    print_mutation_details(cases)
+    print_findings(repro, cases)
+
+    reproduced = sum(1 for r in repro if r.ok)
+    to_catch = [c for c in cases
+                if not c.mutation.control and not c.mutation.blind_spot]
+    caught = sum(1 for c in to_catch if not c.uncaught)
+    controls = [c for c in cases if c.mutation.control]
+    controls_ok = sum(1 for c in controls if c.ok)
+    blind = [c for c in cases if c.mutation.blind_spot]
+
+    if before != after:
+        print(f"acceptance: FAIL: {'/, '.join(STAGED_ROOTS)}/ changed during the "
+              f"run ({before[:12]} -> {after[:12]})")
+        return EXIT_FAILED
+    print(f"real ZiskFv/ and trust/ unchanged: sha256 {before[:16]} before and after")
+    exact = sum(1 for c in to_catch if c.ok)
+    print(f"hand findings reproduced: {reproduced}/{len(repro)};  "
+          f"mutations noticed: {caught}/{len(to_catch)}, of which classified "
+          f"exactly as predicted: {exact}/{len(to_catch)};  "
+          f"neutral controls that stayed put: {controls_ok}/{len(controls)};  "
+          f"known blind spots measured, not covered: {len(blind)};  "
+          f"runtime {time.time() - started:.1f}s")
+
+    failed = [r.case.name for r in repro if not r.ok] + [
+        c.mutation.name for c in cases if not c.ok]
+    if failed:
+        print(f"mirror-roundtrip acceptance: FAIL -- {len(failed)} case(s) did not "
+              f"behave as expected: {', '.join(failed)}")
+        return EXIT_FAILED
+    print(f"mirror-roundtrip acceptance: OK -- all {len(repro) + len(cases)} cases "
+          f"behaved as expected")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv))
+    except HarnessError as error:
+        print(f"acceptance: HARNESS BROKEN, no verdict: {error}", file=sys.stderr)
+        print("acceptance: an anchor no longer occurs in the mirrors; fix the "
+              "anchor, do not delete the case", file=sys.stderr)
+        sys.exit(EXIT_BROKEN)
+    except OSError as error:
+        print(f"acceptance: {error}", file=sys.stderr)
+        sys.exit(EXIT_BROKEN)

--- a/tools/mirror-roundtrip/check_mirrors.py
+++ b/tools/mirror-roundtrip/check_mirrors.py
@@ -1,0 +1,2062 @@
+#!/usr/bin/env python3
+"""The mirror-side round trip: does a handwritten mirror back every constraint?
+
+Issue: eth-act/zisk-fv#304, the other direction of #303. Python 3 standard
+library only, no Lean build needed.
+
+#303 decided `g(f(t)) == t` for every polynomial identity `t` in
+`build/zisk.pilout`: the extractor neither drops nor distorts a constraint on the
+way into `build/extraction/Extraction/`. Nothing in that argument touches
+`ZiskFv/`. The emitted per-AIR files are imported by no Lean under `ZiskFv/` at
+all, so a constraint can round-trip perfectly and still be restated wrongly,
+partially, or not at all in the handwritten Lean the proof actually consumes.
+
+This driver closes that second direction, for the polynomial content: per AIR it
+canonicalises the *comparable generated constraints* and the clauses of every
+*inventoried mirror predicate* into the same `poly.Poly` normal form #303 already
+decides equality in, and pairs the two sets.
+
+    GENERATED  `build/extraction/Extraction/<AIR>.lean`, minus the constraints
+               reading `Extraction.Circuit.challenge` or a stage-2 lane
+    MIRROR     every clause of every `MIRROR*`-class predicate under
+               `ZiskFv/AirsClean/**`, via `mirror_parse`
+
+## Why this is not what a weld already checks
+
+A weld -- `Valid_<AIR>` against the generated definitions, `link_*`,
+`template_*` -- relates a mirror to the generated constraint it was welded *to*.
+That catches a mirror which disagrees with its own counterpart. It is blind in
+both of the directions this tool covers:
+
+* a generated constraint that no mirror models at all is welded to nothing, so
+  no weld can notice its absence;
+* a mirror clause that no generated constraint backs is, in an implication-only
+  weld (`mirror -> generated`, the usual soundness direction), simply an extra
+  hypothesis. It makes the implication *easier* to prove, so the weld passes and
+  gets stronger-looking, which is exactly backwards.
+
+The second is the `Valid_<AIR>` strengthening AGENTS.md requires a source
+citation and a constructibility argument for. This tool finds candidates for
+that review mechanically instead of by reading.
+
+## What it reports, and what it must never do
+
+The classes the issue names, plus one it implies:
+
+    MATCHED           canonical forms agree
+    GAP               a comparable generated constraint with no canonical match
+                      in the mirror set
+    STRENGTHENING     a mirror clause with no canonical match in the generated
+                      set. A SYNTACTIC class: "no constraint carries this form"
+                      is not "the mirror asserts more", because a clause that is
+                      a multiple of a constraint follows from it and is weaker.
+                      So a cofactor search runs first and withdraws AGENTS.md's
+                      citation-and-constructibility demand when it finds one.
+    RECLASSIFICATION  the pairing turns on a LANE KIND -- a fixed column
+                      modelled as a witness, or a stage-2 lane as stage-1.
+                      Reported as one finding, because splitting it into a gap
+                      plus a strengthening would bury the cause.
+    UNBACKED          a mirror equation over a row field this AIR has no lane
+                      for. It has no canonical form, so nothing can pair with
+                      it, and no generated constraint can carry it. This was a
+                      declared exclusion keyed on the FIELD, which meant any
+                      clause naming one of four fields left the comparison
+                      whatever else it asserted; it fails the run now.
+
+Besides the pairing, the run holds its own SCOPE, because a scope taken from a
+declared list fails by shrinking rather than by erroring: `survey.CLASSIFICATION`
+against the declarations actually present, every NEAR_*-classified declaration
+re-parsed and required to be equation-free, `DECLARED_AIRS` through #303's own
+`check._check_scope`, `lanes.gate_lane_map`, every resolved projection against
+the row record it claims, a non-empty floor on both denominators, and a second
+opinion on the canonicaliser both sides fold through.
+
+`RECLASSIFICATION` is reached two ways, and both are the same fact about a lane's
+kind:
+
+* `kind erasure` -- the two sides agree once every atom's kind is erased and not
+  with it kept. That is a mirror pointing at the wrong kind of lane, caught here
+  at pairing time.
+* `declared lane-kind alias` -- the kind-preserving forms agree, but only because
+  `mirror_parse.FIELD_ALIASES` resolved a witness-looking row-record field onto a
+  non-witness lane (`MemAlignRow.preL1` is fixed column `MemAlign.L1`). The
+  polynomial then matches on the assumption that the field IS that lane, which is
+  a weld this tool does not check. Counting it as a plain match would be the
+  quiet version of the inventory's F7.
+
+Plus, separately, every mirror predicate that is UNREACHABLE: defined and
+referenced by nothing else in the checked-in Lean. Its clauses can match
+perfectly and constrain nothing, so a match backed only by an unreachable mirror
+is reported as the hollow match it is.
+
+This tool REPORTS. It never edits a mirror, a `Valid_<AIR>` validator or a row
+record -- those are protected proof interfaces. A gap it finds is a finding to
+cite. Every exclusion is declared in `DECLARED_EXCLUSIONS` below with a source
+citation, printed on every run, and CATEGORY-level: not one entry names an
+individual constraint index or an individual mirror clause. An allowlist keyed by
+index is how a gate gets tuned into silence, so there is not one here.
+
+## Scope
+
+Polynomial identities over lane atoms. Out of scope, and each excluded by a
+declared rule rather than by omission: challenge-mixed and stage-2 constraints
+(the issue's own comparable rule), `.val` bounds, lookups, permutations, channel
+balance, fixed-column *values*, and mirrors declared outside the mirror root.
+See `README.md` for the residual blind spots.
+
+    python3 tools/mirror-roundtrip/check_mirrors.py [--pilout PATH]
+        [--extraction DIR] [--airs-clean DIR] [--air NAME]... [--json PATH]
+        [--quiet]
+
+Exit codes:
+
+    0  every comparable constraint matched, every mirror clause matched, no
+       unreachable mirror, nothing unparsed, nothing undeclared-unresolved, no
+       scope check failed -- and the run covered every declared AIR
+    1  any undeclared finding, or a `--air`-filtered run, which has gated
+       nothing about the AIRs it skipped and so may not report success
+    2  usage or IO error -- artifacts absent is NOT a pass
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import dataclasses
+import io
+import json
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str(REPO_ROOT / "tools" / "pilout-roundtrip"))
+
+import check as pilout_check  # noqa: E402
+import lean_parse  # noqa: E402
+import lean_wiring  # noqa: E402
+import lanes  # noqa: E402
+import mirror_parse  # noqa: E402
+import pilout_atoms  # noqa: E402
+import pilout_wire  # noqa: E402
+import poly  # noqa: E402
+import survey  # noqa: E402
+
+DEFAULT_PILOUT = lanes.DEFAULT_PILOUT
+DEFAULT_EXTRACTION = lanes.DEFAULT_EXTRACTION
+DEFAULT_MIRROR = survey.DEFAULT_MIRROR
+
+EXIT_OK = 0
+EXIT_FAILED = 1
+EXIT_USAGE = 2
+
+MATCHED = "MATCHED"
+GAP = "GAP"
+STRENGTHENING = "STRENGTHENING"
+RECLASSIFICATION = "RECLASSIFICATION"
+UNBACKED = "UNBACKED"
+
+FINDING_CLASSES = (MATCHED, RECLASSIFICATION, GAP, STRENGTHENING, UNBACKED)
+
+# Findings that fail the run. `MATCHED` is the only one that does not.
+FAILING_CLASSES = frozenset({GAP, STRENGTHENING, RECLASSIFICATION, UNBACKED})
+
+DIFF_TERMS_SHOWN = pilout_check.DIFF_TERMS_SHOWN
+CLAUSE_TEXT_SHOWN = 160
+# Mirror-side exclusions name every clause they carried. They are small (tens of
+# clauses), and truncating the list of what an exclusion swallowed is how the
+# exclusion stops being auditable: a reviewer checking that a bucket carries only
+# what its citation covers cannot check the entries that were elided.
+SITES_SHOWN = 200
+
+
+# ------------------------------------------------------------ declared exclusions
+
+
+@dataclass(frozen=True)
+class Exclusion:
+    """One declared, category-level exclusion, with the citation that earns it."""
+
+    key: str
+    side: str
+    rule: str
+    citation: str
+
+
+# The complete exclusion list. Three entries, all category-level; a fourth would
+# be worth arguing about and a per-index one would be laundering. `counts` in the
+# report is computed live, so an entry that stops carrying anything shows as 0 and
+# an entry that starts carrying more shows that too.
+#
+# There used to be a fourth, `mirror_field_has_no_lane`, and it was wrong. It
+# bucketed an equation clause out of the compared set because one of its
+# projections had no lane -- keyed on the FIELD, before pairing, so any clause
+# mentioning one of four fields left the comparison whatever else it asserted,
+# contributing nothing to the failure count and appearing only as a line in this
+# table. An equation with no lane is not "not comparable"; it is an assertion
+# nothing in the AIR's vocabulary can back. It is now the `UNBACKED` finding
+# class, which fails the run and prints the clause verbatim. The per-field
+# citations that justified the bucket did not disappear -- they are printed on
+# each finding, as the reason the field has no lane rather than as a reason to
+# stop looking at it.
+DECLARED_EXCLUSIONS = (
+    Exclusion(
+        "challenge_or_stage2", "generated",
+        "a constraint whose expression reaches `Extraction.Circuit.challenge` or "
+        "a stage-2 lane `main c (id := 2)`",
+        "the issue's own comparable rule. Stage-2 lanes and challenges are the "
+        "prover's random-linear-combination machinery, which no row-local mirror "
+        "restates; implemented independently here (off the emitted Lean) and in "
+        "survey.air_facts (off the pilout operands), and the two index sets are "
+        "required to agree on every run",
+    ),
+    Exclusion(
+        "mirror_carrier_not_a_row", "mirror",
+        "an equation clause over a carrier that is not a row of the AIR",
+        "mirror_parse.NON_ROW_CARRIERS: honest-row builder inputs and a ROM bus "
+        "message (ZiskFv/AirsClean/Main/Circuit.lean:326-339), and a "
+        "component-owned fixed-column schema "
+        "(ZiskFv/AirsClean/Mem/GeneratedTransition.lean:251). These are inputs to "
+        "a row, not slots of one, so they have no lane by construction",
+    ),
+    Exclusion(
+        "mirror_clause_not_an_equation", "mirror",
+        "a clause that is not a polynomial identity: a `.val` bound, or a "
+        "delegation to another named `Prop` whose own clauses are compared "
+        "elsewhere",
+        "this tool's declared scope is polynomial identities. A bound is not one "
+        "(survey.CLASSES `NEAR_RANGE`). A delegation carries no equation of its "
+        "own, and inlining it would double-count the delegate's clauses -- but "
+        "only if something compares them, so this entry covers a delegation "
+        "exactly when the delegate is MIRROR-class (parsed and paired here), a "
+        "declared out-of-root mirror (survey.DELEGATED, named not compared), or "
+        "NEAR_*-classified AND shown equation-free by the near-miss screen below. "
+        "Any other delegate is an undeclared delegation and a finding",
+    ),
+)
+
+
+# ------------------------------------------------------------------ lane erasure
+
+
+def lane_reaches(atom_key: tuple, atoms: tuple) -> bool:
+    """Does any of `atoms` address the reclassified lane, at any row delta?
+
+    `mirror_parse.Reclassified` records the accessor atom's `(kind, index)`
+    alongside the lane, because a lane tuple and an accessor atom are different
+    vocabularies -- `('chal', 2, 0)` is a lane and `('chal', 0)` the atom -- and
+    reconstructing one from the other here was a per-kind translation that had to
+    be extended every time a new lane kind became reachable. It is recorded at
+    the point the atom is built instead.
+    """
+    kind = atom_key[0]
+    if kind not in ("pre", "exposed", "chal"):
+        raise pilout_check.CheckError(
+            f"{atom_key!r}: a lane-kind change onto this head has never been "
+            f"seen; the atom correspondence for it is undeclared")
+    return any(atom[0] == kind and atom[1] == atom_key[1] for atom in atoms)
+
+
+def erase_lane_kind(atom: tuple) -> tuple:
+    """Drop an atom's lane KIND, keep the slot it addresses.
+
+    A witness column and a fixed column at the same index collapse onto one
+    variable, as do two stages of the same column, and a challenge onto an
+    exposed value at the same index. So a mirror modelling fixed column 0 as
+    witness column 0 -- the `h998ExprToField` failure mode, one arm pointing at
+    the wrong lane kind -- canonicalises to the generated form under this map and
+    not under the identity, which is exactly the `RECLASSIFICATION` test.
+
+    It erases the kind at a FIXED index. Kind confusion that also moves the index
+    reads as a gap plus a strengthening; see README.md's blind spots.
+    """
+    kind = atom[0]
+    if kind == "main":
+        return ("slot", atom[2], atom[3])
+    if kind == "pre":
+        return ("slot", atom[1], atom[2])
+    if kind in ("chal", "exposed"):
+        return ("aux", atom[1])
+    raise pilout_check.CheckError(f"not an accessor-vocabulary atom: {atom!r}")
+
+
+def map_atoms(expr: tuple, mapper) -> tuple:
+    """Rewrite every atom of a shared-spec AST, keeping the tree shape.
+
+    Erasure is an AST-to-AST rewrite so that there is exactly one canonicaliser
+    in the tool -- `check.to_poly`, the same function #303 folds every side with.
+    A second fold specialised to erased atoms could disagree with the first about
+    something other than the erasure.
+    """
+    head = expr[0]
+    if head == "const":
+        return expr
+    if head == "atom":
+        return ("atom", mapper(expr[1]))
+    if head == "neg":
+        return ("neg", map_atoms(expr[1], mapper))
+    if head in ("add", "sub", "mul"):
+        return (head, map_atoms(expr[1], mapper), map_atoms(expr[2], mapper))
+    raise pilout_check.CheckError(f"not a shared-spec AST node: {head!r}")
+
+
+def canonical(expr: tuple) -> tuple:
+    return pilout_check.to_poly(expr).canonical()
+
+
+def erased_canonical(expr: tuple) -> tuple:
+    return canonical(map_atoms(expr, erase_lane_kind))
+
+
+# --------------------------------------------------------------- the two sides
+
+
+@dataclass
+class Generated:
+    """One comparable generated constraint."""
+
+    air: str
+    index: int
+    suffix: str
+    provenance: str
+    expr: tuple
+    canon: tuple = ()
+    erased: tuple = ()
+
+    @property
+    def label(self) -> str:
+        return f"{self.air} #{self.index}"
+
+
+@dataclass
+class Clause:
+    """One comparable clause of one inventoried mirror predicate."""
+
+    air: str
+    definition: str
+    cls: str
+    file: str
+    def_line: int
+    line: int
+    index: int
+    text: str
+    expr: tuple
+    unreachable: bool = False
+    canon: tuple = ()
+    erased: tuple = ()
+    # For an `UNBACKED` clause: `(projection, reason, citation)` per projection
+    # this AIR has no lane for. Empty on every comparable clause.
+    laneless: tuple[tuple[str, str, str], ...] = ()
+    # `(projection path, lane name, lane, citation)` per lane-KIND alias this
+    # clause reaches -- a row-record field standing for a non-witness lane.
+    reclassified: tuple[tuple[str, str, tuple, str], ...] = ()
+    # Set to the containing directory when one AIR has two mirrors of the same
+    # name -- `Arith` has an `ArithMul/Spec` and an `ArithDiv/Spec`, and printing
+    # both as `Spec` would read as one mirror restating a constraint twice.
+    qualifier: str = ""
+
+    @property
+    def label(self) -> str:
+        return f"{self.qualifier}{self.definition}#{self.index}"
+
+    @property
+    def site(self) -> str:
+        return f"{self.file}:{self.line}"
+
+
+def load_generated(extraction: Path, air: str) -> tuple[list[Generated], list[int]]:
+    """The comparable and the excluded generated constraints of one AIR.
+
+    The exclusion rule is applied to the atoms of the emitted Lean, which is the
+    artifact the issue words it against. A stage outside {1, 2} raises rather
+    than defaulting to comparable: a third witness stage would be a lane kind
+    this rule has never been asked about.
+    """
+    path = extraction / f"{air}.lean"
+    parsed = lean_parse.parse_air_file(str(path))
+    if parsed.air_name != air:
+        raise pilout_check.CheckError(
+            f"{path}: names air {parsed.air_name!r}, expected {air!r}")
+    comparable: list[Generated] = []
+    excluded: list[int] = []
+    for constraint in parsed.constraints:
+        atoms = set(lean_parse.iter_atoms(constraint.expr))
+        for atom in atoms:
+            if atom[0] == "main" and atom[1] not in (1, 2):
+                raise pilout_check.CheckError(
+                    f"{path} constraint_{constraint.index}: witness stage "
+                    f"{atom[1]} is outside the comparable rule's vocabulary")
+        if any(atom[0] == "chal" or (atom[0] == "main" and atom[1] == 2)
+               for atom in atoms):
+            excluded.append(constraint.index)
+            continue
+        entry = Generated(
+            air=air, index=constraint.index, suffix=constraint.suffix,
+            provenance=constraint.debug_line or "", expr=constraint.expr)
+        entry.canon = canonical(entry.expr)
+        entry.erased = erased_canonical(entry.expr)
+        comparable.append(entry)
+    return comparable, excluded
+
+
+@dataclass
+class MirrorSide:
+    """Every mirror clause of one AIR, and what was declared away."""
+
+    comparable: list[Clause] = field(default_factory=list)
+    # Equation clauses this AIR's lane vocabulary cannot express: the `UNBACKED`
+    # finding class. Not an exclusion -- these fail the run.
+    unbacked: list[Clause] = field(default_factory=list)
+    total_clauses: int = 0
+    not_a_row: int = 0
+    not_an_equation: int = 0
+    # Equation clauses dropped because a projection failed for an UNDECLARED
+    # reason (`no_lane_map`, `row_relation_undetermined`, or an uncited
+    # `no_lane`). Counted separately from the cited ones so the accounting stays
+    # exact; the holes themselves are already failures via `undeclared_unresolved`.
+    undeclared_hole_clauses: list[str] = field(default_factory=list)
+    unparsed: list[str] = field(default_factory=list)
+    undeclared_unresolved: list[str] = field(default_factory=list)
+    undeclared_delegations: list[str] = field(default_factory=list)
+    # `MirrorDef.notes` and `MirrorDef.path_aliases`, which nothing read before.
+    notes: list[str] = field(default_factory=list)
+    path_aliases: list[str] = field(default_factory=list)
+    # Delegations reaching a two-row delegate with its rows in the wrong order.
+    row_order_mismatches: list[str] = field(default_factory=list)
+    # Delegations to a declaration that is classified but NOT compared here, as
+    # `(where, delegate file, delegate name)`. Covered by the delegation exclusion
+    # only if the near-miss screen shows the delegate carries no comparable
+    # equation, so these are carried to the screen rather than judged here.
+    near_miss_delegations: list[tuple[str, str, str]] = field(default_factory=list)
+    # What each mirror-side exclusion actually carried, so the declaration table
+    # can print the clauses it swallowed instead of only a count.
+    excluded_sites: dict[str, list[str]] = field(
+        default_factory=lambda: defaultdict(list))
+
+
+def _reclassified_lanes(definition: mirror_parse.MirrorDef,
+                        clause: mirror_parse.MirrorClause,
+                        ) -> tuple[tuple[str, str, tuple, str], ...]:
+    """The lane-KIND changes `mirror_parse` recorded that this clause reaches.
+
+    `mirror_parse` records every row-record projection that lands on a lane which
+    is not a stage-1 witness column -- through a cited `FIELD_ALIASES` entry, or
+    because the field leaf spells a non-witness lane name directly. This is where
+    that record is attached to the clause it affects, so the pairing can say
+    which of its matches depend on one.
+    """
+    found: dict[tuple[str, tuple], tuple[str, str, tuple, str]] = {}
+    for item in definition.reclassified:
+        if lane_reaches(item.atom_key, clause.atoms):
+            found[(item.path, item.lane)] = (
+                item.path, item.lane_name, item.lane, item.citation)
+    return tuple(found[key] for key in sorted(found))
+
+
+def load_mirrors(defs: list[mirror_parse.MirrorDef],
+                 unreachable: set[tuple[str, str]]) -> dict[str, MirrorSide]:
+    """Group parsed mirror definitions per AIR, splitting off the declared set.
+
+    Every clause lands in exactly one bucket -- comparable, `UNBACKED`, one of the
+    two declared mirror-side exclusions, or dropped for an undeclared hole -- and
+    the sum is checked against the clause count `mirror_parse` reports, so a
+    clause cannot leave the accounting by falling between two buckets.
+
+    `MirrorDef.notes` and `MirrorDef.path_aliases` are consumed here too. They are
+    what `mirror_parse` records when a definition's shape disagrees with its
+    class, when no row binder has a declared role, or when two different field
+    paths of one carrier reach one lane -- the declared mitigation for the
+    leaf-name resolution rule. Reading neither of them left three real defect
+    signals computed and thrown away.
+    """
+    out: dict[str, MirrorSide] = defaultdict(MirrorSide)
+    for definition in defs:
+        if definition.air is None:
+            raise pilout_check.CheckError(
+                f"{definition.site}: mirror {definition.name} has no AIR, so its "
+                f"clauses have nothing to be compared against")
+        side = out[definition.air]
+        side.total_clauses += len(definition.clauses)
+        side.unparsed.extend(definition.unparsed)
+        for note in definition.notes:
+            side.notes.append(f"{definition.site} {definition.name}: {note}")
+        for first, others, lane in definition.path_aliases:
+            side.path_aliases.append(
+                f"{definition.site} {definition.name}: {first} and {others} both "
+                f"resolve to lane {lane}, so one lane is constrained twice under "
+                f"two names and a leaf-name confusion between them is invisible")
+        for hole in definition.undeclared_unresolved:
+            side.undeclared_unresolved.append(
+                f"{definition.site} {definition.name}: {hole.path} ({hole.reason})")
+        for clause in definition.clauses:
+            where = f"{definition.name}#{clause.index} {definition.file}:{clause.line}"
+
+            def make(unresolved=()) -> Clause:
+                entry = Clause(
+                    air=definition.air, definition=definition.name,
+                    cls=definition.cls, file=definition.file,
+                    def_line=definition.line, line=clause.line,
+                    index=clause.index, text=" ".join(clause.source_text.split()),
+                    expr=clause.expr,
+                    unreachable=(definition.file, definition.name) in unreachable,
+                    laneless=unresolved)
+                return entry
+
+            if clause.kind != "equation":
+                side.not_an_equation += 1
+                side.excluded_sites["mirror_clause_not_an_equation"].append(
+                    f"{where} ({clause.kind})")
+                # The declared exclusion for a delegation rests on the delegate's
+                # own clauses being compared -- here, or named as out-of-root, or
+                # shown equation-free by the near-miss screen. A delegate merely
+                # PRESENT in survey.CLASSIFICATION does not earn it: a NEAR_*
+                # entry is inventoried and parsed by nothing.
+                delegate = clause.delegate
+                # `mirror_parse` compares a two-row delegate's own binder roles
+                # against the arguments positionally, and calls a mismatch "a real
+                # defect and invisible to everything else here". It was invisible
+                # to this driver too, which read `Delegation` without ever reading
+                # this field: `f prev curr` written `f curr prev` changed nothing
+                # in the report.
+                if delegate is not None and delegate.row_order_mismatch:
+                    side.row_order_mismatches.append(
+                        f"{definition.site} {definition.name} -> {delegate.name}: "
+                        f"{delegate.note}")
+                if delegate is not None and not delegate.compared:
+                    if delegate.declared:
+                        # Classified, but out of the compared set. Whether that
+                        # hides equations is the near-miss screen's verdict, so
+                        # the reference is recorded rather than judged here.
+                        side.near_miss_delegations.append((
+                            f"{definition.site} {definition.name} -> "
+                            f"{delegate.name} [{delegate.target_class}]",
+                            delegate.target_file or "", delegate.name))
+                    else:
+                        side.undeclared_delegations.append(
+                            f"{definition.site} {definition.name} -> "
+                            f"{delegate.name}: in neither survey.CLASSIFICATION "
+                            f"nor survey.DELEGATED, so its clauses are compared "
+                            f"by nothing")
+                continue
+            if clause.unresolved:
+                fields = ", ".join(sorted({hole.leaf for hole in clause.unresolved}))
+                if any(hole.reason == "carrier_not_a_row" for hole in clause.unresolved):
+                    side.not_a_row += 1
+                    side.excluded_sites["mirror_carrier_not_a_row"].append(
+                        f"{where} ({fields})")
+                    continue
+                # Every remaining reason `mirror_parse` records -- `no_lane`,
+                # `no_lane_map`, `row_relation_undetermined` -- used to land in
+                # one bucket whose citation covered only the first. They are kept
+                # apart now: a cited `no_lane` is an UNBACKED equation, and
+                # anything else is an undeclared hole and a plain failure.
+                undeclared = [hole for hole in clause.unresolved
+                              if hole.reason != "no_lane" or hole.declared is None]
+                if undeclared:
+                    side.undeclared_hole_clauses.append(
+                        f"{where} ({fields}; "
+                        f"{', '.join(sorted({h.reason for h in undeclared}))})")
+                    continue
+                side.unbacked.append(make(tuple(
+                    (hole.path, hole.reason, hole.declared or "")
+                    for hole in clause.unresolved)))
+                continue
+            entry = make()
+            entry.canon = canonical(entry.expr)
+            entry.erased = erased_canonical(entry.expr)
+            entry.reclassified = _reclassified_lanes(definition, clause)
+            side.comparable.append(entry)
+    for air, side in out.items():
+        accounted = (len(side.comparable) + len(side.unbacked) + side.not_a_row
+                     + side.not_an_equation + len(side.undeclared_hole_clauses))
+        if accounted != side.total_clauses:
+            raise pilout_check.CheckError(
+                f"{air}: {accounted} clauses bucketed for {side.total_clauses} "
+                f"parsed -- a clause left the accounting")
+        by_name: dict[str, set[str]] = defaultdict(set)
+        for clause in side.comparable:
+            by_name[clause.definition].add(clause.file)
+        for clause in side.comparable:
+            if len(by_name[clause.definition]) > 1:
+                clause.qualifier = Path(clause.file).parent.name + "/"
+    return out
+
+
+# ---------------------------------------------------------------------- pairing
+
+
+@dataclass
+class Finding:
+    """One pairing outcome: a canonical class and everything on both sides of it."""
+
+    kind: str
+    air: str
+    generated: list[Generated] = field(default_factory=list)
+    clauses: list[Clause] = field(default_factory=list)
+    diff: list[tuple[tuple, int, int]] = field(default_factory=list)
+    kind_pairs: list[tuple[tuple, tuple]] = field(default_factory=list)
+    nearest: tuple[Clause, int, int] | None = None
+    scalar: int | None = None
+    out_of_root: list[str] = field(default_factory=list)
+    # Which of the two routes to `RECLASSIFICATION` this finding came by.
+    route: str = ""
+    # On a `STRENGTHENING`: the generated constraint that entails the clause, if
+    # the cofactor search found one. Its presence withdraws the AGENTS.md demand.
+    implied: Implication | None = None
+
+    @property
+    def many_to_many(self) -> bool:
+        return len(self.generated) > 1 or len(self.clauses) > 1
+
+    @property
+    def reclassified(self) -> list[tuple[str, str, tuple, str]]:
+        """Every lane-kind alias the mirror side of this finding depends on."""
+        found: dict[tuple, tuple[str, str, tuple, str]] = {}
+        for clause in self.clauses:
+            for item in clause.reclassified:
+                found[(item[0], item[2])] = item
+        return [found[key] for key in sorted(found)]
+
+
+def pair_air(air: str, generated: list[Generated], clauses: list[Clause],
+             unbacked: list[Clause] | None = None) -> list[Finding]:
+    """Set-to-set pairing of one AIR's two canonical-form multisets.
+
+    Not positional: a mirror clause pairs with whichever generated constraint has
+    its canonical form, at any index. Both sides are grouped by canonical form
+    first, so a form carried by two generated constraints (`Arith` #29 and #30 are
+    one polynomial) or restated by two mirrors (a `Spec` and its
+    `Valid_<AIR>.constraints_at` twin) is one finding naming all of them rather
+    than an arbitrary choice of pair.
+    """
+    by_gen: dict[tuple, list[Generated]] = defaultdict(list)
+    for entry in generated:
+        by_gen[entry.canon].append(entry)
+    by_mir: dict[tuple, list[Clause]] = defaultdict(list)
+    for clause in clauses:
+        by_mir[clause.canon].append(clause)
+
+    findings: list[Finding] = []
+    for canon in sorted(set(by_gen) & set(by_mir), key=lambda k: by_gen[k][0].index):
+        finding = Finding(MATCHED, air, by_gen[canon], by_mir[canon])
+        # The second route to RECLASSIFICATION: the canonical forms agree, but
+        # only because a declared alias put a row-record field onto a lane of
+        # another kind. The equality is real; what it rests on is not a plain
+        # column correspondence, so it is not reported as a plain match.
+        if finding.reclassified:
+            finding.kind = RECLASSIFICATION
+            finding.route = "declared lane-kind alias"
+        findings.append(finding)
+
+    gen_left = [e for canon, group in by_gen.items() if canon not in by_mir
+                for e in group]
+    mir_left = [c for canon, group in by_mir.items() if canon not in by_gen
+                for c in group]
+
+    # Reclassification is decided only on what is left over: a clause that
+    # already matched kind-preservingly is not a candidate for it.
+    erased_gen: dict[tuple, list[Generated]] = defaultdict(list)
+    for entry in gen_left:
+        erased_gen[entry.erased].append(entry)
+    erased_mir: dict[tuple, list[Clause]] = defaultdict(list)
+    for clause in mir_left:
+        erased_mir[clause.erased].append(clause)
+    reclassified_gen: set[int] = set()
+    reclassified_mir: set[int] = set()
+    for key in sorted(set(erased_gen) & set(erased_mir),
+                      key=lambda k: erased_gen[k][0].index):
+        gens, mirs = erased_gen[key], erased_mir[key]
+        finding = Finding(RECLASSIFICATION, air, gens, mirs, route="kind erasure")
+        finding.diff = pilout_check.canonical_diff(
+            pilout_check.to_poly(gens[0].expr), pilout_check.to_poly(mirs[0].expr))
+        finding.kind_pairs = _kind_pairs(gens[0].expr, mirs[0].expr)
+        findings.append(finding)
+        reclassified_gen.update(id(e) for e in gens)
+        reclassified_mir.update(id(c) for c in mirs)
+
+    gaps = [e for e in gen_left if id(e) not in reclassified_gen]
+    strengthenings = [c for c in mir_left if id(c) not in reclassified_mir]
+
+    for canon in sorted({e.canon for e in gaps},
+                        key=lambda k: min(e.index for e in gaps if e.canon == k)):
+        group = [e for e in gaps if e.canon == canon]
+        finding = Finding(GAP, air, group, [])
+        finding.nearest = _nearest(group[0], strengthenings)
+        if finding.nearest is not None:
+            finding.diff = pilout_check.canonical_diff(
+                pilout_check.to_poly(group[0].expr),
+                pilout_check.to_poly(finding.nearest[0].expr))
+            finding.scalar = _scalar_factor(
+                pilout_check.to_poly(group[0].expr),
+                pilout_check.to_poly(finding.nearest[0].expr))
+        finding.out_of_root = _out_of_root_claims(air, group)
+        findings.append(finding)
+
+    seen: set[tuple] = set()
+    for clause in strengthenings:
+        if clause.canon in seen:
+            continue
+        seen.add(clause.canon)
+        group = [c for c in strengthenings if c.canon == clause.canon]
+        finding = Finding(STRENGTHENING, air, [], group)
+        finding.implied = _implied_by(group[0], generated)
+        findings.append(finding)
+
+    # `UNBACKED` clauses never enter the canonical pairing: an equation with a
+    # projection this AIR has no lane for has no canonical form to pair with. They
+    # are findings all the same -- an assertion the AIR's vocabulary cannot carry
+    # is not the same thing as a clause that is out of scope.
+    for clause in unbacked or []:
+        findings.append(Finding(UNBACKED, air, [], [clause]))
+    return findings
+
+
+def _kind_pairs(gen_expr: tuple, mir_expr: tuple) -> list[tuple[tuple, tuple]]:
+    """The atoms that differ between the two sides but share an erased slot."""
+    gen_atoms = set(lean_parse.iter_atoms(gen_expr))
+    mir_atoms = set(lean_parse.iter_atoms(mir_expr))
+    by_slot: dict[tuple, tuple] = {
+        erase_lane_kind(atom): atom for atom in mir_atoms - gen_atoms}
+    return sorted(
+        (atom, by_slot[erase_lane_kind(atom)])
+        for atom in gen_atoms - mir_atoms
+        if erase_lane_kind(atom) in by_slot
+    )
+
+
+def _nearest(entry: Generated,
+             candidates: list[Clause]) -> tuple[Clause, int, int] | None:
+    """The strengthening clause sharing the most monomials with a gap, if any.
+
+    Presentation only, never classification: two polynomials sharing monomials is
+    a hint about where to look, not a verdict that they were meant to be the same
+    constraint, so the shared count is printed alongside and the reader judges. A
+    candidate sharing nothing is not reported at all, because "these have no
+    monomial in common" is not a lead.
+    """
+    left = pilout_check.to_poly(entry.expr)
+    best: tuple[Clause, int, int] | None = None
+    for clause in candidates:
+        right = pilout_check.to_poly(clause.expr)
+        differing = len(pilout_check.canonical_diff(left, right))
+        shared = left.num_terms() + right.num_terms() - differing
+        if shared <= 0:
+            continue
+        if best is None or differing < best[1]:
+            best = (clause, differing, shared)
+    return best
+
+
+def _scalar_factor(left: poly.Poly, right: poly.Poly) -> int | None:
+    """`s != 0` with `left == s * right`, or None.
+
+    Matching is exact canonical equality, so `e = 0` written as `-e = 0` reads as
+    a gap plus a strengthening. As ASSERTIONS the two are the same constraint
+    over a field, so a pair related by a scalar is a presentation difference and
+    saying so is the difference between a reviewer spending a minute and an hour.
+    It is printed on the finding, never used to reclassify it: this tool decides
+    canonical equality, and softening that decision is how a matcher starts
+    accepting things nobody chose. At HEAD no pair is related this way.
+    """
+    if not left.terms or not right.terms or len(left.terms) != len(right.terms):
+        return None
+    mono = min(right.terms)
+    if mono not in left.terms:
+        return None
+    scalar = left.terms[mono] * pow(right.terms[mono], poly.P - 2, poly.P) % poly.P
+    scaled = poly.Poly({m: c * scalar for m, c in right.terms.items()})
+    return scalar if scaled.canonical() == left.canonical() else None
+
+
+def _square_free(polynomial: poly.Poly, atoms: frozenset) -> poly.Poly:
+    """Reduce by `x*x = x` for each atom in `atoms`."""
+    if not atoms:
+        return polynomial
+    out: dict[tuple, int] = {}
+    for mono, coeff in polynomial.terms.items():
+        key = tuple(sorted((k, 1 if k in atoms else e) for k, e in mono))
+        out[key] = out.get(key, 0) + coeff
+    return poly.Poly(out)
+
+
+def _cofactor_family(shared: list) -> list[tuple[str, poly.Poly]]:
+    """The cofactors this search tries, as `(printed form, polynomial)`.
+
+    A general "is A a multiple of B" search is a multivariate division, and
+    division does not survive the `x*x = x` reduction the interesting case needs:
+    `(1 - L1) * generated` is DEGREE 4 where the mirror clause is degree 3, and
+    they agree only after the reduction collapses `L1*L1`. So this does not
+    divide at all. It enumerates a small declared family of cofactors and
+    VERIFIES each by multiplying out -- the verification is exact, and only the
+    search is a heuristic. The family is one atom wide:
+
+        c,  c * a,  c * (1 - a)
+
+    for `a` an atom of either side and `c` a nonzero field scalar (the scalar is
+    recovered afterwards, so only the three shapes are enumerated). A cofactor
+    outside this family is not found, and not finding one is not evidence that
+    none exists -- which is why a miss only ever leaves the AGENTS.md demand
+    standing, and never asserts anything.
+    """
+    one = poly.Poly.const(1)
+    out: list[tuple[str, poly.Poly]] = [("1", one)]
+    for key in shared:
+        atom = poly.Poly.atom(key)
+        name = pilout_check.fmt_atom(key)
+        out.append((name, atom))
+        out.append((f"1 - {name}", one - atom))
+    return out
+
+
+@dataclass(frozen=True)
+class Implication:
+    """A generated constraint that entails a mirror clause: mirror = q * gen."""
+
+    generated: Generated
+    cofactor: str
+    scalar: int
+    boolean: tuple
+
+
+def _implied_by(clause: Clause,
+                generated: list[Generated]) -> Implication | None:
+    """A comparable generated constraint of which this clause is a multiple.
+
+    `STRENGTHENING` is a SYNTACTIC class -- no generated constraint carries this
+    canonical form -- and the set of clauses with no twin is not the set of
+    clauses asserting more than the AIR. A clause that is a polynomial multiple
+    of a generated constraint is *implied* by it wherever the multiplier is
+    defined, so it is strictly WEAKER, and AGENTS.md's demand for a source
+    citation and a constructibility argument is a demand about the other
+    direction. Reporting a weakening under that banner sends a reviewer to argue
+    for something that needs no argument, and buries a real extra hypothesis in
+    the same pile.
+
+    Tried twice: as polynomials, and again reducing `x*x = x` on the pair's fixed
+    lanes. The second answer is CONDITIONAL and is reported with its condition
+    attached -- whether a fixed column only ever takes the values 0 and 1 is a
+    fact about that column's materialised values, which this tool declares out of
+    scope and does not decide.
+    """
+    left = pilout_check.to_poly(clause.expr)
+    if not left.terms:
+        return None
+    for entry in generated:
+        right = pilout_check.to_poly(entry.expr)
+        if not right.terms:
+            continue
+        fixed = frozenset(
+            key for key in (left.atoms() | right.atoms()) if key[0] == "pre")
+        shared = sorted(left.atoms() & right.atoms())
+        for boolean in ((), tuple(sorted(fixed))) if fixed else ((),):
+            reduce = frozenset(boolean)
+            target = _square_free(left, reduce)
+            for name, cofactor in _cofactor_family(shared):
+                product = _square_free(cofactor * right, reduce)
+                scalar = _scalar_factor(target, product)
+                if scalar is not None:
+                    return Implication(entry, name, scalar, boolean)
+    return None
+
+
+def _out_of_root_claims(air: str, group: list[Generated]) -> list[str]:
+    """Declared mirrors OUTSIDE the mirror root that claim a gapped index.
+
+    `survey.DELEGATED` records mirrors a mirror-root declaration reaches but that
+    are themselves declared elsewhere. This tool parses only the mirror root, so
+    such a constraint is still a gap *here* -- nothing compared it -- but calling
+    it unmirrored would be the opposite of true. The claim is printed as a claim,
+    unverified, and it does not stop the finding being a gap.
+    """
+    indices = {entry.index for entry in group}
+    return [
+        f"{name} {site} claims it (survey.DELEGATED, an audited reading)"
+        for claim_air, site, name, claimed in survey.DELEGATED
+        if claim_air == air and indices & claimed
+    ]
+
+
+# ------------------------------------------------------------------ reachability
+
+
+def unreachable_mirrors(mirror_root: Path) -> dict[tuple[str, str], int]:
+    """Inventoried mirrors that no checked-in Lean references outside their head.
+
+    `survey.reference_counts` does the counting, over `ZiskFv/`, `trust/` and
+    `Tests/`; the discount of a declaration's own head line is per NAME over
+    every Prop-valued declaration, so a name shared by twelve `Spec`s is
+    discounted twelve times. That makes a positive count an upper bound and only
+    a count of zero conclusive -- which is the direction that matters here.
+    """
+    props = [
+        decl
+        for path in sorted(mirror_root.rglob("*.lean"))
+        for decl in survey.declarations(path, survey.canonical_rel(path, mirror_root))
+        if survey.is_prop_valued(decl)
+    ]
+    refs = survey.reference_counts({decl.name for decl in props})
+    own: dict[str, int] = defaultdict(int)
+    for decl in props:
+        own[decl.name] += 1
+    return {
+        (decl.path, decl.name): refs[decl.name] - own[decl.name]
+        for decl in props
+        if refs[decl.name] - own[decl.name] == 0
+        and (decl.path, decl.name) in survey.CLASSIFICATION
+        and survey.CLASSIFICATION[(decl.path, decl.name)].cls in survey.MIRROR_CLASSES
+    }
+
+
+def shared_prop_names(mirror_root: Path) -> list[tuple[str, str, int]]:
+    """Inventoried mirrors whose NAME is borne by another Prop declaration too.
+
+    `unreachable_mirrors` subtracts a per-NAME head-line discount from a per-NAME
+    reference count, so for a shared name the subtraction only reaches zero if
+    every declaration bearing it dies at once. A dead `Spec` among live `Spec`s
+    counts as coverage and raises no hollow-match flag. The upper-bound caveat was
+    documented; this consequence for coverage was not, so the affected mirrors are
+    now named on every run instead of left to be re-derived.
+    """
+    props = [
+        decl
+        for path in sorted(mirror_root.rglob("*.lean"))
+        for decl in survey.declarations(path, survey.canonical_rel(path, mirror_root))
+        if survey.is_prop_valued(decl)
+    ]
+    borne: dict[str, int] = defaultdict(int)
+    for decl in props:
+        borne[decl.name] += 1
+    return sorted(
+        (decl.path, decl.name, borne[decl.name])
+        for decl in props
+        if borne[decl.name] > 1
+        and (decl.path, decl.name) in survey.CLASSIFICATION
+        and survey.CLASSIFICATION[(decl.path, decl.name)].cls in survey.MIRROR_CLASSES
+    )
+
+
+# ------------------------------------------------------------------ scope checks
+
+
+def scope_failures(extraction: Path) -> list[str]:
+    """`DECLARED_AIRS` held against the build's and the extractor's declarations.
+
+    This is #303's own scope gate, called rather than re-implemented. Without it
+    the generated denominator here was reducible by a one-word edit: dropping an
+    AIR from `lanes.DECLARED_AIRS` -- which is `check.DECLARED_AIRS`, re-exported
+    -- took its constraints out of the denominator AND out of `survey.air_facts`,
+    so the two-implementation cross-check agreed about an AIR neither of them
+    looked at, and nothing said an AIR had left the run.
+    """
+    probe = pilout_check.Run(
+        pilout_path="", extraction_dir=str(extraction), prime=poly.P, byte_order="")
+    wiring = None
+    try:
+        wiring = lean_wiring.parse_wiring_file(lean_wiring.wiring_path(str(extraction)))
+    except (lean_wiring.WiringParseError, OSError) as error:
+        probe.global_failures.append(
+            f"scope: LookupWiring.lean is unreadable, so the extractor's own AIR "
+            f"manifest cannot be held against DECLARED_AIRS: {error}")
+    emitted = pilout_atoms.extracted_air_names(str(extraction))
+    pilout_check._check_scope(probe, str(extraction), str(REPO_ROOT), emitted, wiring)
+    return list(probe.global_failures)
+
+
+def lane_gate_failures(pilout: pilout_wire.PilOut) -> list[str]:
+    """`lanes.gate_lane_map`, which nothing in this driver used to call.
+
+    The lane map is the whole mirror-side vocabulary: it decides what column a
+    field name means. `lanes.py` gates it -- closed in both directions, header
+    agreeing with the symbol reconstruction, no duplicate name where uniqueness
+    is required, every constraint atom resolving -- and that gate ran only when a
+    person ran `lanes.py` by hand.
+    """
+    report = lanes.gate_lane_map(pilout)
+    return ([f"lane map: {message}" for message in report.failures]
+            + [f"lane map {gate.air_name}: {message}"
+               for gate in report.airs for message in gate.failures])
+
+
+@dataclass
+class NearMissScreen:
+    """Re-parse of every NEAR_*-classified declaration under the mirror root.
+
+    The mirror scope is `survey.CLASSIFICATION`, and `survey.py` gates that a
+    declaration is classified -- not that it is classified into the compared set.
+    Moving one entry from `MIRROR_VALIDATOR` to `NEAR_SEMANTIC` is a
+    reclassification, not a deletion, so the survey gate stays green while a whole
+    `Valid_<AIR>` validator leaves the comparison. Where the mirror is redundantly
+    backed that changes no matched/gap/strengthening count at all.
+
+    So every near-miss is parsed with the mirror parser and required to yield no
+    comparable polynomial equation. A near-miss that does carry one is a mirror
+    classified out of the audit, and a failure.
+
+    `refused` is the screen's own limit, disclosed rather than folded into the
+    verdict: the parser rejects most near-misses outright (they are bus
+    predicates, `.val` bounds, ℕ statements), and for those "no equation found"
+    means "the parser could not read it", not "it carries no equation".
+    """
+
+    screened: int = 0
+    refused: list[str] = field(default_factory=list)
+    carrying: list[str] = field(default_factory=list)
+    equation_free: set[tuple[str, str]] = field(default_factory=set)
+
+    @property
+    def failures(self) -> list[str]:
+        return list(self.carrying)
+
+
+def near_miss_screen(lane_map_for) -> NearMissScreen:
+    """Parse every NEAR_*-classified mirror-root declaration as if it were one."""
+    out = NearMissScreen()
+    near = sorted((rel, name, entry)
+                  for (rel, name), entry in survey.CLASSIFICATION.items()
+                  if entry.cls not in survey.MIRROR_CLASSES)
+    original = dict(survey.CLASSIFICATION)
+    try:
+        for rel, name, entry in near:
+            out.screened += 1
+            survey.CLASSIFICATION.clear()
+            survey.CLASSIFICATION[(rel, name)] = dataclasses.replace(
+                entry, cls="MIRROR")
+            try:
+                parsed = mirror_parse.parse_mirror_file(
+                    mirror_parse.REPO_ROOT / rel, lane_map_for)
+            except Exception as error:  # noqa: BLE001 - the screen must not abort
+                out.refused.append(f"{rel} {name}: {type(error).__name__}: {error}")
+                continue
+            equations = [clause for definition in parsed
+                         for clause in definition.clauses if clause.comparable]
+            if equations:
+                out.carrying.append(
+                    f"{rel}:{parsed[0].line} {name} [{entry.cls}]: classified out "
+                    f"of the compared set but carries {len(equations)} comparable "
+                    f"polynomial equation(s), so nothing compares them")
+            elif any(definition.unparsed for definition in parsed):
+                out.refused.append(
+                    f"{rel} {name}: {parsed[0].unparsed[0][:120]}")
+            else:
+                out.equation_free.add((rel, name))
+    finally:
+        survey.CLASSIFICATION.clear()
+        survey.CLASSIFICATION.update(original)
+    return out
+
+
+def projection_failures(defs: list[mirror_parse.MirrorDef],
+                        mirror_root: Path) -> list[str]:
+    """Every resolved projection must be a field of the row record it claims.
+
+    The field-to-lane resolution is the direct analogue of `h998ExprToField`, and
+    nothing audited it against the record: a leaf resolving onto a lane was
+    accepted whether or not the declared row record has such a field. That is the
+    half of the totality question this tool can answer -- the other half, whether
+    every field of the record has a lane, is a coverage claim this tool does not
+    make -- and it is the half that catches a projection of a field that is not
+    there.
+    """
+    known = {name: survey.structure_fields(survey.resolve_rel(rel, mirror_root), name)
+             for rel, name, _air in survey.MIRROR_RECORDS}
+    flat = {name: set(survey.flatten_record(mirror_root, rel, name, known))
+            for rel, name, _air in survey.MIRROR_RECORDS}
+    out: list[str] = []
+    for definition in defs:
+        record = definition.row_record
+        if record is None or record not in flat:
+            continue
+        for (carrier, path), lane in sorted(definition.projections.items()):
+            binder = definition.row_vars
+            if carrier not in binder:
+                continue
+            if path not in flat[record]:
+                out.append(
+                    f"{definition.site} {definition.name}: projection "
+                    f"{carrier}.{path} resolved to lane {lane}, but {record} has "
+                    f"no such field -- the field-to-lane map accepted a name the "
+                    f"row record does not carry")
+    return out
+
+
+# --------------------------------------------------------- classifier self-check
+
+
+def _canonicaliser_self_test() -> list[str]:
+    """A second opinion on the one decider, which both sides fold through.
+
+    Every verdict here is `poly.canonical()` equality, and BOTH the generated and
+    the mirror expression fold to a `Poly` through the same `check.to_poly`. A
+    defect in that fold cancels rather than showing up: two sides folded
+    identically wrong still match, and the same cancellation exists inside #303,
+    so neither round trip validates the fold. `poly.py` ships a self-test and
+    `poly.random_screen` is an independent evaluator; nothing here ran either.
+
+    Both run now: the module self-test (its output is captured, since this is a
+    check and not a report), and a screen of `canonical()` against evaluation at
+    pseudo-random points over a handful of shapes with the operators this tool
+    actually emits, including the subtraction whose mis-folding would be
+    invisible.
+    """
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        failed = poly._run_self_test()
+    out: list[str] = []
+    if failed:
+        out.append(f"poly.py self-test reports {failed} failure(s): the "
+                   f"canonicaliser both sides fold through is not sound")
+    a = ("atom", ("main", 1, 0, 0))
+    b = ("atom", ("main", 1, 1, 0))
+    c = ("atom", ("pre", 0, 0))
+    for name, left, right, same in (
+        ("a - b is not a + b", ("sub", a, b), ("add", a, b), False),
+        ("a - b folds as a + (-1)*b", ("sub", a, b),
+         ("add", a, ("mul", ("const", poly.P - 1), b)), True),
+        ("neg is -1 times", ("neg", a), ("mul", ("const", poly.P - 1), a), True),
+        ("(a-b)*c expands", ("mul", ("sub", a, b), c),
+         ("sub", ("mul", a, c), ("mul", b, c)), True),
+        ("a*b is not a*a", ("mul", a, b), ("mul", a, a), False),
+    ):
+        folded_left = pilout_check.to_poly(left)
+        folded_right = pilout_check.to_poly(right)
+        decided = folded_left.canonical() == folded_right.canonical()
+        screened = poly.random_screen(folded_left, folded_right)
+        if decided != same or screened != same:
+            out.append(f"canonicaliser screen: {name}: canonical says "
+                       f"{decided}, random evaluation says {screened}, expected "
+                       f"{same}")
+    return out
+
+
+def _erasure_self_check() -> list[str]:
+    """The `RECLASSIFICATION` class fires on a synthetic defect, and only then.
+
+    `RECLASSIFICATION` finds nothing at HEAD. A class that has never fired is a
+    class nobody has seen work, so it is exercised here on the two shapes it
+    claims -- a fixed column modelled as a witness, a stage-2 lane as stage-1 --
+    plus a negative control that must stay a gap and a strengthening.
+    """
+    def air(*clauses: tuple) -> list[Clause]:
+        return [
+            Clause(air="T", definition="synthetic", cls="MIRROR", file="<self-check>",
+                   def_line=0, line=0, index=i, text="", expr=expr,
+                   canon=canonical(expr), erased=erased_canonical(expr))
+            for i, expr in enumerate(clauses)
+        ]
+
+    def gen(*exprs: tuple) -> list[Generated]:
+        return [
+            Generated(air="T", index=i, suffix="every_row", provenance="",
+                      expr=expr, canon=canonical(expr), erased=erased_canonical(expr))
+            for i, expr in enumerate(exprs)
+        ]
+
+    fixed = ("mul", ("atom", ("pre", 0, 0)), ("atom", ("main", 1, 4, 0)))
+    as_witness = ("mul", ("atom", ("main", 1, 0, 0)), ("atom", ("main", 1, 4, 0)))
+    stage2 = ("atom", ("main", 2, 7, 0))
+    stage1 = ("atom", ("main", 1, 7, 0))
+    other = ("atom", ("main", 1, 99, 0))
+
+    failures: list[str] = []
+    for name, left, right, expected in (
+        ("fixed column as witness", fixed, as_witness, RECLASSIFICATION),
+        ("stage-2 lane as stage-1", stage2, stage1, RECLASSIFICATION),
+        ("unrelated lane", fixed, other, GAP),
+    ):
+        kinds = {f.kind for f in pair_air("T", gen(left), air(right))}
+        if expected == RECLASSIFICATION and kinds != {RECLASSIFICATION}:
+            failures.append(f"{name}: expected RECLASSIFICATION, got {sorted(kinds)}")
+        if expected == GAP and kinds != {GAP, STRENGTHENING}:
+            failures.append(f"{name}: expected a gap and a strengthening, "
+                            f"got {sorted(kinds)}")
+    identical = {f.kind for f in pair_air("T", gen(fixed), air(fixed))}
+    if identical != {MATCHED}:
+        failures.append(f"identical expressions: got {sorted(identical)}")
+    return failures
+
+
+# ----------------------------------------------------------------------- the run
+
+
+@dataclass
+class AirRun:
+    air: str
+    generated: list[Generated]
+    excluded: list[int]
+    mirror: MirrorSide
+    findings: list[Finding]
+
+    def of_kind(self, kind: str) -> list[Finding]:
+        return [f for f in self.findings if f.kind == kind]
+
+    def gen_count(self, kind: str) -> int:
+        return sum(len(f.generated) for f in self.of_kind(kind))
+
+    def mir_count(self, kind: str) -> int:
+        return sum(len(f.clauses) for f in self.of_kind(kind))
+
+
+@dataclass
+class Run:
+    airs: list[AirRun] = field(default_factory=list)
+    unreachable: dict[tuple[str, str], int] = field(default_factory=dict)
+    shared_names: list[tuple[str, str, int]] = field(default_factory=list)
+    hollow: dict[str, list[int]] = field(default_factory=dict)
+    self_check: list[str] = field(default_factory=list)
+    rule_agreement: list[str] = field(default_factory=list)
+    # The scope declarations, each held against something outside this package.
+    coverage: survey.Coverage | None = None
+    scope: list[str] = field(default_factory=list)
+    lane_gate: list[str] = field(default_factory=list)
+    projections: list[str] = field(default_factory=list)
+    screen: NearMissScreen | None = None
+    empty: list[str] = field(default_factory=list)
+    fold_check: list[str] = field(default_factory=list)
+    partial: bool = False
+    definitions: int = 0
+
+    @property
+    def delegation_evidence(self) -> tuple[list[str], list[str]]:
+        """Near-miss delegations the screen corroborated, and the ones it did not.
+
+        The delegation exclusion's citation used to say the delegate "is itself
+        inventoried and compared here", and `mirror_parse` marked a delegate
+        declared if `survey.CLASSIFICATION` named it at ANY class -- so for the
+        NEAR_*-classified delegates the citation was false: inventoried, compared
+        by nothing. The screen is what makes it true or withdraws it.
+        """
+        free = self.screen.equation_free if self.screen else set()
+        corroborated: list[str] = []
+        uncorroborated: list[str] = []
+        for air in self.airs:
+            for where, rel, name in air.mirror.near_miss_delegations:
+                if (rel, name) in free:
+                    corroborated.append(where)
+                else:
+                    uncorroborated.append(where)
+        return sorted(corroborated), sorted(uncorroborated)
+
+    @property
+    def scope_failures(self) -> list[str]:
+        """Everything that says the run's own scope is not what it claims."""
+        return ((self.coverage.failures if self.coverage else [])
+                + self.scope + self.lane_gate + self.projections
+                + (self.screen.failures if self.screen else [])
+                + self.empty + self.fold_check
+                + [message for a in self.airs
+                   for message in a.mirror.notes + a.mirror.path_aliases
+                   + a.mirror.row_order_mismatches])
+
+    @property
+    def failures(self) -> int:
+        return (sum(a.gen_count(GAP) + a.mir_count(STRENGTHENING)
+                    + a.mir_count(UNBACKED)
+                    + len(a.of_kind(RECLASSIFICATION)) + len(a.mirror.unparsed)
+                    + len(a.mirror.undeclared_unresolved)
+                    + len(a.mirror.undeclared_delegations) for a in self.airs)
+                + len(self.unreachable) + len(self.self_check)
+                + len(self.rule_agreement) + len(self.scope_failures))
+
+
+def run_check(pilout_path: Path, extraction: Path, mirror_root: Path,
+              only: set[str] | None) -> Run:
+    pilout = pilout_wire.load(pilout_path)
+    facts = survey.air_facts(pilout)
+    cache: dict[str, lanes.LaneMap] = {}
+
+    def lane_map_for(air: str):
+        if air not in cache:
+            cache[air] = lanes.lane_map(pilout, air)
+        return cache[air]
+
+    out = Run(partial=only is not None)
+    out.self_check = _erasure_self_check()
+    # `poly.canonical()` is the sole decider here and BOTH sides fold through the
+    # same `check.to_poly`, so a defect in the fold cancels: two sides folded
+    # identically wrong still match. #303 keeps a second opinion by screening
+    # `canonical()` against `poly.random_screen`; this run had none, and did not
+    # even run the module's own self-test.
+    out.fold_check = _canonicaliser_self_test()
+    # The mirror scope is `survey.CLASSIFICATION`, and this run reads that table
+    # without ever gating it. A new mirror predicate is added by writing a `def`,
+    # not by editing a list, so an unclassified one is invisible to a scope that
+    # is a declared list.
+    out.coverage = survey.coverage(mirror_root)
+    out.scope = scope_failures(extraction)
+    out.lane_gate = lane_gate_failures(pilout)
+    out.screen = near_miss_screen(lane_map_for)
+    unreachable = unreachable_mirrors(mirror_root)
+    out.shared_names = shared_prop_names(mirror_root)
+    # A filtered run must not fail on a finding outside the AIRs it was asked
+    # about; it also must not claim to have covered them, which is what PARTIAL
+    # says. Clause labelling still uses the unfiltered set, so an unreachable
+    # mirror of another AIR is never mislabelled as reachable.
+    out.unreachable = {
+        key: count for key, count in unreachable.items()
+        if only is None or survey.CLASSIFICATION[key].air in only
+    }
+
+    defs = mirror_parse.parse_all(lane_map_for)
+    out.definitions = len(defs)
+    out.projections = projection_failures(defs, mirror_root)
+    mirrors = load_mirrors(defs, set(unreachable))
+
+    for air in lanes.DECLARED_AIRS:
+        if only is not None and air not in only:
+            continue
+        generated, excluded = load_generated(extraction, air)
+        # Two independent implementations of the issue's comparable rule: this
+        # one over the emitted Lean's accessors, `survey.air_facts` over the
+        # pilout's operands. Disagreement means one of them is not the rule.
+        if sorted(e.index for e in generated) != sorted(facts[air].comparable):
+            out.rule_agreement.append(
+                f"{air}: the comparable set from the emitted Lean "
+                f"({len(generated)}) disagrees with the pilout-side set "
+                f"({len(facts[air].comparable)})")
+        side = mirrors.get(air, MirrorSide())
+        findings = pair_air(air, generated, side.comparable, side.unbacked)
+        run = AirRun(air, generated, excluded, side, findings)
+        if run.gen_count(MATCHED) + run.gen_count(RECLASSIFICATION) + run.gen_count(
+                GAP) != len(generated):
+            raise pilout_check.CheckError(
+                f"{air}: generated constraints do not partition into "
+                f"matched/reclassified/gap")
+        if run.mir_count(MATCHED) + run.mir_count(RECLASSIFICATION) + run.mir_count(
+                STRENGTHENING) != len(side.comparable):
+            raise pilout_check.CheckError(
+                f"{air}: mirror clauses do not partition into "
+                f"matched/reclassified/strengthening")
+        if run.mir_count(UNBACKED) != len(side.unbacked):
+            raise pilout_check.CheckError(
+                f"{air}: UNBACKED clauses do not partition")
+        out.airs.append(run)
+
+    # Exit 0 used to require only that no finding fired, which an empty run
+    # satisfies: with no AIR in scope the summary read `OK 0/0 ... across 0
+    # air(s)` and exited 0. Nothing decided is not success. A per-AIR non-zero
+    # floor would be wrong -- `BinaryExtension` legitimately has 0 comparable
+    # constraints, all 8 of its constraints reaching a challenge -- so the floor
+    # is on the run: every declared AIR present, and something actually compared.
+    expected_airs = (len(lanes.DECLARED_AIRS) if only is None
+                     else len(only & set(lanes.DECLARED_AIRS)))
+    if len(out.airs) != expected_airs:
+        out.empty.append(
+            f"the run covered {len(out.airs)} AIR(s) where {expected_airs} were "
+            f"in scope")
+    if not sum(len(a.generated) for a in out.airs):
+        out.empty.append(
+            "no comparable generated constraint entered the run, so nothing was "
+            "decided; a zero denominator is not a pass")
+    if not sum(len(a.mirror.comparable) for a in out.airs):
+        out.empty.append(
+            "no comparable mirror clause entered the run, so nothing was "
+            "compared against the generated side")
+
+    for run in out.airs:
+        hollow = sorted(
+            entry.index
+            for finding in run.of_kind(MATCHED) + run.of_kind(RECLASSIFICATION)
+            for entry in finding.generated
+            if finding.clauses and all(c.unreachable for c in finding.clauses)
+        )
+        if hollow:
+            out.hollow[run.air] = hollow
+    return out
+
+
+# ------------------------------------------------------------------- the report
+
+_TABLE = "{:<18} {:>9} {:>7} {:>7} {:>5} {:>11} {:>4} {:>9} {:>8} {:>6}"
+
+
+def print_declarations(run: Run, out) -> None:
+    print("declared scope -- what fixes the two denominators, and what holds it",
+          file=out)
+    coverage = run.coverage
+    print(f"  mirror side   survey.CLASSIFICATION: {run.definitions} MIRROR-class "
+          f"definition(s) parsed, {len(survey.CLASSIFICATION)} classified "
+          f"declaration(s) over "
+          f"{coverage.props if coverage else '?'} Prop-valued declaration(s) "
+          f"under the mirror root", file=out)
+    print(f"                held by survey.coverage (nothing unclassified, no "
+          f"entry naming a vanished declaration) and by the near-miss screen "
+          f"below", file=out)
+    print(f"  generated     lanes.DECLARED_AIRS: {len(lanes.DECLARED_AIRS)} AIR(s), "
+          f"{', '.join(lanes.DECLARED_AIRS)}", file=out)
+    print("                held by check._check_scope against "
+          "nix/extracted-lean.nix, LookupWiring.lean's airStatus manifest and "
+          "the emitted files, in both directions", file=out)
+    print(file=out)
+    print("declared exclusions -- the complete list, category-level, each cited",
+          file=out)
+    carried = {
+        "challenge_or_stage2": sum(len(a.excluded) for a in run.airs),
+        "mirror_carrier_not_a_row": sum(a.mirror.not_a_row for a in run.airs),
+        "mirror_clause_not_an_equation":
+            sum(a.mirror.not_an_equation for a in run.airs),
+    }
+    for entry in DECLARED_EXCLUSIONS:
+        print(f"  [{entry.side:<9}] {entry.key}   carries "
+              f"{carried[entry.key]}", file=out)
+        print(f"      rule  {entry.rule}", file=out)
+        print(f"      cite  {entry.citation}", file=out)
+        # The mirror-side entries name every clause they swallowed. Truncating
+        # this list is how an exclusion stops being auditable, so it is not
+        # truncated at HEAD; a list too long to read is a finding to report.
+        sites = sorted(site for air in run.airs
+                       for site in air.mirror.excluded_sites.get(entry.key, ()))
+        for site in sites[:SITES_SHOWN]:
+            print(f"      took  {site}", file=out)
+        if len(sites) > SITES_SHOWN:
+            print(f"      took  ... and {len(sites) - SITES_SHOWN} more -- a list "
+                  f"this long is a finding, not a bucket", file=out)
+        if entry.key == "mirror_clause_not_an_equation":
+            corroborated, uncorroborated = run.delegation_evidence
+            print(f"      of the delegations above, {len(corroborated)} reach a "
+                  f"NEAR_*-classified delegate the near-miss screen parsed and "
+                  f"found equation-free", file=out)
+            for where in corroborated:
+                print(f"        screened  {where}", file=out)
+            if uncorroborated:
+                print(f"      {len(uncorroborated)} reach a NEAR_*-classified "
+                      f"delegate the screen could NOT parse, so for those the "
+                      f"exclusion's citation is uncorroborated -- the delegate "
+                      f"carries no equation this tool could find, which is not "
+                      f"the same as carrying none", file=out)
+                for where in uncorroborated:
+                    print(f"        unscreened  {where}", file=out)
+    print(f"  {len(DECLARED_EXCLUSIONS)} entries, none naming an individual "
+          f"constraint index or mirror clause.", file=out)
+    print("  A per-index entry, or a list too long to read here, is a finding to "
+          "report -- not a place to append.", file=out)
+    print("  There is no `mirror_field_has_no_lane` entry any more: an equation "
+          "over a field with no lane is the UNBACKED finding class, not an "
+          "exclusion. Its per-field citations are printed on each finding.",
+          file=out)
+    print(file=out)
+
+
+def print_table(run: Run, out) -> None:
+    print(_TABLE.format("air", "generated", "mirror", "matched", "gap",
+                        "strengthen", "recl", "unbacked", "unparsed", "unres"),
+          file=out)
+    print("-" * 96, file=out)
+    totals = [0] * 9
+    for air in run.airs:
+        row = [
+            len(air.generated), len(air.mirror.comparable),
+            air.gen_count(MATCHED), air.gen_count(GAP),
+            air.mir_count(STRENGTHENING), len(air.of_kind(RECLASSIFICATION)),
+            air.mir_count(UNBACKED),
+            len(air.mirror.unparsed), len(air.mirror.undeclared_unresolved),
+        ]
+        totals = [t + v for t, v in zip(totals, row)]
+        print(_TABLE.format(air.air, *row), file=out)
+    print("-" * 96, file=out)
+    print(_TABLE.format("TOTAL", *totals), file=out)
+    print("  generated  = comparable generated constraints (total minus the "
+          "declared challenge/stage-2 exclusion)", file=out)
+    print("  mirror     = comparable mirror clauses (polynomial identity, every "
+          "projection resolved)", file=out)
+    print("  matched    = comparable generated constraints with a mirror clause "
+          "of the same canonical form", file=out)
+    print("  unbacked   = equation clauses this AIR has no lane vocabulary for, "
+          "so no generated constraint can carry them", file=out)
+    print("  unres      = UNDECLARED unresolved projections; the declared ones "
+          "are counted in the exclusion table", file=out)
+    print(file=out)
+
+
+def print_pairings(run: Run, out) -> None:
+    print("pairings, set-to-set -- a mirror clause pairs by canonical form, not "
+          "by index", file=out)
+    for air in run.airs:
+        # Reclassified pairings are pairings; leaving them out of this listing
+        # would make the paired set look smaller than it is.
+        paired = sorted(air.of_kind(MATCHED) + air.of_kind(RECLASSIFICATION),
+                        key=lambda f: f.generated[0].index if f.generated else -1)
+        for finding in paired:
+            gens = ", ".join(f"#{e.index}" for e in finding.generated)
+            mirs = ", ".join(
+                f"{c.label}{' [UNREACHABLE]' if c.unreachable else ''}"
+                for c in finding.clauses)
+            flag = "  [many]" if finding.many_to_many else ""
+            if finding.kind == RECLASSIFICATION:
+                flag += f"  [RECLASSIFICATION: {finding.route}]"
+            print(f"  {air.air:<18} {gens:<10} <- {mirs}{flag}", file=out)
+    paired = [f for a in run.airs
+              for f in a.of_kind(MATCHED) + a.of_kind(RECLASSIFICATION)]
+    many = sum(1 for f in paired if f.many_to_many)
+    redundant = [f for f in paired if len(f.clauses) > 1]
+    deletable = sum(len(f.clauses) for f in redundant)
+    same_def = sum(1 for f in redundant
+                   if len({(c.file, c.definition) for c in f.clauses}) == 1)
+    clauses = sum(len(a.mirror.comparable) for a in run.airs)
+    print(f"  {many} pairing(s) are many-to-one or one-to-many. That is not "
+          f"automatically wrong -- one generated constraint restated by both a "
+          f"`Spec` and its `Valid_<AIR>` twin is expected -- but it is where a "
+          f"double count would hide.", file=out)
+    # The magnitude of the redundancy blind spot, measured rather than described:
+    # pairing is set-to-set and coverage is counted per canonical form, never per
+    # mirror definition, so a clause in a redundantly backed form can be deleted
+    # with no change to any count.
+    print(f"  {len(redundant)} canonical form(s) are backed by MORE THAN ONE "
+          f"mirror clause; {deletable} of the {clauses} comparable mirror "
+          f"clause(s) sit in such a form and can each be deleted one at a time "
+          f"with no change to the verdict. For {same_def} of those forms both "
+          f"clauses are in ONE definition, so even the definition count does not "
+          f"move.", file=out)
+    print(file=out)
+
+
+def _print_diff(finding: Finding, out) -> None:
+    if not finding.diff:
+        return
+    print(f"    canonical symmetric difference: {len(finding.diff)} monomial(s), "
+          f"showing {min(len(finding.diff), DIFF_TERMS_SHOWN)}", file=out)
+    width = max(len(pilout_check.fmt_monomial(m))
+                for m, _, _ in finding.diff[:DIFF_TERMS_SHOWN])
+    for mono, left, right in finding.diff[:DIFF_TERMS_SHOWN]:
+        print(f"      {pilout_check.fmt_monomial(mono):<{min(width, 60)}} "
+              f" generated {pilout_check.fmt_coeff(left):>3}"
+              f"  mirror {pilout_check.fmt_coeff(right):>3}", file=out)
+
+
+def _print_clause(clause: Clause, out) -> None:
+    text = clause.text
+    if len(text) > CLAUSE_TEXT_SHOWN:
+        text = text[:CLAUSE_TEXT_SHOWN] + " ..."
+    flag = "  [UNREACHABLE]" if clause.unreachable else ""
+    print(f"    mirror   {clause.definition}#{clause.index} [{clause.cls}] "
+          f"{clause.site}{flag}", file=out)
+    print(f"      {text}", file=out)
+
+
+def _print_canonical(clause: Clause, out) -> None:
+    """A strengthening's own canonical form: there is no counterpart to diff it."""
+    terms = clause.canon
+    print(f"    canonical form: {len(terms)} monomial(s), showing "
+          f"{min(len(terms), DIFF_TERMS_SHOWN)}", file=out)
+    for mono, coeff in terms[:DIFF_TERMS_SHOWN]:
+        print(f"      {pilout_check.fmt_monomial(mono):<40} "
+              f"{pilout_check.fmt_coeff(coeff):>3}", file=out)
+
+
+def _print_reclassified(finding: Finding, out) -> None:
+    for path, name, lane, citation in finding.reclassified:
+        print(f"    lane-kind alias  {path} -> {name} {lane}", file=out)
+        print(f"      cite  {citation}", file=out)
+
+
+def print_details(run: Run, out) -> None:
+    any_printed = False
+    for air in run.airs:
+        findings = [f for f in air.findings if f.kind in FAILING_CLASSES]
+        if not findings:
+            continue
+        any_printed = True
+        print(f"== {air.air} ==", file=out)
+        for finding in findings:
+            if finding.kind == GAP:
+                for entry in finding.generated:
+                    print(f"  GAP  {entry.label}  (constraint_{entry.index}_"
+                          f"{entry.suffix})", file=out)
+                    print(f"    provenance  {entry.provenance}", file=out)
+                print("    no mirror clause of this AIR has this canonical form",
+                      file=out)
+                for claim in finding.out_of_root:
+                    print(f"    out-of-root claim: {claim}", file=out)
+                if finding.nearest is not None:
+                    clause, differing, shared = finding.nearest
+                    print(f"    nearest unmatched mirror clause: {clause.label} "
+                          f"{clause.site}, differing in {differing} monomial(s) "
+                          f"and sharing {shared} -- a lead, not a pairing",
+                          file=out)
+                    _print_clause(clause, out)
+                    if finding.scalar is not None:
+                        inverse = pow(finding.scalar, poly.P - 2, poly.P)
+                        print(f"    the two differ ONLY by a field scalar: "
+                              f"generated = {pilout_check.fmt_coeff(finding.scalar)}"
+                              f" * mirror, mirror = "
+                              f"{pilout_check.fmt_coeff(inverse)} * generated. As "
+                              f"assertions `e = 0` they are the same constraint; "
+                              f"this is a gap only because canonical forms are "
+                              f"compared exactly", file=out)
+                    _print_diff(finding, out)
+            elif finding.kind == UNBACKED:
+                clause = finding.clauses[0]
+                print(f"  UNBACKED  {air.air}: a mirror equation over a field "
+                      f"this AIR has no lane for", file=out)
+                _print_clause(clause, out)
+                for path, reason, citation in clause.laneless:
+                    print(f"    no lane  {path} ({reason})", file=out)
+                    print(f"      cite  {citation}", file=out)
+                _print_reclassified(finding, out)
+                print("    the clause has no canonical form in this AIR's "
+                      "vocabulary, so no generated constraint can carry it and "
+                      "nothing here decides it. It is reported rather than "
+                      "excluded: an equation with no lane is an ASSERTION the "
+                      "comparison cannot express, which is not the same as a "
+                      "clause that is out of scope, and bucketing it under a "
+                      "field-keyed exclusion meant any clause naming that field "
+                      "left the comparison whatever else it said.", file=out)
+                print("    what closing it needs: either a lane for the field, or "
+                      "the argument that the clause is a definition the pilout "
+                      "inlines and therefore never carries as a constraint. This "
+                      "tool supplies neither.", file=out)
+            elif finding.kind == STRENGTHENING:
+                print(f"  STRENGTHENING  {air.air}: {len(finding.clauses)} mirror "
+                      f"clause(s) with this canonical form, no generated "
+                      f"constraint has it", file=out)
+                for clause in finding.clauses:
+                    _print_clause(clause, out)
+                _print_canonical(finding.clauses[0], out)
+                _print_reclassified(finding, out)
+                # The class is SYNTACTIC -- no generated constraint carries this
+                # canonical form -- and that set is not the set of clauses
+                # asserting MORE than the AIR. A clause that is a multiple of a
+                # generated constraint is implied by it, so it is strictly weaker,
+                # and AGENTS.md's demand is about the other direction. Printing
+                # that demand on a weakening sends a reviewer to argue for
+                # something that needs no argument.
+                if finding.implied is not None:
+                    implied = finding.implied
+                    factor = ("" if implied.scalar == 1
+                              else f"{pilout_check.fmt_coeff(implied.scalar)} * ")
+                    print(f"    IMPLIED BY generated #{implied.generated.index}: "
+                          f"this clause is {factor}({implied.cofactor}) * that "
+                          f"constraint", file=out)
+                    print(f"      provenance  #{implied.generated.index} "
+                          f"{implied.generated.provenance}", file=out)
+                    if implied.boolean:
+                        print(f"      CONDITIONAL on "
+                              f"{', '.join(pilout_check.fmt_atom(a) for a in implied.boolean)}"
+                              f" taking only the values 0 and 1. Whether a fixed "
+                              f"column does is a fact about its materialised "
+                              f"values, which this tool declares out of scope and "
+                              f"does not decide -- it is stated as the condition "
+                              f"the equality holds under, not assumed.", file=out)
+                    print("    so this clause is WEAKER than the generated "
+                          "constraint, not stronger: it follows from it wherever "
+                          "the cofactor is defined. AGENTS.md asks for a source "
+                          "citation and a constructibility argument for a mirror "
+                          "asserting MORE than the AIR, and that demand does not "
+                          "apply here. What remains is the GAP half -- nothing "
+                          "restates the generated constraint itself.", file=out)
+                else:
+                    print("    the cofactor search found no generated constraint "
+                          "of this AIR that entails this clause, so it is a "
+                          "candidate for a genuine extra hypothesis. The search is "
+                          "one atom wide (`c`, `c*a`, `c*(1-a)`), so a miss is not "
+                          "evidence that none exists.", file=out)
+                    print("    AGENTS.md: a mirror constraint the generated set "
+                          "does not carry needs a SOURCE CITATION and a "
+                          "CONSTRUCTIBILITY argument. This tool reports that one "
+                          "is required; it does not supply or accept one.",
+                          file=out)
+            elif finding.route == "declared lane-kind alias":
+                gens = ", ".join(f"#{e.index}" for e in finding.generated)
+                print(f"  RECLASSIFICATION  {air.air} {gens}  "
+                      f"[{finding.route}]", file=out)
+                for entry in finding.generated:
+                    print(f"    provenance  #{entry.index} {entry.provenance}",
+                          file=out)
+                for clause in finding.clauses:
+                    _print_clause(clause, out)
+                print("    the canonical forms AGREE, but only under a declared "
+                      "lane-kind alias: a row-record field is read as a lane of "
+                      "another kind. Whether the field is pinned to that lane is "
+                      "a weld, and this tool does not check welds.", file=out)
+                _print_reclassified(finding, out)
+            else:
+                gens = ", ".join(f"#{e.index}" for e in finding.generated)
+                print(f"  RECLASSIFICATION  {air.air} {gens}  "
+                      f"[{finding.route}]", file=out)
+                for entry in finding.generated:
+                    print(f"    provenance  #{entry.index} {entry.provenance}",
+                          file=out)
+                for clause in finding.clauses:
+                    _print_clause(clause, out)
+                print("    kind-erased canonical forms agree, kind-preserving do "
+                      "not. Atoms differing only in lane kind:", file=out)
+                for gen_atom, mir_atom in finding.kind_pairs:
+                    print(f"      generated {pilout_check.fmt_atom(gen_atom):<22} "
+                          f"mirror {pilout_check.fmt_atom(mir_atom)}", file=out)
+                _print_diff(finding, out)
+            print(file=out)
+        claimed = sum(len(f.generated) for f in air.of_kind(GAP) if f.out_of_root)
+        if claimed:
+            print(f"  {claimed} of {air.gen_count(GAP)} {air.air} gap(s) are "
+                  f"claimed by a mirror declared outside the mirror root. This "
+                  f"tool parses only the root, so it compared nothing: the claim "
+                  f"neither closes the gap nor is checked by it.", file=out)
+            print(file=out)
+    if not any_printed:
+        print("no gap, strengthening or reclassification.", file=out)
+        print(file=out)
+
+
+def print_unreachable(run: Run, out) -> None:
+    print("unreachable mirrors -- defined, referenced by nothing else in "
+          "ZiskFv/, trust/ or Tests/", file=out)
+    if not run.unreachable:
+        print("  none", file=out)
+    for (rel, name), _count in sorted(run.unreachable.items()):
+        entry = survey.CLASSIFICATION[(rel, name)]
+        print(f"  {rel}  {name}  [{entry.cls}]  air {entry.air}", file=out)
+    if run.shared_names:
+        print(f"  {len(run.shared_names)} inventoried mirror(s) share their NAME "
+              f"with another Prop-valued declaration, so unreachability can only "
+              f"fire on them if every declaration bearing the name dies at once. "
+              f"A dead one among live ones counts as coverage with no hollow-match "
+              f"flag:", file=out)
+        for rel, name, borne in run.shared_names:
+            print(f"    {rel}  {name}  (the name is borne by {borne} declarations)",
+                  file=out)
+    for air, indices in sorted(run.hollow.items()):
+        print(f"  HOLLOW MATCH  {air}: {len(indices)} matched constraint(s) whose "
+              f"only mirror backing is unreachable", file=out)
+        print(f"    {', '.join(f'#{i}' for i in indices)}", file=out)
+    print("  A clause of an unreachable predicate can be canonically perfect and "
+          "still constrain nothing, because no proof consumes it. That is why a "
+          "match backed only by one is reported here rather than counted as "
+          "coverage.", file=out)
+    print("  Reachability is measured on the DECLARATION's name, so this says "
+          "nothing about the equations: `RomBoolSpec`'s fourteen are asserted by "
+          "`mainWithRom` (ZiskFv/AirsClean/Main/Constraints.lean:247-261) and "
+          "restated inline by `romBoolSpec_of_mainWithRomAndMemBus_constraints` "
+          "(ZiskFv/AirsClean/Main/Circuit.lean:397). An unreferenced predicate is "
+          "a mirror nothing consumes, not a dead constraint.", file=out)
+    print(file=out)
+
+
+def _check_line(label: str, failures: list[str], detail: str, out) -> None:
+    print(f"  {label}: {'passed' if not failures else 'FAILED'} ({detail})",
+          file=out)
+    for message in failures:
+        print(f"    FAIL {message}", file=out)
+
+
+def print_checks(run: Run, out) -> None:
+    print("checks", file=out)
+    _check_line("comparable rule, two implementations agree", run.rule_agreement,
+                "emitted-Lean accessors vs pilout operands, per AIR", out)
+    _check_line("mirror scope, survey.CLASSIFICATION describes the root exactly",
+                run.coverage.failures if run.coverage else [],
+                f"survey.coverage over "
+                f"{run.coverage.props if run.coverage else 0} Prop-valued "
+                f"declaration(s): any unclassified one, and any entry naming a "
+                f"declaration the root no longer has", out)
+    screen = run.screen
+    _check_line("near-miss screen, no classified-out declaration carries "
+                "equations", screen.failures if screen else [],
+                f"{screen.screened if screen else 0} NEAR_*-classified "
+                f"declaration(s) re-parsed as mirrors, "
+                f"{len(screen.equation_free) if screen else 0} read and found "
+                f"equation-free, {len(screen.refused) if screen else 0} the "
+                f"parser refused", out)
+    if screen and screen.refused:
+        print(f"    the {len(screen.refused)} refused are the screen's own limit, "
+              f"not a verdict: for those, `no equation found` means the parser "
+              f"could not read the declaration.", file=out)
+    _check_line("generated scope, DECLARED_AIRS holds", run.scope,
+                "check._check_scope against nix/extracted-lean.nix, the "
+                "LookupWiring airStatus manifest and the emitted files", out)
+    _check_line("lane map gate", run.lane_gate,
+                "lanes.gate_lane_map: closed in both directions, header agreeing "
+                "with the symbol reconstruction, every constraint atom resolving",
+                out)
+    _check_line("projection totality, every resolved field is a field of the row "
+                "record", run.projections,
+                "the field-to-lane map audited against the declared row record",
+                out)
+    _check_line("the run decided something", run.empty,
+                "every declared AIR present, and a non-zero comparable set on "
+                "both sides", out)
+    _check_line("canonicaliser self-test", run.fold_check,
+                "poly.py's own; both sides fold through one `to_poly`, so a "
+                "defect there cancels rather than showing up as a mismatch", out)
+    _check_line("RECLASSIFICATION classifier self-check", run.self_check,
+                "kind-erasure route, on fixed-as-witness, stage-2-as-stage-1, a "
+                "negative control and the identity; the declared-alias route is "
+                "exercised by the tree itself", out)
+    for air in run.airs:
+        for message in air.mirror.unparsed:
+            print(f"  UNPARSED {air.air}: {message}", file=out)
+        for message in air.mirror.undeclared_unresolved:
+            print(f"  UNRESOLVED {air.air}: {message}", file=out)
+        for message in air.mirror.undeclared_delegations:
+            print(f"  UNDECLARED DELEGATION {air.air}: {message}", file=out)
+        for message in air.mirror.notes:
+            print(f"  DEFINITION NOTE {air.air}: {message}", file=out)
+        for message in air.mirror.path_aliases:
+            print(f"  PATH ALIAS {air.air}: {message}", file=out)
+        for message in air.mirror.row_order_mismatches:
+            print(f"  ROW ORDER {air.air}: {message}", file=out)
+    print(file=out)
+
+
+def print_header(run: Run, paths: dict[str, Path], out) -> None:
+    for label, value in paths.items():
+        print(f"{label:<11} {value}", file=out)
+    print(f"mirrors     {run.definitions} inventoried definition(s); "
+          f"{sum(a.mirror.total_clauses for a in run.airs)} clause(s) over the "
+          f"AIRs in this run", file=out)
+    print(file=out)
+
+
+def print_report(run: Run, quiet: bool, paths: dict[str, Path],
+                 out=sys.stdout) -> None:
+    if not quiet:
+        print_header(run, paths, out)
+        print_declarations(run, out)
+        print_table(run, out)
+        print_pairings(run, out)
+        print_checks(run, out)
+        print_details(run, out)
+        print_unreachable(run, out)
+    generated = sum(len(a.generated) for a in run.airs)
+    matched = sum(a.gen_count(MATCHED) for a in run.airs)
+    verdict = "FAILED" if run.failures else ("PARTIAL" if run.partial else "OK")
+    if run.partial:
+        print("PARTIAL: a --air-filtered run gated nothing about the AIRs it "
+              "skipped, so it never exits 0.", file=out)
+    print(f"mirror-roundtrip: {verdict} {matched}/{generated} comparable generated "
+          f"constraints matched across {len(run.airs)} air(s); "
+          f"{sum(a.gen_count(GAP) for a in run.airs)} gap, "
+          f"{sum(a.mir_count(STRENGTHENING) for a in run.airs)} strengthening, "
+          f"{sum(a.mir_count(UNBACKED) for a in run.airs)} unbacked, "
+          f"{sum(len(a.of_kind(RECLASSIFICATION)) for a in run.airs)} "
+          f"reclassification, {len(run.unreachable)} unreachable mirror, "
+          f"{sum(len(a.mirror.unparsed) for a in run.airs)} unparsed, "
+          f"{sum(len(a.mirror.undeclared_unresolved) for a in run.airs)} "
+          f"undeclared unresolved, "
+          f"{sum(len(a.mirror.undeclared_delegations) for a in run.airs)} "
+          f"undeclared delegation, "
+          f"{len(run.scope_failures)} scope failure", file=out)
+
+
+def to_json(run: Run) -> dict:
+    def clause(entry: Clause) -> dict:
+        return {
+            "definition": entry.definition, "class": entry.cls,
+            "file": entry.file, "line": entry.line, "clause": entry.index,
+            "text": entry.text, "unreachable": entry.unreachable,
+            "lane_kind_aliases": [
+                {"path": path, "lane_name": name, "lane": list(lane),
+                 "citation": citation}
+                for path, name, lane, citation in entry.reclassified],
+        }
+
+    def finding(entry: Finding) -> dict:
+        out = {
+            "kind": entry.kind, "air": entry.air, "route": entry.route,
+            "scalar_factor": entry.scalar,
+            "implied_by": None if entry.implied is None else {
+                "generated_index": entry.implied.generated.index,
+                "cofactor": entry.implied.cofactor,
+                "scalar": entry.implied.scalar,
+                "conditional_on_boolean": [
+                    list(atom) for atom in entry.implied.boolean],
+            },
+            "laneless": [
+                {"path": path, "reason": reason, "citation": citation}
+                for clause in entry.clauses for path, reason, citation
+                in clause.laneless],
+            "generated": [
+                {"index": g.index, "suffix": g.suffix, "provenance": g.provenance}
+                for g in entry.generated],
+            "mirror": [clause(c) for c in entry.clauses],
+            "diff": [
+                [[[list(a), e] for a, e in mono], left, right]
+                for mono, left, right in entry.diff],
+        }
+        if entry.kind_pairs:
+            out["kind_pairs"] = [[list(g), list(m)] for g, m in entry.kind_pairs]
+        if entry.out_of_root:
+            out["out_of_root_claims"] = entry.out_of_root
+        if entry.nearest is not None:
+            out["nearest"] = {"clause": clause(entry.nearest[0]),
+                              "differing_monomials": entry.nearest[1],
+                              "shared_monomials": entry.nearest[2]}
+        return out
+
+    corroborated, uncorroborated = run.delegation_evidence
+    return {
+        "ok": run.failures == 0 and not run.partial,
+        "partial": run.partial,
+        "failures": run.failures,
+        "definitions": run.definitions,
+        "declared_exclusions": [
+            {"key": e.key, "side": e.side, "rule": e.rule, "citation": e.citation}
+            for e in DECLARED_EXCLUSIONS],
+        "self_check_failures": run.self_check,
+        "rule_agreement_failures": run.rule_agreement,
+        "scope_failures": {
+            "classification_coverage": run.coverage.failures if run.coverage else [],
+            "declared_airs": run.scope,
+            "lane_map_gate": run.lane_gate,
+            "projection_totality": run.projections,
+            "near_miss_screen": run.screen.failures if run.screen else [],
+            "empty_run": run.empty,
+            "canonicaliser_self_test": run.fold_check,
+            "definition_notes": [m for a in run.airs for m in a.mirror.notes],
+            "path_aliases": [m for a in run.airs for m in a.mirror.path_aliases],
+            "row_order_mismatches": [
+                m for a in run.airs for m in a.mirror.row_order_mismatches],
+        },
+        "near_miss_screen": {
+            "screened": run.screen.screened if run.screen else 0,
+            "equation_free": sorted(
+                list(x) for x in (run.screen.equation_free if run.screen else ())),
+            "refused": run.screen.refused if run.screen else [],
+        },
+        "delegation_evidence": {
+            "screened_equation_free": corroborated,
+            "unscreened": uncorroborated,
+        },
+        "unreachable": [
+            {"file": rel, "name": name} for rel, name in sorted(run.unreachable)],
+        "shared_prop_names": [
+            {"file": rel, "name": name, "borne_by": borne}
+            for rel, name, borne in run.shared_names],
+        "hollow_matches": run.hollow,
+        "airs": [
+            {
+                "air": a.air,
+                "generated_comparable": len(a.generated),
+                "generated_excluded": len(a.excluded),
+                "mirror_comparable": len(a.mirror.comparable),
+                "mirror_unbacked": len(a.mirror.unbacked),
+                "mirror_clauses_total": a.mirror.total_clauses,
+                "mirror_declared_not_a_row": a.mirror.not_a_row,
+                "mirror_declared_not_an_equation": a.mirror.not_an_equation,
+                "mirror_undeclared_hole_clauses": a.mirror.undeclared_hole_clauses,
+                "unparsed": a.mirror.unparsed,
+                "undeclared_unresolved": a.mirror.undeclared_unresolved,
+                "undeclared_delegations": a.mirror.undeclared_delegations,
+                "findings": [finding(f) for f in a.findings],
+            }
+            for a in run.airs
+        ],
+    }
+
+
+# ------------------------------------------------------------------------- main
+
+
+def _redirect_roots(mirror_root: Path) -> None:
+    """Point the audited modules at a mirror root other than the default.
+
+    `mirror_parse` deliberately has no mirror-root parameter: every path it uses
+    derives from its `REPO_ROOT`, so redirecting that one name is how it wants to
+    be pointed at a copy of the tree. `survey.CLASSIFICATION` is keyed by
+    repo-relative path, so the root has to end in `ZiskFv/AirsClean` for those
+    keys to resolve at all -- which is checked rather than assumed.
+    """
+    if mirror_root.parts[-2:] != ("ZiskFv", "AirsClean"):
+        raise UsageError(
+            f"--airs-clean must end in ZiskFv/AirsClean (the classification is "
+            f"keyed by repo-relative path); got {mirror_root}")
+    root = mirror_root.parents[1]
+    mirror_parse.REPO_ROOT = root
+    mirror_parse._HELPER_CACHE.clear()
+    mirror_parse._LINE_CACHE.clear()
+    # Redirecting `survey.REPO_ROOT` also redirects `survey.reference_counts`,
+    # which is what decides reachability. A copy staging less than the roots it
+    # scans would silently OVER-report unreachable mirrors -- a use that lives in
+    # an unstaged directory looks like no use at all -- so the missing roots are
+    # named rather than skipped in silence.
+    survey.REPO_ROOT = root
+    missing = [name for name in survey.REFERENCE_ROOTS
+               if (REPO_ROOT / name).is_dir() and not (root / name).is_dir()]
+    if missing:
+        raise UsageError(
+            f"--airs-clean points at a tree with no {', '.join(missing)}; "
+            f"reachability is measured over {', '.join(survey.REFERENCE_ROOTS)} "
+            f"and a partial copy over-reports unreachable mirrors")
+
+
+class UsageError(Exception):
+    """A bad invocation or a missing artifact: exit 2, and not a pass.
+
+    `artifacts` distinguishes the two, because "the inputs are not there" is the
+    one that a gate could mistake for a pass and so gets the loud line.
+    """
+
+    def __init__(self, message: str, artifacts: bool = False) -> None:
+        super().__init__(message)
+        self.artifacts = artifacts
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Pair every comparable generated constraint against the "
+                    "handwritten mirror clauses that restate it.")
+    parser.add_argument("--pilout", type=Path, default=DEFAULT_PILOUT)
+    parser.add_argument("--extraction", type=Path, default=DEFAULT_EXTRACTION)
+    parser.add_argument("--airs-clean", type=Path, default=DEFAULT_MIRROR,
+                        dest="airs_clean")
+    parser.add_argument("--air", action="append", dest="airs", default=None,
+                        help="restrict to one AIR, repeatable; a filtered run "
+                             "reports PARTIAL, never OK")
+    parser.add_argument("--json", type=Path, default=None)
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        if not args.pilout.exists():
+            raise UsageError(f"no pilout at {args.pilout}", artifacts=True)
+        if not args.extraction.is_dir():
+            raise UsageError(f"no extraction directory at {args.extraction}",
+                             artifacts=True)
+        if not args.airs_clean.is_dir():
+            # A missing mirror root is a missing SOURCE tree, not a missing
+            # generated artifact; pointing the reader at build/ would send them
+            # to run `nix run .#populate` for a directory populate never writes.
+            raise UsageError(
+                f"no mirror root at {args.airs_clean} -- this is checked-in Lean "
+                f"source under ZiskFv/AirsClean, not a generated artifact")
+        only = None
+        if args.airs:
+            only = set(args.airs)
+            unknown = only - set(lanes.DECLARED_AIRS)
+            if unknown:
+                raise UsageError(f"unknown --air {sorted(unknown)}")
+        mirror_root = args.airs_clean.resolve()
+        if mirror_root != DEFAULT_MIRROR:
+            _redirect_roots(mirror_root)
+        run = run_check(args.pilout, args.extraction, mirror_root, only)
+    except UsageError as error:
+        print(f"check_mirrors.py: {error}", file=sys.stderr)
+        if error.artifacts:
+            print("ARTIFACTS ABSENT -- this is not a pass", file=sys.stderr)
+        return EXIT_USAGE
+    except OSError as error:
+        print(f"check_mirrors.py: {error}", file=sys.stderr)
+        print("ARTIFACTS ABSENT -- this is not a pass", file=sys.stderr)
+        return EXIT_USAGE
+
+    print_report(run, args.quiet, {
+        "pilout": args.pilout,
+        "extraction": args.extraction,
+        "mirror root": mirror_root,
+    })
+    # A filtered run has not decided anything about the AIRs it skipped, so it
+    # cannot report the success the exit code would claim.
+    status = EXIT_FAILED if (run.failures or run.partial) else EXIT_OK
+    if args.json is not None:
+        try:
+            args.json.write_text(json.dumps(to_json(run), indent=2) + "\n")
+        except OSError as error:
+            print(f"check_mirrors.py: {error}", file=sys.stderr)
+            # A failing check outranks an unwritable --json.
+            return status or EXIT_USAGE
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/mirror-roundtrip/inventory.md
+++ b/tools/mirror-roundtrip/inventory.md
@@ -1,0 +1,855 @@
+# mirror-roundtrip: the mirror-side inventory
+
+Issue: eth-act/zisk-fv#304, blocked by #303. This is the *other* direction of
+#303's round trip. #303 decided that every polynomial constraint in
+`build/zisk.pilout` reached `build/extraction/Extraction/` unaltered. Nothing in
+that argument touches `ZiskFv/`: the emitted per-AIR files are imported by no
+Lean under `ZiskFv/` at all, so a constraint can round-trip perfectly into the
+extraction and still be restated wrongly, partially, or not at all in the
+handwritten Lean the proof actually consumes.
+
+This document is the denominator for that second direction: every handwritten
+polynomial-constraint mirror under `ZiskFv/AirsClean/**`, the row records they
+project, the existing field-to-column maps, and -- the point -- which generated
+constraints no mirror claims. Anything missing here becomes a constraint a later
+gate silently never checks.
+
+Everything numeric below is produced by `survey.py` and can be regenerated:
+
+```
+python3 tools/mirror-roundtrip/survey.py                      # everything
+python3 tools/mirror-roundtrip/survey.py --section coverage    # one section
+python3 tools/mirror-roundtrip/survey.py --quiet               # summary only
+```
+
+`survey.py` reuses `pilout_wire` and `pilout_atoms` from `tools/pilout-roundtrip`
+for the pilout side, so the two tools cannot disagree about what a column or a
+constraint index is. It reads only; it edits nothing under `ZiskFv/`.
+
+### The inventory can go stale, and says so
+
+The scope is a declared list (`CLASSIFICATION` in `survey.py`), not a shape
+heuristic -- the same discipline as `DECLARED_AIRS` in `check.py`, and for the
+same reason: letting the mirror set be discovered from what looks like a mirror
+would let the mirror choose what the audit covers, and a new predicate that
+classified itself as "not a mirror" is exactly the drop this inventory exists to
+prevent. So the list has the opposite failure mode, going stale, and both
+directions are checked:
+
+* a `Prop`-valued declaration under the mirror root that `CLASSIFICATION` does not
+  name is reported by name and file:line, and the run exits 1;
+* a `CLASSIFICATION` entry naming a declaration that no longer exists is reported
+  the same way.
+
+Verified rather than asserted: copying `ZiskFv/AirsClean` to a temporary tree,
+appending one `def NewGapSpec (row : MemRow FGL) : Prop := row.sel = 0` to
+`Mem/Spec.lean`, and running
+`survey.py --mirror <copy>` exits 1 with
+`FAIL: Prop-valued declarations missing from CLASSIFICATION: ZiskFv/AirsClean/Mem/Spec.lean:143 NewGapSpec`;
+the same copy without the mutation exits 0. `--mirror` accepts a tree outside the
+repo precisely so that check needs no write to `ZiskFv/`.
+
+## Headline counts
+
+| quantity | value |
+| -------- | ----- |
+| Lean files under `ZiskFv/AirsClean/**` | 103 |
+| top-level declarations in them | 1860 |
+| `Prop`-valued `def`/`abbrev` | 104 |
+| classified as mirrors | 40 |
+| classified as near-misses | 64 |
+| unclassified | 0 |
+| top-level conjuncts across the 40 mirrors | 227 (composites re-count their parts) |
+| row records used by a mirror | 27 (10 top-level plus 17 sub-structs) |
+| handwritten field-to-column / `Expr`-to-field maps | 30 |
+| published mirror predicates nothing references | 1 (`Main.RomBoolSpec`) |
+| comparable generated constraints | 176 |
+| comparable constraints no mirror claims | **18** |
+| comparable constraints claimed only outside the mirror root | 15 |
+
+"Comparable" is the issue's own exclusion rule: total minus every constraint
+whose expression tree reaches `Extraction.Circuit.challenge` or a stage-2 lane
+`main c (id := 2)`. `survey.py` computes it off the pilout operands, and it
+reproduces the per-AIR figures independently (Arith 49, Binary 7, BinaryAdd 4,
+BinaryExtension 0, Main 39, Mem 24, MemAlign 33, MemAlignByte 9,
+MemAlignReadByte 4, MemAlignWriteByte 7; total 176).
+
+The **extractor's own single-field/two-field binder distinction is deliberately
+not used** as the exclusion rule. It would exclude nine more Main constraints --
+Main {0, 3, 4, 9, 10, 19, 20, 21, 38}, the ones reaching an `AirValue` or
+`AirGroupValue` but no challenge and no stage-2 lane -- and Main #3 and #9 are
+precisely the flagship gap below. Using the binder rule would make the flagship
+finding disappear.
+
+## Scope, and one place it leaks
+
+The issue scopes the inventory to `ZiskFv/AirsClean/**`. That boundary is not
+where the mirrors stop. `ZiskFv/AirsClean/Mem/GeneratedTransition.lean:251`
+(`generatedTransition`) reaches `ZiskFv.Airs.Mem.segmentResidualEveryRow`
+(`ZiskFv/Airs/Mem.lean:296`, 15 conjuncts) and
+`ZiskFv.Airs.Mem.permutation_every_row`, both of which are polynomial mirrors
+declared *outside* the mirror root. Those 15 conjuncts are exactly Mem's 15
+comparable constraints that no in-root mirror claims, and
+`segmentResidualEveryRow_of_segment_every_row` (`ZiskFv/Airs/Mem.lean:332`)
+destructures the 24-clause `segment_every_row` at indices
+`{0,1,2,9,10,11,12,13,14,15,16,17,19,20,22}`, pinning the index correspondence
+in the source. `survey.py` records this in its `DELEGATED` list and reports it
+separately from the genuinely unmirrored set, so neither is confused with the
+other. **Decision needed from the owner:** whether #305's gate scope is
+`AirsClean` only (in which case 15 Mem constraints are out of scope and should be
+declared so) or "every polynomial mirror the AirsClean components reach" (in
+which case `ZiskFv/Airs/Mem.lean` joins the root). Nothing here changes it.
+
+## 1. Mirror inventory
+
+Classes, as `survey.py` defines them:
+
+| class | meaning |
+| ----- | ------- |
+| `MIRROR` | conjunction of field equations over row-record projections |
+| `MIRROR_2ROW` | same, over two row records at a fixed row offset |
+| `MIRROR_MIXED` | field equations plus non-polynomial clauses in one predicate |
+| `MIRROR_VALIDATOR` | the same equations over `Valid_<AIR>` accessors at a row index |
+| `MIRROR_BUILDER` | the same equations over an honest-row builder's inputs |
+| `MIRROR_ENV` | an adapter restating a mirror at Clean `Environment`s |
+| `MIRROR_COMPOSITE` | a conjunction of other named mirrors, no equations of its own |
+| `MIXED_COMPOSITE` | a conjunction mixing named mirrors with non-polynomial specs |
+
+`conj` is the number of `∧`-separated clauses at bracket depth 0. `claims` is the
+generated constraint indices the mirror is *asserted* to restate: an audited
+reading of the mirror body against `build/extraction/Extraction/<AIR>.lean` and
+its provenance comments, **not** a pairing decided polynomially. #305 decides the
+pairings; what the claim sets buy now is that "which constraints have no mirror"
+is computed arithmetic instead of a reader's impression.
+
+### Arith (row records `ArithMulRow`, `ArithDivRow`)
+
+| file:line | name | class | rows | conj | claims |
+| --------- | ---- | ----- | ---- | ---- | ------ |
+| `ZiskFv/AirsClean/ArithMul/Spec.lean:54` | `Spec` | `MIRROR` | `row : ArithMulRow` | 11 | c6-c8, c31-c38 |
+| `ZiskFv/AirsClean/ArithMul/Spec.lean:166` | `C46Spec` | `MIRROR` | `row : ArithMulRow` | 1 | c46 |
+| `ZiskFv/AirsClean/ArithMul/Spec.lean:238` | `DivModeSpec` | `MIRROR` | `row : ArithMulRow` | 13 | c0-c5, c39-c45 |
+| `ZiskFv/AirsClean/ArithMul/Spec.lean:253` | `DivBoundarySpec` | `MIRROR` | `row : ArithMulRow` | 16 | c9-c24 |
+| `ZiskFv/AirsClean/ArithMul/Spec.lean:271` | `DivInverseSumSpec` | `MIRROR` | `row : ArithMulRow` | 1 | c25 |
+| `ZiskFv/AirsClean/ArithMul/Spec.lean:276` | `DivScopeSpec` | `MIRROR` | `row : ArithMulRow` | 5 | c26-c30 |
+| `ZiskFv/AirsClean/ArithMul/Spec.lean:283` | `DivWModeSpec` | `MIRROR` | `row : ArithMulRow` | 2 | c47, c48 |
+| `ZiskFv/AirsClean/ArithMul/Spec.lean:289` | `SharedDivBlockSpec` | `MIRROR_COMPOSITE` | `row : ArithMulRow` | 5 | (its parts) |
+| `ZiskFv/AirsClean/ArithMul/Spec.lean:234` | `FullSpec` | `MIXED_COMPOSITE` | `row : ArithMulRow` | 6 | (its parts) |
+| `ZiskFv/AirsClean/ArithDiv/Spec.lean:70` | `Spec` | `MIRROR` | `row : ArithDivRow` | 11 | c6-c8, c31-c38 |
+| `ZiskFv/AirsClean/ArithDiv/Spec.lean:186` | `FullSpec` | `MIXED_COMPOSITE` | `row : ArithDivRow` | 3 | (its parts) |
+
+All rows are current-row only; Arith has no cross-row comparable constraint.
+The seven primary `ArithMul` predicates cover c0-c48 exactly, which is all 49
+comparable Arith constraints. `ArithDiv.Spec` is a **second view of the same 11**
+in a different row record, so #305 must decide 60 Arith mirror conjuncts against
+49 generated constraints, with 11 pairings appearing twice.
+
+The circuit-side carrier of the same set is
+`ZiskFv/AirsClean/ArithCompleteConstraints.lean:18` (`sharedMainComplete`, 38
+`assertZero`s over `mainWithArithTable`'s 11), whose comments cite the generated
+constraint ranges directly. It is a `Circuit FGL Unit`, not a `Prop`, so it is
+not in the mirror table; see near-miss category "circuit-side carriers".
+
+### Binary (row record `BinaryRow`)
+
+| file:line | name | class | rows | conj | claims |
+| --------- | ---- | ----- | ---- | ---- | ------ |
+| `ZiskFv/AirsClean/Binary/Spec.lean:45` | `Spec` | `MIRROR` | `row : BinaryRow` | 7 | c0-c6 |
+| `ZiskFv/AirsClean/Binary/Bridge.lean:1100` | `constraints_at` | `MIRROR_VALIDATOR` | `Valid_Binary` at `r` | 7 | c0-c6 |
+
+Complete: 7 conjuncts for 7 comparable constraints.
+
+### BinaryAdd (row record `BinaryAddRow`)
+
+| file:line | name | class | rows | conj | claims |
+| --------- | ---- | ----- | ---- | ---- | ------ |
+| `ZiskFv/AirsClean/BinaryAdd/Circuit.lean:113` | `CoreFacts` | `MIRROR` | `row : BinaryAddRow` | 4 | c0-c3 |
+| `ZiskFv/AirsClean/BinaryAdd/Bridge.lean:82` | `constraints_at` | `MIRROR_VALIDATOR` | `Valid_BinaryAdd` at `r` | 4 | c0-c3 |
+| `ZiskFv/AirsClean/BinaryAdd/Circuit.lean:131` | `ComponentSpecFacts` | `MIXED_COMPOSITE` | `row : BinaryAddRow` | 3 | (its parts) |
+
+Complete: 4 for 4. Note `BinaryAdd.Spec` is **not** a mirror -- it is the
+semantic `cPacked = (packed32 a + packed32 b) % 2^64` statement over `ℕ`. The
+polynomial content is `CoreFacts`, which only `ComponentSpecFacts` references.
+
+### BinaryExtension (row record `BinaryExtensionRow`)
+
+No mirror, and none needed: BinaryExtension has **0** comparable constraints --
+all 8 reach a challenge or a stage-2 lane. `BinaryExtension.Spec` and
+`BinaryExtension.Bridge.constraints_at` are both `True`, which is the correct
+statement here and is classified `NEAR_VACUOUS` rather than as a mirror.
+
+### Main (row records `MainRow`, `MainRowWithRom`)
+
+| file:line | name | class | rows | conj | claims |
+| --------- | ---- | ----- | ---- | ---- | ------ |
+| `ZiskFv/AirsClean/Main/Spec.lean:52` | `Spec` | `MIRROR` | `row : MainRow` | 9 | c7, c8, c13-c17, c22, c28 |
+| `ZiskFv/AirsClean/Main/Spec.lean:68` | `AddressSpec` | `MIRROR` | `row : MainRowWithRom` | 4 | c1, c2 (**only 2 of 4**) |
+| `ZiskFv/AirsClean/Main/Spec.lean:78` | `SourceSpec` | `MIRROR` | `row : MainRowWithRom` | 4 | c5, c6, c11, c12 |
+| `ZiskFv/AirsClean/Main/Circuit.lean:346` | `RomBoolSpec` | `MIRROR` | `row : MainRowWithRom` | 14 | c23-c27, c29-c37 |
+| `ZiskFv/AirsClean/Main/Circuit.lean:708` | `pcHandshakeBetween` | `MIRROR_2ROW` | `prev`, `curr : MainRowWithRom` (`curr` = `prev` + 1) | 1 | c18 |
+| `ZiskFv/AirsClean/Main/Circuit.lean:721` | `sourceCCopyBetween` | `MIRROR_2ROW` | `prev`, `curr : MainRowWithRom` | 2 | c4, c10 |
+| `ZiskFv/AirsClean/Main/Circuit.lean:734` | `transitionBetween` | `MIRROR_COMPOSITE` | `prev`, `curr : MainRowWithRom` | 2 | (its parts) |
+| `ZiskFv/AirsClean/Main/Circuit.lean:942` | `pcHandshakeTransition` | `MIRROR_ENV` | two `Environment`s | 1 | (via `transitionBetween`) |
+| `ZiskFv/AirsClean/Main/Circuit.lean:326` | `MainRomAddressGuard` | `MIRROR_BUILDER` | `(bits, free)` | 1 | c2 |
+| `ZiskFv/AirsClean/Main/Circuit.lean:333` | `MainRomSourceGuard` | `MIRROR_BUILDER` | `(msg, bits, free)` | 4 | c5, c6, c11, c12 |
+| `ZiskFv/AirsClean/Main/Bridge.lean:87` | `constraints_at` | `MIRROR_VALIDATOR` | `Valid_Main` at `r` | 9 | same as `Spec` |
+| `ZiskFv/AirsClean/Main/CrossRow.lean:68` | `pc_handshake_at` | `MIRROR_VALIDATOR` | `Valid_Main` at `r`, `r - 1` over `ℕ` | 1 | c18 |
+
+32 of Main's 39 comparable constraints are claimed. Seven are not; see finding
+F1.
+
+### Mem (row record `MemRow`)
+
+| file:line | name | class | rows | conj | claims |
+| --------- | ---- | ----- | ---- | ---- | ------ |
+| `ZiskFv/AirsClean/Mem/Spec.lean:56` | `Spec` | `MIRROR` | `row : MemRow` | 9 | c3-c8, c18, c21, c23 |
+| `ZiskFv/AirsClean/Mem/Bridge.lean:239` | `constraints_at` | `MIRROR_VALIDATOR` | `Valid_Mem` at `r` | 9 | same |
+| `ZiskFv/AirsClean/Mem/GeneratedTransition.lean:251` | `generatedTransition` | `MIRROR_COMPOSITE` | `previous`, `current : Environment` | 3 | delegates out of root |
+
+9 of 24 in root; the other 15 via `ZiskFv/Airs/Mem.lean:296`. See finding F4.
+
+### MemAlign (row record `MemAlignRow`)
+
+| file:line | name | class | rows | conj | claims |
+| --------- | ---- | ----- | ---- | ---- | ------ |
+| `ZiskFv/AirsClean/MemAlign/Spec.lean:48` | `Spec` | `MIRROR` | `row : MemAlignRow` | 16 | c16-c28, c30-c32 |
+| `ZiskFv/AirsClean/MemAlign/Circuit.lean:233` | `transitionRows` | `MIRROR_2ROW` | `previous` = row -1, `current` = row 0 | 9 | c1, c3, c5, c7, c9, c11, c13, c15, c29 |
+| `ZiskFv/AirsClean/MemAlign/Circuit.lean:254` | `cyclicSuccessorTransitionRows` | `MIRROR_2ROW` | `current` = row 0, `successor` = row +1 | 9 | c0, c2, c4, c6, c8, c10, c12, c14 (**8 claims, 9 conjuncts**) |
+| `ZiskFv/AirsClean/MemAlign/Circuit.lean:244` | `transition` | `MIRROR_ENV` | two `Environment`s | 1 | (via `transitionRows`) |
+| `ZiskFv/AirsClean/MemAlign/Circuit.lean:265` | `cyclicSuccessorTransition` | `MIRROR_ENV` | two `Environment`s | 1 | (via the successor rows) |
+
+All 33 comparable constraints claimed, and one mirror conjunct over: 34
+conjuncts, 33 claims. See finding F3.
+
+### MemAlignByte (row record `MemAlignByteRow`)
+
+| file:line | name | class | rows | conj | claims |
+| --------- | ---- | ----- | ---- | ---- | ------ |
+| `ZiskFv/AirsClean/MemAlignByte/Spec.lean:77` | `Spec` | `MIRROR_MIXED` | `row : MemAlignByteRow` | 8 (5 equations + 3 `.val <`) | c3, c5-c8 |
+| `ZiskFv/AirsClean/MemAlignByte/Bridge.lean:116` | `constraints_at` | `MIRROR_VALIDATOR` | `Valid_MemAlignByte` at `r` | 5 | c3, c5-c8 |
+
+5 of 9. Four selector/`is_write` booleans are unclaimed; see finding F2.
+
+### MemAlignReadByte (row record `MemAlignReadByteRow`)
+
+| file:line | name | class | rows | conj | claims |
+| --------- | ---- | ----- | ---- | ---- | ------ |
+| `ZiskFv/AirsClean/MemAlignReadByte/Spec.lean:73` | `Spec` | `MIRROR_MIXED` | `row : MemAlignReadByteRow` | 2 (1 equation + 1 `.val <`) | c3 |
+| `ZiskFv/AirsClean/MemAlignReadByte/Bridge.lean:98` | `constraints_at` | `MIRROR_VALIDATOR` | `Valid_MemAlignReadByte` at `r` | 4 | c0-c3 |
+
+All 4 claimed, but 3 of them **only** in the validator-indexed form; see F2.
+
+### MemAlignWriteByte
+
+**No mirror of any kind, no row record, no `ZiskFv/AirsClean/MemAlignWriteByte/`
+directory.** The string `MemAlignWriteByte` does not occur anywhere in `ZiskFv/`
+or `trust/`. See finding F5.
+
+## 2. Near-misses
+
+64 `Prop`-valued declarations under the mirror root look like mirrors and are
+not. Grouped by what each actually is. Full list:
+`survey.py --section nearmisses`.
+
+### `NEAR_RANGE` -- bounds on `.val`, not field equations (11)
+
+`ℕ`-valued bit-width facts. They are not polynomial identities and cannot be
+compared against a pilout constraint in the pilout's own algebra: `x.val < 2`
+is not `x * (1 - x) = 0` as a term, even where the two are equivalent facts.
+
+`Binary/Spec.lean:37` `Assumptions`; `BinaryAdd/Spec.lean:49` `Assumptions`;
+`Main/Spec.lean:47` `Assumptions`; `Mem/Spec.lean:51` `Assumptions`;
+`MemAlign/Spec.lean:40` `Assumptions`; `MemAlignByte/Spec.lean:70`
+`Assumptions`; `MemAlignReadByte/Spec.lean:64` `Assumptions`;
+`ArithMul/Spec.lean:182` `ChunkRangeSpec`; `ArithMul/Spec.lean:203`
+`CarryRangeSpec`; `BinaryAdd/Circuit.lean:122` `RangeFacts`;
+`Mem/Constraints.lean:61` `dualMemRowRangeFacts`.
+
+### `NEAR_LOOKUP` -- lookup or static-table membership (12)
+
+Membership in a `StaticTable`, which is a lookup argument, not a polynomial
+identity of the AIR. `ArithMul/Spec.lean:151` and `ArithDiv/Spec.lean:166`
+`ArithTableSpec`; `ArithMul/Spec.lean:216` and `ArithDiv/Spec.lean:172`
+`IndexedRangeSpec`; `Binary/Bridge.lean:24,37,59,79` the four
+`StaticBinaryTable*Facts`; `Binary/Circuit.lean:359`
+`StaticBinaryTableSpecFacts`; `BinaryExtension/Bridge.lean:244`
+`StaticBinaryExtensionTableWfFacts`; `BinaryExtension/Bridge.lean:310`
+`ShiftB0RangeSpecFact`; `BinaryExtension/StaticCircuit.lean:108`
+`StaticBinaryExtensionTableSpecFacts`.
+
+### `NEAR_BUS` -- bus, channel, interaction or trace-replay predicates (30)
+
+Existentials over `witness.interactionsWith`, `providerTable.table`,
+`matches_memory_entry` and replay-row embeddings. They constrain the *channel*
+layer, which #303 also declared out of scope. All 30 are in
+`ZiskFv/AirsClean/FullEnsemble/Balance/` plus `Mem/TraceSpec.lean`:
+`EmbeddedInTrace.lean:31,40,47,82,95,108,121`;
+`MemAlignSkippableProve.lean:22`;
+`MemBusRowBridges.lean:208,879,1000,1556,1639,1674,1707,1743,1758,1778,2094,2118,2158,2200,2760`;
+`RowExtraction.lean:198`; `RowsBridgeFacts.lean:222`;
+`TimelineEvidence.lean:29,1910,1926`; `Mem/TraceSpec.lean:21,30`.
+
+### `NEAR_VACUOUS` -- `True` (5)
+
+`ArithMul/Spec.lean:50` and `ArithDiv/Spec.lean:60` `Assumptions`;
+`BinaryExtension/Spec.lean:35` `Assumptions`; `BinaryExtension/Spec.lean:39`
+`Spec`; `BinaryExtension/Bridge.lean:337` `constraints_at`. For
+BinaryExtension the three vacuous ones are correct -- the AIR has no comparable
+constraint -- but they are `True`, so they are not mirrors and must not be
+counted as coverage.
+
+### `NEAR_SEMANTIC` -- a statement over `ℕ` (1)
+
+`BinaryAdd/Spec.lean:58` `Spec`: `cPacked row = (packed32 a + packed32 b) % 2^64`.
+This is the AIR's *meaning*, proved from `CoreFacts` plus `RangeFacts`. It has no
+pilout counterpart and must not be paired with one.
+
+### `NEAR_SOUNDNESS` -- quantified `ConstraintsHold` surfaces (2)
+
+`Binary/Bridge.lean:1033` and `BinaryExtension/Bridge.lean:344`
+`StaticLookupSoundness`: `∀ r offset env, ConstraintsHold.Soundness env (...)`.
+A surface over a circuit's operations, not a list of equations.
+
+### `NEAR_DATA` -- prover-data / raw-cell bindings (1)
+
+`Mem/GeneratedTransition.lean:239` `memRangeSidecarBridge`: pins four raw Mem
+cells to canonical `ProverData` keys. Not an AIR constraint.
+
+### `NEAR_LITERAL` -- disjunctions of literal values (2)
+
+`RangeTables.lean:289` `ArithRangePosId` and `:295` `ArithRangeNegId`: `r = 3 ∨
+r = 4 ∨ ...` over upstream `arith_range_table.pil` range IDs.
+
+### Circuit-side carriers (not `Prop`, so not in the 104)
+
+Worth naming because they hold the same polynomial content in `Expression FGL`
+over `Var Row` and are the operational source the `Spec`s are proved from. A
+later gate may prefer to compare *these* rather than the `Prop`s, since they are
+what the component actually asserts. `assertZero` counts from `survey.py`'s
+scan:
+
+| file:line | name | `assertZero` | `lookup` |
+| --------- | ---- | ------------ | -------- |
+| `ArithCompleteConstraints.lean:18` | `sharedMainComplete` | 38 | 0 |
+| `ArithDiv/Constraints.lean:49` | `main` | 11 | 0 |
+| `ArithMul/Constraints.lean:136` | `main` | 11 | 0 |
+| `ArithMul/Constraints.lean:240` | `mainWithArithTable` | 1 | 32 |
+| `Binary/Constraints.lean:144` | `main` | 7 | 0 |
+| `BinaryAdd/Constraints.lean:48` | `main` | 4 | 8 |
+| `BinaryExtension/Constraints.lean:69` | `main` | 0 | 0 (one op-bus push; the 8 table tuples are channel `emit`s in `mainWithBinaryExtensionTable` at `:90`) |
+| `Main/Constraints.lean:27` | `main` | 9 | 0 |
+| `Main/Constraints.lean:242` | `mainWithRom` | 22 | 1 |
+| `Mem/Constraints.lean:37` | `main` | 9 | 0 |
+| `Mem/Constraints.lean:112` | `segmentGeneratedConstraintAssertions` | 24 | 0 |
+| `Mem/Constraints.lean:162` | `permutationGeneratedConstraintAssertions` | 10 | 0 |
+| `MemAlign/Constraints.lean:41` | `main` | 16 | 0 |
+| `MemAlignByte/Constraints.lean:58` | `main` | 9 | 5 |
+| `MemAlignReadByte/Constraints.lean:59` | `main` | 4 | 3 |
+
+`Mem/Constraints.lean:112` is the interesting one: 24 `assertZero`s covering
+*all* 24 comparable Mem constraints, over `Valid_Mem` and `SegmentColumns`
+rather than over `MemRow`. So Mem's full comparable set does have a
+handwritten circuit-side carrier inside the mirror root, even though its
+`Prop`-level mirror is split 9-in-root / 15-out-of-root.
+
+### Theorem statements that restate a mirror
+
+Not declarations, so out of the inventory, but they matter for F6:
+`Main/Circuit.lean:397` `romBoolSpec_of_mainWithRomAndMemBus_constraints` states all 14
+`RomBoolSpec` equations inline as its conclusion. The equations are therefore
+live in the proof even though the named predicate is not.
+
+## 3. Row records, fields in declaration order
+
+Indexed dumps: `survey.py --section records`. Positions below are
+`ProvableStruct`-flattened order.
+
+**`MainRow`** (18) `ZiskFv/AirsClean/Main/Row.lean:32`:
+`a_0, a_1, b_0, b_1, c_0, c_1, flag, pc, is_external_op, op, m32, ind_width,
+set_pc, jmp_offset1, jmp_offset2, store_pc, im_high_degree_2, segment_l1`
+
+**`MainRomRow`** (25) `ZiskFv/AirsClean/Main/Row.lean:61`:
+`a_offset_imm0, a_imm1, b_offset_imm0, b_imm1, store_offset, a_src_imm,
+a_src_mem, is_precompiled, b_src_imm, b_src_mem, store_mem, store_ind,
+b_src_ind, a_src_reg, b_src_reg, store_reg, addr0, addr1, addr2, main_step,
+a_reg_prev_mem_step, b_reg_prev_mem_step, store_reg_prev_mem_step,
+store_reg_prev_value_0, store_reg_prev_value_1`
+
+**`MainRowWithRom`** (43 = `core` ++ `rom`) `ZiskFv/AirsClean/Main/Row.lean:127`.
+
+**`MemRow`** (13) `ZiskFv/AirsClean/Mem/Row.lean:23`:
+`addr, step, sel, addr_changes, step_dual, sel_dual, value_0, value_1, wr,
+previous_step, increment_0, increment_1, read_same_addr`
+
+**`MemAlignRow`** (31) `ZiskFv/AirsClean/MemAlign/Row.lean:24`:
+`addr, offset, width, wr, pc, reset, sel_up_to_down, sel_down_to_up, reg_0,
+reg_1, reg_2, reg_3, reg_4, reg_5, reg_6, reg_7, sel_0, sel_1, step, sel_2,
+sel_3, sel_4, sel_5, sel_6, sel_7, sel_prove, preL1, delta_addr, delta_pc,
+value_0, value_1`
+
+**`MemAlignByteRow`** (16) `ZiskFv/AirsClean/MemAlignByte/Row.lean:49`:
+`sel_high_4b, sel_high_2b, sel_high_b, direct_value, composed_value,
+written_composed_value, written_byte_value, value_16b, value_8b, byte_value,
+addr_w, step, is_write, mem_write_values_0, mem_write_values_1, bus_byte`
+
+**`MemAlignReadByteRow`** (10) `ZiskFv/AirsClean/MemAlignReadByte/Row.lean:43`:
+`sel_high_4b, sel_high_2b, sel_high_b, direct_value, composed_value, value_16b,
+value_8b, byte_value, addr_w, step`
+
+**`BinaryRow`** (39 = five sub-structs) `ZiskFv/AirsClean/Binary/Row.lean:78`:
+- `BinaryAByteCols` (8) `:24`: `free_in_a_0 .. free_in_a_7`
+- `BinaryBByteCols` (8) `:35`: `free_in_b_0 .. free_in_b_7`
+- `BinaryCByteCols` (8) `:46`: `free_in_c_0 .. free_in_c_7`
+- `BinaryChainCols` (10) `:57`: `carry_0 .. carry_7, b_op, b_op_or_sext`
+- `BinaryModeCols` (5) `:70`: `mode32, result_is_a, use_first_byte, c_is_signed, mode32_and_c_is_signed`
+
+**`BinaryAddRow`** (10) `ZiskFv/AirsClean/BinaryAdd/Row.lean:43`:
+`a_0, a_1, b_0, b_1, c_chunks_0, c_chunks_1, c_chunks_2, c_chunks_3, cout_0,
+cout_1`
+
+**`BinaryExtensionRow`** (29 = four sub-structs)
+`ZiskFv/AirsClean/BinaryExtension/Row.lean:65`:
+- `BinaryExtensionACols` (8) `:24`: `free_in_a_0 .. free_in_a_7`
+- `BinaryExtensionCColsLo` (8) `:35`: `free_in_c_0 .. free_in_c_7`
+- `BinaryExtensionCColsHi` (8) `:46`: `free_in_c_8 .. free_in_c_15`
+- `BinaryExtensionFlags` (5) `:57`: `op, free_in_b, op_is_shift, b_0, b_1`
+
+**`ArithMulRow`** (44 = three sub-structs) `ZiskFv/AirsClean/ArithMul/Row.lean:81`:
+- `ArithMulChunks` (16) `:23`: `a_0..a_3, b_0..b_3, c_0..c_3, d_0..d_3`
+- `ArithMulFlags` (17) `:42`: `na, nb, nr, np, sext, m32, div, div_by_zero, div_overflow, main_div, main_mul, signed, range_ab, range_cd, op, bus_res1, multiplicity`
+- `ArithMulCarries` (11) `:65`: `carry_0..carry_6, fab, na_fb, nb_fa, inv_sum_all_bs`
+
+**`ArithDivRow`** (43 = three sub-structs) `ZiskFv/AirsClean/ArithDiv/Row.lean:85`:
+- `ArithDivChunks` (16) `:23`: same 16 as `ArithMulChunks`
+- `ArithDivFlags` (17) `:42`: same 17 as `ArithMulFlags`
+- `ArithDivAux` (10) `:72`: `fab, na_fb, nb_fa, carry_0..carry_6` -- **no `inv_sum_all_bs`**
+
+### Field order is not column order
+
+`survey.py --section records` prints, per record, the fields with no same-named
+stage-1 column and the stage-1 columns with no same-named field. Measured:
+
+| record | fields | stage-1 cols | positional? |
+| ------ | ------ | ------------ | ----------- |
+| `MainRowWithRom` | 43 | 38 | no |
+| `MemRow` | 13 | 13 | yes, but two fields renamed |
+| `MemAlignRow` | 31 | 29 | **no** |
+| `MemAlignByteRow` | 16 | 16 | yes |
+| `MemAlignReadByteRow` | 10 | 10 | yes |
+| `BinaryRow` | 39 | 39 | **no** |
+| `BinaryAddRow` | 10 | 10 | yes |
+| `BinaryExtensionRow` | 29 | 29 | **no** |
+| `ArithMulRow` | 44 | 44 | **no** |
+| `ArithDivRow` | 43 | 44 | **no** |
+
+The three positional records (`MemAlignByteRow`, `MemAlignReadByteRow`,
+`BinaryAddRow`) are exactly the three whose docstrings say `AUTO-GENERATED by
+tools/pil-extract (clean-component subcommand)`. Every hand-written record is
+non-positional. Concretely:
+
+* `MemAlignRow` has `... sel_0, sel_1, step, sel_2 ...`; the generated header has
+  `sel[0..7]` contiguous at stage-1 columns 16-23 with `step` at 24,
+  `delta_addr` 25, `sel_prove` 26.
+* `ArithMulRow` starts `chunks.a_0` at position 0; the AIR's column 0 is
+  `carry[0]`, with `a[0]` at column 7 and `fab`/`na_fb`/`nb_fa` at 30-32.
+* `BinaryRow` starts `aBytes.free_in_a_0` at position 0; the AIR's column 0 is
+  `b_op`, with `free_in_a[0]` at column 1.
+* `BinaryExtensionRow` starts `aCols.free_in_a_0`; column 0 is `op`.
+
+**A gate that assumed positional correspondence would be wrong for six of the
+ten records.** The correspondence has to come from a name-or-explicit map.
+
+Fields with no stage-1 column at all, i.e. the reclassification cases:
+
+| record | field | what it is |
+| ------ | ----- | ---------- |
+| `MainRowWithRom` | `core.segment_l1` | fixed column `Main.SEGMENT_L1` (index 0), materialized by `mainFixedColumns` slot 0 |
+| `MainRowWithRom` | `rom.main_step` | fixed column `Main.SEGMENT_STEP` (index 1), `mainFixedColumns` slot 1 |
+| `MainRowWithRom` | `rom.addr0`, `rom.addr2` | PIL `const expr` definitions; **no pilout column and no pilout constraint** |
+| `MainRowWithRom` | `core.im_high_degree_2` | no stage-1 column and no fixed column in this pilout |
+| `MemAlignRow` | `preL1` | fixed column `MemAlign.L1` (index 0) |
+| `MemAlignRow` | `delta_pc` | the `pc' - pc` slot of hint #998, not a column |
+| `MemRow` | `increment_0`, `increment_1` | renamed: columns 10, 11 are `l_increment`, `h_increment` |
+
+Fixed columns and how often the comparable set reads them (`survey.py`):
+
+| AIR | fixed 0 | comparable uses | fixed 1 | uses | fixed 2 | uses |
+| --- | ------- | --------------- | ------- | ---- | ------- | ---- |
+| Main | `Main.SEGMENT_L1` | 9 | `Main.SEGMENT_STEP` | 0 | `__L1__` | 0 |
+| Mem | `Mem.SEGMENT_L1` | 10 | `__L1__` | 0 | | |
+| MemAlign | `MemAlign.L1` | 1 | `__L1__` | 0 | | |
+| Arith, Binary, BinaryAdd, BinaryExtension, MemAlign*Byte | `__L1__` | 0 | | | | |
+
+So fixed columns enter the comparable set in exactly 20 places, across three
+columns, and the mirror represents each differently: `Main.SEGMENT_L1` and
+`Mem.SEGMENT_L1` through component-owned `IndexedFixedColumns` schemas
+(`Main/Circuit.lean:768`, `Mem/GeneratedTransition.lean:40`), and `MemAlign.L1`
+as a plain row field with no fixed schema at all -- see finding F7. `__L1__`
+never reaches a comparable constraint, so the mirror's silence about it is
+correct.
+
+## 4. Existing handwritten field-to-column / `Expr`-to-field maps
+
+30 maps, from `survey.py --section maps`. Four kinds.
+
+### (a) Generated `Expr` term -> mirror expression (2). Both have a zeroing catch-all.
+
+| file:line | name | arms | fallback | gated by |
+| --------- | ---- | ---- | -------- | -------- |
+| `ZiskFv/AirsClean/MemAlign/Bridge.lean:31` | `h998ExprToField` | 38 | **`\| _ => 0`** | `MemAlignRomWiring.sourceBinding` (`:219`), discharged by `rfl` in `h998Wiring` (`:223`); surfaced by `h998_tuple_matches_successor_message` (`:240`) |
+| `ZiskFv/AirsClean/Binary/Wiring.lean:33` | `c10LookupExprToClean` | 18 | **`\| _ => 0`** | `BinaryC10Wiring.sourceBinding` (`:79`), discharged by `rfl` in `c10Wiring` (`:83`); surfaced by `c10_lookup_tuple_matches_lookupMessage7` (`:97`) |
+
+These are the two maps the issue is about. Both are *partial functions with a
+zeroing fallback*: a wrong or missing arm silently becomes `0`, which weakens
+rather than fails. What gates them today is narrow but real: each is used only
+inside one `rfl`-proved structure field asserting that *one specific* generated
+tuple maps to *one specific* live model
+(`hint_MemAlign_36_1.slots` -> `memAlignRomSuccessorTuple`, and
+`derivedTuple_Binary_10_0.slots` -> `lookupMessage7Tuple`). If an arm needed by
+that tuple were wrong, the `rfl` would fail. Both docstrings say the fallback is
+"unreachable for the checked tuple", which is the correct claim and is
+*enforced only for those tuples*: nothing stops a future caller from applying
+either map to a different `Expr` and silently getting zeros. That residual is
+the gap #304 exists to make mechanical, and it is a finding (F8), not something
+to patch by widening the arm list.
+
+### (b) `Valid_<AIR>` accessor <-> row field record literals (20). Total by construction.
+
+`rowAt`-style, one per AIR plus inverses. A record literal must assign every
+field or it does not compile, so there is no fallback and no silent zero; the
+failure mode is a *wrong* assignment, which nothing checks.
+
+| file:line | name | direction | leaf assignments |
+| --------- | ---- | --------- | ---------------- |
+| `ArithDiv/Bridge.lean:189` | `rowAt` | validator -> row | 14 |
+| `ArithMul/Bridge.lean:264` | `rowAt` | validator -> row | 17 |
+| `Binary/Bridge.lean:268` | `rowAt` | validator -> row | 39 |
+| `Binary/Bridge.lean:321` | `validOfRow` | row -> validator | 44 |
+| `BinaryAdd/Bridge.lean:47` | `rowAt` | validator -> row | 10 |
+| `BinaryAdd/Bridge.lean:180` | `validOfRow` | row -> validator | 13 |
+| `BinaryExtension/Bridge.lean:21` | `rowAt` | validator -> row | 33 |
+| `BinaryExtension/Bridge.lean:62` | `validOfRow` | row -> validator | 35 |
+| `Main/Bridge.lean:34` | `rowAt` | validator -> row | 18 |
+| `Main/Bridge.lean:55` | `validOfRow` | row -> validator | 22 |
+| `Mem/Bridge.lean:35` | `rowAt` | validator -> row | 13 |
+| `Mem/Bridge.lean:67` | `validOfRow` | row -> validator | 16 |
+| `MemAlign/Bridge.lean:75` | `rowAtWithDelta` | validator -> row | 31 |
+| `MemAlign/Bridge.lean:113` | `rowAt` | validator -> row | 0 (delegates to `rowAtWithDelta ... 0`) |
+| `MemAlign/Bridge.lean:119` | `validOfRow` | row -> validator | 30 |
+| `MemAlignByte/Bridge.lean:48` | `rowAt` | validator -> row | 16 |
+| `MemAlignByte/Bridge.lean:68` | `validOfRow` | row -> validator | 16 |
+| `MemAlignReadByte/Bridge.lean:44` | `rowAt` | validator -> row | 10 |
+| `MemAlignReadByte/Bridge.lean:58` | `validOfRow` | row -> validator | 10 |
+
+`ArithDiv/Bridge.lean:189` assigns 14 and `ArithMul/Bridge.lean:264` assigns 17,
+against 43 and 44 record fields, because the nested sub-struct groups are
+assigned as whole literals. Note `MemAlign/Bridge.lean:113`'s `rowAt` pins
+`delta_pc := 0` -- documented at `:109` as "the pre-h998 legacy projection has no
+`DELTA_PC` source" -- so the legacy view of a MemAlign row states a *false*
+`delta_pc` unless the caller uses `rowAtWithDelta`. The docstring says it is not
+used as the bus-133 soundness source. Nothing enforces that.
+
+### (c) Effective row slot -> raw witness slot or fixed column (2). Total, `omega`-proved.
+
+| file:line | name | branches | fallback |
+| --------- | ---- | -------- | -------- |
+| `Main/Circuit.lean:744` | `mainFixedLayout` | 5 | none: final `else`, index arithmetic by `omega` |
+| `Mem/GeneratedTransition.lean:26` | `memFixedLayout` | 3 | none: final `else` |
+
+`mainFixedLayout` maps 43 effective slots to 41 raw plus 2 fixed, hardcoding
+slot 17 (`core.segment_l1`) and slot 37 (`rom.main_step`). `memFixedLayout` maps
+19 effective slots to 17 raw plus 2 fixed. Both are total and their index
+arithmetic is proved, but the *choice* of which slot is which fixed column is a
+literal in the source with no cross-check against the pilout's fixed-column
+declaration.
+
+### (d) Named column-index constants and a constraint-index map (6).
+
+| file:line | name | maps | fallback |
+| --------- | ---- | ---- | -------- |
+| `Mem/SidecarColumns.lean:67` | `MemFixedColumn.segmentL1` | -> fixed slot 0 | n/a (a constant) |
+| `Mem/SidecarColumns.lean:68` | `MemFixedColumn.l1` | -> fixed slot 1 | n/a |
+| `Mem/SidecarColumns.lean:77-80` | `MemRangeSidecarRawColumn.distance{Base,End}{0,1}` | -> raw slots 13, 14, 15, 16 | n/a |
+| `Mem/RangeWiring.lean:29` | `memRangeSourceOfConstraint` | generated constraint index 29-32 -> (hint slot AST, raw column, prover-data key) | **`\| _ => none`** |
+
+`memRangeSourceOfConstraint` is the good pattern and the contrast with (a): its
+fallback is `none`, a refusal, not a zero, and it is consumed only through
+`MemRangeWiring.sourceBinding` (`Mem/RangeWiring.lean:57`) which demands
+`= some (hint.slots, rawColumn, proverDataKey)`. A missing arm makes the
+structure unconstructible instead of silently interpreting a term as zero.
+
+### What is *not* wired
+
+Only four files under `ZiskFv/` import anything from `Extraction`:
+`Binary/Wiring.lean`, `Mem/RangeWiring.lean`, `MemAlign/Bridge.lean` (all
+`Extraction.LookupWiring`) and `MemAlignRomTable.lean`
+(`Extraction.MemAlignRom`). The generated per-AIR constraint files
+`Extraction/<AIR>.lean` are imported by nothing under `ZiskFv/`. So the entire
+mirror side is connected to the generated side by three `rfl`-checked tuple
+bindings and one table import -- and by *nothing at all* for the 176 comparable
+polynomial constraints. Every correspondence in section 1's `claims` column is
+today a comment, not a check.
+
+## 5. Per-AIR coverage
+
+| air | pilout total | comparable | excluded | primary mirrors | conjuncts | claimed | unclaimed |
+| --- | -----------: | ---------: | -------: | --------------: | --------: | ------: | --------: |
+| Arith | 65 | 49 | 16 | 8 | 60 | 49 | 0 |
+| Binary | 14 | 7 | 7 | 1 | 7 | 7 | 0 |
+| BinaryAdd | 9 | 4 | 5 | 1 | 4 | 4 | 0 |
+| BinaryExtension | 8 | 0 | 8 | 0 | 0 | 0 | 0 |
+| Main | 144 | 39 | 105 | 6 | 34 | 32 | **7** |
+| Mem | 34 | 24 | 10 | 1 | 9 | 9 | 0 (15 delegated out of root) |
+| MemAlign | 40 | 33 | 7 | 3 | 34 | 33 | 0 |
+| MemAlignByte | 16 | 9 | 7 | 1 | 8 | 5 | **4** |
+| MemAlignReadByte | 10 | 4 | 6 | 1 | 2 | 4 | 0 |
+| MemAlignWriteByte | 15 | 7 | 8 | 0 | 0 | 0 | **7** |
+| TOTAL | 355 | 176 | 179 | 22 | 158 | 143 | **18** |
+
+`primary mirrors` and `conjuncts` count only `MIRROR`, `MIRROR_2ROW` and
+`MIRROR_MIXED`, so a validator-indexed restatement, a builder-input form, an
+environment adapter and a composite are not double-counted. `claimed` aggregates
+every mirror class.
+
+Which of the 10 AIRs have a mirror at all: **nine**. Only
+**MemAlignWriteByte has none**.
+
+## 6. Reachability
+
+`survey.py --section reachability` counts, per `Prop`-valued declaration, lines
+of checked-in Lean under `ZiskFv/`, `trust/` and `Tests/` that mention its name
+(comments stripped), excluding the declaration's own head line. Matching is by
+name, not by resolved constant, so a name reused across namespaces (`Spec`,
+`Assumptions`, `constraints_at`, `transition`) reads as the sum over all of them
+and a positive count is only an upper bound. A count of **zero** is conclusive:
+no line anywhere mentions the name.
+
+Three declarations have zero external references:
+
+| file:line | name | class |
+| --------- | ---- | ----- |
+| `ZiskFv/AirsClean/Main/Circuit.lean:346` | `RomBoolSpec` | **`MIRROR`** |
+| `ZiskFv/AirsClean/FullEnsemble/Balance/EmbeddedInTrace.lean:82` | `MutableMemReadReplayRowsEmbeddedInTrace` | `NEAR_BUS` |
+| `ZiskFv/AirsClean/FullEnsemble/Balance/EmbeddedInTrace.lean:95` | `MutableMemReplayRowsEmbeddedInTrace` | `NEAR_BUS` |
+
+`RomBoolSpec` is the only unreachable *mirror*; the documented case is confirmed.
+See F6. The two `EmbeddedInTrace` predicates are bus predicates, out of scope for
+this round trip, and are reported only so the reachability pass is exhaustive.
+
+Two more are reachable but barely, and worth knowing before #305 wires anything:
+`BinaryAdd.CoreFacts` and `BinaryAdd.RangeFacts` each have exactly one
+reference, both inside `ComponentSpecFacts`.
+
+## 7. Findings
+
+These are reported, not fixed. Each is a mirror-side observation with a source
+citation; none is repaired here, and none is made to disappear by widening a
+list. Deciding what to do about them is the owner's call.
+
+**F1 -- Main's a-side C copy has no mirror (the flagship gap).** Main c3 and c9
+are `(a_src_c)*(a[0]-(previous_c))` and `(a_src_c)*(a[1]-(previous_c))`, both
+`main/pil/main.pil:385`. `sourceCCopyBetween`
+(`ZiskFv/AirsClean/Main/Circuit.lean:721`) mirrors only the **b-side** pair, c4
+and c10 at `main.pil:386`, and its own docstring says so. Nothing in the mirror
+root restates the a-side. Five further Main comparable constraints are also
+unclaimed: c0 (`Main.main_last_segment*(1-Main.main_last_segment)`,
+`main.pil:86`), c19 (`Main.SEGMENT_L1'*(Main.segment_next_pc-(next_pc'))`,
+`main.pil:423`), c20 and c21
+(`Main.SEGMENT_L1'*(Main.segment_last_c[i]-c[i])`, `main.pil:426`) and c38
+(`Main.SEGMENT_L1*(Main.segment_initial_pc-pc)`, `main.pil:508`). All five reach
+an `AirValue`/`AirGroupValue` -- the segment-boundary public inputs -- which is
+consistent with `sourceCCopyBetween`'s docstring stating that Clean's transition
+interface has no public-input surface. c3 and c9 do not have that excuse: they
+reach `a_src_c`, a `const expr` over ordinary Main columns, exactly like c4 and
+c10.
+
+This is not only a mirror-`Prop` gap: the circuit side does not assert them
+either. `main` (`Main/Constraints.lean:27`) and `mainWithRom` (`:242`) together
+carry 31 `assertZero`s and none of them is the a-side copy; c4/c10/c18 live in
+the component transition. `grep -rn 'a_src_c\|previous_c' ZiskFv` finds one
+docstring mention (`ZiskFv/Airs/Main/Main.lean:136`, describing the **b**-side)
+and no constraint. The same holds for the other five:
+`main_last_segment`, `segment_initial_pc`, `segment_next_pc` and
+`segment_last_c` do not occur anywhere in `ZiskFv/`. So all seven are absent from
+the tree, not merely absent from the mirror root.
+
+**F2 -- four MemAlignByte booleans appear in the published `Spec` only as `ℕ`
+range bounds.** MemAlignByte c0, c1, c2 (`sel_high_{4b,2b,b}*(1-...)`,
+`mem_align_byte.pil:35-37`) and c4 (`is_write*(1-is_write)`, `:71`) have no
+field-equation clause in `MemAlignByte.Spec`. Three sit in
+`MemAlignByte.Assumptions` (`Spec.lean:70`) as `.val < 2`, and `is_write` sits in
+`MemAlignByte.Spec` itself as `row.is_write.val < 2 ^ 1`. `x.val < 2` and
+`x * (1 - x) = 0` are equivalent facts over `FGL` but not the same term, so a
+polynomial gate cannot pair them, and an `Assumptions` clause is a
+caller-supplied premise where the generated constraint is an assertion.
+
+**The circuits do assert them.** `MemAlignByte.main`
+(`MemAlignByte/Constraints.lean:58`) has 9 `assertZero`s, one per comparable
+constraint, each carrying an explicit `-- constraint N
+(mem/pil/mem_align_byte.pil:LINE)` comment; `MemAlignReadByte.main`
+(`MemAlignReadByte/Constraints.lean:59`) has 4, likewise. So the polynomial
+content is present circuit-side and complete for both AIRs; what is incomplete is
+the `Prop`-level mirror the component publishes as its `Spec`, and for
+MemAlignReadByte the three booleans exist as field equations only in
+`MemAlignReadByte/Bridge.lean:98`'s `constraints_at` over a `Valid_<AIR>`. This
+is the sharpest illustration of the classification question in section 8: which
+artifact #305 gates decides whether this is a four-constraint gap or none.
+
+**F3 -- `cyclicSuccessorTransitionRows` has one conjunct more than the
+comparable set.** `ZiskFv/AirsClean/MemAlign/Circuit.lean:254` conjunct 1 is
+`current.delta_pc = successor.pc - current.pc`. MemAlign's comparable
+constraints are c0-c32 and none of them is that equation; its only generated
+source is the `(col 4, row+1) - (col 4, row)` subterm inside
+`Extraction.MemAlign.constraint_36_every_row`
+(`build/extraction/Extraction/MemAlign.lean:235`), which is challenge-mixed and
+therefore **excluded** from the comparable set. So this conjunct is a mirror-side
+equation over an excluded constraint's hint payload. It is not obviously wrong --
+`MemAlign/Bridge.lean:240`'s `h998_tuple_matches_successor_message` binds the
+same tuple by `rfl` -- but a gate scoped to the comparable set has nothing to
+pair it against and must either declare it or reach into the excluded set.
+
+**F4 -- 15 of Mem's 24 comparable constraints are mirrored outside the mirror
+root.** `Mem.Spec` covers 9 (c3-c8, c18, c21, c23).
+`Mem/GeneratedTransition.lean:251` reaches
+`ZiskFv.Airs.Mem.segmentResidualEveryRow` (`ZiskFv/Airs/Mem.lean:296`), whose 15
+conjuncts are the remaining c0-c2, c9-c17, c19, c20, c22 -- the index
+correspondence is pinned by the destructuring in
+`segmentResidualEveryRow_of_segment_every_row` (`ZiskFv/Airs/Mem.lean:337-339`).
+A gate scoped literally to `ZiskFv/AirsClean/**` reports 15 Mem constraints as
+unmirrored when they are not. Scope decision needed; see "Scope" above.
+
+**F5 -- MemAlignWriteByte has no mirror, no row record, and no mention in the
+tree.** `grep -rn MemAlignWriteByte ZiskFv trust` returns nothing. The AIR is in
+`DECLARED_AIRS`, #303 round-trips its 15 constraints into
+`build/extraction/Extraction/MemAlignWriteByte.lean`, and 7 of them are
+comparable: c0-c2 (`sel_high_*` booleans, `mem_align_byte.pil:35-37`), c3
+(`composed_value`, `:59`), c4 (`written_composed_value`, `:83`), c5 and c6
+(`mem_write_values[0]`, `[1]`, `:87-88`). Every one of the 7 has a
+character-for-character counterpart among MemAlignByte's constraints, so a mirror
+would be near-mechanical -- which is a reason it is easy to miss, not a reason it
+is covered.
+
+**F6 -- `RomBoolSpec` is a published mirror predicate that nothing references.**
+`ZiskFv/AirsClean/Main/Circuit.lean:346`, 14 conjuncts, claiming Main c23-c27 and
+c29-c37. Zero references anywhere in `ZiskFv/`, `trust/` or `Tests/`. Its own
+docstring says "These are not part of Main's per-row soundness `Spec`; a future
+honest-prover completeness project may consume them separately." The equations
+themselves are *not* dead: `mainWithRom` (`Main/Constraints.lean:247-261`)
+asserts all 14, and
+`romBoolSpec_of_mainWithRomAndMemBus_constraints` (`Main/Circuit.lean:397`) states
+all 14 inline. So the situation is precisely "a published mirror predicate
+checked against nothing", with a live circuit-side twin. A gate that took
+`RomBoolSpec` as evidence of Main coverage would be reading a predicate no proof
+consumes.
+
+**F7 -- `MemAlign.L1` is a fixed column modeled as a free witness field.** The
+generated `constraint_16_every_row` is `MemAlign.L1*pc`
+(`mem_align.pil:121`), rendered as
+`preprocessed c (column := 0) * main c (id := 1) (column := 4)`. The mirror
+represents `MemAlign.L1` as the row field `preL1`
+(`MemAlign/Row.lean:24`, flattened position 26) and `MemAlign.component`
+(`MemAlign/Circuit.lean:279`) declares no `fixedColumns` and no `rawWidth` at all --
+unlike `Main.componentWithRomMemAndOpBus` (`Main/Circuit.lean:952`) and
+`Mem.componentWithDualMemBus` (`Mem/Circuit.lean:253`), both of which carry an
+`IndexedFixedColumns` schema. So PIL's `MemAlign.L1`, a fixed column with a known
+`[1, 0, 0, ...]` value, becomes an unconstrained field whose only constraint is
+`preL1 * pc = 0`. The honest-row builder sets `preL1 := boolF isBoot`
+(`MemAlign/Circuit.lean:137`), which is a completeness-side choice, not a soundness
+pin. This is a candidate mirror-side weakening, and it is a finding for the owner
+-- not something to correct here, since `MemAlignRow` is a protected row
+structure.
+
+**F8 -- both `Expr`-to-field maps are partial with a zeroing fallback, gated only
+for one tuple each.** `h998ExprToField` (`MemAlign/Bridge.lean:31`, 38 arms) and
+`c10LookupExprToClean` (`Binary/Wiring.lean:33`, 18 arms) both end `| _ => 0`.
+Each is protected today by exactly one `rfl`-discharged `sourceBinding` covering
+one generated tuple; applied to any other `Expr`, a missing arm reads as the zero
+polynomial and the caller sees a well-typed, wrong answer. `h998ExprToField` also
+carries four redundant `.add (.witness ...) (.constant "0")` arms (lines 62-65)
+duplicating the bare-witness arms, which is the shape of a map that was extended
+by trial against one artifact. The contrast to copy is
+`memRangeSourceOfConstraint` (`Mem/RangeWiring.lean:29`), which returns `Option`
+and refuses.
+
+**F9 -- `AddressSpec` has two conjuncts with no generated counterpart.**
+`Main/Spec.lean:68` clause 1 is `row.rom.addr0 = row.rom.a_offset_imm0` and
+clause 3 is `row.rom.addr2 = row.rom.store_offset + row.rom.store_ind *
+row.core.a_0`. Main's comparable set contains a constraint for `addr1` (c1,
+`main.pil:192`) and none for `addr0` or `addr2`, and the Main witness header has
+no `addr0` or `addr2` column -- PIL defines them as `const expr`. `mainWithRom`
+(`Main/Constraints.lean:268,270`) asserts both. They look constructibility-neutral
+(the prover can always satisfy a definition of its own witness column), but they
+are mirror conjuncts with no pilout constraint to pair against, and a gate must
+declare them rather than silently drop them. The same is true of
+`core.im_high_degree_2`, a `MainRow` field with neither a stage-1 column nor a
+fixed column in this pilout.
+
+**F10 -- five row docstrings state a slot count that no longer matches the
+record.** `MemAlign/Row.lean:9` says "19-slot" for a 31-field record;
+`ArithMul/Row.lean:9` and `ArithDiv/Row.lean:9` say "28-slot" for 44 and 43;
+`Binary/Row.lean:9` says "38-slot" for 39; `BinaryExtension/Row.lean:9` says
+"30-slot" for 29. Documentation drift, not a proof defect -- but it is the
+first thing a reader uses to size the mirror, and four of the five understate it.
+Related, smaller: `MemAlignReadByte/Spec.lean:10,69` cites
+`mem_align_byte.pil:57` for `composed_value` where the generated provenance says
+`:59`; `MemAlign/Spec.lean:6` says "MemAlign has 25 F-typed constraints" where
+the comparable count is 33.
+
+## 8. Blind spots and classifications I am not certain of
+
+* **`claims` is a reading, not a proof.** Every claim set in section 1 was read
+  off the mirror body against the generated file and its provenance comments. Two
+  of them I am confident about because the source pins the index correspondence
+  (`ZiskFv/Airs/Mem.lean:337`'s destructuring, and Arith's totals landing exactly
+  on 49). The rest are my pairing, and a wrong claim would move a constraint
+  between "claimed" and "unclaimed" without the script noticing. #305 must decide
+  the pairings polynomially; until then, treat the "unclaimed" column as a lower
+  bound on the gap.
+
+* **Whether `MIRROR_VALIDATOR` should count as coverage at all.** A
+  `constraints_at` over a `Valid_<AIR>` is the same equation over a different
+  carrier. For MemAlignReadByte that distinction decides whether 3 constraints
+  are covered or not (F2), and I report both numbers rather than choosing.
+  `Valid_<AIR>` fields are a protected interface, so this is a scope question,
+  not something to normalise away.
+
+* **Whether the circuit-side `assertZero` sequences are the real mirror.** I
+  classified them out of the 104 because they are `Circuit FGL Unit`, not `Prop`
+  -- the issue's own definition. But `Mem/Constraints.lean:112` covers all 24 Mem
+  comparable constraints, and `ArithCompleteConstraints.lean:18` covers Arith's
+  49; both are inside the root. If #305 compares the circuits instead of the
+  `Prop`s, Mem's F4 scope problem mostly evaporates and the inventory's
+  denominator changes. I have not assumed either way.
+
+* **`MIRROR_BUILDER` vs `MIRROR`.** `MainRomAddressGuard` and
+  `MainRomSourceGuard` state the same equations as `AddressSpec` clause 4 and
+  `SourceSpec`, over `(msg, bits, free)` rather than a row record. They are
+  completeness-side constructibility conditions on the honest-row builder. I
+  classified them as mirrors because the equations are the AIR's; someone might
+  reasonably call them near-misses.
+
+* **`Coherent` (`Main/Circuit.lean:250`) is not in the 104** because its result
+  type is `MainRomExecKind → Prop`, which the `: Prop` test does not match. Its
+  body is `Bool` and `msg.op` equalities over a ROM message, not field equations,
+  so it would be `NEAR_SEMANTIC`; I mention it because the same signature shape
+  would hide a genuine mirror if one were ever written that way. `survey.py`'s
+  unclassified check does not catch that case.
+
+* **`.val`-bound clauses inside `MIRROR_MIXED`.** `MemAlignByte.Spec` and
+  `MemAlignReadByte.Spec` mix field equations with `.val <` bounds in one
+  conjunction. I counted their conjuncts as 8 and 2 and their claims as 5 and 1,
+  so the arithmetic is consistent, but a gate splitting a mixed predicate has to
+  do so clause-index by clause-index and those indices are not stable against an
+  edit to the predicate.
+
+* **The reference count over-counts, never under-counts.** Name-based matching
+  aggregates `Spec` across all ten namespaces, so "145 references" means nothing.
+  Only the zeros in section 6 are load-bearing, and they are sound in the
+  direction claimed.
+
+* **Excluded constraints are not inventoried.** 179 of the 355 emitted
+  constraints reach a challenge or a stage-2 lane and are outside this
+  inventory's comparable set, per the issue's rule. Two of them are read by the
+  mirror side anyway -- MemAlign c36's hint payload via F3, and Mem's range
+  sidecar via `Mem/RangeWiring.lean` -- so "excluded" does not mean "the mirror
+  is silent about it".

--- a/tools/mirror-roundtrip/lanes.py
+++ b/tools/mirror-roundtrip/lanes.py
@@ -1,0 +1,1264 @@
+#!/usr/bin/env python3
+"""Per-AIR lane maps, and the gate on them, for eth-act/zisk-fv#304.
+
+A *lane* is one Lean-visible slot of an AIR: a witness column, a fixed column,
+an exposed value, or a challenge. A *lane map* answers, in both directions, "which
+named pilout signal is this slot?" -- and it is built from `build/zisk.pilout` and
+the emitted witness-column header alone. It never reads a mirror, and it never
+reads one of the handwritten maps under `ZiskFv/`, because those are the artifacts
+a later gate has to check *against* this one.
+
+## Why this file exists
+
+The correspondence between a mirror's row-record field and a generated column is
+today handwritten per AIR and gated by nothing. The hazard is not that such a map
+is hard to write; it is the shape it is written in. `h998ExprToField`
+(`ZiskFv/AirsClean/MemAlign/Bridge.lean:31`) is a `match` over 38 arms ending
+
+    | _ => 0
+
+so a lane the map does not mention, or mentions at the wrong index, does not fail:
+it evaluates to the field's zero, and a constraint over it silently becomes
+weaker. Nothing raises, nothing is reported, and the Lean still compiles.
+
+So the map here is the opposite shape in three ways:
+
+* it is derived, not written -- the names come from `PilOut.symbols`;
+* it is total and closed in *both* directions, and the two failure modes are
+  reported separately: a declared lane with no name, and a symbol-derived name
+  whose lane the AIR does not declare;
+* every lookup raises. `LaneMap.resolve` and `LaneMap.name_of` have no fallback
+  and no default. A miss is a `LaneError` naming the miss.
+
+This file only reports. Finding that a mirror omits a lane, or reclassifies one,
+is a finding to be cited -- not something this tool may fix, and not something to
+make disappear by widening a list.
+
+## Lane vocabulary
+
+    ('main', stage, col)              a witness column, stage kept
+    ('pre', col)                      a fixed column (pilout stage 0)
+    ('exposed', source, idx)          an exposed value; `source` is
+                                      'air_value' or 'air_group_value'
+    ('chal', stage, idx)              a challenge, stage unflattened
+
+Two of those deliberately keep a distinction `Extraction.Circuit` loses.
+
+`exposed` carries its `source` as a component of the lane, separate from the
+index, because the emitted accessor vocabulary sends both `Operand.AirValue{idx}`
+and `Operand.AirGroupValue{idx}` to one `exposed (index := idx)`. #303 measured
+that collapse as its principal residual blind spot in the per-AIR files -- 8 of
+the 10 AIRs have index 0 live under both kinds. Inheriting the collapse here
+would make the lane map unable to state which value a mirror field is supposed to
+be, which is the whole question. `accessor_atom` performs the collapse explicitly,
+so it is visible as a non-injective function between two vocabularies rather than
+as a distinction that was never available; `collapsed_indices` counts its fibres.
+
+`chal` keeps the stage for the same reason: the accessor rendering flattens
+`(stage, idx)` to one index, and on this pilout the prefix sum is zero, so the
+flattening is corroborated but not discriminated (`pilout_atoms.flatten_challenge`
+documents this). A lane map that stored only the flat index would bake in the
+undiscriminated reading.
+
+A lane is a *slot*, not a cell: it carries no row offset. `('main', 1, 4)` is
+MemAlign's `pc` column; `pc` at row delta -1 and at delta 0 are the same lane. The
+shared atom vocabularies of #303 add the delta, and `accessor_atom` takes it as an
+argument.
+
+## Sources, in order of authority
+
+1. `PilOut.symbols`. A `Symbol` carries `name`, `airGroupId`, `airId`, `type`,
+   `id`, `stage` and `lengths`; the type is the authoritative lane kind. This is
+   the only source of names.
+2. The emitted `-- stage S col C: name` header in
+   `build/extraction/Extraction/<AIR>.lean`, as an independent cross-check on the
+   witness lanes -- the only lane kind any emitted artifact names at all.
+3. `Air.stageWidths`, `Air.fixedCols`, `Air.airValues`, `AirGroup.airGroupValues`
+   and `PilOut.numChallenges`, as the geometry: they declare how many lanes of
+   each kind exist, which is what makes "closed in both directions" a question
+   with an answer.
+
+Sources 1 and 3 are separate messages in the file and neither is derived from the
+other, so their agreement is evidence and not bookkeeping: a symbol table naming a
+column past its stage width, or a stage width past the last named column, is
+reported rather than reconciled.
+
+`witness_column_names` in `pilout_atoms` already reconstructs source 1 for witness
+columns and #303 checks it against source 2. This file does not re-implement that:
+it walks all five symbol types through one code path -- so fixed columns, air
+values, air group values and challenges are named by exactly the mechanism already
+checked on witness columns -- and then cross-checks its own witness lanes against
+`witness_column_names` *and* against the header. Three-way agreement, reported.
+
+## Array normalisation
+
+The header spells array elements `reg[0]`, `sel[3]`, `value[1]`; the symbol table
+spells the same thing as a name plus `lengths`. The rule, applied to every symbol
+type identically:
+
+* `lengths == []`: the name key is `name`. `indices` is `()` and `flat` is None.
+* `lengths == [n_1, ..., n_d]`: the symbol occupies ids `id .. id + prod(n_i) - 1`
+  and the element at flat offset `k` has name key `f"{name}[{k}]"` -- a *single*
+  flat index, never `name[i][j]`.
+
+The flat spelling is the key because it is the spelling a real artifact uses: the
+emitted header writes `free_in_c[0] .. free_in_c[15]` for `BinaryExtension`'s
+`free_in_c` with `lengths == [8, 2]`, so the flat form is pinned for `d == 2` and
+not merely assumed for `d == 1`.
+
+The multi-index is carried alongside as `LaneInfo.indices`, decomposed row-major
+(last index fastest), so the array structure is not lost -- but it is *not* part of
+the key, and nothing downstream should key on it. `multi_index_order_evidence`
+tests the row-major reading the way #303 tests its byte order: the pilout's own
+`debugLine` strings quote PIL's two-index spellings, and matching them against the
+witness column an expression actually reads decides the order. At HEAD that is 10
+corroborations of row-major and 0 of column-major, all from AIRs outside the
+extracted ten, because no in-scope constraint quotes a two-index reference. So the
+order is evidence about the writer's convention, not a fact pinned in scope, and
+only `indices` depends on it -- `flat`, which is what an operand carries, does not.
+
+Names are kept exactly as the pilout writes them, with nothing added or stripped.
+That matters because the qualification is not uniform: witness names are bare
+(`addr`, `reg[0]`), fixed and air-value names are air-qualified (`MemAlign.L1`,
+`Main.main_last_segment`) except the per-AIR `__L1__`, the single air group value
+is group-qualified (`Zisk.gsum_result`), and challenges are bare and global
+(`std_alpha`). So `MemAlign.L1` cannot collide with a witness column named `L1`
+because they are different strings -- and if a witness column named `MemAlign.L1`
+ever appeared, `LaneMap.by_name` would carry both lanes and `resolve` would raise
+on the ambiguity rather than pick one. Normalising qualification away would turn
+that into a silent overwrite.
+
+The Lean-side spelling of an array element is `reg_0`, not `reg[0]`. That aliasing
+belongs to whoever compares a mirror field against a lane; the key here is the PIL
+spelling, so this file has exactly one spelling and no alias table.
+
+## Name uniqueness is checked, and it does not hold everywhere
+
+Per (air, lane kind), a lane always has exactly one name -- `lanes` is a function.
+The other direction is not injective, and the gate says so rather than assuming it:
+
+* On the lanes #303's comparability rule keeps -- stage-1 witness, fixed, exposed,
+  challenge -- names are unique in every one of the ten AIRs. The gate treats a
+  violation there as a hard failure.
+* On stage-2 witness lanes they are not. Of the 57 stage-2 lanes, 41 share a name
+  with another lane of the same AIR and collapse onto 11 names, in 9 of the 10
+  AIRs, because the pilout reuses `im_cluster` and `im_single` for every
+  accumulator lane -- `Arith` alone has 11 columns named `im_cluster`. That is a
+  property of the input: no edit to this tool or to the extractor changes it, the
+  names are not identifiers on that side, and stage-2 lanes are exactly what the
+  comparability rule excludes. It is reported in full, as a measured
+  non-uniqueness, and does not fail the gate.
+
+The consequence is bounded and worth stating: a consumer that resolves a lane *by
+name* is ambiguous on stage 2, so `resolve` raises there. Every handwritten map in
+the tree resolves by `(stage, column, offset)` instead, which is unique in both
+directions, so nothing in the tree is affected today.
+
+## What a green gate does not assert
+
+* Nothing about fixed column *contents*. Source 3 counts the columns; this pilout
+  stores no payloads for them (every `FixedCol` size reads 0), so `('pre', 0)`
+  being `MemAlign.L1` says which column it is and nothing about its values.
+* Nothing about mirrors. That a lane exists and is named does not mean any mirror
+  projects it, projects it correctly, or projects it at the right kind. Pairing is
+  #305's job; this file is the vocabulary that pairing needs.
+* Nothing about the pool. An AIR's `IM_COL` symbols name entries of its
+  *expression pool*, not slots: their ids index `Air.expressions`, they carry no
+  stage, and no operand kind refers to them (`Operand.Expression{idx}` is inlined
+  by `pilout_atoms`). They are counted here and are deliberately not lanes.
+* The four lane kinds are exhaustive only because the file says so: across the ten
+  AIRs, `numPeriodicCols` and `numCustomCommits` are 0 and no operand of kind
+  `periodic_col`, `custom_col`, `proof_value` or `public_value` occurs. All four
+  are checked, and one appearing is a gate failure rather than a lane kind quietly
+  outside the vocabulary.
+
+    python3 tools/mirror-roundtrip/lanes.py [--pilout PATH] [--extraction DIR]
+                                            [--air NAME]... [--quiet]
+
+Exit codes:
+
+    0  every declared AIR's lane map is closed in both directions, agrees with
+       the emitted header, and resolves every atom its constraints use
+    1  an unnamed lane, an orphan name, a header disagreement, a duplicate name
+       among comparable lanes, an unresolved atom, or a lane kind outside the
+       vocabulary
+    2  usage or IO error: no pilout, no extraction directory, an unknown --air
+
+Exit 2 is not a pass. A missing `build/` means the gate ran on nothing, and this
+tool says so on stderr for the same reason `check.py` does.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "tools" / "pilout-roundtrip"))
+
+import lean_parse  # noqa: E402
+import pilout_atoms  # noqa: E402
+import pilout_wire  # noqa: E402
+from check import DECLARED_AIRS  # noqa: E402
+
+DEFAULT_PILOUT = REPO_ROOT / "build" / "zisk.pilout"
+DEFAULT_EXTRACTION = REPO_ROOT / "build" / "extraction" / "Extraction"
+
+EXIT_OK = 0
+EXIT_FAILED = 1
+EXIT_USAGE = 2
+
+# Symbol type -> (lane head, scope). The scope is which namespace the lane lives
+# in, and it is not decoration: it says where to look for the symbol and how many
+# lanes to expect. Witness, fixed and air-value symbols are keyed by
+# (airGroupId, airId); the one air group value is keyed by airGroupId with airId
+# absent, so every AIR of a group shares it; challenges are keyed by neither, so
+# every AIR of the file shares them.
+LANE_SOURCES = {
+    "WITNESS_COL": ("main", "air"),
+    "FIXED_COL": ("pre", "air"),
+    "AIR_VALUE": ("exposed", "air"),
+    "AIR_GROUP_VALUE": ("exposed", "airgroup"),
+    "CHALLENGE": ("chal", "global"),
+}
+
+# Exposed lanes carry which of the two kinds they came from; these are the values
+# `LaneInfo.lane[1]` can take.
+EXPOSED_SOURCES = ("air_value", "air_group_value")
+
+# Lane heads whose names must be unique per AIR whatever their stage.
+UNIQUE_HEADS = frozenset({"pre", "exposed", "chal"})
+
+
+def uniqueness_required(lane: tuple) -> bool:
+    """Is a duplicate name on this lane a hard failure?
+
+    Every lane except a stage-2 witness column. That is the comparable set of the
+    issue's own exclusion rule, and the exception is a measurement, not a
+    preference: see "Name uniqueness" in the module docstring. A name shared
+    between a stage-1 and a stage-2 lane is still hard, because it is ambiguous
+    inside the comparable set.
+    """
+    if lane[0] == "main":
+        return lane[1] == 1
+    return lane[0] in UNIQUE_HEADS
+
+# Symbol types in scope that are not lanes, each with the reason it is not one.
+# Every entry has to be a *structural* reason -- the symbol does not denote a slot
+# of an AIR row, or the operand kind that would reach it does not exist -- and each
+# is paired with a check elsewhere that fails if the reason stops holding:
+# `_gate_vocabulary` fails on a `public_value` or `proof_value` operand, and the
+# expression pool is inlined by `pilout_atoms` before any atom exists, so an
+# unresolved pool reference surfaces as an unrepresentable constraint.
+#
+# `PERIODIC_COL`, `CUSTOM_COL` and `PUBLIC_TABLE` are deliberately absent. They
+# would be lane kinds this vocabulary does not model, so one appearing in scope
+# must raise rather than be waved through; `_gate_vocabulary` checks the same thing
+# from the geometry side.
+NON_LANE_SYMBOL_TYPES = {
+    "IM_COL": "names an expression-pool entry, not a row slot: its id indexes a "
+              "pool, it carries no stage, and the pool is inlined before any atom",
+    "PUBLIC_VALUE": "a proof-global input, not a slot of any AIR row; no "
+                    "`Extraction.Circuit` accessor reaches one",
+    "PROOF_VALUE": "a proof-global value, not a slot of any AIR row; no "
+                   "`Extraction.Circuit` accessor reaches one",
+}
+
+# Operand kinds with no lane in this vocabulary. None occurs in the declared ten;
+# `gate_lane_map` fails if one appears, rather than letting a new lane kind arrive
+# unnamed.
+UNMODELLED_OPERAND_KINDS = frozenset(
+    {"periodic_col", "custom_col", "proof_value", "public_value"}
+)
+
+# PIL's two-index spelling in a `debugLine`, e.g. `value[2][1]`. The lookbehind
+# keeps `Mem.value[0][1]` from matching at `value` with a truncated base name.
+_RE_TWO_INDEX = re.compile(r"(?<![A-Za-z_0-9.])([A-Za-z_][A-Za-z_0-9]*)\[(\d+)\]\[(\d+)\]")
+
+
+class LaneError(Exception):
+    """A lane lookup missed, or the symbol table cannot define a lane map."""
+
+
+# --- one symbol to its lanes -------------------------------------------------
+
+
+def row_major_indices(flat: int, lengths: tuple[int, ...]) -> tuple[int, ...]:
+    """Decompose a flat array offset row-major (last index fastest)."""
+    out: list[int] = []
+    for length in reversed(lengths):
+        out.append(flat % length)
+        flat //= length
+    return tuple(reversed(out))
+
+
+def array_elements(symbol: pilout_wire.Symbol) -> list[tuple[int, tuple[int, ...], str]]:
+    """Expand one symbol into `(flat offset, multi-index, name key)` per element.
+
+    The single place the array normalisation of the module docstring is applied,
+    for every symbol type alike. `dim` is cross-checked against `lengths` rather
+    than trusted: they are separate fields and either could be the stale one.
+    """
+    lengths = tuple(symbol.lengths)
+    if symbol.dim != len(lengths):
+        raise LaneError(
+            f"symbol {symbol.name!r}: dim {symbol.dim} disagrees with lengths {lengths}"
+        )
+    if not lengths:
+        return [(0, (), symbol.name)]
+    total = 1
+    for length in lengths:
+        if length <= 0:
+            raise LaneError(f"symbol {symbol.name!r}: non-positive length in {lengths}")
+        total *= length
+    return [(k, row_major_indices(k, lengths), f"{symbol.name}[{k}]") for k in range(total)]
+
+
+@dataclass(frozen=True)
+class LaneInfo:
+    """One lane, its name, and the symbol-table facts that produced it."""
+
+    lane: tuple
+    name: str
+    base: str
+    indices: tuple[int, ...]
+    flat: int | None
+    stage: int | None
+    scope: str
+    symbol_type: str
+
+    @property
+    def head(self) -> str:
+        return self.lane[0]
+
+    def __repr__(self) -> str:
+        return f"LaneInfo({self.lane} {self.name!r} {self.symbol_type})"
+
+
+def _lane_of(symbol: pilout_wire.Symbol, flat: int) -> tuple:
+    """The lane tuple one symbol element occupies, from its type and id."""
+    head, _scope = LANE_SOURCES[symbol.type_name]
+    ident = symbol.id + flat
+    if head == "main":
+        return ("main", symbol.stage, ident)
+    if head == "pre":
+        return ("pre", ident)
+    if head == "chal":
+        return ("chal", symbol.stage, ident)
+    source = "air_value" if symbol.type_name == "AIR_VALUE" else "air_group_value"
+    return ("exposed", source, ident)
+
+
+# --- the map ------------------------------------------------------------------
+
+
+@dataclass
+class LaneMap:
+    """Every lane of one AIR, resolvable by lane and by name, with no fallback.
+
+    `lanes` is a function from lane to `LaneInfo`. `by_name` is a *multimap*,
+    because the pilout does not name stage-2 witness columns uniquely; `resolve`
+    raises on an ambiguity rather than choosing.
+
+    `unnamed` and `orphans` are the two closure failures, kept apart on purpose:
+    the first is a lane the AIR declares that no symbol names, the second is a
+    symbol-derived name whose lane the AIR's geometry does not contain. They have
+    different causes and different fixes, and a map with either is not closed.
+    """
+
+    air_name: str
+    airgroup_name: str
+    airgroup_idx: int
+    air_idx: int
+    stage_widths: tuple[int, ...]
+    num_fixed_cols: int
+    num_air_values: int
+    num_air_group_values: int
+    num_challenges: tuple[int, ...]
+    lanes: dict[tuple, LaneInfo] = field(default_factory=dict)
+    by_name: dict[str, tuple] = field(default_factory=dict)
+    unnamed: tuple[tuple, ...] = ()
+    orphans: tuple[tuple[str, tuple, str], ...] = ()
+    non_lane_symbols: dict[tuple[str, str], int] = field(default_factory=dict)
+
+    # --- lookup, in both directions
+
+    def info_of(self, lane: tuple) -> LaneInfo:
+        """Everything known about `lane`, or `LaneError`. Never a default."""
+        info = self.lanes.get(lane)
+        if info is None:
+            raise LaneError(f"{self.air_name}: no lane {lane}")
+        return info
+
+    def name_of(self, lane: tuple) -> str:
+        return self.info_of(lane).name
+
+    def resolve(self, name: str) -> tuple:
+        """The lane named `name`, or `LaneError` -- on a miss *or* an ambiguity."""
+        found = self.by_name.get(name)
+        if not found:
+            raise LaneError(f"{self.air_name}: no lane named {name!r}")
+        if len(found) > 1:
+            raise LaneError(
+                f"{self.air_name}: {name!r} names {len(found)} lanes {found}; "
+                f"resolve by lane instead"
+            )
+        return found[0]
+
+    # --- views
+
+    def of_head(self, head: str) -> list[LaneInfo]:
+        return [info for info in self.lanes.values() if info.head == head]
+
+    def of_exposed(self, source: str) -> list[LaneInfo]:
+        if source not in EXPOSED_SOURCES:
+            raise LaneError(f"unknown exposed source {source!r}")
+        return [
+            info for info in self.lanes.values()
+            if info.head == "exposed" and info.lane[1] == source
+        ]
+
+    def witness_names(self) -> dict[tuple[int, int], str]:
+        """`(stage, column) -> name`, the shape the emitted header is parsed into."""
+        return {
+            (info.lane[1], info.lane[2]): info.name
+            for info in self.lanes.values()
+            if info.head == "main"
+        }
+
+    def counts(self) -> dict[str, int]:
+        counts = {
+            "witness": len(self.of_head("main")),
+            "fixed": len(self.of_head("pre")),
+            "air_value": len(self.of_exposed("air_value")),
+            "air_group_value": len(self.of_exposed("air_group_value")),
+            "challenge": len(self.of_head("chal")),
+        }
+        counts["total"] = sum(counts.values())
+        return counts
+
+    def duplicate_names(self) -> list[tuple[str, tuple]]:
+        """Names that resolve to more than one lane, worst first."""
+        return sorted(
+            ((name, found) for name, found in self.by_name.items() if len(found) > 1),
+            key=lambda item: (-len(item[1]), item[0]),
+        )
+
+    def hard_duplicate_names(self) -> list[tuple[str, tuple]]:
+        """Duplicates on lanes where uniqueness is required; see `uniqueness_required`."""
+        return [
+            (name, found) for name, found in self.duplicate_names()
+            if any(uniqueness_required(lane) for lane in found)
+        ]
+
+    @property
+    def closed(self) -> bool:
+        return not self.unnamed and not self.orphans
+
+    # --- the accessor-vocabulary collapse, made explicit
+
+    def accessor_atom(self, lane: tuple, delta: int = 0) -> tuple:
+        """This lane as a #303 accessor-vocabulary atom, collapse included.
+
+        Not a convenience: it is where the two vocabularies are related, so the
+        information `Extraction.Circuit` cannot express is visible as this
+        function's non-injectivity instead of as a distinction the lane map never
+        had. `collapsed_indices` reports the fibres with more than one lane.
+        """
+        head = lane[0]
+        if head == "main":
+            return ("main", lane[1], lane[2], delta)
+        if head == "pre":
+            return ("pre", lane[1], delta)
+        if head == "chal":
+            return ("chal", pilout_atoms.flatten_challenge(
+                list(self.num_challenges), lane[1], lane[2]))
+        if head == "exposed":
+            return ("exposed", lane[2])
+        raise LaneError(f"{self.air_name}: {lane} is not a lane")
+
+    def collapsed_indices(self) -> list[int]:
+        """Exposed indices live under both kinds, i.e. ambiguous as `exposed idx`."""
+        air = {info.lane[2] for info in self.of_exposed("air_value")}
+        group = {info.lane[2] for info in self.of_exposed("air_group_value")}
+        return sorted(air & group)
+
+
+def _find_air(pilout: pilout_wire.PilOut, air) -> pilout_wire.AirRef:
+    """Accept an `AirRef` or an AIR name; a name must identify exactly one AIR."""
+    if isinstance(air, pilout_wire.AirRef):
+        return air
+    matches = [ref for ref in pilout.airs() if ref.air_name == air]
+    if len(matches) != 1:
+        raise LaneError(f"{air!r} names {len(matches)} AIRs in this pilout")
+    return matches[0]
+
+
+def declared_lanes(pilout: pilout_wire.PilOut, ref: pilout_wire.AirRef) -> set[tuple]:
+    """Every lane the AIR's geometry declares -- source 3, with no names involved.
+
+    The other half of "closed in both directions": without a lane set derived
+    independently of the symbol table, a missing symbol is invisible.
+    """
+    air = ref.air
+    group = pilout.air_groups[ref.airgroup_idx]
+    lanes: set[tuple] = set()
+    for stage_index, width in enumerate(air.stage_widths):
+        lanes.update(("main", stage_index + 1, col) for col in range(width))
+    lanes.update(("pre", col) for col in range(air.num_fixed_cols))
+    lanes.update(("exposed", "air_value", idx) for idx in range(air.num_air_values))
+    lanes.update(
+        ("exposed", "air_group_value", idx) for idx in range(group.num_air_group_values)
+    )
+    for stage_index, count in enumerate(pilout.num_challenges):
+        lanes.update(("chal", stage_index + 1, idx) for idx in range(count))
+    return lanes
+
+
+def lane_map(pilout: pilout_wire.PilOut, air) -> LaneMap:
+    """The lane map of one AIR: `(air, lane) <-> name`, total and closed or not.
+
+    Raises `LaneError` when the symbol table cannot define a map at all -- two
+    symbols claiming one lane, a symbol whose `dim` and `lengths` disagree. The
+    two *closure* failures are recorded on the result instead of raised, so a gate
+    can report both directions of both, for every AIR, in one run.
+    """
+    ref = _find_air(pilout, air)
+    air_obj = ref.air
+    group = pilout.air_groups[ref.airgroup_idx]
+    out = LaneMap(
+        air_name=ref.air_name,
+        airgroup_name=ref.airgroup_name,
+        airgroup_idx=ref.airgroup_idx,
+        air_idx=ref.air_idx,
+        stage_widths=tuple(air_obj.stage_widths),
+        num_fixed_cols=air_obj.num_fixed_cols,
+        num_air_values=air_obj.num_air_values,
+        num_air_group_values=group.num_air_group_values,
+        num_challenges=tuple(pilout.num_challenges),
+    )
+    expected = declared_lanes(pilout, ref)
+    orphans: list[tuple[str, tuple, str]] = []
+    by_name: dict[str, list[tuple]] = {}
+
+    for symbol in pilout.symbols:
+        scoped = _scope_of(symbol, ref)
+        if scoped is None:
+            continue
+        if symbol.type_name in NON_LANE_SYMBOL_TYPES:
+            key = (scoped, symbol.type_name)
+            out.non_lane_symbols[key] = out.non_lane_symbols.get(key, 0) + 1
+            continue
+        if symbol.type_name not in LANE_SOURCES:
+            raise LaneError(
+                f"{ref.air_name}: symbol {symbol.name!r} has type {symbol.type_name}, "
+                f"which is neither a lane kind nor a declared non-lane"
+            )
+        head, scope = LANE_SOURCES[symbol.type_name]
+        if scope != scoped:
+            raise LaneError(
+                f"{ref.air_name}: {symbol.type_name} {symbol.name!r} is scoped "
+                f"{scoped}, not {scope}"
+            )
+        _check_symbol_stage(symbol, ref, group)
+        for flat, indices, name in array_elements(symbol):
+            lane = _lane_of(symbol, flat)
+            if lane not in expected:
+                orphans.append((name, lane, symbol.type_name))
+                continue
+            if lane in out.lanes:
+                raise LaneError(
+                    f"{ref.air_name}: two symbols claim lane {lane}: "
+                    f"{out.lanes[lane].name!r} and {name!r}"
+                )
+            out.lanes[lane] = LaneInfo(
+                lane=lane,
+                name=name,
+                base=symbol.name,
+                indices=indices,
+                flat=flat if symbol.lengths else None,
+                stage=symbol.stage,
+                scope=scope,
+                symbol_type=symbol.type_name,
+            )
+            by_name.setdefault(name, []).append(lane)
+
+    out.by_name = {name: tuple(lanes) for name, lanes in by_name.items()}
+    out.unnamed = tuple(sorted(expected - set(out.lanes), key=repr))
+    out.orphans = tuple(sorted(orphans, key=repr))
+    return out
+
+
+def _scope_of(symbol: pilout_wire.Symbol, ref: pilout_wire.AirRef) -> str | None:
+    """Which namespace this symbol is in for `ref`, or None if it is elsewhere."""
+    if symbol.air_group_id is None and symbol.air_id is None:
+        return "global"
+    if symbol.air_group_id == ref.airgroup_idx and symbol.air_id is None:
+        return "airgroup"
+    if symbol.air_group_id == ref.airgroup_idx and symbol.air_id == ref.air_idx:
+        return "air"
+    return None
+
+
+def _check_symbol_stage(
+    symbol: pilout_wire.Symbol,
+    ref: pilout_wire.AirRef,
+    group: pilout_wire.AirGroup,
+) -> None:
+    """The symbol's stage against the sibling message that also declares it.
+
+    Three independent agreements, each of which would break under a different
+    misreading of the stage lists:
+
+    * a FIXED_COL symbol is stage 0, which is what `stageWidths` "excluding stage
+      0 (fixed columns)" asserts and what makes `stageWidths[i]` stage `i + 1`;
+    * a WITNESS_COL's stage indexes `stageWidths`;
+    * an AIR_VALUE's stage equals `Air.airValues[idx].stage`, a per-index list in
+      a different message from the symbol table.
+    """
+    kind = symbol.type_name
+    if kind == "FIXED_COL":
+        if symbol.stage != 0:
+            raise LaneError(
+                f"{ref.air_name}: FIXED_COL {symbol.name!r} has stage {symbol.stage}, not 0"
+            )
+        return
+    if kind == "WITNESS_COL":
+        widths = ref.air.stage_widths
+        if symbol.stage is None or not 1 <= symbol.stage <= len(widths):
+            raise LaneError(
+                f"{ref.air_name}: WITNESS_COL {symbol.name!r} stage {symbol.stage} "
+                f"outside 1..{len(widths)}"
+            )
+        return
+    if kind in ("AIR_VALUE", "AIR_GROUP_VALUE"):
+        stages = (
+            ref.air.air_value_stages if kind == "AIR_VALUE" else group.air_group_value_stages
+        )
+        for flat, _indices, name in array_elements(symbol):
+            idx = symbol.id + flat
+            if idx < len(stages) and stages[idx] != symbol.stage:
+                raise LaneError(
+                    f"{ref.air_name}: {kind} {name!r} at index {idx} has stage "
+                    f"{symbol.stage}, but the AIR declares stage {stages[idx]}"
+                )
+        return
+    if kind == "CHALLENGE":
+        # The count agreement -- as many CHALLENGE symbols at stage s as
+        # `numChallenges[s - 1]` declares -- is not checked here but by closure:
+        # a surplus symbol is an orphan lane and a shortfall is an unnamed one.
+        # That is also what discriminates the reading of `numChallenges`, since
+        # the alternative alignment puts both symbols at a stage declaring none.
+        if symbol.stage is None or symbol.stage < 1:
+            raise LaneError(f"CHALLENGE {symbol.name!r} has stage {symbol.stage}")
+
+
+# --- exposed-value report -----------------------------------------------------
+
+
+@dataclass
+class ExposedReport:
+    """Which exposed indices are which kind, and where the two overlap."""
+
+    air_name: str
+    air_value_declared: tuple[int, ...]
+    air_group_value_declared: tuple[int, ...]
+    air_value_used: tuple[int, ...]
+    air_group_value_used: tuple[int, ...]
+    declared_both: tuple[int, ...]
+    used_both: tuple[int, ...]
+    names: dict[tuple[str, int], str]
+
+
+def exposed_report(pilout: pilout_wire.PilOut, air, lanes: LaneMap | None = None
+                   ) -> ExposedReport:
+    """The AIR_VALUE / AIR_GROUP_VALUE index tables for one AIR.
+
+    Both declared and constraint-referenced index sets, because they answer
+    different questions: the declared overlap is what `exposed (index := i)` is
+    ambiguous *about*, and the used overlap is how much of that ambiguity the
+    AIR's constraints actually exercise.
+    """
+    ref = _find_air(pilout, air)
+    lanes = lanes or lane_map(pilout, ref)
+    declared = {
+        source: {info.lane[2] for info in lanes.of_exposed(source)}
+        for source in EXPOSED_SOURCES
+    }
+    used: dict[str, set[int]] = {source: set() for source in EXPOSED_SOURCES}
+    for constraint in pilout_atoms.air_constraint_exprs(
+            pilout, ref, pilout_atoms.OPERAND_VOCAB):
+        if constraint.expr is None:
+            continue
+        for atom in pilout_atoms.iter_atoms(constraint.expr):
+            if atom[0] in used:
+                used[atom[0]].add(atom[1])
+    names = {
+        (source, info.lane[2]): info.name
+        for source in EXPOSED_SOURCES
+        for info in lanes.of_exposed(source)
+    }
+    return ExposedReport(
+        air_name=ref.air_name,
+        air_value_declared=tuple(sorted(declared["air_value"])),
+        air_group_value_declared=tuple(sorted(declared["air_group_value"])),
+        air_value_used=tuple(sorted(used["air_value"])),
+        air_group_value_used=tuple(sorted(used["air_group_value"])),
+        declared_both=tuple(lanes.collapsed_indices()),
+        used_both=tuple(sorted(used["air_value"] & used["air_group_value"])),
+        names=names,
+    )
+
+
+# --- row-major evidence -------------------------------------------------------
+
+
+def multi_index_order_evidence(pilout: pilout_wire.PilOut) -> dict[str, int]:
+    """Test the row-major reading of `lengths` against the pilout's own PIL text.
+
+    Only `LaneInfo.indices` depends on the answer, but it is testable, so it is
+    tested rather than asserted. A `debugLine` is PIL-compiler output and quotes
+    array references in their source spelling, `name[i][j]`. Take a constraint
+    whose text quotes exactly one such reference, whose base name identifies
+    exactly one multi-dimensional witness symbol of that AIR, and whose expression
+    reads exactly one witness column inside that symbol's id range: the flat offset
+    is then known, and only one of the two orders predicts it.
+
+    Counted over the whole file, not just the extracted AIRs, because no in-scope
+    constraint quotes a two-index reference -- so this is evidence about the
+    writer's convention, and the report says which AIRs it came from.
+    """
+    counts = {"considered": 0, "row_major": 0, "column_major": 0, "neither": 0,
+              "ambiguous": 0}
+    for ref in pilout.airs():
+        air = ref.air
+        multi = [
+            symbol for symbol in pilout.symbols
+            if symbol.type_name == "WITNESS_COL"
+            and symbol.air_group_id == ref.airgroup_idx
+            and symbol.air_id == ref.air_idx
+            and len(symbol.lengths) == 2
+        ]
+        if not multi:
+            continue
+        for constraint in air.constraints:
+            found = _RE_TWO_INDEX.findall(constraint.debug_line or "")
+            if len(found) != 1:
+                continue
+            base, first, second = found[0][0], int(found[0][1]), int(found[0][2])
+            candidates = [symbol for symbol in multi
+                          if symbol.name == base or symbol.name.endswith("." + base)]
+            if len(candidates) != 1:
+                continue
+            symbol = candidates[0]
+            span = symbol.lengths[0] * symbol.lengths[1]
+            inside = sorted({
+                col for stage, col in _witness_cells(air, constraint.expression_idx)
+                if stage == symbol.stage and symbol.id <= col < symbol.id + span
+            })
+            if len(inside) != 1:
+                continue
+            counts["considered"] += 1
+            flat = inside[0] - symbol.id
+            row = first * symbol.lengths[1] + second
+            column = second * symbol.lengths[0] + first
+            if row == flat and column != flat:
+                counts["row_major"] += 1
+            elif column == flat and row != flat:
+                counts["column_major"] += 1
+            elif row != flat and column != flat:
+                counts["neither"] += 1
+            else:
+                # Both orders predict this offset -- `name[0][0]` and the like.
+                # Corroborates neither, so it is counted apart rather than
+                # inflating the winning side.
+                counts["ambiguous"] += 1
+    return counts
+
+
+def _witness_cells(air: pilout_wire.Air, idx: int) -> set[tuple[int, int]]:
+    """`(stage, column)` of every witness operand reachable from expression `idx`."""
+    out: set[tuple[int, int]] = set()
+    seen: set[int] = set()
+    stack = [idx]
+    while stack:
+        current = stack.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        for operand in air.expressions[current].operands:
+            if operand.kind == "expression":
+                stack.append(operand.idx)
+            elif operand.kind == "witness_col":
+                out.add((operand.stage, operand.col_idx))
+    return out
+
+
+# --- the gate -----------------------------------------------------------------
+
+
+@dataclass
+class AirGate:
+    """One AIR's verdict: its counts, and every way its lane map fell short."""
+
+    air_name: str
+    lanes: LaneMap | None = None
+    exposed: ExposedReport | None = None
+    failures: list[str] = field(default_factory=list)
+    soft_duplicates: list[tuple[str, tuple]] = field(default_factory=list)
+    header_columns: int = 0
+    header_agrees: bool = False
+    atoms_checked: int = 0
+
+    @property
+    def ok(self) -> bool:
+        return not self.failures
+
+
+@dataclass
+class GateReport:
+    airs: list[AirGate] = field(default_factory=list)
+    failures: list[str] = field(default_factory=list)
+    order_evidence: dict[str, int] = field(default_factory=dict)
+    partial: bool = False
+
+    @property
+    def ok(self) -> bool:
+        return not self.failures and all(air.ok for air in self.airs)
+
+
+def gate_lane_map(
+    pilout: pilout_wire.PilOut,
+    extraction: str | Path | None = None,
+    air_names: tuple[str, ...] = DECLARED_AIRS,
+) -> GateReport:
+    """Build and check the lane map of every declared AIR.
+
+    Per AIR: the map is closed in both directions; the emitted header agrees with
+    the symbol reconstruction exactly, and both agree with `witness_column_names`;
+    names are unique where uniqueness is required; every atom the AIR's constraints
+    use resolves to a named lane; and no lane kind outside the vocabulary appears.
+    """
+    report = GateReport(partial=tuple(air_names) != tuple(DECLARED_AIRS))
+    by_name = {ref.air_name: ref for ref in pilout.airs()}
+    for name in air_names:
+        gate = AirGate(air_name=name)
+        report.airs.append(gate)
+        ref = by_name.get(name)
+        if ref is None:
+            gate.failures.append(f"declared AIR {name!r} is not in the pilout")
+            continue
+        try:
+            gate.lanes = lane_map(pilout, ref)
+        except LaneError as exc:
+            gate.failures.append(f"lane map cannot be built: {exc}")
+            continue
+        lanes = gate.lanes
+
+        for lane in lanes.unnamed:
+            gate.failures.append(f"lane {lane} has no name in PilOut.symbols")
+        for symbol_name, lane, kind in lanes.orphans:
+            gate.failures.append(
+                f"{kind} {symbol_name!r} claims lane {lane}, which this AIR does not declare"
+            )
+        for dup_name, found in lanes.hard_duplicate_names():
+            gate.failures.append(f"name {dup_name!r} is shared by lanes {found}")
+        gate.soft_duplicates = [
+            item for item in lanes.duplicate_names()
+            if item not in lanes.hard_duplicate_names()
+        ]
+
+        _gate_vocabulary(pilout, ref, gate)
+        _gate_header(pilout, ref, gate, extraction)
+        _gate_atoms(pilout, ref, gate)
+        gate.exposed = exposed_report(pilout, ref, lanes)
+
+    report.order_evidence = multi_index_order_evidence(pilout)
+    if report.order_evidence["column_major"] or report.order_evidence["neither"]:
+        report.failures.append(
+            f"multi-index order evidence is not row-major: {report.order_evidence}"
+        )
+    if not report.airs:
+        report.failures.append("no AIR was checked")
+    return report
+
+
+def _gate_vocabulary(
+    pilout: pilout_wire.PilOut, ref: pilout_wire.AirRef, gate: AirGate
+) -> None:
+    """The four lane kinds are exhaustive for this AIR, or say what escaped."""
+    if ref.air.num_periodic_cols:
+        gate.failures.append(
+            f"{ref.air.num_periodic_cols} periodic column(s): a lane kind with no "
+            f"symbol type in this file and no lane in this vocabulary"
+        )
+    if ref.air.num_custom_commits:
+        gate.failures.append(
+            f"{ref.air.num_custom_commits} custom commit(s): a lane kind outside "
+            f"this vocabulary"
+        )
+    escaped = sorted({
+        operand.kind
+        for expression in ref.air.expressions
+        for operand in expression.operands
+        if operand.kind in UNMODELLED_OPERAND_KINDS
+    })
+    for kind in escaped:
+        gate.failures.append(f"operand kind {kind!r} occurs and has no lane")
+
+
+def _gate_header(
+    pilout: pilout_wire.PilOut,
+    ref: pilout_wire.AirRef,
+    gate: AirGate,
+    extraction: str | Path | None,
+) -> None:
+    """The emitted witness header against this map and against `witness_column_names`.
+
+    Three readings of the same fact, from three places: this file's uniform symbol
+    walk, #303's witness-only reconstruction, and the header the extractor wrote.
+    Comparing against both is what makes the generalisation to five symbol types
+    checked on the one kind that has an independent artifact to check it against.
+    """
+    assert gate.lanes is not None
+    mine = gate.lanes.witness_names()
+    theirs = pilout_atoms.witness_column_names(pilout, ref)
+    differing = sorted(key for key in set(mine) | set(theirs) if mine.get(key) != theirs.get(key))
+    for key in differing[:5]:
+        gate.failures.append(
+            f"witness lane {key}: this map says {mine.get(key)!r}, "
+            f"pilout_atoms.witness_column_names says {theirs.get(key)!r}"
+        )
+    if extraction is None:
+        return
+    path = Path(extraction) / f"{ref.air_name}.lean"
+    try:
+        emitted = lean_parse.parse_air_file(str(path))
+    except (OSError, lean_parse.LeanParseError) as exc:
+        gate.failures.append(f"emitted header unreadable: {exc}")
+        return
+    header = emitted.witness_names
+    gate.header_columns = len(header)
+    disagree = sorted(key for key in set(mine) | set(header) if mine.get(key) != header.get(key))
+    if not disagree:
+        gate.header_agrees = True
+        return
+    for key in disagree[:5]:
+        gate.failures.append(
+            f"witness lane {key}: symbols say {mine.get(key)!r}, "
+            f"the emitted header says {header.get(key)!r}"
+        )
+    if len(disagree) > 5:
+        gate.failures.append(f"...and {len(disagree) - 5} more header disagreement(s)")
+
+
+def _gate_atoms(
+    pilout: pilout_wire.PilOut, ref: pilout_wire.AirRef, gate: AirGate
+) -> None:
+    """Every atom the AIR's constraints use resolves to a named lane.
+
+    The declared-geometry closure above is about the AIR's *declarations*; this is
+    about its *content*, and it is the direction a consumer feels. An atom that
+    reaches no lane is a slot a mirror would have to name and could not.
+    """
+    assert gate.lanes is not None
+    lanes = gate.lanes
+    unresolved: dict[tuple, int] = {}
+    seen: set[tuple] = set()
+    for constraint in pilout_atoms.air_constraint_exprs(
+            pilout, ref, pilout_atoms.OPERAND_VOCAB):
+        if constraint.expr is None:
+            gate.failures.append(
+                f"constraint #{constraint.index} is unrepresentable: {constraint.unrepresentable}"
+            )
+            continue
+        for atom in pilout_atoms.iter_atoms(constraint.expr):
+            if atom in seen:
+                continue
+            seen.add(atom)
+            lane = _lane_of_atom(atom)
+            try:
+                lanes.name_of(lane)
+            except LaneError:
+                unresolved[atom] = unresolved.get(atom, 0) + 1
+    gate.atoms_checked = len(seen)
+    for atom in sorted(unresolved, key=repr)[:5]:
+        gate.failures.append(f"atom {atom} resolves to no named lane")
+
+
+def _lane_of_atom(atom: tuple) -> tuple:
+    """The lane an operand-vocabulary atom occupies, dropping only the row delta."""
+    kind = atom[0]
+    if kind == "witness_col":
+        return ("main", atom[1], atom[2])
+    if kind == "fixed_col":
+        return ("pre", atom[1])
+    if kind == "challenge":
+        return ("chal", atom[1], atom[2])
+    if kind in EXPOSED_SOURCES:
+        return ("exposed", kind, atom[1])
+    raise LaneError(f"atom {atom} has no lane")
+
+
+# --- reporting ----------------------------------------------------------------
+
+
+def _print_air_table(report: GateReport) -> None:
+    row = "{:<19} {:>10} {:>6} {:>7} {:>4} {:>4} {:>5} {:>6} {:>6} {:>6}"
+    header = row.format(
+        "air", "widths", "fixed", "witness", "av", "agv", "chal", "lanes", "header", "atoms",
+    )
+    print(header)
+    print("-" * len(header))
+    totals = {"witness": 0, "fixed": 0, "air_value": 0, "air_group_value": 0,
+              "challenge": 0, "total": 0}
+    for gate in report.airs:
+        if gate.lanes is None:
+            print(row.format(gate.air_name, "-", "-", "-", "-", "-", "-", "-", "-", "-"))
+            continue
+        counts = gate.lanes.counts()
+        for key in totals:
+            totals[key] += counts[key]
+        print(row.format(
+            gate.air_name,
+            "+".join(str(width) for width in gate.lanes.stage_widths),
+            counts["fixed"], counts["witness"], counts["air_value"],
+            counts["air_group_value"], counts["challenge"], counts["total"],
+            f"{gate.header_columns}{'=' if gate.header_agrees else '?'}",
+            gate.atoms_checked,
+        ))
+    print("-" * len(header))
+    print(row.format(
+        "TOTAL", "", totals["fixed"], totals["witness"], totals["air_value"],
+        totals["air_group_value"], totals["challenge"], totals["total"], "", "",
+    ))
+    print(
+        "  widths = stage 1 + stage 2 witness widths; av/agv = air value / air group\n"
+        "  value lanes; header = witness names in the emitted header, '=' when it\n"
+        "  agrees with the symbol reconstruction exactly; atoms = distinct atoms the\n"
+        "  AIR's constraints use, all of which must resolve to a named lane."
+    )
+
+
+def _print_exposed(report: GateReport) -> None:
+    print("\nexposed lanes: AIR_VALUE vs AIR_GROUP_VALUE")
+    print(
+        "  `Extraction.Circuit.exposed` takes one index for both kinds, so an index\n"
+        "  in the 'both' column is ambiguous in the emitted per-AIR files. The lane\n"
+        "  map keeps the kinds apart; this is the size of what it keeps apart."
+    )
+    row = "{:<19} {:>10} {:>22} {:>10} {:>12} {:>10}"
+    header = row.format("air", "av lanes", "av indices", "agv lanes", "agv indices", "both")
+    print(header)
+    print("-" * len(header))
+    for gate in report.airs:
+        if gate.exposed is None:
+            continue
+        exposed = gate.exposed
+        print(row.format(
+            exposed.air_name,
+            len(exposed.air_value_declared),
+            _fmt_range(exposed.air_value_declared),
+            len(exposed.air_group_value_declared),
+            _fmt_range(exposed.air_group_value_declared),
+            _fmt_range(exposed.declared_both) or "-",
+        ))
+    print("-" * len(header))
+    mismatched = [
+        gate.exposed for gate in report.airs
+        if gate.exposed is not None
+        and (gate.exposed.air_value_used != gate.exposed.air_value_declared
+             or gate.exposed.air_group_value_used != gate.exposed.air_group_value_declared)
+    ]
+    if mismatched:
+        print("  declared but not referenced by any constraint:")
+        for exposed in mismatched:
+            print(
+                f"    {exposed.air_name}: av {_fmt_range(exposed.air_value_used)} used of "
+                f"{_fmt_range(exposed.air_value_declared)}, agv "
+                f"{_fmt_range(exposed.air_group_value_used)} used of "
+                f"{_fmt_range(exposed.air_group_value_declared)}"
+            )
+    else:
+        print("  every declared exposed lane is referenced by a constraint.")
+    for gate in report.airs:
+        if gate.exposed is None or not gate.exposed.declared_both:
+            continue
+        for idx in gate.exposed.declared_both:
+            print(
+                f"    {gate.exposed.air_name} exposed {idx} is both "
+                f"{gate.exposed.names[('air_value', idx)]!r} and "
+                f"{gate.exposed.names[('air_group_value', idx)]!r}"
+            )
+
+
+def _fmt_range(indices: tuple[int, ...]) -> str:
+    if not indices:
+        return ""
+    if len(indices) == 1:
+        return str(indices[0])
+    if indices == tuple(range(indices[0], indices[-1] + 1)):
+        return f"{indices[0]}..{indices[-1]}"
+    return ",".join(str(idx) for idx in indices)
+
+
+def _print_names(report: GateReport, verbose: bool) -> None:
+    print("\nname uniqueness")
+    soft = [(gate, item) for gate in report.airs for item in gate.soft_duplicates]
+    if not soft:
+        print("  every name resolves to exactly one lane, in every AIR.")
+    else:
+        lanes = sum(len(item[1]) for _gate, item in soft)
+        stage2 = sum(
+            len([info for info in gate.lanes.of_head("main") if info.lane[1] == 2])
+            for gate in report.airs if gate.lanes is not None
+        )
+        airs = len({gate.air_name for gate, _item in soft})
+        print(
+            f"  required on stage-1 witness, fixed, exposed and challenge lanes: holds\n"
+            f"  in every AIR (a violation there fails this gate).\n"
+            f"  measured false on stage-2 witness lanes: {lanes} of {stage2} such lanes,\n"
+            f"  in {airs} of {len(report.airs)} AIRs, collapse onto {len(soft)} name(s).\n"
+            f"  The pilout reuses `im_cluster` / `im_single` per accumulator column;"
+            f" it is\n  a property of the input, and the comparability rule excludes"
+            f" stage 2 anyway.\n  `resolve` raises on these rather than choosing one."
+        )
+        for gate, (name, found) in soft:
+            stages = sorted({lane[1] for lane in found})
+            cols = ",".join(str(lane[2]) for lane in found)
+            print(f"    {gate.air_name:<19} {name!r} stage {stages} cols {cols}")
+    if not verbose:
+        return
+    print("\n  fixed lanes, named")
+    for gate in report.airs:
+        if gate.lanes is None:
+            continue
+        # `.lanes.get`, not `name_of`: this runs on the failing path too, and a
+        # report that raises where a lane is unnamed hides the failure it exists
+        # to show.
+        named = [
+            (col, gate.lanes.lanes.get(("pre", col)))
+            for col in range(gate.lanes.num_fixed_cols)
+        ]
+        print(f"    {gate.air_name:<19} " + ", ".join(
+            f"{col}: {info.name if info else 'UNNAMED'}" for col, info in named))
+
+
+def _print_non_lanes(report: GateReport) -> None:
+    print("\nsymbols in scope that are not lanes")
+    print(
+        "  Declared non-lanes, each with the structural reason it is not a slot.\n"
+        "  A symbol type outside this list and outside the four lane kinds raises."
+    )
+    for kind, reason in sorted(NON_LANE_SYMBOL_TYPES.items()):
+        print(f"    {kind:<13} {reason}")
+    total = 0
+    global_counts: dict[str, int] = {}
+    for gate in report.airs:
+        if gate.lanes is None:
+            continue
+        air_scope = {kind: count for (scope, kind), count
+                     in gate.lanes.non_lane_symbols.items() if scope == "air"}
+        for (scope, kind), count in gate.lanes.non_lane_symbols.items():
+            if scope != "air":
+                global_counts[kind] = count
+        total += sum(air_scope.values())
+        print(f"  {gate.air_name:<19} " + (", ".join(
+            f"{kind} x{count}" for kind, count in sorted(air_scope.items())) or "none"))
+    print(f"  {total} AIR-scoped non-lane symbol(s) over the declared AIRs.")
+    print("  shared, once for the whole file: " + (", ".join(
+        f"{kind} x{count}" for kind, count in sorted(global_counts.items())) or "none"))
+
+
+def _print_failures(report: GateReport) -> None:
+    failing = [gate for gate in report.airs if not gate.ok]
+    if not failing and not report.failures:
+        return
+    print("\nFAILURES")
+    for message in report.failures:
+        print(f"  global: {message}")
+    for gate in failing:
+        print(f"  {gate.air_name}:")
+        for message in gate.failures:
+            print(f"    {message}")
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--pilout", default=str(DEFAULT_PILOUT))
+    parser.add_argument("--extraction", default=str(DEFAULT_EXTRACTION))
+    parser.add_argument("--air", action="append", help="restrict the run, repeatable")
+    parser.add_argument("--quiet", action="store_true",
+                        help="print only the summary and any failure")
+    parser.add_argument("--verbose", action="store_true",
+                        help="also print every fixed lane's name")
+    args = parser.parse_args(argv[1:])
+
+    unknown = sorted(set(args.air or ()) - set(DECLARED_AIRS))
+    if unknown:
+        print(f"lanes.py: not a declared AIR: {', '.join(unknown)}", file=sys.stderr)
+        return EXIT_USAGE
+    air_names = tuple(args.air) if args.air else DECLARED_AIRS
+
+    pilout_path = Path(args.pilout)
+    extraction = Path(args.extraction)
+    if not pilout_path.is_file():
+        print(f"lanes.py: no pilout at {pilout_path}", file=sys.stderr)
+        print("ARTIFACTS ABSENT -- this is not a pass", file=sys.stderr)
+        return EXIT_USAGE
+    if not extraction.is_dir():
+        print(f"lanes.py: no extraction directory at {extraction}", file=sys.stderr)
+        print("ARTIFACTS ABSENT -- this is not a pass", file=sys.stderr)
+        return EXIT_USAGE
+    try:
+        pilout = pilout_wire.load(pilout_path)
+    except (OSError, pilout_wire.WireFormatError, pilout_wire.SchemaError) as exc:
+        print(f"lanes.py: cannot read {pilout_path}: {exc}", file=sys.stderr)
+        return EXIT_USAGE
+
+    report = gate_lane_map(pilout, extraction, air_names)
+
+    if not args.quiet:
+        print(f"pilout      {pilout_path}")
+        print(f"extraction  {extraction}")
+        print(f"airs        {len(report.airs)} of {len(DECLARED_AIRS)} declared\n")
+        _print_air_table(report)
+        _print_exposed(report)
+        _print_names(report, args.verbose)
+        _print_non_lanes(report)
+        evidence = report.order_evidence
+        print(
+            f"\nmulti-index order: {evidence['row_major']} corroboration(s) of row-major, "
+            f"{evidence['column_major']} of column-major, {evidence['neither']} of neither, "
+            f"{evidence['ambiguous']} corroborating both,\n  over "
+            f"{evidence['considered']} testable reference(s).\n"
+            f"  Only `LaneInfo.indices` depends on this; `flat` -- what an operand "
+            f"carries -- does not.\n  No in-scope constraint quotes a two-index "
+            f"reference, so the evidence is from\n  other AIRs of the same file."
+        )
+
+    _print_failures(report)
+    closed = sum(1 for gate in report.airs if gate.lanes is not None and gate.lanes.closed)
+    lanes_total = sum(gate.lanes.counts()["total"] for gate in report.airs if gate.lanes)
+    status = "OK" if report.ok else "FAILED"
+    if report.ok and report.partial:
+        status = "PARTIAL"
+    print(
+        f"\n{status}: {closed}/{len(report.airs)} AIR lane maps closed in both "
+        f"directions, {lanes_total} lanes named, "
+        f"{sum(len(gate.failures) for gate in report.airs) + len(report.failures)} failure(s)"
+    )
+    # A filtered run exits 1, like `check_mirrors.py`: it gated nothing about the
+    # AIRs it skipped, and reporting PARTIAL on stdout while exiting 0 is exactly
+    # how a CI step goes quietly green over most of its declared scope.
+    return EXIT_OK if (report.ok and not report.partial) else EXIT_FAILED
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv))
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/tools/mirror-roundtrip/mirror_parse.py
+++ b/tools/mirror-roundtrip/mirror_parse.py
@@ -1,0 +1,2036 @@
+#!/usr/bin/env python3
+"""`g'`: handwritten mirror `Prop`s to the shared #303 expression AST.
+
+Issue: eth-act/zisk-fv#304. This is the mirror side of #303's round trip. #303
+built `g`, emitted-Lean -> AST, and decided `g(f(t)) == t` for every pilout
+polynomial identity `t`. Nothing in that argument touches `ZiskFv/`: the emitted
+per-AIR files are imported by no Lean under `ZiskFv/` at all, so a constraint can
+round-trip perfectly into `build/extraction/` and still be restated wrongly,
+partially, or not at all in the handwritten Lean the proof actually consumes.
+
+This module is the parser for that second direction. It reads a mirror `Prop`
+out of `ZiskFv/AirsClean/**` and returns, per definition, a list of clauses --
+each one polynomial identity over *lane atoms*, in the same AST #303 already
+decides equality in. It parses; it does not compare. Pairing a clause with a
+generated constraint is #305's job, and this file deliberately has no notion of
+which constraint index a clause is supposed to be.
+
+## Why it is strict, and what it must never do
+
+`h998ExprToField` (`ZiskFv/AirsClean/MemAlign/Bridge.lean:31`) is the hazard this
+tool exists to make mechanical: a 38-arm `match` ending
+
+    | _ => 0
+
+so an `Expr` the map does not mention evaluates to the field's zero and a
+constraint over it silently becomes weaker. Nothing raises and the Lean still
+compiles. A parser with the same shape would be worse, because it would convert a
+real mirror-side gap into a passing gate: a clause that vanishes is a constraint
+#305 then reports as "no mirror disagreement".
+
+So every token, projection, numeral form and clause shape is recognised
+explicitly and anything else raises `MirrorParseError`, naming the file, line,
+definition and offending text. There is no fallback, no skip, and no path that
+maps an unknown projection to zero. When a whole definition cannot be parsed it
+is reported as UNPARSED and *counted*, and the count of parsed clauses is
+cross-checked against `survey.top_level_conjuncts` -- a second, independently
+written counter -- so a dropped conjunct fails rather than shrinking the
+denominator.
+
+This module only reports. A gap or a strengthening it finds is a finding to cite,
+never something to fix by editing a mirror, and never something to make disappear
+by widening a declared list. Every entry in every list below carries its source
+citation for exactly that reason.
+
+## The grammar, as derived from the 40 inventoried mirrors
+
+    definition  ::= attrs? ('def' | 'abbrev') name binder* ':' 'Prop' ':='
+                    ('let' name ':=' opaque)* conjunction
+    conjunction ::= clause ('∧' clause)*            -- also the ascii '/\'
+    clause      ::= expr '=' expr                   -- an equation
+                  | expr ('<' | '≤') expr           -- a bound, NOT polynomial
+                  | ident arg*                      -- a delegation to a named Prop
+    expr        ::= term (('+' | '-') term)*
+    term        ::= unary ('*' unary)*
+    unary       ::= '-' unary | power
+    power       ::= primary ('^' primary)?          -- constant folded
+    primary     ::= '(' expr (':' type)? ')' | numeral | application
+    application ::= projection | helper arg* | 'boolF' arg
+    projection  ::= rowvar '.' field+               -- 0 args, row carrier
+                  | validator '.' field index       -- 1 arg, validator carrier
+    index       ::= idxvar | '(' idxvar ('+'|'-') numeral ')'
+
+`*` binds tighter than `+`/`-`, both left-associative; unary minus binds tighter
+than `*`; `^` is folded and only over constants, because a non-constant exponent
+is not a polynomial. `a = b` is normalised to `a - b`, and `a = 0` to `a`, so the
+AST of a clause is always the polynomial that must vanish.
+
+A *bound* clause (`row.byte_value.val < 2 ^ 8`) is kept as a clause with
+`expr is None` and `kind == 'bound'`. It is not a polynomial identity: `x.val < 2`
+and `x * (1 - x) = 0` are equivalent facts over `FGL` but not the same term, so
+pairing one with a pilout constraint would be a category error. `.val` inside an
+equation raises. This is the mixed-predicate case of the inventory's F2.
+
+A *delegation* clause is a conjunct that is an application of another named
+`Prop` -- what the inventory classifies `MIRROR_COMPOSITE`, `MIXED_COMPOSITE` and
+`MIRROR_ENV`. It carries no equations of its own, and inlining it here would
+double-count the delegate's clauses, so the delegate is recorded by name, with
+the class `survey.CLASSIFICATION` gives it and, for a two-row delegate, a
+positional check that the row arguments arrive in the delegate's own order. A
+delegate that is in neither `survey.CLASSIFICATION` nor `survey.DELEGATED` is
+reported as an undeclared delegate rather than followed.
+
+## The shared AST, identical to #303's accessor vocabulary
+
+    ('add', e1, e2) | ('sub', e1, e2) | ('mul', e1, e2) | ('neg', e)
+    ('const', n)                     n a non-negative Python int
+    ('atom', a)                      a one of
+        ('main', stage, column, delta)      delta a SIGNED row offset
+        ('pre', column, delta)
+        ('chal', flat_index)
+        ('exposed', index)
+        ('unresolved', carrier, path, delta)
+
+The last is not one of #303's atoms and is deliberately spelled so it cannot be
+mistaken for one: it is what a projection with no lane becomes, so the clause is
+still returned in full -- with its unresolved projections named in
+`MirrorClause.unresolved` and `MirrorDef.unresolved` -- instead of being dropped
+or zeroed. A consumer must refuse to compare a clause whose `unresolved` is
+non-empty; it is a hole, not a value.
+
+Atoms come from `lanes.LaneMap`, whose names are derived from `PilOut.symbols`
+and never from a handwritten map under `ZiskFv/`. `LaneMap.accessor_atom` does
+the `air_value`/`air_group_value` collapse explicitly; no mirror field at HEAD
+resolves to an exposed or challenge lane, and one that did would be reported,
+because the mirror side is meant to be witness and fixed columns only.
+
+## Row variable to row delta, with the evidence for each
+
+The mirror names rows relationally, so the delta comes from the binder name via
+one declared table (`ROW_ROLE_DELTA`) and never from a per-definition guess. A
+definition whose row binders are not all in that table, or which has no unique
+delta-0 binder, is reported with `row_relation_undetermined` and every projection
+off its rows is unresolved -- not assumed.
+
+The three roles and where each is pinned in the tree:
+
+* `row` (and `current` / `curr` when it is the only row) is delta 0: the row the
+  every-row constraint is being stated at.
+* `previous` / `prev` is delta -1. Evidence, per definition rather than by name:
+  `MemAlign.transitionRows`' first conjunct is `current.delta_addr -
+  (current.addr - previous.addr) * (1 - current.reset)`, and the generated
+  `constraint_29_every_row` (`build/extraction/Extraction/MemAlign.lean:196-198`,
+  `mem/pil/mem_align.pil:142 delta_addr-((addr-'addr)*(1-reset))`) reads column 0
+  at `row - 1`; its `sel_down_to_up` conjuncts match `constraint_1_every_row`
+  (`:56-58`, `'reg[0]`, `row - 1`). `Main.pcHandshakeBetween` matches
+  `constraint_18_every_row` (`Extraction/Main.lean:158-159`,
+  `main.pil:410`), whose whole predecessor mux is at `row - 1`, and
+  `Main.sourceCCopyBetween` matches `constraint_4_every_row` / `_10_`
+  (`:86-87`, `:118-119`), whose `previous_c` is column 4/5 at `row - 1`.
+* `successor` is delta +1. Evidence: `MemAlign.cyclicSuccessorTransitionRows`'
+  `sel_up_to_down` conjuncts match `constraint_0_every_row`
+  (`Extraction/MemAlign.lean:51-53`, `mem_align.pil:116 ((reg[0]'-reg[0])*sel[0])
+  *sel_up_to_down`), which reads column 8 at `row + 1`; `'` after a name is PIL's
+  next row, before it the previous row.
+
+For a `Valid_<AIR>` carrier the delta is not a binder role at all -- it is the
+accessor's row argument, read directly: `v.pc row` is delta 0 and
+`v.set_pc (row - 1)` is delta -1. `ZiskFv/AirsClean/Main/CrossRow.lean:58-63`
+states that reading, and `Extraction/Main.lean:159` corroborates it.
+
+## Field name to lane name
+
+A lane is named as the pilout writes it (`reg[0]`, `Main.SEGMENT_L1`); a mirror
+field is a Lean identifier (`reg_0`, `segment_l1`). `lanes.py` deliberately keeps
+one spelling and no alias table, so the aliasing lives here, in three declared
+steps, in this order:
+
+1. the *leaf* field name is used, sub-struct prefixes dropped: `row.carries.fab`
+   is `fab`, `row.core.a_0` is `a_0`. Justified by `ProvableStruct` flattening --
+   the sub-structs group fields for readability and carry no column of their own
+   (`ZiskFv/AirsClean/ArithMul/Row.lean:81`). Two distinct paths reaching one
+   lane inside one definition are reported (`path_aliases`); at HEAD there are
+   none, so no leaf name is reused across sub-structs.
+2. `FIELD_ALIASES`, five entries, each with its citation, for a field whose lane
+   is genuinely named something else. Two of them are *kind* changes -- a
+   witness-looking row field standing for a fixed column -- and those are
+   reported as `reclassified`, because that is the inventory's F7 and a #305
+   pairing must see it rather than have it smoothed over.
+3. otherwise a trailing `_<digits>` is offered as the pilout's flat array
+   spelling: `reg_0` -> `reg[0]`, `c_chunks_1` -> `c_chunks[1]`. Both the bare
+   and the bracketed candidate are tried and *both* resolving is a hard error,
+   not a choice, because picking one would be the h998 failure with a different
+   surface.
+
+A field that resolves to nothing is an UNRESOLVED FIELD, reported with its leaf
+name and the candidates that were tried. Some are expected and structural rather
+than defects, and those are declared with citations in `EXPECTED_UNRESOLVED` and
+counted separately so a driver can hold them against a small list instead of
+mixing them into gaps -- `Main.addr0` and `Main.addr2` (PIL `const expr`, no
+pilout column: inventory F9), `Main.im_high_degree_2`, and `MemAlign.delta_pc`
+(hint #998's payload slot, not a column: F3). The declaration is a *report*
+category. Adding an entry to it without a source citation would launder a gap
+into a pass; do not.
+
+Builder carriers are a third case: `MIRROR_BUILDER` predicates state the AIR's
+equations over an honest-row builder's inputs (`RomFlagBits`, `MainRomFreeCols`,
+a ROM bus message), which are not row slots of any AIR. Their projections are
+unresolved with `carrier_not_a_row`, which is a different fact from a missing
+lane and is kept apart from it.
+
+## Helper inlining
+
+`MemAlignByte.Spec` is written over three `@[reducible]` field-valued helpers
+(`byte_value_factor` and friends, `MemAlignByte/Spec.lean:52-67`), so the clause
+is not a polynomial until they are inlined. They are inlined by substitution,
+under conditions all of which are checked: the helper is a `def`/`abbrev` in the
+same file or the same directory, every parameter and its result type is `FGL`,
+the argument count equals the parameter count exactly, and the nesting depth is
+bounded. Substitution is capture-free because the parameters are field scalars
+and the grammar has no binders. Anything else raises. This is the same move
+`pilout_atoms` makes when it inlines the pilout's expression pool before any atom
+exists, and for the same reason: the identity, not the abbreviation, is what has
+to be compared.
+
+## What a clean parse does not assert
+
+* Nothing about the *contents* of a clause being right. This module decides what
+  the mirror says, not whether it says the same thing the pilout does.
+* Nothing about coverage. A definition can parse perfectly and restate no
+  generated constraint at all; the inventory's `claims` column is still a
+  reading, and #305 decides pairings.
+* Nothing about a lane's *kind* being the right kind. `FIELD_ALIASES` resolving
+  `preL1` to a fixed lane records the reclassification; it does not bless it.
+* Nothing about `.val` bounds. They are carried as bounds and are not comparable.
+* Nothing about the row-record field order, which the survey measured to be
+  non-positional for six of the ten records -- this module never uses position.
+
+The ASTs it produces were checked once, by hand, against the generated side:
+canonicalising every comparable clause with `poly.py` and looking for a generated
+constraint of the same AIR with the same normal form found one for 188 of the 190,
+the exceptions being `Main.sourceCCopyBetween`'s two clauses, whose difference is
+confined to the `SEGMENT_L1`-gated term the mirror's own docstring says it
+specialises. That is a measurement about this parser, not a claim this file makes
+or re-checks; deciding pairings is #305's job.
+
+## Known blind spots
+
+* **Leaf-name aliasing conflates a name reused across sub-structs.** The rule
+  drops sub-struct prefixes, so if two fields of one row record had the same leaf
+  name they would resolve to one lane. That is checked per carrier and reported as
+  `path_aliases`; at HEAD there are none, so the risk is latent, not present.
+* **`boolF` is dropped**, leaving its argument as the leaf. Its arguments in the
+  tree are all `RomFlagBits` fields on a builder carrier, so they resolve to no
+  lane and no correspondence is claimed either way; a `boolF` over something that
+  did resolve would be worth looking at, and does not occur.
+* **The ambiguous-alias refusal is unexercised.** No AIR at HEAD has both a lane
+  named `x_0` and one named `x[0]`, so the branch that refuses to choose between
+  them is untested against real data.
+* **A delegate's clauses are not inlined.** A composite therefore reports
+  delegations, not equations, and a consumer that wants its equations must follow
+  the delegate itself. Inlining here would double-count.
+* **The conjunct cross-check is against a second counter over the same text.** It
+  catches this parser dropping a conjunct; it cannot notice a conjunct deleted
+  from the Lean, which is what the survey's coverage arithmetic is for.
+* **`row_vars` is empty for a `Valid_<AIR>` carrier.** There is no row variable
+  there: every accessor carries its own row argument, so the deltas are per atom
+  and visible in `atom_shapes()` rather than as a binder table.
+
+    python3 tools/mirror-roundtrip/mirror_parse.py [--pilout PATH] [--air NAME]...
+                                                   [--quiet]
+
+Exit codes:
+
+    0  every inventoried mirror parsed, every conjunct accounted for, and every
+       unresolved field either declared or a builder carrier
+    1  an UNPARSED definition, a conjunct count disagreement, an undeclared
+       unresolved field, an undeclared delegate, a delegate reached with its row
+       arguments out of order, or a row relation that cannot be determined
+    2  usage or IO error: no pilout, an unknown --air, nothing parsed
+
+`--air NAME` restricts the run, repeatable; a filtered run does not cover the
+inventoried scope, so its summary line says PARTIAL and never OK.
+
+Exit 2 is not a pass. It means the parser ran on nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+sys.path.insert(0, str(HERE))
+
+import lanes  # noqa: E402
+import survey  # noqa: E402
+
+DEFAULT_PILOUT = lanes.DEFAULT_PILOUT
+DEFAULT_MIRROR = survey.DEFAULT_MIRROR
+
+EXIT_OK = 0
+EXIT_FAILED = 1
+EXIT_USAGE = 2
+
+
+# --------------------------------------------------------------- declared tables
+
+# Row binder name -> row delta. See "Row variable to row delta" above for the
+# generated-constraint evidence behind each role; the names themselves are not
+# the evidence, they are the key.
+ROW_ROLE_DELTA: dict[str, int] = {
+    "row": 0,
+    "current": 0,
+    "curr": 0,
+    "previous": -1,
+    "prev": -1,
+    "successor": 1,
+}
+
+# Field leaf -> pilout lane name, per AIR, for the fields whose lane is named
+# something else. Every entry carries the citation that establishes it; an entry
+# without one would be an invented correspondence.
+FIELD_ALIASES: dict[tuple[str, str], tuple[str, str]] = {
+    ("Mem", "increment_0"): (
+        "l_increment",
+        "ZiskFv/Airs/Mem.lean:40 lists column 10 as `l_increment`; :77-78 names "
+        "`increment_0` the low chunk of the same increment",
+    ),
+    ("Mem", "increment_1"): (
+        "h_increment",
+        "ZiskFv/Airs/Mem.lean:41 lists column 11 as `h_increment`; :79-80 names "
+        "`increment_1` the high chunk of the same increment",
+    ),
+    # The two Main fixed columns. This is a lane-KIND change, not just a rename.
+    ("Main", "segment_l1"): (
+        "Main.SEGMENT_L1",
+        "ZiskFv/AirsClean/Main/Circuit.lean:744-746 maps flattened slot 17 "
+        "(`core.segment_l1`) to fixed column 0, and :752-757 materialises it as "
+        "`[1, 0, ...]`; Extraction/Main.lean:159 reads it as `preprocessed 0`",
+    ),
+    ("Main", "main_step"): (
+        "Main.SEGMENT_STEP",
+        "ZiskFv/AirsClean/Main/Circuit.lean:744-750 maps flattened slot 37 "
+        "(`rom.main_step`) to fixed column 1, documented at :741-743",
+    ),
+    ("MemAlign", "preL1"): (
+        "MemAlign.L1",
+        "NO WELD, unlike the two Main entries above. The field is declared at "
+        "ZiskFv/AirsClean/MemAlign/Row.lean:51 with nothing pinning it to a "
+        "column, and MemAlign declares no `fixedColumns` anywhere under "
+        "ZiskFv/AirsClean/MemAlign/ -- only Main (Circuit.lean:953) and Mem "
+        "(Circuit.lean:254) do. What the correspondence rests on is the name and "
+        "the fact that fixed column 0 `MemAlign.L1` is read by exactly one "
+        "comparable constraint of this AIR, constraint_16_every_row "
+        "(mem/pil/mem_align.pil:121). That the mirror clause then MATCHES that "
+        "constraint is not evidence for the alias -- the alias is what produces "
+        "the match -- which is why this is reported as a RECLASSIFICATION and not "
+        "as a plain pairing. Inventory finding F7",
+    ),
+}
+
+# Fields with no lane, where that is structural and expected. A REPORT category:
+# these are counted and printed, never hidden. Each needs a citation.
+EXPECTED_UNRESOLVED: dict[tuple[str, str], str] = {
+    ("Main", "addr0"):
+        "PIL defines `addr0` as a `const expr`, so the pilout has no column and "
+        "no constraint for it; `mainWithRom` asserts the definition at "
+        "ZiskFv/AirsClean/Main/Constraints.lean:268. Inventory F9",
+    ("Main", "addr2"):
+        "as `addr0`: a PIL `const expr`, asserted at "
+        "ZiskFv/AirsClean/Main/Constraints.lean:270. Inventory F9",
+    ("Main", "im_high_degree_2"):
+        "a `MainRow` field with neither a stage-1 witness column nor a fixed "
+        "column in this pilout. Inventory F9",
+    ("MemAlign", "delta_pc"):
+        "the `pc' - pc` slot of hint #998, not a column: "
+        "ZiskFv/AirsClean/MemAlign/Row.lean:52-54. Inventory F3",
+}
+
+# Binder types that are carriers but not rows of an AIR, with the structural
+# reason each one has no lane. A type outside this table and outside the row
+# records raises rather than being waved through.
+NON_ROW_CARRIERS: dict[str, tuple[str, str]] = {
+    "RomFlagBits": (
+        "builder",
+        "honest-row builder input, not a row of the AIR: "
+        "ZiskFv/AirsClean/Main/Circuit.lean:326-331",
+    ),
+    "MainRomFreeCols": (
+        "builder",
+        "honest-row builder input: ZiskFv/AirsClean/Main/Circuit.lean:333-339",
+    ),
+    "ZiskRomMessage": (
+        "builder",
+        "a ROM bus message, not a row: "
+        "ZiskFv/AirsClean/Main/Circuit.lean:334",
+    ),
+    "IndexedFixedColumns": (
+        "schema",
+        "the component's fixed-column schema, addressed by index rather than "
+        "projected: ZiskFv/AirsClean/Mem/GeneratedTransition.lean:251",
+    ),
+}
+
+# `Bool -> FGL` coercions the grammar accepts in front of a projection. The
+# projection under one is still resolved (or reported) as a projection.
+BOOL_COERCIONS: dict[str, str] = {
+    "boolF": "ZiskFv/AirsClean/CompletenessHelpers.lean:19 `def boolF (b : Bool) "
+             ": FGL := if b then 1 else 0`",
+}
+
+# The two spellings by which a `MIRROR_ENV` adapter turns a Clean `Environment`
+# into a row of the delegate. Each maps one environment binder to row offset 0;
+# the delta of that row then comes from the environment binder's own role.
+ENV_ROW_ADAPTERS: dict[str, str] = {
+    "rowInputOfEnvironment": "ZiskFv/AirsClean/MemAlign/Circuit.lean:230-231",
+    "Eval.eval": "ZiskFv/AirsClean/Main/Circuit.lean:943-945",
+}
+
+# Type ascriptions the grammar drops, e.g. `(2 : FGL)`.
+ASCRIPTION_TYPES = frozenset({"FGL", "F", "ℕ", "Nat"})
+
+ROW_RECORDS = frozenset(name for _rel, name, _air in survey.MIRROR_RECORDS)
+DELEGATED_NAMES = frozenset(name for _air, _site, name, _ix in survey.DELEGATED)
+
+
+# ------------------------------------------------------------------- exceptions
+
+
+class MirrorParseError(Exception):
+    """A token, projection, numeral form or clause shape not recognised.
+
+    Carries the position and the offending text, because the whole value of
+    raising instead of skipping is that whoever reads the failure can find it.
+    """
+
+    def __init__(self, where: str, message: str, text: str = "") -> None:
+        self.where = where
+        self.message = message
+        self.text = text
+        suffix = f": {text!r}" if text else ""
+        super().__init__(f"{where}: {message}{suffix}")
+
+
+# ----------------------------------------------------------------------- results
+
+
+@dataclass(frozen=True)
+class Unresolved:
+    """One projection with no lane, and why."""
+
+    carrier: str
+    carrier_type: str
+    path: str
+    leaf: str
+    delta: int
+    reason: str
+    candidates: tuple[str, ...]
+    declared: str | None
+
+    def __repr__(self) -> str:
+        state = "declared" if self.declared else "undeclared"
+        return f"Unresolved({self.path} {self.reason} {state})"
+
+
+@dataclass(frozen=True)
+class Reclassified:
+    """A projection whose lane is not the kind the field's spelling suggests.
+
+    `atom_key` is the accessor atom's `(kind, index)`, recorded because a lane
+    tuple and an accessor atom are different vocabularies -- `('chal', 2, 0)` is
+    a lane, `('chal', 0)` the atom -- and a consumer asking "does this clause
+    reach the reclassified lane?" has only the atoms.
+    """
+
+    path: str
+    leaf: str
+    lane: tuple
+    lane_name: str
+    atom_key: tuple
+    citation: str
+
+
+@dataclass(frozen=True)
+class Delegation:
+    """A conjunct that is an application of another named `Prop`.
+
+    `declared` says the delegate is named somewhere -- `survey.CLASSIFICATION`
+    at any class, or `survey.DELEGATED`. That is NOT the same as the delegate's
+    clauses being compared, and conflating the two made the delegation exclusion
+    cite something false for the delegates classified `NEAR_*`: inventoried, but
+    parsed by nothing, because `parse_mirror_file` only reads `MIRROR_CLASSES`.
+    `compared` is the narrower fact the exclusion actually needs.
+    """
+
+    name: str
+    target_file: str | None
+    target_line: int | None
+    target_class: str | None
+    args: tuple[str, ...]
+    row_deltas: tuple[int | None, ...]
+    declared: bool
+    note: str
+    row_order_mismatch: bool = False
+
+    @property
+    def compared(self) -> bool:
+        """Is the delegate's own body compared by this tool, or named out-of-root?"""
+        return (self.target_class in survey.MIRROR_CLASSES
+                or self.target_class == "DELEGATED")
+
+
+@dataclass
+class MirrorClause:
+    """One `∧`-separated conjunct of a mirror definition."""
+
+    index: int
+    source_text: str
+    expr: tuple | None
+    kind: str
+    line: int
+    relation: str | None = None
+    bound: tuple[tuple, tuple] | None = None
+    delegate: Delegation | None = None
+    atoms: tuple[tuple, ...] = ()
+    unresolved: tuple[Unresolved, ...] = ()
+
+    @property
+    def comparable(self) -> bool:
+        """A polynomial identity with no holes, i.e. something #305 may pair."""
+        return self.kind == "equation" and not self.unresolved
+
+
+@dataclass
+class MirrorDef:
+    """One inventoried mirror definition, parsed."""
+
+    name: str
+    file: str
+    line: int
+    air: str | None
+    cls: str
+    row_record: str | None
+    row_vars: dict[str, int]
+    clauses: list[MirrorClause] = field(default_factory=list)
+    unparsed: list[str] = field(default_factory=list)
+    carriers: dict[str, tuple[str, str]] = field(default_factory=dict)
+    unresolved: list[Unresolved] = field(default_factory=list)
+    reclassified: list[Reclassified] = field(default_factory=list)
+    inlined: dict[str, int] = field(default_factory=dict)
+    opaque_locals: tuple[str, ...] = ()
+    path_aliases: list[tuple[str, str, tuple]] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+    # `(carrier, dotted field path) -> lane`, every projection this definition
+    # resolved. Exposed so a consumer can audit the field-to-lane map for
+    # totality against the row record it claims to project -- the analogue of
+    # auditing `h998ExprToField`'s arms against `MemAlignRow`.
+    projections: dict[tuple[str, str], tuple] = field(default_factory=dict)
+
+    @property
+    def site(self) -> str:
+        return f"{self.file}:{self.line}"
+
+    def of_kind(self, kind: str) -> list[MirrorClause]:
+        return [c for c in self.clauses if c.kind == kind]
+
+    @property
+    def equations(self) -> list[MirrorClause]:
+        return self.of_kind("equation")
+
+    @property
+    def undeclared_unresolved(self) -> list[Unresolved]:
+        return [u for u in self.unresolved if u.declared is None]
+
+    def atom_shapes(self) -> list[str]:
+        """The distinct atom shapes the definition's clauses reach."""
+        shapes: set[str] = set()
+        for clause in self.clauses:
+            for atom in clause.atoms:
+                if atom[0] == "main":
+                    shapes.add(f"main(s{atom[1]},d{atom[3]:+d})")
+                elif atom[0] == "pre":
+                    shapes.add(f"pre(d{atom[2]:+d})")
+                elif atom[0] == "chal":
+                    shapes.add("chal")
+                elif atom[0] == "exposed":
+                    shapes.add("exposed")
+                elif atom[0] == "unresolved":
+                    shapes.add(f"unresolved(d{atom[3]:+d})")
+                else:  # pragma: no cover - the vocabulary is closed
+                    raise MirrorParseError(self.site, "unknown atom head", str(atom))
+        return sorted(shapes)
+
+    def __repr__(self) -> str:
+        return (
+            f"MirrorDef({self.air}.{self.name} {len(self.clauses)} clause(s), "
+            f"{len(self.unparsed)} unparsed)"
+        )
+
+
+# --------------------------------------------------------------- source handling
+
+
+def blank_comments(lines: list[str]) -> list[str]:
+    """Replace comment characters with spaces, preserving every position.
+
+    `survey.strip_comments` removes them, which changes columns; this parser
+    slices verbatim text out of the raw lines by token position, so it needs the
+    geometry intact. Nestable `/- -/` (so `/-- -/` docstrings too) and `--`.
+    """
+    out: list[str] = []
+    depth = 0
+    for line in lines:
+        buf = list(line)
+        i = 0
+        while i < len(line):
+            if line.startswith("/-", i):
+                depth += 1
+                buf[i] = buf[i + 1] = " "
+                i += 2
+                continue
+            if depth and line.startswith("-/", i):
+                depth -= 1
+                buf[i] = buf[i + 1] = " "
+                i += 2
+                continue
+            if depth:
+                buf[i] = " "
+                i += 1
+                continue
+            if line.startswith("--", i):
+                for j in range(i, len(line)):
+                    buf[j] = " "
+                break
+            i += 1
+        out.append("".join(buf))
+    return out
+
+
+def _declaration_offset(line: str) -> int:
+    """How far into a declaration's first line the keyword starts.
+
+    A declaration may sit behind same-line `@[attr]`, `set_option ... in`,
+    `open ... in` or a privacy modifier. `survey.declarations` strips exactly that
+    prefix; the same patterns are reused here rather than re-guessed, so the two
+    tools cannot disagree about where a declaration begins.
+    """
+    rest = line
+    while True:
+        for pattern in (survey._ATTR, survey._SET_OPTION, survey._OPEN_IN,
+                        survey._PRIVACY):
+            match = pattern.match(rest)
+            if match:
+                rest = rest[match.end():]
+                break
+        else:
+            break
+    return len(line) - len(rest)
+
+
+@dataclass(frozen=True)
+class Slice:
+    """One declaration's source text, raw and comment-blanked, with positions.
+
+    `start` is the position of the declaration keyword, which is not necessarily
+    column 0 of `first_line`: `@[reducible] def DivModeSpec ...` puts it at
+    column 13.
+    """
+
+    path: str
+    first_line: int
+    raw: tuple[str, ...]
+    blank: tuple[str, ...]
+    start: tuple[int, int]
+
+    def text_between(self, start: tuple[int, int], end: tuple[int, int]) -> str:
+        """Verbatim raw text from `(line, col)` to `(line, col)`, inclusive end."""
+        (l0, c0), (l1, c1) = start, end
+        if l0 == l1:
+            return self.raw[l0 - self.first_line][c0:c1]
+        parts = [self.raw[l0 - self.first_line][c0:]]
+        for line in range(l0 + 1, l1):
+            parts.append(self.raw[line - self.first_line])
+        parts.append(self.raw[l1 - self.first_line][:c1])
+        return "\n".join(parts)
+
+
+def declaration_slices(path: Path, rel: str) -> dict[str, tuple[survey.Decl, Slice]]:
+    """Every top-level declaration of one file, with its source slice.
+
+    Declaration starts and names come from `survey.declarations`, so this module
+    and the survey cannot disagree about what a declaration is or where it
+    begins. The extent is then trimmed to Lean's layout: a declaration body is
+    indented, so it ends at the next line whose first character is in column 0.
+    That drops the trailing `end <namespace>`, `set_option ... in` and
+    `@[attr]` lines that a start-to-next-start slice would otherwise absorb.
+    """
+    raw = path.read_text(errors="replace").split("\n")
+    decls = survey.declarations(path, rel)
+    starts = [d.line for d in decls]
+    out: dict[str, tuple[survey.Decl, Slice]] = {}
+    for k, decl in enumerate(decls):
+        end = starts[k + 1] - 1 if k + 1 < len(starts) else len(raw)
+        lines = raw[decl.line - 1:end]
+        cut = len(lines)
+        for i, line in enumerate(lines[1:], start=1):
+            if line and not line[0].isspace():
+                cut = i
+                break
+        lines = lines[:cut]
+        out[decl.name] = (
+            decl,
+            Slice(rel, decl.line, tuple(lines), tuple(blank_comments(lines)),
+                  (decl.line, _declaration_offset(lines[0]))),
+        )
+    return out
+
+
+# ------------------------------------------------------------------- tokenizer
+
+# Lean identifiers, including the unicode letter blocks `survey._NAME` allows, so
+# `ℕ` in a binder type lexes as a name rather than as an unknown character. Dotted
+# projections lex as one identifier; splitting them is the parser's job.
+_IDENT_HEAD = r"[A-Za-z_Ͱ-῿℀-⅏]"
+_IDENT_TAIL = r"[A-Za-z0-9_'!?Ͱ-῿℀-⅏]"
+_IDENT = re.compile(rf"{_IDENT_HEAD}{_IDENT_TAIL}*(?:\.{_IDENT_TAIL}+)*")
+_NUM = re.compile(r"[0-9]+")
+
+# Exact operator spellings, longest first. Both spellings of conjunction and of
+# disjunction are here so an ascii `/\` is recognised rather than mis-lexed, and
+# `≤` so a bound written with it is not a surprise.
+_OPERATORS = (
+    ":=", "/\\", "\\/", "∧", "∨", "≤", "^", "<", "=", "+", "-", "*", "(", ")",
+    ":", ",",
+)
+
+# Characters that are specifically worth a named refusal, because each is a real
+# Lean token this grammar does not model and each would otherwise lex into
+# something misleading.
+_REFUSED = {
+    "−": "unicode minus U+2212 is not Lean's ascii '-'",
+    "·": "unicode middle dot U+00B7 is not Lean's '*'",
+    "≠": "'≠' is not an equation this grammar models",
+    "→": "'→' is a function arrow, not an operator of a field expression",
+    "↔": "'↔' is a logical connective this grammar does not model",
+    "¬": "'¬' is a logical connective this grammar does not model",
+    "∀": "'∀' introduces a binder this grammar does not model",
+    "∃": "'∃' introduces a binder this grammar does not model",
+    "⟨": "'⟨' is an anonymous constructor, not a field expression",
+    "{": "'{' is a structure instance or implicit binder, not a field expression",
+    "[": "'[' is an instance binder or list literal",
+}
+
+
+@dataclass(frozen=True)
+class Token:
+    kind: str  # 'ident' | 'num' | 'op'
+    text: str
+    line: int
+    col: int
+
+    @property
+    def start(self) -> tuple[int, int]:
+        return (self.line, self.col)
+
+    @property
+    def end(self) -> tuple[int, int]:
+        return (self.line, self.col + len(self.text))
+
+    def __repr__(self) -> str:
+        return f"{self.kind}({self.text!r})@{self.line}:{self.col}"
+
+
+def tokenize(src: Slice, where: str, start: tuple[int, int] | None = None,
+             stop: tuple[int, int] | None = None) -> list[Token]:
+    """The comment-blanked slice as a token list, or raise on anything else.
+
+    `start` and `stop` bound the region, which is what lets the signature and the
+    body be tokenized separately -- necessary because a `let`-bound term may
+    contain syntax (`fun x => ...`) this grammar refuses, and refusing it before
+    the `let` chain has been recognised would report a shape the parser is
+    actually able to handle as unparsable.
+    """
+    out: list[Token] = []
+    begin = start if start is not None else src.start
+    for offset, line in enumerate(src.blank):
+        lineno = src.first_line + offset
+        if lineno < begin[0]:
+            continue
+        if stop is not None and lineno > stop[0]:
+            break
+        i = begin[1] if lineno == begin[0] else 0
+        line = line[:stop[1]] if stop is not None and lineno == stop[0] else line
+        while i < len(line):
+            ch = line[i]
+            if ch in " \t":
+                i += 1
+                continue
+            if ch in _REFUSED:
+                raise MirrorParseError(
+                    f"{where} ({src.path}:{lineno})", _REFUSED[ch], ch
+                )
+            match = _IDENT.match(line, i)
+            if match:
+                out.append(Token("ident", match.group(0), lineno, i))
+                i = match.end()
+                continue
+            match = _NUM.match(line, i)
+            if match:
+                out.append(Token("num", match.group(0), lineno, i))
+                i = match.end()
+                continue
+            for op in _OPERATORS:
+                if line.startswith(op, i):
+                    out.append(Token("op", op, lineno, i))
+                    i += len(op)
+                    break
+            else:
+                raise MirrorParseError(
+                    f"{where} ({src.path}:{lineno}:{i + 1})",
+                    "unrecognised character",
+                    ch,
+                )
+    return out
+
+
+_OPEN = "("
+_CLOSE = ")"
+
+
+def _split_top_level(tokens: list[Token], seps: frozenset[str]) -> list[list[Token]]:
+    """Split a token list on `seps` at bracket depth 0."""
+    parts: list[list[Token]] = [[]]
+    depth = 0
+    for token in tokens:
+        if token.kind == "op" and token.text == _OPEN:
+            depth += 1
+        elif token.kind == "op" and token.text == _CLOSE:
+            depth -= 1
+        if depth == 0 and token.kind == "op" and token.text in seps:
+            parts.append([])
+            continue
+        parts[-1].append(token)
+    return parts
+
+
+def _find_top_level(tokens: list[Token], wanted: frozenset[str]) -> list[int]:
+    """Indices of depth-0 tokens whose text is in `wanted`."""
+    found: list[int] = []
+    depth = 0
+    for i, token in enumerate(tokens):
+        if token.kind == "op" and token.text == _OPEN:
+            depth += 1
+        elif token.kind == "op" and token.text == _CLOSE:
+            depth -= 1
+        elif depth == 0 and token.kind == "op" and token.text in wanted:
+            found.append(i)
+    return found
+
+
+AND_TOKENS = frozenset({"∧", "/\\"})
+RELATIONS = frozenset({"=", "<", "≤"})
+
+
+# --------------------------------------------------- source-level positions
+
+def assign_position(src: Slice) -> tuple[int, int] | None:
+    """The `(line, col)` of the declaration's own `:=`, at paren depth 0.
+
+    Found on the blanked text rather than on tokens, because the body after it may
+    contain syntax the tokenizer refuses; a named argument's `(F := FGL)` is
+    nested and therefore not it.
+    """
+    depth = 0
+    for offset, line in enumerate(src.blank):
+        lineno = src.first_line + offset
+        if lineno < src.start[0]:
+            continue
+        i = src.start[1] if lineno == src.start[0] else 0
+        while i < len(line):
+            if line[i] == "(":
+                depth += 1
+            elif line[i] == ")":
+                depth -= 1
+            elif depth == 0 and line.startswith(":=", i):
+                return (lineno, i)
+            i += 1
+    return None
+
+
+def first_word(src: Slice, start: tuple[int, int]) -> tuple[int, int, str] | None:
+    """`(line, col, word)` of the first identifier-or-symbol at or after `start`."""
+    for offset, line in enumerate(src.blank):
+        lineno = src.first_line + offset
+        if lineno < start[0]:
+            continue
+        i = start[1] if lineno == start[0] else 0
+        stripped = line[i:]
+        if not stripped.strip():
+            continue
+        col = i + len(stripped) - len(stripped.lstrip())
+        match = _IDENT.match(line, col)
+        return (lineno, col, match.group(0) if match else line[col])
+    return None
+
+
+def skip_let_chain(src: Slice, start: tuple[int, int],
+                   where: str) -> tuple[tuple[int, int], tuple[str, ...]]:
+    """Skip a leading `let name := <term>` chain, by Lean's layout rule.
+
+    A `let` binding runs to the next line whose first character is at or left of
+    the `let`'s own column, which is how Lean delimits it. The bound terms in the
+    tree are non-polynomial (`memWindow`,
+    `memSegmentColumnsOfProverDataAndFixed`), so they are not parsed at all: each
+    name is recorded as an *opaque local*, usable as a delegation argument and
+    nowhere else. A `let` can therefore never contribute a silent value to an
+    equation -- an equation mentioning one raises.
+    """
+    names: list[str] = []
+    position = start
+    while True:
+        head = first_word(src, position)
+        if head is None or head[2] != "let":
+            return position, tuple(names)
+        let_line, let_col, _ = head
+        bound = first_word(src, (let_line, let_col + 3))
+        if bound is None or not _IDENT.fullmatch(bound[2]):
+            raise MirrorParseError(where, "`let` without a bound name")
+        names.append(bound[2])
+        nxt = None
+        for offset, line in enumerate(src.blank):
+            lineno = src.first_line + offset
+            if lineno <= let_line or not line.strip():
+                continue
+            col = len(line) - len(line.lstrip())
+            if col <= let_col:
+                nxt = (lineno, col)
+                break
+        if nxt is None:
+            raise MirrorParseError(where, "`let` chain with no body after it")
+        position = nxt
+
+
+# --------------------------------------------------------------------- binders
+
+
+@dataclass(frozen=True)
+class Binder:
+    name: str
+    kind: str  # 'row' | 'validator' | 'index' | 'env' | 'builder' | 'schema'
+    type_name: str
+    note: str
+
+
+def _classify_type(type_tokens: list[Token], where: str) -> tuple[str, str, str]:
+    """`(kind, short type name, note)` for one binder's type, or raise."""
+    if not type_tokens:
+        raise MirrorParseError(where, "binder with no type")
+    head = type_tokens[0]
+    if head.kind != "ident":
+        raise MirrorParseError(where, "binder type does not start with a name", head.text)
+    short = head.text.rsplit(".", 1)[-1]
+    if short in ROW_RECORDS:
+        return ("row", short, "row record from survey.MIRROR_RECORDS")
+    if short.startswith("Valid_"):
+        return ("validator", short, "a `Valid_<AIR>` accessor record")
+    if short in ("ℕ", "Nat"):
+        return ("index", short, "a row index")
+    if short == "Environment":
+        return ("env", short, "a Clean `Environment`")
+    if short in NON_ROW_CARRIERS:
+        kind, note = NON_ROW_CARRIERS[short]
+        return (kind, short, note)
+    raise MirrorParseError(
+        where,
+        "binder type is neither a row record nor a declared non-row carrier",
+        " ".join(t.text for t in type_tokens),
+    )
+
+
+def parse_binders(tokens: list[Token], where: str) -> list[Binder]:
+    """The binders of a signature, from its token list after the declaration name.
+
+    Implicit `{...}` and instance `[...]` binders are refused by the tokenizer's
+    `_REFUSED` table rather than silently dropped: none of the 40 inventoried
+    mirrors has one, and a mirror that grew one would change what a projection
+    can mean, so it must be looked at rather than absorbed.
+    """
+    binders: list[Binder] = []
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        if token.kind == "op" and token.text == _OPEN:
+            depth = 1
+            j = i + 1
+            while j < len(tokens) and depth:
+                if tokens[j].kind == "op" and tokens[j].text == _OPEN:
+                    depth += 1
+                elif tokens[j].kind == "op" and tokens[j].text == _CLOSE:
+                    depth -= 1
+                j += 1
+            group = tokens[i + 1:j - 1]
+            colons = _find_top_level(group, frozenset({":"}))
+            if len(colons) != 1:
+                raise MirrorParseError(
+                    where,
+                    "binder group is not exactly `names : type`",
+                    " ".join(t.text for t in group),
+                )
+            names, type_tokens = group[:colons[0]], group[colons[0] + 1:]
+            kind, short, note = _classify_type(type_tokens, where)
+            for name in names:
+                if name.kind != "ident" and not (name.kind == "op" and name.text == "_"):
+                    raise MirrorParseError(where, "binder name is not an identifier",
+                                           name.text)
+                binders.append(Binder(name.text, kind, short, note))
+            i = j
+            continue
+        if token.kind == "op" and token.text == ":":
+            break  # the result type
+        if token.kind == "ident" and token.text == "_":
+            binders.append(Binder("_", "index", "?", "anonymous binder"))
+            i += 1
+            continue
+        raise MirrorParseError(where, "unexpected token in a signature", token.text)
+    return binders
+
+
+# ------------------------------------------------------------- helper inlining
+
+
+@dataclass(frozen=True)
+class Helper:
+    """A field-valued `def`/`abbrev` the grammar may inline."""
+
+    name: str
+    params: tuple[str, ...]
+    tokens: tuple[Token, ...]
+    src: Slice
+    site: str
+
+
+_HELPER_CACHE: dict[Path, dict[str, Helper]] = {}
+
+# A helper is recognised from its *signature* before its body is looked at:
+# `def|abbrev <name> (<params> : FGL)+ : FGL`. Everything else in the directory is
+# not a field abbreviation, and pre-filtering keeps the parser from tokenizing the
+# structure instances, tactic blocks and `Prop`s that fill these files.
+_HELPER_SIG = re.compile(
+    r"\s*(?:def|abbrev)\s+(?P<name>[A-Za-z_][A-Za-z0-9_'!?]*)"
+    r"(?P<params>(?:\s*\([^()]*:\s*FGL\s*\))+)\s*:\s*FGL\s*\Z"
+)
+_HELPER_PARAM = re.compile(r"\(([^():]*):\s*FGL\s*\)")
+
+
+def field_helpers(path: Path, rel: str) -> dict[str, Helper]:
+    """`FGL -> FGL` helpers visible to a mirror in `path`: its file, then its dir.
+
+    A helper qualifies only if every parameter and the result type is exactly
+    `FGL`, and its body is a term this grammar can read. A declaration that looks
+    like a helper but whose body it cannot read is *not* offered as one, so a use
+    site raises "not a field-valued helper in scope" instead of receiving a
+    partially understood body.
+    """
+    directory = path.parent
+    if directory in _HELPER_CACHE:
+        return _HELPER_CACHE[directory]
+    found: dict[str, Helper] = {}
+    for candidate in sorted(directory.glob("*.lean")):
+        candidate_rel = (str(candidate.relative_to(REPO_ROOT))
+                         if candidate.is_relative_to(REPO_ROOT) else candidate.name)
+        for name, (decl, src) in declaration_slices(candidate, candidate_rel).items():
+            if decl.keyword not in ("def", "abbrev"):
+                continue
+            match = _HELPER_SIG.fullmatch(decl.signature)
+            if match is None or match["name"] != name:
+                continue
+            params = tuple(
+                word
+                for group in _HELPER_PARAM.findall(match["params"])
+                for word in group.split()
+            )
+            try:
+                tokens = tokenize(src, f"helper {name} ({candidate_rel}:{decl.line})")
+            except MirrorParseError:
+                continue
+            assign = _find_top_level(tokens, frozenset({":="}))
+            if not assign:
+                continue
+            found[name] = Helper(
+                name, params, tuple(tokens[assign[0] + 1:]), src,
+                f"{candidate_rel}:{decl.line}",
+            )
+    _HELPER_CACHE[directory] = found
+    return found
+
+
+# ---------------------------------------------------------------- the parser
+
+
+MAX_INLINE_DEPTH = 8
+
+
+@dataclass
+class Context:
+    """Everything a clause parse needs, and the collectors it fills."""
+
+    where: str
+    src: Slice
+    air: str | None
+    lane_map: object | None
+    binders: dict[str, Binder]
+    row_deltas: dict[str, int]
+    index_binder: str | None
+    helpers: dict[str, Helper]
+    opaque_locals: frozenset[str]
+    locals: dict[str, tuple] = field(default_factory=dict)
+    depth: int = 0
+    atoms: list[tuple] = field(default_factory=list)
+    unresolved: list[Unresolved] = field(default_factory=list)
+    reclassified: list[Reclassified] = field(default_factory=list)
+    inlined: dict[str, int] = field(default_factory=dict)
+    lane_of_path: dict[str, tuple] = field(default_factory=dict)
+    row_relation_ok: bool = True
+
+
+def _candidates(air: str | None, leaf: str) -> tuple[str, ...]:
+    """The lane names a field leaf may spell, in the declared order."""
+    if air is not None and (air, leaf) in FIELD_ALIASES:
+        return (FIELD_ALIASES[(air, leaf)][0],)
+    match = re.fullmatch(r"(?P<base>.+?)_(?P<index>[0-9]+)", leaf)
+    if match:
+        return (leaf, f"{match['base']}[{int(match['index'])}]")
+    return (leaf,)
+
+
+def _resolve(ctx: Context, carrier: Binder, path: tuple[str, ...], delta: int) -> tuple:
+    """One projection as an atom: a lane atom, or a reported `unresolved` marker."""
+    dotted = f"{carrier.name}." + ".".join(path)
+    leaf = path[-1]
+    if carrier.kind != "row" and carrier.kind != "validator":
+        kind, note = NON_ROW_CARRIERS.get(carrier.type_name, ("carrier", carrier.note))
+        return _unresolved(ctx, carrier, dotted, leaf, delta, "carrier_not_a_row",
+                           (), note)
+    if not ctx.row_relation_ok:
+        return _unresolved(ctx, carrier, dotted, leaf, delta,
+                           "row_relation_undetermined", (), None)
+    if ctx.lane_map is None:
+        return _unresolved(ctx, carrier, dotted, leaf, delta, "no_lane_map", (), None)
+    candidates = _candidates(ctx.air, leaf)
+    hits: list[tuple[str, tuple]] = []
+    for candidate in candidates:
+        try:
+            hits.append((candidate, ctx.lane_map.resolve(candidate)))
+        except lanes.LaneError:
+            continue
+    if len(hits) > 1:
+        raise MirrorParseError(
+            ctx.where,
+            f"field {leaf!r} resolves under {len(hits)} of the declared spellings "
+            f"({', '.join(name for name, _ in hits)}); refusing to choose",
+            dotted,
+        )
+    if not hits:
+        declared = EXPECTED_UNRESOLVED.get((ctx.air, leaf))
+        return _unresolved(ctx, carrier, dotted, leaf, delta, "no_lane", candidates,
+                           declared)
+    name, lane = hits[0]
+    key = (carrier.name, ".".join(path))
+    previous = ctx.lane_of_path.get(key)
+    if previous is not None and previous != lane:  # pragma: no cover - a function
+        raise MirrorParseError(ctx.where, "one path resolved to two lanes", dotted)
+    ctx.lane_of_path[key] = lane
+    atom = ctx.lane_map.accessor_atom(lane, delta)
+    # A row-record projection landing on a lane that is not a stage-1 witness
+    # column is a KIND change, and it is recorded whether or not a declared alias
+    # produced it. Gating this on `FIELD_ALIASES` was wrong: a leaf that spells a
+    # non-witness lane name *directly* resolves with no alias involved and was
+    # reported as an ordinary match. `__L1__` is an unqualified fixed-column name
+    # in all ten AIRs -- and in MemAlign it is fixed column 1 while `MemAlign.L1`
+    # is fixed column 0 -- so the undeclared route reaches a different fixed
+    # column than the declared one does and said nothing about it. `std_alpha`
+    # and `std_gamma` are unqualified challenge names on the same footing.
+    if lane[0] != "main":
+        alias = FIELD_ALIASES.get((ctx.air, leaf)) if ctx.air is not None else None
+        ctx.reclassified.append(Reclassified(
+            dotted, leaf, lane, name, (atom[0], atom[1]),
+            alias[1] if alias else
+            f"NO DECLARED ALIAS: the field leaf {leaf!r} spells lane {name!r} "
+            f"directly, so a row-record projection resolved onto a non-witness "
+            f"lane with nothing declared pinning the field to it"))
+    ctx.atoms.append(atom)
+    return ("atom", atom)
+
+
+def _unresolved(ctx: Context, carrier: Binder, dotted: str, leaf: str, delta: int,
+                reason: str, candidates: tuple[str, ...], declared: str | None) -> tuple:
+    ctx.unresolved.append(Unresolved(
+        carrier.name, carrier.type_name, dotted, leaf, delta, reason,
+        tuple(candidates), declared))
+    return ("atom", ("unresolved", carrier.name, ".".join(dotted.split(".")[1:]), delta))
+
+
+class _ExprParser:
+    """Recursive descent over one clause's tokens, with the token stream checked
+    to be fully consumed by the caller."""
+
+    def __init__(self, tokens: list[Token], ctx: Context) -> None:
+        self.tokens = tokens
+        self.ctx = ctx
+        self.i = 0
+
+    # --- token access
+
+    def peek(self) -> Token | None:
+        return self.tokens[self.i] if self.i < len(self.tokens) else None
+
+    def next(self) -> Token:
+        token = self.peek()
+        if token is None:
+            raise MirrorParseError(self.ctx.where, "expression ended early")
+        self.i += 1
+        return token
+
+    def eat(self, text: str) -> Token:
+        token = self.next()
+        if token.kind != "op" or token.text != text:
+            raise MirrorParseError(self.ctx.where, f"expected {text!r}", token.text)
+        return token
+
+    def at_op(self, *texts: str) -> bool:
+        token = self.peek()
+        return token is not None and token.kind == "op" and token.text in texts
+
+    def done(self) -> bool:
+        return self.i >= len(self.tokens)
+
+    # --- grammar
+
+    def expr(self) -> tuple:
+        node = self.term()
+        while self.at_op("+", "-"):
+            op = self.next().text
+            rhs = self.term()
+            node = ("add", node, rhs) if op == "+" else ("sub", node, rhs)
+        return node
+
+    def term(self) -> tuple:
+        node = self.unary()
+        while self.at_op("*"):
+            self.next()
+            node = ("mul", node, self.unary())
+        return node
+
+    def unary(self) -> tuple:
+        if self.at_op("-"):
+            self.next()
+            return ("neg", self.unary())
+        return self.power()
+
+    def power(self) -> tuple:
+        base = self.primary()
+        if not self.at_op("^"):
+            return base
+        self.next()
+        exponent = self.power()
+        if base[0] != "const" or exponent[0] != "const":
+            raise MirrorParseError(
+                self.ctx.where,
+                "'^' over a non-constant is not a polynomial in this grammar",
+            )
+        return ("const", base[1] ** exponent[1])
+
+    def primary(self) -> tuple:
+        token = self.peek()
+        if token is None:
+            raise MirrorParseError(self.ctx.where, "expression ended early")
+        if token.kind == "op" and token.text == _OPEN:
+            self.next()
+            inner = self.expr()
+            if self.at_op(":"):
+                self.next()
+                ascription = self.next()
+                if ascription.text not in ASCRIPTION_TYPES:
+                    raise MirrorParseError(
+                        self.ctx.where, "unrecognised type ascription", ascription.text)
+            self.eat(_CLOSE)
+            return inner
+        if token.kind == "num":
+            self.next()
+            return ("const", int(token.text))
+        if token.kind == "ident":
+            return self.application()
+        raise MirrorParseError(self.ctx.where, "unexpected token", token.text)
+
+    def argument(self) -> tuple:
+        """One application argument: parenthesised, a numeral, or a 0-arg leaf."""
+        token = self.peek()
+        if token is None:
+            raise MirrorParseError(self.ctx.where, "application argument missing")
+        if token.kind == "op" and token.text == _OPEN:
+            return self.primary()
+        if token.kind == "num":
+            self.next()
+            return ("const", int(token.text))
+        if token.kind == "ident":
+            head = token.text
+            if "." in head or head in self.ctx.locals:
+                return self.application()
+            raise MirrorParseError(
+                self.ctx.where, "bare identifier as an application argument", head)
+        raise MirrorParseError(self.ctx.where, "unexpected application argument",
+                               token.text)
+
+    def application(self) -> tuple:
+        token = self.next()
+        head = token.text
+        parts = head.split(".")
+        binder = self.ctx.binders.get(parts[0])
+
+        if binder is not None and len(parts) > 1:
+            return self.projection(binder, tuple(parts[1:]), token)
+
+        if head in self.ctx.locals:
+            return self.ctx.locals[head]
+
+        if head in BOOL_COERCIONS:
+            inner = self.argument()
+            return inner
+
+        helper = self.ctx.helpers.get(head)
+        if helper is not None:
+            return self.inline(helper)
+
+        if binder is not None:
+            raise MirrorParseError(
+                self.ctx.where,
+                f"binder {head!r} of kind {binder.kind!r} used without a projection",
+                head)
+        raise MirrorParseError(
+            self.ctx.where,
+            "identifier is not a binder projection, a declared coercion or a "
+            "field-valued helper in scope",
+            head)
+
+    def projection(self, binder: Binder, path: tuple[str, ...], token: Token) -> tuple:
+        if path[-1] == "val":
+            raise MirrorParseError(
+                self.ctx.where,
+                "`.val` is a ℕ coercion and cannot occur in a field equation",
+                f"{binder.name}." + ".".join(path))
+        if binder.kind == "validator":
+            delta = self.row_index()
+            return _resolve(self.ctx, binder, path, delta)
+        if binder.kind == "row":
+            delta = self.ctx.row_deltas.get(binder.name)
+            if delta is None:
+                self.ctx.row_relation_ok = False
+                delta = 0
+            return _resolve(self.ctx, binder, path, delta)
+        return _resolve(self.ctx, binder, path, 0)
+
+    def row_index(self) -> int:
+        """The row argument of a `Valid_<AIR>` accessor, as a signed delta."""
+        token = self.next()
+        if token.kind == "ident":
+            if token.text != self.ctx.index_binder:
+                raise MirrorParseError(
+                    self.ctx.where, "accessor row argument is not the index binder",
+                    token.text)
+            return 0
+        if token.kind == "op" and token.text == _OPEN:
+            base = self.next()
+            if base.kind != "ident" or base.text != self.ctx.index_binder:
+                raise MirrorParseError(
+                    self.ctx.where, "accessor row argument is not the index binder",
+                    base.text)
+            sign = self.next()
+            if sign.kind != "op" or sign.text not in ("+", "-"):
+                raise MirrorParseError(
+                    self.ctx.where, "accessor row offset is not `+` or `-`", sign.text)
+            offset = self.next()
+            if offset.kind != "num":
+                raise MirrorParseError(
+                    self.ctx.where, "accessor row offset is not a numeral", offset.text)
+            self.eat(_CLOSE)
+            return int(offset.text) * (1 if sign.text == "+" else -1)
+        raise MirrorParseError(
+            self.ctx.where, "unrecognised accessor row argument", token.text)
+
+    def inline(self, helper: Helper) -> tuple:
+        if self.ctx.depth >= MAX_INLINE_DEPTH:
+            raise MirrorParseError(
+                self.ctx.where, f"helper inlining deeper than {MAX_INLINE_DEPTH}",
+                helper.name)
+        args = [self.argument() for _ in helper.params]
+        inner = Context(
+            where=f"{self.ctx.where} -> {helper.name} ({helper.site})",
+            src=helper.src,
+            air=self.ctx.air,
+            lane_map=self.ctx.lane_map,
+            binders=self.ctx.binders,
+            row_deltas=self.ctx.row_deltas,
+            index_binder=self.ctx.index_binder,
+            helpers=self.ctx.helpers,
+            opaque_locals=self.ctx.opaque_locals,
+            locals=dict(zip(helper.params, args)),
+            depth=self.ctx.depth + 1,
+            atoms=self.ctx.atoms,
+            unresolved=self.ctx.unresolved,
+            reclassified=self.ctx.reclassified,
+            inlined=self.ctx.inlined,
+            lane_of_path=self.ctx.lane_of_path,
+        )
+        parser = _ExprParser(list(helper.tokens), inner)
+        node = parser.expr()
+        if not parser.done():
+            raise MirrorParseError(
+                inner.where, "helper body not fully consumed",
+                " ".join(t.text for t in parser.tokens[parser.i:]))
+        self.ctx.inlined[helper.name] = self.ctx.inlined.get(helper.name, 0) + 1
+        self.ctx.row_relation_ok &= inner.row_relation_ok
+        return node
+
+
+# ------------------------------------------------------------ clause assembly
+
+
+def _delegate_targets(rel: str) -> dict[str, tuple[str, int, str]]:
+    """`name -> (file, line, class)` for the mirror-root declarations in scope.
+
+    An unqualified reference resolves in its own file first, then in its own
+    directory, and never further: `Spec` names ten different declarations across
+    the root, so a wider search would silently pick one. A name that resolves
+    nowhere, or in two files of the same directory, is reported by the caller as
+    an undeclared delegate rather than followed.
+    """
+    directory = str(Path(rel).parent)
+    out: dict[str, tuple[str, int, str]] = {}
+    siblings: dict[str, list[tuple[str, str]]] = {}
+    for (path, name), entry in survey.CLASSIFICATION.items():
+        if path == rel:
+            out[name] = (path, _line_of(path, name), entry.cls)
+        elif str(Path(path).parent) == directory:
+            siblings.setdefault(name, []).append((path, entry.cls))
+    for name, found in siblings.items():
+        if name in out or len(found) != 1:
+            continue  # two files of one directory define it: report, do not pick
+        path, cls = found[0]
+        out[name] = (path, _line_of(path, name), cls)
+    return out
+
+
+_LINE_CACHE: dict[tuple[str, str], int] = {}
+
+
+def _line_of(rel: str, name: str) -> int:
+    key = (rel, name)
+    if key not in _LINE_CACHE:
+        path = REPO_ROOT / rel
+        for decl in survey.declarations(path, rel):
+            _LINE_CACHE[(rel, decl.name)] = decl.line
+    return _LINE_CACHE.get(key, 0)
+
+
+def _row_binder_deltas(rel: str, name: str) -> tuple[int | None, ...]:
+    """The row binders of another mirror, as deltas, in declaration order.
+
+    `survey.bound_row_variables` reads them off the signature, so a delegate whose
+    *body* this grammar cannot read (`IndexedRangeSpec`'s `#v[...]`, `BinaryAdd`'s
+    `%`) still contributes its row order to the positional check.
+    """
+    path = REPO_ROOT / rel
+    for decl in survey.declarations(path, rel):
+        if decl.name != name:
+            continue
+        return tuple(
+            ROW_ROLE_DELTA.get(binder)
+            for binder, _record in survey.bound_row_variables(decl, set(ROW_RECORDS))
+        )
+    return ()
+
+
+def _parse_delegation(tokens: list[Token], ctx: Context, rel: str) -> Delegation:
+    """A conjunct that applies another named `Prop` to row-shaped arguments."""
+    head = tokens[0]
+    if head.kind != "ident":
+        raise MirrorParseError(ctx.where, "clause is neither a relation nor an "
+                               "application", head.text)
+    name = head.text
+    short = name.rsplit(".", 1)[-1]
+    args: list[str] = []
+    i = 1
+    while i < len(tokens):
+        token = tokens[i]
+        if token.kind == "ident":
+            args.append(token.text)
+            i += 1
+            continue
+        if token.kind == "op" and token.text == _OPEN:
+            depth = 1
+            j = i + 1
+            while j < len(tokens) and depth:
+                if tokens[j].kind == "op" and tokens[j].text == _OPEN:
+                    depth += 1
+                elif tokens[j].kind == "op" and tokens[j].text == _CLOSE:
+                    depth -= 1
+                j += 1
+            args.append(_env_adapter_argument(tokens[i + 1:j - 1], ctx))
+            i = j
+            continue
+        raise MirrorParseError(ctx.where, "unrecognised delegation argument",
+                               token.text)
+    for arg in args:
+        if not (arg in ctx.binders or arg in ctx.opaque_locals):
+            raise MirrorParseError(
+                ctx.where, "delegation argument is neither a binder nor a local", arg)
+    targets = _delegate_targets(rel)
+    row_args = [a for a in args if a in ctx.binders
+                and ctx.binders[a].kind in ("row", "env")]
+    deltas = tuple(ROW_ROLE_DELTA.get(a) for a in row_args)
+    if short in targets:
+        path, line, cls = targets[short]
+        note = ""
+        mismatch = False
+        # A two-row delegate reached with its rows in the wrong order is a real
+        # defect and invisible to everything else here, so the delegate's own
+        # binder roles are compared against the arguments' positionally.
+        expected = _row_binder_deltas(path, short)
+        if expected and deltas and len(expected) == len(deltas) and expected != deltas:
+            note = f"row arguments arrive as {deltas} where {short} binds {expected}"
+            mismatch = True
+        return Delegation(name, path, line, cls, tuple(args), deltas, True, note,
+                          mismatch)
+    if short in DELEGATED_NAMES or name in DELEGATED_NAMES:
+        site = next(s for _air, s, n, _ix in survey.DELEGATED if n == short)
+        return Delegation(name, site.rsplit(":", 1)[0], int(site.rsplit(":", 1)[1]),
+                          "DELEGATED", tuple(args), deltas, True,
+                          "declared out-of-root delegate (survey.DELEGATED)")
+    return Delegation(name, None, None, None, tuple(args), deltas, False,
+                      "in neither survey.CLASSIFICATION nor survey.DELEGATED")
+
+
+def _env_adapter_argument(tokens: list[Token], ctx: Context) -> str:
+    """The environment binder a declared `Environment -> row` adapter reads."""
+    if not tokens or tokens[0].kind != "ident":
+        raise MirrorParseError(ctx.where, "parenthesised delegation argument is not "
+                               "an application")
+    head = tokens[0].text
+    if head not in ENV_ROW_ADAPTERS:
+        raise MirrorParseError(
+            ctx.where, "not a declared `Environment` row adapter", head)
+    for token in tokens[1:]:
+        if token.kind == "ident" and token.text in ctx.binders:
+            if ctx.binders[token.text].kind == "env":
+                return token.text
+    raise MirrorParseError(
+        ctx.where, "row adapter does not read an `Environment` binder",
+        " ".join(t.text for t in tokens))
+
+
+def _parse_clause(index: int, tokens: list[Token], ctx: Context, src: Slice,
+                  rel: str) -> MirrorClause:
+    source_text = src.text_between(tokens[0].start, tokens[-1].end)
+    line = tokens[0].line
+    where = f"{ctx.where} clause {index}"
+    relations = _find_top_level(tokens, RELATIONS)
+    if len(relations) > 1:
+        raise MirrorParseError(where, "clause has more than one depth-0 relation",
+                               " ".join(t.text for t in tokens))
+    if not relations:
+        delegate = _parse_delegation(tokens, ctx, rel)
+        return MirrorClause(index, source_text, None, "delegation", line,
+                            delegate=delegate)
+    at = relations[0]
+    relation = tokens[at].text
+    lhs_tokens, rhs_tokens = tokens[:at], tokens[at + 1:]
+    if relation in ("<", "≤"):
+        return _parse_bound(index, source_text, line, relation, lhs_tokens,
+                            rhs_tokens, ctx, where)
+    before = len(ctx.atoms)
+    unresolved_before = len(ctx.unresolved)
+    lhs = _parse_expression(lhs_tokens, ctx, where + " lhs")
+    rhs = _parse_expression(rhs_tokens, ctx, where + " rhs")
+    expr = lhs if rhs == ("const", 0) else ("sub", lhs, rhs)
+    return MirrorClause(
+        index, source_text, expr, "equation", line, relation="=",
+        atoms=tuple(dict.fromkeys(ctx.atoms[before:])),
+        unresolved=tuple(ctx.unresolved[unresolved_before:]),
+    )
+
+
+def _parse_bound(index: int, source_text: str, line: int, relation: str,
+                 lhs_tokens: list[Token], rhs_tokens: list[Token], ctx: Context,
+                 where: str) -> MirrorClause:
+    """A `.val` bound: recorded, resolved, and explicitly not a polynomial.
+
+    The bound's subject is still resolved to its lane, because knowing *which*
+    column a bound is about is what makes it reportable against F2; but `expr`
+    stays `None` so nothing can pair it with a pilout constraint.
+    """
+    if not (len(lhs_tokens) == 1 and lhs_tokens[0].kind == "ident"
+            and lhs_tokens[0].text.endswith(".val")):
+        raise MirrorParseError(
+            where, "a bound's left side must be a single `<projection>.val`",
+            " ".join(t.text for t in lhs_tokens))
+    dotted = lhs_tokens[0].text[: -len(".val")]
+    parts = dotted.split(".")
+    binder = ctx.binders.get(parts[0])
+    if binder is None or len(parts) < 2:
+        raise MirrorParseError(where, "bound subject is not a binder projection",
+                               dotted)
+    before = len(ctx.atoms)
+    unresolved_before = len(ctx.unresolved)
+    delta = ctx.row_deltas.get(binder.name, 0) if binder.kind == "row" else 0
+    subject = _resolve(ctx, binder, tuple(parts[1:]), delta)
+    bound = _parse_expression(rhs_tokens, ctx, where + " rhs")
+    return MirrorClause(
+        index, source_text, None, "bound", line, relation=relation,
+        bound=(subject, bound),
+        atoms=tuple(dict.fromkeys(ctx.atoms[before:])),
+        unresolved=tuple(ctx.unresolved[unresolved_before:]),
+    )
+
+
+def _parse_expression(tokens: list[Token], ctx: Context, where: str) -> tuple:
+    inner = Context(**{**ctx.__dict__, "where": where})
+    inner.atoms = ctx.atoms
+    inner.unresolved = ctx.unresolved
+    inner.reclassified = ctx.reclassified
+    inner.inlined = ctx.inlined
+    inner.lane_of_path = ctx.lane_of_path
+    parser = _ExprParser(tokens, inner)
+    node = parser.expr()
+    if not parser.done():
+        raise MirrorParseError(
+            where, "expression not fully consumed",
+            " ".join(t.text for t in parser.tokens[parser.i:]))
+    ctx.row_relation_ok &= inner.row_relation_ok
+    return node
+
+
+# ------------------------------------------------------------------ public API
+
+
+def parse_mirror_definition(decl: survey.Decl, src: Slice, entry: survey.Entry,
+                            rel: str, lane_map_for) -> MirrorDef:
+    """One inventoried mirror definition, parsed into clauses."""
+    where = f"{rel}:{decl.line} {decl.name}"
+    out = MirrorDef(
+        name=decl.name, file=rel, line=decl.line, air=entry.air, cls=entry.cls,
+        row_record=None, row_vars={},
+    )
+    assign = assign_position(src)
+    if assign is None:
+        out.unparsed.append(f"{where}: no `:=` at depth 0")
+        return out
+    sig_tokens = tokenize(src, where, stop=assign)
+    if len(sig_tokens) < 2 or sig_tokens[0].text not in ("def", "abbrev"):
+        out.unparsed.append(f"{where}: not a `def`/`abbrev`")
+        return out
+    body_start, opaque = skip_let_chain(src, (assign[0], assign[1] + 2), where)
+    body_tokens = tokenize(src, where, start=body_start)
+
+    binders = parse_binders(sig_tokens[2:], where)
+    out.carriers = {b.name: (b.kind, b.type_name) for b in binders}
+    by_name = {b.name: b for b in binders}
+    rows = [b for b in binders if b.kind in ("row", "env")]
+    records = {b.type_name for b in binders if b.kind == "row"}
+    out.row_record = sorted(records)[0] if len(records) == 1 else (
+        "+".join(sorted(records)) if records else None)
+    indexes = [b.name for b in binders if b.kind == "index" and b.name != "_"]
+    index_binder = indexes[0] if len(indexes) == 1 else None
+
+    deltas: dict[str, int] = {}
+    row_relation_ok = True
+    for binder in rows:
+        role = ROW_ROLE_DELTA.get(binder.name)
+        if role is None:
+            row_relation_ok = False
+            out.notes.append(
+                f"row_relation_undetermined: binder {binder.name!r} "
+                f"({binder.type_name}) has no declared role")
+            continue
+        deltas[binder.name] = role
+    if rows and row_relation_ok and sum(1 for d in deltas.values() if d == 0) != 1:
+        row_relation_ok = False
+        out.notes.append(
+            "row_relation_undetermined: no unique delta-0 row binder among "
+            + ", ".join(f"{b.name}={deltas.get(b.name)}" for b in rows))
+    out.row_vars = dict(deltas)
+    if entry.cls == "MIRROR_2ROW" and len(rows) != 2:
+        out.notes.append(f"class MIRROR_2ROW but {len(rows)} row binder(s)")
+    if entry.cls in ("MIRROR", "MIRROR_MIXED") and len(rows) != 1:
+        out.notes.append(f"class {entry.cls} but {len(rows)} row binder(s)")
+
+    out.opaque_locals = opaque
+
+    lane_map = None
+    if entry.air is not None:
+        lane_map = lane_map_for(entry.air)
+
+    ctx = Context(
+        where=where, src=src, air=entry.air, lane_map=lane_map, binders=by_name,
+        row_deltas=deltas, index_binder=index_binder,
+        helpers=field_helpers(REPO_ROOT / rel, rel), opaque_locals=frozenset(opaque),
+        row_relation_ok=row_relation_ok,
+    )
+    conjuncts = [part for part in _split_top_level(body_tokens, AND_TOKENS)]
+    if any(not part for part in conjuncts):
+        out.unparsed.append(f"{where}: empty conjunct in the body")
+        return out
+    for index, part in enumerate(conjuncts):
+        try:
+            out.clauses.append(_parse_clause(index, part, ctx, src, rel))
+        except MirrorParseError as error:
+            out.unparsed.append(str(error))
+        except lanes.LaneError as error:  # pragma: no cover - lane map is closed
+            out.unparsed.append(f"{where} clause {index}: LaneError: {error}")
+    out.unresolved = list(ctx.unresolved)
+    out.reclassified = list(ctx.reclassified)
+    out.inlined = dict(ctx.inlined)
+    out.projections = dict(ctx.lane_of_path)
+    if not ctx.row_relation_ok and row_relation_ok:
+        out.notes.append("row_relation_undetermined during clause parsing")
+
+    expected = survey.top_level_conjuncts(decl)
+    got = len(out.clauses) + len(out.unparsed)
+    if expected != got:
+        out.unparsed.append(
+            f"{where}: parsed {len(out.clauses)} clause(s) for {expected} depth-0 "
+            f"conjunct(s) counted by survey.top_level_conjuncts")
+    # Two *different* field paths off one carrier reaching one lane. The same
+    # field on two rows is not that (`previous.reg_0` and `current.reg_0` are one
+    # lane by construction), so the grouping is per carrier: what this would catch
+    # is a leaf name reused across sub-structs, which the leaf-only alias rule
+    # would then conflate.
+    by_lane: dict[tuple[str, tuple], list[str]] = {}
+    for (carrier, path), lane in ctx.lane_of_path.items():
+        by_lane.setdefault((carrier, lane), []).append(path)
+    for (carrier, lane), paths in sorted(by_lane.items()):
+        if len(paths) > 1:
+            out.path_aliases.append(
+                (f"{carrier}.{sorted(paths)[0]}",
+                 ", ".join(f"{carrier}.{p}" for p in sorted(paths)[1:]), lane))
+    return out
+
+
+def parse_mirror_file(path: Path | str, lane_map_for) -> list[MirrorDef]:
+    """Every inventoried mirror in one Lean file, parsed.
+
+    `path` is a Lean file under the mirror root; `lane_map_for` maps an AIR name
+    to a `lanes.LaneMap` (or `None` when no lane map is available, in which case
+    every projection is reported unresolved rather than guessed). Which
+    declarations are mirrors is `survey.CLASSIFICATION`'s answer, not a shape
+    heuristic in this file: the survey already gates that list in both
+    directions, and re-deciding it here would let the mirror side choose what the
+    audit covers.
+    """
+    path = Path(path)
+    rel = str(path.relative_to(REPO_ROOT)) if path.is_relative_to(REPO_ROOT) else str(
+        path)
+    wanted = {
+        name: entry for (file, name), entry in survey.CLASSIFICATION.items()
+        if file == rel and entry.cls in survey.MIRROR_CLASSES
+    }
+    if not wanted:
+        return []
+    slices = declaration_slices(path, rel)
+    out: list[MirrorDef] = []
+    for name, entry in sorted(wanted.items()):
+        if name not in slices:
+            out.append(MirrorDef(
+                name=name, file=rel, line=0, air=entry.air, cls=entry.cls,
+                row_record=None, row_vars={},
+                unparsed=[f"{rel}: CLASSIFICATION names {name} but the file has no "
+                          f"such declaration"]))
+            continue
+        decl, src = slices[name]
+        try:
+            out.append(parse_mirror_definition(decl, src, entry, rel, lane_map_for))
+        except MirrorParseError as error:
+            out.append(MirrorDef(
+                name=name, file=rel, line=decl.line, air=entry.air, cls=entry.cls,
+                row_record=None, row_vars={}, unparsed=[str(error)]))
+    return sorted(out, key=lambda d: d.line)
+
+
+def inventoried_files() -> list[str]:
+    """The mirror-root files carrying at least one inventoried mirror."""
+    return sorted({
+        file for (file, _name), entry in survey.CLASSIFICATION.items()
+        if entry.cls in survey.MIRROR_CLASSES
+    })
+
+
+def parse_all(lane_map_for) -> list[MirrorDef]:
+    """Every inventoried mirror in the tree, in file order.
+
+    Every path in this module derives from `REPO_ROOT`, so a mutation test that
+    wants to parse a *copy* of the tree redirects that one name (and clears
+    `_HELPER_CACHE` and `_LINE_CACHE`) rather than passing a second root that
+    could drift out of step with it.
+    """
+    out: list[MirrorDef] = []
+    for rel in inventoried_files():
+        out.extend(parse_mirror_file(REPO_ROOT / rel, lane_map_for))
+    return out
+
+
+# ------------------------------------------------------------------- reporting
+
+
+def _lane_map_source(pilout_path: Path, wanted: set[str] | None):
+    """`air -> LaneMap`, memoised, from one pilout."""
+    import pilout_wire
+
+    pilout = pilout_wire.load(pilout_path)
+    cache: dict[str, object] = {}
+
+    def lane_map_for(air: str):
+        if wanted is not None and air not in wanted:
+            return None
+        if air not in cache:
+            cache[air] = lanes.lane_map(pilout, air)
+        return cache[air]
+
+    return lane_map_for
+
+
+def _report(defs: list[MirrorDef], quiet: bool, partial: bool = False) -> int:
+    failures = 0
+    print(f"mirrors     {len(defs)} inventoried definition(s) in "
+          f"{len({d.file for d in defs})} file(s)"
+          + (f", of {len(survey.CLASSIFICATION)} classified in "
+             f"{len(inventoried_files())}" if partial else ""))
+    print()
+    header = (f"{'air':<17} {'class':<17} {'name':<30} {'eqn':>4} {'bnd':>4} "
+              f"{'del':>4} {'unp':>4} {'unres':>6}  atom shapes")
+    print(header)
+    print("-" * len(header))
+    totals = dict(eqn=0, bnd=0, dele=0, unp=0, unres=0, declared=0)
+    for mirror in defs:
+        equations = len(mirror.equations)
+        bounds = len(mirror.of_kind("bound"))
+        delegations = len(mirror.of_kind("delegation"))
+        unresolved = len(mirror.unresolved)
+        declared = sum(1 for u in mirror.unresolved if u.declared)
+        totals["eqn"] += equations
+        totals["bnd"] += bounds
+        totals["dele"] += delegations
+        totals["unp"] += len(mirror.unparsed)
+        totals["unres"] += unresolved
+        totals["declared"] += declared
+        print(f"{mirror.air or '-':<17} {mirror.cls:<17} {mirror.name:<30} "
+              f"{equations:>4} {bounds:>4} {delegations:>4} {len(mirror.unparsed):>4} "
+              f"{unresolved:>6}  {' '.join(mirror.atom_shapes())}")
+    print("-" * len(header))
+    print(f"{'TOTAL':<17} {'':<17} {'':<30} {totals['eqn']:>4} {totals['bnd']:>4} "
+          f"{totals['dele']:>4} {totals['unp']:>4} {totals['unres']:>6}")
+    print("  eqn = polynomial identity clauses; bnd = `.val` bounds (NOT polynomial);")
+    print("  del = delegations to another named Prop; unp = unparsed conjuncts;")
+    print(f"  unres = unresolved projections, of which {totals['declared']} declared.")
+    conjuncts = sum(
+        survey.top_level_conjuncts(decl)
+        for mirror in defs
+        for decl, _src in [declaration_slices(REPO_ROOT / mirror.file,
+                                              mirror.file)[mirror.name]]
+    )
+    print(f"  total clauses {totals['eqn'] + totals['bnd'] + totals['dele']} against "
+          f"{conjuncts} depth-0 conjunct(s) counted independently by "
+          f"survey.top_level_conjuncts.")
+    if totals["eqn"] + totals["bnd"] + totals["dele"] + totals["unp"] != conjuncts:
+        print("  MISMATCH: a conjunct is unaccounted for")
+        failures += 1
+
+    print()
+    print("carriers, per definition")
+    for mirror in defs:
+        spelled = ", ".join(f"{name}:{kind}({type_name})"
+                            for name, (kind, type_name) in mirror.carriers.items())
+        record = mirror.row_record or "-"
+        print(f"  {mirror.air or '-':<17} {mirror.name:<30} {record:<20} {spelled}")
+
+    print()
+    print("row-delta conventions in force")
+    for mirror in defs:
+        if len(mirror.row_vars) > 1 or (mirror.row_vars and mirror.cls == "MIRROR_ENV"):
+            spelled = ", ".join(f"{k}={v:+d}" for k, v in mirror.row_vars.items())
+            print(f"  {mirror.air:<17} {mirror.name:<30} {spelled}")
+    single = sum(1 for m in defs if len(m.row_vars) == 1)
+    print(f"  {single} definition(s) are single-row at delta 0.")
+    undetermined = [m for m in defs if any(
+        n.startswith("row_relation_undetermined") for n in m.notes)]
+    print(f"  row relation undetermined: {len(undetermined)}"
+          + ("" if not undetermined else
+             " -- " + ", ".join(f"{m.air}.{m.name}" for m in undetermined)))
+    if undetermined:
+        failures += 1
+
+    unparsed = [m for m in defs if m.unparsed]
+    print()
+    print(f"UNPARSED definitions: {len(unparsed)}")
+    for mirror in unparsed:
+        print(f"  {mirror.site} {mirror.name} [{mirror.cls}]")
+        for reason in mirror.unparsed:
+            print(f"    {reason}")
+    if unparsed:
+        failures += 1
+
+    print()
+    print("UNRESOLVED fields")
+    grouped: dict[tuple[str, str, str, str | None], list[str]] = {}
+    for mirror in defs:
+        for item in mirror.unresolved:
+            key = (mirror.air or "-", item.leaf, item.reason, item.declared)
+            grouped.setdefault(key, []).append(f"{mirror.name}")
+    if not grouped:
+        print("  none.")
+    for (air, leaf, reason, declared), users in sorted(grouped.items()):
+        if reason == "carrier_not_a_row":
+            state = "CARRIER"
+        elif declared:
+            state = "DECLARED"
+        else:
+            state = "UNDECLARED"
+        print(f"  {state:<11} {air:<17} {leaf:<24} {reason:<26} "
+              f"in {len(users)} definition(s): {', '.join(sorted(set(users)))}")
+        if declared and not quiet:
+            print(f"              {declared}")
+    kinds = {"CARRIER": 0, "DECLARED": 0, "UNDECLARED": 0}
+    for mirror in defs:
+        for item in mirror.unresolved:
+            if item.reason == "carrier_not_a_row":
+                kinds["CARRIER"] += 1
+            elif item.declared:
+                kinds["DECLARED"] += 1
+            else:
+                kinds["UNDECLARED"] += 1
+    print(f"  {kinds['CARRIER']} on a declared non-row carrier (a builder input, "
+          f"structurally not a lane), {kinds['DECLARED']} declared expected, "
+          f"{kinds['UNDECLARED']} undeclared.")
+    if kinds["UNDECLARED"]:
+        failures += 1
+    if partial:
+        print("  EXPECTED_UNRESOLVED staleness not decidable on a filtered run.")
+    else:
+        exercised = {(m.air, u.leaf) for m in defs for u in m.unresolved if u.declared}
+        stale = sorted(set(EXPECTED_UNRESOLVED) - exercised)
+        print(f"  EXPECTED_UNRESOLVED entries no mirror reaches: {len(stale)}"
+              + ("" if not stale else " -- " + ", ".join(f"{a}.{f}" for a, f in stale)
+                 + " (a stale declaration, not a gap)"))
+
+    print()
+    print("kind reclassifications (a row field standing for a non-witness lane)")
+    seen: set[tuple] = set()
+    for mirror in defs:
+        for item in mirror.reclassified:
+            key = (mirror.air, item.leaf, item.lane)
+            if key in seen:
+                continue
+            seen.add(key)
+            print(f"  {mirror.air:<17} {item.path:<28} -> {item.lane} "
+                  f"{item.lane_name}")
+            if not quiet:
+                print(f"    {item.citation}")
+    if not seen:
+        print("  none.")
+
+    print()
+    print("delegations")
+    undeclared_delegates = []
+    mismatched = []
+    for mirror in defs:
+        for clause in mirror.of_kind("delegation"):
+            delegate = clause.delegate
+            assert delegate is not None
+            if delegate.row_order_mismatch:
+                state = "ROW ORDER"
+            elif delegate.declared:
+                state = "declared"
+            else:
+                state = "UNDECLARED"
+            target = (f"{delegate.target_file}:{delegate.target_line}"
+                      if delegate.target_file else "?")
+            print(f"  {state:<11} {mirror.name:<30} -> {delegate.name} "
+                  f"[{delegate.target_class}] {target}")
+            if delegate.note and (not quiet or delegate.row_order_mismatch):
+                print(f"    {delegate.note}")
+            if not delegate.declared:
+                undeclared_delegates.append((mirror.name, delegate.name))
+            if delegate.row_order_mismatch:
+                mismatched.append((mirror.name, delegate.name))
+    print(f"  {len(undeclared_delegates)} undeclared, {len(mismatched)} with the "
+          f"delegate's row arguments out of order.")
+    if undeclared_delegates or mismatched:
+        failures += 1
+
+    inlined: dict[str, int] = {}
+    for mirror in defs:
+        for name, count in mirror.inlined.items():
+            inlined[name] = inlined.get(name, 0) + count
+    print()
+    print("inlined field helpers: " + (", ".join(
+        f"{name} x{count}" for name, count in sorted(inlined.items())) or "none"))
+    aliases = [(m.name, a) for m in defs for a in m.path_aliases]
+    print("distinct paths sharing one lane inside a definition: "
+          + (str(len(aliases)) if aliases else "0"))
+    for name, (first, others, lane) in aliases:
+        print(f"  {name}: {first} and {others} both resolve to {lane}")
+
+    print()
+    comparable = sum(1 for m in defs for c in m.clauses if c.comparable)
+    print(f"comparable clauses (polynomial identity, no unresolved projection): "
+          f"{comparable} of {totals['eqn']} equation(s)")
+    if failures:
+        print(f"FAILED: {failures} failing category(ies)")
+        return EXIT_FAILED
+    if partial:
+        # Exit 1, like `check_mirrors.py`: a filtered run has decided nothing
+        # about the AIRs it skipped, and exiting 0 is how a CI step that
+        # acquired an `--air` flag goes quietly green over most of its scope.
+        print("PARTIAL: a filtered run, so it does not cover the inventoried "
+              "scope and cannot report success")
+        return EXIT_FAILED
+    print("OK: every inventoried mirror parsed, every conjunct accounted for")
+    return EXIT_OK
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Parse every inventoried mirror Prop into the shared AST.")
+    parser.add_argument("--pilout", type=Path, default=DEFAULT_PILOUT)
+    parser.add_argument("--air", action="append", dest="airs", default=None)
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args(argv)
+
+    if not args.pilout.exists():
+        print(f"mirror_parse.py: no pilout at {args.pilout}", file=sys.stderr)
+        print("ARTIFACTS ABSENT -- this is not a pass", file=sys.stderr)
+        return EXIT_USAGE
+    wanted = set(args.airs) if args.airs else None
+    if wanted:
+        unknown = wanted - set(lanes.DECLARED_AIRS)
+        if unknown:
+            print(f"mirror_parse.py: unknown --air {sorted(unknown)}", file=sys.stderr)
+            return EXIT_USAGE
+
+    lane_map_for = _lane_map_source(args.pilout, wanted)
+    defs = parse_all(lane_map_for)
+    if wanted:
+        defs = [d for d in defs if d.air in wanted]
+    if not defs:
+        print("mirror_parse.py: nothing parsed", file=sys.stderr)
+        return EXIT_USAGE
+    print(f"pilout      {args.pilout}")
+    print(f"mirror root {DEFAULT_MIRROR}")
+    return _report(defs, args.quiet, partial=bool(wanted))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/mirror-roundtrip/survey.py
+++ b/tools/mirror-roundtrip/survey.py
@@ -1,0 +1,1208 @@
+#!/usr/bin/env python3
+"""Mirror-side inventory for eth-act/zisk-fv#304.
+
+Reports, reproducibly, what is on the *mirror* side of the pilout/Lean round
+trip: the handwritten predicates under `ZiskFv/AirsClean/**` that restate a
+generated polynomial constraint, the row records they project, the existing
+field-to-column maps, and which published mirror predicates nothing references.
+
+It only reads. Nothing here edits `ZiskFv/`, and nothing here decides whether a
+mirror conjunct *equals* its generated counterpart -- that is #305's job. What
+this establishes is the denominator: the set of mirror conjuncts a later gate
+has to pair, and the set of generated constraints no mirror conjunct claims.
+
+The pilout side is not re-implemented: `pilout_wire` and `pilout_atoms` from
+`tools/pilout-roundtrip` (#303) supply the AIR list, the stage-1 column names
+and the comparable-constraint rule, so the two tools cannot drift apart on what
+a column or a constraint index means.
+
+    python3 tools/mirror-roundtrip/survey.py [--pilout PATH] [--mirror DIR]
+                                             [--section NAME]... [--quiet]
+
+Exit codes:
+
+    0  every Prop-valued declaration under the mirror root is classified
+    1  an unclassified declaration, an unreadable classification entry, or a
+       declaration named in `CLASSIFICATION` that no longer exists
+    2  usage or IO error
+
+Exit 1 on an unclassified declaration is the point. `CLASSIFICATION` below is a
+declared list, in the same spirit as `DECLARED_AIRS` in `check.py`: discovering
+the mirror set from a shape heuristic would let the mirror choose what the audit
+covers, and a new mirror predicate that silently classified itself as "not a
+mirror" is exactly the drop this inventory exists to prevent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "tools" / "pilout-roundtrip"))
+
+import pilout_atoms  # noqa: E402
+import pilout_wire  # noqa: E402
+from check import DECLARED_AIRS  # noqa: E402
+
+DEFAULT_PILOUT = REPO_ROOT / "build" / "zisk.pilout"
+DEFAULT_MIRROR = REPO_ROOT / "ZiskFv" / "AirsClean"
+
+# Reference counting scans these roots, so "unreachable" means unreachable from
+# any checked-in Lean, not just from within `AirsClean`.
+REFERENCE_ROOTS = ("ZiskFv", "trust", "Tests")
+
+
+# --------------------------------------------------------------- classification
+
+# class -> what it means. The MIRROR_* classes are in scope for the round trip;
+# the NEAR_* classes are the near-misses, kept explicit so a later reader can
+# see why each is out of scope rather than having to re-derive it.
+CLASSES = {
+    "MIRROR": "conjunction of field equations over row-record projections",
+    "MIRROR_2ROW": "same, over two row records at a fixed row offset",
+    "MIRROR_MIXED": "field equations plus non-polynomial clauses in one predicate",
+    "MIRROR_VALIDATOR": "same equations, over `Valid_<AIR>` accessors at a row index",
+    "MIRROR_BUILDER": "same equations, over an honest-row builder's inputs",
+    "MIRROR_ENV": "an adapter restating a mirror at Clean `Environment`s",
+    "MIRROR_COMPOSITE": "a conjunction of other named mirrors, no equations of its own",
+    "MIXED_COMPOSITE": "a conjunction mixing named mirrors with non-polynomial specs",
+    "NEAR_RANGE": "range/bit-width bounds on `.val`, not a field equation",
+    "NEAR_LOOKUP": "lookup or static-table membership",
+    "NEAR_SEMANTIC": "a semantic statement over ℕ, not a polynomial identity",
+    "NEAR_VACUOUS": "`True`",
+    "NEAR_BUS": "bus/channel/interaction or trace-replay predicate",
+    "NEAR_DATA": "prover-data or raw-cell binding, not an AIR constraint",
+    "NEAR_SOUNDNESS": "a quantified `ConstraintsHold` surface, not an equation list",
+    "NEAR_LITERAL": "a disjunction of literal values",
+}
+
+MIRROR_CLASSES = frozenset(k for k in CLASSES if k.startswith("MIRROR") or k == "MIXED_COMPOSITE")
+
+
+@dataclass(frozen=True)
+class Entry:
+    """One classified declaration.
+
+    `claims` is the set of generated constraint indices this mirror is *asserted*
+    to restate, read off the mirror's own body and provenance comments against
+    `build/extraction/Extraction/<AIR>.lean`. It is an audited reading, NOT a
+    machine-checked pairing: #305 decides each pairing polynomially, and until it
+    does, a claim here could be wrong in either direction. What the claim set
+    does buy now is arithmetic: any comparable constraint index that no mirror
+    claims is printed, so the set of constraints with no mirror at all is a
+    computed output rather than a reader's impression.
+    """
+
+    cls: str
+    air: str | None
+    note: str
+    claims: frozenset[int]
+
+
+def _ix(spec: str) -> frozenset[int]:
+    """Parse a compact index spec: `"0-5,9,12-14"` -> {0,1,2,3,4,5,9,12,13,14}."""
+    out: set[int] = set()
+    for part in spec.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part.lstrip("-"):
+            lo, hi = part.split("-", 1)
+            out.update(range(int(lo), int(hi) + 1))
+        else:
+            out.add(int(part))
+    return frozenset(out)
+
+
+def _e(cls: str, air: str | None = None, note: str = "", claims: str = "") -> Entry:
+    if cls not in CLASSES:
+        raise SystemExit(f"survey.py: unknown class {cls!r}")
+    return Entry(cls, air, note, _ix(claims))
+
+
+# Keyed by (path relative to the repo root, declaration name). Every
+# Prop-valued `def`/`abbrev` under the mirror root must appear exactly once.
+CLASSIFICATION: dict[tuple[str, str], Entry] = {
+    # ---- Arith (ArithMul view: the whole comparable set; ArithDiv view: c6-c8, c31-c38)
+    ("ZiskFv/AirsClean/ArithMul/Spec.lean", "Spec"):
+        _e("MIRROR", "Arith", "c6-c8 sign products, c31-c38 carry chain (arith.pil:58-60,205-219)",
+           claims="6-8,31-38"),
+    ("ZiskFv/AirsClean/ArithMul/Spec.lean", "C46Spec"):
+        _e("MIRROR", "Arith", "c46 bus_res1 mux (arith.pil:262)", claims="46"),
+    ("ZiskFv/AirsClean/ArithMul/Spec.lean", "DivModeSpec"):
+        _e("MIRROR", "Arith", "c0-c5 and c39-c45 flag booleans (arith.pil:50-55,212-218)",
+           claims="0-5,39-45"),
+    ("ZiskFv/AirsClean/ArithMul/Spec.lean", "DivBoundarySpec"):
+        _e("MIRROR", "Arith", "c9-c24 div-by-zero/overflow pins (arith.pil:64,69-84)",
+           claims="9-24"),
+    ("ZiskFv/AirsClean/ArithMul/Spec.lean", "DivInverseSumSpec"):
+        _e("MIRROR", "Arith", "c25 inverse-sum witness (arith.pil:92)", claims="25"),
+    ("ZiskFv/AirsClean/ArithMul/Spec.lean", "DivScopeSpec"):
+        _e("MIRROR", "Arith", "c26-c30 scope exclusions (arith.pil:95-102)", claims="26-30"),
+    ("ZiskFv/AirsClean/ArithMul/Spec.lean", "DivWModeSpec"):
+        _e("MIRROR", "Arith", "c47-c48 W-mode high-lane pins (arith.pil:264-265)", claims="47,48"),
+    ("ZiskFv/AirsClean/ArithMul/Spec.lean", "SharedDivBlockSpec"):
+        _e("MIRROR_COMPOSITE", "Arith", "DivMode/DivBoundary/DivInverseSum/DivScope/DivWMode"),
+    ("ZiskFv/AirsClean/ArithMul/Spec.lean", "FullSpec"):
+        _e("MIXED_COMPOSITE", "Arith", "Spec + table membership + c46 + range specs"),
+    ("ZiskFv/AirsClean/ArithMul/Spec.lean", "Assumptions"): _e("NEAR_VACUOUS", "Arith"),
+    ("ZiskFv/AirsClean/ArithMul/Spec.lean", "ArithTableSpec"): _e("NEAR_LOOKUP", "Arith"),
+    ("ZiskFv/AirsClean/ArithMul/Spec.lean", "ChunkRangeSpec"): _e("NEAR_RANGE", "Arith"),
+    ("ZiskFv/AirsClean/ArithMul/Spec.lean", "CarryRangeSpec"): _e("NEAR_RANGE", "Arith"),
+    ("ZiskFv/AirsClean/ArithMul/Spec.lean", "IndexedRangeSpec"): _e("NEAR_LOOKUP", "Arith"),
+    ("ZiskFv/AirsClean/ArithDiv/Spec.lean", "Spec"):
+        _e("MIRROR", "Arith", "c6-c8 and c31-c38 again, in the ArithDiv row view",
+           claims="6-8,31-38"),
+    ("ZiskFv/AirsClean/ArithDiv/Spec.lean", "FullSpec"):
+        _e("MIXED_COMPOSITE", "Arith", "Spec + table membership + indexed ranges"),
+    ("ZiskFv/AirsClean/ArithDiv/Spec.lean", "Assumptions"): _e("NEAR_VACUOUS", "Arith"),
+    ("ZiskFv/AirsClean/ArithDiv/Spec.lean", "ArithTableSpec"): _e("NEAR_LOOKUP", "Arith"),
+    ("ZiskFv/AirsClean/ArithDiv/Spec.lean", "IndexedRangeSpec"): _e("NEAR_LOOKUP", "Arith"),
+
+    # ---- Binary
+    ("ZiskFv/AirsClean/Binary/Spec.lean", "Spec"):
+        _e("MIRROR", "Binary", "c0-c6 (binary.pil booleans, b_op_or_sext, mode32_and_c_is_signed)",
+           claims="0-6"),
+    ("ZiskFv/AirsClean/Binary/Spec.lean", "Assumptions"): _e("NEAR_RANGE", "Binary"),
+    ("ZiskFv/AirsClean/Binary/Bridge.lean", "constraints_at"):
+        _e("MIRROR_VALIDATOR", "Binary", "the same 7, over `Valid_Binary` accessors at row r", claims="0-6"),
+    ("ZiskFv/AirsClean/Binary/Bridge.lean", "StaticBinaryTableWfFacts"):
+        _e("NEAR_LOOKUP", "Binary"),
+    ("ZiskFv/AirsClean/Binary/Bridge.lean", "StaticBinaryTableGtFacts"):
+        _e("NEAR_LOOKUP", "Binary"),
+    ("ZiskFv/AirsClean/Binary/Bridge.lean", "StaticBinaryTableLtAbsNpFacts"):
+        _e("NEAR_LOOKUP", "Binary"),
+    ("ZiskFv/AirsClean/Binary/Bridge.lean", "StaticBinaryTableLtAbsPnFacts"):
+        _e("NEAR_LOOKUP", "Binary"),
+    ("ZiskFv/AirsClean/Binary/Bridge.lean", "StaticLookupSoundness"):
+        _e("NEAR_SOUNDNESS", "Binary"),
+    ("ZiskFv/AirsClean/Binary/Circuit.lean", "StaticBinaryTableSpecFacts"):
+        _e("NEAR_LOOKUP", "Binary"),
+
+    # ---- BinaryAdd
+    ("ZiskFv/AirsClean/BinaryAdd/Circuit.lean", "CoreFacts"):
+        _e("MIRROR", "BinaryAdd", "c0-c3 cout booleans and the two half-lane adds", claims="0-3"),
+    ("ZiskFv/AirsClean/BinaryAdd/Circuit.lean", "RangeFacts"): _e("NEAR_RANGE", "BinaryAdd"),
+    ("ZiskFv/AirsClean/BinaryAdd/Circuit.lean", "ComponentSpecFacts"):
+        _e("MIXED_COMPOSITE", "BinaryAdd", "semantic Spec + CoreFacts + RangeFacts"),
+    ("ZiskFv/AirsClean/BinaryAdd/Bridge.lean", "constraints_at"):
+        _e("MIRROR_VALIDATOR", "BinaryAdd", "the same 4, over `Valid_BinaryAdd`", claims="0-3"),
+    ("ZiskFv/AirsClean/BinaryAdd/Spec.lean", "Spec"):
+        _e("NEAR_SEMANTIC", "BinaryAdd", "cPacked = (packed32 a + packed32 b) % 2^64"),
+    ("ZiskFv/AirsClean/BinaryAdd/Spec.lean", "Assumptions"): _e("NEAR_RANGE", "BinaryAdd"),
+
+    # ---- BinaryExtension (zero comparable constraints in the pilout)
+    ("ZiskFv/AirsClean/BinaryExtension/Spec.lean", "Spec"): _e("NEAR_VACUOUS", "BinaryExtension"),
+    ("ZiskFv/AirsClean/BinaryExtension/Spec.lean", "Assumptions"):
+        _e("NEAR_VACUOUS", "BinaryExtension"),
+    ("ZiskFv/AirsClean/BinaryExtension/Bridge.lean", "constraints_at"):
+        _e("NEAR_VACUOUS", "BinaryExtension", "`True`; the AIR has no comparable constraint"),
+    ("ZiskFv/AirsClean/BinaryExtension/Bridge.lean", "StaticBinaryExtensionTableWfFacts"):
+        _e("NEAR_LOOKUP", "BinaryExtension"),
+    ("ZiskFv/AirsClean/BinaryExtension/Bridge.lean", "ShiftB0RangeSpecFact"):
+        _e("NEAR_LOOKUP", "BinaryExtension"),
+    ("ZiskFv/AirsClean/BinaryExtension/Bridge.lean", "StaticLookupSoundness"):
+        _e("NEAR_SOUNDNESS", "BinaryExtension"),
+    ("ZiskFv/AirsClean/BinaryExtension/StaticCircuit.lean",
+     "StaticBinaryExtensionTableSpecFacts"): _e("NEAR_LOOKUP", "BinaryExtension"),
+
+    # ---- Main
+    ("ZiskFv/AirsClean/Main/Spec.lean", "Spec"):
+        _e("MIRROR", "Main", "c7,c8,c13,c14,c15,c16,c17,c22,c28 (main.pil:393-404,459,472)",
+           claims="7,8,13,14,15,16,17,22,28"),
+    ("ZiskFv/AirsClean/Main/Spec.lean", "AddressSpec"):
+        _e("MIRROR", "Main", "c1 and c2; the addr0/addr2 clauses have no generated counterpart",
+           claims="1,2"),
+    ("ZiskFv/AirsClean/Main/Spec.lean", "SourceSpec"):
+        _e("MIRROR", "Main", "c5,c6,c11,c12 immediate-source lanes (main.pil:389-390)",
+           claims="5,6,11,12"),
+    ("ZiskFv/AirsClean/Main/Spec.lean", "Assumptions"): _e("NEAR_RANGE", "Main"),
+    ("ZiskFv/AirsClean/Main/Circuit.lean", "RomBoolSpec"):
+        _e("MIRROR", "Main", "c23-c27,c29-c37 rom_flags booleans (main.pil:467-481)",
+           claims="23-27,29-37"),
+    ("ZiskFv/AirsClean/Main/Circuit.lean", "MainRomAddressGuard"):
+        _e("MIRROR_BUILDER", "Main", "c2, over (bits, free) instead of a row record", claims="2"),
+    ("ZiskFv/AirsClean/Main/Circuit.lean", "MainRomSourceGuard"):
+        _e("MIRROR_BUILDER", "Main", "c5,c6,c11,c12, over (msg, bits, free)", claims="5,6,11,12"),
+    ("ZiskFv/AirsClean/Main/Circuit.lean", "pcHandshakeBetween"):
+        _e("MIRROR_2ROW", "Main", "c18 PC handshake (main.pil:410)", claims="18"),
+    ("ZiskFv/AirsClean/Main/Circuit.lean", "sourceCCopyBetween"):
+        _e("MIRROR_2ROW", "Main", "c4 and c10, the b-side C copy (main.pil:386)", claims="4,10"),
+    ("ZiskFv/AirsClean/Main/Circuit.lean", "transitionBetween"):
+        _e("MIRROR_COMPOSITE", "Main", "pcHandshakeBetween + sourceCCopyBetween"),
+    ("ZiskFv/AirsClean/Main/Circuit.lean", "pcHandshakeTransition"):
+        _e("MIRROR_ENV", "Main", "transitionBetween at two Environments"),
+    ("ZiskFv/AirsClean/Main/Bridge.lean", "constraints_at"):
+        _e("MIRROR_VALIDATOR", "Main", "the same 9 as Spec, over `Valid_Main`",
+           claims="7,8,13,14,15,16,17,22,28"),
+    ("ZiskFv/AirsClean/Main/CrossRow.lean", "pc_handshake_at"):
+        _e("MIRROR_VALIDATOR", "Main", "c18, over `Valid_Main` with ℕ-saturating row - 1", claims="18"),
+
+    # ---- Mem
+    ("ZiskFv/AirsClean/Mem/Spec.lean", "Spec"):
+        _e("MIRROR", "Mem", "c3-c8, c18, c21, c23 (mem.pil per-row invariants)",
+           claims="3-8,18,21,23"),
+    ("ZiskFv/AirsClean/Mem/Spec.lean", "Assumptions"): _e("NEAR_RANGE", "Mem"),
+    ("ZiskFv/AirsClean/Mem/Bridge.lean", "constraints_at"):
+        _e("MIRROR_VALIDATOR", "Mem", "the same 9, over `Valid_Mem`", claims="3-8,18,21,23"),
+    ("ZiskFv/AirsClean/Mem/GeneratedTransition.lean", "generatedTransition"):
+        _e("MIRROR_COMPOSITE", "Mem",
+           "delegates to ZiskFv/Airs/Mem.segmentResidualEveryRow and permutation_every_row, "
+           "which are OUTSIDE the mirror root"),
+    ("ZiskFv/AirsClean/Mem/GeneratedTransition.lean", "memRangeSidecarBridge"):
+        _e("NEAR_DATA", "Mem"),
+    ("ZiskFv/AirsClean/Mem/Constraints.lean", "dualMemRowRangeFacts"): _e("NEAR_RANGE", "Mem"),
+    ("ZiskFv/AirsClean/Mem/TraceSpec.lean", "MemoryBusRowsChronological"): _e("NEAR_BUS", "Mem"),
+    ("ZiskFv/AirsClean/Mem/TraceSpec.lean", "GeneratedMemRows"): _e("NEAR_BUS", "Mem"),
+
+    # ---- MemAlign
+    ("ZiskFv/AirsClean/MemAlign/Spec.lean", "Spec"):
+        _e("MIRROR", "MemAlign", "c16-c28, c30-c32 (mem_align.pil:121,125-130,165,187)",
+           claims="16-28,30-32"),
+    ("ZiskFv/AirsClean/MemAlign/Spec.lean", "Assumptions"): _e("NEAR_RANGE", "MemAlign"),
+    ("ZiskFv/AirsClean/MemAlign/Circuit.lean", "transitionRows"):
+        _e("MIRROR_2ROW", "MemAlign", "c29 delta_addr and the odd c1..c15 down-to-up chain",
+           claims="1,3,5,7,9,11,13,15,29"),
+    ("ZiskFv/AirsClean/MemAlign/Circuit.lean", "cyclicSuccessorTransitionRows"):
+        _e("MIRROR_2ROW", "MemAlign",
+           "the even c0..c14 up-to-down chain, plus one delta_pc clause whose only "
+           "generated source is the h998 hint tuple inside the excluded c36",
+           claims="0,2,4,6,8,10,12,14"),
+    ("ZiskFv/AirsClean/MemAlign/Circuit.lean", "transition"):
+        _e("MIRROR_ENV", "MemAlign", "transitionRows at two Environments"),
+    ("ZiskFv/AirsClean/MemAlign/Circuit.lean", "cyclicSuccessorTransition"):
+        _e("MIRROR_ENV", "MemAlign", "cyclicSuccessorTransitionRows at two Environments"),
+
+    # ---- MemAlignByte / MemAlignReadByte
+    ("ZiskFv/AirsClean/MemAlignByte/Spec.lean", "Spec"):
+        _e("MIRROR_MIXED", "MemAlignByte", "5 field equations plus 3 `.val <` bounds; the 4 selector booleans "
+           "c0-c2 and c5 are represented only as `.val < 2` in Assumptions",
+           claims="3,5-8"),
+    ("ZiskFv/AirsClean/MemAlignByte/Spec.lean", "Assumptions"): _e("NEAR_RANGE", "MemAlignByte"),
+    ("ZiskFv/AirsClean/MemAlignByte/Bridge.lean", "constraints_at"):
+        _e("MIRROR_VALIDATOR", "MemAlignByte", "the 5 equations, over `Valid_MemAlignByte`", claims="3,5-8"),
+    ("ZiskFv/AirsClean/MemAlignReadByte/Spec.lean", "Spec"):
+        _e("MIRROR_MIXED", "MemAlignReadByte", "1 field equation plus 1 `.val <` bound; the 3 selector booleans c0-c2 "
+           "are represented only as `.val < 2` in Assumptions",
+           claims="3"),
+    ("ZiskFv/AirsClean/MemAlignReadByte/Spec.lean", "Assumptions"):
+        _e("NEAR_RANGE", "MemAlignReadByte"),
+    ("ZiskFv/AirsClean/MemAlignReadByte/Bridge.lean", "constraints_at"):
+        _e("MIRROR_VALIDATOR", "MemAlignReadByte",
+           "3 selector booleans plus composed_value, over `Valid_MemAlignReadByte`",
+           claims="0-3"),
+
+    # ---- shared tables
+    ("ZiskFv/AirsClean/RangeTables.lean", "ArithRangePosId"): _e("NEAR_LITERAL", "Arith"),
+    ("ZiskFv/AirsClean/RangeTables.lean", "ArithRangeNegId"): _e("NEAR_LITERAL", "Arith"),
+
+    # ---- full-ensemble balance layer: bus, interaction and replay predicates
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/EmbeddedInTrace.lean",
+     "MemReadReplayRowsEmbeddedInTrace"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/EmbeddedInTrace.lean",
+     "MemReplayRowsEmbeddedInTrace"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/EmbeddedInTrace.lean",
+     "ActiveMemReplayRowsEmbeddedInTrace"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/EmbeddedInTrace.lean",
+     "MutableMemReadReplayRowsEmbeddedInTrace"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/EmbeddedInTrace.lean",
+     "MutableMemReplayRowsEmbeddedInTrace"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/EmbeddedInTrace.lean",
+     "MutableActiveMemReplayRowsEmbeddedInTrace"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/EmbeddedInTrace.lean",
+     "FullWitnessMemReplayBridgeCoversMutableMemTables"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/MemAlignSkippableProve.lean",
+     "MemAlignSkippableProveForge"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean",
+     "MainMemBusRowInteractionMatchEval"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean",
+     "ActiveMainMemProviderRowMatchSpec"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean",
+     "ActiveMainMutableMemProviderRowMatchSpec"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean",
+     "ActiveMainNonMutableMemProviderRowMatchSpec"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean",
+     "ActiveMainMemAlignReadByteProviderRowMatchSpec"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean",
+     "ActiveMainMemAlignByteProviderRowMatchSpec"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean",
+     "ActiveMainMemAlignProviderRowMatchSpec"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean",
+     "MemAlignReadByteLoadProviderRowMatchSpec"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean",
+     "MemAlignByteLoadProviderRowMatchSpec"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean",
+     "MemAlignLoadProviderRowMatchSpec"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean",
+     "ActiveMainSelfMemProviderRowMatchSpec"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean",
+     "ActiveMainSelfAMemProviderRowMatchSpec"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean",
+     "ActiveMainSelfBMemProviderRowMatchSpec"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean",
+     "ActiveMainSelfCMemProviderRowMatchSpec"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean",
+     "ActiveMainRegisterBoundaryProviderRowMatchSpec"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/RowExtraction.lean",
+     "MainMemBusRowInteractionEval"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/RowsBridgeFacts.lean",
+     "FullWitnessMemTableGeneratedRowsBridge"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/TimelineEvidence.lean",
+     "ActiveMemReplayRowsOfTablePrimaryReadPrefixSound"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/TimelineEvidence.lean",
+     "MemReplayRowsOfTablePrefixReadSound"): _e("NEAR_BUS"),
+    ("ZiskFv/AirsClean/FullEnsemble/Balance/TimelineEvidence.lean",
+     "ActiveMemReplayRowsOfTablePrefixReadSound"): _e("NEAR_BUS"),
+}
+
+
+# Mirrors that a declaration *inside* the mirror root reaches, but that are
+# themselves declared outside it. They are not part of the #304 inventory proper
+# -- the issue scopes the inventory to `ZiskFv/AirsClean/**` -- but leaving them
+# unrecorded would report their constraints as having no mirror at all, which is
+# the opposite of true. Each is reported separately from the genuinely unmirrored
+# set so the two are never confused.
+DELEGATED: list[tuple[str, str, str, frozenset[int]]] = [
+    ("Mem", "ZiskFv/Airs/Mem.lean:296", "segmentResidualEveryRow",
+     _ix("0-2,9-17,19,20,22")),
+]
+
+# Row records used by a mirror, in the order a reader should see them, together
+# with the AIR whose columns they claim to lay out. `None` means the record is a
+# sub-struct of a larger row and carries no AIR of its own.
+MIRROR_RECORDS: list[tuple[str, str, str | None]] = [
+    ("ZiskFv/AirsClean/Main/Row.lean", "MainRow", None),
+    ("ZiskFv/AirsClean/Main/Row.lean", "MainRomRow", None),
+    ("ZiskFv/AirsClean/Main/Row.lean", "MainRowWithRom", "Main"),
+    ("ZiskFv/AirsClean/Mem/Row.lean", "MemRow", "Mem"),
+    ("ZiskFv/AirsClean/MemAlign/Row.lean", "MemAlignRow", "MemAlign"),
+    ("ZiskFv/AirsClean/MemAlignByte/Row.lean", "MemAlignByteRow", "MemAlignByte"),
+    ("ZiskFv/AirsClean/MemAlignReadByte/Row.lean", "MemAlignReadByteRow", "MemAlignReadByte"),
+    ("ZiskFv/AirsClean/Binary/Row.lean", "BinaryAByteCols", None),
+    ("ZiskFv/AirsClean/Binary/Row.lean", "BinaryBByteCols", None),
+    ("ZiskFv/AirsClean/Binary/Row.lean", "BinaryCByteCols", None),
+    ("ZiskFv/AirsClean/Binary/Row.lean", "BinaryChainCols", None),
+    ("ZiskFv/AirsClean/Binary/Row.lean", "BinaryModeCols", None),
+    ("ZiskFv/AirsClean/Binary/Row.lean", "BinaryRow", "Binary"),
+    ("ZiskFv/AirsClean/BinaryAdd/Row.lean", "BinaryAddRow", "BinaryAdd"),
+    ("ZiskFv/AirsClean/BinaryExtension/Row.lean", "BinaryExtensionACols", None),
+    ("ZiskFv/AirsClean/BinaryExtension/Row.lean", "BinaryExtensionCColsLo", None),
+    ("ZiskFv/AirsClean/BinaryExtension/Row.lean", "BinaryExtensionCColsHi", None),
+    ("ZiskFv/AirsClean/BinaryExtension/Row.lean", "BinaryExtensionFlags", None),
+    ("ZiskFv/AirsClean/BinaryExtension/Row.lean", "BinaryExtensionRow", "BinaryExtension"),
+    ("ZiskFv/AirsClean/ArithMul/Row.lean", "ArithMulChunks", None),
+    ("ZiskFv/AirsClean/ArithMul/Row.lean", "ArithMulFlags", None),
+    ("ZiskFv/AirsClean/ArithMul/Row.lean", "ArithMulCarries", None),
+    ("ZiskFv/AirsClean/ArithMul/Row.lean", "ArithMulRow", "Arith"),
+    ("ZiskFv/AirsClean/ArithDiv/Row.lean", "ArithDivChunks", None),
+    ("ZiskFv/AirsClean/ArithDiv/Row.lean", "ArithDivFlags", None),
+    ("ZiskFv/AirsClean/ArithDiv/Row.lean", "ArithDivAux", None),
+    ("ZiskFv/AirsClean/ArithDiv/Row.lean", "ArithDivRow", "Arith"),
+]
+
+
+# ------------------------------------------------------------------ Lean reader
+
+DECL_KEYWORDS = (
+    "def", "abbrev", "theorem", "lemma", "structure", "inductive", "instance",
+    "example", "opaque", "axiom", "class",
+)
+_ATTR = re.compile(r"@\[[^\]]*\]\s*")
+_SET_OPTION = re.compile(r"set_option\s+\S+\s+\S+\s+in\s+")
+_OPEN_IN = re.compile(r"open\s+[^\n]*?\s+in\s+")
+_PRIVACY = re.compile(r"(private|protected|noncomputable|partial|unsafe)\s+")
+_NAME = re.compile(r"[A-Za-z_Ͱ-῿℀-⅏][A-Za-z0-9_.'!?Ͱ-῿]*")
+
+
+def strip_comments(lines: list[str]) -> list[str]:
+    """Blank out `--` and nestable `/- -/` comments, preserving line numbering.
+
+    Docstrings routinely contain `∧`, `= 0` and the words this survey keys on,
+    so a survey that counted them would report prose as constraints.
+    """
+    out: list[str] = []
+    depth = 0
+    for line in lines:
+        keep: list[str] = []
+        i = 0
+        while i < len(line):
+            if line.startswith("/-", i):
+                depth += 1
+                i += 2
+                continue
+            if depth and line.startswith("-/", i):
+                depth -= 1
+                i += 2
+                continue
+            if not depth and line.startswith("--", i):
+                break
+            if not depth:
+                keep.append(line[i])
+            i += 1
+        out.append("".join(keep))
+    return out
+
+
+@dataclass
+class Decl:
+    path: str
+    line: int
+    keyword: str
+    name: str
+    body: list[str]
+
+    @property
+    def text(self) -> str:
+        return "\n".join(self.body)
+
+    @property
+    def signature(self) -> str:
+        """Everything before the first `:=`, i.e. binders and result type."""
+        return self.text.split(":=", 1)[0]
+
+
+def declarations(path: Path, rel: str) -> list[Decl]:
+    """Top-level declarations of one Lean file.
+
+    A declaration starts at column 0, optionally behind same-line attributes,
+    `set_option ... in`, `open ... in` or a privacy modifier, and runs to the
+    next such start. Anything more precise needs Lean itself; this is enough to
+    delimit a body for counting and for locating a name, and it is checked
+    against `CLASSIFICATION` so a missed declaration surfaces as unclassified
+    rather than as silence.
+    """
+    raw = path.read_text(errors="replace").split("\n")
+    src = strip_comments(raw)
+    starts: list[tuple[int, str, int]] = []
+    for i, line in enumerate(src):
+        if not line or line[0] in " \t":
+            continue
+        rest = line
+        while True:
+            for pattern in (_ATTR, _SET_OPTION, _OPEN_IN, _PRIVACY):
+                match = pattern.match(rest)
+                if match:
+                    rest = rest[match.end():]
+                    break
+            else:
+                break
+        for keyword in DECL_KEYWORDS:
+            if rest.startswith(keyword + " ") or rest == keyword:
+                starts.append((i, keyword, len(line) - len(rest)))
+                break
+    out: list[Decl] = []
+    for k, (i, keyword, offset) in enumerate(starts):
+        end = starts[k + 1][0] if k + 1 < len(starts) else len(src)
+        body = list(src[i:end])
+        body[0] = body[0][offset:]
+        head = body[0][len(keyword):].lstrip()
+        head = re.sub(r"^\{[^}]*\}\s*", "", head)
+        match = _NAME.match(head)
+        out.append(Decl(rel, i + 1, keyword, match.group(0) if match else "?", body))
+    return out
+
+
+def is_prop_valued(decl: Decl) -> bool:
+    return decl.keyword in ("def", "abbrev") and re.search(r":\s*Prop\b", decl.signature) is not None
+
+
+_OPENERS = "([{⟨⟦"
+_CLOSERS = ")]}⟩⟧"
+
+
+def top_level_conjuncts(decl: Decl) -> int:
+    """Number of conjuncts at depth 0 of a declaration body.
+
+    Depth counts brackets only. A conjunction nested inside a clause's
+    parentheses -- which happens in `CarryRangeSpec`'s disjunctions and in the
+    ensemble predicates -- is not a clause of the outer conjunction and is not
+    counted.
+
+    Both spellings Lean accepts are counted, `∧` and the ascii `/\\`. This
+    count is cross-checked against `mirror_parse`'s own clause split, and
+    `mirror_parse.AND_TOKENS` accepts both; counting only `∧` here made an
+    ascii conjunct read as an UNPARSED clause-count disagreement, which is a
+    false alarm rather than a silence but still a wrong report.
+    """
+    body = decl.text.split(":=", 1)
+    if len(body) < 2:
+        return 0
+    depth = 0
+    conjuncts = 1
+    text = body[1]
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if ch in _OPENERS:
+            depth += 1
+        elif ch in _CLOSERS:
+            depth -= 1
+        elif ch == "∧" and depth == 0:
+            conjuncts += 1
+        elif text.startswith("/\\", i) and depth == 0:
+            conjuncts += 1
+            i += 2
+            continue
+        i += 1
+    return conjuncts
+
+
+def bound_row_variables(decl: Decl, records: set[str]) -> list[tuple[str, str]]:
+    """`(binder, record)` pairs for binders whose type is a known row record."""
+    found: list[tuple[str, str]] = []
+    for names, typename in re.findall(
+        r"\(([^():]+?)\s*:\s*([A-Za-z_][A-Za-z0-9_.]*)\s+FGL\s*\)", decl.signature
+    ):
+        short = typename.rsplit(".", 1)[-1]
+        if short in records:
+            for name in names.split():
+                found.append((name, short))
+    return found
+
+
+# ------------------------------------------------------------ path canonicalisation
+
+# `CLASSIFICATION` and `MIRROR_RECORDS` are keyed by repo-relative path, and they
+# have to stay keyed that way even when `--mirror` points at a copy of the tree
+# outside the repo -- which is how a mutation test would exercise this gate
+# without writing to `ZiskFv/`. So a scanned file is named by its canonical
+# repo-relative path regardless of where it was actually read from.
+MIRROR_PREFIX = "ZiskFv/AirsClean"
+
+
+def canonical_rel(path: Path, mirror_root: Path) -> str:
+    """Repo-relative name for a file read from `mirror_root`, real or substituted."""
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return f"{MIRROR_PREFIX}/{path.relative_to(mirror_root)}"
+
+
+def resolve_rel(rel: str, mirror_root: Path) -> Path:
+    """Inverse of `canonical_rel`: where to actually read a repo-relative name."""
+    if rel.startswith(MIRROR_PREFIX + "/"):
+        return mirror_root / rel[len(MIRROR_PREFIX) + 1:]
+    return REPO_ROOT / rel
+
+
+# ------------------------------------------------------------------- structures
+
+def structure_fields(path: Path, name: str) -> list[str]:
+    """Field names of `structure <name> ... where`, in declaration order."""
+    raw = path.read_text(errors="replace").split("\n")
+    src = strip_comments(raw)
+    start = None
+    for i, line in enumerate(src):
+        if re.match(rf"structure\s+{re.escape(name)}\b", line):
+            start = i
+            break
+    if start is None:
+        raise SystemExit(f"survey.py: no structure {name} in {path}")
+    fields: list[str] = []
+    for line in src[start + 1:]:
+        if line and line[0] not in " \t":
+            break
+        match = re.match(r"\s+([A-Za-z_][A-Za-z0-9_']*)\s*:\s*\S", line)
+        if match:
+            fields.append(match.group(1))
+    return fields
+
+
+def flatten_record(mirror_root: Path, rel: str, name: str,
+                   known: dict[str, list[str]]) -> list[str]:
+    """Field list, expanding a field whose type is another known record."""
+    path = resolve_rel(rel, mirror_root)
+    out: list[str] = []
+    raw = strip_comments(path.read_text(errors="replace").split("\n"))
+    start = next(i for i, l in enumerate(raw)
+                 if re.match(rf"structure\s+{re.escape(name)}\b", l))
+    for line in raw[start + 1:]:
+        if line and line[0] not in " \t":
+            break
+        match = re.match(r"\s+([A-Za-z_][A-Za-z0-9_']*)\s*:\s*([A-Za-z_][A-Za-z0-9_.]*)", line)
+        if not match:
+            continue
+        fld, typ = match.group(1), match.group(2).rsplit(".", 1)[-1]
+        if typ in known and typ != name:
+            out.extend(f"{fld}.{sub}" for sub in known[typ])
+        else:
+            out.append(fld)
+    return out
+
+
+# ------------------------------------------------------------------------- maps
+
+@dataclass
+class MapInfo:
+    path: str
+    line: int
+    name: str
+    what: str
+    arms: int
+    fallback: str
+    gate: str
+
+
+def find_expr_maps(decls_by_file: dict[str, list[Decl]]) -> list[MapInfo]:
+    """Functions that consume the generated `Expr` inductive by pattern match."""
+    out: list[MapInfo] = []
+    for rel, decls in decls_by_file.items():
+        for decl in decls:
+            if decl.keyword not in ("def", "abbrev"):
+                continue
+            if "Expr →" not in decl.signature and "Expr →" not in decl.signature:
+                continue
+            arms = len(re.findall(r"^\s*\|", decl.text, re.M))
+            catch = re.findall(r"^\s*\|\s*_\s*=>\s*(.+)$", decl.text, re.M)
+            out.append(MapInfo(
+                rel, decl.line, decl.name,
+                "generated LookupWiring `Expr` term -> mirror expression",
+                arms,
+                f"catch-all `| _ => {catch[-1].strip()}`" if catch else "none (total by cases)",
+                "",
+            ))
+    return out
+
+
+def result_type(signature: str) -> str:
+    """The declaration's result type: everything after the last depth-0 `:`.
+
+    Needed because both directions of a row/validator map mention both types --
+    `validOfRow (row : BinaryRow FGL) : Valid_Binary FGL FGL` has `BinaryRow` in
+    a binder and `Valid_Binary` as the result -- so keying on "the signature
+    mentions X" reports the direction backwards.
+    """
+    depth = 0
+    last = -1
+    for i, ch in enumerate(signature):
+        if ch in _OPENERS:
+            depth += 1
+        elif ch in _CLOSERS:
+            depth -= 1
+        elif ch == ":" and depth == 0:
+            last = i
+    return signature[last + 1:].strip() if last >= 0 else ""
+
+
+def find_validator_projections(decls_by_file: dict[str, list[Decl]]) -> list[MapInfo]:
+    """`Valid_<AIR>` accessor -> row-record field maps, and their inverses."""
+    out: list[MapInfo] = []
+    for rel, decls in decls_by_file.items():
+        for decl in decls:
+            if decl.keyword not in ("def", "abbrev"):
+                continue
+            sig, text = decl.signature, decl.text
+            result = result_type(sig)
+            mentions_valid = re.search(r"Valid_[A-Za-z]+\s+FGL\s+FGL", sig) is not None
+            mentions_row = re.search(r"[A-Za-z_.]*Row\s+FGL", sig) is not None
+            if not (mentions_valid and mentions_row):
+                continue
+            to_row = re.match(r"[A-Za-z_.]*Row\s+FGL", result) is not None
+            to_valid = re.match(r"[A-Za-z_.]*Valid_[A-Za-z]+\s+FGL\s+FGL", result) is not None
+            if not (to_row or to_valid):
+                continue
+            # Count leaf assignments only: `field := {` opens a nested record
+            # group and is not itself a column.
+            assigns = len(re.findall(
+                r"^\s+[A-Za-z_][A-Za-z0-9_']*\s*:=\s*(?!\{\s*$)\S", text, re.M))
+            if assigns:
+                fallback = "none (record literal: every field assigned or it does not compile)"
+            else:
+                fallback = "not a record literal (delegates to another projection)"
+            out.append(MapInfo(
+                rel, decl.line, decl.name,
+                "`Valid_<AIR>` accessor -> row field" if to_row
+                else "row field -> `Valid_<AIR>` accessor",
+                assigns, fallback, "",
+            ))
+    return out
+
+
+def find_slot_layouts(decls_by_file: dict[str, list[Decl]]) -> list[MapInfo]:
+    """Effective-slot -> raw/fixed column layouts and raw-column index tables."""
+    out: list[MapInfo] = []
+    for rel, decls in decls_by_file.items():
+        for decl in decls:
+            if decl.keyword not in ("def", "abbrev"):
+                continue
+            sig = decl.signature
+            if re.search(r"Fin\s+\d+\s*\)\s*:\s*Sum\s*\(Fin", sig):
+                out.append(MapInfo(
+                    rel, decl.line, decl.name,
+                    "effective row slot -> raw witness slot or fixed column",
+                    len(re.findall(r"\bif\b", decl.text)) + 1,
+                    "none (final else branch; index arithmetic proved by omega)",
+                    "",
+                ))
+            if re.search(r":\s*Option\s*\(", sig) and "constraintIndex" in sig:
+                arms = len(re.findall(r"^\s*\|", decl.text, re.M))
+                catch = re.findall(r"^\s*\|\s*_\s*=>\s*(.+)$", decl.text, re.M)
+                out.append(MapInfo(
+                    rel, decl.line, decl.name,
+                    "generated constraint index -> (hint slot AST, raw column, prover-data key)",
+                    arms,
+                    f"catch-all `| _ => {catch[-1].strip()}`" if catch else "none",
+                    "",
+                ))
+    return out
+
+
+def find_index_abbrevs(mirror_root: Path) -> list[MapInfo]:
+    """`abbrev <name> : Nat := <k>` column-index constants, grouped per file."""
+    out: list[MapInfo] = []
+    for path in sorted(mirror_root.rglob("*.lean")):
+        rel = canonical_rel(path, mirror_root)
+        src = strip_comments(path.read_text(errors="replace").split("\n"))
+        namespace = ""
+        for i, line in enumerate(src):
+            match = re.match(r"namespace\s+([A-Za-z0-9_.]+)", line)
+            if match:
+                namespace = match.group(1)
+            match = re.match(r"abbrev\s+([A-Za-z0-9_']+)\s*:\s*Nat\s*:=\s*(\d+)", line)
+            if match:
+                out.append(MapInfo(
+                    rel, i + 1, f"{namespace}.{match.group(1)}",
+                    f"named column index -> raw slot {match.group(2)}",
+                    1, "not applicable (a constant)", "",
+                ))
+    return out
+
+
+# ------------------------------------------------------------------ pilout side
+
+@dataclass
+class AirFacts:
+    name: str
+    total: int
+    comparable: list[int]
+    excluded: list[int]
+    stage1: list[str]
+    fixed: int
+    provenance: dict[int, str]
+    stage_widths: list[int] = field(default_factory=list)
+    fixed_names: dict[int, str] = field(default_factory=dict)
+    # fixed column index -> (comparable uses, excluded uses)
+    fixed_uses: dict[int, tuple[int, int]] = field(default_factory=dict)
+
+
+def fixed_column_names(pilout: pilout_wire.PilOut,
+                       ref: pilout_wire.AirRef) -> dict[str, str]:
+    """`index -> name` for an AIR's FIXED_COL symbols, arrays flattened.
+
+    Same shape as `pilout_atoms.witness_column_names`, for the other column kind.
+    Fixed columns matter to this survey because the mirror side does not have a
+    fixed/witness distinction: a fixed column is either a field of the row record,
+    a slot of a component-owned `IndexedFixedColumns` schema, or absent.
+    """
+    names: dict[str, str] = {}
+    for symbol in pilout.symbols:
+        if (symbol.type_name != "FIXED_COL"
+                or symbol.air_group_id != ref.airgroup_idx
+                or symbol.air_id != ref.air_idx):
+            continue
+        if not symbol.lengths:
+            names[symbol.id] = symbol.name
+            continue
+        total = 1
+        for length in symbol.lengths:
+            total *= length
+        for k in range(total):
+            names[symbol.id + k] = f"{symbol.name}[{k}]"
+    return names
+
+
+def air_facts(pilout: pilout_wire.PilOut) -> dict[str, AirFacts]:
+    """Per declared AIR: comparable constraint indices, stage-1 names, provenance.
+
+    "Comparable" is the issue's own exclusion rule -- drop every constraint whose
+    expression tree reaches a challenge or a stage-2 witness lane -- computed off
+    the operands via `pilout_atoms`, not off the emitted Lean's binder form. The
+    binder form excludes nine more Main constraints, including the two the mirror
+    side is missing, so using it here would hide the finding.
+    """
+    out: dict[str, AirFacts] = {}
+    for ref in pilout.airs():
+        if ref.air_name not in DECLARED_AIRS:
+            continue
+        air = ref.air
+        constraints = pilout_atoms.air_constraint_exprs(
+            pilout, ref, vocab=pilout_atoms.OPERAND_VOCAB)
+        comparable, excluded = [], []
+        fixed_uses: dict[int, list[int]] = {}
+        for entry in constraints:
+            atoms = set(pilout_atoms.iter_atoms(entry.expr)) if entry.expr else set()
+            reaches = any(
+                atom[0] == "challenge" or (atom[0] == "witness_col" and atom[1] == 2)
+                for atom in atoms
+            )
+            (excluded if reaches else comparable).append(entry.index)
+            for atom in atoms:
+                if atom[0] == "fixed_col":
+                    slot = fixed_uses.setdefault(atom[1], [0, 0])
+                    slot[1 if reaches else 0] += 1
+        names = pilout_atoms.witness_column_names(pilout, ref)
+        stage1 = [names.get((1, col), "?") for col in range(air.stage_widths[0])]
+        out[ref.air_name] = AirFacts(
+            ref.air_name, len(constraints), comparable, excluded, stage1,
+            air.num_fixed_cols,
+            {c.index: (c.debug_line or "") for c in constraints},
+            list(air.stage_widths),
+            fixed_column_names(pilout, ref),
+            {k: (v[0], v[1]) for k, v in fixed_uses.items()},
+        )
+    return out
+
+
+# ------------------------------------------------------------------- references
+
+def reference_counts(names: set[str]) -> dict[str, int]:
+    """Lines outside a declaration's own head that mention its name.
+
+    Bare and `.`-qualified occurrences both count, comments do not, and the
+    declaration's own first line is excluded by the caller.
+
+    Matching is by name, not by resolved constant, so a name reused across
+    namespaces -- `Spec`, `Assumptions`, `constraints_at`, `transition` -- reads
+    as the sum over all of them. That makes a *positive* count an upper bound and
+    nothing more. It leaves a count of **zero** conclusive in the direction that
+    matters: no line of checked-in Lean mentions the name at all, so no
+    namespace-resolution subtlety can be hiding a use, and the declaration is
+    reachable from nothing.
+    """
+    hits: dict[str, int] = {name: 0 for name in names}
+    patterns = {
+        name: re.compile(r"(?<![A-Za-z0-9_'.])" + re.escape(name) + r"(?![A-Za-z0-9_'])")
+        for name in names
+    }
+    for root in REFERENCE_ROOTS:
+        base = REPO_ROOT / root
+        if not base.is_dir():
+            continue
+        for path in base.rglob("*.lean"):
+            for line in strip_comments(path.read_text(errors="replace").split("\n")):
+                if not line.strip():
+                    continue
+                for name, pattern in patterns.items():
+                    if pattern.search(line):
+                        hits[name] += 1
+    return hits
+
+
+# ---------------------------------------------------------------------- report
+
+SECTIONS = ("mirrors", "nearmisses", "records", "maps", "coverage", "reachability")
+
+
+@dataclass(frozen=True)
+class Coverage:
+    """Whether `CLASSIFICATION` still describes the mirror root exactly.
+
+    Two ways the declared inventory goes stale, and both are fatal to any run
+    that takes its scope from it:
+
+    * `unclassified` -- a Prop-valued declaration under the mirror root with no
+      `CLASSIFICATION` entry. It is compared by nothing, and adding one is a
+      `def`, not an edit to any list a reviewer watches;
+    * `vanished` -- an entry naming a declaration the root no longer has.
+
+    This lives here rather than inside `main` so that `check_mirrors` -- which
+    takes its whole mirror scope from `CLASSIFICATION` -- can run the same gate
+    instead of trusting that somebody ran `survey.py` by hand.
+    """
+
+    props: int
+    unclassified: tuple[tuple[str, int, str], ...]
+    vanished: tuple[tuple[str, str], ...]
+
+    @property
+    def failures(self) -> list[str]:
+        return (
+            [f"{path}:{line} {name}: Prop-valued declaration under the mirror "
+             f"root with no CLASSIFICATION entry, so nothing compares it"
+             for path, line, name in self.unclassified]
+            + [f"{path} {name}: CLASSIFICATION names a declaration the mirror "
+               f"root no longer has" for path, name in self.vanished]
+        )
+
+
+def coverage(mirror_root: Path) -> Coverage:
+    """Run the classification gate over one mirror root."""
+    props = [
+        decl
+        for path in sorted(mirror_root.rglob("*.lean"))
+        for decl in declarations(path, canonical_rel(path, mirror_root))
+        if is_prop_valued(decl)
+    ]
+    present = {(d.path, d.name) for d in props}
+    return Coverage(
+        props=len(props),
+        unclassified=tuple(
+            (d.path, d.line, d.name) for d in props
+            if (d.path, d.name) not in CLASSIFICATION),
+        vanished=tuple(sorted(k for k in CLASSIFICATION if k not in present)),
+    )
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--pilout", default=str(DEFAULT_PILOUT))
+    parser.add_argument("--mirror", default=str(DEFAULT_MIRROR))
+    parser.add_argument("--section", action="append", choices=SECTIONS,
+                        help="restrict output, repeatable")
+    parser.add_argument("--quiet", action="store_true",
+                        help="print only the summary and any failure")
+    args = parser.parse_args(argv[1:])
+    wanted = set(args.section) if args.section else set(SECTIONS)
+
+    mirror_root = Path(args.mirror)
+    if not mirror_root.is_dir():
+        print(f"survey.py: no mirror root at {mirror_root}", file=sys.stderr)
+        return 2
+
+    decls_by_file: dict[str, list[Decl]] = {}
+    for path in sorted(mirror_root.rglob("*.lean")):
+        rel = canonical_rel(path, mirror_root)
+        decls_by_file[rel] = declarations(path, rel)
+
+    # --- classification, and the two ways it can be stale
+    props = [d for decls in decls_by_file.values() for d in decls if is_prop_valued(d)]
+    gate = coverage(mirror_root)
+    unclassified = [d for d in props if (d.path, d.name) not in CLASSIFICATION]
+    vanished = list(gate.vanished)
+
+    record_names = {name for _, name, _ in MIRROR_RECORDS}
+    known_fields: dict[str, list[str]] = {}
+    for rel, name, _air in MIRROR_RECORDS:
+        known_fields[name] = structure_fields(resolve_rel(rel, mirror_root), name)
+    flattened = {
+        name: flatten_record(mirror_root, rel, name, known_fields)
+        for rel, name, _air in MIRROR_RECORDS
+    }
+
+    mirrors = [d for d in props
+               if (d.path, d.name) in CLASSIFICATION
+               and CLASSIFICATION[(d.path, d.name)].cls in MIRROR_CLASSES]
+    near = [d for d in props
+            if (d.path, d.name) in CLASSIFICATION
+            and CLASSIFICATION[(d.path, d.name)].cls not in MIRROR_CLASSES]
+
+    refs = reference_counts({d.name for d in props})
+    # A declaration's own head line mentions its name; discount exactly one.
+    own = {d.name: 0 for d in props}
+    for d in props:
+        own[d.name] += 1
+    external = {d.name: refs[d.name] - own[d.name] for d in props}
+
+    pilout = None
+    facts: dict[str, AirFacts] = {}
+    if "coverage" in wanted or "records" in wanted:
+        try:
+            pilout = pilout_wire.load(args.pilout)
+        except OSError as exc:
+            print(f"survey.py: {exc}", file=sys.stderr)
+            print("ARTIFACTS ABSENT -- coverage and record tables need build/zisk.pilout",
+                  file=sys.stderr)
+            return 2
+        facts = air_facts(pilout)
+
+    def out(text: str = "") -> None:
+        if not args.quiet:
+            print(text)
+
+    out(f"mirror root   {mirror_root}")
+    out(f"pilout        {args.pilout if pilout else '(not read)'}")
+    out(f"lean files    {len(decls_by_file)}")
+    out(f"declarations  {sum(len(v) for v in decls_by_file.values())} top-level, "
+        f"{len(props)} Prop-valued")
+    out()
+
+    if "mirrors" in wanted:
+        out("== 1. mirrors: polynomial-constraint predicates ==")
+        out(f"{'air':<17} {'class':<17} {'conj':>4} {'refs':>4}  file:line  name")
+        for d in sorted(mirrors, key=lambda d: (CLASSIFICATION[(d.path, d.name)].air or "",
+                                                d.path, d.line)):
+            entry = CLASSIFICATION[(d.path, d.name)]
+            rows = bound_row_variables(d, record_names)
+            out(f"{entry.air or '-':<17} {entry.cls:<17} {top_level_conjuncts(d):>4} "
+                f"{external[d.name]:>4}  {d.path}:{d.line}  {d.name}")
+            if rows:
+                out(f"{'':<45}rows: " + ", ".join(f"{n} : {t}" for n, t in rows))
+            if entry.note:
+                out(f"{'':<45}{entry.note}")
+        out(f"total {len(mirrors)} mirror declarations, "
+            f"{sum(top_level_conjuncts(d) for d in mirrors)} top-level conjuncts "
+            "(composites double-count their parts)")
+        out()
+
+    if "nearmisses" in wanted:
+        out("== 2. near-misses: mirror-shaped but not polynomial identities ==")
+        by_class: dict[str, list[Decl]] = {}
+        for d in near:
+            by_class.setdefault(CLASSIFICATION[(d.path, d.name)].cls, []).append(d)
+        for cls in sorted(by_class):
+            out(f"  {cls}: {CLASSES[cls]}")
+            for d in sorted(by_class[cls], key=lambda d: (d.path, d.line)):
+                note = CLASSIFICATION[(d.path, d.name)].note
+                out(f"    {d.path}:{d.line}  {d.name}" + (f"  -- {note}" if note else ""))
+        out(f"total {len(near)} near-miss declarations")
+        out()
+
+    if "records" in wanted:
+        out("== 3. row records used by a mirror, fields in declaration order ==")
+        for rel, name, air in MIRROR_RECORDS:
+            fields = flattened[name]
+            head = f"  {name}  ({len(fields)} fields)  {rel}"
+            if air and air in facts:
+                width = facts[air].stage_widths[0]
+                head += (f"   [{air}: {width} stage-1 columns, "
+                         f"{facts[air].fixed} fixed]")
+            out(head)
+            for i, fld in enumerate(fields):
+                out(f"    {i:>3}  {fld}")
+            if air and air in facts:
+                cols = facts[air].stage1
+                leaves = [f.rsplit(".", 1)[-1] for f in fields]
+                unmatched = [f for f, leaf in zip(fields, leaves)
+                             if leaf not in _column_aliases(cols)]
+                if unmatched:
+                    out(f"    fields with no same-named stage-1 column: "
+                        + ", ".join(unmatched))
+                spare = [c for c in cols if c not in _field_aliases(leaves)]
+                if spare:
+                    out(f"    stage-1 columns with no same-named field: " + ", ".join(spare))
+            out()
+
+    if "maps" in wanted:
+        out("== 4. existing handwritten field-to-column / Expr-to-field maps ==")
+        maps = (find_expr_maps(decls_by_file)
+                + find_validator_projections(decls_by_file)
+                + find_slot_layouts(decls_by_file)
+                + find_index_abbrevs(mirror_root))
+        for info in sorted(maps, key=lambda m: (m.path, m.line)):
+            out(f"  {info.path}:{info.line}  {info.name}")
+            out(f"      maps     {info.what}")
+            out(f"      arms     {info.arms}")
+            out(f"      fallback {info.fallback}")
+        out(f"total {len(maps)} maps")
+        out()
+
+    if "coverage" in wanted:
+        out("== 5. per-AIR coverage ==")
+        mirror_airs: dict[str, list[Decl]] = {}
+        for d in mirrors:
+            entry = CLASSIFICATION[(d.path, d.name)]
+            if entry.air:
+                mirror_airs.setdefault(entry.air, []).append(d)
+        out(f"{'air':<18} {'total':>6} {'compar':>7} {'excl':>5} {'mirrors':>8} {'conj':>5} "
+            f"{'claimed':>8} {'unclaimed':>10}")
+        unclaimed_all: dict[str, list[int]] = {}
+        for name in DECLARED_AIRS:
+            f = facts.get(name)
+            if f is None:
+                out(f"{name:<18}   (absent from pilout -- scope failure)")
+                continue
+            ds = [d for d in mirror_airs.get(name, [])
+                  if CLASSIFICATION[(d.path, d.name)].cls
+                  in ("MIRROR", "MIRROR_2ROW", "MIRROR_MIXED")]
+            claimed: set[int] = set()
+            for d in mirror_airs.get(name, []):
+                claimed |= CLASSIFICATION[(d.path, d.name)].claims
+            delegated: set[int] = set()
+            for air, _where, _who, indices in DELEGATED:
+                if air == name:
+                    delegated |= indices
+            unclaimed = sorted(set(f.comparable) - claimed - delegated)
+            unclaimed_all[name] = unclaimed
+            out(f"{name:<18} {f.total:>6} {len(f.comparable):>7} {len(f.excluded):>5} "
+                f"{len(ds):>8} {sum(top_level_conjuncts(d) for d in ds):>5} "
+                f"{len(claimed & set(f.comparable)):>8} {len(unclaimed):>10}")
+        out()
+        if DELEGATED:
+            out("  claimed by a mirror declared OUTSIDE the mirror root:")
+            for air, where, who, indices in DELEGATED:
+                out(f"    {air}: {len(indices)} constraints -> {where}  {who}")
+            out()
+        out("  'mirrors' and 'conj' count only the primary row-record mirrors:")
+        out("  MIRROR, MIRROR_2ROW, MIRROR_MIXED. Validator-indexed restatements,")
+        out("  builder-input forms, environment adapters and composites are excluded")
+        out("  so nothing is counted twice. 'claimed' aggregates the claim sets of")
+        out("  every mirror class for the AIR; those claims are audited readings,")
+        out("  not pairings decided by #305.")
+        out()
+        out("  comparable constraints no mirror claims:")
+        for name in DECLARED_AIRS:
+            unclaimed = unclaimed_all.get(name)
+            if not unclaimed:
+                continue
+            out(f"    {name}: {len(unclaimed)}")
+            f = facts[name]
+            for index in unclaimed:
+                out(f"      c{index:<4} {f.provenance.get(index, '')[:110]}")
+        out()
+        out("  fixed columns, and how often the comparable set reads them:")
+        for name in DECLARED_AIRS:
+            f = facts.get(name)
+            if f is None:
+                continue
+            for index in range(f.fixed):
+                comparable_uses, excluded_uses = f.fixed_uses.get(index, (0, 0))
+                out(f"    {name:<18} fixed {index}  {f.fixed_names.get(index, '?'):<20} "
+                    f"{comparable_uses:>3} comparable, {excluded_uses:>3} excluded")
+        out()
+
+    if "reachability" in wanted:
+        out("== 6. reachability of Prop-valued declarations ==")
+        dead = sorted((d for d in props if external[d.name] == 0),
+                      key=lambda d: (d.path, d.line))
+        for d in dead:
+            entry = CLASSIFICATION.get((d.path, d.name))
+            cls = entry.cls if entry else "UNCLASSIFIED"
+            flag = "MIRROR" if entry and entry.cls in MIRROR_CLASSES else "near-miss"
+            out(f"  {d.path}:{d.line}  {d.name}   [{cls}]  {flag}, 0 external references")
+        out(f"total {len(dead)} declarations referenced by nothing outside their own head")
+        out()
+
+    print(f"SUMMARY  mirrors {len(mirrors)}  near-misses {len(near)}  "
+          f"records {len(MIRROR_RECORDS)}  unclassified {len(unclassified)}  "
+          f"stale-entries {len(vanished)}")
+    if unclassified:
+        print("FAIL: Prop-valued declarations missing from CLASSIFICATION:", file=sys.stderr)
+        for d in unclassified:
+            print(f"  {d.path}:{d.line}  {d.name}", file=sys.stderr)
+        return 1
+    if vanished:
+        print("FAIL: CLASSIFICATION names declarations that no longer exist:", file=sys.stderr)
+        for rel, name in vanished:
+            print(f"  {rel}  {name}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def _column_aliases(cols: list[str]) -> set[str]:
+    """Column names in both PIL and Lean spelling (`reg[0]` and `reg_0`)."""
+    out: set[str] = set()
+    for col in cols:
+        out.add(col)
+        out.add(col.replace("[", "_").replace("]", ""))
+    return out
+
+
+def _field_aliases(fields: list[str]) -> set[str]:
+    out: set[str] = set()
+    for fld in fields:
+        out.add(fld)
+        match = re.match(r"(.*)_(\d+)$", fld)
+        if match:
+            out.add(f"{match.group(1)}[{match.group(2)}]")
+    return out
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv))
+    except KeyboardInterrupt:
+        sys.exit(130)


### PR DESCRIPTION
Closes #304. **Stacked on #312** (base is `s11-roundtrip`); merge that first.

Welding ties one mirror clause to one generated constraint and is kernel-checked, but a missing weld
fails nothing. Every mirror gap found on 2026-07-28 surfaced because a person happened to work that
AIR. This applies #303's canonicaliser in the other direction: pair each comparable generated
constraint against the mirror clauses under `ZiskFv/AirsClean/**` that restate it, and classify every
difference.

## ⚠️ This step FAILS at HEAD, and that is the deliverable

```
mirror-roundtrip: FAILED 139/176 matched; 35 gap, 2 strengthening, 3 unbacked,
                  2 reclassification, 1 unreachable mirror, 0 unparsed
acceptance:       OK, 16 cases -- 4/4 hand findings reproduced, 8/8 mutations
                  classified as predicted, 3/3 neutral controls, 1 measured blind spot
```

**Merging this reds `nix run .#test` until the findings are closed or declared.** That is a decision
for you, not for me, and it is the one thing in this PR I would not merge without a ruling. The two
defensible options:

- **(a) as written.** The gate is a hard failure at step 4/10. Maximum pressure, red main.
- **(b) a citation-bearing baseline that can only shrink**, in the idiom this repo already uses for
  `check-shrinkage.sh` and `check-defect-count.sh`. The 42 current findings become a checked-in
  declared list, the gate goes green, and any *new* gap fails. The issue's own text authorises this
  ("either fixed or explicitly declared with a citation, and the declaration list must be small
  enough to read").

I did not build (b), because the instruction to the implementer was not to silence findings and I did
not want that judgement made by an agent. Say the word and it is a small follow-up.

## Per-AIR

| air | comparable | mirror | matched | gap | strengthen | recl | unbacked |
|---|---:|---:|---:|---:|---:|---:|---:|
| Arith | 49 | 60 | 49 | 0 | 0 | 0 | 0 |
| Binary | 7 | 14 | 7 | 0 | 0 | 0 | 0 |
| BinaryAdd | 4 | 8 | 4 | 0 | 0 | 0 | 0 |
| BinaryExtension | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| **Main** | 39 | 42 | 29 | **9** | 2 | 1 | 2 |
| **Mem** | 24 | 18 | 9 | **15** | 0 | 0 | 0 |
| MemAlign | 33 | 33 | 32 | 0 | 0 | 1 | 1 |
| **MemAlignByte** | 9 | 10 | 5 | **4** | 0 | 0 | 0 |
| MemAlignReadByte | 4 | 5 | 4 | 0 | 0 | 0 | 0 |
| **MemAlignWriteByte** | 7 | 0 | 0 | **7** | 0 | 0 | 0 |
| **total** | **176** | **190** | **139** | **35** | 2 | 2 | 3 |

**The 35 gaps are not all the same thing, and the headline count overstates.** 15 of them are Mem's,
and each is annotated `out-of-root claim: segmentResidualEveryRow ZiskFv/Airs/Mem.lean:296 claims it`
— that predicate exists, is documented as "the generated segment constraints not already enforced by
the nine local Mem component equations", and `:334-339` destructures a 24-conjunct
`segment_every_row` into exactly those 15. So Mem is modelled, just split across `Airs/` and
`AirsClean/`, and the declared mirror root (`ZiskFv/AirsClean`, from the issue's own wording) does not
see it. Either widen the root or declare the split. **Constraints nothing models anywhere: 20.**

## The findings

**Main #3 and #9 — the flagship, confirmed independently.** `main.pil:385`
`(a_src_c)*(a[i]-(previous_c))`. `grep a_src_c ZiskFv/` returns **zero files**: unmodelled tree-wide,
not merely absent from the mirror. `sourceCCopyBetween` covers only the b-side #4/#10 at `:386`.

**A second unmodelled Main cluster the hand fan-out did not name** — the segment boundary: #19
`SEGMENT_L1'*(segment_next_pc-(next_pc'))` (`:423`), #20/#21 `SEGMENT_L1'*(segment_last_c[i]-c[i])`
(`:426`), #38 `SEGMENT_L1*(segment_initial_pc-pc)` (`:508`), and #0
`main_last_segment*(1-main_last_segment)` (`:86`).

**MemAlignWriteByte has no mirror at all** — zero mentions in `ZiskFv/` or `trust/`, and no
`AirsClean/MemAlignWriteByte/` beside `MemAlign/`, `MemAlignByte/`, `MemAlignReadByte/`. Easy to
misread, so stating it precisely: all three byte-family AIRs instantiate one PIL template
(`mem_align_byte.pil:35,36,37,59,83,87,88`), so terms like `written_composed_value` *do* appear in the
tree — in `AirsClean/MemAlignByte/`, over that AIR's columns. Stage widths differ per AIR (16+4 /
10+3 / 14+4), so those are different polynomials and genuinely do not cover the write-byte AIR. Given
the family provides tuples for sub-doubleword *loads*, a loads-only scope may well be deliberate —
but nothing declares it, which is exactly what this issue turns into a declared exclusion.

**`RomBoolSpec` is unreachable, and 14 Main constraints are hollow.** Confirmed 0 external
references. The tool reports these separately rather than counting them as coverage: a clause of an
unreachable predicate can be canonically perfect and still constrain nothing, because no proof
consumes it.

**MemAlign's ninth conjunct (the issue's strengthening case) resolved mechanically**:
`cyclicSuccessorTransitionRows` has 9 conjuncts for 8 comparable constraints, and the extra
`delta_pc` clause's only generated source sits inside the *excluded* challenge-mixed
`constraint_36`. So it is a strengthening relative to the F-only slice specifically.

**`MemAlign.L1` is a fixed column modelled as the free field `preL1`** — the reclassification case —
and `MemAlign.component` declares no `fixedColumns` at all, unlike Main and Mem.

## Evidence the gate can fail, and one measured blind spot

`acceptance.py`: the 4 hand findings must be rediscovered without being told where to look, plus 8
mutations of a *copy* of the mirrors (delete a matching clause, add a plausible extra, repoint a
projection, swap a fixed reference for a witness, change a row variable, …), each required to move the
report in exactly the predicted way, plus 3 neutral controls (reorder conjuncts, restate `a = b` as
`a - b = 0`) that must not move it. The real tree's sha256 is checked unchanged at the end.

One blind spot is *measured* rather than claimed: deleting a mirror clause that a **second** mirror
also restates keeps the match, because pairing is set-to-set and there is no per-mirror coverage
count. That case passes, and the pass is recorded as a blind spot, not as coverage.

## Lane map with kind, which is what makes `constraint_16` mechanical

`lanes.py` derives, per AIR, name → lane from `PilOut.symbols` and the emitted header only —
never from a mirror and never from an existing handwritten map, since those are what is being gated.
Lanes carry KIND (stage-1 witness / stage-2 / fixed / exposed), and `AirValue` is kept apart from
`AirGroupValue` rather than inheriting #303's collapse. It is total and closed in both directions and
**raises** instead of defaulting.

That matters because the existing maps do not. `h998ExprToField`
(`ZiskFv/AirsClean/MemAlign/Bridge.lean:31`, 38 arms) and `c10LookupExprToClean`
(`Binary/Wiring.lean:33`, 18 arms) both end in `| _ => 0`, each gated by a single `rfl` over one
tuple: a wrong or missing index becomes a silent zero, which weakens rather than fails. The survey
inventoried all 30 such maps in the tree; `Mem/RangeWiring.lean:29` is the one that refuses
(`| _ => none`) and is the pattern to copy.

## Declared exclusions — three categories, each cited, each listing what it took

`challenge_or_stage2` (179 generated; the issue's own comparable rule, implemented twice
independently and required to agree every run), `mirror_carrier_not_a_row` (5; honest-row builder
inputs and a component-owned fixed-column schema, which are inputs to a row rather than slots of one),
`mirror_clause_not_an_equation` (29; `.val` bounds and delegations whose delegate is compared
elsewhere — and a delegate that is *not* is reported as an undeclared delegation, of which there is
currently 1).

## Scope and trust

Polynomial identities only, same as #303. This tool **reports**; nothing under `ZiskFv/` or `trust/`
was modified (verified in the diff and by checksum in `acceptance.py`). The gaps and strengthenings
are real proof work and are not the tool's to fix — mirrors are protected proof interfaces.
No axiom, no ledger change, no TCB change. #303's gate still passes on this branch.

## Not verified

`nix run .#test` was not run end to end. `check_mirrors.py` (exit 1, as designed) and
`acceptance.py` (exit 0) were both run directly, as was `tools/pilout-roundtrip/check.py` (exit 0).

## Overlap to resolve before both land

PR #310 makes the weld column-map gate AIR-parameterised; `lanes.py` is the same gate with lane kind
added. The issue says #304 absorbs the column-map gate. Pick one rather than merging both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)