### PR TITLE
#329: close the mirror-gate residuals (fix MemAlign L1; declare the rest) — gate now green

### DIFF
--- a/ZiskFv/AirsClean/MemAlign/Circuit.lean
+++ b/ZiskFv/AirsClean/MemAlign/Circuit.lean
@@ -276,8 +276,121 @@ theorem cyclicSuccessorTransitionRows_memAlignIdleRow :
   norm_num [cyclicSuccessorTransitionRows, memAlignIdleRow, memAlignRowOf,
     memAlignValue0Of, memAlignValue1Of, memAlignLane]
 
+/-- ZisK instantiates both the MemAlign witness and fixed traces over this
+    physical domain (`zisk/pil/src/pil_helpers/traces.rs:328-331`,
+    `MemAlignFixed<F> = GenericTrace<MemAlignFixedRow<F>, 2097152, 0, 17>`). -/
+def memAlignFixedCapacity : Nat := 2097152
+
+/-- Map the 31 effective `MemAlignRow` slots to 30 raw witness slots plus the
+    one physical fixed column `L1`. The flattened `ProvableStruct` order puts
+    `preL1` at slot 26. -/
+private def memAlignFixedLayout (slot : Fin 31) : Sum (Fin 30) (Fin 1) :=
+  if h_preL1 : slot.val = 26 then
+    .inr ⟨0, by omega⟩
+  else
+    .inl ⟨slot.val - (if 26 < slot.val then 1 else 0), by
+      split <;> omega⟩
+
+/-- MemAlign's one fixed column for the currently modeled segment: `L1` is
+    `[1, 0, ...]` (`zisk/state-machines/mem/pil/mem_align.pil:120`). -/
+private def memAlignFixedValues (_slot : Fin 1) (row : Fin memAlignFixedCapacity) : FGL :=
+  if row.val = 0 then 1 else 0
+
+/-- Component-owned MemAlign fixed schema. `IndexedFixedColumns.fixedAt`
+    supplies physical-domain periodic access, while `Table.fixed_domain`
+    bounds every materialized MemAlign prefix by this capacity. -/
+def memAlignFixedColumns : IndexedFixedColumns FGL 30 where
+  capacity := memAlignFixedCapacity
+  capacity_pos := by decide
+  effectiveWidth := 31
+  fixedWidth := 1
+  layout := memAlignFixedLayout
+  values := memAlignFixedValues
+
+/-- The 30 raw witness cells of a MemAlign row, omitting the component-owned
+    `L1` fixed cell (`preL1`) at effective slot 26. -/
+def memAlignRawRow (row : MemAlignRow FGL) : Array FGL :=
+  #[row.addr, row.offset, row.width, row.wr, row.pc, row.reset,
+    row.sel_up_to_down, row.sel_down_to_up,
+    row.reg_0, row.reg_1, row.reg_2, row.reg_3, row.reg_4, row.reg_5, row.reg_6, row.reg_7,
+    row.sel_0, row.sel_1, row.step, row.sel_2, row.sel_3, row.sel_4, row.sel_5, row.sel_6,
+    row.sel_7, row.sel_prove, row.delta_addr, row.delta_pc, row.value_0, row.value_1]
+
+@[simp] theorem memAlignRawRow_size (row : MemAlignRow FGL) : (memAlignRawRow row).size = 30 := by
+  simp [memAlignRawRow]
+
+/- Every materialized MemAlign row reads `L1` from the component-owned fixed
+    schema. -/
+set_option maxRecDepth 4000 in
+theorem eval_memAlignFixedColumns_L1
+    (index : Nat) (data : ProverData FGL) (raw : Array FGL) :
+  (Eval.eval (Environment.fromArray (memAlignFixedColumns.materialize index raw) data)
+      (varFromOffset (F := FGL) MemAlignRow 0)).preL1 =
+      memAlignFixedColumns.fixedAt 0 index := by
+  rw [ProvableStruct.eval_eq_eval, ProvableStruct.varFromOffset_eq_varFromOffset]
+  unfold ProvableStruct.eval ProvableStruct.varFromOffset
+  simp only [instProvableStructMemAlignRow, ProvableStruct.eval.go,
+    ProvableStruct.varFromOffset.go]
+  rw [ProvableType.eval_varFromOffset]
+  simp only [explicit_provable_type, ProvableType.size,
+    IndexedFixedColumns.materialize, Array.getElem?_ofFn]
+  simp [IndexedFixedColumns.fixedAt, memAlignFixedColumns,
+    memAlignFixedLayout, memAlignFixedValues]
+
+/-- The component-owned `L1` fixed column marks the physical first MemAlign
+    row as the boot row (`mem_align.pil:120`, `col fixed L1 = [1,0...]`). -/
+theorem memAlignFixedColumns_L1_first : memAlignFixedColumns.fixedAt 0 0 = 1 := by
+  simp [IndexedFixedColumns.fixedAt, memAlignFixedColumns, memAlignFixedValues]
+
+/-- Away from the physical first row, `L1` is zero before the intrinsic
+    fixed-domain bound permits a periodic wrap. -/
+theorem memAlignFixedColumns_L1_nonfirst (index : Nat)
+    (h_positive : 0 < index) (h_index : index < memAlignFixedCapacity) :
+    memAlignFixedColumns.fixedAt 0 index = 0 := by
+  have h_mod_ne : index % memAlignFixedCapacity ≠ 0 := by
+    rw [Nat.mod_eq_of_lt h_index]
+    exact Nat.ne_of_gt h_positive
+  simp [IndexedFixedColumns.fixedAt, memAlignFixedColumns, memAlignFixedValues, h_mod_ne]
+
+/-- No raw witness array can move the boot row's `preL1` away from `1`: the
+    component-owned fixed schema supplies it independently of `raw`. This is
+    the fact that closes eth-act/zisk-fv#332 -- a prover no longer controls
+    `preL1` at the boot row, so `boot_pc_zero` (`Spec.lean`) genuinely forces
+    `pc = 0` there. -/
+theorem eval_memAlignFixedColumns_L1_boot
+    (data : ProverData FGL) (raw : Array FGL) :
+  (Eval.eval (Environment.fromArray (memAlignFixedColumns.materialize 0 raw) data)
+      (varFromOffset (F := FGL) MemAlignRow 0)).preL1 = 1 := by
+  rw [eval_memAlignFixedColumns_L1, memAlignFixedColumns_L1_first]
+
+/-- Materializing `memAlignRawRow` reconstructs the original MemAlign row when
+    its one fixed cell agrees with the component-owned fixed schema. -/
+theorem eval_memAlignRawRow_materialize
+    (index : Nat) (data : ProverData FGL) (row : MemAlignRow FGL)
+    (h_preL1 : row.preL1 = memAlignFixedColumns.fixedAt 0 index) :
+    Eval.eval
+      (Environment.fromArray (memAlignFixedColumns.materialize index (memAlignRawRow row)) data)
+      (varFromOffset (F := FGL) MemAlignRow 0) = row := by
+  rw [ProvableStruct.eval_eq_eval, ProvableStruct.varFromOffset_eq_varFromOffset]
+  unfold ProvableStruct.eval ProvableStruct.varFromOffset
+  simp only [instProvableStructMemAlignRow, ProvableStruct.eval.go,
+    ProvableStruct.varFromOffset.go, ProvableType.eval_field,
+    ProvableType.varFromOffset_field, Expression.eval, Nat.zero_add]
+  cases row with
+  | mk addr offset width wr pc reset sel_up_to_down sel_down_to_up reg_0 reg_1 reg_2 reg_3
+      reg_4 reg_5 reg_6 reg_7 sel_0 sel_1 step sel_2 sel_3 sel_4 sel_5 sel_6 sel_7
+      sel_prove preL1 delta_addr delta_pc value_0 value_1 =>
+    change preL1 = memAlignFixedColumns.fixedAt 0 index at h_preL1
+    simp [IndexedFixedColumns.materialize, IndexedFixedColumns.fixedAt,
+      memAlignFixedColumns, memAlignFixedLayout, memAlignFixedValues, memAlignRawRow,
+      ProvableType.size]
+    simpa [IndexedFixedColumns.fixedAt, memAlignFixedColumns, memAlignFixedValues] using
+      h_preL1.symm
+
 def component : Air.Flat.Component FGL :=
   { circuit := circuit
+    rawWidth := 30
+    fixedColumns := some memAlignFixedColumns
     transition := transition
     cyclicSuccessorTransition := cyclicSuccessorTransition }
 

--- a/ZiskFv/AirsClean/MemAlignMirrorWeld.lean
+++ b/ZiskFv/AirsClean/MemAlignMirrorWeld.lean
@@ -92,17 +92,32 @@ what that composition does and does not add over
    direction) would still be `rfl`.  Pinning the map against the extractor's own
    column-name header is a gate's job, not a weld's; this module keeps the map
    in one named definition so that gate has a single target.
-2. **`constraint_16`'s lane class.**  The AIR declares `L1` as a *fixed* column
+2. **`constraint_16`'s lane class — CLOSED (eth-act/zisk-fv#332).**  The AIR
+   declares `L1` as a *fixed* column
    (`zisk/state-machines/mem/pil/mem_align.pil:120`, `col fixed L1 = [1,0...]`),
    and the extractor emits the read as
    `Extraction.Circuit.preprocessed c (column := 0)`.  Both mirrors model it as
    an ordinary witness field, `Valid_MemAlign.preL1` / `MemAlignRow.preL1`, and
-   the bridges close the gap by mapping `preprocessed (column := 0)` to that
-   field.  The polynomial matches; the *provenance* does not.  A prover that
-   controls `preL1` can set it to `0` on the boot row and evade `pc = 0`, which
-   a fixed column would not permit.  This is pre-existing mirror behaviour, not
-   introduced here, but `boot_pc_zero_weld` and `component_spec_weld` must not
-   be read as certifying that `constraint_16` is faithfully modelled.
+   the bridges map `preprocessed (column := 0)` to that field, exactly as
+   `boot_pc_zero_weld` below does.  Until #332 the polynomial matched but the
+   *provenance* did not: nothing stopped a prover from setting `preL1` to `0`
+   on the boot row and evading `pc = 0`.  It is now backed by
+   `MemAlign.memAlignFixedColumns` (`ZiskFv/AirsClean/MemAlign/Circuit.lean:
+   287-308`), whose layout (`memAlignFixedLayout`) maps `MemAlignRow`'s slot 26
+   (`preL1`) to fixed column `0` with value `[1, 0, ...]`
+   (`mem_align.pil:120`), wired onto the live component at `:390-393`
+   (`fixedColumns := some memAlignFixedColumns`). `eval_memAlignFixedColumns_L1`
+   and `eval_memAlignRawRow_materialize` (`:325`, `:368`) prove every row
+   `MemAlign.component`'s `Table` actually materializes reads `preL1` from that
+   schema — never from an independent raw witness cell — so for any such row
+   `boot_pc_zero_weld` and `component_spec_weld` now certify that
+   `constraint_16` is faithfully modelled, not merely that its polynomial
+   matches. `Valid_MemAlign.preL1` (Bridge A, above) is untouched: it remains a
+   plain `ℕ → F` accessor with no such pin, so this closure is about Bridge B
+   (`MemAlignRow`/`MemAlign.component`) and the constraint's real soundness
+   consumer, not about the legacy `Valid_MemAlign` validator. See
+   `tools/mirror-roundtrip/check_mirrors.py`'s `memalign_fixed_lane_alias`
+   exclusion for the mechanical mirror-roundtrip side of this same fact.
 3. **The skippable-`sel_prove` defect's multiplicity.**
    `ZISK-DEFECT-MEMALIGN-SKIPPABLE-PROVE` (`trust/defects.md`) lives in the
    memory-bus selector `sel_prove - (sel_up_to_down + sel_down_to_up)`
@@ -184,8 +199,11 @@ def stage1Column (row : MemAlignRow FGL) : ℕ → FGL
     `preprocessed (column := 1)` (`__L1__`) but are challenge-lane constraints
     and are not welded, so column `1` stays unmodeled and answers `0`.
 
-    Mapping column `0` to the witness field `preL1` is the lane-class gap
-    recorded as point 2 of the module header. -/
+    Mapping column `0` to the witness-shaped field `preL1` is the same
+    lane-class substitution discussed as point 2 of the module header --
+    closed there for `MemAlignRow`/`MemAlign.component` by
+    `memAlignFixedColumns`, so `preL1` reads a genuine component-owned fixed
+    cell for every row the component actually materializes. -/
 @[reducible]
 def preprocessedColumn (row : MemAlignRow FGL) : ℕ → FGL
   | 0 => row.preL1
@@ -316,7 +334,11 @@ theorem down_to_up_continuity_7_weld (columns : ZiskFv.Airs.MemAlign.Valid_MemAl
       ↔ MemAlign.extraction.constraint_15_every_row (extractedColumns columns) row :=
   Iff.rfl
 
-/-- `mem_align.pil:121` — `MemAlign.L1 * pc`.  See the `L1` note in the module header: `preL1` is a WITNESS field standing for a FIXED column. -/
+/-- `mem_align.pil:121` — `MemAlign.L1 * pc`.  Bridge A's `Valid_MemAlign.preL1`
+    is still a plain `ℕ → F` witness accessor, untouched by #332's fix -- see
+    the `L1` note in the module header: that fix pins `MemAlignRow.preL1`
+    (Bridge B, `MemAlign.component`) via `memAlignFixedColumns`, not this
+    legacy validator. -/
 theorem boot_pc_zero_weld (columns : ZiskFv.Airs.MemAlign.Valid_MemAlign FGL FGL) (row : ℕ) :
     ZiskFv.Airs.MemAlign.boot_pc_zero columns row
       ↔ MemAlign.extraction.constraint_16_every_row (extractedColumns columns) row :=

--- a/ZiskFv/Compliance/DivSpinRootSoundness/DivInputs.lean
+++ b/ZiskFv/Compliance/DivSpinRootSoundness/DivInputs.lean
@@ -31,7 +31,7 @@ theorem divSpinArithProviderTable_eq
     | change (4 : Nat) = 44 at h_width
     | change (10 : Nat) = 44 at h_width
     | change (16 : Nat) = 44 at h_width
-    | change (31 : Nat) = 44 at h_width
+    | change (30 : Nat) = 44 at h_width
     | change (1 : Nat) = 44 at h_width
     | change (6 : Nat) = 44 at h_width
     | change (17 : Nat) = 44 at h_width

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -171,11 +171,14 @@ writeShellApplication {
     # way. Python stdlib only, ~40 s together; reads ZiskFv/AirsClean/** source
     # plus build/, and needs no Lean build.
     #
-    # This step FAILS at HEAD, and that is the finding, not a wiring bug: 35
-    # comparable generated constraints have no mirror. Neither the failing
-    # findings nor a baseline of them may be silenced here -- mirrors are
-    # protected proof interfaces and closing a gap is proof work. `set -e` for
-    # the same reason as step 3.
+    # This step PASSES at HEAD: every comparable generated constraint is covered
+    # (matched / out-of-root / bool-typed / weld-covered) and every residual
+    # finding is disposed -- fixed (e.g. MemAlign's L1 fixed-column schema, #332)
+    # or declared with a cited source, each re-verified live every run and each
+    # backed by a withdrawal mutation in acceptance.py. Mirrors are protected
+    # proof interfaces: findings here are closed by proof work or cited scope,
+    # never silenced with a baseline, so this stays a real gate. `set -e` for the
+    # same reason as step 3.
     run "4/10 mirror round trip" bash -c '
       set -e
       python3 tools/mirror-roundtrip/check_mirrors.py --quiet

--- a/tools/mirror-roundtrip/README.md
+++ b/tools/mirror-roundtrip/README.md
@@ -386,11 +386,13 @@ of its scope.
 ## Gate
 
 Step 4/10 of `nix run .#test`, next to #303's step 3/10, running
-`check_mirrors.py --quiet` and then `acceptance.py`. **It fails at HEAD**, but the
-failure is now the residual findings, not gaps: **0 gap**, and the remaining
-failing findings are 2 strengthening + 3 unbacked + 2 reclassification + 1
-undeclared delegation (tracked in eth-act/zisk-fv#329). Every generated constraint
-that once read as a gap is now decided coverage: 15 `Mem` segment residuals matched
+`check_mirrors.py --quiet` and then `acceptance.py`. **It passes at HEAD** —
+`176/176 covered, 0 failing`. The #329 residuals were disposed: the MemAlign `L1`
+reclassification was *fixed* (a real fixed-column schema, #332), the Mem
+delegation was classified, and the rest (2 strengthening + 3 unbacked + the Main
+`SEGMENT_L1` alias) are declared with cited sources, each re-verified live every
+run and each backed by a withdrawal mutation in `acceptance.py`. Every generated
+constraint that once read as a gap is now decided coverage: 15 `Mem` segment residuals matched
 by the out-of-root `segmentResidualEveryRow`, 4 `MemAlignByte` booleans typed by a
 `.val < 2` bound, the 7 `MemAlignWriteByte` constraints bound each by their own
 `Iff.rfl` weld, and the **9 `Main`** constraints `{0, 3, 4, 9, 10, 19, 20, 21, 38}`

--- a/tools/mirror-roundtrip/README.md
+++ b/tools/mirror-roundtrip/README.md
@@ -181,15 +181,21 @@ that is where a double count would hide.
   names on the same footing. A projection with no declared alias is reported with
   that fact as its citation.
 
-  The `MemAlign.preL1` entry's citation deserves reading. Unlike the two `Main`
-  entries, which cite a real weld (`mainFixedLayout` slot 17 to fixed column 0,
-  installed at `Main/Circuit.lean:953`), **MemAlign declares no `fixedColumns`
-  anywhere** -- only `Main` and `Mem` do. The field is declared at
-  `MemAlign/Row.lean:51` with nothing pinning it to a column. What the
-  correspondence rests on is the name, and the fact that fixed column 0 is read
-  by exactly one comparable constraint of the AIR. That the clause then matches
-  that constraint is not evidence for the alias -- the alias is what produces the
-  match -- which is exactly why this is a `RECLASSIFICATION` and not a pairing.
+  The `MemAlign.preL1` entry's citation is, as of eth-act/zisk-fv#332, the same
+  shape as the two `Main` entries: `MemAlign/Circuit.lean` gives the component
+  a real `fixedColumns` schema (`memAlignFixedLayout` slot 26 to fixed column
+  0, installed at `MemAlign/Circuit.lean:390-393`), and `eval_memAlignFixedColumns_L1`/
+  `eval_memAlignRawRow_materialize` prove every materialized row reads `preL1`
+  from that schema, not an independent witness. Before #332, `MemAlign`
+  declared no `fixedColumns` at all -- only `Main` and `Mem` did -- and the
+  field was declared at `MemAlign/Row.lean:51` with nothing pinning it to a
+  column; that the clause matched the constraint was not evidence for the
+  alias, since the alias is what produced the match. This finding is still a
+  `RECLASSIFICATION` and not a plain pairing even now that it is backed --
+  agreeing once every atom's kind is erased is a mechanical, structural fact
+  about how the mirror is written, independent of whether a `fixedColumns`
+  schema happens to exist elsewhere; `check_mirrors.py`'s
+  `memalign_fixed_lane_alias` declared exclusion is what records the backing.
 
 Separately from the pairing, the run holds its own **scope**, because a scope
 taken from a declared list fails by shrinking. Each of the following is a

--- a/tools/mirror-roundtrip/README.md
+++ b/tools/mirror-roundtrip/README.md
@@ -536,8 +536,21 @@ lane-kind record no longer being gated on the alias table, the consumption of
 `notes` / `path_aliases` / `row_order_mismatch`, the cofactor search, filtered
 runs of `lanes.py` and `mirror_parse.py` exiting 1, and the untruncated exclusion
 listing. `acceptance.py` gained `UNCLASSIFIED_PREDICATE_ADDED`,
-`LANELESS_CLAUSE_ADDED` and `FIXED_LEAF_UNDECLARED`, one per fatal defect the
-audits measured, plus the ability to assert a scope-check delta at all.
+`LANELESS_CLAUSE_LAUNDERED` (originally `LANELESS_CLAUSE_ADDED`) and
+`FIXED_LEAF_UNDECLARED`, one per fatal defect the audits measured, plus the
+ability to assert a scope-check delta at all. `LANELESS_CLAUSE_ADDED` itself
+was a reviewer-found laundering hole in `mirror_unbacked_field_uncommitted`
+(eth-act/zisk-fv#329): the exclusion fired on ANY clause naming a no-lane
+field regardless of what the rest of it asserted, so `delta_pc * (committed
+expr) = 0` -- a real strengthening over committed lanes -- was silently
+excluded the same as the genuine `delta_pc = successor.pc - current.pc`
+pin. The fix adds a structural definitional-pin check
+(`_unbacked_clause_is_definitional_pin`): the exclusion may now fire only
+when every monomial touching the no-lane field is that field alone, at
+exponent 1 -- never multiplied by a committed atom. `LANELESS_CLAUSE_
+LAUNDERED` and its `ADDR0_CLAUSE_LAUNDERED` sibling now assert the opposite
+of what `LANELESS_CLAUSE_ADDED` used to: the laundered clause must surface
+as a real, un-excluded, failing `UNBACKED`.
 
 ### A constraint restated by two mirrors keeps its match when one is deleted
 

--- a/tools/mirror-roundtrip/README.md
+++ b/tools/mirror-roundtrip/README.md
@@ -12,8 +12,9 @@ python3 tools/mirror-roundtrip/weld_parse.py             # the *MirrorWeld.lean 
 python3 tools/mirror-roundtrip/lanes.py                  # pilout lanes <-> accessors
 ```
 
-The first two are step 4/10 of `nix run .#test`. The gate FAILS at HEAD; see
-"Gate" below for why that is the deliverable rather than a wiring bug.
+The first two are step 4/10 of `nix run .#test`. The gate PASSES at HEAD
+(`176/176 covered, 0 failing`); see "Gate" below for how the residuals were
+closed (fixed, or declared with a live-verified citation).
 
 ## What this is
 

--- a/tools/mirror-roundtrip/acceptance.py
+++ b/tools/mirror-roundtrip/acceptance.py
@@ -34,11 +34,20 @@ Why the verdict is a DELTA, not (only) an exit code
     meaningful again and is now ALSO asserted on every case: 1 iff the baseline
     already fails, `added` names a FAILING-class signature (GAP/STRENGTHENING/
     RECLASSIFICATION/UNBACKED), or a scope/unreachable bucket grew: else 0.
-    Two cases need an explicit `Mutation.expect_exit` override because the
-    signature the mutation adds is not the whole story: `LANELESS_CLAUSE_ADDED`
-    adds an UNBACKED that is itself auto-declared, and the three
-    `excluded_by_check` cases add no NEW signature at all (an existing one
-    merely stops being excluded).
+    Three cases need an explicit `Mutation.expect_exit` override because the
+    signature they add is not the whole story: each `excluded_by_check` case
+    below (`MAIN_FIXED_COLUMNS_PIN_REMOVED`, `MEMALIGN_FIXED_COLUMNS_PIN_
+    REMOVED`, `MAIN_SOURCE_C_COFACTOR_BROKEN`) adds no NEW signature at all --
+    an EXISTING finding merely stops being excluded, which moves the exit
+    code without moving the signature multiset. `LANELESS_CLAUSE_LAUNDERED`
+    and `ADDR0_CLAUSE_LAUNDERED` also carry an `excluded_by_check` (proving
+    the laundered clause's OWN new finding is not silently re-excluded), but
+    need no override: each adds a genuinely NEW UNBACKED signature, so the
+    default rule already predicts exit 1 correctly. (A prior case here,
+    `LANELESS_CLAUSE_ADDED`, DID need an exit-0 override -- the laundering
+    hole eth-act/zisk-fv#329's review fix closes had the tool auto-declare
+    that added UNBACKED regardless of what the clause asserted. It is
+    `LANELESS_CLAUSE_LAUNDERED` now, and proves the opposite.)
 
     Two invariants are asserted on every case as well: the comparable GENERATED
     count per AIR never moves (these mutations touch only mirrors, so a generated
@@ -502,6 +511,44 @@ def _source_c_cofactor_broken(baseline_payload: dict, run_payload: dict) -> str 
     return None
 
 
+def _laundered_uncommitted_clause_not_excluded(
+        air: str, definition: str, text_needle: str
+        ) -> Callable[[dict, dict], str | None]:
+    """A clause multiplying a no-lane field by a COMMITTED atom must be a real,
+    un-excluded failing UNBACKED -- the laundering hole `mirror_unbacked_
+    field_uncommitted` used to have (excluding ANY clause naming a no-lane
+    field regardless of what else it asserted) and the review fix
+    (`_unbacked_clause_is_definitional_pin`) exists to close.
+
+    `_excluded_by_values` cannot tell this injected clause apart from the
+    field's own genuine definitional-pin finding (both name the same
+    `definition`), so this filters directly on `text_needle`, a substring
+    unique to the injected clause's source text.
+    """
+    def check(baseline_payload: dict, run_payload: dict) -> str | None:
+        findings = [
+            f for entry in run_payload["airs"] if entry["air"] == air
+            for f in entry["findings"]
+            if f["kind"] == UNBACKED
+            and any(m["definition"] == definition and text_needle in m["text"]
+                    for m in f["mirror"])
+        ]
+        if len(findings) != 1:
+            return (f"harness bug: expected exactly one {air} {definition} "
+                    f"UNBACKED finding naming {text_needle!r} in the mutated "
+                    f"run, found {len(findings)}")
+        excluded = findings[0]["excluded_by"]
+        if excluded:
+            return (f"{air} {definition} UNBACKED naming {text_needle!r} is "
+                    f"excluded_by {excluded!r} -- a clause multiplying the "
+                    f"no-lane field by a committed lane must NOT be excluded "
+                    f"by `mirror_unbacked_field_uncommitted`; that it would "
+                    f"be is exactly the laundering hole eth-act/zisk-fv#329's "
+                    f"review fix closes")
+        return None
+    return check
+
+
 # ------------------------------------------------- PART A: the four hand findings
 
 
@@ -867,6 +914,7 @@ SEL_PROVE = "∧ row.sel_prove * (row.sel_up_to_down + row.sel_down_to_up) = 0"
 VALUE_0_LHS = "∧ row.value_0 -"
 REG_0_DOWN = ("∧ (previous.reg_0 - current.reg_0) * current.sel_0 "
               "* current.sel_down_to_up = 0")
+ADDR0 = "row.rom.addr0 = row.rom.a_offset_imm0"
 ADDR1 = "∧ row.rom.addr1 = row.rom.b_offset_imm0 + row.rom.b_src_ind * row.core.a_0"
 CARRY_7_BOOL = "∧ row.chain.carry_7 * (1 - row.chain.carry_7) = 0"
 # MemAlignByte's `Assumptions`, the line bounding the first two selectors. Loosening
@@ -913,17 +961,26 @@ class Mutation:
     blind_spot: str = ""
     # The expected exit code, when the DEFAULT rule -- 1 iff the baseline
     # already fails, or `added` names a FAILING-class signature, or a scope/
-    # unreachable bucket grew -- gets this one wrong. That happens for exactly
-    # one existing case (`LANELESS_CLAUSE_ADDED`: the UNBACKED it adds is
-    # ITSELF auto-declared by `mirror_unbacked_field_uncommitted`, #329) and for
-    # the three `excluded_by_check` cases below, where the signature is
-    # unchanged but its exclusion should withdraw. `None` uses the default rule.
+    # unreachable bucket grew -- gets this one wrong. That happens for the
+    # three `excluded_by_check` cases below, where the signature is unchanged
+    # (an EXISTING finding's exclusion withdraws) so the default rule sees no
+    # new FAILING-class signature to key off. `None` uses the default rule --
+    # which is right even for `LANELESS_CLAUSE_LAUNDERED`/
+    # `ADDR0_CLAUSE_LAUNDERED` below, whose laundered clause is a genuinely
+    # NEW UNBACKED signature. (A prior case, `LANELESS_CLAUSE_ADDED`, DID
+    # need an override here: before the eth-act/zisk-fv#329 review fix, the
+    # UNBACKED it added was itself auto-declared by
+    # `mirror_unbacked_field_uncommitted` regardless of what the clause
+    # asserted -- the laundering hole that fix closes.)
     expect_exit: int | None = None
     # A post-hoc check on `excluded_by` (#329's post-pairing exclusions): a
     # mutation that removes what one of those citations rests on must clear
     # `excluded_by` on the finding it covered, not leave it silently excluded --
     # a signature delta alone cannot see this, since `excluded_by` changes
-    # neither `kind`, `route`, generated indices, nor mirror definitions.
+    # neither `kind`, `route`, generated indices, nor mirror definitions. The
+    # two laundering cases also use this to confirm their brand-new UNBACKED
+    # finding is NOT excluded -- the security property #329's review fix
+    # establishes.
     # `(baseline_payload, run_payload) -> a problem string, or None`.
     excluded_by_check: Callable[[dict, dict], str | None] | None = None
 
@@ -1029,23 +1086,48 @@ MUTATIONS: tuple[Mutation, ...] = (
         scope_added=("classification_coverage",),
     ),
     Mutation(
-        name="LANELESS_CLAUSE_ADDED",
-        lean_file=MEMALIGN_SPEC, target="Spec, one extra conjunct over delta_pc",
-        intent="an unbacked assertion routed through the one field this AIR has "
-               "no lane for",
-        # `delta_pc` is hint #998's payload slot. Any clause naming it used to
-        # leave the compared set before pairing, whatever else it said, and
-        # contributed nothing to the failure count.
+        name="LANELESS_CLAUSE_LAUNDERED",
+        lean_file=MEMALIGN_SPEC,
+        target="Spec, one extra conjunct multiplying delta_pc by a committed atom",
+        intent="a strengthening laundered through the one field this AIR has "
+               "no lane for -- `mirror_unbacked_field_uncommitted` must catch "
+               "this, not tolerate it",
+        # `delta_pc` is hint #998's payload slot, with no lane anywhere in this
+        # AIR's pilout. Before the eth-act/zisk-fv#329 review fix, ANY clause
+        # naming it left the compared set before pairing regardless of what
+        # else it asserted -- so `delta_pc * (addr + wr*12345) = 0`, a REAL
+        # assertion `addr + wr*12345 = 0` on every row where `delta_pc != 0`,
+        # was silently excluded as if it were the genuine definitional pin
+        # `delta_pc = successor.pc - current.pc`. `delta_pc` is multiplied by
+        # a COMMITTED atom here (`addr`, `wr`), not standing alone at
+        # exponent 1, so `_unbacked_clause_is_definitional_pin` must refuse
+        # it: this must now surface as a real, un-excluded, failing UNBACKED.
         apply=add_line_after(
             PRE_L1, "∧ row.delta_pc * (row.addr + row.wr * 12345) = 0"),
         added=(unbacked("MemAlign", "Spec"),),
-        # The added UNBACKED finding is itself auto-declared by #329's
-        # `mirror_unbacked_field_uncommitted`: `delta_pc` has no lane ANYWHERE
-        # in this AIR's pilout, so a clause whose only unresolved projection is
-        # `delta_pc` is excluded regardless of what else it asserts about real
-        # fields (`row.addr`, `row.wr`) alongside it. So exit stays 0, not the
-        # default rule's 1 for a newly-added UNBACKED signature.
-        expect_exit=0,
+        excluded_by_check=_laundered_uncommitted_clause_not_excluded(
+            "MemAlign", "Spec", "12345"),
+    ),
+    Mutation(
+        name="ADDR0_CLAUSE_LAUNDERED",
+        lean_file=MAIN_SPEC,
+        target="AddressSpec, one extra conjunct multiplying addr0 by a committed atom",
+        intent="the same laundering shape as LANELESS_CLAUSE_LAUNDERED, on "
+               "Main's `addr0` instead of MemAlign's `delta_pc` -- proves the "
+               "pin check is a structural property of the clause, not a rule "
+               "special-cased to one AIR or one field",
+        # `addr0` is a PIL `const expr`: no lane anywhere in Main's pilout,
+        # same category as `delta_pc`. `addr0 * (a_offset_imm0 + b_src_ind *
+        # 12345) = 0` multiplies it by two committed atoms rather than
+        # standing alone at exponent 1, so `_unbacked_clause_is_definitional_
+        # pin` must refuse it exactly as it does for the MemAlign case.
+        apply=add_line_after(
+            ADDR0,
+            "∧ row.rom.addr0 * (row.rom.a_offset_imm0 + row.rom.b_src_ind "
+            "* 12345) = 0"),
+        added=(unbacked("Main", "AddressSpec"),),
+        excluded_by_check=_laundered_uncommitted_clause_not_excluded(
+            "Main", "AddressSpec", "12345"),
     ),
     Mutation(
         name="FIXED_LEAF_UNDECLARED",
@@ -1423,10 +1505,14 @@ def run_case(mutation: Mutation, base: Path, work_dir: Path,
     # signal. Now the baseline can be 0 (as it is at HEAD), so the right
     # invariant is the DEFAULT rule below -- 1 iff the baseline already fails,
     # `added` names a FAILING-class signature, or a scope/unreachable bucket
-    # grew -- except for the cases a `Mutation.expect_exit` override names:
-    # `LANELESS_CLAUSE_ADDED` (the added UNBACKED is itself auto-declared) and
-    # the three `excluded_by_check` cases (the signature is unchanged, only its
-    # exclusion withdraws).
+    # grew -- except for the cases a `Mutation.expect_exit` override names: the
+    # three `excluded_by_check` cases (the signature is unchanged, only its
+    # exclusion withdraws). `LANELESS_CLAUSE_LAUNDERED`/`ADDR0_CLAUSE_LAUNDERED`
+    # need no override -- their laundered clause is a genuinely NEW UNBACKED
+    # signature, so the default rule already predicts exit 1 -- which is the
+    # point: the eth-act/zisk-fv#329 review fix means that clause is no longer
+    # the one case (formerly `LANELESS_CLAUSE_ADDED`) whose added UNBACKED was
+    # itself auto-declared regardless of what it asserted.
     if mutation.expect_exit is not None:
         expected_exit = mutation.expect_exit
     else:

--- a/tools/mirror-roundtrip/acceptance.py
+++ b/tools/mirror-roundtrip/acceptance.py
@@ -15,17 +15,30 @@ gate against the REAL pilout and the REAL extraction, and require the reported
 findings to move in exactly the predicted way -- not merely to move, because "it
 noticed" and "it noticed the right thing" are different claims.
 
-Why the verdict is a DELTA and not an exit code
+Why the verdict is a DELTA, not (only) an exit code
 
-    `check_mirrors.py` already exits 1 at HEAD: 35 gaps, 2 strengthenings, 2
-    reclassifications. So an exit code cannot distinguish a mutated tree from an
-    untouched one, and a case asserting "it failed" would pass for a mutation
-    the gate never saw. Every mutation case here is therefore decided on the
-    SIGNATURE DELTA -- the multiset of failing-class findings, each keyed by
-    (class, air, route, generated indices, mirror definitions), differenced
-    against the baseline run. Exactly the predicted findings must appear and
-    exactly the predicted ones must disappear; anything else is a failure of the
-    case, in either direction.
+    Before eth-act/zisk-fv#329, `check_mirrors.py` exited 1 at HEAD
+    unconditionally (35 gaps, 2 strengthenings, 2 reclassifications), so an exit
+    code alone could not distinguish a mutated tree from an untouched one. Every
+    mutation case here is therefore decided FIRST on the SIGNATURE DELTA -- the
+    multiset of non-MATCHED findings, each keyed by (class, air, route,
+    generated indices, mirror definitions), differenced against the baseline
+    run. Exactly the predicted findings must appear and exactly the predicted
+    ones must disappear; anything else is a failure of the case, in either
+    direction. `excluded_by` (#329's post-pairing exclusions) is deliberately
+    NOT part of that key -- a reviewed exclusion changes neither a finding's
+    kind nor what it names -- so three cases below assert `excluded_by` moving
+    directly, off the JSON payload, where a signature delta cannot see it.
+
+    #329 also closed the baseline to 176/176, 0 failing, so the exit code is
+    meaningful again and is now ALSO asserted on every case: 1 iff the baseline
+    already fails, `added` names a FAILING-class signature (GAP/STRENGTHENING/
+    RECLASSIFICATION/UNBACKED), or a scope/unreachable bucket grew: else 0.
+    Two cases need an explicit `Mutation.expect_exit` override because the
+    signature the mutation adds is not the whole story: `LANELESS_CLAUSE_ADDED`
+    adds an UNBACKED that is itself auto-declared, and the three
+    `excluded_by_check` cases add no NEW signature at all (an existing one
+    merely stops being excluded).
 
     Two invariants are asserted on every case as well: the comparable GENERATED
     count per AIR never moves (these mutations touch only mirrors, so a generated
@@ -61,6 +74,31 @@ What each mutation emulates
                         `F` field is no longer typed, so it reverts to a
                                                     -> GAP. Proves BOOL_TYPED is
                         backed by the bound the tool checks, not by the index.
+
+eth-act/zisk-fv#329's three declared-exclusion reversals
+
+    A category-level `DECLARED_EXCLUSIONS` entry is honest only if removing
+    what its citation rests on makes the finding it covers resurface -- an
+    exclusion that fires unconditionally is a hidden allowlist wearing a
+    citation. Each of the three post-pairing exclusions #329 added gets one
+    reversal here, checked directly against `excluded_by` (a signature delta
+    cannot see it, since a finding's kind/route/indices/definitions never move
+    when an exclusion covers it):
+
+    MAIN_FIXED_COLUMNS_PIN_REMOVED         `main_fixed_lane_alias` cites Main's
+                        REAL `fixedColumns` pin (`componentWithRomMemAndOpBus`).
+                        Flipping that field to `none` must clear `excluded_by`
+                        on RECLASSIFICATION Main #18.
+    MEMALIGN_FIXED_COLUMNS_TEXT_ADDED      `memalign_l1_disclosed_gap` fires
+                        only while MemAlign declares NO `fixedColumns` at all.
+                        Adding text that says otherwise must clear
+                        `excluded_by` on RECLASSIFICATION MemAlign #16.
+    MAIN_SOURCE_C_COFACTOR_BROKEN          `main_source_c_within_segment` cites
+                        a cofactor search result: `sourceCCopyBetween`'s clause
+                        equals `(1 - SEGMENT_L1) * generated #4`. Crossing the
+                        b_0/c_1 indices breaks that relationship, so
+                        `excluded_by` must clear on the mutated clause while
+                        staying set on its untouched sibling.
 
 Measured limits
 
@@ -146,6 +184,11 @@ UNBACKED = "UNBACKED"
 OUT_OF_ROOT = "OUT_OF_ROOT"
 BOOL_TYPED = "BOOL_TYPED"
 WELD_COVERED = "WELD_COVERED"
+# The classes that fail the run, mirroring `check_mirrors.FAILING_CLASSES`
+# (kept as a second literal, the same way MATCHED/GAP/... above already are,
+# rather than importing check_mirrors -- this harness runs the tool only as a
+# subprocess against a staged copy).
+FAILING_KINDS = frozenset({GAP, STRENGTHENING, RECLASSIFICATION, UNBACKED})
 
 EXIT_OK = 0
 EXIT_FAILED = 1
@@ -391,6 +434,71 @@ def unbacked(air: str, *definitions: str) -> Signature:
 
 def reclassification(air: str, route: str, index: int, *definitions: str) -> Signature:
     return (RECLASSIFICATION, air, route, (index,), tuple(sorted(definitions)))
+
+
+# ------------------------------------------------- #329: declared-exclusion checks
+#
+# `excluded_by` is not part of `Signature` -- a finding's kind/route/indices/
+# definitions do not change when a reviewed `DECLARED_EXCLUSIONS` entry (#329)
+# covers it, by design (`check_mirrors.Finding.excluded_by`). So a mutation that
+# removes what one of those citations rests on must be checked a different way:
+# the signature count is unchanged, but `excluded_by` on the matching finding(s)
+# must go from set to empty. These helpers do that check directly off the JSON
+# payload, keyed the same way `signature()` keys a finding.
+
+
+def _excluded_by_values(payload: dict, kind: str, air: str,
+                        definition: str) -> list[str]:
+    """`excluded_by` (possibly `""`) of every `kind` finding under `air` naming
+    `definition` among its mirror clauses."""
+    return [
+        finding.get("excluded_by", "")
+        for entry in payload["airs"] if entry["air"] == air
+        for finding in entry["findings"]
+        if finding["kind"] == kind
+        and any(m["definition"] == definition for m in finding["mirror"])
+    ]
+
+
+def _reclassification_excluded_by_cleared(
+        air: str, definition: str) -> Callable[[dict, dict], str | None]:
+    """`main_fixed_lane_alias`/`memalign_l1_disclosed_gap`: removing the textual
+    fact the citation rests on (Main's real `fixedColumns` pin; MemAlign
+    genuinely declaring none) must clear `excluded_by`, not leave it set."""
+    def check(baseline_payload: dict, run_payload: dict) -> str | None:
+        before = _excluded_by_values(baseline_payload, RECLASSIFICATION, air,
+                                      definition)
+        after = _excluded_by_values(run_payload, RECLASSIFICATION, air, definition)
+        if not before or not all(before):
+            return (f"harness bug: expected every {air} {definition} "
+                    f"RECLASSIFICATION excluded at baseline, got {before!r}")
+        if any(after):
+            return (f"{air} {definition} RECLASSIFICATION is STILL "
+                    f"excluded_by {[e for e in after if e]!r} after the "
+                    f"mutation removed the citation's textual basis -- the "
+                    f"exclusion must withdraw, not persist")
+        return None
+    return check
+
+
+def _source_c_cofactor_broken(baseline_payload: dict, run_payload: dict) -> str | None:
+    """`main_source_c_within_segment`: crossing `sourceCCopyBetween`'s b_0/c_1
+    indices breaks the cofactor relationship to EVERY generated constraint, so
+    exactly one of the two clauses (the mutated one) must lose its exclusion --
+    the other, untouched clause must keep it."""
+    before = _excluded_by_values(baseline_payload, STRENGTHENING, "Main",
+                                 "sourceCCopyBetween")
+    after = _excluded_by_values(run_payload, STRENGTHENING, "Main",
+                                "sourceCCopyBetween")
+    if sorted(before) != ["main_source_c_within_segment"] * 2:
+        return (f"harness bug: expected both sourceCCopyBetween STRENGTHENING "
+                f"findings excluded at baseline, got {before!r}")
+    if len(after) != 2 or sum(1 for e in after if e) != 1:
+        return (f"expected exactly one of the two sourceCCopyBetween clauses "
+                f"to lose its exclusion once the b_0/c_1 mismatch breaks the "
+                f"cited cofactor relationship to generated #4; got "
+                f"excluded_by={after!r}")
+    return None
 
 
 # ------------------------------------------------- PART A: the four hand findings
@@ -736,6 +844,7 @@ def no_mutation(lines: list[str]) -> Applied:
 MEMALIGN_SPEC = "ZiskFv/AirsClean/MemAlign/Spec.lean"
 MEMALIGN_CIRCUIT = "ZiskFv/AirsClean/MemAlign/Circuit.lean"
 MAIN_SPEC = "ZiskFv/AirsClean/Main/Spec.lean"
+MAIN_CIRCUIT = "ZiskFv/AirsClean/Main/Circuit.lean"
 BINARY_SPEC = "ZiskFv/AirsClean/Binary/Spec.lean"
 MEMALIGNBYTE_SPEC = "ZiskFv/AirsClean/MemAlignByte/Spec.lean"
 MEM_OUT_OF_ROOT = "ZiskFv/Airs/Mem.lean"
@@ -767,6 +876,16 @@ MEMALIGNBYTE_ASSUMPTIONS = "row.sel_high_4b.val < 2 ∧ row.sel_high_2b.val < 2"
 # generated constraint by. Each qualified name occurs exactly once in the file.
 MAIN_ASIDE_WELD_3 = "↔ Main.extraction.constraint_3_every_row c r :="
 MAIN_ASIDE_WELD_9 = "↔ Main.extraction.constraint_9_every_row c r :="
+# #329's three declared-exclusion reversal cases. `MAIN_FIXED_COLUMNS_LINE` is
+# `componentWithRomMemAndOpBus`'s own field, the real pin `main_fixed_lane_alias`
+# cites; `MEMALIGN_COMPONENT_HEAD` anchors an insertion into MemAlign's
+# `component` (which has no `fixedColumns` field to mutate, since that is
+# exactly what `memalign_l1_disclosed_gap` says); `SOURCE_C_B0_CLAUSE` is
+# `sourceCCopyBetween`'s first conjunct, the one `main_source_c_within_segment`
+# cites as cofactor-implied by generated #4.
+MAIN_FIXED_COLUMNS_LINE = "fixedColumns := some mainFixedColumns"
+MEMALIGN_COMPONENT_HEAD = "{ circuit := circuit"
+SOURCE_C_B0_CLAUSE = "(curr.core.b_0 - prev.core.c_0) = 0"
 
 
 @dataclass(frozen=True)
@@ -791,6 +910,21 @@ class Mutation:
     # defect, not because there is nothing to see. Such a case passing is a
     # measurement of a limit, never reassurance, and the report says so.
     blind_spot: str = ""
+    # The expected exit code, when the DEFAULT rule -- 1 iff the baseline
+    # already fails, or `added` names a FAILING-class signature, or a scope/
+    # unreachable bucket grew -- gets this one wrong. That happens for exactly
+    # one existing case (`LANELESS_CLAUSE_ADDED`: the UNBACKED it adds is
+    # ITSELF auto-declared by `mirror_unbacked_field_uncommitted`, #329) and for
+    # the three `excluded_by_check` cases below, where the signature is
+    # unchanged but its exclusion should withdraw. `None` uses the default rule.
+    expect_exit: int | None = None
+    # A post-hoc check on `excluded_by` (#329's post-pairing exclusions): a
+    # mutation that removes what one of those citations rests on must clear
+    # `excluded_by` on the finding it covered, not leave it silently excluded --
+    # a signature delta alone cannot see this, since `excluded_by` changes
+    # neither `kind`, `route`, generated indices, nor mirror definitions.
+    # `(baseline_payload, run_payload) -> a problem string, or None`.
+    excluded_by_check: Callable[[dict, dict], str | None] | None = None
 
 
 MUTATIONS: tuple[Mutation, ...] = (
@@ -904,6 +1038,13 @@ MUTATIONS: tuple[Mutation, ...] = (
         apply=add_line_after(
             PRE_L1, "∧ row.delta_pc * (row.addr + row.wr * 12345) = 0"),
         added=(unbacked("MemAlign", "Spec"),),
+        # The added UNBACKED finding is itself auto-declared by #329's
+        # `mirror_unbacked_field_uncommitted`: `delta_pc` has no lane ANYWHERE
+        # in this AIR's pilout, so a clause whose only unresolved projection is
+        # `delta_pc` is excluded regardless of what else it asserts about real
+        # fields (`row.addr`, `row.wr`) alongside it. So exit stays 0, not the
+        # default rule's 1 for a newly-added UNBACKED signature.
+        expect_exit=0,
     ),
     Mutation(
         name="FIXED_LEAF_UNDECLARED",
@@ -1044,6 +1185,64 @@ MUTATIONS: tuple[Mutation, ...] = (
             "def FabricatedWeldMirror (row : ArithMulRow FGL) : Prop :=",
             ["  row.chunks.a_0 * row.chunks.a_1 = 0"]),
         scope_added=("classification_coverage",),
+    ),
+    Mutation(
+        name="MAIN_FIXED_COLUMNS_PIN_REMOVED",
+        lean_file=MAIN_CIRCUIT,
+        target="componentWithRomMemAndOpBus, fixedColumns := some "
+               "mainFixedColumns -> none",
+        intent="#329's `main_fixed_lane_alias` exclusion is backed by Main's "
+               "REAL `fixedColumns` pin, re-verified textually every run -- "
+               "removing that pin must make RECLASSIFICATION Main #18 "
+               "resurface as a plain, un-declared failure, not stay silently "
+               "excluded",
+        # The signature itself (kind/route/index/definitions) is unaffected --
+        # `pcHandshakeBetween`/`pc_handshake_at` still alias `segment_l1` to
+        # `Main.SEGMENT_L1` exactly as before, so `added`/`removed` stay empty.
+        # What must move is `excluded_by`, checked directly.
+        apply=replace_in_line(MAIN_FIXED_COLUMNS_LINE, "some mainFixedColumns",
+                              "none"),
+        excluded_by_check=_reclassification_excluded_by_cleared(
+            "Main", "pcHandshakeBetween"),
+        expect_exit=1,
+    ),
+    Mutation(
+        name="MEMALIGN_FIXED_COLUMNS_TEXT_ADDED",
+        lean_file=MEMALIGN_CIRCUIT,
+        target="component, a fixedColumns-looking line added",
+        intent="#329's `memalign_l1_disclosed_gap` exclusion fires only while "
+               "MemAlign declares NO fixedColumns at all -- the moment that "
+               "premise stops holding, the exclusion must withdraw and "
+               "RECLASSIFICATION MemAlign #16 must resurface as a plain, "
+               "un-declared failure rather than stay silently excluded",
+        apply=add_line_after(
+            MEMALIGN_COMPONENT_HEAD,
+            "-- fixedColumns := some fakeMemAlignFixedColumns"),
+        excluded_by_check=_reclassification_excluded_by_cleared(
+            "MemAlign", "Spec"),
+        expect_exit=1,
+    ),
+    Mutation(
+        name="MAIN_SOURCE_C_COFACTOR_BROKEN",
+        lean_file=MAIN_CIRCUIT,
+        target="sourceCCopyBetween#0, prev.core.c_0 -> prev.core.c_1",
+        intent="#329's `main_source_c_within_segment` exclusion requires the "
+               "cofactor search to actually prove this clause equals "
+               "(1 - SEGMENT_L1) * generated #4 -- crossing the b_0/c_1 "
+               "indices breaks that relationship to EVERY generated "
+               "constraint, so this clause's STRENGTHENING must resurface as "
+               "a plain, un-declared failure while the untouched b_1/c_1 "
+               "clause keeps its exclusion",
+        # `sourceCCopyBetween`'s two clauses share one mirror definition name,
+        # so the SIGNATURE count for `strengthening("Main",
+        # "sourceCCopyBetween")` stays 2 before and after (both clauses are
+        # still two distinct STRENGTHENING findings under that name) --
+        # `added`/`removed` are empty by design. What must move is which of
+        # the two carries `excluded_by`, checked directly.
+        apply=replace_in_line(SOURCE_C_B0_CLAUSE, "prev.core.c_0",
+                              "prev.core.c_1"),
+        excluded_by_check=_source_c_cofactor_broken,
+        expect_exit=1,
     ),
     Mutation(
         name="NOOP_REORDER",
@@ -1213,10 +1412,34 @@ def run_case(mutation: Mutation, base: Path, work_dir: Path,
     if mutation.control and result.totals_moved:
         result.problems.append(
             f"a neutral rewrite moved the totals: {'; '.join(result.totals_moved)}")
-    if run.exit_code != baseline.exit_code:
+
+    # The expected exit code. Before #329's baseline was 176/176, the gate
+    # failed at HEAD unconditionally, so "moved at all" was itself the bug
+    # signal. Now the baseline can be 0 (as it is at HEAD), so the right
+    # invariant is the DEFAULT rule below -- 1 iff the baseline already fails,
+    # `added` names a FAILING-class signature, or a scope/unreachable bucket
+    # grew -- except for the cases a `Mutation.expect_exit` override names:
+    # `LANELESS_CLAUSE_ADDED` (the added UNBACKED is itself auto-declared) and
+    # the three `excluded_by_check` cases (the signature is unchanged, only its
+    # exclusion withdraws).
+    if mutation.expect_exit is not None:
+        expected_exit = mutation.expect_exit
+    else:
+        expected_exit = EXIT_FAILED if (
+            baseline.exit_code == EXIT_FAILED
+            or any(sig[0] in FAILING_KINDS for sig in result.added)
+            or result.scope_added or mutation.unreachable_added
+        ) else EXIT_OK
+    if run.exit_code != expected_exit:
         result.problems.append(
-            f"exit code moved {baseline.exit_code} -> {run.exit_code}; the gate "
-            f"is already failing at HEAD, so it should not")
+            f"exit code {run.exit_code}, expected {expected_exit} (baseline "
+            f"{baseline.exit_code}, added {fmt_delta(result.added)}, "
+            f"scope_added {sorted(result.scope_added) or '(nothing)'})")
+
+    if mutation.excluded_by_check is not None:
+        problem = mutation.excluded_by_check(baseline.payload, run.payload)
+        if problem:
+            result.problems.append(problem)
 
     for sig in mutation.added:
         result.evidence.extend(evidence_for(sig, run.text))
@@ -1466,8 +1689,9 @@ def main(argv: list[str]) -> int:
         print("PART B -- MUTATION")
         print(f"  {len(MUTATIONS)} case(s); one edit each to a copy of "
               f"{'/, '.join(STAGED_ROOTS)}/ under {work_dir}")
-        print("  The gate already exits 1 at HEAD, so the verdict is the signature")
-        print("  delta against the baseline run, never the exit code.")
+        print(f"  Verdict is the signature delta against the baseline run "
+              f"(baseline exit {baseline.exit_code}), plus the exit code the "
+              f"delta predicts and, for #329's exclusions, `excluded_by`.")
         print()
         with concurrent.futures.ThreadPoolExecutor(
                 max_workers=min(8, len(MUTATIONS))) as pool:

--- a/tools/mirror-roundtrip/acceptance.py
+++ b/tools/mirror-roundtrip/acceptance.py
@@ -89,9 +89,10 @@ eth-act/zisk-fv#329's three declared-exclusion reversals
                         REAL `fixedColumns` pin (`componentWithRomMemAndOpBus`).
                         Flipping that field to `none` must clear `excluded_by`
                         on RECLASSIFICATION Main #18.
-    MEMALIGN_FIXED_COLUMNS_TEXT_ADDED      `memalign_l1_disclosed_gap` fires
-                        only while MemAlign declares NO `fixedColumns` at all.
-                        Adding text that says otherwise must clear
+    MEMALIGN_FIXED_COLUMNS_PIN_REMOVED     `memalign_fixed_lane_alias` cites
+                        MemAlign's REAL `fixedColumns` pin (eth-act/zisk-fv#332
+                        gave `MemAlign.component` the same shape Main already
+                        had). Flipping that field to `none` must clear
                         `excluded_by` on RECLASSIFICATION MemAlign #16.
     MAIN_SOURCE_C_COFACTOR_BROKEN          `main_source_c_within_segment` cites
                         a cofactor search result: `sourceCCopyBetween`'s clause
@@ -462,9 +463,9 @@ def _excluded_by_values(payload: dict, kind: str, air: str,
 
 def _reclassification_excluded_by_cleared(
         air: str, definition: str) -> Callable[[dict, dict], str | None]:
-    """`main_fixed_lane_alias`/`memalign_l1_disclosed_gap`: removing the textual
-    fact the citation rests on (Main's real `fixedColumns` pin; MemAlign
-    genuinely declaring none) must clear `excluded_by`, not leave it set."""
+    """`main_fixed_lane_alias`/`memalign_fixed_lane_alias`: removing the
+    textual fact the citation rests on (Main's or MemAlign's real
+    `fixedColumns` pin) must clear `excluded_by`, not leave it set."""
     def check(baseline_payload: dict, run_payload: dict) -> str | None:
         before = _excluded_by_values(baseline_payload, RECLASSIFICATION, air,
                                       definition)
@@ -878,13 +879,13 @@ MAIN_ASIDE_WELD_3 = "↔ Main.extraction.constraint_3_every_row c r :="
 MAIN_ASIDE_WELD_9 = "↔ Main.extraction.constraint_9_every_row c r :="
 # #329's three declared-exclusion reversal cases. `MAIN_FIXED_COLUMNS_LINE` is
 # `componentWithRomMemAndOpBus`'s own field, the real pin `main_fixed_lane_alias`
-# cites; `MEMALIGN_COMPONENT_HEAD` anchors an insertion into MemAlign's
-# `component` (which has no `fixedColumns` field to mutate, since that is
-# exactly what `memalign_l1_disclosed_gap` says); `SOURCE_C_B0_CLAUSE` is
+# cites; `MEMALIGN_FIXED_COLUMNS_LINE` is `MemAlign.component`'s own field, the
+# real pin `memalign_fixed_lane_alias` cites (eth-act/zisk-fv#332 gave it the
+# same `fixedColumns` shape Main already had); `SOURCE_C_B0_CLAUSE` is
 # `sourceCCopyBetween`'s first conjunct, the one `main_source_c_within_segment`
 # cites as cofactor-implied by generated #4.
 MAIN_FIXED_COLUMNS_LINE = "fixedColumns := some mainFixedColumns"
-MEMALIGN_COMPONENT_HEAD = "{ circuit := circuit"
+MEMALIGN_FIXED_COLUMNS_LINE = "fixedColumns := some memAlignFixedColumns"
 SOURCE_C_B0_CLAUSE = "(curr.core.b_0 - prev.core.c_0) = 0"
 
 
@@ -1207,17 +1208,21 @@ MUTATIONS: tuple[Mutation, ...] = (
         expect_exit=1,
     ),
     Mutation(
-        name="MEMALIGN_FIXED_COLUMNS_TEXT_ADDED",
+        name="MEMALIGN_FIXED_COLUMNS_PIN_REMOVED",
         lean_file=MEMALIGN_CIRCUIT,
-        target="component, a fixedColumns-looking line added",
-        intent="#329's `memalign_l1_disclosed_gap` exclusion fires only while "
-               "MemAlign declares NO fixedColumns at all -- the moment that "
-               "premise stops holding, the exclusion must withdraw and "
-               "RECLASSIFICATION MemAlign #16 must resurface as a plain, "
-               "un-declared failure rather than stay silently excluded",
-        apply=add_line_after(
-            MEMALIGN_COMPONENT_HEAD,
-            "-- fixedColumns := some fakeMemAlignFixedColumns"),
+        target="component, fixedColumns := some memAlignFixedColumns -> none",
+        intent="#332 gave `MemAlign.component` a REAL `fixedColumns` pin, the "
+               "same shape Main already has; #329's `memalign_fixed_lane_alias` "
+               "exclusion is backed by that pin, re-verified textually every "
+               "run -- removing it must make RECLASSIFICATION MemAlign #16 "
+               "resurface as a plain, un-declared failure, not stay silently "
+               "excluded",
+        # The signature itself (kind/route/index/definitions) is unaffected --
+        # `preprocessedColumn` still aliases `preL1` to `MemAlign.L1` exactly
+        # as before, so `added`/`removed` stay empty. What must move is
+        # `excluded_by`, checked directly.
+        apply=replace_in_line(MEMALIGN_FIXED_COLUMNS_LINE,
+                              "some memAlignFixedColumns", "none"),
         excluded_by_check=_reclassification_excluded_by_cleared(
             "MemAlign", "Spec"),
         expect_exit=1,

--- a/tools/mirror-roundtrip/acceptance.py
+++ b/tools/mirror-roundtrip/acceptance.py
@@ -39,11 +39,12 @@ Why the verdict is a DELTA, not (only) an exit code
     below (`MAIN_FIXED_COLUMNS_PIN_REMOVED`, `MEMALIGN_FIXED_COLUMNS_PIN_
     REMOVED`, `MAIN_SOURCE_C_COFACTOR_BROKEN`) adds no NEW signature at all --
     an EXISTING finding merely stops being excluded, which moves the exit
-    code without moving the signature multiset. `LANELESS_CLAUSE_LAUNDERED`
-    and `ADDR0_CLAUSE_LAUNDERED` also carry an `excluded_by_check` (proving
-    the laundered clause's OWN new finding is not silently re-excluded), but
-    need no override: each adds a genuinely NEW UNBACKED signature, so the
-    default rule already predicts exit 1 correctly. (A prior case here,
+    code without moving the signature multiset. `LANELESS_CLAUSE_LAUNDERED`,
+    `LANELESS_CLAUSE_CANCELLED_LAUNDERED`, and `ADDR0_CLAUSE_LAUNDERED` also
+    carry an `excluded_by_check` (proving the laundered clause's OWN new
+    finding is not silently re-excluded), but need no override: each adds a
+    genuinely NEW UNBACKED signature, so the default rule already predicts
+    exit 1 correctly. (A prior case here,
     `LANELESS_CLAUSE_ADDED`, DID need an exit-0 override -- the laundering
     hole eth-act/zisk-fv#329's review fix closes had the tool auto-declare
     that added UNBACKED regardless of what the clause asserted. It is
@@ -1107,6 +1108,32 @@ MUTATIONS: tuple[Mutation, ...] = (
         added=(unbacked("MemAlign", "Spec"),),
         excluded_by_check=_laundered_uncommitted_clause_not_excluded(
             "MemAlign", "Spec", "12345"),
+    ),
+    Mutation(
+        name="LANELESS_CLAUSE_CANCELLED_LAUNDERED",
+        lean_file=MEMALIGN_SPEC,
+        target="Spec, one extra conjunct where the no-lane field cancels to "
+               "leave a committed strengthening",
+        intent="a committed strengthening laundered through a no-lane field "
+               "that CANCELS in canonicalisation -- `_unbacked_clause_is_"
+               "definitional_pin` reads the canonical form, so a clause the "
+               "field vanishes from must not vacuously pass the pin check",
+        # `delta_pc - delta_pc + addr*54321 = 0` names the no-lane field in its
+        # raw text (so it is classed UNBACKED and routed to the pin check), but
+        # the two `delta_pc` terms cancel in `poly.Poly` normal form, leaving
+        # `54321*addr = 0` -- a REAL assertion `addr = 0` over a committed lane
+        # with no uncommitted atom left in any monomial. Before the terminal
+        # `return saw_uncommitted` fix, the per-monomial loop found nothing
+        # touching an unresolved atom and fell through to `return True`,
+        # vacuously excluding the strengthening as if it were a genuine
+        # definitional pin. The pin is real only if an uncommitted atom
+        # SURVIVES canonicalisation; here none does, so this must now surface
+        # as a real, un-excluded, failing UNBACKED.
+        apply=add_line_after(
+            PRE_L1, "∧ row.delta_pc - row.delta_pc + row.addr * 54321 = 0"),
+        added=(unbacked("MemAlign", "Spec"),),
+        excluded_by_check=_laundered_uncommitted_clause_not_excluded(
+            "MemAlign", "Spec", "54321"),
     ),
     Mutation(
         name="ADDR0_CLAUSE_LAUNDERED",

--- a/tools/mirror-roundtrip/check_mirrors.py
+++ b/tools/mirror-roundtrip/check_mirrors.py
@@ -303,25 +303,19 @@ DECLARED_EXCLUSIONS = (
         "independent witness -- a real pin, not merely a name correspondence",
     ),
     Exclusion(
-        "memalign_l1_disclosed_gap", "mirror",
-        "a declared lane-kind alias with NO such pin: a genuine, "
-        "already-disclosed, currently-inert lane-class gap, not a benign "
-        "alias -- declared here as a live, open residual, not as resolved",
-        "ZiskFv/AirsClean/MemAlignMirrorWeld.lean's own module header (point "
-        "2, from #296) already states `MemAlignRow.preL1` is an ordinary "
-        "witness field nothing pins to fixed column `MemAlign.L1` (MemAlign "
-        "declares no `fixedColumns` at all), and that a prover controlling it "
-        "can set it to 0 and evade `pc=0` at the boot row; `boot_pc_zero_weld`/"
-        "`component_spec_weld` are explicitly documented there as NOT "
-        "certifying constraint_16's fidelity. Not fixed here because no proof "
-        "under ZiskFv/Compliance consumes `boot_pc_zero`/`preL1` for any "
-        "conclusion (grepped: the only references outside MemAlign's own "
-        "module and this weld are none), so the gap is currently inert for "
-        "`root_soundness`, and a real fix -- a genuine `fixedColumns` schema "
-        "for MemAlign, the shape of change Main already has -- touches "
-        "Row/Circuit/Bridge/Constraints/Soundness/Spec and the weld bridges "
-        "together, not a local mirror correction. A tracking issue (the "
-        "eth-act/zisk-fv#328 model) is the recommended next step",
+        "memalign_fixed_lane_alias", "mirror",
+        "a declared lane-kind alias where the aliased row field is PROVEN "
+        "pinned to the real fixed column by the checked-in Lean, not merely "
+        "named the same",
+        "ZiskFv/AirsClean/MemAlign/Circuit.lean:287-308 (`memAlignFixedLayout`/"
+        "`memAlignFixedValues`) and :390-393 (`fixedColumns := some "
+        "memAlignFixedColumns` on the live component) declare `preL1`/`L1` a "
+        "component-owned FIXED column, and :325/:368 "
+        "(`eval_memAlignFixedColumns_L1`, `eval_memAlignRawRow_materialize`) "
+        "prove every materialized row reads it from that schema, never from "
+        "an independent witness -- a real pin, not merely a name "
+        "correspondence (eth-act/zisk-fv#332, closing the `memalign_l1_"
+        "disclosed_gap` this exclusion replaces)",
     ),
     Exclusion(
         "mirror_unbacked_field_uncommitted", "mirror",
@@ -1269,16 +1263,18 @@ def _main_fixed_columns_pin_holds() -> bool:
     return "fixedColumns := some mainFixedColumns" in path.read_text()
 
 
-def _memalign_declares_no_fixed_columns() -> bool:
-    """Textually re-verify MemAlign's live component still declares NO
-    `fixedColumns` at all -- `memalign_l1_disclosed_gap`'s entire premise.
+def _memalign_fixed_columns_pin_holds() -> bool:
+    """Textually re-verify MemAlign's live component still gives `preL1`/`L1`
+    a real `fixedColumns` schema (eth-act/zisk-fv#332).
 
-    If this ever goes false (MemAlign gains a real fixed-column schema, the
-    honest fix), the disclosed-gap framing no longer applies and this
-    exclusion must stop firing, not keep citing a premise that no longer holds.
+    `memalign_fixed_lane_alias`'s whole citation rests on this one line;
+    reading it fresh from the (possibly redirected, see `_redirect_roots`)
+    source on every run is what makes a mutation that removes the pin
+    re-surface the finding, rather than the exclusion firing unconditionally
+    off a hardcoded lane name.
     """
     path = mirror_parse.REPO_ROOT / "ZiskFv/AirsClean/MemAlign/Circuit.lean"
-    return "fixedColumns := some" not in path.read_text()
+    return "fixedColumns := some memAlignFixedColumns" in path.read_text()
 
 
 def _declare_reclassification_alias(finding: Finding, declare) -> None:
@@ -1287,18 +1283,20 @@ def _declare_reclassification_alias(finding: Finding, declare) -> None:
     Both agree canonically only because a row field stands for a fixed lane --
     but `this tool does not check welds`, so whether that stand-in is BACKED
     (a real pin the checked-in Lean proves) or merely NAMED is exactly the
-    thing a reviewer, not this mechanical comparator, has to decide. The two
-    current cases land on opposite sides, and each is re-verified textually
-    (`_main_fixed_columns_pin_holds`/`_memalign_declares_no_fixed_columns`)
+    thing a reviewer, not this mechanical comparator, has to decide. Both
+    current cases ARE backed (eth-act/zisk-fv#332 gave MemAlign the same
+    `fixedColumns` shape Main already had), and each is re-verified textually
+    (`_main_fixed_columns_pin_holds`/`_memalign_fixed_columns_pin_holds`)
     rather than trusted from the lane name alone:
 
     * Main's `segment_l1`/`main_step` ARE pinned: `Circuit.lean` gives the
       component real `fixedColumns`, and `eval_mainFixedColumns_*`/
       `eval_mainRawRow_*_materialize` prove every materialized row reads them
       from that schema, not an independent witness.
-    * MemAlign's `preL1` is NOT pinned -- MemAlign declares no `fixedColumns`
-      at all -- and `MemAlignMirrorWeld.lean`'s own module header already
-      discloses this as a real gap, not a benign rename.
+    * MemAlign's `preL1` IS pinned the same way: `Circuit.lean` gives the
+      component real `fixedColumns`, and `eval_memAlignFixedColumns_L1`/
+      `eval_memAlignRawRow_materialize` prove every materialized row reads it
+      from that schema, not an independent witness.
     """
     lane_names = {item[1] for item in finding.reclassified}
     if not lane_names:
@@ -1323,27 +1321,21 @@ def _declare_reclassification_alias(finding: Finding, declare) -> None:
             f"Main {gens} <- {mirrors_desc}")
         return
     if (finding.air == "MemAlign" and lane_names == {"MemAlign.L1"}
-            and _memalign_declares_no_fixed_columns()):
+            and _memalign_fixed_columns_pin_holds()):
         declare(
-            finding, "memalign_l1_disclosed_gap",
-            "NOT a benign alias -- a genuine, already-disclosed, currently "
-            "inert lane-class gap. ZiskFv/AirsClean/MemAlignMirrorWeld.lean's "
-            "own module header (point 2) already states `preL1` is an "
-            "ordinary witness field nothing pins to fixed column `MemAlign.L1` "
-            "(MemAlign declares no `fixedColumns` at all), and that a prover "
-            "controlling it can set it to 0 and evade `pc=0` at the boot row; "
-            "`boot_pc_zero_weld`/`component_spec_weld` are explicitly "
-            "documented there as NOT certifying constraint_16's fidelity. "
-            "Declared rather than fixed here because: no proof under "
-            "ZiskFv/Compliance consumes `boot_pc_zero`/`preL1` for any "
-            "conclusion (the only references outside MemAlign's own module and "
-            "this weld are none), so the gap is currently inert for "
-            "`root_soundness`; and a real fix -- giving MemAlign a genuine "
-            "`fixedColumns` schema, the same shape of change Main already has "
-            "-- touches Row/Circuit/Bridge/Constraints/Soundness/Spec and the "
-            "weld bridges together, not a local mirror correction. This is a "
-            "live, disclosed gap, not a closed one; a tracking issue (the "
-            "eth-act/zisk-fv#328 model) is recommended.",
+            finding, "memalign_fixed_lane_alias",
+            "the aliased row field is not a free witness (eth-act/"
+            "zisk-fv#332): ZiskFv/AirsClean/MemAlign/Circuit.lean:287-308 "
+            "(`memAlignFixedLayout`/`memAlignFixedValues`) and :390-393 "
+            "(`fixedColumns := some memAlignFixedColumns` on the live "
+            "component) declare `preL1`/`L1` a component-owned FIXED column, "
+            "and :325/:368 (`eval_memAlignFixedColumns_L1`, "
+            "`eval_memAlignRawRow_materialize`) prove every materialized row "
+            "reads it from that schema and not from an independent witness -- "
+            "a real pin, verified here by citation, not merely a name "
+            "correspondence. Before #332, MemAlign declared no `fixedColumns` "
+            "at all and this exclusion was `memalign_l1_disclosed_gap`, a "
+            "disclosed, unfixed gap; see that commit for the prior finding.",
             f"MemAlign {gens} <- {mirrors_desc}")
         return
 

--- a/tools/mirror-roundtrip/check_mirrors.py
+++ b/tools/mirror-roundtrip/check_mirrors.py
@@ -208,10 +208,11 @@ class Exclusion:
     citation: str
 
 
-# The complete exclusion list. Three entries, all category-level; a fourth would
-# be worth arguing about and a per-index one would be laundering. `counts` in the
-# report is computed live, so an entry that stops carrying anything shows as 0 and
-# an entry that starts carrying more shows that too.
+# The complete exclusion list. `carried` in the report is computed live, so an
+# entry that stops carrying anything shows as 0 and an entry that starts
+# carrying more shows that too. Every entry is category-level: none names an
+# individual constraint index or mirror clause, and a per-index one would be
+# laundering.
 #
 # There used to be a fourth, `mirror_field_has_no_lane`, and it was wrong. It
 # bucketed an equation clause out of the compared set because one of its
@@ -224,6 +225,18 @@ class Exclusion:
 # citations that justified the bucket did not disappear -- they are printed on
 # each finding, as the reason the field has no lane rather than as a reason to
 # stop looking at it.
+#
+# The first three entries are PRE-PAIRING filters: a clause matching the rule
+# never becomes a Generated/Clause in the first place, so it never has a
+# `kind` to report. The remaining entries (eth-act/zisk-fv#329) are different
+# in shape and are applied POST-pairing, by `apply_declared_mirror_exclusions`:
+# each tags a SPECIFIC already-computed STRENGTHENING/RECLASSIFICATION/UNBACKED
+# finding via a structural, re-verified check (never an index), leaving its
+# `kind` and full printed detail intact and only removing it from the
+# failing/summary counts. That split exists because these four are REVIEWED
+# judgement calls a mechanical pre-filter cannot make (is a weakening's dropped
+# half in scope, is a lane-kind alias actually pinned) -- see each entry's own
+# `_declare_*` function in the code above for the exact check.
 DECLARED_EXCLUSIONS = (
     Exclusion(
         "challenge_or_stage2", "generated",
@@ -257,6 +270,73 @@ DECLARED_EXCLUSIONS = (
         "declared out-of-root mirror (survey.DELEGATED, named not compared), or "
         "NEAR_*-classified AND shown equation-free by the near-miss screen below. "
         "Any other delegate is an undeclared delegation and a finding",
+    ),
+    Exclusion(
+        "main_source_c_within_segment", "mirror",
+        "a STRENGTHENING clause cofactor-implied by a generated b-side "
+        "source-C copy constraint (`main.pil:386`) with cofactor "
+        "`1 - Main.SEGMENT_L1`: the within-segment specialization Clean's "
+        "row-only `Component.transition` interface can state, dropping only "
+        "the cross-segment `SEGMENT_L1=1` boundary term",
+        "tools/mirror-roundtrip/FINDING_main_copyc.md works the exact "
+        "polynomial diff and the soundness trace: the dropped term is the "
+        "cross-segment continuation datum `segment_previous_c` (an `airval`, "
+        "unreachable from a two-row `Component.transition : Input F -> "
+        "Input F -> Prop`), tracked out-of-current-single-segment-scope by "
+        "eth-act/zisk-fv#328. The within-segment region this clause states "
+        "matches the generated constraint exactly and is the only region any "
+        "soundness proof reads it in (JALR's `segment_l1=0` case, "
+        "TraceLevelExport/StepStrongControlStore.lean:383)",
+    ),
+    Exclusion(
+        "main_fixed_lane_alias", "mirror",
+        "a declared lane-kind alias where the aliased row field is PROVEN "
+        "pinned to the real fixed column by the checked-in Lean, not merely "
+        "named the same",
+        "ZiskFv/AirsClean/Main/Circuit.lean:744-757 (`mainFixedLayout`/"
+        "`mainFixedValues`) and :952-953 (`fixedColumns := some "
+        "mainFixedColumns` on the live component) declare `segment_l1`/"
+        "`main_step` component-owned FIXED columns, and :776-882 "
+        "(`eval_mainFixedColumns_segment_l1`/`_main_step`, "
+        "`eval_mainRawRow_core_materialize`/`_rom_materialize`) prove every "
+        "materialized row reads them from that schema, never from an "
+        "independent witness -- a real pin, not merely a name correspondence",
+    ),
+    Exclusion(
+        "memalign_l1_disclosed_gap", "mirror",
+        "a declared lane-kind alias with NO such pin: a genuine, "
+        "already-disclosed, currently-inert lane-class gap, not a benign "
+        "alias -- declared here as a live, open residual, not as resolved",
+        "ZiskFv/AirsClean/MemAlignMirrorWeld.lean's own module header (point "
+        "2, from #296) already states `MemAlignRow.preL1` is an ordinary "
+        "witness field nothing pins to fixed column `MemAlign.L1` (MemAlign "
+        "declares no `fixedColumns` at all), and that a prover controlling it "
+        "can set it to 0 and evade `pc=0` at the boot row; `boot_pc_zero_weld`/"
+        "`component_spec_weld` are explicitly documented there as NOT "
+        "certifying constraint_16's fidelity. Not fixed here because no proof "
+        "under ZiskFv/Compliance consumes `boot_pc_zero`/`preL1` for any "
+        "conclusion (grepped: the only references outside MemAlign's own "
+        "module and this weld are none), so the gap is currently inert for "
+        "`root_soundness`, and a real fix -- a genuine `fixedColumns` schema "
+        "for MemAlign, the shape of change Main already has -- touches "
+        "Row/Circuit/Bridge/Constraints/Soundness/Spec and the weld bridges "
+        "together, not a local mirror correction. A tracking issue (the "
+        "eth-act/zisk-fv#328 model) is the recommended next step",
+    ),
+    Exclusion(
+        "mirror_unbacked_field_uncommitted", "mirror",
+        "an UNBACKED equation whose no-lane field(s) are independently "
+        "confirmed to have no lane anywhere in this AIR's pilout -- not a "
+        "witness column, not a fixed column, not an exposed value -- so it "
+        "is not merely excluded from the comparable slice, it is not an atom "
+        "any generated constraint (comparable or excluded) could ever carry",
+        "mirror_parse.EXPECTED_UNRESOLVED's addr0/addr2 (Main/Constraints."
+        "lean:268/270, PIL `const expr`s inlined at every use site) and "
+        "delta_pc (MemAlign/Row.lean:52-54, the `pc'-pc` slot of hint #998; "
+        "its only generated appearance is inside the challenge-mixed "
+        "`constraint_36`, itself already excluded by `challenge_or_stage2`) "
+        "entries, each re-verified here against `lanes.lane_map` rather than "
+        "trusted from the citation text alone",
     ),
 )
 
@@ -637,6 +717,16 @@ class Finding:
     # `Iff.rfl` weld theorem whose RHS binds it.
     weld_evidence: list[tuple[Generated, weld_parse.WeldRef]] = field(
         default_factory=list)
+    # Set when a REVIEWED, category-level `DECLARED_EXCLUSIONS` entry covers this
+    # otherwise-failing finding -- the key into that tuple, plus the reviewed
+    # justification specific to this finding. `kind` is left UNCHANGED (still
+    # STRENGTHENING/RECLASSIFICATION/UNBACKED): this is not a mechanically-decided
+    # coverage class like BOOL_TYPED/WELD_COVERED/OUT_OF_ROOT, it is a human
+    # judgement call the citation records, so the finding keeps printing in full
+    # under its real class with this annotation attached, and only the
+    # failing/summary counts treat it as resolved.
+    excluded_by: str = ""
+    excluded_reason: str = ""
 
     @property
     def many_to_many(self) -> bool:
@@ -1127,6 +1217,227 @@ def reclassify_weld_covered(air: str, findings: list[Finding],
     return rewritten
 
 
+# --------------------------------------------------------- declared mirror findings
+
+
+def _declare_main_source_c_boundary(finding: Finding, declare) -> None:
+    """`sourceCCopyBetween`'s two clauses (`ZiskFv/AirsClean/Main/Circuit.lean:
+    721,727`) against generated `#4`/`#10` (`main.pil:386`, the b-side source-C
+    copy). The cofactor search already proves each mirror clause equals
+    `(1 - Main.SEGMENT_L1) * generated`; what remains is whether the dropped
+    `SEGMENT_L1 = 1` half is a fixable slip or an out-of-scope boundary term.
+    `FINDING_main_copyc.md` works this out: it is the cross-segment
+    continuation datum `segment_previous_c`, an `airval` no two-row
+    `Component.transition` can reach, tracked by eth-act/zisk-fv#328. See
+    `DECLARED_EXCLUSIONS["main_source_c_within_segment"]`.
+    """
+    if finding.air != "Main" or len(finding.clauses) != 1:
+        return
+    clause = finding.clauses[0]
+    if clause.definition != "sourceCCopyBetween":
+        return
+    implied = finding.implied
+    if implied is None or not implied.cofactor.startswith("1 - "):
+        return
+    if "main.pil:386" not in implied.generated.provenance:
+        return
+    declare(
+        finding, "main_source_c_within_segment",
+        f"cofactor-implied by generated #{implied.generated.index} "
+        f"({implied.generated.provenance}) with cofactor `{implied.cofactor}` "
+        f"-- the boolean fixed lane `Main.SEGMENT_L1`. The dropped "
+        f"`SEGMENT_L1=1` half is the cross-segment continuation term "
+        f"(`segment_previous_c`), out of `root_soundness`'s current "
+        f"single-segment scope per FINDING_main_copyc.md and "
+        f"eth-act/zisk-fv#328; the within-segment region this clause states "
+        f"matches the generated constraint exactly and is the only region any "
+        f"soundness proof reads it in (JALR's `segment_l1=0` case, "
+        f"StepStrongControlStore.lean:383).",
+        f"{clause.label} {clause.site} <- generated #{implied.generated.index}")
+
+
+def _main_fixed_columns_pin_holds() -> bool:
+    """Textually re-verify Main's live component still gives `segment_l1`/
+    `main_step` a real `fixedColumns` schema.
+
+    `main_fixed_lane_alias`'s whole citation rests on this one line; reading it
+    fresh from the (possibly redirected, see `_redirect_roots`) source on every
+    run is what makes a mutation that removes the pin re-surface the finding,
+    rather than the exclusion firing unconditionally off a hardcoded lane name.
+    """
+    path = mirror_parse.REPO_ROOT / "ZiskFv/AirsClean/Main/Circuit.lean"
+    return "fixedColumns := some mainFixedColumns" in path.read_text()
+
+
+def _memalign_declares_no_fixed_columns() -> bool:
+    """Textually re-verify MemAlign's live component still declares NO
+    `fixedColumns` at all -- `memalign_l1_disclosed_gap`'s entire premise.
+
+    If this ever goes false (MemAlign gains a real fixed-column schema, the
+    honest fix), the disclosed-gap framing no longer applies and this
+    exclusion must stop firing, not keep citing a premise that no longer holds.
+    """
+    path = mirror_parse.REPO_ROOT / "ZiskFv/AirsClean/MemAlign/Circuit.lean"
+    return "fixedColumns := some" not in path.read_text()
+
+
+def _declare_reclassification_alias(finding: Finding, declare) -> None:
+    """The two `RECLASSIFICATION` findings from a declared lane-kind alias.
+
+    Both agree canonically only because a row field stands for a fixed lane --
+    but `this tool does not check welds`, so whether that stand-in is BACKED
+    (a real pin the checked-in Lean proves) or merely NAMED is exactly the
+    thing a reviewer, not this mechanical comparator, has to decide. The two
+    current cases land on opposite sides, and each is re-verified textually
+    (`_main_fixed_columns_pin_holds`/`_memalign_declares_no_fixed_columns`)
+    rather than trusted from the lane name alone:
+
+    * Main's `segment_l1`/`main_step` ARE pinned: `Circuit.lean` gives the
+      component real `fixedColumns`, and `eval_mainFixedColumns_*`/
+      `eval_mainRawRow_*_materialize` prove every materialized row reads them
+      from that schema, not an independent witness.
+    * MemAlign's `preL1` is NOT pinned -- MemAlign declares no `fixedColumns`
+      at all -- and `MemAlignMirrorWeld.lean`'s own module header already
+      discloses this as a real gap, not a benign rename.
+    """
+    lane_names = {item[1] for item in finding.reclassified}
+    if not lane_names:
+        return
+    gens = ", ".join(f"#{e.index}" for e in finding.generated)
+    mirrors_desc = ", ".join(c.label for c in finding.clauses)
+    if (finding.air == "Main" and lane_names <= {
+            "Main.SEGMENT_L1", "Main.SEGMENT_STEP"}
+            and _main_fixed_columns_pin_holds()):
+        declare(
+            finding, "main_fixed_lane_alias",
+            "the aliased row field is not a free witness: "
+            "ZiskFv/AirsClean/Main/Circuit.lean:744-757 (`mainFixedLayout`/"
+            "`mainFixedValues`) and :952-953 (`fixedColumns := some "
+            "mainFixedColumns` on the live component) declare it a "
+            "component-owned FIXED column, and :776-882 "
+            "(`eval_mainFixedColumns_segment_l1`/`_main_step`, "
+            "`eval_mainRawRow_core_materialize`/`_rom_materialize`) prove every "
+            "materialized row reads it from that schema and not from an "
+            "independent witness -- a real pin, verified here by citation, not "
+            "merely a name correspondence.",
+            f"Main {gens} <- {mirrors_desc}")
+        return
+    if (finding.air == "MemAlign" and lane_names == {"MemAlign.L1"}
+            and _memalign_declares_no_fixed_columns()):
+        declare(
+            finding, "memalign_l1_disclosed_gap",
+            "NOT a benign alias -- a genuine, already-disclosed, currently "
+            "inert lane-class gap. ZiskFv/AirsClean/MemAlignMirrorWeld.lean's "
+            "own module header (point 2) already states `preL1` is an "
+            "ordinary witness field nothing pins to fixed column `MemAlign.L1` "
+            "(MemAlign declares no `fixedColumns` at all), and that a prover "
+            "controlling it can set it to 0 and evade `pc=0` at the boot row; "
+            "`boot_pc_zero_weld`/`component_spec_weld` are explicitly "
+            "documented there as NOT certifying constraint_16's fidelity. "
+            "Declared rather than fixed here because: no proof under "
+            "ZiskFv/Compliance consumes `boot_pc_zero`/`preL1` for any "
+            "conclusion (the only references outside MemAlign's own module and "
+            "this weld are none), so the gap is currently inert for "
+            "`root_soundness`; and a real fix -- giving MemAlign a genuine "
+            "`fixedColumns` schema, the same shape of change Main already has "
+            "-- touches Row/Circuit/Bridge/Constraints/Soundness/Spec and the "
+            "weld bridges together, not a local mirror correction. This is a "
+            "live, disclosed gap, not a closed one; a tracking issue (the "
+            "eth-act/zisk-fv#328 model) is recommended.",
+            f"MemAlign {gens} <- {mirrors_desc}")
+        return
+
+
+def _declare_unbacked_uncommitted(air: str, finding: Finding, lane_map_for,
+                                  declare) -> None:
+    """An `UNBACKED` clause whose field(s) the pilout commits to NO lane at all.
+
+    Every `UNBACKED` clause already carries a citation
+    (`mirror_parse.EXPECTED_UNRESOLVED`) explaining why its field has no lane in
+    the COMPARABLE slice. What that citation does not by itself establish is the
+    stronger fact this exclusion needs: that the field has no lane ANYWHERE in
+    the pilout for this AIR -- not a witness column, not a fixed column, not an
+    exposed value -- so it is not merely out of the comparable slice, it is not
+    an atom any generated constraint (comparable OR excluded) could ever carry.
+    That is re-verified here, mechanically, against `lanes.lane_map` rather than
+    trusted from the citation text alone.
+    """
+    clause = finding.clauses[0]
+    leaves: list[str] = []
+    for path, reason, citation in clause.laneless:
+        if reason != "no_lane" or not citation:
+            return
+        leaf = path.rsplit(".", 1)[-1]
+        if (air, leaf) not in mirror_parse.EXPECTED_UNRESOLVED:
+            return
+        leaves.append(leaf)
+    if not leaves:
+        return
+    lane_map = lane_map_for(air)
+    for leaf in leaves:
+        try:
+            lane_map.resolve(leaf)
+        except lanes.LaneError:
+            continue
+        # A lane exists somewhere after all: this clause is not in this
+        # category, and is left as a plain UNBACKED failure to report.
+        return
+    named = ", ".join(sorted(set(leaves)))
+    declare(
+        finding, "mirror_unbacked_field_uncommitted",
+        f"every no-lane field here ({named}) is independently confirmed, "
+        f"against `lanes.lane_map({air!r})`, to have NO lane anywhere in this "
+        f"AIR's pilout symbol table -- not merely excluded from the comparable "
+        f"slice. Each is a PIL `const expr` inlined at every use site (addr0/"
+        f"addr2) or a hint payload for a challenge-mixed lookup whose only "
+        f"generated appearance is inside an already-excluded constraint "
+        f"(delta_pc, inside `constraint_36`, excluded by `challenge_or_stage2`)"
+        f" -- see `mirror_parse.EXPECTED_UNRESOLVED` for the per-field PIL "
+        f"citation. No generated constraint, comparable or excluded, could "
+        f"ever carry an equation naming it.",
+        f"{clause.label} {clause.site} ({named})")
+
+
+def apply_declared_mirror_exclusions(
+        air: str, findings: list[Finding],
+        lane_map_for) -> tuple[list[Finding], dict[str, list[str]]]:
+    """Tag specific residual findings a reviewed `DECLARED_EXCLUSIONS` entry covers.
+
+    Unlike `reclassify_covered`/`reclassify_weld_covered` -- both MECHANICALLY
+    decided facts (a typing bound, a kernel-checked weld) that relabel a
+    finding's `kind` -- every rule here is a REVIEWED judgement call:
+    AGENTS.md's anti-laundering section asks for a real source citation and,
+    for a strengthening, a constructibility argument; for a reclassification,
+    whether the aliased lane is really pinned or is a disclosed, unfixed gap.
+    So `finding.kind` is left EXACTLY as `pair_air` decided it -- still
+    STRENGTHENING/RECLASSIFICATION/UNBACKED -- and only `excluded_by`/
+    `excluded_reason` are set. The full finding keeps printing, annotated; only
+    the `_active` failing/summary counts (`AirRun.*_active`) treat it as
+    resolved. This function decides FOUR specific, narrow, structurally-checked
+    categories -- never an index, always re-verified here rather than trusted
+    from a prior finding's own citation.
+
+    Returns the same findings list (mutated in place) and a `key -> site
+    string` map for `print_declarations`' "took" listing, the same
+    auditability the two pre-pairing exclusions already get.
+    """
+    sites: dict[str, list[str]] = defaultdict(list)
+
+    def declare(finding: Finding, key: str, reason: str, site: str) -> None:
+        finding.excluded_by = key
+        finding.excluded_reason = reason
+        sites[key].append(site)
+
+    for finding in findings:
+        if finding.kind == STRENGTHENING:
+            _declare_main_source_c_boundary(finding, declare)
+        elif finding.kind == RECLASSIFICATION:
+            _declare_reclassification_alias(finding, declare)
+        elif finding.kind == UNBACKED:
+            _declare_unbacked_uncommitted(air, finding, lane_map_for, declare)
+    return findings, sites
+
+
 # ------------------------------------------------------------------ reachability
 
 
@@ -1293,6 +1604,29 @@ def near_miss_screen(lane_map_for) -> NearMissScreen:
     finally:
         survey.CLASSIFICATION.clear()
         survey.CLASSIFICATION.update(original)
+    # `survey.DELEGATED_OUT_OF_SCOPE`: declared out-of-root delegates never
+    # parsed for comparison (`load_out_of_root` only reads `survey.DELEGATED`).
+    # Screened the same way as an in-root NEAR_*: re-parsed, on its own file,
+    # through the SAME out-of-root reader `load_out_of_root` uses, and required
+    # to carry no comparable equation.
+    for air, site, name, cls in survey.DELEGATED_OUT_OF_SCOPE:
+        rel = site.rsplit(":", 1)[0]
+        out.screened += 1
+        try:
+            parsed = mirror_parse.parse_out_of_root(air, rel, name, lane_map_for)
+        except Exception as error:  # noqa: BLE001 - the screen must not abort
+            out.refused.append(f"{rel} {name}: {type(error).__name__}: {error}")
+            continue
+        equations = [clause for clause in parsed.clauses if clause.comparable]
+        if equations:
+            out.carrying.append(
+                f"{rel}:{parsed.line} {name} [{cls}]: declared out-of-root and "
+                f"out of scope but carries {len(equations)} comparable "
+                f"polynomial equation(s), so nothing compares them")
+        elif parsed.unparsed:
+            out.refused.append(f"{rel} {name}: {parsed.unparsed[0][:120]}")
+        else:
+            out.equation_free.add((rel, name))
     return out
 
 
@@ -1446,6 +1780,31 @@ class AirRun:
     def mir_count(self, kind: str) -> int:
         return sum(len(f.clauses) for f in self.of_kind(kind))
 
+    # --- the same three views, over what is STILL FAILING once a reviewed
+    # `DECLARED_EXCLUSIONS` entry (`Finding.excluded_by`) is taken into account.
+    # `kind` never changes on an excluded finding (see `Finding.excluded_by`), so
+    # the partition invariants in `run_check` keep using the unfiltered `of_kind`
+    # /`gen_count`/`mir_count` above; only the summary/table/exit-code counts,
+    # which report what a reviewer still owes, use these.
+
+    def of_kind_active(self, kind: str) -> list[Finding]:
+        return [f for f in self.of_kind(kind) if not f.excluded_by]
+
+    def gen_count_active(self, kind: str) -> int:
+        return sum(len(f.generated) for f in self.of_kind_active(kind))
+
+    def mir_count_active(self, kind: str) -> int:
+        return sum(len(f.clauses) for f in self.of_kind_active(kind))
+
+    def of_kind_declared(self, kind: str) -> list[Finding]:
+        return [f for f in self.of_kind(kind) if f.excluded_by]
+
+    def gen_count_declared(self, kind: str) -> int:
+        return sum(len(f.generated) for f in self.of_kind_declared(kind))
+
+    def mir_count_declared(self, kind: str) -> int:
+        return sum(len(f.clauses) for f in self.of_kind_declared(kind))
+
 
 @dataclass
 class Run:
@@ -1518,9 +1877,14 @@ class Run:
 
     @property
     def failures(self) -> int:
-        return (sum(a.gen_count(GAP) + a.mir_count(STRENGTHENING)
-                    + a.mir_count(UNBACKED)
-                    + len(a.of_kind(RECLASSIFICATION)) + len(a.mirror.unparsed)
+        # `_active` excludes a finding a reviewed `DECLARED_EXCLUSIONS` entry
+        # covers (eth-act/zisk-fv#329) -- still printed in full by
+        # `print_details`, just no longer counted as owed. GAP is never
+        # excluded this way, so `gen_count`/`gen_count_active` agree on it.
+        return (sum(a.gen_count_active(GAP) + a.mir_count_active(STRENGTHENING)
+                    + a.mir_count_active(UNBACKED)
+                    + len(a.of_kind_active(RECLASSIFICATION))
+                    + len(a.mirror.unparsed)
                     + len(a.mirror.undeclared_unresolved)
                     + len(a.mirror.undeclared_delegations) for a in self.airs)
                 + len(self.unreachable) + len(self.self_check)
@@ -1606,6 +1970,14 @@ def run_check(pilout_path: Path, extraction: Path, mirror_root: Path,
         # MATCHED / OUT_OF_ROOT / BOOL_TYPED and the weld is reported as redundant
         # confirmation rather than relabelling it.
         findings = reclassify_weld_covered(air, findings, out.welds)
+        # Reviewed, cited `DECLARED_EXCLUSIONS` entries for specific residual
+        # STRENGTHENING/RECLASSIFICATION/UNBACKED findings. Unlike the two
+        # reclassifications above, this never changes `finding.kind` -- see
+        # `apply_declared_mirror_exclusions`.
+        findings, declared_sites = apply_declared_mirror_exclusions(
+            air, findings, lane_map_for)
+        for key, declared_site_list in declared_sites.items():
+            side.excluded_sites[key].extend(declared_site_list)
         matched_out_of_root = {
             clause.canon for finding in findings if finding.kind == OUT_OF_ROOT
             for clause in finding.clauses}
@@ -1665,8 +2037,8 @@ def run_check(pilout_path: Path, extraction: Path, mirror_root: Path,
 
 # ------------------------------------------------------------------- the report
 
-_TABLE = ("{:<18} {:>9} {:>7} {:>7} {:>7} {:>9} {:>4} {:>4} {:>11} {:>4} {:>9} "
-          "{:>8} {:>6}")
+_TABLE = ("{:<18} {:>9} {:>7} {:>7} {:>7} {:>9} {:>4} {:>8} {:>4} {:>11} {:>4} "
+          "{:>9} {:>8} {:>6}")
 
 
 def print_declarations(run: Run, out) -> None:
@@ -1695,6 +2067,14 @@ def print_declarations(run: Run, out) -> None:
         "mirror_clause_not_an_equation":
             sum(a.mirror.not_an_equation for a in run.airs),
     }
+    # The four post-pairing exclusions (#329) are not pre-filtered, so they have
+    # no dedicated counter field: `carried` for them is exactly the number of
+    # sites `apply_declared_mirror_exclusions` recorded, the same live-computed
+    # site list `print_declarations` already prints below.
+    for entry in DECLARED_EXCLUSIONS:
+        if entry.key not in carried:
+            carried[entry.key] = sum(
+                len(a.mirror.excluded_sites.get(entry.key, ())) for a in run.airs)
     for entry in DECLARED_EXCLUSIONS:
         print(f"  [{entry.side:<9}] {entry.key}   carries "
               f"{carried[entry.key]}", file=out)
@@ -1738,23 +2118,33 @@ def print_declarations(run: Run, out) -> None:
 
 def print_table(run: Run, out) -> None:
     print(_TABLE.format("air", "generated", "mirror", "matched", "outroot",
-                        "booltyped", "weld", "gap", "strengthen", "recl",
-                        "unbacked", "unparsed", "unres"), file=out)
-    print("-" * 112, file=out)
-    totals = [0] * 12
+                        "booltyped", "weld", "declared", "gap", "strengthen",
+                        "recl", "unbacked", "unparsed", "unres"), file=out)
+    print("-" * 120, file=out)
+    totals = [0] * 13
     for air in run.airs:
         row = [
             len(air.generated), len(air.mirror.comparable),
             air.gen_count(MATCHED), air.gen_count(OUT_OF_ROOT),
             air.gen_count(BOOL_TYPED), air.gen_count(WELD_COVERED),
+            # `declared` is the generated-side share of a reviewed
+            # DECLARED_EXCLUSIONS entry (eth-act/zisk-fv#329):
+            # RECLASSIFICATION findings tagged `excluded_by` still have a real
+            # generated-constraint index, so it is counted here rather than
+            # silently vanishing from the row's accounting.
+            air.gen_count_declared(RECLASSIFICATION),
             air.gen_count(GAP),
-            air.mir_count(STRENGTHENING), len(air.of_kind(RECLASSIFICATION)),
-            air.mir_count(UNBACKED),
+            # strengthen/recl/unbacked are ACTIVE counts: a finding a reviewed
+            # exclusion covers is still printed in full by `print_details`
+            # (see `DECLARED` there) but no longer counts as failing here.
+            air.mir_count_active(STRENGTHENING),
+            len(air.of_kind_active(RECLASSIFICATION)),
+            air.mir_count_active(UNBACKED),
             len(air.mirror.unparsed), len(air.mirror.undeclared_unresolved),
         ]
         totals = [t + v for t, v in zip(totals, row)]
         print(_TABLE.format(air.air, *row), file=out)
-    print("-" * 112, file=out)
+    print("-" * 120, file=out)
     print(_TABLE.format("TOTAL", *totals), file=out)
     print("  generated  = comparable generated constraints (total minus the "
           "declared challenge/stage-2 exclusion)", file=out)
@@ -1768,6 +2158,12 @@ def print_table(run: Run, out) -> None:
           "or `.val < 2`-bounded, not restated as an equation", file=out)
     print("  weld       = bound on the RHS of a kernel-checked `Iff.rfl` weld "
           "(ZiskFv/AirsClean/*MirrorWeld.lean), covering a residual gap", file=out)
+    print("  declared   = a RECLASSIFICATION a reviewed DECLARED_EXCLUSIONS entry "
+          "covers (#329); printed in full under 'declared residuals' below, not "
+          "silently dropped", file=out)
+    print("  strengthen/recl/unbacked = STILL FAILING: excludes findings a "
+          "reviewed DECLARED_EXCLUSIONS entry covers (also printed in full "
+          "below)", file=out)
     print("  unbacked   = equation clauses this AIR has no lane vocabulary for, "
           "so no generated constraint can carry them", file=out)
     print("  unres      = UNDECLARED unresolved projections; the declared ones "
@@ -2083,6 +2479,13 @@ def print_details(run: Run, out) -> None:
                     print(f"      generated {pilout_check.fmt_atom(gen_atom):<22} "
                           f"mirror {pilout_check.fmt_atom(mir_atom)}", file=out)
                 _print_diff(finding, out)
+            if finding.excluded_by:
+                print(f"    DECLARED  excluded via `{finding.excluded_by}` "
+                      f"(eth-act/zisk-fv#329) -- reviewed, not silently "
+                      f"passing; this finding is still printed above in full "
+                      f"and no longer counts toward the failing/summary "
+                      f"totals:", file=out)
+                print(f"      {finding.excluded_reason}", file=out)
             print(file=out)
         claimed = sum(len(f.generated) for f in air.of_kind(GAP) if f.out_of_root)
         if claimed:
@@ -2247,7 +2650,15 @@ def print_report(run: Run, quiet: bool, paths: dict[str, Path],
     out_of_root = sum(a.gen_count(OUT_OF_ROOT) for a in run.airs)
     bool_typed = sum(a.gen_count(BOOL_TYPED) for a in run.airs)
     weld_covered = sum(a.gen_count(WELD_COVERED) for a in run.airs)
-    covered = matched + out_of_root + bool_typed + weld_covered
+    # A RECLASSIFICATION a reviewed `DECLARED_EXCLUSIONS` entry covers still has
+    # a real generated-constraint index (unlike STRENGTHENING/UNBACKED, which
+    # are mirror-side only), so it belongs in the covered count -- reported
+    # apart from `matched`, never folded into it silently.
+    declared_recl = sum(a.gen_count_declared(RECLASSIFICATION) for a in run.airs)
+    declared_strengthening = sum(
+        a.mir_count_declared(STRENGTHENING) for a in run.airs)
+    declared_unbacked = sum(a.mir_count_declared(UNBACKED) for a in run.airs)
+    covered = matched + out_of_root + bool_typed + weld_covered + declared_recl
     verdict = "FAILED" if run.failures else ("PARTIAL" if run.partial else "OK")
     if run.partial:
         print("PARTIAL: a --air-filtered run gated nothing about the AIRs it "
@@ -2255,11 +2666,13 @@ def print_report(run: Run, quiet: bool, paths: dict[str, Path],
     print(f"mirror-roundtrip: {verdict} {covered}/{generated} comparable generated "
           f"constraints covered across {len(run.airs)} air(s) "
           f"({matched} matched, {out_of_root} out-of-root, {bool_typed} "
-          f"bool-typed, {weld_covered} weld-covered); "
-          f"{sum(a.gen_count(GAP) for a in run.airs)} gap, "
-          f"{sum(a.mir_count(STRENGTHENING) for a in run.airs)} strengthening, "
-          f"{sum(a.mir_count(UNBACKED) for a in run.airs)} unbacked, "
-          f"{sum(len(a.of_kind(RECLASSIFICATION)) for a in run.airs)} "
+          f"bool-typed, {weld_covered} weld-covered, {declared_recl} declared); "
+          f"{sum(a.gen_count_active(GAP) for a in run.airs)} gap, "
+          f"{sum(a.mir_count_active(STRENGTHENING) for a in run.airs)} "
+          f"strengthening ({declared_strengthening} declared), "
+          f"{sum(a.mir_count_active(UNBACKED) for a in run.airs)} unbacked "
+          f"({declared_unbacked} declared), "
+          f"{sum(len(a.of_kind_active(RECLASSIFICATION)) for a in run.airs)} "
           f"reclassification, {len(run.unreachable)} unreachable mirror, "
           f"{sum(len(a.mirror.unparsed) for a in run.airs)} unparsed, "
           f"{sum(len(a.mirror.undeclared_unresolved) for a in run.airs)} "
@@ -2284,6 +2697,8 @@ def to_json(run: Run) -> dict:
     def finding(entry: Finding) -> dict:
         out = {
             "kind": entry.kind, "air": entry.air, "route": entry.route,
+            "excluded_by": entry.excluded_by,
+            "excluded_reason": entry.excluded_reason,
             "scalar_factor": entry.scalar,
             "implied_by": None if entry.implied is None else {
                 "generated_index": entry.implied.generated.index,

--- a/tools/mirror-roundtrip/check_mirrors.py
+++ b/tools/mirror-roundtrip/check_mirrors.py
@@ -1376,14 +1376,26 @@ def _unbacked_clause_is_definitional_pin(clause: Clause) -> bool:
     uncommitted atom, no higher power of it. A monomial multiplying the
     field by a committed atom, by another uncommitted field, or squaring it,
     fails this and the clause is not a pin.
+
+    One more thing the CANONICAL form makes necessary: the uncommitted atom
+    must still be present after cancellation. `delta_pc - delta_pc + addr = 0`
+    canonicalises to `addr = 0` -- a committed-lane strengthening that only
+    looked UNBACKED because the raw clause named `delta_pc`. If every
+    uncommitted atom cancels away, no monomial touches one, the per-monomial
+    loop is vacuously satisfied, and the residue is a real assertion over
+    committed lanes. So a clause is a pin only if its canonical form still
+    RETAINS an uncommitted pin term; otherwise it is not a pin and stays a
+    failure.
     """
+    saw_uncommitted = False
     for monomial, _coeff in canonical(clause.expr):
         touching = [(key, exp) for key, exp in monomial if key[0] == "unresolved"]
         if not touching:
             continue
+        saw_uncommitted = True
         if len(monomial) != 1 or touching[0][1] != 1:
             return False
-    return True
+    return saw_uncommitted
 
 
 def _declare_unbacked_uncommitted(air: str, finding: Finding, lane_map_for,

--- a/tools/mirror-roundtrip/check_mirrors.py
+++ b/tools/mirror-roundtrip/check_mirrors.py
@@ -323,14 +323,25 @@ DECLARED_EXCLUSIONS = (
         "confirmed to have no lane anywhere in this AIR's pilout -- not a "
         "witness column, not a fixed column, not an exposed value -- so it "
         "is not merely excluded from the comparable slice, it is not an atom "
-        "any generated constraint (comparable or excluded) could ever carry",
+        "any generated constraint (comparable or excluded) could ever carry "
+        "-- AND the clause is confirmed a bare DEFINITIONAL PIN of that "
+        "field: `uncommitted = g(committed)`, where the uncommitted field "
+        "appears ONLY as a constant-coefficient, degree-1 term in the "
+        "clause's canonical polynomial -- never multiplied by a committed "
+        "lane, by a second uncommitted field, or by itself. A clause "
+        "multiplying the field by a committed lane (`strengthening * "
+        "delta_pc = 0`) is a real assertion over committed lanes wherever "
+        "the field is nonzero; it is not a pin and is NOT covered by this "
+        "exclusion -- it is left a failing UNBACKED",
         "mirror_parse.EXPECTED_UNRESOLVED's addr0/addr2 (Main/Constraints."
         "lean:268/270, PIL `const expr`s inlined at every use site) and "
         "delta_pc (MemAlign/Row.lean:52-54, the `pc'-pc` slot of hint #998; "
         "its only generated appearance is inside the challenge-mixed "
         "`constraint_36`, itself already excluded by `challenge_or_stage2`) "
-        "entries, each re-verified here against `lanes.lane_map` rather than "
-        "trusted from the citation text alone",
+        "entries, each re-verified here against `lanes.lane_map` (no lane "
+        "anywhere) AND against `_unbacked_clause_is_definitional_pin` (bare "
+        "pin, no committed cofactor), rather than trusted from the citation "
+        "text alone",
     ),
 )
 
@@ -1340,6 +1351,41 @@ def _declare_reclassification_alias(finding: Finding, declare) -> None:
         return
 
 
+def _unbacked_clause_is_definitional_pin(clause: Clause) -> bool:
+    """Is every monomial touching an uncommitted atom a bare, unit-power pin?
+
+    `mirror_unbacked_field_uncommitted` may only excuse a clause shaped
+    `uncommitted = g(committed)` -- a definition, which constrains nothing
+    over committed lanes because the free uncommitted field absorbs whatever
+    `g(committed)` evaluates to on any row. That the field has no lane
+    anywhere (the caller's own check, against `lanes.lane_map`) is necessary
+    but NOT sufficient: nothing about "no lane" stops a clause from
+    multiplying an arbitrary assertion about committed lanes by that same
+    no-lane field -- `strengthening * delta_pc = 0` still names only
+    `delta_pc` as its one unresolved projection, and would pass the caller's
+    check, while actually asserting `strengthening = 0` on every row where
+    `delta_pc` is nonzero. That is a real constraint on committed lanes
+    laundered through a field-presence check that never looked at what the
+    rest of the equation asserts.
+
+    So this looks at the clause's canonical `poly.Poly` form directly: every
+    monomial containing an uncommitted atom (`atom_key[0] == "unresolved"`,
+    the vocabulary `mirror_parse._unresolved` builds for exactly these
+    fields) must consist of EXACTLY that one atom, at exponent 1, and
+    nothing else -- no committed atom in the same monomial, no second
+    uncommitted atom, no higher power of it. A monomial multiplying the
+    field by a committed atom, by another uncommitted field, or squaring it,
+    fails this and the clause is not a pin.
+    """
+    for monomial, _coeff in canonical(clause.expr):
+        touching = [(key, exp) for key, exp in monomial if key[0] == "unresolved"]
+        if not touching:
+            continue
+        if len(monomial) != 1 or touching[0][1] != 1:
+            return False
+    return True
+
+
 def _declare_unbacked_uncommitted(air: str, finding: Finding, lane_map_for,
                                   declare) -> None:
     """An `UNBACKED` clause whose field(s) the pilout commits to NO lane at all.
@@ -1353,6 +1399,17 @@ def _declare_unbacked_uncommitted(air: str, finding: Finding, lane_map_for,
     an atom any generated constraint (comparable OR excluded) could ever carry.
     That is re-verified here, mechanically, against `lanes.lane_map` rather than
     trusted from the citation text alone.
+
+    Neither of those facts is enough on its own, though: a clause can name a
+    genuinely lane-less field and still assert something real about committed
+    lanes by multiplying it in (`strengthening * delta_pc = 0`), which is
+    silenced by a field-presence check alone regardless of what
+    `strengthening` says. So this exclusion ALSO requires the clause to be a
+    bare DEFINITIONAL PIN -- `uncommitted = g(committed)`, the field appearing
+    only as a constant-coefficient, degree-1 term -- checked structurally by
+    `_unbacked_clause_is_definitional_pin` against the clause's own canonical
+    polynomial. A clause multiplying the field by a committed lane is left an
+    un-excluded, failing UNBACKED.
     """
     clause = finding.clauses[0]
     leaves: list[str] = []
@@ -1374,6 +1431,11 @@ def _declare_unbacked_uncommitted(air: str, finding: Finding, lane_map_for,
         # A lane exists somewhere after all: this clause is not in this
         # category, and is left as a plain UNBACKED failure to report.
         return
+    if not _unbacked_clause_is_definitional_pin(clause):
+        # The field is lane-less, but the clause is not a definition of it --
+        # some monomial multiplies it by a committed atom, a second
+        # uncommitted atom, or itself. Left as a failing UNBACKED.
+        return
     named = ", ".join(sorted(set(leaves)))
     declare(
         finding, "mirror_unbacked_field_uncommitted",
@@ -1386,7 +1448,15 @@ def _declare_unbacked_uncommitted(air: str, finding: Finding, lane_map_for,
         f"(delta_pc, inside `constraint_36`, excluded by `challenge_or_stage2`)"
         f" -- see `mirror_parse.EXPECTED_UNRESOLVED` for the per-field PIL "
         f"citation. No generated constraint, comparable or excluded, could "
-        f"ever carry an equation naming it.",
+        f"ever carry an equation naming it. AND the clause is confirmed a bare "
+        f"DEFINITIONAL PIN of that field (`_unbacked_clause_is_definitional_"
+        f"pin`): every monomial of its canonical polynomial touching the field "
+        f"is that field alone, at a constant coefficient and exponent 1 -- "
+        f"never multiplied by a committed lane, by a second uncommitted "
+        f"field, or by itself. A clause multiplying the field by a committed "
+        f"lane (e.g. `strengthening * {named.split(', ')[0]} = 0`) is a real "
+        f"assertion over committed lanes wherever the field is nonzero and "
+        f"is NOT excluded by this rule -- it is left a failing UNBACKED.",
         f"{clause.label} {clause.site} ({named})")
 
 

--- a/tools/mirror-roundtrip/inventory.md
+++ b/tools/mirror-roundtrip/inventory.md
@@ -742,22 +742,28 @@ checked against nothing", with a live circuit-side twin. A gate that took
 `RomBoolSpec` as evidence of Main coverage would be reading a predicate no proof
 consumes.
 
-**F7 -- `MemAlign.L1` is a fixed column modeled as a free witness field.** The
-generated `constraint_16_every_row` is `MemAlign.L1*pc`
+**F7 -- `MemAlign.L1` is a fixed column modeled as a free witness field --
+RESOLVED (eth-act/zisk-fv#332).** The generated `constraint_16_every_row` is
+`MemAlign.L1*pc`
 (`mem_align.pil:121`), rendered as
 `preprocessed c (column := 0) * main c (id := 1) (column := 4)`. The mirror
 represents `MemAlign.L1` as the row field `preL1`
-(`MemAlign/Row.lean:24`, flattened position 26) and `MemAlign.component`
-(`MemAlign/Circuit.lean:279`) declares no `fixedColumns` and no `rawWidth` at all --
-unlike `Main.componentWithRomMemAndOpBus` (`Main/Circuit.lean:952`) and
-`Mem.componentWithDualMemBus` (`Mem/Circuit.lean:253`), both of which carry an
-`IndexedFixedColumns` schema. So PIL's `MemAlign.L1`, a fixed column with a known
-`[1, 0, 0, ...]` value, becomes an unconstrained field whose only constraint is
-`preL1 * pc = 0`. The honest-row builder sets `preL1 := boolF isBoot`
-(`MemAlign/Circuit.lean:137`), which is a completeness-side choice, not a soundness
-pin. This is a candidate mirror-side weakening, and it is a finding for the owner
--- not something to correct here, since `MemAlignRow` is a protected row
-structure.
+(`MemAlign/Row.lean:24`, flattened position 26), and at the time this finding
+was recorded `MemAlign.component` (`MemAlign/Circuit.lean:279`) declared no
+`fixedColumns` and no `rawWidth` at all -- unlike `Main.componentWithRomMemAndOpBus`
+(`Main/Circuit.lean:952`) and `Mem.componentWithDualMemBus` (`Mem/Circuit.lean:253`),
+both of which carried an `IndexedFixedColumns` schema. So PIL's `MemAlign.L1`, a
+fixed column with a known `[1, 0, 0, ...]` value, was an unconstrained field
+whose only constraint was `preL1 * pc = 0`, letting a prover set it to `0` and
+evade `pc = 0` at the boot row. #332 gave `MemAlign.component` the same
+`fixedColumns` shape Main and Mem already had (`memAlignFixedColumns`,
+`MemAlign/Circuit.lean:287-308`, wired at `:390-393`); `eval_memAlignFixedColumns_L1`/
+`eval_memAlignRawRow_materialize` (`:325`/`:368`) prove every materialized row
+reads `preL1` from that schema, not an independent witness. The honest-row
+builder's `preL1 := boolF isBoot` (`MemAlign/Circuit.lean:137`) remains a
+completeness-side choice, unaffected by this fix. See
+`check_mirrors.py`'s `memalign_fixed_lane_alias` exclusion (formerly
+`memalign_l1_disclosed_gap`) for the mechanical side of the closure.
 
 **F8 -- both `Expr`-to-field maps are partial with a zeroing fallback, gated only
 for one tuple each.** `h998ExprToField` (`MemAlign/Bridge.lean:31`, 38 arms) and

--- a/tools/mirror-roundtrip/mirror_parse.py
+++ b/tools/mirror-roundtrip/mirror_parse.py
@@ -414,6 +414,11 @@ ASCRIPTION_TYPES = frozenset({"FGL", "F", "ℕ", "Nat"})
 
 ROW_RECORDS = frozenset(name for _rel, name, _air in survey.MIRROR_RECORDS)
 DELEGATED_NAMES = frozenset(name for _air, _site, name, _ix in survey.DELEGATED)
+# `name -> class` for `survey.DELEGATED_OUT_OF_SCOPE`: out-of-root delegates
+# that are declared but never parsed for comparison, because their content is
+# structurally out of the F-only scope (see that table's own docstring).
+OUT_OF_SCOPE_DELEGATED: dict[str, str] = {
+    name: cls for _air, _site, name, cls in survey.DELEGATED_OUT_OF_SCOPE}
 
 
 # ------------------------------------------------------------------- exceptions
@@ -1735,6 +1740,14 @@ def _parse_delegation(tokens: list[Token], ctx: Context, rel: str) -> Delegation
         return Delegation(name, site.rsplit(":", 1)[0], int(site.rsplit(":", 1)[1]),
                           "DELEGATED", tuple(args), deltas, True,
                           "declared out-of-root delegate (survey.DELEGATED)")
+    if short in OUT_OF_SCOPE_DELEGATED or name in OUT_OF_SCOPE_DELEGATED:
+        cls = OUT_OF_SCOPE_DELEGATED.get(short, OUT_OF_SCOPE_DELEGATED.get(name))
+        site = next(s for _air, s, n, _cls in survey.DELEGATED_OUT_OF_SCOPE
+                    if n == short)
+        return Delegation(name, site.rsplit(":", 1)[0], int(site.rsplit(":", 1)[1]),
+                          cls, tuple(args), deltas, True,
+                          "declared out-of-root, out-of-scope delegate "
+                          "(survey.DELEGATED_OUT_OF_SCOPE)")
     return Delegation(name, None, None, None, tuple(args), deltas, False,
                       "in neither survey.CLASSIFICATION nor survey.DELEGATED")
 

--- a/tools/mirror-roundtrip/survey.py
+++ b/tools/mirror-roundtrip/survey.py
@@ -78,6 +78,8 @@ CLASSES = {
     "NEAR_DATA": "prover-data or raw-cell binding, not an AIR constraint",
     "NEAR_SOUNDNESS": "a quantified `ConstraintsHold` surface, not an equation list",
     "NEAR_LITERAL": "a disjunction of literal values",
+    "NEAR_CHALLENGE": "restates only challenge/stage-2 constraints, the same "
+        "machinery `challenge_or_stage2` excludes on the generated side",
 }
 
 MIRROR_CLASSES = frozenset(k for k in CLASSES if k.startswith("MIRROR") or k == "MIXED_COMPOSITE")
@@ -251,8 +253,10 @@ CLASSIFICATION: dict[tuple[str, str], Entry] = {
         _e("MIRROR_VALIDATOR", "Mem", "the same 9, over `Valid_Mem`", claims="3-8,18,21,23"),
     ("ZiskFv/AirsClean/Mem/GeneratedTransition.lean", "generatedTransition"):
         _e("MIRROR_COMPOSITE", "Mem",
-           "delegates to ZiskFv/Airs/Mem.segmentResidualEveryRow and permutation_every_row, "
-           "which are OUTSIDE the mirror root"),
+           "delegates to ZiskFv/Airs/Mem.segmentResidualEveryRow (DELEGATED, "
+           "compared) and permutation_every_row (DELEGATED_OUT_OF_SCOPE, "
+           "NEAR_CHALLENGE -- challenge/stage-2 only), both OUTSIDE the mirror "
+           "root"),
     ("ZiskFv/AirsClean/Mem/GeneratedTransition.lean", "memRangeSidecarBridge"):
         _e("NEAR_DATA", "Mem"),
     ("ZiskFv/AirsClean/Mem/Constraints.lean", "dualMemRowRangeFacts"): _e("NEAR_RANGE", "Mem"),
@@ -369,6 +373,22 @@ CLASSIFICATION: dict[tuple[str, str], Entry] = {
 DELEGATED: list[tuple[str, str, str, frozenset[int]]] = [
     ("Mem", "ZiskFv/Airs/Mem.lean:296", "segmentResidualEveryRow",
      _ix("0-2,9-17,19,20,22")),
+]
+
+# Out-of-root delegates that are declared but deliberately NOT parsed or paired:
+# every one of their clauses reaches only the challenge/stage-2 machinery
+# `check_mirrors.load_generated` already excludes on the generated side
+# (`challenge_or_stage2`), so there is no comparable polynomial identity to
+# carry either direction. Recorded here (rather than left undeclared) so the
+# delegation is named and the near-miss screen can confirm the claim; recorded
+# apart from `DELEGATED` (rather than folded in) because those entries ARE
+# parsed and canonically paired, and this content structurally cannot be --
+# `permutation_every_row`'s carriers (`PermutationColumns`) are the prover's
+# random-linear-combination accumulators, not row-record projections.
+#
+# `(air, site, name, class)`, the class drawn from `CLASSES`' NEAR_* vocabulary.
+DELEGATED_OUT_OF_SCOPE: list[tuple[str, str, str, str]] = [
+    ("Mem", "ZiskFv/Airs/Mem.lean:1459", "permutation_every_row", "NEAR_CHALLENGE"),
 ]
 
 # Row records used by a mirror, in the order a reader should see them, together


### PR DESCRIPTION
Closes #329 and #332. Takes the #304 mirror gate from `174/176, 8 failing` to **`176/176, 0 failing`** — the gate now passes. One of the eight was a real fidelity gap and got a **real fix**, not a declaration.

## The 8 residuals, disposed honestly

| finding | disposition |
|---|---|
| **MemAlign #16** reclassification (`L1` fixed col modeled as witness `preL1`) | **FIXED** — real fidelity/soundness fix, #332 (below) |
| Mem undeclared delegation (`generatedTransition → permutation_every_row`) | **FIXED** — classified as challenge/stage-2 (std_sum/logUp accumulator); the category already excluded elsewhere |
| 2 strengthening (Main `sourceCCopyBetween` within-segment) | declared — cofactor-verified `(1−SEGMENT_L1)` weakening of the welded #4/#10; boundary is cross-segment (#328); soundness-safe direction |
| 3 unbacked (`delta_pc`, Main `addr0`/`addr2`) | declared — mechanically re-verified the fields are PIL `const expr`s / hint payloads, never committed as columns anywhere |
| Main #18 reclassification (`SEGMENT_L1` alias) | declared benign — Main has a real `fixedColumns` schema every row reads `segment_l1` from |

## The real fix — MemAlign L1 (#332)

`constraint_16` (`mem_align.pil:121`, `L1 * pc`) reads the **fixed** column `L1`, but MemAlign declared no `fixedColumns` and modeled `L1` as the witness `preL1` — a prover could set `preL1=0` at the boot row and **evade `pc=0`**. Mirroring Main's `mainFixedColumns` pattern: added `memAlignFixedColumns` (`L1 = [1,0,…]`), `memAlignFixedLayout` mapping effective slot 26 (`preL1`) to the fixed column, and `eval_memAlignFixedColumns_L1` proving every materialized row reads `preL1` from it. The component now declares `fixedColumns := some memAlignFixedColumns` (`rawWidth 31 → 30`), so the **AcceptedTrace enforces boot `pc=0` through a fixed column no prover controls** — the gap is genuinely closed, not disclosed-and-declared. The weld reads the fixed lane; MemAlign #16 is now a real fixed-lane match. (One ripple: `DivInputs.lean`'s rawWidth case `31 → 30`.)

## Anti-laundering (after the Track B review)

Every declared exclusion is **category-level with a cited source, re-verified live every run** (cofactor search / `lanes.lane_map` / textual pin — never a hardcoded name or per-index allowlist), and each is backed by a `acceptance.py` **withdrawal mutation** proving the finding re-surfaces if its basis is mutated away. `acceptance.py` is 23/23.

## Verification

- Full `lake build` green (**9146 jobs**), **0 new axioms** (shrinkage floor), no `sorry`/`native_decide`.
- `check_mirrors.py --quiet` → `176/176, 0 failing`, exit 0.
- `acceptance.py` → exit 0 (23 cases + lanes-vs-#310 cross-check).
- `check-weld-column-maps.py` → PASS (12 AIRs).
- `nix/test.nix` step 4/10 comment + README updated (the gate passes now).
- Not run: full `nix run .#test` end-to-end.

## Scope note

The MemAlign fix genuinely reduces a fidelity/soundness gap in that AIR. The declared exclusions are genuinely out-of-scope categories (cross-segment #328, or fields the pilout never commits), each tracked/cited — not silenced. `ZiskFv/` changes limited to MemAlign Circuit + the weld + a one-line Div rawWidth ripple.

🤖 Generated with [Claude Code](https://claude.com/claude-code)