### PR TITLE
#325: replace raw provider-table binders with evidence bundles across ALU/Binary, shift, and BinaryAdd equiv layers

### DIFF
--- a/ZiskFv/AirsClean/BinaryFamily/Balance.lean
+++ b/ZiskFv/AirsClean/BinaryFamily/Balance.lean
@@ -240,6 +240,31 @@ theorem StaticBinaryProvider.facts (p : StaticBinaryProvider) :
   rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_component_spec
   exact ⟨h_component_spec.1, h_core, h_component_spec.2, h_wf⟩
 
+/-- Caller-facing bundle for a BinaryAdd provider row backing an op-bus
+    request (the `via_binaryadd` ADD/ADDI route): same shape as
+    `StaticBinaryProvider`, pinned to `BinaryAdd.component`. -/
+structure BinaryAddProvider where
+  table : Table FGL
+  row : Array FGL
+  h_component : table.component = ZiskFv.AirsClean.BinaryAdd.component
+  h_spec : table.Spec
+  h_row : row ∈ table.table
+
+/-- The Clean BinaryAdd row selected by the provider evidence. -/
+def BinaryAddProvider.rowInput (p : BinaryAddProvider) :=
+  ZiskFv.AirsClean.BinaryAdd.component.rowInput (p.table.environment p.row)
+
+/-- One-shot lowering of the BinaryAdd provider evidence to the component
+    spec facts consumed by the `equiv_<op>_of_binaryadd_row` cores. -/
+theorem BinaryAddProvider.facts (p : BinaryAddProvider) :
+    ZiskFv.AirsClean.BinaryAdd.ComponentSpecFacts p.rowInput := by
+  have h_component_spec :
+      ZiskFv.AirsClean.BinaryAdd.component.Spec
+        (p.table.environment p.row) := by
+    simpa [p.h_component] using p.h_spec p.row p.h_row
+  simpa [BinaryAddProvider.rowInput,
+    ZiskFv.AirsClean.BinaryAdd.component_spec] using h_component_spec
+
 /-- Row extraction for a BinaryExtension operation-bus provider interaction. -/
 theorem exists_binaryExtension_row_eval_of_interaction_mem
     {table : Table FGL}

--- a/ZiskFv/AirsClean/BinaryFamily/Balance.lean
+++ b/ZiskFv/AirsClean/BinaryFamily/Balance.lean
@@ -203,6 +203,43 @@ theorem staticBinary_spec_facts_of_table_spec
   rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_component_spec
   exact h_component_spec.2
 
+/-- Caller-facing bundle for a lookup-aware static Binary provider: the
+    provider table, the selected row, and the three table-level facts that the
+    ALU/Binary `equiv_<op>` wrappers previously took as separate binders. The
+    balance derivations (`main_request_*_provided`) produce exactly these
+    fields. -/
+structure StaticBinaryProvider where
+  table : Table FGL
+  row : Array FGL
+  h_component : table.component = ZiskFv.AirsClean.Binary.staticLookupComponent
+  h_spec : table.Spec
+  h_row : row ∈ table.table
+
+/-- The Clean `BinaryRow` selected by the provider evidence. -/
+def StaticBinaryProvider.rowInput (p : StaticBinaryProvider) :
+    ZiskFv.AirsClean.Binary.BinaryRow FGL :=
+  ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
+    (p.table.environment p.row)
+
+/-- One-shot lowering of the table-level provider evidence to the four
+    row-level facts consumed by the `equiv_<op>_of_static_row` cores. Single
+    home of the projection previously repeated inside every ALU/Binary
+    wrapper. -/
+theorem StaticBinaryProvider.facts (p : StaticBinaryProvider) :
+    ZiskFv.AirsClean.Binary.Spec p.rowInput
+      ∧ ZiskFv.Airs.Binary.core_every_row
+          (ZiskFv.AirsClean.Binary.validOfRow p.rowInput) 0
+      ∧ ZiskFv.AirsClean.Binary.StaticBinaryTableSpecFacts p.rowInput
+      ∧ ZiskFv.AirsClean.Binary.StaticBinaryTableWfFacts p.rowInput := by
+  obtain ⟨h_core, h_wf⟩ :=
+    staticBinary_core_and_wf_of_table_spec p.h_component p.h_spec p.h_row
+  have h_component_spec :
+      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec
+        (p.table.environment p.row) := by
+    simpa [p.h_component] using p.h_spec p.row p.h_row
+  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_component_spec
+  exact ⟨h_component_spec.1, h_core, h_component_spec.2, h_wf⟩
+
 /-- Row extraction for a BinaryExtension operation-bus provider interaction. -/
 theorem exists_binaryExtension_row_eval_of_interaction_mem
     {table : Table FGL}
@@ -301,6 +338,30 @@ theorem shiftStaticBinaryExtension_wf_and_b0_range_of_table_spec
   rw [ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent_spec] at h_component_spec
   exact ⟨ZiskFv.AirsClean.BinaryExtension.static_table_wf_facts_of_spec_facts _
       h_component_spec.2.1, h_component_spec.2.2⟩
+
+/-- Caller-facing bundle for a shift-range lookup-aware static BinaryExtension
+    provider (the twelve shifts): same shape as `StaticBinaryProvider`, pinned
+    to `shiftStaticLookupComponent`. -/
+structure ShiftStaticProvider where
+  table : Table FGL
+  row : Array FGL
+  h_component :
+    table.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+  h_spec : table.Spec
+  h_row : row ∈ table.table
+
+/-- The Clean BinaryExtension row selected by the provider evidence. -/
+def ShiftStaticProvider.rowInput (p : ShiftStaticProvider) :=
+  ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
+    (p.table.environment p.row)
+
+/-- One-shot lowering of the shift provider evidence to the row-level facts
+    consumed by the `equiv_<shift>_of_static_row` cores. -/
+theorem ShiftStaticProvider.facts (p : ShiftStaticProvider) :
+    ZiskFv.AirsClean.BinaryExtension.StaticBinaryExtensionTableWfFacts p.rowInput
+      ∧ ZiskFv.AirsClean.BinaryExtension.ShiftB0RangeSpecFact p.rowInput :=
+  shiftStaticBinaryExtension_wf_and_b0_range_of_table_spec
+    p.h_component p.h_spec p.h_row
 
 /-- Convenience projection for consumers that only need the shift-selected
     `b_0 < 2^24` range fact. -/

--- a/ZiskFv/Compliance/ConstructionAdd.lean
+++ b/ZiskFv/Compliance/ConstructionAdd.lean
@@ -490,15 +490,17 @@ theorem construction_add_sound_claimed_dead
           m providerInput i.val (regidx_to_fin r2) add_input.r2_val
           h_matches h_m32_zero h_b_lo_t h_b_hi_t h_match h_input_r2
     exact ZiskFv.Compliance.equiv_ADD
-      state add_input r1 r2 rd m providerTable providerRow i.val bus pins
-      h_component h_table_spec h_provider_row h_match
+      state add_input r1 r2 rd m
+      ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      i.val bus pins h_match
       h_input_r1_row h_input_r2_row h_lane_rd promises
   · -- BinaryAdd arm: discharge via `equiv_ADD_via_binaryadd`.
     obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
         h_component, h_table_spec, h_match⟩ := h_binaryadd
     exact ZiskFv.Compliance.equiv_ADD_via_binaryadd
-      state add_input r1 r2 rd m providerTable providerRow i.val bus pins
-      h_component h_table_spec h_provider_row h_match
+      state add_input r1 r2 rd m
+      ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      i.val bus pins h_match
       h_add_subset h_a_lo_t h_a_hi_t h_b_lo_t h_b_hi_t h_m32_zero
       h_lane_rd promises
 
@@ -699,15 +701,17 @@ theorem construction_addi_sound_claimed_dead
           m providerInput i.val addi_input.imm h_matches h_m32_zero h_match
           h_addi_subset
     exact ZiskFv.Compliance.equiv_ADDI
-      state addi_input r1 rd imm m providerTable providerRow i.val bus pins
-      h_component h_table_spec h_provider_row h_match
+      state addi_input r1 rd imm m
+      ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      i.val bus pins h_match
       h_addi_subset h_input_r1_row h_input_imm_row h_lane_rd promises
   · -- BinaryAdd arm: discharge via `equiv_ADDI_via_binaryadd`.
     obtain ⟨providerTable, _h_pt_mem, providerRow, h_provider_row,
         h_component, h_table_spec, h_match⟩ := h_binaryadd
     exact ZiskFv.Compliance.equiv_ADDI_via_binaryadd
-      state addi_input r1 rd imm m providerTable providerRow i.val bus pins
-      h_component h_table_spec h_provider_row h_match
+      state addi_input r1 rd imm m
+      ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      i.val bus pins h_match
       h_add_subset h_addi_subset h_a_lo_t h_a_hi_t h_m32_zero h_set_pc_zero
       h_lane_rd promises
 

--- a/ZiskFv/Compliance/ConstructionAnd.lean
+++ b/ZiskFv/Compliance/ConstructionAnd.lean
@@ -293,8 +293,9 @@ theorem construction_and_sound_claimed_dead
         m providerInput i.val (regidx_to_fin r2) and_input.r2_val
         h_matches h_m32_zero h_b_lo_t h_b_hi_t h_match h_input_r2
   exact ZiskFv.Compliance.equiv_AND
-    state and_input r1 r2 rd m providerTable providerRow i.val bus pins
-    h_component h_table_spec h_provider_row h_match
+    state and_input r1 r2 rd m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus pins h_match
     h_input_r1_row h_input_r2_row h_lane_rd promises
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/ConstructionCompare.lean
+++ b/ZiskFv/Compliance/ConstructionCompare.lean
@@ -261,8 +261,9 @@ theorem construction_slt_sound_claimed_dead
         m providerInput i.val (regidx_to_fin r2) slt_input.r2_val
         h_matches h_m32_zero h_b_lo_t h_b_hi_t h_match h_input_r2
   exact ZiskFv.Compliance.equiv_SLT
-    state slt_input r1 r2 rd m providerTable providerRow i.val bus pins
-    h_component h_table_spec h_provider_row h_match
+    state slt_input r1 r2 rd m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus pins h_match
     h_input_r1_row h_input_r2_row h_lane_rd promises
 
 /-- Sound SLTU construction: from the accepted trace + honest residual binders,
@@ -456,8 +457,9 @@ theorem construction_sltu_sound_claimed_dead
         m providerInput i.val (regidx_to_fin r2) sltu_input.r2_val
         h_matches h_m32_zero h_b_lo_t h_b_hi_t h_match h_input_r2
   exact ZiskFv.Compliance.equiv_SLTU
-    state sltu_input r1 r2 rd m providerTable providerRow i.val bus pins
-    h_component h_table_spec h_provider_row h_match
+    state sltu_input r1 r2 rd m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus pins h_match
     h_input_r1_row h_input_r2_row h_lane_rd promises
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/ConstructionIType.lean
+++ b/ZiskFv/Compliance/ConstructionIType.lean
@@ -301,8 +301,9 @@ theorem construction_andi_sound_claimed_dead
         m providerInput i.val andi_input.imm h_matches h_m32_zero h_match
         h_andi_subset
   exact ZiskFv.Compliance.equiv_ANDI
-    state andi_input r1 rd imm m providerTable providerRow i.val bus pins
-    h_component h_table_spec h_provider_row h_match
+    state andi_input r1 rd imm m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus pins h_match
     h_input_r1_row h_input_imm_row h_andi_subset h_lane_rd promises
 
 /-- Sound ORI construction: from the accepted trace + honest residual binders,
@@ -480,8 +481,9 @@ theorem construction_ori_sound_claimed_dead
         m providerInput i.val ori_input.imm h_matches h_m32_zero h_match
         h_ori_subset
   exact ZiskFv.Compliance.equiv_ORI
-    state ori_input r1 rd imm m providerTable providerRow i.val bus pins
-    h_component h_table_spec h_provider_row h_match
+    state ori_input r1 rd imm m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus pins h_match
     h_input_r1_row h_input_imm_row h_ori_subset h_lane_rd promises
 
 /-- Sound XORI construction: from the accepted trace + honest residual binders,
@@ -661,8 +663,9 @@ theorem construction_xori_sound_claimed_dead
         m providerInput i.val xori_input.imm h_matches h_m32_zero h_match
         h_xori_subset
   exact ZiskFv.Compliance.equiv_XORI
-    state xori_input r1 rd imm m providerTable providerRow i.val bus pins
-    h_component h_table_spec h_provider_row h_match
+    state xori_input r1 rd imm m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus pins h_match
     h_input_r1_row h_input_imm_row h_xori_subset h_lane_rd promises
 
 /-- Sound SLTI construction: from the accepted trace + honest residual binders,
@@ -836,8 +839,9 @@ theorem construction_slti_sound_claimed_dead
         m providerInput i.val (regidx_to_fin r1) slti_input.r1_val
         h_matches h_m32_zero h_a_lo_t h_a_hi_t h_match h_input_r1
   exact ZiskFv.Compliance.equiv_SLTI
-    state slti_input r1 rd imm m providerTable providerRow i.val bus pins
-    h_component h_table_spec h_provider_row h_match h_m32_zero
+    state slti_input r1 rd imm m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus pins h_match h_m32_zero
     h_input_r1_row h_slti_subset h_lane_rd promises
 
 /-- Sound SLTIU construction: from the accepted trace + honest residual binders,
@@ -1011,8 +1015,9 @@ theorem construction_sltiu_sound_claimed_dead
         m providerInput i.val (regidx_to_fin r1) sltiu_input.r1_val
         h_matches h_m32_zero h_a_lo_t h_a_hi_t h_match h_input_r1
   exact ZiskFv.Compliance.equiv_SLTIU
-    state sltiu_input r1 rd imm m providerTable providerRow i.val bus pins
-    h_component h_table_spec h_provider_row h_match h_m32_zero
+    state sltiu_input r1 rd imm m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus pins h_match h_m32_zero
     h_input_r1_row h_sltiu_subset h_lane_rd promises
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/ConstructionLogic.lean
+++ b/ZiskFv/Compliance/ConstructionLogic.lean
@@ -269,8 +269,9 @@ theorem construction_or_sound_claimed_dead
         m providerInput i.val (regidx_to_fin r2) or_input.r2_val
         h_matches h_m32_zero h_b_lo_t h_b_hi_t h_match h_input_r2
   exact ZiskFv.Compliance.equiv_OR
-    state or_input r1 r2 rd m providerTable providerRow i.val bus pins
-    h_component h_table_spec h_provider_row h_match
+    state or_input r1 r2 rd m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus pins h_match
     h_input_r1_row h_input_r2_row h_lane_rd promises
 
 /-- Sound XOR construction: from the accepted trace + honest residual binders,
@@ -467,8 +468,9 @@ theorem construction_xor_sound_claimed_dead
         m providerInput i.val (regidx_to_fin r2) xor_input.r2_val
         h_matches h_m32_zero h_b_lo_t h_b_hi_t h_match h_input_r2
   exact ZiskFv.Compliance.equiv_XOR
-    state xor_input r1 r2 rd m providerTable providerRow i.val bus pins
-    h_component h_table_spec h_provider_row h_match
+    state xor_input r1 r2 rd m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus pins h_match
     h_input_r1_row h_input_r2_row h_lane_rd promises
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/ConstructionShift.lean
+++ b/ZiskFv/Compliance/ConstructionShift.lean
@@ -457,8 +457,9 @@ theorem construction_sll_sound_claimed_dead
       h_m32_zero h_b_lo_t h_b_hi_t h_input_r2 h_match h_shift_facts.1 h_shift_facts.2
       h_op_is_shift
   exact ZiskFv.Compliance.equiv_SLL
-    state sll_input r1 r2 rd m providerTable providerRow i.val bus
-    promises pins h_component h_table_spec h_provider_row h_match
+    state sll_input r1 r2 rd m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 /-- Sound SRL construction: from the accepted trace + honest residual binders,
@@ -623,8 +624,9 @@ theorem construction_srl_sound_claimed_dead
       h_m32_zero h_b_lo_t h_b_hi_t h_input_r2 h_match h_shift_facts.1 h_shift_facts.2
       h_op_is_shift
   exact ZiskFv.Compliance.equiv_SRL
-    state srl_input r1 r2 rd m providerTable providerRow i.val bus
-    promises pins h_component h_table_spec h_provider_row h_match
+    state srl_input r1 r2 rd m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 /-- Sound SRA construction: from the accepted trace + honest residual binders,
@@ -789,8 +791,9 @@ theorem construction_sra_sound_claimed_dead
       h_m32_zero h_b_lo_t h_b_hi_t h_input_r2 h_match h_shift_facts.1 h_shift_facts.2
       h_op_is_shift
   exact ZiskFv.Compliance.equiv_SRA
-    state sra_input r1 r2 rd m providerTable providerRow i.val bus
-    promises pins h_component h_table_spec h_provider_row h_match
+    state sra_input r1 r2 rd m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 /-- Sound SLLI construction (m32 = 0 immediate shift exemplar). The DELTA from
@@ -935,8 +938,9 @@ theorem construction_slli_sound_claimed_dead
     exact shift_imm_shift_pin_row_of_facts m _ i.val shamt
       h_b_lo_t h_match h_shift_facts.1 h_shift_facts.2 h_op_is_shift
   exact ZiskFv.Compliance.equiv_SLLI
-    state slli_input r1 rd shamt m providerTable providerRow i.val bus
-    promises pins h_component h_table_spec h_provider_row h_match
+    state slli_input r1 rd shamt m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 /-- Sound SRLI construction (m32 = 0 immediate shift; literal swap of SLLI). The DELTA from
@@ -1081,8 +1085,9 @@ theorem construction_srli_sound_claimed_dead
     exact shift_imm_shift_pin_row_of_facts m _ i.val shamt
       h_b_lo_t h_match h_shift_facts.1 h_shift_facts.2 h_op_is_shift
   exact ZiskFv.Compliance.equiv_SRLI
-    state srli_input r1 rd shamt m providerTable providerRow i.val bus
-    promises pins h_component h_table_spec h_provider_row h_match
+    state srli_input r1 rd shamt m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 /-- Sound SRAI construction (m32 = 0 immediate shift; literal swap of SLLI). The DELTA from
@@ -1227,8 +1232,9 @@ theorem construction_srai_sound_claimed_dead
     exact shift_imm_shift_pin_row_of_facts m _ i.val shamt
       h_b_lo_t h_match h_shift_facts.1 h_shift_facts.2 h_op_is_shift
   exact ZiskFv.Compliance.equiv_SRAI
-    state srai_input r1 rd shamt m providerTable providerRow i.val bus
-    promises pins h_component h_table_spec h_provider_row h_match
+    state srai_input r1 rd shamt m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 /-! ## m32 = 1 W-shift sibling helpers (PLAN §PR6b)
@@ -1557,8 +1563,9 @@ theorem construction_sllw_sound_claimed_dead
       h_b_lo_t h_b_hi_t h_input_r2 h_match h_shift_facts.1 h_shift_facts.2
       h_op_is_shift
   exact ZiskFv.Compliance.equiv_SLLW
-    state sllw_input r1 r2 rd m providerTable providerRow i.val bus
-    promises pins h_component h_table_spec h_provider_row h_match
+    state sllw_input r1 r2 rd m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 /-- Sound SRLW construction (m32 = 1 W-shift; literal swap of SLLW). DELTA
@@ -1697,8 +1704,9 @@ theorem construction_srlw_sound_claimed_dead
       h_b_lo_t h_b_hi_t h_input_r2 h_match h_shift_facts.1 h_shift_facts.2
       h_op_is_shift
   exact ZiskFv.Compliance.equiv_SRLW
-    state srlw_input r1 r2 rd m providerTable providerRow i.val bus
-    promises pins h_component h_table_spec h_provider_row h_match
+    state srlw_input r1 r2 rd m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 /-- Sound SRAW construction (m32 = 1 W signed shift; literal swap of SLLW).
@@ -1838,8 +1846,9 @@ theorem construction_sraw_sound_claimed_dead
       h_b_lo_t h_b_hi_t h_input_r2 h_match h_shift_facts.1 h_shift_facts.2
       h_op_is_shift
   exact ZiskFv.Compliance.equiv_SRAW
-    state sraw_input r1 r2 rd m providerTable providerRow i.val bus
-    promises pins h_component h_table_spec h_provider_row h_match
+    state sraw_input r1 r2 rd m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 /-- Sound SLLIW construction (m32 = 1 W immediate-shift exemplar). The DELTA
@@ -1980,8 +1989,9 @@ theorem construction_slliw_sound_claimed_dead
     shift_m32_1_imm_shift_pin_row_of_facts m _ i.val slliw_input.shamt
       h_b_lo_t h_match h_shift_facts.1 h_shift_facts.2 h_op_is_shift
   exact ZiskFv.Compliance.equiv_SLLIW
-    state slliw_input r1 rd m providerTable providerRow i.val bus
-    promises pins h_component h_table_spec h_provider_row h_match
+    state slliw_input r1 rd m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 /-- Sound SRLIW construction (m32 = 1 W immediate-shift; literal swap of
@@ -2107,8 +2117,9 @@ theorem construction_srliw_sound_claimed_dead
     shift_m32_1_imm_shift_pin_row_of_facts m _ i.val srliw_input.shamt
       h_b_lo_t h_match h_shift_facts.1 h_shift_facts.2 h_op_is_shift
   exact ZiskFv.Compliance.equiv_SRLIW
-    state srliw_input r1 rd m providerTable providerRow i.val bus
-    promises pins h_component h_table_spec h_provider_row h_match
+    state srliw_input r1 rd m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 /-- Sound SRAIW construction (m32 = 1 W signed immediate-shift; literal swap
@@ -2235,8 +2246,9 @@ theorem construction_sraiw_sound_claimed_dead
     shift_m32_1_imm_shift_pin_row_of_facts m _ i.val sraiw_input.shamt
       h_b_lo_t h_match h_shift_facts.1 h_shift_facts.2 h_op_is_shift
   exact ZiskFv.Compliance.equiv_SRAIW
-    state sraiw_input r1 rd m providerTable providerRow i.val bus
-    promises pins h_component h_table_spec h_provider_row h_match
+    state sraiw_input r1 rd m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/ConstructionSub.lean
+++ b/ZiskFv/Compliance/ConstructionSub.lean
@@ -345,8 +345,9 @@ theorem construction_sub_sound_claimed_dead
         m providerInput i.val (regidx_to_fin r2) sub_input.r2_val
         h_matches h_m32_zero h_b_lo_t h_b_hi_t h_match h_input_r2
   exact ZiskFv.Compliance.equiv_SUB
-    state sub_input r1 r2 rd m providerTable providerRow i.val bus pins
-    h_component h_table_spec h_provider_row h_match
+    state sub_input r1 r2 rd m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus pins h_match
     h_input_r1_row h_input_r2_row h_lane_rd promises
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/ConstructionWAlu.lean
+++ b/ZiskFv/Compliance/ConstructionWAlu.lean
@@ -251,8 +251,9 @@ theorem construction_subw_sound_claimed_dead
         m providerInput i.val (regidx_to_fin r2) subw_input.r2_val
         hb0 hb1 hb2 hb3 h_m32_one h_b_lo_t h_b_hi_t h_match h_input_r2
   exact ZiskFv.Compliance.equiv_SUBW
-    state subw_input r1 r2 rd m providerTable providerRow i.val bus pins
-    h_component h_table_spec h_provider_row h_match
+    state subw_input r1 r2 rd m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus pins h_match
     h_input_r1_extract h_input_r2_extract h_lane_rd promises
 
 /-- Sound ADDW construction (m32 = 1 word ALU). DELTA from
@@ -424,8 +425,9 @@ theorem construction_addw_sound_claimed_dead
         m providerInput i.val (regidx_to_fin r2) addw_input.r2_val
         hb0 hb1 hb2 hb3 h_m32_one h_b_lo_t h_b_hi_t h_match h_input_r2
   exact ZiskFv.Compliance.equiv_ADDW
-    state addw_input r1 r2 rd m providerTable providerRow i.val bus pins
-    h_component h_table_spec h_provider_row h_match
+    state addw_input r1 r2 rd m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus pins h_match
     h_input_r1_extract h_input_r2_extract h_lane_rd promises
 
 /-- Sound ADDIW construction (m32 = 1 word ALU, ITYPE immediate). DELTA from
@@ -577,8 +579,9 @@ theorem construction_addiw_sound_claimed_dead
         m providerInput i.val (regidx_to_fin r1) addiw_input.r1_val
         ha0 ha1 ha2 ha3 h_m32_one h_a_lo_t h_a_hi_t h_match h_input_r1
   exact ZiskFv.Compliance.equiv_ADDIW
-    state addiw_input r1 rd imm m providerTable providerRow i.val bus pins
-    h_addiw_subset h_component h_table_spec h_provider_row h_match
+    state addiw_input r1 rd imm m
+    ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+    i.val bus pins h_addiw_subset h_match
     h_input_r1_extract h_lane_rd promises
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/Dispatch/ADD_RTYPEW.lean
+++ b/ZiskFv/Compliance/Dispatch/ADD_RTYPEW.lean
@@ -58,8 +58,9 @@ theorem zisk_riscv_compliant_program_bus_add_rtypew
     change execute_instruction (instruction.RTYPE (r2, r1, rd, rop.ADD)) state
       = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
     exact ZiskFv.Equivalence.Add.equiv_ADD
-      state add_input r1 r2 rd m providerTable providerRow r_main bus pins
-      h_component h_table_spec h_provider_row h_match_static
+      state add_input r1 r2 rd m
+      ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus pins h_match_static
       h_input_r1_row h_input_r2_row h_lane_rd promises
   | add_via_binaryadd add_input r1 r2 rd bus pins providerTable providerRow
       h_component h_table_spec h_provider_row h_match_binaryadd h_main_subset
@@ -96,8 +97,9 @@ theorem zisk_riscv_compliant_program_bus_add_rtypew
           (instruction.RTYPEW (r2, r1, rd, ropw.ADDW))) state
         = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
     exact ZiskFv.Equivalence.Addw.equiv_ADDW
-      state addw_input r1 r2 rd m providerTable providerRow r_main bus pins
-      h_component h_table_spec h_provider_row h_match_static
+      state addw_input r1 r2 rd m
+      ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus pins h_match_static
       h_input_r1_extract h_input_r2_extract h_lane_rd promises
   | subw subw_input r1 r2 rd _v bus pins providerTable providerRow h_component
       h_table_spec h_provider_row h_match_static
@@ -110,8 +112,9 @@ theorem zisk_riscv_compliant_program_bus_add_rtypew
           (instruction.RTYPEW (r2, r1, rd, ropw.SUBW))) state
         = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
     exact ZiskFv.Equivalence.Subw.equiv_SUBW
-      state subw_input r1 r2 rd m providerTable providerRow r_main bus pins
-      h_component h_table_spec h_provider_row h_match_static
+      state subw_input r1 r2 rd m
+      ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus pins h_match_static
       h_input_r1_extract h_input_r2_extract h_lane_rd promises
   | _ => trivial
 

--- a/ZiskFv/Compliance/Dispatch/ITYPE.lean
+++ b/ZiskFv/Compliance/Dispatch/ITYPE.lean
@@ -85,8 +85,9 @@ theorem zisk_riscv_compliant_program_bus_itype_binary
         = state_effect_via_channels
             ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
     exact ZiskFv.Equivalence.Andi.equiv_ANDI
-      state andi_input r1 rd imm m providerTable providerRow r_main bus pins
-      h_component h_table_spec h_provider_row h_match_static
+      state andi_input r1 rd imm m
+      ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus pins h_match_static
       h_input_r1_row h_input_imm_row h_andi_subset
       h_lane_rd promises
   | ori ori_input r1 rd imm v bus pins providerTable providerRow
@@ -102,8 +103,9 @@ theorem zisk_riscv_compliant_program_bus_itype_binary
         = state_effect_via_channels
             ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
     exact ZiskFv.Equivalence.Ori.equiv_ORI
-      state ori_input r1 rd imm m providerTable providerRow r_main bus pins
-      h_component h_table_spec h_provider_row h_match_static
+      state ori_input r1 rd imm m
+      ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus pins h_match_static
       h_input_r1_row h_input_imm_row h_ori_subset
       h_lane_rd promises
   | xori xori_input r1 rd imm v bus pins providerTable providerRow
@@ -119,8 +121,9 @@ theorem zisk_riscv_compliant_program_bus_itype_binary
         = state_effect_via_channels
             ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
     exact ZiskFv.Equivalence.Xori.equiv_XORI
-      state xori_input r1 rd imm m providerTable providerRow r_main bus pins
-      h_component h_table_spec h_provider_row h_match_static
+      state xori_input r1 rd imm m
+      ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus pins h_match_static
       h_input_r1_row h_input_imm_row h_xori_subset
       h_lane_rd promises
   | slti slti_input r1 rd imm v bus pins providerTable providerRow
@@ -135,8 +138,9 @@ theorem zisk_riscv_compliant_program_bus_itype_binary
         = state_effect_via_channels
             ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
     exact ZiskFv.Equivalence.Slti.equiv_SLTI
-      state slti_input r1 rd imm m providerTable providerRow r_main bus pins
-      h_component h_table_spec h_provider_row h_match_static
+      state slti_input r1 rd imm m
+      ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus pins h_match_static
       h_main_m32 h_input_r1_row h_slti_subset h_lane_rd promises
   | sltiu sltiu_input r1 rd imm v bus pins providerTable providerRow
       h_component h_table_spec h_provider_row h_match_static
@@ -150,8 +154,9 @@ theorem zisk_riscv_compliant_program_bus_itype_binary
         = state_effect_via_channels
             ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
     exact ZiskFv.Equivalence.Sltiu.equiv_SLTIU
-      state sltiu_input r1 rd imm m providerTable providerRow r_main bus pins
-      h_component h_table_spec h_provider_row h_match_static
+      state sltiu_input r1 rd imm m
+      ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus pins h_match_static
       h_main_m32 h_input_r1_row h_sltiu_subset h_lane_rd promises
   | _ => trivial
 

--- a/ZiskFv/Compliance/Dispatch/Misc.lean
+++ b/ZiskFv/Compliance/Dispatch/Misc.lean
@@ -162,8 +162,9 @@ theorem zisk_riscv_compliant_program_bus_misc
         LeanRV64D.Functions.execute (instruction.ITYPE (imm, r1, rd, iop.ADDI))) state
         = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
     exact ZiskFv.Equivalence.Addi.equiv_ADDI
-      state addi_input r1 rd imm m providerTable providerRow r_main bus pins
-      h_component h_table_spec h_provider_row h_match_static h_addi_subset
+      state addi_input r1 rd imm m
+      ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus pins h_match_static h_addi_subset
       h_input_r1_row h_input_imm_row h_lane_rd promises
   | addi_via_binaryadd addi_input r1 rd imm bus pins providerTable providerRow
       h_component h_table_spec h_provider_row h_match_binaryadd h_main_subset
@@ -201,8 +202,9 @@ theorem zisk_riscv_compliant_program_bus_misc
         LeanRV64D.Functions.execute (instruction.ADDIW (imm, r1, rd))) state
         = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
     exact ZiskFv.Equivalence.Addiw.equiv_ADDIW
-      state addiw_input r1 rd imm m providerTable providerRow r_main bus pins
-      h_addiw_subset h_component h_table_spec h_provider_row h_match_static
+      state addiw_input r1 rd imm m
+      ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus pins h_addiw_subset h_match_static
       h_input_r1_extract h_lane_rd promises
   | _ => trivial
 

--- a/ZiskFv/Compliance/Dispatch/RTYPE.lean
+++ b/ZiskFv/Compliance/Dispatch/RTYPE.lean
@@ -132,8 +132,9 @@ theorem zisk_riscv_compliant_program_bus_rtype_binary
       h_lane_rd promises =>
     simp only [OpEnvelope.exec_eq_rtype_binary]
     exact ZiskFv.Equivalence.And.equiv_AND
-      state and_input r1 r2 rd m providerTable providerRow r_main bus pins
-      h_component h_table_spec h_provider_row h_match_static
+      state and_input r1 r2 rd m
+      ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus pins h_match_static
       h_input_r1_row h_input_r2_row h_lane_rd promises
   | or or_input r1 r2 rd v bus pins providerTable providerRow h_component
       h_table_spec h_provider_row h_match_static h_input_r1_row h_input_r2_row

--- a/ZiskFv/Compliance/Dispatch/RTYPE.lean
+++ b/ZiskFv/Compliance/Dispatch/RTYPE.lean
@@ -124,8 +124,9 @@ theorem zisk_riscv_compliant_program_bus_rtype_binary
       h_input_r1_row h_input_r2_row h_lane_rd promises =>
     simp only [OpEnvelope.exec_eq_rtype_binary]
     exact ZiskFv.Equivalence.Sub.equiv_SUB
-      state sub_input r1 r2 rd m providerTable providerRow r_main bus pins
-      h_component h_table_spec h_provider_row h_match_static
+      state sub_input r1 r2 rd m
+      ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus pins h_match_static
       h_input_r1_row h_input_r2_row h_lane_rd promises
   | and and_input r1 r2 rd v bus pins providerTable providerRow h_component
       h_table_spec h_provider_row h_match_static h_input_r1_row h_input_r2_row
@@ -141,32 +142,36 @@ theorem zisk_riscv_compliant_program_bus_rtype_binary
       h_lane_rd promises =>
     simp only [OpEnvelope.exec_eq_rtype_binary]
     exact ZiskFv.Equivalence.Or.equiv_OR
-      state or_input r1 r2 rd m providerTable providerRow r_main bus pins
-      h_component h_table_spec h_provider_row h_match_static
+      state or_input r1 r2 rd m
+      ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus pins h_match_static
       h_input_r1_row h_input_r2_row h_lane_rd promises
   | xor xor_input r1 r2 rd v bus pins providerTable providerRow h_component
       h_table_spec h_provider_row h_match_static h_input_r1_row h_input_r2_row
       h_lane_rd promises =>
     simp only [OpEnvelope.exec_eq_rtype_binary]
     exact ZiskFv.Equivalence.Xor.equiv_XOR
-      state xor_input r1 r2 rd m providerTable providerRow r_main bus pins
-      h_component h_table_spec h_provider_row h_match_static
+      state xor_input r1 r2 rd m
+      ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus pins h_match_static
       h_input_r1_row h_input_r2_row h_lane_rd promises
   | slt slt_input r1 r2 rd v bus pins providerTable providerRow h_component
       h_table_spec h_provider_row h_match_static h_input_r1_row h_input_r2_row
       h_lane_rd promises =>
     simp only [OpEnvelope.exec_eq_rtype_binary]
     exact ZiskFv.Equivalence.Slt.equiv_SLT
-      state slt_input r1 r2 rd m providerTable providerRow r_main bus pins
-      h_component h_table_spec h_provider_row h_match_static
+      state slt_input r1 r2 rd m
+      ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus pins h_match_static
       h_input_r1_row h_input_r2_row h_lane_rd promises
   | sltu sltu_input r1 r2 rd v bus pins providerTable providerRow h_component
       h_table_spec h_provider_row h_match_static h_input_r1_row h_input_r2_row
       h_lane_rd promises =>
     simp only [OpEnvelope.exec_eq_rtype_binary]
     exact ZiskFv.Equivalence.Sltu.equiv_SLTU
-      state sltu_input r1 r2 rd m providerTable providerRow r_main bus pins
-      h_component h_table_spec h_provider_row h_match_static
+      state sltu_input r1 r2 rd m
+      ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus pins h_match_static
       h_input_r1_row h_input_r2_row h_lane_rd promises
   | _ => trivial
 

--- a/ZiskFv/Compliance/Dispatch/Remaining.lean
+++ b/ZiskFv/Compliance/Dispatch/Remaining.lean
@@ -355,8 +355,8 @@ theorem zisk_riscv_compliant_program_bus_remaining
         m2_as := h_m2_as
         rd_idx := h_rd_idx }
     exact ZiskFv.Equivalence.Sllw.equiv_SLLW state sllw_input r1 r2 rd
-      m providerTable providerRow r_main bus promises
-      pins h_component h_table_spec h_provider_row h_match
+      m ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus promises pins h_match
       h_input_r1_row h_shift_pin_row h_lane_rd
   | srlw srlw_input r1 r2 rd providerTable providerRow bus
          h_input_r1_sail h_input_r2_sail h_input_rd h_input_pc
@@ -386,8 +386,8 @@ theorem zisk_riscv_compliant_program_bus_remaining
         m2_as := h_m2_as
         rd_idx := h_rd_idx }
     exact ZiskFv.Equivalence.Srlw.equiv_SRLW state srlw_input r1 r2 rd
-      m providerTable providerRow r_main bus promises
-      pins h_component h_table_spec h_provider_row h_match
+      m ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus promises pins h_match
       h_input_r1_row h_shift_pin_row h_lane_rd
   | sraw sraw_input r1 r2 rd providerTable providerRow bus
          h_input_r1_sail h_input_r2_sail h_input_rd h_input_pc
@@ -417,8 +417,8 @@ theorem zisk_riscv_compliant_program_bus_remaining
         m2_as := h_m2_as
         rd_idx := h_rd_idx }
     exact ZiskFv.Equivalence.Sraw.equiv_SRAW state sraw_input r1 r2 rd
-      m providerTable providerRow r_main bus promises
-      pins h_component h_table_spec h_provider_row h_match
+      m ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus promises pins h_match
       h_input_r1_row h_shift_pin_row h_lane_rd
   | slliw slliw_input r1 rd providerTable providerRow bus promises pins
       h_component h_table_spec h_provider_row h_match
@@ -426,8 +426,8 @@ theorem zisk_riscv_compliant_program_bus_remaining
     change execute_instruction (instruction.SHIFTIWOP (slliw_input.shamt, r1, rd, sopw.SLLIW)) state
         = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
     exact ZiskFv.Equivalence.Slliw.equiv_SLLIW state slliw_input r1 rd
-      m providerTable providerRow r_main bus promises pins
-      h_component h_table_spec h_provider_row h_match
+      m ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus promises pins h_match
       h_input_r1_row h_shift_pin_row h_lane_rd
   | srliw srliw_input r1 rd providerTable providerRow bus promises pins
       h_component h_table_spec h_provider_row h_match
@@ -435,8 +435,8 @@ theorem zisk_riscv_compliant_program_bus_remaining
     change execute_instruction (instruction.SHIFTIWOP (srliw_input.shamt, r1, rd, sopw.SRLIW)) state
         = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
     exact ZiskFv.Equivalence.Srliw.equiv_SRLIW state srliw_input r1 rd
-      m providerTable providerRow r_main bus promises pins
-      h_component h_table_spec h_provider_row h_match
+      m ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus promises pins h_match
       h_input_r1_row h_shift_pin_row h_lane_rd
   | sraiw sraiw_input r1 rd providerTable providerRow bus promises pins
       h_component h_table_spec h_provider_row h_match
@@ -444,8 +444,8 @@ theorem zisk_riscv_compliant_program_bus_remaining
     change execute_instruction (instruction.SHIFTIWOP (sraiw_input.shamt, r1, rd, sopw.SRAIW)) state
         = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
     exact ZiskFv.Equivalence.Sraiw.equiv_SRAIW state sraiw_input r1 rd
-      m providerTable providerRow r_main bus promises pins
-      h_component h_table_spec h_provider_row h_match
+      m ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus promises pins h_match
       h_input_r1_row h_shift_pin_row h_lane_rd
   -- Mul family
   | mul mul_input r1 r2 rd srs1 srs2 bus v r_a pins h_match_primary
@@ -812,8 +812,8 @@ theorem zisk_riscv_compliant_program_bus_remaining_except_known_defects
         m2_as := h_m2_as
         rd_idx := h_rd_idx }
     exact ZiskFv.Equivalence.Sllw.equiv_SLLW state sllw_input r1 r2 rd
-      m providerTable providerRow r_main bus promises
-      pins h_component h_table_spec h_provider_row h_match
+      m ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus promises pins h_match
       h_input_r1_row h_shift_pin_row h_lane_rd
   | srlw srlw_input r1 r2 rd providerTable providerRow bus
          h_input_r1_sail h_input_r2_sail h_input_rd h_input_pc
@@ -843,8 +843,8 @@ theorem zisk_riscv_compliant_program_bus_remaining_except_known_defects
         m2_as := h_m2_as
         rd_idx := h_rd_idx }
     exact ZiskFv.Equivalence.Srlw.equiv_SRLW state srlw_input r1 r2 rd
-      m providerTable providerRow r_main bus promises
-      pins h_component h_table_spec h_provider_row h_match
+      m ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus promises pins h_match
       h_input_r1_row h_shift_pin_row h_lane_rd
   | sraw sraw_input r1 r2 rd providerTable providerRow bus
          h_input_r1_sail h_input_r2_sail h_input_rd h_input_pc
@@ -874,8 +874,8 @@ theorem zisk_riscv_compliant_program_bus_remaining_except_known_defects
         m2_as := h_m2_as
         rd_idx := h_rd_idx }
     exact ZiskFv.Equivalence.Sraw.equiv_SRAW state sraw_input r1 r2 rd
-      m providerTable providerRow r_main bus promises
-      pins h_component h_table_spec h_provider_row h_match
+      m ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus promises pins h_match
       h_input_r1_row h_shift_pin_row h_lane_rd
   | slliw slliw_input r1 rd providerTable providerRow bus promises pins
       h_component h_table_spec h_provider_row h_match
@@ -883,8 +883,8 @@ theorem zisk_riscv_compliant_program_bus_remaining_except_known_defects
     change execute_instruction (instruction.SHIFTIWOP (slliw_input.shamt, r1, rd, sopw.SLLIW)) state
         = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
     exact ZiskFv.Equivalence.Slliw.equiv_SLLIW state slliw_input r1 rd
-      m providerTable providerRow r_main bus promises pins
-      h_component h_table_spec h_provider_row h_match
+      m ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus promises pins h_match
       h_input_r1_row h_shift_pin_row h_lane_rd
   | srliw srliw_input r1 rd providerTable providerRow bus promises pins
       h_component h_table_spec h_provider_row h_match
@@ -892,8 +892,8 @@ theorem zisk_riscv_compliant_program_bus_remaining_except_known_defects
     change execute_instruction (instruction.SHIFTIWOP (srliw_input.shamt, r1, rd, sopw.SRLIW)) state
         = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
     exact ZiskFv.Equivalence.Srliw.equiv_SRLIW state srliw_input r1 rd
-      m providerTable providerRow r_main bus promises pins
-      h_component h_table_spec h_provider_row h_match
+      m ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus promises pins h_match
       h_input_r1_row h_shift_pin_row h_lane_rd
   | sraiw sraiw_input r1 rd providerTable providerRow bus promises pins
       h_component h_table_spec h_provider_row h_match
@@ -901,8 +901,8 @@ theorem zisk_riscv_compliant_program_bus_remaining_except_known_defects
     change execute_instruction (instruction.SHIFTIWOP (sraiw_input.shamt, r1, rd, sopw.SRAIW)) state
         = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
     exact ZiskFv.Equivalence.Sraiw.equiv_SRAIW state sraiw_input r1 rd
-      m providerTable providerRow r_main bus promises pins
-      h_component h_table_spec h_provider_row h_match
+      m ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus promises pins h_match
       h_input_r1_row h_shift_pin_row h_lane_rd
   | mul mul_input r1 r2 rd srs1 srs2 bus v r_a pins h_match_primary
         promises arith_mem bounds h_row_constraints arith_table

--- a/ZiskFv/Compliance/Dispatch/Shift.lean
+++ b/ZiskFv/Compliance/Dispatch/Shift.lean
@@ -58,8 +58,8 @@ theorem zisk_riscv_compliant_program_bus_shift
     change execute_instruction (instruction.RTYPE (r2, r1, rd, rop.SLL)) state
         = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
     exact ZiskFv.Equivalence.Sll.equiv_SLL state sll_input r1 r2 rd
-      m providerTable providerRow r_main bus promises pins
-      h_component h_table_spec h_provider_row h_match
+      m ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus promises pins h_match
       h_input_r1_row h_shift_pin_row h_lane_rd
   | srl srl_input r1 r2 rd providerTable providerRow bus promises pins
       h_component h_table_spec h_provider_row h_match
@@ -67,8 +67,8 @@ theorem zisk_riscv_compliant_program_bus_shift
     change execute_instruction (instruction.RTYPE (r2, r1, rd, rop.SRL)) state
         = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
     exact ZiskFv.Equivalence.Srl.equiv_SRL state srl_input r1 r2 rd
-      m providerTable providerRow r_main bus promises pins
-      h_component h_table_spec h_provider_row h_match
+      m ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus promises pins h_match
       h_input_r1_row h_shift_pin_row h_lane_rd
   | sra sra_input r1 r2 rd providerTable providerRow bus promises pins
       h_component h_table_spec h_provider_row h_match
@@ -76,8 +76,8 @@ theorem zisk_riscv_compliant_program_bus_shift
     change execute_instruction (instruction.RTYPE (r2, r1, rd, rop.SRA)) state
         = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
     exact ZiskFv.Equivalence.Sra.equiv_SRA state sra_input r1 r2 rd
-      m providerTable providerRow r_main bus promises pins
-      h_component h_table_spec h_provider_row h_match
+      m ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus promises pins h_match
       h_input_r1_row h_shift_pin_row h_lane_rd
   | slli slli_input r1 rd shamt providerTable providerRow bus promises pins
       h_component h_table_spec h_provider_row h_match
@@ -85,8 +85,8 @@ theorem zisk_riscv_compliant_program_bus_shift
     change execute_instruction (instruction.SHIFTIOP (shamt, r1, rd, sop.SLLI)) state
         = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
     exact ZiskFv.Equivalence.Slli.equiv_SLLI state slli_input r1 rd shamt
-      m providerTable providerRow r_main bus promises pins
-      h_component h_table_spec h_provider_row h_match
+      m ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus promises pins h_match
       h_input_r1_row h_shift_pin_row h_lane_rd
   | srli srli_input r1 rd shamt providerTable providerRow bus promises pins
       h_component h_table_spec h_provider_row h_match
@@ -94,8 +94,8 @@ theorem zisk_riscv_compliant_program_bus_shift
     change execute_instruction (instruction.SHIFTIOP (shamt, r1, rd, sop.SRLI)) state
         = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
     exact ZiskFv.Equivalence.Srli.equiv_SRLI state srli_input r1 rd shamt
-      m providerTable providerRow r_main bus promises pins
-      h_component h_table_spec h_provider_row h_match
+      m ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus promises pins h_match
       h_input_r1_row h_shift_pin_row h_lane_rd
   | srai srai_input r1 rd shamt providerTable providerRow bus promises pins
       h_component h_table_spec h_provider_row h_match
@@ -103,8 +103,8 @@ theorem zisk_riscv_compliant_program_bus_shift
     change execute_instruction (instruction.SHIFTIOP (shamt, r1, rd, sop.SRAI)) state
         = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state
     exact ZiskFv.Equivalence.Srai.equiv_SRAI state srai_input r1 rd shamt
-      m providerTable providerRow r_main bus promises pins
-      h_component h_table_spec h_provider_row h_match
+      m ⟨providerTable, providerRow, h_component, h_table_spec, h_provider_row⟩
+      r_main bus promises pins h_match
       h_input_r1_row h_shift_pin_row h_lane_rd
   | _ => trivial
 

--- a/ZiskFv/Compliance/Wrappers/Add.lean
+++ b/ZiskFv/Compliance/Wrappers/Add.lean
@@ -45,29 +45,18 @@ lemma equiv_ADD
     (add_input : PureSpec.AddInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_ADD)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry
       (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_input_r1_row : add_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_input_r2_row : add_input.r2_val =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowB64 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
         state add_input.r1_val add_input.r2_val add_input.rd add_input.PC
@@ -76,16 +65,8 @@ lemma equiv_ADD
     execute_instruction (instruction.RTYPE (r2, r1, rd, rop.ADD)) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
   obtain ⟨h_main_active, h_main_op_add⟩ := pins
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_spec_facts :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_spec_facts_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_emit : row.chain.b_op + 16 * row.mode.mode32 = (10 : FGL) := by
+  obtain ⟨_, h_core, h_spec_facts, h_facts⟩ := p.facts
+  have h_emit : p.rowInput.chain.b_op + 16 * p.rowInput.mode.mode32 = (10 : FGL) := by
     have h_lane_eqs := h_match
     simp only [matches_entry, opBus_row_Main] at h_lane_eqs
     obtain ⟨_, h_op_match, _, _, _, _, _, _, _, _, _, _⟩ := h_lane_eqs
@@ -93,15 +74,14 @@ lemma equiv_ADD
     simpa [ZiskFv.Trusted.OP_ADD] using h_main_op_add
   obtain ⟨h_mode32_zero, h_bop_val, _⟩ :=
     ZiskFv.EquivCore.Bridge.Binary.logic_row_mode_pins_of_emit_op_lt_16_of_static_spec
-      row h_spec_facts 10 (by decide) h_core h_emit
-  have h_b_op : row.chain.b_op.val = ZiskFv.Airs.Tables.BinaryTable.OP_ADD := by
+      p.rowInput h_spec_facts 10 (by decide) h_core h_emit
+  have h_b_op : p.rowInput.chain.b_op.val = ZiskFv.Airs.Tables.BinaryTable.OP_ADD := by
     simpa [ZiskFv.Airs.Tables.BinaryTable.OP_ADD] using h_bop_val
   exact ZiskFv.EquivCore.Add.equiv_ADD_of_static_row
-    state add_input r1 r2 rd m row r_main bus promises
+    state add_input r1 r2 rd m p.rowInput r_main bus promises
     ⟨h_main_active, h_main_op_add⟩
     h_match h_core h_facts h_mode32_zero h_b_op
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_r2_row)
+    h_input_r1_row h_input_r2_row
     h_lane_rd
 
 /-- ADD wrapper via the BinaryAdd provider arm. The provider table's Clean
@@ -112,21 +92,14 @@ lemma equiv_ADD_via_binaryadd
     (add_input : PureSpec.AddInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.BinaryAddProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_ADD)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryAdd.component)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry
       (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryAdd.opBusMessage
-          (ZiskFv.AirsClean.BinaryAdd.component.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryAdd.opBusMessage p.rowInput) 1))
     (h_main_subset : ZiskFv.Airs.Main.add_subset_holds m r_main)
     (h_a_lo_t : m.a_0 r_main =
       ZiskFv.Trusted.lane_lo
@@ -152,22 +125,19 @@ lemma equiv_ADD_via_binaryadd
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2) :
     execute_instruction (instruction.RTYPE (r2, r1, rd, rop.ADD)) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.BinaryAdd.component.rowInput
-      (providerTable.environment providerRow)
-  have h_facts : ZiskFv.AirsClean.BinaryAdd.ComponentSpecFacts row := by
-    have h_component_spec :
-        ZiskFv.AirsClean.BinaryAdd.component.Spec
-          (providerTable.environment providerRow) := by
-      simpa [h_component] using h_table_spec providerRow h_provider_row
-    simpa [row, ZiskFv.AirsClean.BinaryAdd.component_spec] using h_component_spec
+  have h_facts : ZiskFv.AirsClean.BinaryAdd.ComponentSpecFacts p.rowInput :=
+    p.facts
   exact ZiskFv.EquivCore.Add.equiv_ADD_of_binaryadd_row
-    state add_input r1 r2 rd m row r_main bus promises pins h_match
-    (ZiskFv.AirsClean.BinaryAdd.core_every_row_of_component_spec_facts row h_facts)
+    state add_input r1 r2 rd m p.rowInput r_main bus promises pins h_match
+    (ZiskFv.AirsClean.BinaryAdd.core_every_row_of_component_spec_facts
+      p.rowInput h_facts)
     h_main_subset h_a_lo_t h_a_hi_t h_b_lo_t h_b_hi_t h_m32
-    (ZiskFv.AirsClean.BinaryAdd.a_chunks_in_range_of_component_spec_facts row h_facts)
-    (ZiskFv.AirsClean.BinaryAdd.b_chunks_in_range_of_component_spec_facts row h_facts)
-    (ZiskFv.AirsClean.BinaryAdd.c_chunks_in_range_of_component_spec_facts row h_facts)
+    (ZiskFv.AirsClean.BinaryAdd.a_chunks_in_range_of_component_spec_facts
+      p.rowInput h_facts)
+    (ZiskFv.AirsClean.BinaryAdd.b_chunks_in_range_of_component_spec_facts
+      p.rowInput h_facts)
+    (ZiskFv.AirsClean.BinaryAdd.c_chunks_in_range_of_component_spec_facts
+      p.rowInput h_facts)
     h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/Wrappers/Addi.lean
+++ b/ZiskFv/Compliance/Wrappers/Addi.lean
@@ -38,32 +38,21 @@ lemma equiv_ADDI
     (addi_input : PureSpec.AddiInput)
     (r1 rd : regidx) (imm : BitVec 12)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_ADD)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry
       (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_addi_subset :
       ZiskFv.Tactics.ALUITypeArchetype.itype_imm_subset_holds_main
         m r_main addi_input.imm)
     (h_input_r1_row : addi_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_input_imm_row : BitVec.signExtend 64 addi_input.imm =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowB64 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.ITypePromises
         state addi_input.r1_val addi_input.imm addi_input.rd addi_input.PC
@@ -76,16 +65,8 @@ lemma equiv_ADDI
         (instruction.ITYPE (imm, r1, rd, iop.ADDI))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
   obtain ⟨h_main_active, h_main_op_add⟩ := pins
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_spec_facts :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_spec_facts_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_emit : row.chain.b_op + 16 * row.mode.mode32 = (10 : FGL) := by
+  obtain ⟨_, h_core, h_spec_facts, h_facts⟩ := p.facts
+  have h_emit : p.rowInput.chain.b_op + 16 * p.rowInput.mode.mode32 = (10 : FGL) := by
     have h_lane_eqs := h_match
     simp only [matches_entry, opBus_row_Main] at h_lane_eqs
     obtain ⟨_, h_op_match, _, _, _, _, _, _, _, _, _, _⟩ := h_lane_eqs
@@ -93,15 +74,14 @@ lemma equiv_ADDI
     simpa [ZiskFv.Trusted.OP_ADD] using h_main_op_add
   obtain ⟨h_mode32_zero, h_bop_val, _⟩ :=
     ZiskFv.EquivCore.Bridge.Binary.logic_row_mode_pins_of_emit_op_lt_16_of_static_spec
-      row h_spec_facts 10 (by decide) h_core h_emit
-  have h_b_op : row.chain.b_op.val = ZiskFv.Airs.Tables.BinaryTable.OP_ADD := by
+      p.rowInput h_spec_facts 10 (by decide) h_core h_emit
+  have h_b_op : p.rowInput.chain.b_op.val = ZiskFv.Airs.Tables.BinaryTable.OP_ADD := by
     simpa [ZiskFv.Airs.Tables.BinaryTable.OP_ADD] using h_bop_val
   exact ZiskFv.EquivCore.Addi.equiv_ADDI_of_static_row
-    state addi_input r1 rd imm m row r_main bus promises
+    state addi_input r1 rd imm m p.rowInput r_main bus promises
     ⟨h_main_active, h_main_op_add⟩
     h_match h_addi_subset h_core h_facts h_mode32_zero h_b_op
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_imm_row)
+    h_input_r1_row h_input_imm_row
     h_lane_rd
 
 lemma equiv_ADDI_via_binaryadd
@@ -109,21 +89,14 @@ lemma equiv_ADDI_via_binaryadd
     (addi_input : PureSpec.AddiInput)
     (r1 rd : regidx) (imm : BitVec 12)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.BinaryAddProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_ADD)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryAdd.component)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry
       (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryAdd.opBusMessage
-          (ZiskFv.AirsClean.BinaryAdd.component.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryAdd.opBusMessage p.rowInput) 1))
     (h_main_subset : ZiskFv.Airs.Main.add_subset_holds m r_main)
     (h_addi_subset :
       ZiskFv.Tactics.ALUITypeArchetype.itype_imm_subset_holds_main
@@ -149,22 +122,19 @@ lemma equiv_ADDI_via_binaryadd
       LeanRV64D.Functions.execute
         (instruction.ITYPE (imm, r1, rd, iop.ADDI))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.BinaryAdd.component.rowInput
-      (providerTable.environment providerRow)
-  have h_facts : ZiskFv.AirsClean.BinaryAdd.ComponentSpecFacts row := by
-    have h_component_spec :
-        ZiskFv.AirsClean.BinaryAdd.component.Spec
-          (providerTable.environment providerRow) := by
-      simpa [h_component] using h_table_spec providerRow h_provider_row
-    simpa [row, ZiskFv.AirsClean.BinaryAdd.component_spec] using h_component_spec
+  have h_facts : ZiskFv.AirsClean.BinaryAdd.ComponentSpecFacts p.rowInput :=
+    p.facts
   exact ZiskFv.EquivCore.Addi.equiv_ADDI_of_binaryadd_row
-    state addi_input r1 rd imm m row r_main bus promises pins h_match
-    (ZiskFv.AirsClean.BinaryAdd.core_every_row_of_component_spec_facts row h_facts)
+    state addi_input r1 rd imm m p.rowInput r_main bus promises pins h_match
+    (ZiskFv.AirsClean.BinaryAdd.core_every_row_of_component_spec_facts
+      p.rowInput h_facts)
     h_main_subset h_a_lo_t h_a_hi_t
-    (ZiskFv.AirsClean.BinaryAdd.a_chunks_in_range_of_component_spec_facts row h_facts)
-    (ZiskFv.AirsClean.BinaryAdd.b_chunks_in_range_of_component_spec_facts row h_facts)
-    (ZiskFv.AirsClean.BinaryAdd.c_chunks_in_range_of_component_spec_facts row h_facts)
+    (ZiskFv.AirsClean.BinaryAdd.a_chunks_in_range_of_component_spec_facts
+      p.rowInput h_facts)
+    (ZiskFv.AirsClean.BinaryAdd.b_chunks_in_range_of_component_spec_facts
+      p.rowInput h_facts)
+    (ZiskFv.AirsClean.BinaryAdd.c_chunks_in_range_of_component_spec_facts
+      p.rowInput h_facts)
     h_addi_subset h_m32 h_set_pc h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/Wrappers/Addiw.lean
+++ b/ZiskFv/Compliance/Wrappers/Addiw.lean
@@ -38,27 +38,18 @@ lemma equiv_ADDIW
     (addiw_input : PureSpec.AddiwInput)
     (r1 rd : regidx) (imm : BitVec 12)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_ADD_W)
     (h_addiw_subset : itype_imm_subset_holds_main m r_main addiw_input.imm)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry
       (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_input_r1_extract :
       (Sail.BitVec.extractLsb addiw_input.r1_val 31 0 : BitVec (31 - 0 + 1)).toNat
-        = ZiskFv.EquivCore.Addw.binaryRowA32
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow)) % 2^32)
+        = ZiskFv.EquivCore.Addw.binaryRowA32 p.rowInput % 2^32)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.ITypePromises
         state addiw_input.r1_val addiw_input.imm addiw_input.rd addiw_input.PC
@@ -71,16 +62,8 @@ lemma equiv_ADDIW
         (instruction.ADDIW (imm, r1, rd))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
   obtain ⟨h_main_active, h_main_op_addiw⟩ := pins
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_spec_facts :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_spec_facts_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_emit : row.chain.b_op + 16 * row.mode.mode32 = (0x1A : FGL) := by
+  obtain ⟨_, h_core, h_spec_facts, h_facts⟩ := p.facts
+  have h_emit : p.rowInput.chain.b_op + 16 * p.rowInput.mode.mode32 = (0x1A : FGL) := by
     have h_lane_eqs := h_match
     simp only [matches_entry, opBus_row_Main,
       ] at h_lane_eqs
@@ -89,13 +72,13 @@ lemma equiv_ADDIW
     simpa [ZiskFv.Trusted.OP_ADD_W] using h_main_op_addiw
   obtain ⟨h_mode32_one, h_bop_val⟩ :=
     ZiskFv.EquivCore.Bridge.Binary.chain_row_shape_W_of_emit
-      row h_spec_facts h_core 0x1A (Or.inl rfl) h_emit
-  have h_b_op : row.chain.b_op.val = ZiskFv.Airs.Tables.BinaryTable.OP_ADD := by
+      p.rowInput h_spec_facts h_core 0x1A (Or.inl rfl) h_emit
+  have h_b_op : p.rowInput.chain.b_op.val = ZiskFv.Airs.Tables.BinaryTable.OP_ADD := by
     simpa [ZiskFv.Airs.Tables.BinaryTable.OP_ADD] using h_bop_val
-  let v := ZiskFv.AirsClean.Binary.validOfRow row
+  let v := ZiskFv.AirsClean.Binary.validOfRow p.rowInput
   obtain ⟨h_sext_choice_row, h_carry_7_zero_row⟩ :=
     ZiskFv.EquivCore.Bridge.Binary.w_mode_sext_choice_and_carry_7_zero_of_static_row
-      row h_spec_facts h_facts h_core h_mode32_one (Or.inl h_b_op)
+      p.rowInput h_spec_facts h_facts h_core h_mode32_one (Or.inl h_b_op)
   have h_b_lo_m : m.b_0 r_main = v.free_in_b_0 0 + 256 * v.free_in_b_1 0
                                   + 65536 * v.free_in_b_2 0
                                   + 16777216 * v.free_in_b_3 0 := by
@@ -148,10 +131,10 @@ lemma equiv_ADDIW
   have h_input_imm_extract :
       (Sail.BitVec.extractLsb (BitVec.signExtend 64 imm : BitVec 64) 31 0
         : BitVec (31 - 0 + 1)).toNat
-      = (((ZiskFv.AirsClean.Binary.validOfRow row).free_in_b_0 0).val
-          + ((ZiskFv.AirsClean.Binary.validOfRow row).free_in_b_1 0).val * 256
-          + ((ZiskFv.AirsClean.Binary.validOfRow row).free_in_b_2 0).val * 65536
-          + ((ZiskFv.AirsClean.Binary.validOfRow row).free_in_b_3 0).val * 16777216)
+      = (((ZiskFv.AirsClean.Binary.validOfRow p.rowInput).free_in_b_0 0).val
+          + ((ZiskFv.AirsClean.Binary.validOfRow p.rowInput).free_in_b_1 0).val * 256
+          + ((ZiskFv.AirsClean.Binary.validOfRow p.rowInput).free_in_b_2 0).val * 65536
+          + ((ZiskFv.AirsClean.Binary.validOfRow p.rowInput).free_in_b_3 0).val * 16777216)
               % 2^32 := by
     show _ = ((v.free_in_b_0 0).val + (v.free_in_b_1 0).val * 256
               + (v.free_in_b_2 0).val * 65536
@@ -166,11 +149,11 @@ lemma equiv_ADDIW
     have h_b1_lt : (m.b_1 r_main).val < GL_prime := (m.b_1 r_main).isLt
     omega
   exact ZiskFv.EquivCore.Addiw.equiv_ADDIW_of_static_row
-    state addiw_input r1 rd imm m row r_main bus promises
+    state addiw_input r1 rd imm m p.rowInput r_main bus promises
     ⟨h_main_active, h_main_op_addiw⟩
     h_match h_core h_facts h_mode32_one h_b_op
     h_sext_choice_row h_carry_7_zero_row
-    (by simpa [row] using h_input_r1_extract)
+    h_input_r1_extract
     h_lane_rd h_input_imm_extract
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/Wrappers/Addw.lean
+++ b/ZiskFv/Compliance/Wrappers/Addw.lean
@@ -34,31 +34,20 @@ lemma equiv_ADDW
     (addw_input : PureSpec.AddwInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_ADD_W)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry
       (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_input_r1_extract :
       (Sail.BitVec.extractLsb addw_input.r1_val 31 0 : BitVec (31 - 0 + 1)).toNat
-        = ZiskFv.EquivCore.Addw.binaryRowA32
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow)) % 2^32)
+        = ZiskFv.EquivCore.Addw.binaryRowA32 p.rowInput % 2^32)
     (h_input_r2_extract :
       (Sail.BitVec.extractLsb addw_input.r2_val 31 0 : BitVec (31 - 0 + 1)).toNat
-        = ZiskFv.EquivCore.Addw.binaryRowB32
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow)) % 2^32)
+        = ZiskFv.EquivCore.Addw.binaryRowB32 p.rowInput % 2^32)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
         state addw_input.r1_val addw_input.r2_val addw_input.rd addw_input.PC
@@ -71,16 +60,8 @@ lemma equiv_ADDW
         (instruction.RTYPEW (r2, r1, rd, ropw.ADDW))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
   obtain ⟨h_main_active, h_main_op_addw⟩ := pins
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_spec_facts :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_spec_facts_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_emit : row.chain.b_op + 16 * row.mode.mode32 = (0x1A : FGL) := by
+  obtain ⟨_, h_core, h_spec_facts, h_facts⟩ := p.facts
+  have h_emit : p.rowInput.chain.b_op + 16 * p.rowInput.mode.mode32 = (0x1A : FGL) := by
     have h_lane_eqs := h_match
     simp only [matches_entry, opBus_row_Main,
       ] at h_lane_eqs
@@ -89,19 +70,18 @@ lemma equiv_ADDW
     simpa [ZiskFv.Trusted.OP_ADD_W] using h_main_op_addw
   obtain ⟨h_mode32_one, h_bop_val⟩ :=
     ZiskFv.EquivCore.Bridge.Binary.chain_row_shape_W_of_emit
-      row h_spec_facts h_core 0x1A (Or.inl rfl) h_emit
-  have h_b_op : row.chain.b_op.val = ZiskFv.Airs.Tables.BinaryTable.OP_ADD := by
+      p.rowInput h_spec_facts h_core 0x1A (Or.inl rfl) h_emit
+  have h_b_op : p.rowInput.chain.b_op.val = ZiskFv.Airs.Tables.BinaryTable.OP_ADD := by
     simpa [ZiskFv.Airs.Tables.BinaryTable.OP_ADD] using h_bop_val
   obtain ⟨h_sext_choice_row, h_carry_7_zero_row⟩ :=
     ZiskFv.EquivCore.Bridge.Binary.w_mode_sext_choice_and_carry_7_zero_of_static_row
-      row h_spec_facts h_facts h_core h_mode32_one (Or.inl h_b_op)
+      p.rowInput h_spec_facts h_facts h_core h_mode32_one (Or.inl h_b_op)
   exact ZiskFv.EquivCore.Addw.equiv_ADDW_of_static_row
-    state addw_input r1 r2 rd m row r_main bus promises
+    state addw_input r1 r2 rd m p.rowInput r_main bus promises
     ⟨h_main_active, h_main_op_addw⟩
     h_match h_core h_facts h_mode32_one h_b_op
     h_sext_choice_row h_carry_7_zero_row
-    (by simpa [row] using h_input_r1_extract)
-    (by simpa [row] using h_input_r2_extract)
+    h_input_r1_extract h_input_r2_extract
     h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/Wrappers/And.lean
+++ b/ZiskFv/Compliance/Wrappers/And.lean
@@ -32,28 +32,17 @@ lemma equiv_AND
     (and_input : PureSpec.AndInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_AND)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_input_r1_row : and_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_input_r2_row : and_input.r2_val =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowB64 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
         state and_input.r1_val and_input.r2_val and_input.rd and_input.PC
@@ -65,23 +54,10 @@ lemma equiv_AND
       LeanRV64D.Functions.execute
         (instruction.RTYPE (r2, r1, rd, rop.AND))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_component_spec :
-      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec
-        (providerTable.environment providerRow) := by
-    simpa [h_component] using h_table_spec providerRow h_provider_row
-  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_component_spec
-  obtain ⟨h_row_spec, h_static_specs⟩ := h_component_spec
+  obtain ⟨h_row_spec, h_core, h_static_specs, h_facts⟩ := p.facts
   exact ZiskFv.EquivCore.And.equiv_AND_of_static_row
-    state and_input r1 r2 rd m row r_main bus promises pins
+    state and_input r1 r2 rd m p.rowInput r_main bus promises pins
     h_match h_row_spec h_core h_static_specs h_facts
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_r2_row)
-    h_lane_rd
+    h_input_r1_row h_input_r2_row h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/Wrappers/Andi.lean
+++ b/ZiskFv/Compliance/Wrappers/Andi.lean
@@ -92,28 +92,17 @@ lemma equiv_ANDI
     (andi_input : PureSpec.AndiInput)
     (r1 rd : regidx) (imm : BitVec 12)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_AND)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_input_r1_row : andi_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_input_imm_row : BitVec.signExtend 64 andi_input.imm =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowB64 p.rowInput)
     (h_andi_subset : itype_imm_subset_holds_main m r_main andi_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.ITypePromises
@@ -126,23 +115,11 @@ lemma equiv_ANDI
       LeanRV64D.Functions.execute
         (instruction.ITYPE (imm, r1, rd, iop.ANDI))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_component_spec :
-      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec
-        (providerTable.environment providerRow) := by
-    simpa [h_component] using h_table_spec providerRow h_provider_row
-  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_component_spec
-  obtain ⟨h_row_spec, h_static_specs⟩ := h_component_spec
+  obtain ⟨h_row_spec, h_core, h_static_specs, h_facts⟩ := p.facts
   exact ZiskFv.EquivCore.Andi.equiv_ANDI_of_static_row
-    state andi_input r1 rd imm m row r_main bus promises pins
+    state andi_input r1 rd imm m p.rowInput r_main bus promises pins
     h_match h_row_spec h_core h_static_specs h_facts
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_imm_row)
+    h_input_r1_row h_input_imm_row
     h_lane_rd h_andi_subset
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/Wrappers/Or.lean
+++ b/ZiskFv/Compliance/Wrappers/Or.lean
@@ -134,28 +134,17 @@ lemma equiv_OR
     (or_input : PureSpec.OrInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_OR)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_input_r1_row : or_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_input_r2_row : or_input.r2_val =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowB64 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
         state or_input.r1_val or_input.r2_val or_input.rd or_input.PC
@@ -167,23 +156,10 @@ lemma equiv_OR
       LeanRV64D.Functions.execute
         (instruction.RTYPE (r2, r1, rd, rop.OR))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_component_spec :
-      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec
-        (providerTable.environment providerRow) := by
-    simpa [h_component] using h_table_spec providerRow h_provider_row
-  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_component_spec
-  obtain ⟨h_row_spec, h_static_specs⟩ := h_component_spec
+  obtain ⟨h_row_spec, h_core, h_static_specs, h_facts⟩ := p.facts
   exact ZiskFv.EquivCore.Or.equiv_OR_of_static_row
-    state or_input r1 r2 rd m row r_main bus promises pins
+    state or_input r1 r2 rd m p.rowInput r_main bus promises pins
     h_match h_row_spec h_core h_static_specs h_facts
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_r2_row)
-    h_lane_rd
+    h_input_r1_row h_input_r2_row h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/Wrappers/Ori.lean
+++ b/ZiskFv/Compliance/Wrappers/Ori.lean
@@ -34,28 +34,17 @@ lemma equiv_ORI
     (ori_input : PureSpec.OriInput)
     (r1 rd : regidx) (imm : BitVec 12)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_OR)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_input_r1_row : ori_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_input_imm_row : BitVec.signExtend 64 ori_input.imm =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowB64 p.rowInput)
     (h_ori_subset : itype_imm_subset_holds_main m r_main ori_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.ITypePromises
@@ -68,23 +57,11 @@ lemma equiv_ORI
       LeanRV64D.Functions.execute
         (instruction.ITYPE (imm, r1, rd, iop.ORI))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_component_spec :
-      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec
-        (providerTable.environment providerRow) := by
-    simpa [h_component] using h_table_spec providerRow h_provider_row
-  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_component_spec
-  obtain ⟨h_row_spec, h_static_specs⟩ := h_component_spec
+  obtain ⟨h_row_spec, h_core, h_static_specs, h_facts⟩ := p.facts
   exact ZiskFv.EquivCore.Ori.equiv_ORI_of_static_row
-    state ori_input r1 rd imm m row r_main bus promises pins
+    state ori_input r1 rd imm m p.rowInput r_main bus promises pins
     h_match h_row_spec h_core h_static_specs h_facts
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_imm_row)
+    h_input_r1_row h_input_imm_row
     h_lane_rd h_ori_subset
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/Wrappers/Shift.lean
+++ b/ZiskFv/Compliance/Wrappers/Shift.lean
@@ -28,8 +28,7 @@ lemma equiv_SLLW
     (sllw_input : PureSpec.SllwInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
@@ -37,40 +36,22 @@ lemma equiv_SLLW
         (PureSpec.execute_RTYPE_sllw_pure sllw_input).nextPC
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 ZiskFv.Trusted.OP_SLL_W)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row :
       (Sail.BitVec.extractLsb sllw_input.r1_val 31 0 : BitVec (31 - 0 + 1)).toNat =
-        ZiskFv.AirsClean.BinaryExtension.rowA32
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow)))
+        ZiskFv.AirsClean.BinaryExtension.rowA32 p.rowInput)
     (h_shift_pin_row : sllw_input.r2_val.toNat % 32 =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2) :
     execute_instruction (instruction.RTYPEW (r2, r1, rd, ropw.SLLW)) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  have h_shift_facts :=
-    ZiskFv.AirsClean.BinaryFamily.shiftStaticBinaryExtension_wf_and_b0_range_of_table_spec
-      h_component h_table_spec h_provider_row
   exact ZiskFv.EquivCore.Sllw.equiv_SLLW_of_static_row state sllw_input r1 r2 rd
-    m row r_main bus
+    m p.rowInput r_main bus
     promises
-    pins h_match h_shift_facts.1 h_shift_facts.2
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_shift_pin_row)
-    h_lane_rd
+    pins h_match p.facts.1 p.facts.2
+    h_input_r1_row h_shift_pin_row h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (alt route, op_bus_perm_sound) deleted in T4-purge P3.2.
 

--- a/ZiskFv/Compliance/Wrappers/ShiftLI.lean
+++ b/ZiskFv/Compliance/Wrappers/ShiftLI.lean
@@ -29,8 +29,7 @@ lemma equiv_SLLIW
     (slliw_input : PureSpec.SlliwInput)
     (r1 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.ShiftWImmPromises
@@ -38,39 +37,21 @@ lemma equiv_SLLIW
         (PureSpec.execute_SHIFTIWOP_slliw_pure slliw_input).nextPC
         r1 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 ZiskFv.Trusted.OP_SLL_W)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row :
       (Sail.BitVec.extractLsb slliw_input.r1_val 31 0 : BitVec (31 - 0 + 1)).toNat =
-        ZiskFv.AirsClean.BinaryExtension.rowA32
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow)))
+        ZiskFv.AirsClean.BinaryExtension.rowA32 p.rowInput)
     (h_shift_pin_row : slliw_input.shamt.toNat =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2) :
     execute_instruction
       (instruction.SHIFTIWOP (slliw_input.shamt, r1, rd, sopw.SLLIW)) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  have h_shift_facts :=
-    ZiskFv.AirsClean.BinaryFamily.shiftStaticBinaryExtension_wf_and_b0_range_of_table_spec
-      h_component h_table_spec h_provider_row
   exact ZiskFv.EquivCore.Slliw.equiv_SLLIW_of_static_row state slliw_input r1 rd
-    m row r_main bus promises pins h_match h_shift_facts.1 h_shift_facts.2
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_shift_pin_row)
-    h_lane_rd
+    m p.rowInput r_main bus promises pins h_match p.facts.1 p.facts.2
+    h_input_r1_row h_shift_pin_row h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (alt route, op_bus_perm_sound) deleted in T4-purge P3.2.
 

--- a/ZiskFv/Compliance/Wrappers/ShiftR.lean
+++ b/ZiskFv/Compliance/Wrappers/ShiftR.lean
@@ -28,8 +28,7 @@ lemma equiv_SRLW
     (srlw_input : PureSpec.SrlwInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
@@ -37,40 +36,22 @@ lemma equiv_SRLW
         (PureSpec.execute_RTYPE_srlw_pure srlw_input).nextPC
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 ZiskFv.Trusted.OP_SRL_W)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row :
       (Sail.BitVec.extractLsb srlw_input.r1_val 31 0 : BitVec (31 - 0 + 1)).toNat =
-        ZiskFv.AirsClean.BinaryExtension.rowA32
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow)))
+        ZiskFv.AirsClean.BinaryExtension.rowA32 p.rowInput)
     (h_shift_pin_row : srlw_input.r2_val.toNat % 32 =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2) :
     execute_instruction (instruction.RTYPEW (r2, r1, rd, ropw.SRLW)) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  have h_shift_facts :=
-    ZiskFv.AirsClean.BinaryFamily.shiftStaticBinaryExtension_wf_and_b0_range_of_table_spec
-      h_component h_table_spec h_provider_row
   exact ZiskFv.EquivCore.Srlw.equiv_SRLW_of_static_row state srlw_input r1 r2 rd
-    m row r_main bus
+    m p.rowInput r_main bus
     promises
-    pins h_match h_shift_facts.1 h_shift_facts.2
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_shift_pin_row)
-    h_lane_rd
+    pins h_match p.facts.1 p.facts.2
+    h_input_r1_row h_shift_pin_row h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (alt route, op_bus_perm_sound) deleted in T4-purge P3.2.
 

--- a/ZiskFv/Compliance/Wrappers/ShiftRA.lean
+++ b/ZiskFv/Compliance/Wrappers/ShiftRA.lean
@@ -28,8 +28,7 @@ lemma equiv_SRAW
     (sraw_input : PureSpec.SrawInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
@@ -37,40 +36,22 @@ lemma equiv_SRAW
         (PureSpec.execute_RTYPE_sraw_pure sraw_input).nextPC
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 ZiskFv.Trusted.OP_SRA_W)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row :
       (Sail.BitVec.extractLsb sraw_input.r1_val 31 0 : BitVec (31 - 0 + 1)).toNat =
-        ZiskFv.AirsClean.BinaryExtension.rowA32
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow)))
+        ZiskFv.AirsClean.BinaryExtension.rowA32 p.rowInput)
     (h_shift_pin_row : sraw_input.r2_val.toNat % 32 =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2) :
     execute_instruction (instruction.RTYPEW (r2, r1, rd, ropw.SRAW)) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  have h_shift_facts :=
-    ZiskFv.AirsClean.BinaryFamily.shiftStaticBinaryExtension_wf_and_b0_range_of_table_spec
-      h_component h_table_spec h_provider_row
   exact ZiskFv.EquivCore.Sraw.equiv_SRAW_of_static_row state sraw_input r1 r2 rd
-    m row r_main bus
+    m p.rowInput r_main bus
     promises
-    pins h_match h_shift_facts.1 h_shift_facts.2
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_shift_pin_row)
-    h_lane_rd
+    pins h_match p.facts.1 p.facts.2
+    h_input_r1_row h_shift_pin_row h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (alt route, op_bus_perm_sound) deleted in T4-purge P3.2.
 

--- a/ZiskFv/Compliance/Wrappers/ShiftRAI.lean
+++ b/ZiskFv/Compliance/Wrappers/ShiftRAI.lean
@@ -29,8 +29,7 @@ lemma equiv_SRAIW
     (sraiw_input : PureSpec.SraiwInput)
     (r1 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.ShiftWImmPromises
@@ -38,39 +37,21 @@ lemma equiv_SRAIW
         (PureSpec.execute_SHIFTIWOP_sraiw_pure sraiw_input).nextPC
         r1 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 ZiskFv.Trusted.OP_SRA_W)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row :
       (Sail.BitVec.extractLsb sraiw_input.r1_val 31 0 : BitVec (31 - 0 + 1)).toNat =
-        ZiskFv.AirsClean.BinaryExtension.rowA32
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow)))
+        ZiskFv.AirsClean.BinaryExtension.rowA32 p.rowInput)
     (h_shift_pin_row : sraiw_input.shamt.toNat =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2) :
     execute_instruction
       (instruction.SHIFTIWOP (sraiw_input.shamt, r1, rd, sopw.SRAIW)) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  have h_shift_facts :=
-    ZiskFv.AirsClean.BinaryFamily.shiftStaticBinaryExtension_wf_and_b0_range_of_table_spec
-      h_component h_table_spec h_provider_row
   exact ZiskFv.EquivCore.Sraiw.equiv_SRAIW_of_static_row state sraiw_input r1 rd
-    m row r_main bus promises pins h_match h_shift_facts.1 h_shift_facts.2
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_shift_pin_row)
-    h_lane_rd
+    m p.rowInput r_main bus promises pins h_match p.facts.1 p.facts.2
+    h_input_r1_row h_shift_pin_row h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (alt route, op_bus_perm_sound) deleted in T4-purge P3.2.
 

--- a/ZiskFv/Compliance/Wrappers/ShiftRLI.lean
+++ b/ZiskFv/Compliance/Wrappers/ShiftRLI.lean
@@ -29,8 +29,7 @@ lemma equiv_SRLIW
     (srliw_input : PureSpec.SrliwInput)
     (r1 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.ShiftWImmPromises
@@ -38,39 +37,21 @@ lemma equiv_SRLIW
         (PureSpec.execute_SHIFTIWOP_srliw_pure srliw_input).nextPC
         r1 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 ZiskFv.Trusted.OP_SRL_W)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row :
       (Sail.BitVec.extractLsb srliw_input.r1_val 31 0 : BitVec (31 - 0 + 1)).toNat =
-        ZiskFv.AirsClean.BinaryExtension.rowA32
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow)))
+        ZiskFv.AirsClean.BinaryExtension.rowA32 p.rowInput)
     (h_shift_pin_row : srliw_input.shamt.toNat =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2) :
     execute_instruction
       (instruction.SHIFTIWOP (srliw_input.shamt, r1, rd, sopw.SRLIW)) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  have h_shift_facts :=
-    ZiskFv.AirsClean.BinaryFamily.shiftStaticBinaryExtension_wf_and_b0_range_of_table_spec
-      h_component h_table_spec h_provider_row
   exact ZiskFv.EquivCore.Srliw.equiv_SRLIW_of_static_row state srliw_input r1 rd
-    m row r_main bus promises pins h_match h_shift_facts.1 h_shift_facts.2
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_shift_pin_row)
-    h_lane_rd
+    m p.rowInput r_main bus promises pins h_match p.facts.1 p.facts.2
+    h_input_r1_row h_shift_pin_row h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (alt route, op_bus_perm_sound) deleted in T4-purge P3.2.
 

--- a/ZiskFv/Compliance/Wrappers/Sll.lean
+++ b/ZiskFv/Compliance/Wrappers/Sll.lean
@@ -81,8 +81,7 @@ lemma equiv_SLL
     -- AIR validators + row index. Compliance.lean shares (m, v)
     -- across all BinaryExtension-shape opcodes (twelve shifts).
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     -- Structural promise bundle (15 fields). Subsumes the prior inline
@@ -94,39 +93,21 @@ lemma equiv_SLL
     -- Activation / opcode pins. Compliance.lean derives these from
     -- the Main AIR's ROM handshake on the row hosting SLL.
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 ZiskFv.Trusted.OP_SLL)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row : sll_input.r1_val =
-      ZiskFv.AirsClean.BinaryExtension.rowA64
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowA64 p.rowInput)
     (h_shift_pin_row : sll_input.r2_val.toNat % 64 =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount p.rowInput)
     -- Lane-match for the rd-write entry — caller-supplied; discharged
     -- downstream from `memory_bus_register_write_perm_sound`.
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2) :
     execute_instruction (instruction.RTYPE (r2, r1, rd, rop.SLL)) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  have h_shift_facts :=
-    ZiskFv.AirsClean.BinaryFamily.shiftStaticBinaryExtension_wf_and_b0_range_of_table_spec
-      h_component h_table_spec h_provider_row
   exact ZiskFv.EquivCore.Sll.equiv_SLL_of_static_row state sll_input r1 r2 rd
-    m row r_main bus promises pins h_match h_shift_facts.1
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_shift_pin_row)
-    h_shift_facts.2 h_lane_rd
+    m p.rowInput r_main bus promises pins h_match p.facts.1
+    h_input_r1_row h_shift_pin_row p.facts.2 h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (alt route, op_bus_perm_sound) deleted in T4-purge P3.2.
 

--- a/ZiskFv/Compliance/Wrappers/Slli.lean
+++ b/ZiskFv/Compliance/Wrappers/Slli.lean
@@ -36,8 +36,7 @@ lemma equiv_SLLI
     (slli_input : PureSpec.SlliInput)
     (r1 rd : regidx) (shamt : BitVec 6)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.ShiftImmPromises
@@ -45,37 +44,19 @@ lemma equiv_SLLI
         (PureSpec.execute_SHIFTIOP_slli_pure slli_input).nextPC
         r1 rd shamt bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 ZiskFv.Trusted.OP_SLL)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row : slli_input.r1_val =
-      ZiskFv.AirsClean.BinaryExtension.rowA64
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowA64 p.rowInput)
     (h_shift_pin_row : slli_input.shamt.toNat =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2) :
     execute_instruction (instruction.SHIFTIOP (shamt, r1, rd, sop.SLLI)) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  have h_shift_facts :=
-    ZiskFv.AirsClean.BinaryFamily.shiftStaticBinaryExtension_wf_and_b0_range_of_table_spec
-      h_component h_table_spec h_provider_row
   exact ZiskFv.EquivCore.Slli.equiv_SLLI_of_static_row state slli_input r1 rd shamt
-    m row r_main bus promises pins h_match h_shift_facts.1 h_shift_facts.2
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_shift_pin_row)
-    h_lane_rd
+    m p.rowInput r_main bus promises pins h_match p.facts.1 p.facts.2
+    h_input_r1_row h_shift_pin_row h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (alt route, op_bus_perm_sound) deleted in T4-purge P3.2.
 

--- a/ZiskFv/Compliance/Wrappers/Slt.lean
+++ b/ZiskFv/Compliance/Wrappers/Slt.lean
@@ -32,28 +32,17 @@ lemma equiv_SLT
     (slt_input : PureSpec.SltInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_LT)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_input_r1_row : slt_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_input_r2_row : slt_input.r2_val =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowB64 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
         state slt_input.r1_val slt_input.r2_val slt_input.rd slt_input.PC
@@ -65,36 +54,27 @@ lemma equiv_SLT
       LeanRV64D.Functions.execute
         (instruction.RTYPE (r2, r1, rd, rop.SLT))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_spec_facts :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_spec_facts_of_table_spec
-      h_component h_table_spec h_provider_row
+  obtain ⟨h_row_spec, h_core, h_spec_facts, h_facts⟩ := p.facts
   obtain ⟨h_main_active, h_main_op_slt⟩ := pins
-  have h_emit : row.chain.b_op + 16 * row.mode.mode32 =
+  have h_emit : p.rowInput.chain.b_op + 16 * p.rowInput.mode.mode32 =
       (ZiskFv.Airs.Tables.BinaryTable.OP_LT : FGL) := by
     have h_match_op := h_match
     simp only [matches_entry, opBus_row_Main] at h_match_op
     have h_op_match :
-        m.op r_main = row.chain.b_op + 16 * row.mode.mode32 := h_match_op.2.1
+        m.op r_main = p.rowInput.chain.b_op + 16 * p.rowInput.mode.mode32 :=
+      h_match_op.2.1
     rw [← h_op_match]
     simpa [ZiskFv.Airs.Tables.BinaryTable.OP_LT, ZiskFv.Trusted.OP_LT] using
       h_main_op_slt
   obtain ⟨h_row_m32, h_bop, _⟩ :=
     ZiskFv.EquivCore.Bridge.Binary.logic_row_mode_pins_of_emit_op_lt_16_of_static_spec
-      row h_spec_facts ZiskFv.Airs.Tables.BinaryTable.OP_LT (by
+      p.rowInput h_spec_facts ZiskFv.Airs.Tables.BinaryTable.OP_LT (by
         simp [ZiskFv.Airs.Tables.BinaryTable.OP_LT])
       h_core h_emit
   exact ZiskFv.EquivCore.Slt.equiv_SLT_of_static_row
-    state slt_input r1 r2 rd m row r_main bus promises
+    state slt_input r1 r2 rd m p.rowInput r_main bus promises
     ⟨h_main_active, h_main_op_slt⟩
     h_match h_core h_facts h_row_m32 h_bop
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_r2_row)
-    h_lane_rd
+    h_input_r1_row h_input_r2_row h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/Wrappers/Slti.lean
+++ b/ZiskFv/Compliance/Wrappers/Slti.lean
@@ -35,25 +35,16 @@ lemma equiv_SLTI
     (slti_input : PureSpec.SltiInput)
     (r1 rd : regidx) (imm : BitVec 12)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_LT)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_main_m32 : m.m32 r_main = 0)
     (h_input_r1_row : slti_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_slti_subset : itype_imm_subset_holds_main m r_main slti_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.ITypePromises
@@ -66,31 +57,24 @@ lemma equiv_SLTI
       LeanRV64D.Functions.execute
         (instruction.ITYPE (imm, r1, rd, iop.SLTI))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_spec_facts :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_spec_facts_of_table_spec
-      h_component h_table_spec h_provider_row
+  obtain ⟨_, h_core, h_spec_facts, h_facts⟩ := p.facts
   obtain ⟨h_main_active, h_main_op_slti⟩ := pins
-  have h_emit : row.chain.b_op + 16 * row.mode.mode32 =
+  have h_emit : p.rowInput.chain.b_op + 16 * p.rowInput.mode.mode32 =
       (ZiskFv.Airs.Tables.BinaryTable.OP_LT : FGL) := by
     have h_match_op := h_match
     simp only [matches_entry, opBus_row_Main] at h_match_op
     have h_op_match :
-        m.op r_main = row.chain.b_op + 16 * row.mode.mode32 := h_match_op.2.1
+        m.op r_main = p.rowInput.chain.b_op + 16 * p.rowInput.mode.mode32 :=
+      h_match_op.2.1
     rw [← h_op_match]
     simpa [ZiskFv.Airs.Tables.BinaryTable.OP_LT, ZiskFv.Trusted.OP_LT] using
       h_main_op_slti
   obtain ⟨h_row_m32, h_bop, _⟩ :=
     ZiskFv.EquivCore.Bridge.Binary.logic_row_mode_pins_of_emit_op_lt_16_of_static_spec
-      row h_spec_facts ZiskFv.Airs.Tables.BinaryTable.OP_LT (by
+      p.rowInput h_spec_facts ZiskFv.Airs.Tables.BinaryTable.OP_LT (by
         simp [ZiskFv.Airs.Tables.BinaryTable.OP_LT])
       h_core h_emit
-  let v := ZiskFv.AirsClean.Binary.validOfRow row
+  let v := ZiskFv.AirsClean.Binary.validOfRow p.rowInput
   have h_match_v : matches_entry (opBus_row_Main m r_main) (opBus_row_Binary v 0) := by
     simpa [v, ZiskFv.AirsClean.Binary.validOfRow,
       ZiskFv.AirsClean.Binary.opBusMessage,
@@ -100,7 +84,7 @@ lemma equiv_SLTI
     simpa [v, ZiskFv.AirsClean.Binary.validOfRow] using h_row_m32
   have h_bop_v : (v.b_op 0).val = ZiskFv.Airs.Tables.BinaryTable.OP_LT := by
     simpa [v, ZiskFv.AirsClean.Binary.validOfRow] using h_bop
-  have h_bop_or_sext : row.chain.b_op_or_sext.val =
+  have h_bop_or_sext : p.rowInput.chain.b_op_or_sext.val =
       ZiskFv.Airs.Tables.BinaryTable.OP_LT := by
     have h :=
       ZiskFv.EquivCore.Bridge.Binary.b_op_or_sext_val_eq_of_mode32_zero
@@ -108,25 +92,26 @@ lemma equiv_SLTI
     simpa [v, ZiskFv.AirsClean.Binary.validOfRow] using h
   have h_matches :=
     ZiskFv.EquivCore.Bridge.Binary.byte_chain_discharge_logic_of_static_row
-      row h_facts ZiskFv.Airs.Tables.BinaryTable.OP_LT h_bop h_bop_or_sext
+      p.rowInput h_facts ZiskFv.Airs.Tables.BinaryTable.OP_LT h_bop h_bop_or_sext
   have h_input_imm_v :=
     ZiskFv.EquivCore.Bridge.Binary.itype_imm_subset_binary_row_of_main_row
-      m row r_main slti_input.imm h_matches h_main_m32 h_match h_slti_subset
+      m p.rowInput r_main slti_input.imm h_matches h_main_m32 h_match h_slti_subset
   have h_input_imm_row : BitVec.signExtend 64 slti_input.imm
       = BitVec.ofNat 64
-          ((row.bBytes.free_in_b_0).val + (row.bBytes.free_in_b_1).val * 256
-            + (row.bBytes.free_in_b_2).val * 65536
-            + (row.bBytes.free_in_b_3).val * 16777216
-            + (row.bBytes.free_in_b_4).val * 4294967296
-            + (row.bBytes.free_in_b_5).val * 1099511627776
-            + (row.bBytes.free_in_b_6).val * 281474976710656
-            + (row.bBytes.free_in_b_7).val * 72057594037927936) := by
+          ((p.rowInput.bBytes.free_in_b_0).val
+            + (p.rowInput.bBytes.free_in_b_1).val * 256
+            + (p.rowInput.bBytes.free_in_b_2).val * 65536
+            + (p.rowInput.bBytes.free_in_b_3).val * 16777216
+            + (p.rowInput.bBytes.free_in_b_4).val * 4294967296
+            + (p.rowInput.bBytes.free_in_b_5).val * 1099511627776
+            + (p.rowInput.bBytes.free_in_b_6).val * 281474976710656
+            + (p.rowInput.bBytes.free_in_b_7).val * 72057594037927936) := by
     exact h_input_imm_v
   exact ZiskFv.EquivCore.Slti.equiv_SLTI_of_static_row
-    state slti_input r1 rd imm m row r_main bus promises
+    state slti_input r1 rd imm m p.rowInput r_main bus promises
     ⟨h_main_active, h_main_op_slti⟩
     h_match h_core h_facts h_row_m32 h_bop
-    (by simpa [row] using h_input_r1_row)
+    h_input_r1_row
     h_lane_rd h_input_imm_row
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/Wrappers/Sltiu.lean
+++ b/ZiskFv/Compliance/Wrappers/Sltiu.lean
@@ -35,25 +35,16 @@ lemma equiv_SLTIU
     (sltiu_input : PureSpec.SltiuInput)
     (r1 rd : regidx) (imm : BitVec 12)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_LTU)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_main_m32 : m.m32 r_main = 0)
     (h_input_r1_row : sltiu_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_sltiu_subset : itype_imm_subset_holds_main m r_main sltiu_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.ITypePromises
@@ -66,31 +57,24 @@ lemma equiv_SLTIU
       LeanRV64D.Functions.execute
         (instruction.ITYPE (imm, r1, rd, iop.SLTIU))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_spec_facts :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_spec_facts_of_table_spec
-      h_component h_table_spec h_provider_row
+  obtain ⟨_, h_core, h_spec_facts, h_facts⟩ := p.facts
   obtain ⟨h_main_active, h_main_op_sltiu⟩ := pins
-  have h_emit : row.chain.b_op + 16 * row.mode.mode32 =
+  have h_emit : p.rowInput.chain.b_op + 16 * p.rowInput.mode.mode32 =
       (ZiskFv.Airs.Tables.BinaryTable.OP_LTU : FGL) := by
     have h_match_op := h_match
     simp only [matches_entry, opBus_row_Main] at h_match_op
     have h_op_match :
-        m.op r_main = row.chain.b_op + 16 * row.mode.mode32 := h_match_op.2.1
+        m.op r_main = p.rowInput.chain.b_op + 16 * p.rowInput.mode.mode32 :=
+      h_match_op.2.1
     rw [← h_op_match]
     simpa [ZiskFv.Airs.Tables.BinaryTable.OP_LTU, ZiskFv.Trusted.OP_LTU] using
       h_main_op_sltiu
   obtain ⟨h_row_m32, h_bop, _⟩ :=
     ZiskFv.EquivCore.Bridge.Binary.logic_row_mode_pins_of_emit_op_lt_16_of_static_spec
-      row h_spec_facts ZiskFv.Airs.Tables.BinaryTable.OP_LTU (by
+      p.rowInput h_spec_facts ZiskFv.Airs.Tables.BinaryTable.OP_LTU (by
         simp [ZiskFv.Airs.Tables.BinaryTable.OP_LTU])
       h_core h_emit
-  let v := ZiskFv.AirsClean.Binary.validOfRow row
+  let v := ZiskFv.AirsClean.Binary.validOfRow p.rowInput
   have h_match_v : matches_entry (opBus_row_Main m r_main) (opBus_row_Binary v 0) := by
     simpa [v, ZiskFv.AirsClean.Binary.validOfRow,
       ZiskFv.AirsClean.Binary.opBusMessage,
@@ -100,7 +84,7 @@ lemma equiv_SLTIU
     simpa [v, ZiskFv.AirsClean.Binary.validOfRow] using h_row_m32
   have h_bop_v : (v.b_op 0).val = ZiskFv.Airs.Tables.BinaryTable.OP_LTU := by
     simpa [v, ZiskFv.AirsClean.Binary.validOfRow] using h_bop
-  have h_bop_or_sext : row.chain.b_op_or_sext.val =
+  have h_bop_or_sext : p.rowInput.chain.b_op_or_sext.val =
       ZiskFv.Airs.Tables.BinaryTable.OP_LTU := by
     have h :=
       ZiskFv.EquivCore.Bridge.Binary.b_op_or_sext_val_eq_of_mode32_zero
@@ -108,25 +92,26 @@ lemma equiv_SLTIU
     simpa [v, ZiskFv.AirsClean.Binary.validOfRow] using h
   have h_matches :=
     ZiskFv.EquivCore.Bridge.Binary.byte_chain_discharge_logic_of_static_row
-      row h_facts ZiskFv.Airs.Tables.BinaryTable.OP_LTU h_bop h_bop_or_sext
+      p.rowInput h_facts ZiskFv.Airs.Tables.BinaryTable.OP_LTU h_bop h_bop_or_sext
   have h_input_imm_v :=
     ZiskFv.EquivCore.Bridge.Binary.itype_imm_subset_binary_row_of_main_row
-      m row r_main sltiu_input.imm h_matches h_main_m32 h_match h_sltiu_subset
+      m p.rowInput r_main sltiu_input.imm h_matches h_main_m32 h_match h_sltiu_subset
   have h_input_imm_row : BitVec.signExtend 64 sltiu_input.imm
       = BitVec.ofNat 64
-          ((row.bBytes.free_in_b_0).val + (row.bBytes.free_in_b_1).val * 256
-            + (row.bBytes.free_in_b_2).val * 65536
-            + (row.bBytes.free_in_b_3).val * 16777216
-            + (row.bBytes.free_in_b_4).val * 4294967296
-            + (row.bBytes.free_in_b_5).val * 1099511627776
-            + (row.bBytes.free_in_b_6).val * 281474976710656
-            + (row.bBytes.free_in_b_7).val * 72057594037927936) := by
+          ((p.rowInput.bBytes.free_in_b_0).val
+            + (p.rowInput.bBytes.free_in_b_1).val * 256
+            + (p.rowInput.bBytes.free_in_b_2).val * 65536
+            + (p.rowInput.bBytes.free_in_b_3).val * 16777216
+            + (p.rowInput.bBytes.free_in_b_4).val * 4294967296
+            + (p.rowInput.bBytes.free_in_b_5).val * 1099511627776
+            + (p.rowInput.bBytes.free_in_b_6).val * 281474976710656
+            + (p.rowInput.bBytes.free_in_b_7).val * 72057594037927936) := by
     exact h_input_imm_v
   exact ZiskFv.EquivCore.Sltiu.equiv_SLTIU_of_static_row
-    state sltiu_input r1 rd imm m row r_main bus promises
+    state sltiu_input r1 rd imm m p.rowInput r_main bus promises
     ⟨h_main_active, h_main_op_sltiu⟩
     h_match h_core h_facts h_row_m32 h_bop
-    (by simpa [row] using h_input_r1_row)
+    h_input_r1_row
     h_lane_rd h_input_imm_row
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/Wrappers/Sltu.lean
+++ b/ZiskFv/Compliance/Wrappers/Sltu.lean
@@ -32,28 +32,17 @@ lemma equiv_SLTU
     (sltu_input : PureSpec.SltuInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_LTU)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_input_r1_row : sltu_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_input_r2_row : sltu_input.r2_val =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowB64 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
         state sltu_input.r1_val sltu_input.r2_val sltu_input.rd sltu_input.PC
@@ -65,36 +54,27 @@ lemma equiv_SLTU
       LeanRV64D.Functions.execute
         (instruction.RTYPE (r2, r1, rd, rop.SLTU))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_spec_facts :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_spec_facts_of_table_spec
-      h_component h_table_spec h_provider_row
+  obtain ⟨h_row_spec, h_core, h_spec_facts, h_facts⟩ := p.facts
   obtain ⟨h_main_active, h_main_op_sltu⟩ := pins
-  have h_emit : row.chain.b_op + 16 * row.mode.mode32 =
+  have h_emit : p.rowInput.chain.b_op + 16 * p.rowInput.mode.mode32 =
       (ZiskFv.Airs.Tables.BinaryTable.OP_LTU : FGL) := by
     have h_match_op := h_match
     simp only [matches_entry, opBus_row_Main] at h_match_op
     have h_op_match :
-        m.op r_main = row.chain.b_op + 16 * row.mode.mode32 := h_match_op.2.1
+        m.op r_main = p.rowInput.chain.b_op + 16 * p.rowInput.mode.mode32 :=
+      h_match_op.2.1
     rw [← h_op_match]
     simpa [ZiskFv.Airs.Tables.BinaryTable.OP_LTU, ZiskFv.Trusted.OP_LTU] using
       h_main_op_sltu
   obtain ⟨h_row_m32, h_bop, _⟩ :=
     ZiskFv.EquivCore.Bridge.Binary.logic_row_mode_pins_of_emit_op_lt_16_of_static_spec
-      row h_spec_facts ZiskFv.Airs.Tables.BinaryTable.OP_LTU (by
+      p.rowInput h_spec_facts ZiskFv.Airs.Tables.BinaryTable.OP_LTU (by
         simp [ZiskFv.Airs.Tables.BinaryTable.OP_LTU])
       h_core h_emit
   exact ZiskFv.EquivCore.Sltu.equiv_SLTU_of_static_row
-    state sltu_input r1 r2 rd m row r_main bus promises
+    state sltu_input r1 r2 rd m p.rowInput r_main bus promises
     ⟨h_main_active, h_main_op_sltu⟩
     h_match h_core h_facts h_row_m32 h_bop
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_r2_row)
-    h_lane_rd
+    h_input_r1_row h_input_r2_row h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/Wrappers/Sra.lean
+++ b/ZiskFv/Compliance/Wrappers/Sra.lean
@@ -33,8 +33,7 @@ lemma equiv_SRA
     (sra_input : PureSpec.SraInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
@@ -42,37 +41,19 @@ lemma equiv_SRA
         (PureSpec.execute_RTYPE_sra_pure sra_input).nextPC
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 ZiskFv.Trusted.OP_SRA)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row : sra_input.r1_val =
-      ZiskFv.AirsClean.BinaryExtension.rowA64
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowA64 p.rowInput)
     (h_shift_pin_row : sra_input.r2_val.toNat % 64 =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2) :
     execute_instruction (instruction.RTYPE (r2, r1, rd, rop.SRA)) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  have h_shift_facts :=
-    ZiskFv.AirsClean.BinaryFamily.shiftStaticBinaryExtension_wf_and_b0_range_of_table_spec
-      h_component h_table_spec h_provider_row
   exact ZiskFv.EquivCore.Sra.equiv_SRA_of_static_row state sra_input r1 r2 rd
-    m row r_main bus promises pins h_match h_shift_facts.1
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_shift_pin_row)
-    h_shift_facts.2 h_lane_rd
+    m p.rowInput r_main bus promises pins h_match p.facts.1
+    h_input_r1_row h_shift_pin_row p.facts.2 h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (alt route, op_bus_perm_sound) deleted in T4-purge P3.2.
 

--- a/ZiskFv/Compliance/Wrappers/Srai.lean
+++ b/ZiskFv/Compliance/Wrappers/Srai.lean
@@ -29,8 +29,7 @@ lemma equiv_SRAI
     (srai_input : PureSpec.SraiInput)
     (r1 rd : regidx) (shamt : BitVec 6)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.ShiftImmPromises
@@ -38,37 +37,19 @@ lemma equiv_SRAI
         (PureSpec.execute_SHIFTIOP_srai_pure srai_input).nextPC
         r1 rd shamt bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 ZiskFv.Trusted.OP_SRA)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row : srai_input.r1_val =
-      ZiskFv.AirsClean.BinaryExtension.rowA64
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowA64 p.rowInput)
     (h_shift_pin_row : srai_input.shamt.toNat =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2) :
     execute_instruction (instruction.SHIFTIOP (shamt, r1, rd, sop.SRAI)) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  have h_shift_facts :=
-    ZiskFv.AirsClean.BinaryFamily.shiftStaticBinaryExtension_wf_and_b0_range_of_table_spec
-      h_component h_table_spec h_provider_row
   exact ZiskFv.EquivCore.Srai.equiv_SRAI_of_static_row state srai_input r1 rd shamt
-    m row r_main bus promises pins h_match h_shift_facts.1 h_shift_facts.2
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_shift_pin_row)
-    h_lane_rd
+    m p.rowInput r_main bus promises pins h_match p.facts.1 p.facts.2
+    h_input_r1_row h_shift_pin_row h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (alt route, op_bus_perm_sound) deleted in T4-purge P3.2.
 

--- a/ZiskFv/Compliance/Wrappers/Srl.lean
+++ b/ZiskFv/Compliance/Wrappers/Srl.lean
@@ -33,8 +33,7 @@ lemma equiv_SRL
     (srl_input : PureSpec.SrlInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
@@ -42,37 +41,19 @@ lemma equiv_SRL
         (PureSpec.execute_RTYPE_srl_pure srl_input).nextPC
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 ZiskFv.Trusted.OP_SRL)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-          (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+          (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row : srl_input.r1_val =
-      ZiskFv.AirsClean.BinaryExtension.rowA64
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowA64 p.rowInput)
     (h_shift_pin_row : srl_input.r2_val.toNat % 64 =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2) :
     execute_instruction (instruction.RTYPE (r2, r1, rd, rop.SRL)) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  have h_shift_facts :=
-    ZiskFv.AirsClean.BinaryFamily.shiftStaticBinaryExtension_wf_and_b0_range_of_table_spec
-      h_component h_table_spec h_provider_row
   exact ZiskFv.EquivCore.Srl.equiv_SRL_of_static_row state srl_input r1 r2 rd
-    m row r_main bus promises pins h_match h_shift_facts.1
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_shift_pin_row)
-    h_shift_facts.2 h_lane_rd
+    m p.rowInput r_main bus promises pins h_match p.facts.1
+    h_input_r1_row h_shift_pin_row p.facts.2 h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (alt route, op_bus_perm_sound) deleted in T4-purge P3.2.
 

--- a/ZiskFv/Compliance/Wrappers/Srli.lean
+++ b/ZiskFv/Compliance/Wrappers/Srli.lean
@@ -29,8 +29,7 @@ lemma equiv_SRLI
     (srli_input : PureSpec.SrliInput)
     (r1 rd : regidx) (shamt : BitVec 6)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.ShiftImmPromises
@@ -38,37 +37,19 @@ lemma equiv_SRLI
         (PureSpec.execute_SHIFTIOP_srli_pure srli_input).nextPC
         r1 rd shamt bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 ZiskFv.Trusted.OP_SRL)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row : srli_input.r1_val =
-      ZiskFv.AirsClean.BinaryExtension.rowA64
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowA64 p.rowInput)
     (h_shift_pin_row : srli_input.shamt.toNat =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2) :
     execute_instruction (instruction.SHIFTIOP (shamt, r1, rd, sop.SRLI)) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  have h_shift_facts :=
-    ZiskFv.AirsClean.BinaryFamily.shiftStaticBinaryExtension_wf_and_b0_range_of_table_spec
-      h_component h_table_spec h_provider_row
   exact ZiskFv.EquivCore.Srli.equiv_SRLI_of_static_row state srli_input r1 rd shamt
-    m row r_main bus promises pins h_match h_shift_facts.1 h_shift_facts.2
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_shift_pin_row)
-    h_lane_rd
+    m p.rowInput r_main bus promises pins h_match p.facts.1 p.facts.2
+    h_input_r1_row h_shift_pin_row h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (alt route, op_bus_perm_sound) deleted in T4-purge P3.2.
 

--- a/ZiskFv/Compliance/Wrappers/Sub.lean
+++ b/ZiskFv/Compliance/Wrappers/Sub.lean
@@ -32,28 +32,17 @@ lemma equiv_SUB
     (sub_input : PureSpec.SubInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_SUB)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
       (h_match : matches_entry (opBus_row_Main m r_main)
         (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-          (ZiskFv.AirsClean.Binary.opBusMessage
-            (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-              (providerTable.environment providerRow))) 1))
+          (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
       (h_input_r1_row : sub_input.r1_val =
-        ZiskFv.EquivCore.Add.binaryRowA64
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow)))
+        ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
       (h_input_r2_row : sub_input.r2_val =
-        ZiskFv.EquivCore.Add.binaryRowB64
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow)))
+        ZiskFv.EquivCore.Add.binaryRowB64 p.rowInput)
       (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
         state sub_input.r1_val sub_input.r2_val sub_input.rd sub_input.PC
@@ -65,36 +54,27 @@ lemma equiv_SUB
       LeanRV64D.Functions.execute
         (instruction.RTYPE (r2, r1, rd, rop.SUB))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_spec_facts :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_spec_facts_of_table_spec
-      h_component h_table_spec h_provider_row
+  obtain ⟨h_row_spec, h_core, h_spec_facts, h_facts⟩ := p.facts
   obtain ⟨h_main_active, h_main_op_sub⟩ := pins
-  have h_emit : row.chain.b_op + 16 * row.mode.mode32 =
+  have h_emit : p.rowInput.chain.b_op + 16 * p.rowInput.mode.mode32 =
       (ZiskFv.Airs.Tables.BinaryTable.OP_SUB : FGL) := by
     have h_match_op := h_match
     simp only [matches_entry, opBus_row_Main] at h_match_op
     have h_op_match :
-        m.op r_main = row.chain.b_op + 16 * row.mode.mode32 := h_match_op.2.1
+        m.op r_main = p.rowInput.chain.b_op + 16 * p.rowInput.mode.mode32 :=
+      h_match_op.2.1
     rw [← h_op_match]
     simpa [ZiskFv.Airs.Tables.BinaryTable.OP_SUB, ZiskFv.Trusted.OP_SUB] using
       h_main_op_sub
   obtain ⟨h_row_m32, h_bop, _⟩ :=
     ZiskFv.EquivCore.Bridge.Binary.logic_row_mode_pins_of_emit_op_lt_16_of_static_spec
-      row h_spec_facts ZiskFv.Airs.Tables.BinaryTable.OP_SUB (by
+      p.rowInput h_spec_facts ZiskFv.Airs.Tables.BinaryTable.OP_SUB (by
         simp [ZiskFv.Airs.Tables.BinaryTable.OP_SUB])
       h_core h_emit
   exact ZiskFv.EquivCore.Sub.equiv_SUB_of_static_row
-    state sub_input r1 r2 rd m row r_main bus promises
+    state sub_input r1 r2 rd m p.rowInput r_main bus promises
     ⟨h_main_active, h_main_op_sub⟩
     h_match h_core h_facts h_row_m32 h_bop
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_r2_row)
-    h_lane_rd
+    h_input_r1_row h_input_r2_row h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/Wrappers/Subw.lean
+++ b/ZiskFv/Compliance/Wrappers/Subw.lean
@@ -39,31 +39,20 @@ lemma equiv_SUBW
     (subw_input : PureSpec.SubwInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_SUB_W)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
       (h_match : matches_entry
         (opBus_row_Main m r_main)
         (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-          (ZiskFv.AirsClean.Binary.opBusMessage
-            (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-              (providerTable.environment providerRow))) 1))
+          (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
       (h_input_r1_extract :
         (Sail.BitVec.extractLsb subw_input.r1_val 31 0 : BitVec (31 - 0 + 1)).toNat
-          = ZiskFv.EquivCore.Addw.binaryRowA32
-            (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-              (providerTable.environment providerRow)) % 2^32)
+          = ZiskFv.EquivCore.Addw.binaryRowA32 p.rowInput % 2^32)
       (h_input_r2_extract :
         (Sail.BitVec.extractLsb subw_input.r2_val 31 0 : BitVec (31 - 0 + 1)).toNat
-          = ZiskFv.EquivCore.Addw.binaryRowB32
-            (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-              (providerTable.environment providerRow)) % 2^32)
+          = ZiskFv.EquivCore.Addw.binaryRowB32 p.rowInput % 2^32)
       (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
         state subw_input.r1_val subw_input.r2_val subw_input.rd subw_input.PC
@@ -76,16 +65,8 @@ lemma equiv_SUBW
         (instruction.RTYPEW (r2, r1, rd, ropw.SUBW))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
   obtain ⟨h_main_active, h_main_op_subw⟩ := pins
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_spec_facts :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_spec_facts_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_emit : row.chain.b_op + 16 * row.mode.mode32 = (0x1B : FGL) := by
+  obtain ⟨_, h_core, h_spec_facts, h_facts⟩ := p.facts
+  have h_emit : p.rowInput.chain.b_op + 16 * p.rowInput.mode.mode32 = (0x1B : FGL) := by
     have h_lane_eqs := h_match
     simp only [matches_entry, opBus_row_Main,
       ] at h_lane_eqs
@@ -94,19 +75,18 @@ lemma equiv_SUBW
     simpa [ZiskFv.Trusted.OP_SUB_W] using h_main_op_subw
   obtain ⟨h_mode32_one, h_bop_val⟩ :=
     ZiskFv.EquivCore.Bridge.Binary.chain_row_shape_W_of_emit
-      row h_spec_facts h_core 0x1B (Or.inr rfl) h_emit
-  have h_b_op : row.chain.b_op.val = ZiskFv.Airs.Tables.BinaryTable.OP_SUB := by
+      p.rowInput h_spec_facts h_core 0x1B (Or.inr rfl) h_emit
+  have h_b_op : p.rowInput.chain.b_op.val = ZiskFv.Airs.Tables.BinaryTable.OP_SUB := by
     simpa [ZiskFv.Airs.Tables.BinaryTable.OP_SUB] using h_bop_val
   obtain ⟨h_sext_choice_row, h_carry_7_zero_row⟩ :=
     ZiskFv.EquivCore.Bridge.Binary.w_mode_sext_choice_and_carry_7_zero_of_static_row
-      row h_spec_facts h_facts h_core h_mode32_one (Or.inr h_b_op)
+      p.rowInput h_spec_facts h_facts h_core h_mode32_one (Or.inr h_b_op)
   exact ZiskFv.EquivCore.Subw.equiv_SUBW_of_static_row
-      state subw_input r1 r2 rd m row r_main bus promises
+      state subw_input r1 r2 rd m p.rowInput r_main bus promises
       ⟨h_main_active, h_main_op_subw⟩
       h_match h_core h_facts h_mode32_one h_b_op
       h_sext_choice_row h_carry_7_zero_row
-      (by simpa [row] using h_input_r1_extract)
-      (by simpa [row] using h_input_r2_extract)
+      h_input_r1_extract h_input_r2_extract
       h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/Wrappers/Subw.lean
+++ b/ZiskFv/Compliance/Wrappers/Subw.lean
@@ -31,7 +31,7 @@ open ZiskFv.EquivCore.Promises
 /-- Compliance-namespace canonical wrapper for SUBW. T2.4 retired the
     original (which routed through `op_bus_perm_sound_Binary` +
     `binary_chain_pin_obtain_W` + `binary_consumer_byte_match_chain_pin`).
-    This version takes the canonical Clean providerTable/providerRow shape
+    This version takes the canonical Clean `StaticBinaryProvider` bundle
     and dispatches through `EquivCore.Subw.equiv_SUBW_of_static_row`.
     `Equivalence.Subw.equiv_SUBW` is a thin channel-balance shim over this. -/
 lemma equiv_SUBW

--- a/ZiskFv/Compliance/Wrappers/Xor.lean
+++ b/ZiskFv/Compliance/Wrappers/Xor.lean
@@ -32,28 +32,17 @@ lemma equiv_XOR
     (xor_input : PureSpec.XorInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_XOR)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_input_r1_row : xor_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_input_r2_row : xor_input.r2_val =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowB64 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
         state xor_input.r1_val xor_input.r2_val xor_input.rd xor_input.PC
@@ -65,23 +54,10 @@ lemma equiv_XOR
       LeanRV64D.Functions.execute
         (instruction.RTYPE (r2, r1, rd, rop.XOR))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_component_spec :
-      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec
-        (providerTable.environment providerRow) := by
-    simpa [h_component] using h_table_spec providerRow h_provider_row
-  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_component_spec
-  obtain ⟨h_row_spec, h_static_specs⟩ := h_component_spec
+  obtain ⟨h_row_spec, h_core, h_static_specs, h_facts⟩ := p.facts
   exact ZiskFv.EquivCore.Xor.equiv_XOR_of_static_row
-    state xor_input r1 r2 rd m row r_main bus promises pins
+    state xor_input r1 r2 rd m p.rowInput r_main bus promises pins
     h_match h_row_spec h_core h_static_specs h_facts
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_r2_row)
-    h_lane_rd
+    h_input_r1_row h_input_r2_row h_lane_rd
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/Wrappers/Xori.lean
+++ b/ZiskFv/Compliance/Wrappers/Xori.lean
@@ -34,28 +34,17 @@ lemma equiv_XORI
     (xori_input : PureSpec.XoriInput)
     (r1 rd : regidx) (imm : BitVec 12)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_XOR)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : matches_entry (opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_input_r1_row : xori_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_input_imm_row : BitVec.signExtend 64 xori_input.imm =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowB64 p.rowInput)
     (h_xori_subset : itype_imm_subset_holds_main m r_main xori_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.ITypePromises
@@ -68,23 +57,11 @@ lemma equiv_XORI
       LeanRV64D.Functions.execute
         (instruction.ITYPE (imm, r1, rd, iop.XORI))) state
       = (bus_effect bus.exec_row [bus.e0, bus.e1, bus.e2] state).2 := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_component_spec :
-      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec
-        (providerTable.environment providerRow) := by
-    simpa [h_component] using h_table_spec providerRow h_provider_row
-  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_component_spec
-  obtain ⟨h_row_spec, h_static_specs⟩ := h_component_spec
+  obtain ⟨h_row_spec, h_core, h_static_specs, h_facts⟩ := p.facts
   exact ZiskFv.EquivCore.Xori.equiv_XORI_of_static_row
-    state xori_input r1 rd imm m row r_main bus promises pins
+    state xori_input r1 rd imm m p.rowInput r_main bus promises pins
     h_match h_row_spec h_core h_static_specs h_facts
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_imm_row)
+    h_input_r1_row h_input_imm_row
     h_lane_rd h_xori_subset
 
 end ZiskFv.Compliance

--- a/ZiskFv/Equivalence/Add.lean
+++ b/ZiskFv/Equivalence/Add.lean
@@ -23,29 +23,18 @@ theorem equiv_ADD
     (add_input : PureSpec.AddInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_ADD)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_input_r1_row : add_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_input_r2_row : add_input.r2_val =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowB64 p.rowInput)
     (h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
@@ -57,8 +46,7 @@ theorem equiv_ADD
           ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
   exact ZiskFv.Compliance.equiv_ADD
-    state add_input r1 r2 rd m providerTable providerRow r_main bus pins
-    h_component h_table_spec h_provider_row h_match
-    h_input_r1_row h_input_r2_row h_lane_rd promises
+    state add_input r1 r2 rd m p r_main bus pins
+    h_match h_input_r1_row h_input_r2_row h_lane_rd promises
 
 end ZiskFv.Equivalence.Add

--- a/ZiskFv/Equivalence/Addi.lean
+++ b/ZiskFv/Equivalence/Addi.lean
@@ -22,30 +22,19 @@ theorem equiv_ADDI
     (addi_input : PureSpec.AddiInput)
     (r1 rd : regidx) (imm : BitVec 12)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_ADD)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_addi_subset : itype_imm_subset_holds_main m r_main addi_input.imm)
     (h_input_r1_row : addi_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_input_imm_row : BitVec.signExtend 64 addi_input.imm =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowB64 p.rowInput)
     (h_lane_rd :
       ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.ITypePromises
@@ -58,8 +47,8 @@ theorem equiv_ADDI
       = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
   exact ZiskFv.Compliance.equiv_ADDI
-    state addi_input r1 rd imm m providerTable providerRow r_main bus pins
-    h_component h_table_spec h_provider_row h_match h_addi_subset
+    state addi_input r1 rd imm m p r_main bus pins
+    h_match h_addi_subset
     h_input_r1_row h_input_imm_row h_lane_rd promises
 
 end ZiskFv.Equivalence.Addi

--- a/ZiskFv/Equivalence/Addiw.lean
+++ b/ZiskFv/Equivalence/Addiw.lean
@@ -33,27 +33,18 @@ theorem equiv_ADDIW
     (addiw_input : PureSpec.AddiwInput)
     (r1 rd : regidx) (imm : BitVec 12)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_ADD_W)
     (h_addiw_subset : itype_imm_subset_holds_main m r_main addiw_input.imm)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_input_r1_extract :
       (Sail.BitVec.extractLsb addiw_input.r1_val 31 0 : BitVec (31 - 0 + 1)).toNat
-        = ZiskFv.EquivCore.Addw.binaryRowA32
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow)) % 2^32)
+        = ZiskFv.EquivCore.Addw.binaryRowA32 p.rowInput % 2^32)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.ITypePromises
         state addiw_input.r1_val addiw_input.imm addiw_input.rd addiw_input.PC
@@ -65,8 +56,8 @@ theorem equiv_ADDIW
       = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
   exact ZiskFv.Compliance.equiv_ADDIW state addiw_input r1 rd imm m
-    providerTable providerRow r_main bus pins h_addiw_subset
-    h_component h_table_spec h_provider_row h_match h_input_r1_extract
+    p r_main bus pins h_addiw_subset
+    h_match h_input_r1_extract
     h_lane_rd promises
 
 

--- a/ZiskFv/Equivalence/Addw.lean
+++ b/ZiskFv/Equivalence/Addw.lean
@@ -31,31 +31,20 @@ theorem equiv_ADDW
     (addw_input : PureSpec.AddwInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_ADD_W)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_input_r1_extract :
       (Sail.BitVec.extractLsb addw_input.r1_val 31 0 : BitVec (31 - 0 + 1)).toNat
-        = ZiskFv.EquivCore.Addw.binaryRowA32
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow)) % 2^32)
+        = ZiskFv.EquivCore.Addw.binaryRowA32 p.rowInput % 2^32)
     (h_input_r2_extract :
       (Sail.BitVec.extractLsb addw_input.r2_val 31 0 : BitVec (31 - 0 + 1)).toNat
-        = ZiskFv.EquivCore.Addw.binaryRowB32
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow)) % 2^32)
+        = ZiskFv.EquivCore.Addw.binaryRowB32 p.rowInput % 2^32)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
         state addw_input.r1_val addw_input.r2_val addw_input.rd addw_input.PC
@@ -70,8 +59,7 @@ theorem equiv_ADDW
           ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
   exact ZiskFv.Compliance.equiv_ADDW state addw_input r1 r2 rd m
-    providerTable providerRow r_main bus pins
-    h_component h_table_spec h_provider_row h_match
+    p r_main bus pins h_match
     h_input_r1_extract h_input_r2_extract h_lane_rd promises
 
 /-- Row-native static-provider route for `equiv_ADDW`. Mirrors

--- a/ZiskFv/Equivalence/And.lean
+++ b/ZiskFv/Equivalence/And.lean
@@ -31,29 +31,18 @@ theorem equiv_AND
     (and_input : PureSpec.AndInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_AND)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_input_r1_row : and_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_input_r2_row : and_input.r2_val =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowB64 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
         state and_input.r1_val and_input.r2_val and_input.rd and_input.PC
@@ -66,25 +55,10 @@ theorem equiv_AND
         (instruction.RTYPE (r2, r1, rd, rop.AND))) state
       = state_effect_via_channels
           ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_component_spec :
-      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec
-        (providerTable.environment providerRow) := by
-    simpa [h_component] using h_table_spec providerRow h_provider_row
-  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_component_spec
-  obtain ⟨h_row_spec, h_static_specs⟩ := h_component_spec
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
-  exact ZiskFv.EquivCore.And.equiv_AND_of_static_row
-    state and_input r1 r2 rd m row r_main bus promises pins
-    h_match h_row_spec h_core h_static_specs h_facts
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_r2_row)
-    h_lane_rd
+  exact ZiskFv.Compliance.equiv_AND
+    state and_input r1 r2 rd m p r_main bus pins
+    h_match h_input_r1_row h_input_r2_row h_lane_rd promises
 
 
 /-- Row-native static-provider route for `equiv_AND`. This is noncanonical C7
@@ -127,67 +101,5 @@ lemma equiv_AND_of_static_row
     state and_input r1 r2 rd m row r_main bus promises pins
     h_match h_row_spec h_core h_static h_facts
     h_input_r1_row h_input_r2_row h_lane_rd
-
-/-- Noncanonical C7 route for `AND` from a lookup-aware Clean Binary table
-    row. The caller supplies the concrete provider row and `table.Spec`; the
-    Binary core facts and static BinaryTable facts are projected from that
-    Clean table spec rather than supplied as promises. -/
-lemma equiv_AND_of_static_table_row
-    (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
-    (and_input : PureSpec.AndInput)
-    (r1 r2 rd : regidx)
-    (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
-    (r_main : ℕ)
-    (bus : ZiskFv.Compliance.BusRows)
-    (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_AND)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
-    (h_match : ZiskFv.Airs.OperationBus.matches_entry
-      (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
-      (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
-    (h_input_r1_row : and_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
-    (h_input_r2_row : and_input.r2_val =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
-    (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
-    (promises : ZiskFv.EquivCore.Promises.RTypePromises
-        state and_input.r1_val and_input.r2_val and_input.rd and_input.PC
-        (PureSpec.execute_RTYPE_and_pure and_input).nextPC
-        r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
-    : (do
-      Sail.writeReg Register.nextPC
-        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
-      LeanRV64D.Functions.execute
-        (instruction.RTYPE (r2, r1, rd, rop.AND))) state
-      = state_effect_via_channels
-          ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_component_spec :
-      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec
-        (providerTable.environment providerRow) := by
-    simpa [h_component] using h_table_spec providerRow h_provider_row
-  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_component_spec
-  obtain ⟨h_row_spec, h_static_specs⟩ := h_component_spec
-  exact equiv_AND_of_static_row state and_input r1 r2 rd m row r_main bus pins
-    h_match h_core h_row_spec h_static_specs h_facts
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_r2_row)
-    h_lane_rd promises
 
 end ZiskFv.Equivalence.And

--- a/ZiskFv/Equivalence/Andi.lean
+++ b/ZiskFv/Equivalence/Andi.lean
@@ -32,29 +32,18 @@ theorem equiv_ANDI
     (andi_input : PureSpec.AndiInput)
     (r1 rd : regidx) (imm : BitVec 12)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_AND)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_input_r1_row : andi_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_input_imm_row : BitVec.signExtend 64 andi_input.imm =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowB64 p.rowInput)
     (h_andi_subset : itype_imm_subset_holds_main m r_main andi_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.ITypePromises
@@ -68,25 +57,10 @@ theorem equiv_ANDI
         (instruction.ITYPE (imm, r1, rd, iop.ANDI))) state
       = state_effect_via_channels
           ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_component_spec :
-      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec
-        (providerTable.environment providerRow) := by
-    simpa [h_component] using h_table_spec providerRow h_provider_row
-  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_component_spec
-  obtain ⟨h_row_spec, h_static_specs⟩ := h_component_spec
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
-  exact ZiskFv.EquivCore.Andi.equiv_ANDI_of_static_row
-    state andi_input r1 rd imm m row r_main bus promises pins
-    h_match h_row_spec h_core h_static_specs h_facts
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_imm_row)
-    h_lane_rd h_andi_subset
+  exact ZiskFv.Compliance.equiv_ANDI
+    state andi_input r1 rd imm m p r_main bus pins
+    h_match h_input_r1_row h_input_imm_row h_andi_subset h_lane_rd promises
 
 
 /-- Row-native static-provider route for `equiv_ANDI`. -/
@@ -129,65 +103,5 @@ lemma equiv_ANDI_of_static_row
     state andi_input r1 rd imm m row r_main bus promises pins
     h_match h_row_spec h_core h_static h_facts
     h_input_r1_row h_input_imm_row h_lane_rd h_andi_subset
-
-/-- Lookup-aware Clean table-row route for `ANDI`. -/
-lemma equiv_ANDI_of_static_table_row
-    (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
-    (andi_input : PureSpec.AndiInput)
-    (r1 rd : regidx) (imm : BitVec 12)
-    (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
-    (r_main : ℕ)
-    (bus : ZiskFv.Compliance.BusRows)
-    (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_AND)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
-    (h_match : ZiskFv.Airs.OperationBus.matches_entry
-      (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
-      (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
-    (h_input_r1_row : andi_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
-    (h_input_imm_row : BitVec.signExtend 64 andi_input.imm =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
-    (h_andi_subset : itype_imm_subset_holds_main m r_main andi_input.imm)
-    (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
-    (promises : ZiskFv.EquivCore.Promises.ITypePromises
-        state andi_input.r1_val andi_input.imm andi_input.rd andi_input.PC
-        (PureSpec.execute_ITYPE_andi_pure andi_input).nextPC
-        r1 rd imm bus.exec_row bus.e0 bus.e1 bus.e2)
-    : (do
-      Sail.writeReg Register.nextPC
-        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
-      LeanRV64D.Functions.execute
-        (instruction.ITYPE (imm, r1, rd, iop.ANDI))) state
-      = state_effect_via_channels
-          ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_component_spec :
-      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec
-        (providerTable.environment providerRow) := by
-    simpa [h_component] using h_table_spec providerRow h_provider_row
-  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_component_spec
-  obtain ⟨h_row_spec, h_static_specs⟩ := h_component_spec
-  exact equiv_ANDI_of_static_row state andi_input r1 rd imm m row r_main
-    bus pins h_match h_core h_row_spec h_static_specs h_facts
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_imm_row)
-    h_andi_subset h_lane_rd promises
 
 end ZiskFv.Equivalence.Andi

--- a/ZiskFv/Equivalence/Or.lean
+++ b/ZiskFv/Equivalence/Or.lean
@@ -31,29 +31,18 @@ theorem equiv_OR
     (or_input : PureSpec.OrInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_OR)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_input_r1_row : or_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_input_r2_row : or_input.r2_val =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowB64 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
         state or_input.r1_val or_input.r2_val or_input.rd or_input.PC
@@ -66,25 +55,10 @@ theorem equiv_OR
         (instruction.RTYPE (r2, r1, rd, rop.OR))) state
       = state_effect_via_channels
           ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_component_spec :
-      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec
-        (providerTable.environment providerRow) := by
-    simpa [h_component] using h_table_spec providerRow h_provider_row
-  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_component_spec
-  obtain ⟨h_row_spec, h_static_specs⟩ := h_component_spec
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
-  exact ZiskFv.EquivCore.Or.equiv_OR_of_static_row
-    state or_input r1 r2 rd m row r_main bus promises pins
-    h_match h_row_spec h_core h_static_specs h_facts
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_r2_row)
-    h_lane_rd
+  exact ZiskFv.Compliance.equiv_OR
+    state or_input r1 r2 rd m p r_main bus pins
+    h_match h_input_r1_row h_input_r2_row h_lane_rd promises
 
 
 /-- Row-native static-provider route for `equiv_OR`. -/
@@ -125,66 +99,5 @@ lemma equiv_OR_of_static_row
     state or_input r1 r2 rd m row r_main bus promises pins
     h_match h_row_spec h_core h_static h_facts
     h_input_r1_row h_input_r2_row h_lane_rd
-
-/-- Noncanonical C7 route for `OR` from a lookup-aware Clean Binary table
-    row. The provider row's Binary core and static BinaryTable facts are
-    projected from `table.Spec`. -/
-lemma equiv_OR_of_static_table_row
-    (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
-    (or_input : PureSpec.OrInput)
-    (r1 r2 rd : regidx)
-    (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
-    (r_main : ℕ)
-    (bus : ZiskFv.Compliance.BusRows)
-    (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_OR)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
-    (h_match : ZiskFv.Airs.OperationBus.matches_entry
-      (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
-      (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
-    (h_input_r1_row : or_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
-    (h_input_r2_row : or_input.r2_val =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
-    (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
-    (promises : ZiskFv.EquivCore.Promises.RTypePromises
-        state or_input.r1_val or_input.r2_val or_input.rd or_input.PC
-        (PureSpec.execute_RTYPE_or_pure or_input).nextPC
-        r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
-    : (do
-      Sail.writeReg Register.nextPC
-        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
-      LeanRV64D.Functions.execute
-        (instruction.RTYPE (r2, r1, rd, rop.OR))) state
-      = state_effect_via_channels
-          ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_component_spec :
-      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec
-        (providerTable.environment providerRow) := by
-    simpa [h_component] using h_table_spec providerRow h_provider_row
-  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_component_spec
-  obtain ⟨h_row_spec, h_static_specs⟩ := h_component_spec
-  exact equiv_OR_of_static_row state or_input r1 r2 rd m row r_main bus pins
-    h_match h_core h_row_spec h_static_specs h_facts
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_r2_row)
-    h_lane_rd promises
 
 end ZiskFv.Equivalence.Or

--- a/ZiskFv/Equivalence/Ori.lean
+++ b/ZiskFv/Equivalence/Ori.lean
@@ -32,29 +32,18 @@ theorem equiv_ORI
     (ori_input : PureSpec.OriInput)
     (r1 rd : regidx) (imm : BitVec 12)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_OR)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_input_r1_row : ori_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_input_imm_row : BitVec.signExtend 64 ori_input.imm =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowB64 p.rowInput)
     (h_ori_subset : itype_imm_subset_holds_main m r_main ori_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.ITypePromises
@@ -68,25 +57,10 @@ theorem equiv_ORI
         (instruction.ITYPE (imm, r1, rd, iop.ORI))) state
       = state_effect_via_channels
           ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_component_spec :
-      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec
-        (providerTable.environment providerRow) := by
-    simpa [h_component] using h_table_spec providerRow h_provider_row
-  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_component_spec
-  obtain ⟨h_row_spec, h_static_specs⟩ := h_component_spec
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
-  exact ZiskFv.EquivCore.Ori.equiv_ORI_of_static_row
-    state ori_input r1 rd imm m row r_main bus promises pins
-    h_match h_row_spec h_core h_static_specs h_facts
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_imm_row)
-    h_lane_rd h_ori_subset
+  exact ZiskFv.Compliance.equiv_ORI
+    state ori_input r1 rd imm m p r_main bus pins
+    h_match h_input_r1_row h_input_imm_row h_ori_subset h_lane_rd promises
 
 
 /-- Row-native static-provider route for `equiv_ORI`. -/
@@ -129,65 +103,5 @@ lemma equiv_ORI_of_static_row
     state ori_input r1 rd imm m row r_main bus promises pins
     h_match h_row_spec h_core h_static h_facts
     h_input_r1_row h_input_imm_row h_lane_rd h_ori_subset
-
-/-- Lookup-aware Clean table-row route for `ORI`. -/
-lemma equiv_ORI_of_static_table_row
-    (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
-    (ori_input : PureSpec.OriInput)
-    (r1 rd : regidx) (imm : BitVec 12)
-    (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
-    (r_main : ℕ)
-    (bus : ZiskFv.Compliance.BusRows)
-    (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_OR)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
-    (h_match : ZiskFv.Airs.OperationBus.matches_entry
-      (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
-      (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
-    (h_input_r1_row : ori_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
-    (h_input_imm_row : BitVec.signExtend 64 ori_input.imm =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
-    (h_ori_subset : itype_imm_subset_holds_main m r_main ori_input.imm)
-    (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
-    (promises : ZiskFv.EquivCore.Promises.ITypePromises
-        state ori_input.r1_val ori_input.imm ori_input.rd ori_input.PC
-        (PureSpec.execute_ITYPE_ori_pure ori_input).nextPC
-        r1 rd imm bus.exec_row bus.e0 bus.e1 bus.e2)
-    : (do
-      Sail.writeReg Register.nextPC
-        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
-      LeanRV64D.Functions.execute
-        (instruction.ITYPE (imm, r1, rd, iop.ORI))) state
-      = state_effect_via_channels
-          ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_component_spec :
-      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec
-        (providerTable.environment providerRow) := by
-    simpa [h_component] using h_table_spec providerRow h_provider_row
-  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_component_spec
-  obtain ⟨h_row_spec, h_static_specs⟩ := h_component_spec
-  exact equiv_ORI_of_static_row state ori_input r1 rd imm m row r_main
-    bus pins h_match h_core h_row_spec h_static_specs h_facts
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_imm_row)
-    h_ori_subset h_lane_rd promises
 
 end ZiskFv.Equivalence.Ori

--- a/ZiskFv/Equivalence/Sll.lean
+++ b/ZiskFv/Equivalence/Sll.lean
@@ -31,8 +31,7 @@ theorem equiv_SLL
     (sll_input : PureSpec.SllInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
@@ -40,24 +39,14 @@ theorem equiv_SLL
         (PureSpec.execute_RTYPE_sll_pure sll_input).nextPC
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_SLL)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row : sll_input.r1_val =
-      ZiskFv.AirsClean.BinaryExtension.rowA64
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowA64 p.rowInput)
     (h_shift_pin_row : sll_input.r2_val.toNat % 64 =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     : (do
       Sail.writeReg Register.nextPC
@@ -68,8 +57,7 @@ theorem equiv_SLL
           ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
   exact ZiskFv.Compliance.equiv_SLL state sll_input r1 r2 rd
-    m providerTable providerRow r_main bus promises pins
-    h_component h_table_spec h_provider_row h_match
+    m p r_main bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (noncanonical alt route) deleted in T4-purge step P3.1.

--- a/ZiskFv/Equivalence/Slli.lean
+++ b/ZiskFv/Equivalence/Slli.lean
@@ -30,8 +30,7 @@ theorem equiv_SLLI
     (slli_input : PureSpec.SlliInput)
     (r1 rd : regidx) (shamt : BitVec 6)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.ShiftImmPromises
@@ -39,32 +38,21 @@ theorem equiv_SLLI
         (PureSpec.execute_SHIFTIOP_slli_pure slli_input).nextPC
         r1 rd shamt bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_SLL)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row : slli_input.r1_val =
-      ZiskFv.AirsClean.BinaryExtension.rowA64
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowA64 p.rowInput)
     (h_shift_pin_row : slli_input.shamt.toNat =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     : execute_instruction (instruction.SHIFTIOP (shamt, r1, rd, sop.SLLI)) state
       = state_effect_via_channels
           ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
   exact ZiskFv.Compliance.equiv_SLLI state slli_input r1 rd shamt
-    m providerTable providerRow r_main bus promises pins
-    h_component h_table_spec h_provider_row h_match
+    m p r_main bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (noncanonical alt route) deleted in T4-purge step P3.1.

--- a/ZiskFv/Equivalence/Slliw.lean
+++ b/ZiskFv/Equivalence/Slliw.lean
@@ -30,8 +30,7 @@ theorem equiv_SLLIW
     (slliw_input : PureSpec.SlliwInput)
     (r1 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.ShiftWImmPromises
@@ -39,32 +38,21 @@ theorem equiv_SLLIW
         (PureSpec.execute_SHIFTIWOP_slliw_pure slliw_input).nextPC
         r1 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_SLL_W)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row :
       (Sail.BitVec.extractLsb slliw_input.r1_val 31 0 : BitVec (31 - 0 + 1)).toNat =
-        ZiskFv.AirsClean.BinaryExtension.rowA32
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow)))
+        ZiskFv.AirsClean.BinaryExtension.rowA32 p.rowInput)
     (h_shift_pin_row : slliw_input.shamt.toNat =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     : execute_instruction (instruction.SHIFTIWOP (slliw_input.shamt, r1, rd, sopw.SLLIW)) state
       = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
   exact ZiskFv.Compliance.equiv_SLLIW state slliw_input r1 rd
-    m providerTable providerRow r_main bus promises pins
-    h_component h_table_spec h_provider_row h_match
+    m p r_main bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (noncanonical alt route) deleted in T4-purge step P3.1.

--- a/ZiskFv/Equivalence/Sllw.lean
+++ b/ZiskFv/Equivalence/Sllw.lean
@@ -30,8 +30,7 @@ theorem equiv_SLLW
     (sllw_input : PureSpec.SllwInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
@@ -39,33 +38,21 @@ theorem equiv_SLLW
       (PureSpec.execute_RTYPE_sllw_pure sllw_input).nextPC
       r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_SLL_W)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row :
       (Sail.BitVec.extractLsb sllw_input.r1_val 31 0 : BitVec (31 - 0 + 1)).toNat =
-        ZiskFv.AirsClean.BinaryExtension.rowA32
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow)))
+        ZiskFv.AirsClean.BinaryExtension.rowA32 p.rowInput)
     (h_shift_pin_row : sllw_input.r2_val.toNat % 32 =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     : execute_instruction (instruction.RTYPEW (r2, r1, rd, ropw.SLLW)) state
       = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
   exact ZiskFv.Compliance.equiv_SLLW state sllw_input r1 r2 rd
-    m providerTable providerRow r_main bus
-    promises pins
-    h_component h_table_spec h_provider_row h_match
+    m p r_main bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (noncanonical alt route) deleted in T4-purge step P3.1.

--- a/ZiskFv/Equivalence/Slt.lean
+++ b/ZiskFv/Equivalence/Slt.lean
@@ -32,29 +32,18 @@ theorem equiv_SLT
     (slt_input : PureSpec.SltInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_LT)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_input_r1_row : slt_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_input_r2_row : slt_input.r2_val =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowB64 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
         state slt_input.r1_val slt_input.r2_val slt_input.rd slt_input.PC
@@ -69,8 +58,7 @@ theorem equiv_SLT
           ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
   exact ZiskFv.Compliance.equiv_SLT
-    state slt_input r1 r2 rd m providerTable providerRow r_main bus pins
-    h_component h_table_spec h_provider_row h_match
-    h_input_r1_row h_input_r2_row h_lane_rd promises
+    state slt_input r1 r2 rd m p r_main bus pins
+    h_match h_input_r1_row h_input_r2_row h_lane_rd promises
 
 end ZiskFv.Equivalence.Slt

--- a/ZiskFv/Equivalence/Slti.lean
+++ b/ZiskFv/Equivalence/Slti.lean
@@ -32,26 +32,17 @@ theorem equiv_SLTI
     (slti_input : PureSpec.SltiInput)
     (r1 rd : regidx) (imm : BitVec 12)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_LT)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_main_m32 : m.m32 r_main = 0)
     (h_input_r1_row : slti_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_slti_subset : itype_imm_subset_holds_main m r_main slti_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.ITypePromises
@@ -67,8 +58,7 @@ theorem equiv_SLTI
           ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
   exact ZiskFv.Compliance.equiv_SLTI
-    state slti_input r1 rd imm m providerTable providerRow r_main bus pins
-    h_component h_table_spec h_provider_row h_match
+    state slti_input r1 rd imm m p r_main bus pins h_match
     h_main_m32 h_input_r1_row h_slti_subset h_lane_rd promises
 
 end ZiskFv.Equivalence.Slti

--- a/ZiskFv/Equivalence/Sltiu.lean
+++ b/ZiskFv/Equivalence/Sltiu.lean
@@ -32,26 +32,17 @@ theorem equiv_SLTIU
     (sltiu_input : PureSpec.SltiuInput)
     (r1 rd : regidx) (imm : BitVec 12)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_LTU)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_main_m32 : m.m32 r_main = 0)
     (h_input_r1_row : sltiu_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_sltiu_subset : itype_imm_subset_holds_main m r_main sltiu_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.ITypePromises
@@ -67,8 +58,7 @@ theorem equiv_SLTIU
           ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
   exact ZiskFv.Compliance.equiv_SLTIU
-    state sltiu_input r1 rd imm m providerTable providerRow r_main bus pins
-    h_component h_table_spec h_provider_row h_match
+    state sltiu_input r1 rd imm m p r_main bus pins h_match
     h_main_m32 h_input_r1_row h_sltiu_subset h_lane_rd promises
 
 end ZiskFv.Equivalence.Sltiu

--- a/ZiskFv/Equivalence/Sltu.lean
+++ b/ZiskFv/Equivalence/Sltu.lean
@@ -32,29 +32,18 @@ theorem equiv_SLTU
     (sltu_input : PureSpec.SltuInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_LTU)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_input_r1_row : sltu_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_input_r2_row : sltu_input.r2_val =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowB64 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
         state sltu_input.r1_val sltu_input.r2_val sltu_input.rd sltu_input.PC
@@ -69,8 +58,7 @@ theorem equiv_SLTU
           ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
   exact ZiskFv.Compliance.equiv_SLTU
-    state sltu_input r1 r2 rd m providerTable providerRow r_main bus pins
-    h_component h_table_spec h_provider_row h_match
-    h_input_r1_row h_input_r2_row h_lane_rd promises
+    state sltu_input r1 r2 rd m p r_main bus pins
+    h_match h_input_r1_row h_input_r2_row h_lane_rd promises
 
 end ZiskFv.Equivalence.Sltu

--- a/ZiskFv/Equivalence/Sra.lean
+++ b/ZiskFv/Equivalence/Sra.lean
@@ -31,8 +31,7 @@ theorem equiv_SRA
     (sra_input : PureSpec.SraInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
@@ -40,32 +39,21 @@ theorem equiv_SRA
         (PureSpec.execute_RTYPE_sra_pure sra_input).nextPC
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_SRA)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row : sra_input.r1_val =
-      ZiskFv.AirsClean.BinaryExtension.rowA64
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowA64 p.rowInput)
     (h_shift_pin_row : sra_input.r2_val.toNat % 64 =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     : execute_instruction (instruction.RTYPE (r2, r1, rd, rop.SRA)) state
       = state_effect_via_channels
           ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
   exact ZiskFv.Compliance.equiv_SRA state sra_input r1 r2 rd
-    m providerTable providerRow r_main bus promises pins
-    h_component h_table_spec h_provider_row h_match
+    m p r_main bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (noncanonical alt route) deleted in T4-purge step P3.1.

--- a/ZiskFv/Equivalence/Srai.lean
+++ b/ZiskFv/Equivalence/Srai.lean
@@ -30,8 +30,7 @@ theorem equiv_SRAI
     (srai_input : PureSpec.SraiInput)
     (r1 rd : regidx) (shamt : BitVec 6)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.ShiftImmPromises
@@ -39,32 +38,21 @@ theorem equiv_SRAI
         (PureSpec.execute_SHIFTIOP_srai_pure srai_input).nextPC
         r1 rd shamt bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_SRA)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row : srai_input.r1_val =
-      ZiskFv.AirsClean.BinaryExtension.rowA64
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowA64 p.rowInput)
     (h_shift_pin_row : srai_input.shamt.toNat =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     : execute_instruction (instruction.SHIFTIOP (shamt, r1, rd, sop.SRAI)) state
       = state_effect_via_channels
           ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
   exact ZiskFv.Compliance.equiv_SRAI state srai_input r1 rd shamt
-    m providerTable providerRow r_main bus promises pins
-    h_component h_table_spec h_provider_row h_match
+    m p r_main bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (noncanonical alt route) deleted in T4-purge step P3.1.

--- a/ZiskFv/Equivalence/Sraiw.lean
+++ b/ZiskFv/Equivalence/Sraiw.lean
@@ -30,8 +30,7 @@ theorem equiv_SRAIW
     (sraiw_input : PureSpec.SraiwInput)
     (r1 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.ShiftWImmPromises
@@ -39,32 +38,21 @@ theorem equiv_SRAIW
         (PureSpec.execute_SHIFTIWOP_sraiw_pure sraiw_input).nextPC
         r1 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_SRA_W)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row :
       (Sail.BitVec.extractLsb sraiw_input.r1_val 31 0 : BitVec (31 - 0 + 1)).toNat =
-        ZiskFv.AirsClean.BinaryExtension.rowA32
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow)))
+        ZiskFv.AirsClean.BinaryExtension.rowA32 p.rowInput)
     (h_shift_pin_row : sraiw_input.shamt.toNat =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     : execute_instruction (instruction.SHIFTIWOP (sraiw_input.shamt, r1, rd, sopw.SRAIW)) state
       = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
   exact ZiskFv.Compliance.equiv_SRAIW state sraiw_input r1 rd
-    m providerTable providerRow r_main bus promises pins
-    h_component h_table_spec h_provider_row h_match
+    m p r_main bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (noncanonical alt route) deleted in T4-purge step P3.1.

--- a/ZiskFv/Equivalence/Sraw.lean
+++ b/ZiskFv/Equivalence/Sraw.lean
@@ -30,8 +30,7 @@ theorem equiv_SRAW
     (sraw_input : PureSpec.SrawInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
@@ -39,33 +38,21 @@ theorem equiv_SRAW
       (PureSpec.execute_RTYPE_sraw_pure sraw_input).nextPC
       r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_SRA_W)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row :
       (Sail.BitVec.extractLsb sraw_input.r1_val 31 0 : BitVec (31 - 0 + 1)).toNat =
-        ZiskFv.AirsClean.BinaryExtension.rowA32
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow)))
+        ZiskFv.AirsClean.BinaryExtension.rowA32 p.rowInput)
     (h_shift_pin_row : sraw_input.r2_val.toNat % 32 =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     : execute_instruction (instruction.RTYPEW (r2, r1, rd, ropw.SRAW)) state
       = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
   exact ZiskFv.Compliance.equiv_SRAW state sraw_input r1 r2 rd
-    m providerTable providerRow r_main bus
-    promises pins
-    h_component h_table_spec h_provider_row h_match
+    m p r_main bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (noncanonical alt route) deleted in T4-purge step P3.1.

--- a/ZiskFv/Equivalence/Srl.lean
+++ b/ZiskFv/Equivalence/Srl.lean
@@ -31,8 +31,7 @@ theorem equiv_SRL
     (srl_input : PureSpec.SrlInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
@@ -40,32 +39,21 @@ theorem equiv_SRL
         (PureSpec.execute_RTYPE_srl_pure srl_input).nextPC
         r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_SRL)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-          (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+          (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row : srl_input.r1_val =
-      ZiskFv.AirsClean.BinaryExtension.rowA64
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowA64 p.rowInput)
     (h_shift_pin_row : srl_input.r2_val.toNat % 64 =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     : execute_instruction (instruction.RTYPE (r2, r1, rd, rop.SRL)) state
       = state_effect_via_channels
           ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
   exact ZiskFv.Compliance.equiv_SRL state srl_input r1 r2 rd
-    m providerTable providerRow r_main bus promises pins
-    h_component h_table_spec h_provider_row h_match
+    m p r_main bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (noncanonical alt route) deleted in T4-purge step P3.1.

--- a/ZiskFv/Equivalence/Srli.lean
+++ b/ZiskFv/Equivalence/Srli.lean
@@ -30,8 +30,7 @@ theorem equiv_SRLI
     (srli_input : PureSpec.SrliInput)
     (r1 rd : regidx) (shamt : BitVec 6)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.ShiftImmPromises
@@ -39,32 +38,21 @@ theorem equiv_SRLI
         (PureSpec.execute_SHIFTIOP_srli_pure srli_input).nextPC
         r1 rd shamt bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_SRL)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row : srli_input.r1_val =
-      ZiskFv.AirsClean.BinaryExtension.rowA64
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowA64 p.rowInput)
     (h_shift_pin_row : srli_input.shamt.toNat =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     : execute_instruction (instruction.SHIFTIOP (shamt, r1, rd, sop.SRLI)) state
       = state_effect_via_channels
           ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
   exact ZiskFv.Compliance.equiv_SRLI state srli_input r1 rd shamt
-    m providerTable providerRow r_main bus promises pins
-    h_component h_table_spec h_provider_row h_match
+    m p r_main bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (noncanonical alt route) deleted in T4-purge step P3.1.

--- a/ZiskFv/Equivalence/Srliw.lean
+++ b/ZiskFv/Equivalence/Srliw.lean
@@ -30,8 +30,7 @@ theorem equiv_SRLIW
     (srliw_input : PureSpec.SrliwInput)
     (r1 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.ShiftWImmPromises
@@ -39,32 +38,21 @@ theorem equiv_SRLIW
         (PureSpec.execute_SHIFTIWOP_srliw_pure srliw_input).nextPC
         r1 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_SRL_W)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row :
       (Sail.BitVec.extractLsb srliw_input.r1_val 31 0 : BitVec (31 - 0 + 1)).toNat =
-        ZiskFv.AirsClean.BinaryExtension.rowA32
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow)))
+        ZiskFv.AirsClean.BinaryExtension.rowA32 p.rowInput)
     (h_shift_pin_row : srliw_input.shamt.toNat =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     : execute_instruction (instruction.SHIFTIWOP (srliw_input.shamt, r1, rd, sopw.SRLIW)) state
       = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
   exact ZiskFv.Compliance.equiv_SRLIW state srliw_input r1 rd
-    m providerTable providerRow r_main bus promises pins
-    h_component h_table_spec h_provider_row h_match
+    m p r_main bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (noncanonical alt route) deleted in T4-purge step P3.1.

--- a/ZiskFv/Equivalence/Srlw.lean
+++ b/ZiskFv/Equivalence/Srlw.lean
@@ -30,8 +30,7 @@ theorem equiv_SRLW
     (srlw_input : PureSpec.SrlwInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.ShiftStaticProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
@@ -39,33 +38,21 @@ theorem equiv_SRLW
       (PureSpec.execute_RTYPE_srlw_pure srlw_input).nextPC
       r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_SRL_W)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.BinaryExtension.opBusMessage
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.BinaryExtension.opBusMessage p.rowInput) 1))
     (h_input_r1_row :
       (Sail.BitVec.extractLsb srlw_input.r1_val 31 0 : BitVec (31 - 0 + 1)).toNat =
-        ZiskFv.AirsClean.BinaryExtension.rowA32
-          (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-            (providerTable.environment providerRow)))
+        ZiskFv.AirsClean.BinaryExtension.rowA32 p.rowInput)
     (h_shift_pin_row : srlw_input.r2_val.toNat % 32 =
-      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32
-        (ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.AirsClean.BinaryExtension.rowShiftAmount32 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     : execute_instruction (instruction.RTYPEW (r2, r1, rd, ropw.SRLW)) state
       = state_effect_via_channels ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
   exact ZiskFv.Compliance.equiv_SRLW state srlw_input r1 r2 rd
-    m providerTable providerRow r_main bus
-    promises pins
-    h_component h_table_spec h_provider_row h_match
+    m p r_main bus promises pins h_match
     h_input_r1_row h_shift_pin_row h_lane_rd
 
 -- equiv_<OP>_of_static_lookup (noncanonical alt route) deleted in T4-purge step P3.1.

--- a/ZiskFv/Equivalence/Sub.lean
+++ b/ZiskFv/Equivalence/Sub.lean
@@ -31,29 +31,18 @@ theorem equiv_SUB
     (sub_input : PureSpec.SubInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_SUB)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
       (h_match : ZiskFv.Airs.OperationBus.matches_entry
         (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
         (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-          (ZiskFv.AirsClean.Binary.opBusMessage
-            (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-              (providerTable.environment providerRow))) 1))
+          (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
       (h_input_r1_row : sub_input.r1_val =
-        ZiskFv.EquivCore.Add.binaryRowA64
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow)))
+        ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
       (h_input_r2_row : sub_input.r2_val =
-        ZiskFv.EquivCore.Add.binaryRowB64
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow)))
+        ZiskFv.EquivCore.Add.binaryRowB64 p.rowInput)
       (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
         state sub_input.r1_val sub_input.r2_val sub_input.rd sub_input.PC
@@ -66,38 +55,9 @@ theorem equiv_SUB
         (instruction.RTYPE (r2, r1, rd, rop.SUB))) state
       = state_effect_via_channels
           ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_spec_facts :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_spec_facts_of_table_spec
-      h_component h_table_spec h_provider_row
-  obtain ⟨h_main_active, h_main_op_sub⟩ := pins
-  have h_emit : row.chain.b_op + 16 * row.mode.mode32 =
-      (ZiskFv.Airs.Tables.BinaryTable.OP_SUB : FGL) := by
-    have h_match_op := h_match
-    simp only [ZiskFv.Airs.OperationBus.matches_entry,
-      ZiskFv.Airs.OperationBus.opBus_row_Main] at h_match_op
-    have h_op_match :
-        m.op r_main = row.chain.b_op + 16 * row.mode.mode32 := h_match_op.2.1
-    rw [← h_op_match]
-    simpa [ZiskFv.Airs.Tables.BinaryTable.OP_SUB, ZiskFv.Trusted.OP_SUB] using
-      h_main_op_sub
-  obtain ⟨h_row_m32, h_bop, _⟩ :=
-    ZiskFv.EquivCore.Bridge.Binary.logic_row_mode_pins_of_emit_op_lt_16_of_static_spec
-      row h_spec_facts ZiskFv.Airs.Tables.BinaryTable.OP_SUB (by
-        simp [ZiskFv.Airs.Tables.BinaryTable.OP_SUB])
-      h_core h_emit
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
-  exact ZiskFv.EquivCore.Sub.equiv_SUB_of_static_row
-    state sub_input r1 r2 rd m row r_main bus promises
-    ⟨h_main_active, h_main_op_sub⟩
-    h_match h_core h_facts h_row_m32 h_bop
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_r2_row)
-    h_lane_rd
+  exact ZiskFv.Compliance.equiv_SUB
+    state sub_input r1 r2 rd m p r_main bus pins
+    h_match h_input_r1_row h_input_r2_row h_lane_rd promises
 
 end ZiskFv.Equivalence.Sub

--- a/ZiskFv/Equivalence/Subw.lean
+++ b/ZiskFv/Equivalence/Subw.lean
@@ -31,31 +31,20 @@ theorem equiv_SUBW
     (subw_input : PureSpec.SubwInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_SUB_W)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
       (h_match : ZiskFv.Airs.OperationBus.matches_entry
         (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
         (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-          (ZiskFv.AirsClean.Binary.opBusMessage
-            (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-              (providerTable.environment providerRow))) 1))
+          (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
       (h_input_r1_extract :
         (Sail.BitVec.extractLsb subw_input.r1_val 31 0 : BitVec (31 - 0 + 1)).toNat
-          = ZiskFv.EquivCore.Addw.binaryRowA32
-            (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-              (providerTable.environment providerRow)) % 2^32)
+          = ZiskFv.EquivCore.Addw.binaryRowA32 p.rowInput % 2^32)
       (h_input_r2_extract :
         (Sail.BitVec.extractLsb subw_input.r2_val 31 0 : BitVec (31 - 0 + 1)).toNat
-          = ZiskFv.EquivCore.Addw.binaryRowB32
-            (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-              (providerTable.environment providerRow)) % 2^32)
+          = ZiskFv.EquivCore.Addw.binaryRowB32 p.rowInput % 2^32)
       (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
         state subw_input.r1_val subw_input.r2_val subw_input.rd subw_input.PC
@@ -70,8 +59,7 @@ theorem equiv_SUBW
             ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
     rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
     exact ZiskFv.Compliance.equiv_SUBW state subw_input r1 r2 rd m
-      providerTable providerRow r_main bus pins
-      h_component h_table_spec h_provider_row h_match
+      p r_main bus pins h_match
       h_input_r1_extract h_input_r2_extract h_lane_rd promises
 
 /-- Row-native static-provider route for `equiv_SUBW`. Bypasses the

--- a/ZiskFv/Equivalence/Xor.lean
+++ b/ZiskFv/Equivalence/Xor.lean
@@ -31,29 +31,18 @@ theorem equiv_XOR
     (xor_input : PureSpec.XorInput)
     (r1 r2 rd : regidx)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_XOR)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_input_r1_row : xor_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_input_r2_row : xor_input.r2_val =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowB64 p.rowInput)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.RTypePromises
         state xor_input.r1_val xor_input.r2_val xor_input.rd xor_input.PC
@@ -66,25 +55,10 @@ theorem equiv_XOR
         (instruction.RTYPE (r2, r1, rd, rop.XOR))) state
       = state_effect_via_channels
           ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_component_spec :
-      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec
-        (providerTable.environment providerRow) := by
-    simpa [h_component] using h_table_spec providerRow h_provider_row
-  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_component_spec
-  obtain ⟨h_row_spec, h_static_specs⟩ := h_component_spec
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
-  exact ZiskFv.EquivCore.Xor.equiv_XOR_of_static_row
-    state xor_input r1 r2 rd m row r_main bus promises pins
-    h_match h_row_spec h_core h_static_specs h_facts
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_r2_row)
-    h_lane_rd
+  exact ZiskFv.Compliance.equiv_XOR
+    state xor_input r1 r2 rd m p r_main bus pins
+    h_match h_input_r1_row h_input_r2_row h_lane_rd promises
 
 
 
@@ -126,67 +100,5 @@ lemma equiv_XOR_of_static_row
     state xor_input r1 r2 rd m row r_main bus promises pins
     h_match h_row_spec h_core h_static h_facts
     h_input_r1_row h_input_r2_row h_lane_rd
-
-/-- Noncanonical C7 route for `XOR` from a lookup-aware Clean Binary table
-    row. The provider row's Binary core, static BinaryTable facts, and
-    `b_op_or_sext = OP_XOR` mode pin are projected from `table.Spec` plus the
-    op-bus match. -/
-lemma equiv_XOR_of_static_table_row
-    (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
-    (xor_input : PureSpec.XorInput)
-    (r1 r2 rd : regidx)
-    (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
-    (r_main : ℕ)
-    (bus : ZiskFv.Compliance.BusRows)
-    (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_XOR)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
-    (h_match : ZiskFv.Airs.OperationBus.matches_entry
-      (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
-      (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
-    (h_input_r1_row : xor_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
-    (h_input_r2_row : xor_input.r2_val =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
-    (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
-    (promises : ZiskFv.EquivCore.Promises.RTypePromises
-        state xor_input.r1_val xor_input.r2_val xor_input.rd xor_input.PC
-        (PureSpec.execute_RTYPE_xor_pure xor_input).nextPC
-        r1 r2 rd bus.exec_row bus.e0 bus.e1 bus.e2)
-    : (do
-      Sail.writeReg Register.nextPC
-        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
-      LeanRV64D.Functions.execute
-        (instruction.RTYPE (r2, r1, rd, rop.XOR))) state
-      = state_effect_via_channels
-          ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_component_spec :
-      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec
-        (providerTable.environment providerRow) := by
-    simpa [h_component] using h_table_spec providerRow h_provider_row
-  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_component_spec
-  obtain ⟨h_row_spec, h_static_specs⟩ := h_component_spec
-  exact equiv_XOR_of_static_row state xor_input r1 r2 rd m row r_main bus pins
-    h_match h_row_spec h_core h_static_specs h_facts
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_r2_row)
-    h_lane_rd promises
 
 end ZiskFv.Equivalence.Xor

--- a/ZiskFv/Equivalence/Xori.lean
+++ b/ZiskFv/Equivalence/Xori.lean
@@ -32,29 +32,18 @@ theorem equiv_XORI
     (xori_input : PureSpec.XoriInput)
     (r1 rd : regidx) (imm : BitVec 12)
     (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
+    (p : ZiskFv.AirsClean.BinaryFamily.StaticBinaryProvider)
     (r_main : ℕ)
     (bus : ZiskFv.Compliance.BusRows)
     (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_XOR)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
     (h_match : ZiskFv.Airs.OperationBus.matches_entry
       (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
+        (ZiskFv.AirsClean.Binary.opBusMessage p.rowInput) 1))
     (h_input_r1_row : xori_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowA64 p.rowInput)
     (h_input_imm_row : BitVec.signExtend 64 xori_input.imm =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
+      ZiskFv.EquivCore.Add.binaryRowB64 p.rowInput)
     (h_xori_subset : itype_imm_subset_holds_main m r_main xori_input.imm)
     (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
     (promises : ZiskFv.EquivCore.Promises.ITypePromises
@@ -68,25 +57,10 @@ theorem equiv_XORI
         (instruction.ITYPE (imm, r1, rd, iop.XORI))) state
       = state_effect_via_channels
           ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_component_spec :
-      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec
-        (providerTable.environment providerRow) := by
-    simpa [h_component] using h_table_spec providerRow h_provider_row
-  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_component_spec
-  obtain ⟨h_row_spec, h_static_specs⟩ := h_component_spec
   rw [ZiskFv.Channels.state_effect_via_channels_eq_bus_effect_2]
-  exact ZiskFv.EquivCore.Xori.equiv_XORI_of_static_row
-    state xori_input r1 rd imm m row r_main bus promises pins
-    h_match h_row_spec h_core h_static_specs h_facts
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_imm_row)
-    h_lane_rd h_xori_subset
+  exact ZiskFv.Compliance.equiv_XORI
+    state xori_input r1 rd imm m p r_main bus pins
+    h_match h_input_r1_row h_input_imm_row h_xori_subset h_lane_rd promises
 
 
 /-- Row-native static-provider route for `equiv_XORI`. -/
@@ -129,65 +103,5 @@ lemma equiv_XORI_of_static_row
     state xori_input r1 rd imm m row r_main bus promises pins
     h_match h_row_spec h_core h_static h_facts
     h_input_r1_row h_input_imm_row h_lane_rd h_xori_subset
-
-/-- Lookup-aware Clean table-row route for `XORI`. -/
-lemma equiv_XORI_of_static_table_row
-    (state : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
-    (xori_input : PureSpec.XoriInput)
-    (r1 rd : regidx) (imm : BitVec 12)
-    (m : Valid_Main FGL FGL)
-    (providerTable : Air.Flat.Table FGL)
-    (providerRow : Array FGL)
-    (r_main : ℕ)
-    (bus : ZiskFv.Compliance.BusRows)
-    (pins : ZiskFv.Compliance.MainRowPins m r_main 1 OP_XOR)
-    (h_component :
-      providerTable.component = ZiskFv.AirsClean.Binary.staticLookupComponent)
-    (h_table_spec : providerTable.Spec)
-    (h_provider_row : providerRow ∈ providerTable.table)
-    (h_match : ZiskFv.Airs.OperationBus.matches_entry
-      (ZiskFv.Airs.OperationBus.opBus_row_Main m r_main)
-      (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry
-        (ZiskFv.AirsClean.Binary.opBusMessage
-          (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-            (providerTable.environment providerRow))) 1))
-    (h_input_r1_row : xori_input.r1_val =
-      ZiskFv.EquivCore.Add.binaryRowA64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
-    (h_input_imm_row : BitVec.signExtend 64 xori_input.imm =
-      ZiskFv.EquivCore.Add.binaryRowB64
-        (ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-          (providerTable.environment providerRow)))
-    (h_xori_subset : itype_imm_subset_holds_main m r_main xori_input.imm)
-    (h_lane_rd : ZiskFv.Airs.MemoryBus.register_write_lanes_match m r_main bus.e2)
-    (promises : ZiskFv.EquivCore.Promises.ITypePromises
-        state xori_input.r1_val xori_input.imm xori_input.rd xori_input.PC
-        (PureSpec.execute_ITYPE_xori_pure xori_input).nextPC
-        r1 rd imm bus.exec_row bus.e0 bus.e1 bus.e2)
-    : (do
-      Sail.writeReg Register.nextPC
-        (Sail.BitVec.addInt (← Sail.readReg Register.PC) 4)
-      LeanRV64D.Functions.execute
-        (instruction.ITYPE (imm, r1, rd, iop.XORI))) state
-      = state_effect_via_channels
-          ⟨bus.exec_row, [bus.e0, bus.e1, bus.e2]⟩ state := by
-  let row :=
-    ZiskFv.AirsClean.Binary.staticLookupComponent.rowInput
-      (providerTable.environment providerRow)
-  obtain ⟨h_core, h_facts⟩ :=
-    ZiskFv.AirsClean.BinaryFamily.staticBinary_core_and_wf_of_table_spec
-      h_component h_table_spec h_provider_row
-  have h_component_spec :
-      ZiskFv.AirsClean.Binary.staticLookupComponent.Spec
-        (providerTable.environment providerRow) := by
-    simpa [h_component] using h_table_spec providerRow h_provider_row
-  rw [ZiskFv.AirsClean.Binary.staticLookupComponent_spec] at h_component_spec
-  obtain ⟨h_row_spec, h_static_specs⟩ := h_component_spec
-  exact equiv_XORI_of_static_row state xori_input r1 rd imm m row r_main
-    bus pins h_match h_row_spec h_core h_static_specs h_facts
-    (by simpa [row] using h_input_r1_row)
-    (by simpa [row] using h_input_imm_row)
-    h_xori_subset h_lane_rd promises
 
 end ZiskFv.Equivalence.Xori


### PR DESCRIPTION
Resolves #325.

## What

Replaces the raw provider-table binder lists in the ALU/Binary, shift, and BinaryAdd `equiv_<op>` layers with three evidence bundles, mirroring the derived-bundle shape PR #294 established for Arith. All bundles live in `ZiskFv/AirsClean/BinaryFamily/Balance.lean`, next to the lowering lemmas they package:

- `StaticBinaryProvider` — pinned to `Binary.staticLookupComponent`; `facts` lowers to the four row-level facts (`Spec`, `core_every_row`, `StaticBinaryTableSpecFacts`, `StaticBinaryTableWfFacts`) the `equiv_<op>_of_static_row` cores consume.
- `ShiftStaticProvider` — pinned to `BinaryExtension.shiftStaticLookupComponent`; `facts` gives `WfFacts ∧ ShiftB0RangeSpecFact`.
- `BinaryAddProvider` — pinned to `BinaryAdd.component` (the ADD/ADDI `via_binaryadd` route); `facts` gives `ComponentSpecFacts`.

Per opcode: the `Compliance/Wrappers` lemma and the canonical `Equivalence` theorem take the bundle; the canonical theorem now genuinely delegates to the wrapper (several docstrings always claimed this while the proofs re-derived everything inline — And, Or, Xor, Andi, Ori, Xori, Sub); the dead `equiv_<op>_of_static_table_row` variants (definition-only, zero callers — verified per file by repo-wide grep before each deletion) are deleted; Dispatch/Construction callers build the bundle inline from the same five fields they already destructure. 28 wrapper files, 28 Equivalence files, 6 Dispatch files, 8 Construction files. Net: **−1,252 lines**.

## Why

- The table→row lowering block was copy-pasted up to 3× per opcode (~84 copies across wrapper + canonical + dead variant). It now lives once per provider family.
- Wrapper signatures no longer suggest caller-supplied trust that no caller supplies: the component pin, table spec, and row membership travel as one named bundle, exactly like the Arith witness bundles after #294.
- No trust-surface change: the frozen global binder baselines bind `env : OpEnvelope` by type only and are byte-identical; per-op axiom closures unchanged (V2 verifies closures, not binder text).

## Explicitly out of scope (deferred leg, needs owner sign-off — protected surface)

`OpEnvelope.lean` constructors still carry the raw five fields, and the `AeneasBridgeTrust/*` envelope builders mirror them; the Dispatch arms bridge between the two shapes with an inline anonymous constructor (definitionally free). Converting the envelope itself is the leg flagged in #325's scope comment.

## Review evidence and steering record

Work split: coordinator authored the bundles + AND pilot end-to-end, validated it compiled first-try, then fanned out four parallel agents (R-type, I-type, Add/W-forms, shifts) with the pilot diff as template and disjoint file ownership; coordinator then closed the BinaryAdd route the agents correctly refused to guess at.

- Each agent verified every edited wrapper with `lake env lean` (28/28 exit 0) before the coordinator's full builds.
- Agent-flagged anomalies, all resolved deliberately: (1) both `via_binaryadd` lemmas were skipped as unrepresentable by the two original bundles — resolved by adding `BinaryAddProvider` rather than forcing a wrong pin; (2) the shift agent found the six W-shift arms duplicated across two dispatcher theorems in `Dispatch/Remaining.lean` (12 call sites, not 6) and converted both copies; (3) variant wrapper bodies (mode-pin shape in Sub/Slt/Sltu/Addi/Slti/Sltiu, W-mode in Addw/Subw, immediate-decomposition in Addiw) were mapped onto `facts` components while preserving each file's existing core-call argument order.
- Reviewer pass (coordinator): leftover-binder grep across all converted layers found exactly one stale docstring (Subw, fixed); full-diff spot-checks (e.g. `Equivalence/Srliw.lean`) confirmed binder-substitution-only changes with conclusions and non-provider hypotheses untouched; the 28 remaining `h_component h_table_spec h_provider_row` occurrences in Dispatch are OpEnvelope case patterns, intentionally raw.
- `trust/generated/clean-integration-audit.md` is not regenerated: its generator input (`baseline-caller-burden.txt`) was retired before this PR, so its per-op "caller pins providerTable.component" lines are a historical snapshot of the pre-bundle shape. The live gate (V1 check 9, `check-clean-integration.py`) is structural and passes unchanged.

## Verification

- `lake build ZiskFv`: 9,144 jobs, green (only pre-existing `DivSpinRootSoundness` linter warnings).
- V1 `trust/scripts/check-all.sh`: **19/19 PASSED** (zisk submodule seeded at pinned `9ca88b5b`).
- V2 `trust/scripts/check-all-semantic.sh`: **19/19 PASSED** (all raw closures ⊆ {propext, Classical.choice, Quot.sound}; binder baselines byte-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
