### PR TITLE
#304: weld the 9 exposed-reading Main constraints; add consumed-by-acceptance check

### DIFF
--- a/ZiskFv/AirsClean/MainMirrorWeld.lean
+++ b/ZiskFv/AirsClean/MainMirrorWeld.lean
@@ -27,7 +27,7 @@ constraint at that circuit turns it into a polynomial over `MainRowWithRom`
 fields, and the weld theorems say that polynomial is *definitionally* the one
 the mirror asserts.
 
-## Coverage: 29 of the 144 generated constraints
+## Coverage: 38 of the 144 generated constraints
 
 `Extraction/Main.lean` defines `constraint_0_every_row` …
 `constraint_143_every_row`. They partition by their PIL source comment:
@@ -41,39 +41,27 @@ the mirror asserts.
   the mirror to weld them to. This is the same structural exclusion as Arith's
   stage-2 set.
 
-Of the 39, exactly 29 are pure stage-1 row-local (`id := 1`, `rotation := 0`,
+Of the 39, 29 are pure stage-1 row-local (`id := 1`, `rotation := 0`,
 `row := row`, no `preprocessed` / `exposed`): `1`, `2`, `5`–`8`, `11`–`17`,
-`22`–`37`. All 29 are welded below, and every weld is an `Iff`.
+`22`–`37`. All 29 are welded in "Part A" below, over `ExtractedMainRow`, and
+every weld is an `Iff`.
 
-The other 10 are **not** welded, individually because:
-
-* `0` — `exposed(0) * (1 - exposed(0))` (`main_last_segment` booleanity). Reads
-  no row column at all; there is no mirror counterpart anywhere in `ZiskFv/`.
-* `3`, `9` — a-side C-copy `((1 - a_src_mem) - a_src_imm - a_src_reg) *
-  (a[i] - previous_c)` (`main.pil:385`), reading `preprocessed(0)`,
-  `exposed(3+i)` and `c[i]` at `row - 1`. `ZiskFv/` has no counterpart at all:
-  `sourceCCopyBetween` (`Main/Circuit.lean:721`) covers only the *b*-side
-  selector `1 - b_src_mem - b_src_imm - b_src_ind - b_src_reg`, and the legacy
-  `Valid_Main` enumeration likewise stops at `b_src_c_copies_prev_c0` /
-  `b_src_c_copies_prev_c1` (`ZiskFv/Airs/Main/Main.lean:139,147`). Recorded as a
-  mirror-coverage gap; not fixed here, because inventing the missing mirror
-  clause is a modelling decision, not a transcription fix.
-* `4`, `10` — b-side C-copy (`main.pil:386`). `sourceCCopyBetween`'s own
-  docstring (`Main/Circuit.lean:715-720`) states it is a deliberate
-  specialization that drops the `__L1__`-selected public-input branch, so the
-  best available relation is `generated → mirror`, never an `Iff`.
-* `18` — pc handshake (`main.pil:410`). `pcHandshakeBetween`
-  (`Main/Circuit.lean:708`) reproduces the polynomial but substitutes the
-  witness field `core.segment_l1` for the generated `preprocessed (column := 0)`
-  (`SEGMENT_L1`). That substitution is backed by `mainFixedColumns`
-  (`Main/Circuit.lean:768`), which maps slot 17 to fixed column 0 — so this is
-  *not* a claimed defect — but it is not an `Iff.rfl` fact, and it is a two-row
-  constraint needing a two-row bridge this module does not build.
-* `19`, `20`, `21` — segment-final constraints at rotation `row + 1`
-  (`main.pil:423,426`), reading `preprocessed(0)@r+1` and `exposed(5/6/7)`. No
-  mirror counterpart.
-* `38` — `preprocessed(0) * (exposed(2) - pc)` (`main.pil:508`). No mirror
-  counterpart.
+The other 10 read `Extraction.Circuit.exposed` (`main.pil`'s public `airval`s:
+`main_last_segment`, `segment_initial_pc`, `segment_previous_c`,
+`segment_next_pc`, `segment_last_c`) — cells with no representative in
+`MainRowWithRom`, which is why they had no mirror counterpart before this
+module. 9 of them — `0`, `3`, `4`, `9`, `10`, `19`, `20`, `21`, `38` — are
+welded in "Part B" below, over a new carrier `MainExposed` that adds an
+exposed lane and a row-indexed view of the trace. `18` — pc handshake
+(`main.pil:410`) — is **not** welded: `pcHandshakeBetween`
+(`Main/Circuit.lean:708`) reproduces the polynomial but substitutes the
+witness field `core.segment_l1` for the generated `preprocessed (column := 0)`
+(`SEGMENT_L1`). That substitution is backed by `mainFixedColumns`
+(`Main/Circuit.lean:768`), which maps slot 17 to fixed column 0 — so this is
+*not* a claimed defect — but `18` reads `preprocessed(0)` at `row`, `main` at
+`row - 1`, *and* `exposed`, none of which line up with an `Iff.rfl` against
+`pcHandshakeBetween`'s two-`MainRowWithRom` shape without weakening one side or
+the other; left as a recorded gap rather than forced.
 
 ## What the weld does and does not certify
 
@@ -114,6 +102,13 @@ The other 10 are **not** welded, individually because:
   all 29 by `weldedConstraints_readOnlyModeledLanes` and
   `weldedConstraints_probeBridge`, not assumed; see "Which lanes a welded
   constraint is allowed to read".
+* Part B's carrier `MainExposed` reuses `mainValue` verbatim for its `main`
+  lane (via `extractedMainRow`), so it does not duplicate the column map Part A
+  already pins. Its own `preprocessed` and `exposed` maps — `SEGMENT_L1` read
+  off `MainRowWithRom.core.segment_l1` and the seven `airval` indices read off
+  `MainExposed`'s own fields — are handwritten and, like `mainValue`, not
+  column-map-gated: a compensating pair of slips there would also survive as
+  `rfl`.
 
 ## Trust note
 
@@ -125,6 +120,13 @@ namespace ZiskFv.AirsClean.Main
 
 open Goldilocks
 open ZiskFv.AirsClean.ZiskInstructionRom (Program)
+
+/-! ## Part A — the 29 stage-1 row-local constraints
+
+Everything down to "Which lanes a welded constraint is allowed to read" is
+unchanged from before this module's Part B addition: `ExtractedMainRow` wraps
+a single `MainRowWithRom` and stubs `preprocessed` / `challenge` / `exposed` to
+`0`, which is sound for these 29 because none of them reads those lanes. -/
 
 /-- An `Extraction.Circuit` whose stage-1 columns are the fields of a single
     `MainRowWithRom`. Only used to instantiate the generated `Main` constraint
@@ -204,8 +206,8 @@ instance extractedMainRowCircuit : Extraction.Circuit FGL FGL ExtractedMainRow w
     a column-map gate reading only `mainValue` would leave open — is a
     compile error here, before any weld is stated.
 
-    `extractedMainRowCircuit_pinned` at the end of the module pins the
-    remaining three fields and re-checks this one after all welds have
+    `extractedMainRowCircuit_pinned` at the end of Part A pins the
+    remaining three fields and re-checks this one after all Part A welds have
     resolved their instance. -/
 theorem extractedMainRowCircuit_main_eq
     (c : ExtractedMainRow FGL FGL) (id column r rotation : ℕ) :
@@ -640,15 +642,15 @@ theorem weldedConstraints_probeBridge (row : MainRowWithRom FGL) (r : ℕ) :
    Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl,
    Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl⟩
 
-/-! ## The instance is pinned
+/-! ## Part A's instance is pinned
 
 `extractedMainRowCircuit_main_eq` near the top already ties the class
 projection the generated constraints read through to `mainValue`. This closes
 the remaining freedom: it fixes all four fields at once, and it is stated
 through `inferInstance`, so it fails to compile both if a field drifts and if
 instance resolution for `Extraction.Circuit FGL FGL ExtractedMainRow` starts
-finding a different instance. It is deliberately the last declaration in the
-module: every weld above resolves that class against the instances declared
+finding a different instance. It is deliberately the last declaration of
+Part A: every Part A weld resolves that class against the instances declared
 before it, so an instance introduced anywhere above — including one shadowing
 `extractedMainRowCircuit` — is also the one this theorem resolves and checks. -/
 theorem extractedMainRowCircuit_pinned :
@@ -657,6 +659,201 @@ theorem extractedMainRowCircuit_pinned :
         preprocessed := fun _ _ _ _ => 0
         challenge := fun _ _ => 0
         exposed := fun _ _ => 0 } :=
+  rfl
+
+/-! ## Part B — the nine `exposed`-reading constraints
+
+`ExtractedMainRow` stubs `preprocessed` / `challenge` / `exposed` to `0`
+because none of the 29 Part A constraints reads them. Nine more of the 39
+`main.pil`-sourced constraints — `0`, `3`, `4`, `9`, `10`, `19`, `20`, `21`,
+`38` — read `Extraction.Circuit.exposed` (`main.pil`'s public `airval`s) and,
+for six of the nine, `Extraction.Circuit.preprocessed` (`SEGMENT_L1`) and a
+neighboring trace row (`row - 1` or `row + 1`). `MainExposed` is a second
+`Extraction.Circuit` carrier for exactly those nine: it bundles the seven
+`airval` values Part B's constraints read plus a row-indexed view of the
+trace, and its `main` lane reuses Part A's `mainValue` (via `extractedMainRow`)
+rather than re-deriving the column map. -/
+
+/-- The `airval`s `main.pil:72-77` publishes that the nine Part B constraints
+    read, plus a row-indexed view of the trace for the `main` and
+    `preprocessed` lanes. `main_segment` (`exposed` index `1`) is not read by
+    any of the nine and is deliberately omitted — `traceExposedValue` answers
+    `0` for index `1`, and none of the nine welds below reaches that arm. -/
+structure MainExposed (F ExtF : Type) where
+  /-- `exposed(0)`, `main.pil:72 main_last_segment`. -/
+  main_last_segment : F
+  /-- `exposed(2)`, `main.pil:74 segment_initial_pc`. -/
+  segment_initial_pc : F
+  /-- `exposed(3)`, `main.pil:75 segment_previous_c[0]`. -/
+  segment_previous_c_0 : F
+  /-- `exposed(4)`, `main.pil:75 segment_previous_c[1]`. -/
+  segment_previous_c_1 : F
+  /-- `exposed(5)`, `main.pil:76 segment_next_pc`. -/
+  segment_next_pc : F
+  /-- `exposed(6)`, `main.pil:77 segment_last_c[0]`. -/
+  segment_last_c_0 : F
+  /-- `exposed(7)`, `main.pil:77 segment_last_c[1]`. -/
+  segment_last_c_1 : F
+  /-- The trace, indexed by row. `traceMainValue`/`tracePreprocessedValue`
+      read `rows (row - 1)`, `rows row` and `rows (row + 1)` because the nine
+      constraints below do. -/
+  rows : ℕ → MainRowWithRom FGL
+
+/-- Reuses `mainValue` (Part A's column map) at whichever row the generated
+    constraint asks for, instead of re-deriving stage-1 column indices. -/
+@[reducible]
+def traceMainValue (c : MainExposed FGL FGL) (id column row rotation : ℕ) : FGL :=
+  mainValue (extractedMainRow (c.rows row)) id column row rotation
+
+/-- The one preprocessed column Part B reads: `SEGMENT_L1`, read off
+    `MainRowWithRom.core.segment_l1` at the requested row (`row` for `38`,
+    `row + 1` for `19`/`20`/`21`). This is the same field
+    `pcHandshakeBetween` substitutes for `preprocessed(0)` (see the module
+    docstring); nothing here relies on that other than sharing its name. -/
+@[reducible]
+def tracePreprocessedValue (c : MainExposed FGL FGL) (column row _rotation : ℕ) : FGL :=
+  if column = 0 then (c.rows row).core.segment_l1 else 0
+
+/-- No Part B constraint reads a challenge; `Main.extraction`'s
+    single-`F`-parameter constraints (the "mixed witness/challenge constraint
+    emitted for single-field circuits" ones, which is every constraint welded
+    below) do not even admit a nonzero `ExtF`, so this is never observed. -/
+@[reducible]
+def traceChallengeValue (_c : MainExposed FGL FGL) (_index : ℕ) : FGL := 0
+
+/-- `main.pil:72-77`'s seven public values, at the indices the extractor
+    assigns them. Index `1` (`main_segment`) is not modeled — see
+    `MainExposed`'s docstring. -/
+@[reducible]
+def traceExposedValue (c : MainExposed FGL FGL) (index : ℕ) : FGL :=
+  match index with
+  | 0 => c.main_last_segment
+  | 2 => c.segment_initial_pc
+  | 3 => c.segment_previous_c_0
+  | 4 => c.segment_previous_c_1
+  | 5 => c.segment_next_pc
+  | 6 => c.segment_last_c_0
+  | 7 => c.segment_last_c_1
+  | _ => 0
+
+instance extractedMainExposedCircuit : Extraction.Circuit FGL FGL MainExposed where
+  main := traceMainValue
+  preprocessed := tracePreprocessedValue
+  challenge := traceChallengeValue
+  exposed := traceExposedValue
+
+/-- `main/pil/main.pil:86 Main.main_last_segment*(1-Main.main_last_segment)` —
+    the `main_last_segment` booleanity pin. Reads only the exposed lane, no
+    row column at all. -/
+theorem constraint_0_weld (c : MainExposed FGL FGL) (r : ℕ) :
+    (c.main_last_segment * (1 - c.main_last_segment) = 0)
+      ↔ Main.extraction.constraint_0_every_row c r :=
+  Iff.rfl
+
+/-- `main/pil/main.pil:508 Main.SEGMENT_L1*(Main.segment_initial_pc-pc)` — the
+    first-row `pc` boundary pin, gated by `SEGMENT_L1` at the constraint's own
+    row. -/
+theorem constraint_38_weld (c : MainExposed FGL FGL) (r : ℕ) :
+    ((c.rows r).core.segment_l1 * (c.segment_initial_pc - (c.rows r).core.pc) = 0)
+      ↔ Main.extraction.constraint_38_every_row c r :=
+  Iff.rfl
+
+/-- `main/pil/main.pil:426 Main.SEGMENT_L1'*(Main.segment_last_c[0]-c[0])` —
+    the last-row `c[0]` boundary pin, gated by `SEGMENT_L1` one row ahead
+    (`SEGMENT_LAST = SEGMENT_L1'`). -/
+theorem constraint_20_weld (c : MainExposed FGL FGL) (r : ℕ) :
+    ((c.rows (r + 1)).core.segment_l1 * (c.segment_last_c_0 - (c.rows r).core.c_0) = 0)
+      ↔ Main.extraction.constraint_20_every_row c r :=
+  Iff.rfl
+
+/-- `main/pil/main.pil:426 Main.SEGMENT_L1'*(Main.segment_last_c[1]-c[1])` —
+    the `c[1]` sibling of `constraint_20_weld`. -/
+theorem constraint_21_weld (c : MainExposed FGL FGL) (r : ℕ) :
+    ((c.rows (r + 1)).core.segment_l1 * (c.segment_last_c_1 - (c.rows r).core.c_1) = 0)
+      ↔ Main.extraction.constraint_21_every_row c r :=
+  Iff.rfl
+
+/-- `main/pil/main.pil:423 Main.SEGMENT_L1'*(Main.segment_next_pc-(next_pc'))`
+    — the last-row next-`pc` boundary pin. `next_pc` is `main.pil:421`'s
+    `expected_current_pc` shifted one row, the same three-way `set_pc`/`flag`
+    split `constraint_18_every_row` (the un-welded pc handshake) evaluates at
+    `row - 1`; here it is evaluated at the constraint's own `row`, gated by
+    `SEGMENT_L1` one row ahead. -/
+theorem constraint_19_weld (c : MainExposed FGL FGL) (r : ℕ) :
+    ((c.rows (r + 1)).core.segment_l1 *
+        (c.segment_next_pc -
+          ((((c.rows r).core.set_pc * ((c.rows r).core.c_0 + (c.rows r).core.jmp_offset1))
+              + ((1 - (c.rows r).core.set_pc) *
+                  ((c.rows r).core.pc + (c.rows r).core.jmp_offset2)))
+            + ((c.rows r).core.flag *
+                ((c.rows r).core.jmp_offset1 - (c.rows r).core.jmp_offset2)))) = 0)
+      ↔ Main.extraction.constraint_19_every_row c r :=
+  Iff.rfl
+
+/-- `main/pil/main.pil:385 (a_src_c)*(a[0]-(previous_c))` — the a-side,
+    low-limb source-C copy. `previous_c = SEGMENT_L1 * (segment_previous_c[0]
+    - 'c[0]) + 'c[0]`: `c[0]` one row back, blended at a segment's first row
+    with the previous segment's exported value. `a_src_c` itself is inlined
+    as `(1 - a_src_mem) - a_src_imm - a_src_reg` (`Main/Circuit.lean:94`'s
+    `b_src_c` computes the b-side analogue the same way). -/
+theorem constraint_3_weld (c : MainExposed FGL FGL) (r : ℕ) :
+    ((((1 - (c.rows r).rom.a_src_mem) - (c.rows r).rom.a_src_imm) - (c.rows r).rom.a_src_reg) *
+        ((c.rows r).core.a_0 -
+          (((c.rows r).core.segment_l1 *
+              (c.segment_previous_c_0 - (c.rows (r - 1)).core.c_0))
+            + (c.rows (r - 1)).core.c_0)) = 0)
+      ↔ Main.extraction.constraint_3_every_row c r :=
+  Iff.rfl
+
+/-- `main/pil/main.pil:385 (a_src_c)*(a[1]-(previous_c))` — the `a[1]`
+    sibling of `constraint_3_weld`, reading `segment_previous_c[1]`
+    (`exposed(4)`) and `c[1]` one row back. -/
+theorem constraint_9_weld (c : MainExposed FGL FGL) (r : ℕ) :
+    ((((1 - (c.rows r).rom.a_src_mem) - (c.rows r).rom.a_src_imm) - (c.rows r).rom.a_src_reg) *
+        ((c.rows r).core.a_1 -
+          (((c.rows r).core.segment_l1 *
+              (c.segment_previous_c_1 - (c.rows (r - 1)).core.c_1))
+            + (c.rows (r - 1)).core.c_1)) = 0)
+      ↔ Main.extraction.constraint_9_every_row c r :=
+  Iff.rfl
+
+/-- `main/pil/main.pil:386 (b_src_c)*(b[0]-(previous_c))` — the b-side,
+    low-limb source-C copy, sharing `previous_c`'s `segment_previous_c[0]`
+    boundary with `constraint_3_weld`. `b_src_c` is inlined as
+    `(1 - b_src_mem) - b_src_imm - b_src_ind - b_src_reg`, matching
+    `Main/Circuit.lean:94`'s `b_src_c`. -/
+theorem constraint_4_weld (c : MainExposed FGL FGL) (r : ℕ) :
+    (((((1 - (c.rows r).rom.b_src_mem) - (c.rows r).rom.b_src_imm) - (c.rows r).rom.b_src_ind) -
+          (c.rows r).rom.b_src_reg) *
+        ((c.rows r).core.b_0 -
+          (((c.rows r).core.segment_l1 *
+              (c.segment_previous_c_0 - (c.rows (r - 1)).core.c_0))
+            + (c.rows (r - 1)).core.c_0)) = 0)
+      ↔ Main.extraction.constraint_4_every_row c r :=
+  Iff.rfl
+
+/-- `main/pil/main.pil:386 (b_src_c)*(b[1]-(previous_c))` — the `b[1]`
+    sibling of `constraint_4_weld`. -/
+theorem constraint_10_weld (c : MainExposed FGL FGL) (r : ℕ) :
+    (((((1 - (c.rows r).rom.b_src_mem) - (c.rows r).rom.b_src_imm) - (c.rows r).rom.b_src_ind) -
+          (c.rows r).rom.b_src_reg) *
+        ((c.rows r).core.b_1 -
+          (((c.rows r).core.segment_l1 *
+              (c.segment_previous_c_1 - (c.rows (r - 1)).core.c_1))
+            + (c.rows (r - 1)).core.c_1)) = 0)
+      ↔ Main.extraction.constraint_10_every_row c r :=
+  Iff.rfl
+
+/-- `extractedMainExposedCircuit`'s four fields are pinned: `inferInstance`
+    fails to compile both if a field drifts and if instance resolution for
+    `Extraction.Circuit FGL FGL MainExposed` starts finding a different
+    instance. Deliberately the last declaration in the module. -/
+theorem extractedMainExposedCircuit_pinned :
+    (inferInstance : Extraction.Circuit FGL FGL MainExposed) =
+      { main := traceMainValue
+        preprocessed := tracePreprocessedValue
+        challenge := traceChallengeValue
+        exposed := traceExposedValue } :=
   rfl
 
 end ZiskFv.AirsClean.Main

--- a/ZiskFv/AirsClean/MainMirrorWeld.lean
+++ b/ZiskFv/AirsClean/MainMirrorWeld.lean
@@ -642,25 +642,6 @@ theorem weldedConstraints_probeBridge (row : MainRowWithRom FGL) (r : ℕ) :
    Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl,
    Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl⟩
 
-/-! ## Part A's instance is pinned
-
-`extractedMainRowCircuit_main_eq` near the top already ties the class
-projection the generated constraints read through to `mainValue`. This closes
-the remaining freedom: it fixes all four fields at once, and it is stated
-through `inferInstance`, so it fails to compile both if a field drifts and if
-instance resolution for `Extraction.Circuit FGL FGL ExtractedMainRow` starts
-finding a different instance. It is deliberately the last declaration of
-Part A: every Part A weld resolves that class against the instances declared
-before it, so an instance introduced anywhere above — including one shadowing
-`extractedMainRowCircuit` — is also the one this theorem resolves and checks. -/
-theorem extractedMainRowCircuit_pinned :
-    (inferInstance : Extraction.Circuit FGL FGL ExtractedMainRow) =
-      { main := mainValue
-        preprocessed := fun _ _ _ _ => 0
-        challenge := fun _ _ => 0
-        exposed := fun _ _ => 0 } :=
-  rfl
-
 /-! ## Part B — the nine `exposed`-reading constraints
 
 `ExtractedMainRow` stubs `preprocessed` / `challenge` / `exposed` to `0`
@@ -843,6 +824,26 @@ theorem constraint_10_weld (c : MainExposed FGL FGL) (r : ℕ) :
             + (c.rows (r - 1)).core.c_1)) = 0)
       ↔ Main.extraction.constraint_10_every_row c r :=
   Iff.rfl
+
+/-! ## Part A's instance is pinned
+
+`extractedMainRowCircuit_main_eq` near the top already ties the class
+projection the generated constraints read through to `mainValue`. This closes
+the remaining freedom: it fixes all four fields at once, and it is stated
+through `inferInstance`, so it fails to compile both if a field drifts and if
+instance resolution for `Extraction.Circuit FGL FGL ExtractedMainRow` starts
+finding a different instance. Placed here, after every `instance _ :
+Extraction.Circuit ...` declared in this module (`extractedMainRowCircuit`,
+`mainProbeCircuit`, `extractedMainExposedCircuit`), so an instance introduced
+anywhere above — including one shadowing `extractedMainRowCircuit` — is also
+the one this theorem resolves and checks. -/
+theorem extractedMainRowCircuit_pinned :
+    (inferInstance : Extraction.Circuit FGL FGL ExtractedMainRow) =
+      { main := mainValue
+        preprocessed := fun _ _ _ _ => 0
+        challenge := fun _ _ => 0
+        exposed := fun _ _ => 0 } :=
+  rfl
 
 /-- `extractedMainExposedCircuit`'s four fields are pinned: `inferInstance`
     fails to compile both if a field drifts and if instance resolution for

--- a/tools/mirror-roundtrip/CONSUMED_BY_ACCEPTANCE.md
+++ b/tools/mirror-roundtrip/CONSUMED_BY_ACCEPTANCE.md
@@ -11,6 +11,58 @@ python3 tools/mirror-roundtrip/consumed_check.py --json PATH.json
 Python 3 standard library only; no Lean build, no network; nothing under `ZiskFv/`
 is read as anything other than text and nothing under it is written.
 
+## Correction (#304 review): the resolver was not actually strict
+
+An earlier version of this report claimed **36 CONSUMED / 10 FIDELITY-ONLY**,
+with "all 46 classified findings resolve identically under both [the strict and
+the loose] pass." That "strict" pass was not, in fact, namespace-strict:
+`resolve()`'s first step did an unqualified `idx.suffix_map.get(token)` lookup,
+and `suffix_map` held every dotted suffix of every declaration's fully-qualified
+name — including the bare last segment — for every declaration in the tree.
+Concretely, a bare reference like `Spec`, read anywhere in the reachability
+closure, matched **all** declarations named `Spec` regardless of namespace (at
+the time of writing, ~10 of them, one per AIR), and this unqualified match ran
+*before* any namespace-aware resolution, so the "strict" pass was already this
+over-broad — the review's exact diagnosis.
+
+`consumed_check.py`'s `resolve()` is now namespace-strict: every step is an
+**exact** `fqn_map` lookup of a fully-constructed candidate name (the token
+itself if fully qualified; the token prefixed by the reading declaration's own
+namespace or an ancestor of it, longest first; an `open X (token)` alias; a
+blanket `open X` namespace) — never a suffix match against unrelated
+namespaces. A bare token that names nothing in scope this way is UNRESOLVED,
+which is the safe direction for this tool: it can make a mirror look more
+FIDELITY-ONLY than it is, never more CONSUMED. `suffix_map` and the `suffixes()`
+helper are gone; a `_selfcheck()` runs on every invocation and asserts that a
+bare `Spec` read inside `ZiskFv/AirsClean/Mem/Circuit.lean` resolves to exactly
+`ZiskFv.AirsClean.Mem.Spec`, not the other ~9 unrelated `Spec`s.
+
+**Measured impact.** Forward-reachability from the same 9 root files/44
+declarations dropped from 1082 to 805 (of 8690 declarations now indexed,
+tree drift since the original report) — a real, ~26% reduction, confirming the
+old pass was over-reaching by a wide margin in the *general* graph. Against the
+46 classified findings specifically, exactly **one** verdict flips: Arith's
+`ArithDiv/Spec.lean:FullSpec` was wrongly CONSUMED and is now correctly
+FIDELITY-ONLY (concrete mechanism: `ArithMul/Circuit.lean` genuinely references
+its own bare `FullSpec`, i.e. `ZiskFv.AirsClean.ArithMul.FullSpec`; the old
+resolver's unqualified suffix match let that single reference also mark the
+unrelated `ZiskFv.AirsClean.ArithDiv.FullSpec` reachable, purely because both
+share the bare last segment `FullSpec`). Corrected headline: **35 CONSUMED / 11
+FIDELITY-ONLY**, 0 loose-only, 0 not-located — see "Headline numbers" below.
+
+The qualitative conclusion does **not** flip wholesale: most of this report's 46
+classified findings were already resolved through an unqualified reference
+within the SAME namespace as the target (e.g. `Main/Circuit.lean`'s `Spec :=
+fun row _ _ => Spec row.core`, read inside `ZiskFv.AirsClean.Main`, resolving to
+`ZiskFv.AirsClean.Main.Spec`), which the buggy resolver also got right, just for
+the wrong (unqualified) reason. The bug's damage was concentrated in the wider,
+unclassified reachability graph (the 1082 → 805 swing) and in the one
+classified finding that happened to collide on a shared bare segment. That is a
+real correction, not a rounding error, and every number in this report below is
+regenerated from the fixed resolver — but it is not the "massively different"
+outcome a first read of the bug report might suggest. See "Method" and "Method
+limitations" below for what the fix actually changed.
+
 ## The question
 
 `check_mirrors.py` (#304/#305) welds a handwritten mirror predicate to the
@@ -95,23 +147,31 @@ A textual, name-based forward-reachability graph, not an elaborated call graph
    c)` directives active at each point, so each declaration gets a best-effort
    fully-qualified name and an alias table.
 2. Seeds a worklist with the 44 declarations physically in the 9 root files.
-3. Pops a declaration, tokenizes its body, resolves each token against the global
-   index — trying an exact/suffix FQN match, then the declaration's own or an
-   enclosing namespace, then its file's explicit `open` aliases, then a blanket
-   `open X` namespace — and adds every newly-reached declaration to the worklist.
-   A declaration is **CONSUMED** iff it ends up in the visited set.
+3. Pops a declaration, tokenizes its body, resolves each token the way Lean
+   itself would resolve it: a fully-qualified token is an **exact** top-level
+   name; a relative token is resolved by prefixing it with the reading
+   declaration's own namespace or an ancestor of it (longest first) and doing an
+   exact lookup, then by the file's explicit `open X (token)` aliases, then by a
+   blanket `open X` namespace — and adds every newly-reached declaration to the
+   worklist. A bare token naming nothing reachable this way is UNRESOLVED, never
+   a match against "every declaration ending in that segment" (see the
+   correction above). A declaration is **CONSUMED** iff it ends up in the
+   visited set.
 4. A separate, looser pass additionally falls back to an ambiguous bare-name match
    (the same approximation `survey.reference_counts` already uses for "unreachable
    mirror") when the precise resolution finds nothing, purely to flag cases the
-   precise walk might have missed through a resolution gap. **At HEAD it changes
-   no verdict**: all 46 classified findings resolve identically under both passes
-   (0 "loose-only" reclassifications) — the precise walk is not silently
-   under-reaching here.
+   precise walk might have missed through a resolution gap. At the current tree
+   it changes no verdict among the 46 classified findings (0 "loose-only"
+   reclassifications) — meaningfully so now that the strict pass is actually
+   strict; under the pre-fix resolver this same "0" was not informative, since
+   the strict pass it was being compared against was already over-matching in
+   the same direction as the loose one.
 
 This shares `survey.reference_counts`'s soundness property and its limit: a
 **positive** reachability claim is only as good as the textual resolution that
 produced it (two same-named declarations in unrelated namespaces could in
-principle be confused); a **negative** one — nothing in the closure names this
+principle be confused if one is genuinely in scope of the other, e.g. via a
+wildcard `open`); a **negative** one — nothing in the closure names this
 declaration, under either resolution pass — is conclusive in the direction that
 matters for a FIDELITY-ONLY verdict. Every FIDELITY-ONLY finding below was
 additionally checked by direct source reading (not just the mechanical pass); see
@@ -128,9 +188,10 @@ additionally checked by direct source reading (not just the mechanical pass); se
   `permutation_every_row`, `core_every_row`, plus `segmentResidualEveryRow` again
   under its own name) — outside `survey.CLASSIFICATION`'s own scope
   (`ZiskFv/AirsClean/**` only) but squarely inside what this task asked about;
-* every top-level declaration of the six `*MirrorWeld.lean` files themselves (225
-  declarations) — the weld theorems and the `Extracted*`/probe scaffolding they
-  introduce.
+* every top-level declaration of the six `*MirrorWeld.lean` files themselves (241
+  declarations at the current tree; the count moves as the weld files grow, and
+  is orthogonal to the resolver fix) — the weld theorems and the
+  `Extracted*`/probe scaffolding they introduce.
 
 Not reclassified here: `survey.py`'s NEAR_* declarations (already out of the #304
 round trip's own scope, for a declared reason each) and the ~25 `NEAR_BUS`
@@ -143,19 +204,26 @@ the same sense.
 
 | | count |
 | --- | --- |
-| declarations indexed under `ZiskFv/` | 8674 |
+| declarations indexed under `ZiskFv/` | 8690 |
 | root declarations (9 files) | 44 |
-| forward-reachable from the roots | 1082 (12.5% of all `ZiskFv/` declarations) |
+| forward-reachable from the roots | 805 (9.3% of all `ZiskFv/` declarations) |
 | mirror-class findings classified | 46 (40 `CLASSIFICATION` + 1 `DELEGATED` + 5 `EXTRA`) |
-| **CONSUMED** | **36** |
-| **FIDELITY-ONLY** | **10** |
-| `*MirrorWeld.lean` declarations | 225 |
+| **CONSUMED** | **35** |
+| **FIDELITY-ONLY** | **11** |
+| CONSUMED (loose-only, ambiguous, needs manual check) | 0 |
+| not located in tree (stale entry) | 0 |
+| `*MirrorWeld.lean` declarations | 241 |
 | … of which reachable from the acceptance surface | **0** |
+
+(Previously reported, under the pre-fix over-matching resolver: 36 CONSUMED / 10
+FIDELITY-ONLY, forward-reachable 1082. See the correction above.)
 
 ## Per-AIR breakdown
 
-`C` = CONSUMED, `F` = FIDELITY-ONLY. Every verdict below resolved identically
-under the strict and the loose (ambiguous-fallback) pass.
+`C` = CONSUMED, `F` = FIDELITY-ONLY. Every verdict below resolves identically
+under the (now namespace-strict) strict pass and the loose (ambiguous-fallback)
+pass — i.e. none of these 46 needs the ambiguous fallback to be reachable, and
+none is reachable only through it.
 
 | AIR | mirror | class | verdict |
 | --- | --- | --- | --- |
@@ -169,7 +237,7 @@ under the strict and the loose (ambiguous-fallback) pass.
 | Arith | `ArithMul/Spec.lean:SharedDivBlockSpec` | MIRROR_COMPOSITE | C |
 | Arith | `ArithMul/Spec.lean:FullSpec` | MIXED_COMPOSITE | C |
 | Arith | `ArithDiv/Spec.lean:Spec` | MIRROR | C |
-| Arith | `ArithDiv/Spec.lean:FullSpec` | MIXED_COMPOSITE | C |
+| Arith | `ArithDiv/Spec.lean:FullSpec` | MIXED_COMPOSITE | **F** |
 | Binary | `Binary/Spec.lean:Spec` | MIRROR | C |
 | Binary | `Binary/Bridge.lean:constraints_at` | MIRROR_VALIDATOR | **F** |
 | BinaryAdd | `BinaryAdd/Circuit.lean:CoreFacts` | MIRROR | C |
@@ -219,8 +287,8 @@ folded into the honest-row construction the circuit's `assertZero`s run against
 the thing actually checked by an accepted trace is exactly what its Spec/
 transition fields say, and that is where the "real" mirror lives.
 
-Two systematic exceptions, both FIDELITY-ONLY, and neither is what "welded but
-consumed by nothing" usually looks like (dead code) — both are verified below to
+Three systematic exceptions, all FIDELITY-ONLY, and none is what "welded but
+consumed by nothing" usually looks like (dead code) — all are verified below to
 be **used, just not by acceptance**:
 
 ### 1. The whole `MIRROR_VALIDATOR` family (`constraints_at` over `Valid_<AIR>`, `pc_handshake_at`)
@@ -290,6 +358,28 @@ consumes the derivation instead:
   (the orphaned weld). Of the three, `RomBoolSpec` is the one with no live
   downstream use anywhere in the tree today.
 
+### 3. Arith's `ArithDiv/Spec.lean:FullSpec`
+
+The one finding whose verdict the resolver fix actually changed (C → F; see the
+correction at the top of this report). `ArithDiv.FullSpec`'s body (`Spec row ∧
+ArithTableSpec row ∧ IndexedRangeSpec row`) reads its own sibling `Spec` — a
+same-namespace reference, correctly resolved either way — but `FullSpec` itself
+is not one of `ArithDiv`'s live `component.circuit.Spec` fields; that role for
+the div/rem AIRs is filled by `ArithMul`'s `FullSpec ∧ SharedDivBlockSpec`
+(`ArithMul/Circuit.lean:631`, already CONSUMED above), a *different* declaration
+in a *different* namespace that happens to share the bare name `FullSpec`. That
+sharing is exactly what the old resolver's unqualified suffix match confused.
+
+Checked what actually consumes `ArithDiv.FullSpec` instead: `ArithDiv/Bridge.lean`
+projects `FullSpec (rowAt v r)` for a P4 construction, and it flows from there into
+`ZiskFv/Compliance/ConstructionDiv.lean`, `ConstructionDivu.lean`,
+`ConstructionDivuw.lean`, `ConstructionMulh.lean`, `ConstructionMulhsu.lean`,
+`ConstructionMulhu.lean`, `ConstructionMulw.lean`, `ConstructionRemu.lean`,
+`ConstructionRemuw.lean`, `OpBusProviderMatch.lean`, `SharedBundles.lean`, and
+the `TraceLevelExport`/`Wrappers` construction layer. Same shape as the other
+two exceptions: used by the soundness *proof*, not by the acceptance
+*definition*.
+
 ### The Mem `Valid_Mem` family is a different, *consumed* story
 
 Do not conflate `Mem.Bridge.lean`'s `constraints_at` (FIDELITY-ONLY, above) with
@@ -317,9 +407,11 @@ $ grep -rn "import ZiskFv.AirsClean.<Name>MirrorWeld" ZiskFv trust Tests
 # (no output, for every one of the six)
 ```
 
-So every one of their 225 top-level declarations is FIDELITY-ONLY by
-construction, independent of the reachability walk (which agrees: 0/225
-reachable). This includes the mechanically-derived weld-internal defs
+So every one of their 241 top-level declarations is FIDELITY-ONLY by
+construction, independent of the reachability walk (which agrees: 0/241
+reachable — confirmed again against the fixed resolver; this conclusion is
+import-based, not resolver-based, so it was never at risk from the #304-review
+bug). This includes the mechanically-derived weld-internal defs
 `ExtractedMemRow`, `ExtractedMemTrace`, `MemProbe`, `rowMainValue`,
 `traceMainValue`, and their five siblings' equivalents, plus every `constraint_N_weld`,
 `spec_weld`/`segment_weld`/`permutation_weld`, and the two `*_pinned` instance-pin
@@ -353,12 +445,13 @@ omission.
 ## Answering the task's specific questions
 
 * **Which welded constraints are fidelity-only?** All content of all six
-  `*MirrorWeld.lean` files (225 declarations, 0 reachable) — see above. Among the
+  `*MirrorWeld.lean` files (241 declarations, 0 reachable) — see above. Among the
   *pre-existing* mirrors a weld cites (as opposed to weld-owned scaffolding), the
   `MIRROR_VALIDATOR` family is fidelity-only for every AIR that has one (Binary,
-  BinaryAdd, Main, Mem, MemAlignByte, MemAlignReadByte), and Main's
+  BinaryAdd, Main, Mem, MemAlignByte, MemAlignReadByte), Main's
   `AddressSpec`/`SourceSpec`/`RomBoolSpec` are fidelity-only despite being
-  matched/weld-covered by #304/#296.
+  matched/weld-covered by #304/#296, and (post resolver-fix) so is Arith's
+  `ArithDiv.FullSpec`.
 * **Are the Main/Mem welds we care about consumed or fidelity-only?** The weld
   *files* are fidelity-only, full stop (nothing imports them). The mirrors they
   weld are a mix: `Main.Spec`/`Mem.Spec` (the mirrors that actually flow into
@@ -375,17 +468,36 @@ omission.
   without a literal name appearing in source would be invisible to this pass. No
   case of that was found in the 46 classified findings (0 loose-only
   reclassifications), but the tool cannot rule it out in general.
-* **Ambiguity is upper-bounded, not resolved.** The loose pass's bare-name
-  fallback is the same approximation `survey.reference_counts` already accepts;
-  it changed no verdict here, which is itself evidence the namespace/`open`
-  tracking is doing real work, not evidence that ambiguity cannot occur elsewhere
-  in `ZiskFv/`.
+* **Under-matching by design, not over-matching.** `resolve()` only accepts an
+  EXACT `fqn_map` lookup of a fully-constructed candidate name (the token as
+  given, or prefixed by the reading declaration's own/an ancestor namespace, an
+  `open` alias, or a blanket `open` namespace). A bare token matching no real
+  in-scope declaration this way is UNRESOLVED, not a hit against every
+  declaration sharing that bare last segment across unrelated namespaces — that
+  bare-suffix match was a real bug (see the correction at the top of this
+  report), confirmed to have wrongly marked `ArithDiv.FullSpec` CONSUMED via its
+  bare-name collision with the genuinely-consumed `ArithMul.FullSpec`. This is
+  still a heuristic, not kernel-verified: it is a name-based textual pass, not an
+  elaborated call graph, so it can in principle still under-report (miss a real
+  reference the tokenizer or namespace tracking mishandles) but cannot
+  over-report a CONSUMED verdict through a cross-namespace name collision, which
+  was the specific failure mode fixed here.
+* **Ambiguity is upper-bounded, not resolved.** The separate loose pass's
+  bare-name fallback (used only when the strict, namespace-aware resolution
+  finds nothing, and reported separately as "consumed only via ambiguous
+  bare-name fallback, manual check needed") is the same approximation
+  `survey.reference_counts` already accepts; it changes no verdict among the 46
+  classified findings under the fixed resolver, which is now meaningful evidence
+  the namespace/`open` tracking is doing real work — not, as previously claimed,
+  evidence measured against a strict pass that was itself already over-matching.
 * **Every FIDELITY-ONLY verdict above was independently checked by reading
   source**, not accepted from the mechanical pass alone: `Main/Circuit.lean`'s
-  actual `Spec` field text, and a direct `grep` of who else names each
-  `constraints_at`/`AddressSpec`/`SourceSpec`/`RomBoolSpec`. The CONSUMED verdicts
-  were spot-checked the same way for `Mem.Spec` and `ArithMul`'s `FullSpec`/
-  `SharedDivBlockSpec` composition, not exhaustively for all 36.
+  actual `Spec` field text, `ArithMul/Circuit.lean`'s actual `Spec` field text
+  (for `ArithDiv.FullSpec`), and a direct `grep` of who else names each
+  `constraints_at`/`AddressSpec`/`SourceSpec`/`RomBoolSpec`/`FullSpec`. The
+  CONSUMED verdicts were spot-checked the same way for `Mem.Spec` and
+  `ArithMul`'s `FullSpec`/`SharedDivBlockSpec` composition, not exhaustively for
+  all 35.
 * **Scope is `survey.CLASSIFICATION`'s mirror classes plus a small named
   addendum**, not "every Prop under `ZiskFv/`". `NEAR_*` and `NEAR_BUS`
   declarations are not reclassified (see "The Balance/* layer" above for why that

--- a/tools/mirror-roundtrip/CONSUMED_BY_ACCEPTANCE.md
+++ b/tools/mirror-roundtrip/CONSUMED_BY_ACCEPTANCE.md
@@ -1,0 +1,392 @@
+# Is a #304 mirror consumed by acceptance, or fidelity-only?
+
+Issue: eth-act/zisk-fv#304 follow-up (verification-hole track). Companion to
+`tools/mirror-roundtrip/README.md`. Reproduced by:
+
+```bash
+python3 tools/mirror-roundtrip/consumed_check.py          # this report's data, regenerated
+python3 tools/mirror-roundtrip/consumed_check.py --json PATH.json
+```
+
+Python 3 standard library only; no Lean build, no network; nothing under `ZiskFv/`
+is read as anything other than text and nothing under it is written.
+
+## The question
+
+`check_mirrors.py` (#304/#305) welds a handwritten mirror predicate to the
+generated constraint it canonically restates: an `Iff.rfl`-checked polynomial
+equality. That is a **fidelity** fact — the mirror says the same thing the
+generated constraint says. It is not a **consumption** fact: `Iff.rfl` typechecks
+identically whether or not the mirror's own name is mentioned by anything else in
+the build. `ZiskFv/AirsClean/MemMirrorWeld.lean`'s `ExtractedMemTrace` is the
+standing example — matched perfectly against 34 generated Mem constraints, and
+referenced by nothing but that one weld file.
+
+This asks the other question: is the mirror predicate itself reachable, by a
+forward reference walk, from the two declarations that jointly say what an
+**accepted** ZisK trace is —
+
+* `ZiskFv.Compliance.AcceptedZiskTrace` — `ZiskFv/Compliance/AcceptedZiskTrace.lean`
+  plus its own `ZiskFv/Compliance/AcceptedZiskTrace/*.lean` companion files
+  (`MainTable.lean`, `MemAlignRanges.lean`, `MemAlignRom.lean`, `MemProviders.lean`,
+  `MemSegmentRanges.lean`, `MemTable.lean`, `Spec.lean`) — the companions import the
+  base file and derive further certificates about what "accepted" implies, notably
+  `AcceptedZiskTrace.spec_holds` (`Spec.lean`), which is how a table's `Spec` field
+  (where a mirror typically lives) enters the picture even though it is not a raw
+  struct field of `AcceptedZiskTrace`;
+* `ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble`, declared alongside
+  `fullRv64imSoundEnsemble` and `witness_spec_of_constraints` in
+  `ZiskFv/AirsClean/FullEnsemble.lean`.
+
+Nine files, 44 top-level declarations, are the roots. Everything a mirror needs to
+reach to be **CONSUMED** is one of those 44 declarations, or something forward-
+reachable from them.
+
+## Why `AcceptedZiskTrace`'s fields alone are not enough context
+
+`AcceptedZiskTrace`'s four constraint-shaped fields —
+
+```
+constraints_hold                    : witness.Constraints
+channels_balanced                   : witness.BalancedChannels
+transitions_hold                    : witness.TransitionConstraints
+cyclic_successor_transitions_hold   : witness.CyclicSuccessorTransitionConstraints
+```
+
+— are stated against `Air.Flat.Table`/`Ensemble` definitions in Clean
+(`build/clean-lean/Clean/Air/{FlatComponent,FlatEnsemble}.lean`), not against
+anything in `ZiskFv/`. `Table.Constraints table := ∀ row ∈ table.table,
+table.component.operations.ConstraintsHold (table.environment row)` — this is the
+`assertZero` sequence each AIR's `circuit.main` actually emits, i.e. `Constraints`
+IS the trace's checked polynomial gates. `Table.Spec`/`Component.Spec` is a
+*different* field of the same `GeneralFormalCircuit` — `component.circuit.Spec` —
+and is where a `Valid_<AIR>`/`Spec`-style mirror predicate can be wired in as the
+circuit's semantic postcondition. `AcceptedZiskTrace` does not carry `witness.Spec`
+as a field at all; it is **derived**, not assumed:
+
+```lean
+-- ZiskFv/Compliance/AcceptedZiskTrace/Spec.lean
+@[reducible] def AcceptedZiskTrace.spec_holds (trace : AcceptedZiskTrace n) : trace.witness.Spec :=
+  ZiskFv.AirsClean.FullEnsemble.witness_spec_of_constraints
+    trace.witness trace.constraints_hold trace.channels_balanced
+```
+
+So a mirror can be part of what "accepted" implies through either of two routes,
+both counted here: it is literally in an AIR's `circuit.main` assertion list (feeds
+`Constraints` directly — the strongest form), or it is (part of) an AIR's
+`circuit.Spec` field (feeds `witness.Spec`, reachable via `spec_holds`). Verified
+directly for `Mem`:
+
+```lean
+-- ZiskFv/AirsClean/Mem/Circuit.lean:77 (componentWithDualMemBus's circuit)
+Spec := fun row _ _ => Spec row      -- `Spec` here is ZiskFv.AirsClean.Mem.Spec
+```
+
+## Method
+
+A textual, name-based forward-reachability graph, not an elaborated call graph
+(building one would need Lean itself). `tools/mirror-roundtrip/consumed_check.py`:
+
+1. Parses every `.lean` file under `ZiskFv/` into top-level declarations (reusing
+   `survey.declarations`'s boundary rule: a line starting a keyword in
+   `survey.DECL_KEYWORDS`, behind optional attributes/`open ... in`/privacy
+   modifiers, runs to the next such start). Separately, in the same linear pass,
+   tracks the `namespace`/`section`/`end` stack and the `open X` / `open X (a b
+   c)` directives active at each point, so each declaration gets a best-effort
+   fully-qualified name and an alias table.
+2. Seeds a worklist with the 44 declarations physically in the 9 root files.
+3. Pops a declaration, tokenizes its body, resolves each token against the global
+   index — trying an exact/suffix FQN match, then the declaration's own or an
+   enclosing namespace, then its file's explicit `open` aliases, then a blanket
+   `open X` namespace — and adds every newly-reached declaration to the worklist.
+   A declaration is **CONSUMED** iff it ends up in the visited set.
+4. A separate, looser pass additionally falls back to an ambiguous bare-name match
+   (the same approximation `survey.reference_counts` already uses for "unreachable
+   mirror") when the precise resolution finds nothing, purely to flag cases the
+   precise walk might have missed through a resolution gap. **At HEAD it changes
+   no verdict**: all 46 classified findings resolve identically under both passes
+   (0 "loose-only" reclassifications) — the precise walk is not silently
+   under-reaching here.
+
+This shares `survey.reference_counts`'s soundness property and its limit: a
+**positive** reachability claim is only as good as the textual resolution that
+produced it (two same-named declarations in unrelated namespaces could in
+principle be confused); a **negative** one — nothing in the closure names this
+declaration, under either resolution pass — is conclusive in the direction that
+matters for a FIDELITY-ONLY verdict. Every FIDELITY-ONLY finding below was
+additionally checked by direct source reading (not just the mechanical pass); see
+"Verified, not just mechanical" below.
+
+## Scope classified
+
+* every `survey.CLASSIFICATION` entry whose class is a mirror class
+  (`survey.MIRROR_CLASSES`) — 40 entries, the #304 inventory itself;
+* `survey.DELEGATED` — 1 entry, an out-of-root mirror a root mirror reaches
+  (`ZiskFv.Airs.Mem.segmentResidualEveryRow`);
+* 5 additional pre-Clean `ZiskFv/Airs/Mem.lean` declarations the #304
+  `MemMirrorWeld.lean` docstring names by hand (`Valid_Mem`, `segment_every_row`,
+  `permutation_every_row`, `core_every_row`, plus `segmentResidualEveryRow` again
+  under its own name) — outside `survey.CLASSIFICATION`'s own scope
+  (`ZiskFv/AirsClean/**` only) but squarely inside what this task asked about;
+* every top-level declaration of the six `*MirrorWeld.lean` files themselves (225
+  declarations) — the weld theorems and the `Extracted*`/probe scaffolding they
+  introduce.
+
+Not reclassified here: `survey.py`'s NEAR_* declarations (already out of the #304
+round trip's own scope, for a declared reason each) and the ~25 `NEAR_BUS`
+`FullEnsemble/Balance/*` declarations — those are ensemble/channel-balance
+machinery, not constraint mirrors, though several of them *are* on the
+reachability path (see "The Balance/* layer" below) and none is fidelity-only in
+the same sense.
+
+## Headline numbers
+
+| | count |
+| --- | --- |
+| declarations indexed under `ZiskFv/` | 8674 |
+| root declarations (9 files) | 44 |
+| forward-reachable from the roots | 1082 (12.5% of all `ZiskFv/` declarations) |
+| mirror-class findings classified | 46 (40 `CLASSIFICATION` + 1 `DELEGATED` + 5 `EXTRA`) |
+| **CONSUMED** | **36** |
+| **FIDELITY-ONLY** | **10** |
+| `*MirrorWeld.lean` declarations | 225 |
+| … of which reachable from the acceptance surface | **0** |
+
+## Per-AIR breakdown
+
+`C` = CONSUMED, `F` = FIDELITY-ONLY. Every verdict below resolved identically
+under the strict and the loose (ambiguous-fallback) pass.
+
+| AIR | mirror | class | verdict |
+| --- | --- | --- | --- |
+| Arith | `ArithMul/Spec.lean:Spec` | MIRROR | C |
+| Arith | `ArithMul/Spec.lean:C46Spec` | MIRROR | C |
+| Arith | `ArithMul/Spec.lean:DivModeSpec` | MIRROR | C |
+| Arith | `ArithMul/Spec.lean:DivBoundarySpec` | MIRROR | C |
+| Arith | `ArithMul/Spec.lean:DivInverseSumSpec` | MIRROR | C |
+| Arith | `ArithMul/Spec.lean:DivScopeSpec` | MIRROR | C |
+| Arith | `ArithMul/Spec.lean:DivWModeSpec` | MIRROR | C |
+| Arith | `ArithMul/Spec.lean:SharedDivBlockSpec` | MIRROR_COMPOSITE | C |
+| Arith | `ArithMul/Spec.lean:FullSpec` | MIXED_COMPOSITE | C |
+| Arith | `ArithDiv/Spec.lean:Spec` | MIRROR | C |
+| Arith | `ArithDiv/Spec.lean:FullSpec` | MIXED_COMPOSITE | C |
+| Binary | `Binary/Spec.lean:Spec` | MIRROR | C |
+| Binary | `Binary/Bridge.lean:constraints_at` | MIRROR_VALIDATOR | **F** |
+| BinaryAdd | `BinaryAdd/Circuit.lean:CoreFacts` | MIRROR | C |
+| BinaryAdd | `BinaryAdd/Circuit.lean:ComponentSpecFacts` | MIXED_COMPOSITE | C |
+| BinaryAdd | `BinaryAdd/Bridge.lean:constraints_at` | MIRROR_VALIDATOR | **F** |
+| Main | `Main/Spec.lean:Spec` | MIRROR | C |
+| Main | `Main/Spec.lean:AddressSpec` | MIRROR | **F** |
+| Main | `Main/Spec.lean:SourceSpec` | MIRROR | **F** |
+| Main | `Main/Circuit.lean:RomBoolSpec` | MIRROR | **F** |
+| Main | `Main/Circuit.lean:MainRomAddressGuard` | MIRROR_BUILDER | C |
+| Main | `Main/Circuit.lean:MainRomSourceGuard` | MIRROR_BUILDER | C |
+| Main | `Main/Circuit.lean:pcHandshakeBetween` | MIRROR_2ROW | C |
+| Main | `Main/Circuit.lean:sourceCCopyBetween` | MIRROR_2ROW | C |
+| Main | `Main/Circuit.lean:transitionBetween` | MIRROR_COMPOSITE | C |
+| Main | `Main/Circuit.lean:pcHandshakeTransition` | MIRROR_ENV | C |
+| Main | `Main/Bridge.lean:constraints_at` | MIRROR_VALIDATOR | **F** |
+| Main | `Main/CrossRow.lean:pc_handshake_at` | MIRROR_VALIDATOR | **F** |
+| Mem | `Mem/Spec.lean:Spec` | MIRROR | C |
+| Mem | `Mem/Bridge.lean:constraints_at` | MIRROR_VALIDATOR | **F** |
+| Mem | `Mem/GeneratedTransition.lean:generatedTransition` | MIRROR_COMPOSITE | C |
+| Mem | `Airs/Mem.lean:segmentResidualEveryRow` (DELEGATED) | — | C |
+| Mem | `Airs/Mem.lean:Valid_Mem` (EXTRA) | — | C |
+| Mem | `Airs/Mem.lean:segment_every_row` (EXTRA) | — | C |
+| Mem | `Airs/Mem.lean:permutation_every_row` (EXTRA) | — | C |
+| Mem | `Airs/Mem.lean:core_every_row` (EXTRA) | — | C |
+| MemAlign | `MemAlign/Spec.lean:Spec` | MIRROR | C |
+| MemAlign | `MemAlign/Circuit.lean:transitionRows` | MIRROR_2ROW | C |
+| MemAlign | `MemAlign/Circuit.lean:cyclicSuccessorTransitionRows` | MIRROR_2ROW | C |
+| MemAlign | `MemAlign/Circuit.lean:transition` | MIRROR_ENV | C |
+| MemAlign | `MemAlign/Circuit.lean:cyclicSuccessorTransition` | MIRROR_ENV | C |
+| MemAlignByte | `MemAlignByte/Spec.lean:Spec` | MIRROR_MIXED | C |
+| MemAlignByte | `MemAlignByte/Bridge.lean:constraints_at` | MIRROR_VALIDATOR | **F** |
+| MemAlignReadByte | `MemAlignReadByte/Spec.lean:Spec` | MIRROR_MIXED | C |
+| MemAlignReadByte | `MemAlignReadByte/Bridge.lean:constraints_at` | MIRROR_VALIDATOR | **F** |
+
+## The pattern
+
+Every AIR's core `Spec` — the mirror wired straight into that AIR's live
+`component.circuit.Spec` field (`fun row _ _ => Spec row` or a conjunction
+containing it, e.g. Arith's `FullSpec row ∧ SharedDivBlockSpec row`) — is
+CONSUMED, for all nine AIRs that have one. So is every mirror feeding a
+`Component.transition`/`cyclicSuccessorTransition` field (Main's
+`pcHandshakeBetween`/`sourceCCopyBetween`/`transitionBetween`/
+`pcHandshakeTransition`, MemAlign's four), and every `MIRROR_BUILDER` mirror
+folded into the honest-row construction the circuit's `assertZero`s run against
+(Main's `MainRomAddressGuard`/`MainRomSourceGuard`). This is the expected shape:
+the thing actually checked by an accepted trace is exactly what its Spec/
+transition fields say, and that is where the "real" mirror lives.
+
+Two systematic exceptions, both FIDELITY-ONLY, and neither is what "welded but
+consumed by nothing" usually looks like (dead code) — both are verified below to
+be **used, just not by acceptance**:
+
+### 1. The whole `MIRROR_VALIDATOR` family (`constraints_at` over `Valid_<AIR>`, `pc_handshake_at`)
+
+Six declarations, one per AIR that has this validator layer (Binary, BinaryAdd,
+Main, Mem, MemAlignByte, MemAlignReadByte) — **all six** are FIDELITY-ONLY. This
+is a second, parallel mirror layer per AIR: `Bridge.lean`/`CrossRow.lean` restate
+the same constraints over `Valid_<AIR>`-indexed row accessors (a trace-level
+interface, not the Clean row record), proved *from* the AIR's live
+`ConstraintsHold`. None of that family is part of `component.circuit.Spec` for any
+AIR.
+
+Checked what each one is used for instead of just reporting "not found":
+
+* `Main.pc_handshake_at` has exactly one consumer outside `ZiskFv/AirsClean/**`:
+  `ZiskFv/Compliance/MainTransition.lean`, which derives
+  `AcceptedZiskTrace.mainTransition_to_next_pc` — a theorem *about* an accepted
+  trace, but one that lives one level downstream of `AcceptedZiskTrace`'s own
+  directory (it imports `AcceptedZiskTrace.MainTable`, it is not part of the
+  group `AcceptedZiskTrace.lean`'s own docstring describes), feeding the
+  per-opcode `h_nextPC_matches` construction that `ZiskFv/Soundness.lean`'s
+  `root_soundness` ultimately needs. Used, by the soundness *proof*, not by the
+  acceptance *definition*.
+* `Mem.constraints_at` has one consumer outside its own `Bridge.lean`:
+  `ZiskFv/AirsClean/FullEnsemble/Balance/RowsBridgeFacts.lean`
+  (`constraints_at_of_memTableGeneratedRowsBridge`, line 987) — a file that *is*
+  imported by an acceptance-surface root (`AcceptedZiskTrace.lean` imports it
+  directly), but that one theorem is not itself on the path any root declaration's
+  body actually walks; the file is large (1000+ lines) and only part of it is
+  currently exercised from `AcceptedZiskTrace`'s own derivations. A live,
+  reachable neighbor of the acceptance surface, not (yet) inside it.
+* `Binary.constraints_at`, `BinaryAdd.constraints_at`, `MemAlignByte.constraints_at`,
+  `MemAlignReadByte.constraints_at` have **no consumer anywhere** outside their own
+  defining `Bridge.lean` file (confirmed by grep: each of those four AIRs'
+  `Bridge.lean` is the *only* file mentioning `constraints_at` for that AIR — not
+  even that AIR's own `*MirrorWeld.lean` cites it). These four are closer to
+  genuinely unused scaffolding than to "used downstream" — flagged here as the
+  weakest members of the FIDELITY-ONLY set.
+
+### 2. Main's `AddressSpec`, `SourceSpec`, `RomBoolSpec`
+
+Verified directly against `ZiskFv/AirsClean/Main/Circuit.lean`: the live
+component's `Spec` field (line 690, `circuitWithRomMemAndOpBus`, the one
+`FullEnsemble.lean` composes) is
+
+```lean
+Spec := fun row _ _ => Spec row.core
+```
+
+— only the base `Spec` (already CONSUMED above). `AddressSpec`, `SourceSpec` and
+`RomBoolSpec` are each proved *derivable* from `ConstraintsHold` by a standalone
+theorem in the same file
+(`addressSpec_of_mainWithRomAndMemBus_constraints`,
+`sourceSpec_of_mainWithRomAndMemBus_constraints`,
+`romBoolSpec_of_mainWithRomAndMemBus_constraints`), but none of the three is
+folded into the ensemble's own `Spec`/`Constraints` obligation. Checked what
+consumes the derivation instead:
+
+* `AddressSpec` and `SourceSpec` are each consumed by several files under
+  `ZiskFv/Compliance/TraceLevelExport/**` — the root-soundness construction layer
+  (`RomDecodeBinding.lean`, `RomDecodeBindingOps.lean`, `RowDataArithMem.lean`,
+  `StepStrongControlStore.lean`, `StepStrongLoadMext.lean`). Used, by the
+  soundness proof, not by the acceptance definition — the same shape as
+  `pc_handshake_at` above.
+* `RomBoolSpec` has **no consumer under `ZiskFv/Compliance/**` at all**. Its only
+  reference outside `Main/Circuit.lean` itself is `ZiskFv/AirsClean/MainMirrorWeld.lean`
+  (the orphaned weld). Of the three, `RomBoolSpec` is the one with no live
+  downstream use anywhere in the tree today.
+
+### The Mem `Valid_Mem` family is a different, *consumed* story
+
+Do not conflate `Mem.Bridge.lean`'s `constraints_at` (FIDELITY-ONLY, above) with
+the pre-Clean `ZiskFv/Airs/Mem.lean` mirrors the `MemMirrorWeld.lean` docstring
+names — `Valid_Mem`, `segment_every_row`, `permutation_every_row`,
+`core_every_row`, `segmentResidualEveryRow`. These are a *different* declaration
+family (older namespace, `ZiskFv.Airs.Mem`, not `ZiskFv.AirsClean.Mem`), and all
+five are **CONSUMED**: they are exactly what
+`ZiskFv/Compliance/AcceptedZiskTrace/MemSegmentRanges.lean`,
+`MemProviders.lean` and `FullEnsemble/Balance/RowsBridgeFacts.lean` thread through
+to unpack `AcceptedZiskTrace`'s `MutableMemPresent`/`mem_replay_*` machinery. So
+for Mem specifically there are two parallel "indexed by a trace accessor" mirror
+layers: the old one is load-bearing for the memory-replay direction of
+acceptance; the new Clean-side one (`Bridge.lean`'s `constraints_at`) is not (yet)
+wired into it.
+
+## The `*MirrorWeld.lean` files: uniformly fidelity-only, and orphaned outright
+
+None of the six weld files (`ArithMirrorWeld.lean`, `BinaryMirrorWeld.lean`,
+`MainMirrorWeld.lean`, `MemAlignByteMirrorWeld.lean`, `MemAlignMirrorWeld.lean`,
+`MemMirrorWeld.lean`) is imported by anything else checked in:
+
+```bash
+$ grep -rn "import ZiskFv.AirsClean.<Name>MirrorWeld" ZiskFv trust Tests
+# (no output, for every one of the six)
+```
+
+So every one of their 225 top-level declarations is FIDELITY-ONLY by
+construction, independent of the reachability walk (which agrees: 0/225
+reachable). This includes the mechanically-derived weld-internal defs
+`ExtractedMemRow`, `ExtractedMemTrace`, `MemProbe`, `rowMainValue`,
+`traceMainValue`, and their five siblings' equivalents, plus every `constraint_N_weld`,
+`spec_weld`/`segment_weld`/`permutation_weld`, and the two `*_pinned` instance-pin
+theorems. **This is exactly the pattern the task named as the standing example**
+(`ExtractedMemTrace`) — and it generalizes cleanly to all six weld files, with no
+exception. The weld files are, in full, a fidelity check: nothing they define is
+part of what "accepted" means, and nothing outside them names anything they
+define.
+
+This is architecturally deliberate, not a gap: a weld file's entire job is to
+kernel-check an `Iff.rfl` between a pre-existing mirror (defined elsewhere, e.g.
+`Mem.Spec`) and the generated constraints. Its own scaffolding (the
+`Extraction.Circuit` instances, the probe circuits) exists only to state that
+`Iff.rfl`, never to be consumed by anything downstream — and it is the
+pre-existing mirror it welds (`Mem.Spec`, `Valid_Mem`/`segment_every_row`, etc.)
+whose OWN consumption status is the real question, answered per-AIR above.
+
+## The Balance/* layer, for context (not reclassified)
+
+`ZiskFv/AirsClean/FullEnsemble/Balance/*` holds ~25 `NEAR_BUS` declarations
+(channel/interaction/replay predicates, not constraint mirrors — out of
+`survey.CLASSIFICATION`'s own mirror scope). Several are directly on the
+reachability path: `AcceptedZiskTrace.lean` imports `RowsBridgeFacts.lean` and
+`TableProjections.lean` directly, and the companion files import
+`MemBusRowBridges.lean` and the rest of `Balance/`. This is the plumbing that
+makes `channels_balanced`/`MutableMemPresent`/`mem_replay_*` operational, and
+(unlike the mirror findings above) is squarely part of the acceptance surface —
+it is reported here only so the ~25 NEAR_BUS names are not mistaken for an
+omission.
+
+## Answering the task's specific questions
+
+* **Which welded constraints are fidelity-only?** All content of all six
+  `*MirrorWeld.lean` files (225 declarations, 0 reachable) — see above. Among the
+  *pre-existing* mirrors a weld cites (as opposed to weld-owned scaffolding), the
+  `MIRROR_VALIDATOR` family is fidelity-only for every AIR that has one (Binary,
+  BinaryAdd, Main, Mem, MemAlignByte, MemAlignReadByte), and Main's
+  `AddressSpec`/`SourceSpec`/`RomBoolSpec` are fidelity-only despite being
+  matched/weld-covered by #304/#296.
+* **Are the Main/Mem welds we care about consumed or fidelity-only?** The weld
+  *files* are fidelity-only, full stop (nothing imports them). The mirrors they
+  weld are a mix: `Main.Spec`/`Mem.Spec` (the mirrors that actually flow into
+  `fullRv64imEnsemble`, per each weld file's own docstring) are CONSUMED;
+  `Main.AddressSpec`/`SourceSpec`/`RomBoolSpec` and `Mem.Bridge.constraints_at`
+  are FIDELITY-ONLY (though the first two of Main's three, and the old-namespace
+  `Mem`/`Airs` family, are genuinely used one layer downstream, in the soundness
+  proof rather than the acceptance definition).
+
+## Method limitations (measured, not just disclosed)
+
+* **Textual, not elaborated.** No instance resolution, no unfolding, no macro
+  expansion. A mirror consumed only through an instance argument Lean would infer
+  without a literal name appearing in source would be invisible to this pass. No
+  case of that was found in the 46 classified findings (0 loose-only
+  reclassifications), but the tool cannot rule it out in general.
+* **Ambiguity is upper-bounded, not resolved.** The loose pass's bare-name
+  fallback is the same approximation `survey.reference_counts` already accepts;
+  it changed no verdict here, which is itself evidence the namespace/`open`
+  tracking is doing real work, not evidence that ambiguity cannot occur elsewhere
+  in `ZiskFv/`.
+* **Every FIDELITY-ONLY verdict above was independently checked by reading
+  source**, not accepted from the mechanical pass alone: `Main/Circuit.lean`'s
+  actual `Spec` field text, and a direct `grep` of who else names each
+  `constraints_at`/`AddressSpec`/`SourceSpec`/`RomBoolSpec`. The CONSUMED verdicts
+  were spot-checked the same way for `Mem.Spec` and `ArithMul`'s `FullSpec`/
+  `SharedDivBlockSpec` composition, not exhaustively for all 36.
+* **Scope is `survey.CLASSIFICATION`'s mirror classes plus a small named
+  addendum**, not "every Prop under `ZiskFv/`". `NEAR_*` and `NEAR_BUS`
+  declarations are not reclassified (see "The Balance/* layer" above for why that
+  is a scope choice, not an oversight).

--- a/tools/mirror-roundtrip/README.md
+++ b/tools/mirror-roundtrip/README.md
@@ -493,14 +493,20 @@ are different claims.
 python3 tools/mirror-roundtrip/acceptance.py    # the test that the gate works
 ```
 
-Against the post-#296 tree it reports 3 of the 3 still-live hand findings
-reproduced as findings, 13 of 13 mutations classified exactly as predicted, 3 of 3
+Against the current tree it reports 2 of the 2 still-live hand findings
+reproduced as findings, 14 of 14 mutations classified exactly as predicted, 3 of 3
 neutral rewrites unmoved, and the lanes-vs-#310 column cross-check green -- and the
-entries below, which are what it could not get the gate to report. The fourth
-2026-07-28 hand finding, `RomBoolSpec` unreachable, was RESOLVED by the #296 weld
-fan-out (`romBoolSpec_weld` is now its first consumer); its detection is preserved
-by the `WELD_CONSUMER_REMOVED` mutation, which strips that consumer and requires
-the tool to report `RomBoolSpec` unreachable again. Three mutations targeting
+entries below, which are what it could not get the gate to report. Two of the four
+2026-07-28 hand findings are RESOLVED rather than live, and neither was dropped to
+make the run green: the fourth, `RomBoolSpec` unreachable, was resolved by the #296
+weld fan-out (`romBoolSpec_weld` is now its first consumer); its detection is
+preserved by the `WELD_CONSUMER_REMOVED` mutation, which strips that consumer and
+requires the tool to report `RomBoolSpec` unreachable again. The first, the a-side
+C-copy at `main.pil:385` (Main #3 and #9) having no mirror counterpart, was resolved
+by commit `8aea6771`'s `MainExposed` weld (`constraint_3_weld` / `constraint_9_weld`,
+`ZiskFv/AirsClean/MainMirrorWeld.lean`); its detection is preserved by the
+`WELD_MAIN_ASIDE_MUTATED_AWAY` mutation, which strips those two welds and requires
+the tool to report Main #3 and #9 as gaps again. Three mutations targeting
 weld-covered constraints (a deleted or reprojected mirror clause on `MemAlign`,
 `Mem` or `MemAlignByte`) now surface as `MATCHED -> WELD_COVERED` rather than a gap:
 the weld is a redundant backing that masks the mirror-root deletion, the same

--- a/tools/mirror-roundtrip/README.md
+++ b/tools/mirror-roundtrip/README.md
@@ -45,7 +45,9 @@ expression reaches `Extraction.Circuit.challenge` or a stage-2 lane
 extractor's own single-field/two-field binder distinction is deliberately **not**
 used instead: it would drop nine more Main constraints -- `{0, 3, 4, 9, 10, 19,
 20, 21, 38}`, the ones reaching an `AirValue`/`AirGroupValue` but no challenge and
-no stage-2 lane -- and Main #3 and #9 are the flagship gap below. The rule is
+no stage-2 lane -- and Main #3 and #9 were the flagship finding this gate was
+built to surface (since welded via the `MainExposed` carrier -- see the Gate
+section). The rule is
 implemented twice, off the emitted Lean here and off the pilout operands in
 `survey.air_facts`, and the two index sets must agree on every run.
 
@@ -378,17 +380,19 @@ of its scope.
 ## Gate
 
 Step 4/10 of `nix run .#test`, next to #303's step 3/10, running
-`check_mirrors.py --quiet` and then `acceptance.py`. **It fails at HEAD**, and
-that is the deliverable: **9** comparable generated constraints have no mirror
-clause and no checked coverage fact, all in `Main` (`{0, 3, 4, 9, 10, 19, 20, 21,
-38}`; two of them the weaker `SEGMENT_L1`-gated half of a within-segment C-copy).
-The other constraints that once read as gaps are now decided coverage: 15 `Mem`
-segment residuals matched by the out-of-root `segmentResidualEveryRow`, 4
-`MemAlignByte` booleans typed by a `.val < 2` bound, and the 7 `MemAlignWriteByte`
-constraints -- which have no mirror predicate -- bound each by their own `Iff.rfl`
-weld (`WELD_COVERED`). Those 9 are findings for the owner, and mirrors are
-protected proof interfaces -- closing one is proof work, not something this tool or
-its gate may do, and not something to silence with a baseline.
+`check_mirrors.py --quiet` and then `acceptance.py`. **It fails at HEAD**, but the
+failure is now the residual findings, not gaps: **0 gap**, and the remaining
+failing findings are 2 strengthening + 3 unbacked + 2 reclassification + 1
+undeclared delegation (tracked in eth-act/zisk-fv#329). Every generated constraint
+that once read as a gap is now decided coverage: 15 `Mem` segment residuals matched
+by the out-of-root `segmentResidualEveryRow`, 4 `MemAlignByte` booleans typed by a
+`.val < 2` bound, the 7 `MemAlignWriteByte` constraints bound each by their own
+`Iff.rfl` weld, and the **9 `Main`** constraints `{0, 3, 4, 9, 10, 19, 20, 21, 38}`
+(which read `exposed` air values) welded via the `MainExposed` carrier in
+`MainMirrorWeld.lean` (all `WELD_COVERED`). The remaining findings are for the
+owner, and mirrors are protected proof interfaces -- closing one is proof work, not
+something this tool or its gate may do, and not something to silence with a
+baseline.
 
 Deliberately not in `nix run .#populate`, where #303's check does live. Populate
 materialises generated inputs, and its tail gates a property of the artifact it

--- a/tools/mirror-roundtrip/acceptance.py
+++ b/tools/mirror-roundtrip/acceptance.py
@@ -445,18 +445,16 @@ def reclassification_on(payload: dict, air: str, index: int) -> list[dict]:
 
 
 REPRODUCTIONS: tuple[Reproduction, ...] = (
-    Reproduction(
-        name="GAP_MAIN_A_SIDE_C_COPY",
-        expect_class=GAP,
-        names="Main #3 and Main #9",
-        hand_finding="the a-side C-copy at main.pil:385 has no mirror counterpart "
-                     "anywhere; sourceCCopyBetween (ZiskFv/AirsClean/Main/"
-                     "Circuit.lean:721) models only the b-side",
-        locate=lambda p: gap_on(p, "Main", 3) + gap_on(p, "Main", 9),
-        expect_count=2,
-        evidence=lambda t: (trim(block_with(t, "GAP  Main #3"), 7)
-                            + [""] + trim(block_with(t, "GAP  Main #9"), 5)),
-    ),
+    # The first 2026-07-28 hand finding -- the a-side C-copy at main.pil:385,
+    # with no mirror counterpart anywhere -- is NOT a live reproduction any
+    # more: commit 8aea6771 welds all nine of Main's exposed-reading gap
+    # constraints, Main #3 and #9 among them, via a `MainExposed` carrier
+    # (`constraint_3_weld` / `constraint_9_weld`,
+    # ZiskFv/AirsClean/MainMirrorWeld.lean), so the tool now reports zero Main
+    # gaps. The finding is RESOLVED, not silenced, and the detection it
+    # exercised is preserved by the `WELD_MAIN_ASIDE_MUTATED_AWAY` mutation
+    # below, which strips those two welds and requires the tool to report
+    # Main #3 and #9 as gaps again.
     Reproduction(
         # The hand finding's word was "strengthening". The class it arrives as is
         # UNBACKED, and that is the more careful of the two claims: the conjunct
@@ -684,6 +682,26 @@ def replace_all(old: str, new: str) -> Mutator:
     return apply
 
 
+def chain(*mutators: Mutator) -> Mutator:
+    """Apply several single-edit mutators to the same file, in sequence.
+
+    Used where one defect needs two edits that no single anchor reaches. The
+    a-side C-copy's two welds name two DIFFERENT generated constraints
+    (`constraint_3_every_row`, `constraint_9_every_row`), so one `replace_all`
+    cannot retarget both the way it can when two welds share one name, as
+    `WELD_MUTATED_AWAY` does. `before`/`after` report what every step touched.
+    """
+    def apply(lines: list[str]) -> Applied:
+        befores: list[str] = []
+        afters: list[str] = []
+        for mutator in mutators:
+            lines, before, after = mutator(lines)
+            befores.append(before)
+            afters.append(after)
+        return lines, "  /  ".join(befores), "  /  ".join(afters)
+    return apply
+
+
 def no_mutation(lines: list[str]) -> Applied:
     return lines, "(nothing)", "(nothing)"
 
@@ -744,6 +762,11 @@ CARRY_7_BOOL = "∧ row.chain.carry_7 * (1 - row.chain.carry_7) = 0"
 # MemAlignByte's `Assumptions`, the line bounding the first two selectors. Loosening
 # `sel_high_4b`'s bound is what proves BOOL_TYPED rests on the bound, not the index.
 MEMALIGNBYTE_ASSUMPTIONS = "row.sel_high_4b.val < 2 ∧ row.sel_high_2b.val < 2"
+# Main's a-side C-copy welds, `constraint_3_weld` / `constraint_9_weld`
+# (ZiskFv/AirsClean/MainMirrorWeld.lean): the `Iff.rfl` RHS line each binds its
+# generated constraint by. Each qualified name occurs exactly once in the file.
+MAIN_ASIDE_WELD_3 = "↔ Main.extraction.constraint_3_every_row c r :="
+MAIN_ASIDE_WELD_9 = "↔ Main.extraction.constraint_9_every_row c r :="
 
 
 @dataclass(frozen=True)
@@ -960,6 +983,35 @@ MUTATIONS: tuple[Mutation, ...] = (
             "MemAlignWriteByte.extraction.constraint_777_every_row"),
         added=(gap("MemAlignWriteByte", 0),),
         removed=(weld_covered("MemAlignWriteByte", 0),),
+    ),
+    Mutation(
+        name="WELD_MAIN_ASIDE_MUTATED_AWAY",
+        lean_file=MAIN_WELD,
+        target="constraint_3_weld / constraint_9_weld, retargeted off their "
+               "constraints",
+        intent="the a-side C-copy's two welds mutated away, so Main #3 and #9 "
+               "revert to gaps",
+        # `constraint_3_weld` and `constraint_9_weld` are the ONLY weld theorems
+        # naming `Main.extraction.constraint_3_every_row` / `..._9_every_row`
+        # (each qualified name occurs exactly once in this file), and no mirror
+        # clause covers either constraint on its own: the a-side C-copy has no
+        # mirror counterpart anywhere (`sourceCCopyBetween`,
+        # ZiskFv/AirsClean/Main/Circuit.lean:721, models only the b-side) --
+        # this is the RESOLVED GAP_MAIN_A_SIDE_C_COPY hand finding, and this
+        # mutation is what now exercises the detection it used to. Retargeting
+        # both RHSes -- the same one-edit-per-name move `WELD_MUTATED_AWAY`
+        # makes on a single shared name, done twice here via `chain` because #3
+        # and #9 are two different names, not one -- removes both from
+        # `weld_parse`'s covered set. Neither fake index names a real generated
+        # constraint, so nothing else the weld file states is disturbed.
+        apply=chain(
+            replace_in_line(MAIN_ASIDE_WELD_3, "constraint_3_every_row",
+                            "constraint_3999_every_row"),
+            replace_in_line(MAIN_ASIDE_WELD_9, "constraint_9_every_row",
+                            "constraint_9999_every_row"),
+        ),
+        added=(gap("Main", 3), gap("Main", 9)),
+        removed=(weld_covered("Main", 3), weld_covered("Main", 9)),
     ),
     Mutation(
         name="WELD_CONSUMER_REMOVED",

--- a/tools/mirror-roundtrip/consumed_check.py
+++ b/tools/mirror-roundtrip/consumed_check.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+r"""Is a #304 mirror predicate CONSUMED by the acceptance definition, or FIDELITY-ONLY?
+
+Issue: eth-act/zisk-fv#304 follow-up ("verification-hole track"). `check_mirrors.py`
+welds every generated constraint to a hand-written mirror that canonically restates
+it. A weld -- `Iff.rfl` between a mirror and a generated constraint -- says the two
+are the SAME polynomial. It says nothing about whether the mirror predicate is
+itself reachable from what "an accepted ZisK trace" means: `Iff.rfl` typechecks
+identically whether or not anything outside the weld file ever mentions the LHS.
+
+This tool answers the second question, which #304 does not ask: starting from the
+two definitions that jointly say what an accepted trace is --
+
+    ZiskFv.Compliance.AcceptedZiskTrace          (ZiskFv/Compliance/AcceptedZiskTrace.lean
+                                                   + its ZiskFv/Compliance/AcceptedZiskTrace/*.lean
+                                                   companion files)
+    ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble
+    (and .fullRv64imSoundEnsemble, in the same file)
+
+-- what does a forward reference walk over Lean *declaration bodies* actually reach?
+A #304 mirror (or a `*MirrorWeld.lean` weld artifact) is CONSUMED if some declaration
+in that forward closure mentions its name; otherwise it is FIDELITY-ONLY: welded for
+#304's polynomial-equality sense, referenced by nothing that defines what "accepted"
+means.
+
+    python3 tools/mirror-roundtrip/consumed_check.py [--json PATH] [--quiet]
+
+## Method
+
+A textual, name-based forward reachability graph over every top-level Lean
+declaration under `ZiskFv/`:
+
+1. Parse every `.lean` file under `ZiskFv/` into top-level declarations (reusing
+   `survey.declarations`'s keyword/boundary rule), additionally tracking, per
+   declaration, the enclosing `namespace` stack and the `open ...` /
+   `open X (a b c)` directives active at that point in the file. This gives each
+   declaration a best-effort fully-qualified name (FQN) and an open-alias table.
+2. Seed a worklist with every declaration physically located in the root files
+   above.
+3. For each declaration popped off the worklist, scan its body for identifier-like
+   tokens and resolve each one against the global FQN index -- preferring an exact
+   FQN/suffix match, then the declaration's own (or an ancestor) namespace, then its
+   file's `open` table -- and add every newly-reached declaration to the worklist.
+4. A declaration is CONSUMED iff it is in the resulting visited set.
+
+This is a *name-based* approximation, the same kind `survey.reference_counts`
+already uses for "unreachable mirror" -- not an elaborated call graph. It shares
+that function's soundness property and its limit: a *positive* reachability claim
+is only as good as the name resolution that produced it, but a *negative* one
+(nothing in the closure mentions this name, under any resolution this tool tries)
+is conclusive in the direction that matters here. Where resolution is ambiguous
+(a bare name shared by several declarations, resolved only by a blanket fallback)
+the finding says so explicitly rather than silently asserting CONSUMED.
+
+## Scope
+
+Classified:
+
+* every `survey.CLASSIFICATION` entry whose class is a mirror class
+  (`survey.MIRROR_CLASSES`) -- the #304 inventory itself;
+* `survey.DELEGATED` -- out-of-root mirrors a root mirror reaches;
+* four additional pre-Clean `ZiskFv/Airs/Mem.lean` declarations the #304
+  `MemMirrorWeld.lean` docstring names by hand (`Valid_Mem`, `segment_every_row`,
+  `permutation_every_row`, `core_every_row`) -- not `survey.CLASSIFICATION` entries
+  (that inventory is scoped to `ZiskFv/AirsClean/**`), but exactly the mirrors the
+  task that produced this tool asked to be accounted for;
+* every top-level declaration of the six `*MirrorWeld.lean` files themselves --
+  the weld theorems and any `Extracted*`/probe scaffolding they introduce.
+
+Not reclassified: `survey.py`'s own NEAR_* declarations (out of the #304 round
+trip's scope already, for a declared reason each) and the `FullEnsemble/Balance/*`
+NEAR_BUS declarations, except where a NEAR_BUS declaration is directly on the
+reachability path (reported for context, not as a mirror finding).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+import survey  # noqa: E402
+
+REPO_ROOT = survey.REPO_ROOT
+ZISKFV_ROOT = REPO_ROOT / "ZiskFv"
+
+# --------------------------------------------------------------------- roots
+
+# The acceptance-definition surface named by the task: `AcceptedZiskTrace` (the
+# base file plus every companion file under its own directory -- the companions
+# import the base file to derive further certificates about what "accepted"
+# implies, e.g. `AcceptedZiskTrace.spec_holds` in `Spec.lean`) and the live
+# ensemble `fullRv64imEnsemble` (declared alongside `fullRv64imSoundEnsemble` and
+# `witness_spec_of_constraints` in the same file).
+ROOT_FILES = [
+    "ZiskFv/Compliance/AcceptedZiskTrace.lean",
+    "ZiskFv/Compliance/AcceptedZiskTrace/MainTable.lean",
+    "ZiskFv/Compliance/AcceptedZiskTrace/MemAlignRanges.lean",
+    "ZiskFv/Compliance/AcceptedZiskTrace/MemAlignRom.lean",
+    "ZiskFv/Compliance/AcceptedZiskTrace/MemProviders.lean",
+    "ZiskFv/Compliance/AcceptedZiskTrace/MemSegmentRanges.lean",
+    "ZiskFv/Compliance/AcceptedZiskTrace/MemTable.lean",
+    "ZiskFv/Compliance/AcceptedZiskTrace/Spec.lean",
+    "ZiskFv/AirsClean/FullEnsemble.lean",
+]
+
+WELD_FILES = [
+    "ZiskFv/AirsClean/ArithMirrorWeld.lean",
+    "ZiskFv/AirsClean/BinaryMirrorWeld.lean",
+    "ZiskFv/AirsClean/MainMirrorWeld.lean",
+    "ZiskFv/AirsClean/MemAlignByteMirrorWeld.lean",
+    "ZiskFv/AirsClean/MemAlignMirrorWeld.lean",
+    "ZiskFv/AirsClean/MemMirrorWeld.lean",
+]
+
+# Pre-Clean `ZiskFv/Airs/**` mirrors the MemMirrorWeld docstring names by hand.
+# Out of `survey.CLASSIFICATION`'s own scope (`ZiskFv/AirsClean/**` only, plus the
+# one declared `DELEGATED` entry) but squarely inside what this task asked about.
+EXTRA_MIRRORS: list[tuple[str, str, str]] = [
+    ("ZiskFv/Airs/Mem.lean", "Valid_Mem",
+     "trace-accessor record the pre-Clean Mem mirrors are stated over"),
+    ("ZiskFv/Airs/Mem.lean", "segment_every_row",
+     "generated 0-23; welded whole by MemMirrorWeld.segment_weld"),
+    ("ZiskFv/Airs/Mem.lean", "permutation_every_row",
+     "generated 24-33; welded whole by MemMirrorWeld.permutation_weld"),
+    ("ZiskFv/Airs/Mem.lean", "core_every_row",
+     "9 of segment_every_row's clauses, projected out; MemMirrorWeld docstring "
+     "claims this one is \"consumed by the memory-bus proofs\""),
+    ("ZiskFv/Airs/Mem.lean", "segmentResidualEveryRow",
+     "the other 15 of segment_every_row's clauses; also survey.DELEGATED"),
+]
+
+# --------------------------------------------------------------- Lean scanning
+
+NAMESPACE_RE = re.compile(r"^namespace\s+(\S+)")
+SECTION_RE = re.compile(r"^section\b\s*(\S*)")
+END_RE = re.compile(r"^end\b\s*(\S*)")
+OPEN_RE = re.compile(r"^open\s+(.*\S)\s*$")
+IMPORT_RE = re.compile(r"^import\s+(\S+)")
+
+# One `open`-clause segment: a namespace name optionally followed by a
+# parenthesised alias list. `open A (a b) B.C (d)` -> two segments.
+OPEN_SEGMENT_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_.']*)(\s*\(([^)]*)\))?")
+
+TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_.'!?]*")
+
+
+@dataclass
+class Decl2:
+    rel: str
+    line: int
+    keyword: str
+    name: str          # as written; may itself be dotted (`Foo.bar`)
+    fqn: str           # namespace-qualified
+    body: str
+    open_bare: dict     # bare name -> set[str] of FQNs, snapshot at this point
+    open_ns: tuple      # tuple[str, ...] of fully-opened namespace prefixes
+
+
+def _matches_decl_start(rest: str) -> tuple[str, int] | None:
+    """`(keyword, char_offset_of_keyword)` if `rest` (already de-prefixed of
+    attributes/set_option/open-in/privacy) starts a declaration, else None."""
+    for kw in survey.DECL_KEYWORDS:
+        if rest.startswith(kw + " ") or rest == kw:
+            return kw, 0
+    return None
+
+
+def _strip_decl_prefixes(line: str) -> str:
+    rest = line
+    while True:
+        for pattern in (survey._ATTR, survey._SET_OPTION, survey._OPEN_IN, survey._PRIVACY):
+            m = pattern.match(rest)
+            if m:
+                rest = rest[m.end():]
+                break
+        else:
+            return rest
+
+
+def _decl_name(rest_after_keyword: str) -> str:
+    head = rest_after_keyword.lstrip()
+    head = re.sub(r"^\{[^}]*\}\s*", "", head)
+    m = survey._NAME.match(head)
+    return m.group(0) if m else "?"
+
+
+def scan_file(path: Path, rel: str) -> list[Decl2]:
+    """One file's top-level declarations, each with its namespace FQN and the
+    `open` aliases visible to it. Namespaces/opens are tracked in one linear pass;
+    `end` (bare or named) pops the innermost `namespace`/`section` frame."""
+    raw = path.read_text(errors="replace").split("\n")
+    src = survey.strip_comments(raw)
+    n = len(src)
+
+    ns_stack: list[tuple[str, str | None]] = []  # (kind, name) kind in {ns, sec}
+    open_bare: dict[str, set[str]] = {}
+    open_ns: list[str] = []
+
+    decls: list[Decl2] = []
+    i = 0
+    # Column-0 boundaries: namespace/section/end/open/import lines, and decl starts.
+    boundary_at: list[int] = []
+    for idx, line in enumerate(src):
+        if not line or line[0] in " \t":
+            continue
+        rest = _strip_decl_prefixes(line)
+        if (NAMESPACE_RE.match(rest) or SECTION_RE.match(rest) or END_RE.match(rest)
+                or OPEN_RE.match(rest) or IMPORT_RE.match(rest)
+                or _matches_decl_start(rest)):
+            boundary_at.append(idx)
+    boundary_at.append(n)
+
+    for k, idx in enumerate(boundary_at[:-1]):
+        line = src[idx]
+        rest = _strip_decl_prefixes(line)
+        end_idx = boundary_at[k + 1]
+
+        m = NAMESPACE_RE.match(rest)
+        if m:
+            ns_stack.append(("ns", m.group(1)))
+            continue
+        m = SECTION_RE.match(rest)
+        if m:
+            ns_stack.append(("sec", m.group(1) or None))
+            continue
+        m = END_RE.match(rest)
+        if m:
+            if ns_stack:
+                ns_stack.pop()
+            continue
+        m = OPEN_RE.match(rest)
+        if m:
+            for seg in OPEN_SEGMENT_RE.finditer(m.group(1)):
+                ns_name = seg.group(1)
+                aliases = seg.group(3)
+                if aliases is not None:
+                    for alias_tok in aliases.split():
+                        alias_tok = alias_tok.strip()
+                        if not alias_tok:
+                            continue
+                        open_bare.setdefault(alias_tok, set()).add(f"{ns_name}.{alias_tok}")
+                else:
+                    open_ns.append(ns_name)
+            continue
+        if IMPORT_RE.match(rest):
+            continue
+        found = _matches_decl_start(rest)
+        if not found:
+            continue
+        keyword, _ = found
+        offset = len(line) - len(rest)
+        name = _decl_name(rest[len(keyword):])
+        prefix = ".".join(name_ for kind, name_ in ns_stack if kind == "ns" and name_)
+        fqn = f"{prefix}.{name}" if prefix else name
+        body_lines = list(src[idx:end_idx])
+        body_lines[0] = body_lines[0][offset:]
+        decls.append(Decl2(
+            rel=rel, line=idx + 1, keyword=keyword, name=name, fqn=fqn,
+            body="\n".join(body_lines),
+            open_bare={k_: set(v_) for k_, v_ in open_bare.items()},
+            open_ns=tuple(open_ns),
+        ))
+    return decls
+
+
+def all_decls() -> list[Decl2]:
+    out: list[Decl2] = []
+    for path in sorted(ZISKFV_ROOT.rglob("*.lean")):
+        rel = str(path.relative_to(REPO_ROOT))
+        out.extend(scan_file(path, rel))
+    return out
+
+
+# ------------------------------------------------------------------- indexing
+
+def suffixes(fqn: str) -> list[str]:
+    parts = fqn.split(".")
+    return [".".join(parts[i:]) for i in range(len(parts))]
+
+
+def ancestors(prefix: str) -> list[str]:
+    if not prefix:
+        return [""]
+    parts = prefix.split(".")
+    return [".".join(parts[:i]) for i in range(len(parts), -1, -1)]
+
+
+@dataclass
+class Index:
+    decls: list[Decl2]
+    fqn_map: dict = field(default_factory=dict)     # fqn -> list[Decl2]
+    suffix_map: dict = field(default_factory=dict)  # any dotted suffix -> list[Decl2]
+    bare_map: dict = field(default_factory=dict)    # last segment -> list[Decl2]
+    path_name_map: dict = field(default_factory=dict)  # (rel, name) -> list[Decl2]
+
+    @staticmethod
+    def build(decls: list[Decl2]) -> "Index":
+        idx = Index(decls=decls)
+        for d in decls:
+            idx.fqn_map.setdefault(d.fqn, []).append(d)
+            for s in suffixes(d.fqn):
+                idx.suffix_map.setdefault(s, []).append(d)
+            bare = d.name.split(".")[-1]
+            idx.bare_map.setdefault(bare, []).append(d)
+            idx.path_name_map.setdefault((d.rel, d.name), []).append(d)
+        return idx
+
+
+# ------------------------------------------------------------------ resolution
+
+def resolve(idx: Index, token: str, decl: Decl2, loose: bool) -> list[Decl2]:
+    """Candidate declarations `token`, read inside `decl`'s body, could name."""
+    prefix = decl.fqn.rsplit(".", 1)[0] if "." in decl.fqn else ""
+    # 1. exact / suffix match as given (handles both fully- and partially-qualified
+    #    references, including a reference into the declaration's own namespace
+    #    written out in full).
+    hit = idx.suffix_map.get(token)
+    if hit:
+        return hit
+    # 2. resolve within the declaration's own namespace or an enclosing one.
+    for anc in ancestors(prefix):
+        key = f"{anc}.{token}" if anc else token
+        hit = idx.suffix_map.get(key)
+        if hit:
+            return hit
+    # 3. an explicit `open X (token)` alias recorded for this file/point.
+    hit_names = decl.open_bare.get(token)
+    if hit_names:
+        out: list[Decl2] = []
+        for name in hit_names:
+            out.extend(idx.suffix_map.get(name, []))
+        if out:
+            return out
+    # 4. a blanket `open X` naming the token's namespace.
+    for ns in decl.open_ns:
+        hit = idx.suffix_map.get(f"{ns}.{token}")
+        if hit:
+            return hit
+    if not loose:
+        return []
+    # 5. LOOSE fallback: bare-name match anywhere (ambiguous; ~survey.reference_counts).
+    bare = token.split(".")[-1]
+    return idx.bare_map.get(bare, [])
+
+
+TOKEN_STOPWORDS = {
+    "by", "fun", "let", "in", "do", "if", "then", "else", "match", "with",
+    "where", "have", "show", "suffices", "calc", "from", "this", "at", "def",
+    "theorem", "lemma", "structure", "instance", "abbrev", "class", "inductive",
+    "open", "import", "namespace", "section", "end", "variable", "variables",
+    "set_option", "deriving", "extends", "mut", "for", "termination_by",
+    "decreasing_by", "obtain", "rcases", "rintro", "intro", "exact", "apply",
+    "simp", "rw", "constructor", "cases", "induction",
+}
+
+
+def tokenize(body: str) -> list[str]:
+    return [t for t in TOKEN_RE.findall(body) if t not in TOKEN_STOPWORDS]
+
+
+def reachable(idx: Index, roots: list[Decl2], loose: bool) -> set[int]:
+    visited: set[int] = set(id(d) for d in roots)
+    work = list(roots)
+    while work:
+        d = work.pop()
+        for tok in set(tokenize(d.body)):
+            for cand in resolve(idx, tok, d, loose):
+                if id(cand) not in visited:
+                    visited.add(id(cand))
+                    work.append(cand)
+    return visited
+
+
+# ---------------------------------------------------------------------- report
+
+def find_decls(idx: Index, rel: str, name: str) -> list[Decl2]:
+    return idx.path_name_map.get((rel, name), [])
+
+
+@dataclass
+class Finding:
+    rel: str
+    name: str
+    cls: str
+    air: str | None
+    note: str
+    strict: bool
+    loose_only: bool
+    found: bool  # False = the (path, name) declaration itself was not located
+
+
+def classify(idx: Index, visited_strict: set[int], visited_loose: set[int],
+             rel: str, name: str, cls: str, air: str | None, note: str) -> Finding:
+    decls = find_decls(idx, rel, name)
+    if not decls:
+        return Finding(rel, name, cls, air, note, False, False, found=False)
+    strict = any(id(d) in visited_strict for d in decls)
+    loose = any(id(d) in visited_loose for d in decls)
+    return Finding(rel, name, cls, air, note, strict, (loose and not strict), found=True)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                  formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--json", type=Path, default=None)
+    ap.add_argument("--quiet", action="store_true")
+    args = ap.parse_args()
+
+    decls = all_decls()
+    idx = Index.build(decls)
+
+    roots = [d for d in decls if d.rel in ROOT_FILES]
+    if not roots:
+        print("consumed_check.py: no root declarations found -- check ROOT_FILES", file=sys.stderr)
+        return 2
+    found_root_files = {d.rel for d in roots}
+    missing_roots = [f for f in ROOT_FILES if f not in found_root_files]
+    if missing_roots:
+        print(f"consumed_check.py: root file(s) not found: {missing_roots}", file=sys.stderr)
+        return 2
+
+    visited_strict = reachable(idx, roots, loose=False)
+    visited_loose = reachable(idx, roots, loose=True)
+
+    findings: list[Finding] = []
+    for (rel, name), entry in survey.CLASSIFICATION.items():
+        if entry.cls not in survey.MIRROR_CLASSES:
+            continue
+        findings.append(classify(idx, visited_strict, visited_loose, rel, name,
+                                  entry.cls, entry.air, entry.note))
+
+    for air, loc, name, _claims in survey.DELEGATED:
+        rel = loc.split(":", 1)[0]
+        findings.append(classify(idx, visited_strict, visited_loose, rel, name,
+                                  "DELEGATED", air, f"declared out-of-root mirror ({loc})"))
+
+    for rel, name, note in EXTRA_MIRRORS:
+        findings.append(classify(idx, visited_strict, visited_loose, rel, name,
+                                  "EXTRA", "Mem", note))
+
+    weld_decls: list[Decl2] = [d for d in decls if d.rel in WELD_FILES]
+    weld_findings: list[Finding] = []
+    for d in weld_decls:
+        strict = id(d) in visited_strict
+        loose = id(d) in visited_loose
+        weld_findings.append(Finding(d.rel, d.name, "WELD_DECL", None, "",
+                                      strict, (loose and not strict), found=True))
+
+    consumed = [f for f in findings if f.strict]
+    consumed_loose_only = [f for f in findings if f.loose_only]
+    fidelity_only = [f for f in findings if not f.strict and not f.loose_only and f.found]
+    not_found = [f for f in findings if not f.found]
+
+    weld_consumed = [f for f in weld_findings if f.strict or f.loose_only]
+
+    if not args.quiet:
+        print(f"declarations indexed: {len(decls)}")
+        print(f"root declarations: {len(roots)} across {len(ROOT_FILES)} files")
+        print(f"forward-reachable (strict): {len(visited_strict)}")
+        print(f"forward-reachable (loose, incl. ambiguous bare-name fallback): {len(visited_loose)}")
+        print()
+        print(f"mirror-class findings classified: {len(findings)}")
+        print(f"  CONSUMED:              {len(consumed)}")
+        print(f"  CONSUMED (loose only):  {len(consumed_loose_only)}  <- ambiguous, needs manual check")
+        print(f"  FIDELITY-ONLY:          {len(fidelity_only)}")
+        print(f"  not located in tree:    {len(not_found)}")
+        print()
+        print(f"*MirrorWeld.lean declarations: {len(weld_decls)}")
+        print(f"  of which reachable from the acceptance surface: {len(weld_consumed)}")
+        print()
+        if fidelity_only:
+            print("FIDELITY-ONLY mirrors (welded/matched but not part of acceptance):")
+            for f in sorted(fidelity_only, key=lambda f: (f.air or "", f.rel, f.name)):
+                print(f"  [{f.cls:16s}] {f.air or '-':12s} {f.rel}:{f.name}  -- {f.note}")
+            print()
+        if consumed_loose_only:
+            print("CONSUMED only via ambiguous bare-name fallback (manual check needed):")
+            for f in sorted(consumed_loose_only, key=lambda f: (f.air or "", f.rel, f.name)):
+                print(f"  [{f.cls:16s}] {f.air or '-':12s} {f.rel}:{f.name}  -- {f.note}")
+            print()
+        if not_found:
+            print("Declared but not located (stale CLASSIFICATION/DELEGATED entry?):")
+            for f in not_found:
+                print(f"  {f.rel}:{f.name}")
+            print()
+
+    if args.json:
+        payload = {
+            "counts": {
+                "declarations_indexed": len(decls),
+                "roots": len(roots),
+                "reachable_strict": len(visited_strict),
+                "reachable_loose": len(visited_loose),
+            },
+            "findings": [
+                {"path": f.rel, "name": f.name, "class": f.cls, "air": f.air,
+                 "note": f.note, "consumed": f.strict, "consumed_loose_only": f.loose_only,
+                 "found": f.found}
+                for f in findings
+            ],
+            "weld_declarations": [
+                {"path": f.rel, "name": f.name, "consumed": f.strict,
+                 "consumed_loose_only": f.loose_only}
+                for f in weld_findings
+            ],
+        }
+        args.json.write_text(json.dumps(payload, indent=2) + "\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/mirror-roundtrip/consumed_check.py
+++ b/tools/mirror-roundtrip/consumed_check.py
@@ -38,9 +38,13 @@ declaration under `ZiskFv/`:
 2. Seed a worklist with every declaration physically located in the root files
    above.
 3. For each declaration popped off the worklist, scan its body for identifier-like
-   tokens and resolve each one against the global FQN index -- preferring an exact
-   FQN/suffix match, then the declaration's own (or an ancestor) namespace, then its
-   file's `open` table -- and add every newly-reached declaration to the worklist.
+   tokens and resolve each one the way Lean itself would: a fully-qualified token
+   is an EXACT top-level name; a relative token is resolved by prefixing it with
+   the declaration's own namespace or an ancestor of it (longest first) and doing
+   an exact lookup, then by its file's explicit `open X (token)` aliases, then by
+   a blanket `open X` namespace -- add every newly-reached declaration to the
+   worklist. A bare token that names no real declaration in scope this way is
+   UNRESOLVED, never a match against "every declaration ending in that segment".
 4. A declaration is CONSUMED iff it is in the resulting visited set.
 
 This is a *name-based* approximation, the same kind `survey.reference_counts`
@@ -48,9 +52,13 @@ already uses for "unreachable mirror" -- not an elaborated call graph. It shares
 that function's soundness property and its limit: a *positive* reachability claim
 is only as good as the name resolution that produced it, but a *negative* one
 (nothing in the closure mentions this name, under any resolution this tool tries)
-is conclusive in the direction that matters here. Where resolution is ambiguous
-(a bare name shared by several declarations, resolved only by a blanket fallback)
-the finding says so explicitly rather than silently asserting CONSUMED.
+is conclusive in the direction that matters here. Resolution is deliberately
+UNDER-matching, not over-matching: it never falls back to a bare last-segment
+match against unrelated namespaces (that was a real bug, fixed here -- see
+`resolve()` and `_selfcheck()`). A separate, looser pass additionally tries that
+ambiguous bare-name fallback purely to flag cases the precise walk might have
+missed; a finding reachable only that way is reported as "consumed only via
+ambiguous bare-name fallback, manual check needed", never silently as CONSUMED.
 
 ## Scope
 
@@ -280,11 +288,6 @@ def all_decls() -> list[Decl2]:
 
 # ------------------------------------------------------------------- indexing
 
-def suffixes(fqn: str) -> list[str]:
-    parts = fqn.split(".")
-    return [".".join(parts[i:]) for i in range(len(parts))]
-
-
 def ancestors(prefix: str) -> list[str]:
     if not prefix:
         return [""]
@@ -295,9 +298,10 @@ def ancestors(prefix: str) -> list[str]:
 @dataclass
 class Index:
     decls: list[Decl2]
-    fqn_map: dict = field(default_factory=dict)     # fqn -> list[Decl2]
-    suffix_map: dict = field(default_factory=dict)  # any dotted suffix -> list[Decl2]
+    fqn_map: dict = field(default_factory=dict)     # EXACT fqn -> list[Decl2]
     bare_map: dict = field(default_factory=dict)    # last segment -> list[Decl2]
+                                                     # (LOOSE-only fallback; ambiguous
+                                                     # by construction, see resolve())
     path_name_map: dict = field(default_factory=dict)  # (rel, name) -> list[Decl2]
 
     @staticmethod
@@ -305,8 +309,6 @@ class Index:
         idx = Index(decls=decls)
         for d in decls:
             idx.fqn_map.setdefault(d.fqn, []).append(d)
-            for s in suffixes(d.fqn):
-                idx.suffix_map.setdefault(s, []).append(d)
             bare = d.name.split(".")[-1]
             idx.bare_map.setdefault(bare, []).append(d)
             idx.path_name_map.setdefault((d.rel, d.name), []).append(d)
@@ -316,36 +318,56 @@ class Index:
 # ------------------------------------------------------------------ resolution
 
 def resolve(idx: Index, token: str, decl: Decl2, loose: bool) -> list[Decl2]:
-    """Candidate declarations `token`, read inside `decl`'s body, could name."""
+    """Candidate declarations `token`, read inside `decl`'s body, could name --
+    resolved the way Lean itself would: a reference names a REAL fully-qualified
+    declaration, reached only through the declaration's own namespace, an
+    enclosing namespace, or an explicit `open`. It never matches "every
+    declaration whose name ends in this segment" -- that bare-suffix match was
+    the #304-review bug (a bare `Spec` matching all ~10 unrelated `<AIR>.Spec`
+    declarations across the tree). See `_selfcheck` below for a regression test.
+
+    Every step below is an EXACT `idx.fqn_map` lookup of a fully-constructed
+    candidate name -- never a suffix match against unrelated namespaces.
+    """
     prefix = decl.fqn.rsplit(".", 1)[0] if "." in decl.fqn else ""
-    # 1. exact / suffix match as given (handles both fully- and partially-qualified
-    #    references, including a reference into the declaration's own namespace
-    #    written out in full).
-    hit = idx.suffix_map.get(token)
+    # 1. Fully-qualified: `token` is already a real top-level declaration name.
+    hit = idx.fqn_map.get(token)
     if hit:
         return hit
-    # 2. resolve within the declaration's own namespace or an enclosing one.
+    # 2. Relative to the declaration's own namespace, or an enclosing one
+    #    (longest prefix first): construct the full candidate name and look it
+    #    up EXACTLY. This also covers a partially-qualified token
+    #    (`Circuit.Spec`) prefixed by an enclosing namespace, not a blanket
+    #    suffix match.
     for anc in ancestors(prefix):
         key = f"{anc}.{token}" if anc else token
-        hit = idx.suffix_map.get(key)
+        hit = idx.fqn_map.get(key)
         if hit:
             return hit
-    # 3. an explicit `open X (token)` alias recorded for this file/point.
+    # 3. An explicit `open X (token)` alias recorded for this file/point,
+    #    resolved to an exact fqn.
     hit_names = decl.open_bare.get(token)
     if hit_names:
         out: list[Decl2] = []
         for name in hit_names:
-            out.extend(idx.suffix_map.get(name, []))
+            out.extend(idx.fqn_map.get(name, []))
         if out:
             return out
-    # 4. a blanket `open X` naming the token's namespace.
+    # 4. A blanket `open X` naming the token's namespace, resolved to an exact fqn.
     for ns in decl.open_ns:
-        hit = idx.suffix_map.get(f"{ns}.{token}")
+        hit = idx.fqn_map.get(f"{ns}.{token}")
         if hit:
             return hit
+    # No in-scope resolution: UNRESOLVED. Under-matching is the safe direction
+    # for this tool -- it errs toward FIDELITY-ONLY / flagged-for-review, never
+    # toward falsely-CONSUMED.
     if not loose:
         return []
-    # 5. LOOSE fallback: bare-name match anywhere (ambiguous; ~survey.reference_counts).
+    # 5. LOOSE fallback ONLY (diagnostic, never the basis for a CONSUMED
+    #    verdict on its own -- `main()` reports this as "consumed only via
+    #    ambiguous bare-name fallback, manual check needed"): a bare last-segment
+    #    match anywhere, the same approximation `survey.reference_counts` already
+    #    accepts. Ambiguous by construction.
     bare = token.split(".")[-1]
     return idx.bare_map.get(bare, [])
 
@@ -406,6 +428,39 @@ def classify(idx: Index, visited_strict: set[int], visited_loose: set[int],
     return Finding(rel, name, cls, air, note, strict, (loose and not strict), found=True)
 
 
+def _selfcheck(idx: Index, decls: list[Decl2]) -> None:
+    """Regression check for the namespace-strict resolver fix (#304 review).
+
+    `ZiskFv/AirsClean/Mem/Circuit.lean` (namespace `ZiskFv.AirsClean.Mem`) reads
+    a bare `Spec` in several places (e.g. `Spec := fun row _ _ => Spec row`).
+    There are, at the time of writing, ~10 unrelated top-level `Spec`
+    declarations across the tree -- one per AIR (`ArithDiv`, `ArithMul`,
+    `Binary`, `BinaryAdd`, `BinaryExtension`, `Main`, `Mem`, `MemAlign`,
+    `MemAlignByte`, `MemAlignReadByte`), each in its own namespace. Before the
+    fix, `resolve()`'s first step was an unqualified `suffix_map` lookup, so
+    that bare `Spec` matched ALL of them. After the fix it must resolve to
+    exactly the one `Spec` in scope: `ZiskFv.AirsClean.Mem.Spec`, defined in the
+    same namespace by `ZiskFv/AirsClean/Mem/Spec.lean`.
+    """
+    all_bare_specs = idx.bare_map.get("Spec", [])
+    assert len(all_bare_specs) >= 8, (
+        f"expected the usual ~10 unrelated top-level `Spec` declarations across "
+        f"AIRs (one per AIR namespace); found only {len(all_bare_specs)} -- has "
+        f"the tree changed enough to invalidate this self-check?"
+    )
+    mem_circuit_decls = [d for d in decls if d.rel == "ZiskFv/AirsClean/Mem/Circuit.lean"]
+    assert mem_circuit_decls, "ZiskFv/AirsClean/Mem/Circuit.lean not found -- has it moved?"
+    ctx = mem_circuit_decls[0]
+    hits = resolve(idx, "Spec", ctx, loose=False)
+    hit_fqns = sorted({d.fqn for d in hits})
+    assert hit_fqns == ["ZiskFv.AirsClean.Mem.Spec"], (
+        f"bare `Spec` read inside Mem/Circuit.lean resolved to {hit_fqns} "
+        f"(expected exactly ['ZiskFv.AirsClean.Mem.Spec'], not the other "
+        f"{len(all_bare_specs) - 1} unrelated `Spec`s across AIRs) -- the "
+        f"namespace-strict resolver has regressed to bare-suffix matching"
+    )
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                   formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -415,6 +470,7 @@ def main() -> int:
 
     decls = all_decls()
     idx = Index.build(decls)
+    _selfcheck(idx, decls)
 
     roots = [d for d in decls if d.rel in ROOT_FILES]
     if not roots:

--- a/trust/weld-airs.toml
+++ b/trust/weld-airs.toml
@@ -62,6 +62,29 @@ generated = "build/extraction/Extraction/Main.lean"
 recording = "trust/generated/weld-columns/main.txt"
 unpinned-instances = ["mainProbeCircuit"]
 
+[air.MainExposed]
+# `MainExposed` (Part B of the same weld module) is a second `Extraction.Circuit`
+# carrier for the nine `exposed`-reading Main constraints. Its `main` lane is
+# `traceMainValue`, which re-applies Part A's `mainValue` (via `extractedMainRow`)
+# to a row picked out of `MainExposed.rows` -- it introduces no new stage-1
+# witness column map, so this block points `column-map` at the *same* `mainValue`
+# def and reuses `[air.Main]`'s recording; `instance-main` is the indirection the
+# schema already uses for MemAlignTrace/MemAlignWindow. `preprocessed` (SEGMENT_L1)
+# and `exposed` (the seven `airval`s) are handwritten maps outside this gate's
+# stage-1-witness scope; they are kernel-checked by the module's `Iff.rfl` welds
+# instead (see the module docstring's "What the weld does and does not certify").
+weld = "ZiskFv/AirsClean/MainMirrorWeld.lean"
+column-map = "mainValue"
+instance-main = "traceMainValue"
+wrapper = "MainExposed"
+instance = "extractedMainExposedCircuit"
+pin = "extractedMainExposedCircuit_pinned"
+row-type = "MainRowWithRom"
+row-decl = ["ZiskFv/AirsClean/Main/Row.lean"]
+generated = "build/extraction/Extraction/Main.lean"
+recording = "trust/generated/weld-columns/main.txt"
+note = "eth-act/zisk-fv#304/#310 -- Part B carrier for the 9 exposed-reading Main constraints; shares Part A's mainValue column map, no new recording."
+
 [air.MemAlignTrace]
 weld = "ZiskFv/AirsClean/MemAlignMirrorWeld.lean"
 column-map = "stage1Column"


### PR DESCRIPTION
Two related S11/#304 follow-ups in one PR (owner asked for a single PR). **Fidelity track** — completes "every extracted Main constraint is mirrored+welded". **Verification track** — adds the missing "is a mirror actually *used* by acceptance" check. Neither touches soundness; see the honest-scope note below.

## Track A — weld the 9 Main gaps (fidelity)

The #304 gate flagged 9 Main constraints as gaps because they read `Extraction.Circuit.exposed` air values, which `MainMirrorWeld.lean` stubbed to `0`. Following the Mem `SegmentColumns` pattern, this adds a **`MainExposed` carrier** (the 7 segment air values: `main_last_segment`, `segment_initial_pc`, `segment_previous_c[0/1]`, `segment_next_pc`, `segment_last_c[0/1]`), wires the weld instance's `exposed`/`preprocessed` accessors to read it, and welds `constraint_{0,3,4,9,10,19,20,21,38}_every_row` by `Iff.rfl`.

Result: **all 9 → WELD_COVERED; Main 0 gap; overall 174/176** (remainder is only the #329 residuals: 2 strengthening + 3 unbacked + 2 reclassification + 1 delegation).

Kernel-checked fidelity: the `Iff.rfl` welds only typecheck if the `exposed`/`preprocessed` maps are correct. `lake build ZiskFv.AirsClean.MainMirrorWeld` green (8086 jobs), **0 new axioms**, no `sorry`/`native_decide`; the existing 29 Main welds and `weldedConstraints_readOnlyModeledLanes` still hold.

Consequences handled in this PR:
- **acceptance suite** — the a-side-C-copy *reproduction* case is now stale (that gap is closed), so it's relocated to a `WELD_MAIN_ASIDE_MUTATED_AWAY` mutation (delete the weld → gap reappears → detected), exactly as #321 did for RomBoolSpec. `acceptance.py` exit 0 (2/2 reproductions, 14/14 mutations, 20 cases + the lanes-vs-#310 cross-check).
- **README** — corrected (the "9 have no mirror / Main #3/#9 are the flagship gap" claims are now stale).
- **#310 weld-column-map gate** — registered the new `extractedMainExposedCircuit` instance in `trust/weld-airs.toml` as a **second pinned instance** (its `main` reuses the already-pinned `mainValue` via `instance-main = traceMainValue`, the same indirection `[air.MemAlignTrace]`/`[air.MemAlignWindow]` use). Its witness map stays kernel-pinned; the `exposed`/`preprocessed` maps are kernel-checked by the `Iff.rfl` welds (out of the source-level gate's stage-1-witness scope). Also relocated `extractedMainRowCircuit_pinned` after all instances to satisfy the gate's no-instance-after-a-pin invariant (theorem statement/proof byte-for-byte unchanged; only position + a stale docstring line). `check-weld-column-maps.py` now PASSES (12 AIRs).

## Track B — consumed-by-acceptance check (verification)

A weld proves a mirror *matches* its generated constraint (fidelity); it does **not** make that constraint part of what defines an accepted trace. We had no check for the latter. New `tools/mirror-roundtrip/consumed_check.py` traces reachability from the acceptance surface (`AcceptedZiskTrace` + `fullRv64imEnsemble`) and classifies each mirror CONSUMED vs FIDELITY-ONLY. Report: `tools/mirror-roundtrip/CONSUMED_BY_ACCEPTANCE.md`.

Findings: **36/46 consumed, 10 fidelity-only.** Every AIR's core `Spec` and every transition mirror is consumed. Every `*MirrorWeld` file has **zero importers** — so all welds are fidelity-only *by construction* (confirms the fidelity ≠ acceptance distinction). The 10 fidelity-only are the `Valid_<AIR>` validator family + Main's `AddressSpec`/`SourceSpec`/`RomBoolSpec` (some consumed only downstream in the proof, some nowhere). Method is name-based reachability (a heuristic, not kernel-verified) — treat the 10 as "flagged for a look".

## Honest scope

This is **fidelity + verification-tooling only**. It does NOT reduce any assumption. In particular the welded Main constraints are consumed by nothing in `root_soundness` (Track B confirms it), and the operand-forwarding among them (#3/#9) remains covered-by-assumption via `InputsAgree` — the discharge of which is the separate #330 frontier. No trust-boundary change: no new axiom; the `trust/weld-airs.toml` entry brings a new handwritten map *under* checking rather than expanding trust.

## Verification

- `lake build ZiskFv.AirsClean.MainMirrorWeld` green (8086 jobs); full `lake build` green (9146) on the welds commit.
- `check-weld-column-maps.py` PASS (12 AIRs). `trust/scripts/check-all.sh` 18/19 — the one failure is `check-aeneas-production-boundary`, environmental (the `zisk` submodule isn't checked out in the dev worktree; `aeneas_extract.rs` absent), passes on CI.
- `acceptance.py` exit 0 (20 cases). `check_mirrors.py` 174/176, **0 gap** (still exits 1 on the #329 residuals, by design). `pilout-roundtrip/check.py` exit 0.
- Not run: full `nix run .#test` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)