### PR TITLE
#320: witness the raw-program root_soundness premises (non-vacuity)

### DIFF
--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -188,6 +188,7 @@ import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingMext
 import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingControl
 import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingNonvacuity
 import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingMemoryNonvacuity
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingJalrExpansionNonvacuity
 import ZiskFv.Compliance
 import ZiskFv.Compliance.EnsembleWitnessBuilder
 import ZiskFv.Compliance.RegisterMemBusBalance

--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -200,6 +200,10 @@ import ZiskFv.Compliance.AddAddiSpinRootSoundness
 import ZiskFv.Compliance.SdLdSpinRootSoundness
 import ZiskFv.Compliance.JalrSpinRootSoundness
 import ZiskFv.Compliance.DivSpinRootSoundness
+import ZiskFv.Compliance.MemoryRawRootSoundness
+import ZiskFv.Compliance.AddFaithfulPaddedWitness
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingAddFaithfulNonvacuity
+import ZiskFv.Compliance.AddFaithfulPaddedRootSoundness
 import ZiskFv.Compliance.RangeWiringWitness
 -- In-build per-opcode static decode/row-mode pin discharge from the real
 -- Aeneas-extracted ZisK lowerer (eth-act/zisk-fv#111). Standalone; not yet

--- a/ZiskFv/Compliance/AddFaithfulPaddedRootSoundness.lean
+++ b/ZiskFv/Compliance/AddFaithfulPaddedRootSoundness.lean
@@ -1,0 +1,263 @@
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingAddFaithfulNonvacuity
+import ZiskFv.Soundness
+
+/-!
+# Non-vacuous raw-program `root_soundness` instantiation (#320)
+
+This applies the public `ZiskFv.Compliance.root_soundness` theorem — the raw-program-decode
+entrypoint, NOT `stepSound_of_programDecodes` — to `addFaithfulAcceptedTrace`
+(`AddFaithfulPaddedWitness.lean`) via the genuine raw-program binding
+(`RawProgramBindingAddFaithfulNonvacuity.lean`). The executed step (`numInstructions = 1`) is real
+(`i = 0`, not `Fin 0`), so the conclusion is non-vacuous: this is the first in-tree instantiation of
+`root_soundness` that actually lifts through `programDecode_of_rawProgramDecode` for a real
+executed step.
+-/
+
+set_option maxRecDepth 10000
+
+open Goldilocks
+open Air.Flat
+open ZiskFv.Compliance
+open ZiskFv.Compliance.AddFaithfulPaddedWitness
+open ZiskFv.Compliance.AddSpinWitness
+open ZiskFv.Compliance.Instantiation
+open ZiskFv.Compliance.RegisterMemBusBalance
+open ZiskFv.Compliance.RomDecodeBinding
+open ZiskFv.ZiskCircuit.MemTrace
+open ZiskFv.Trusted
+
+namespace ZiskFv.Compliance.AddFaithfulPaddedRootSoundness
+
+def x1 : regidx := regidx.Regidx (1#5)
+
+def addFaithfulAddIndex : Fin 1 := ⟨0, by decide⟩
+
+def addFaithfulAddClaim : Claim_add addFaithfulAcceptedTrace addFaithfulAddIndex where
+  r1 := x1
+  r2 := x1
+  rd := x1
+
+def addFaithfulZiskStep : ∀ i : Fin 1, ZiskStep addFaithfulAcceptedTrace i
+  | ⟨0, _⟩ => .add addFaithfulAddClaim
+
+def addFaithfulMisa : RegisterType Register.misa := 0#64
+
+def addFaithfulRegs (pc : BitVec 64) : Std.ExtDHashMap Register RegisterType :=
+  let regs0 := (default : PreSail.SequentialState RegisterType Sail.trivialChoiceSource).regs
+  let regs1 := regs0.insert Register.PC pc
+  let regs2 := regs1.insert Register.misa addFaithfulMisa
+  regs2.insert (reg_of_fin (regidx_to_fin x1)) (0#64)
+
+def addFaithfulState (pc : BitVec 64) :
+    PreSail.SequentialState RegisterType Sail.trivialChoiceSource :=
+  { (default : PreSail.SequentialState RegisterType Sail.trivialChoiceSource) with
+    regs := addFaithfulRegs pc
+    mem := {} }
+
+def addFaithfulSailTrace : SailTrace 1
+  | ⟨0, _⟩ => addFaithfulState (0#64)
+
+theorem addFaithfulRowsOf_empty_readSound :
+    MemoryBusRowsPrefixReadSound
+      ({} : Std.ExtHashMap Nat (BitVec 8))
+      ((List.range addFaithfulAcceptedTrace.numInstructions).flatMap (fun _ => [])) := by
+  change MemoryBusRowsPrefixReadSound ({} : Std.ExtHashMap Nat (BitVec 8)) []
+  intro priorRows entry laterRows h_split h_selected
+  simp at h_split
+
+def addFaithfulBootSeed :
+    BootSegmentMemorySeed addFaithfulAcceptedTrace addFaithfulSailTrace addFaithfulZiskStep where
+  memInit := {}
+  rowsOf := fun _ => []
+  boot := by
+    intro h
+    rfl
+  step := by
+    intro j h
+    change j + 1 < 1 at h
+    omega
+  readSoundInputs := fun h => absurd h addFaithfulWitness_not_mutableMemPresent
+  memPresent_of_executionRows_nonempty := by
+    intro h_nonempty
+    exact absurd (by simp [AcceptedZiskTrace.numInstructions]) h_nonempty
+  placement := by
+    intro i
+    fin_cases i
+    simp [MemoryOpPlacement, addFaithfulZiskStep]
+
+private theorem addFaithfulAcceptedTrace_program :
+    addFaithfulAcceptedTrace.program = addFaithfulProgram := rfl
+
+private theorem addFaithfulMainRowAt_zero :
+    ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero addFaithfulProgram
+      addFaithfulMainTable 0 = addX1Row := by
+  unfold ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
+  rw [dif_pos (by norm_num [addFaithfulMainTable, mainRowsTable, addFaithfulMainRows])]
+  simpa [Table.environmentAt] using addFaithfulMainTable_evalAt_zero
+
+private theorem addFaithfulMainPc_add :
+    (ZiskFv.AirsClean.FullEnsemble.mainOfTable addFaithfulAcceptedTrace.program
+        addFaithfulAcceptedTrace.mainTable).pc addFaithfulAddIndex.val = 0 := by
+  rw [addFaithfulAcceptedTrace_mainTable_eq]
+  change (ZiskFv.AirsClean.FullEnsemble.mainOfTable addFaithfulProgram
+      addFaithfulMainTable).pc 0 = 0
+  simp [addFaithfulMainRowAt_zero, addX1Row]
+
+private theorem addFaithfulReadX1_add :
+    read_xreg (regidx_to_fin x1) (addFaithfulSailTrace addFaithfulAddIndex) =
+      EStateM.Result.ok (0#64) (addFaithfulSailTrace addFaithfulAddIndex) := by
+  simp [addFaithfulSailTrace, addFaithfulAddIndex, addFaithfulState, addFaithfulRegs, x1,
+    regidx_to_fin, read_xreg, reg_of_fin]
+
+def addFaithfulAddInput : PureSpec.AddInput where
+  r1_val := 0#64
+  r2_val := 0#64
+  rd := regidx_to_fin x1
+  PC := 0#64
+
+private theorem addFaithfulAddLaneLo
+    (field : ZiskFv.Airs.Main.Valid_Main FGL FGL → Nat → FGL)
+    (h_field :
+      (field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addFaithfulProgram
+          addFaithfulMainTable) 0) = 0) :
+    field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addFaithfulAcceptedTrace.program
+        addFaithfulAcceptedTrace.mainTable) addFaithfulAddIndex.val =
+      lane_lo ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64
+        (addFaithfulSailTrace addFaithfulAddIndex)).xreg (regidx_to_fin x1)) := by
+  rw [ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64_xreg_eq_of_read_xreg
+    (addFaithfulSailTrace addFaithfulAddIndex) (regidx_to_fin x1) (0#64) addFaithfulReadX1_add]
+  rw [addFaithfulAcceptedTrace_mainTable_eq]
+  change field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addFaithfulProgram
+      addFaithfulMainTable) 0 = _
+  rw [h_field]
+  simp [lane_lo]
+
+private theorem addFaithfulAddLaneHi
+    (field : ZiskFv.Airs.Main.Valid_Main FGL FGL → Nat → FGL)
+    (h_field :
+      (field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addFaithfulProgram
+          addFaithfulMainTable) 0) = 0) :
+    field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addFaithfulAcceptedTrace.program
+        addFaithfulAcceptedTrace.mainTable) addFaithfulAddIndex.val =
+      lane_hi ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64
+        (addFaithfulSailTrace addFaithfulAddIndex)).xreg (regidx_to_fin x1)) := by
+  rw [ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64_xreg_eq_of_read_xreg
+    (addFaithfulSailTrace addFaithfulAddIndex) (regidx_to_fin x1) (0#64) addFaithfulReadX1_add]
+  rw [addFaithfulAcceptedTrace_mainTable_eq]
+  change field (ZiskFv.AirsClean.FullEnsemble.mainOfTable addFaithfulProgram
+      addFaithfulMainTable) 0 = _
+  rw [h_field]
+  simp [lane_hi]
+
+def addFaithfulAddInputs :
+    Inputs_add addFaithfulAcceptedTrace addFaithfulSailTrace addFaithfulAddIndex
+      addFaithfulAddClaim where
+  add_input := addFaithfulAddInput
+  h_input_r1 := by
+    simpa [addFaithfulAddInput, addFaithfulAddClaim] using addFaithfulReadX1_add
+  h_input_r2 := by
+    simpa [addFaithfulAddInput, addFaithfulAddClaim] using addFaithfulReadX1_add
+  h_input_pc := by
+    simp [addFaithfulAddInput, addFaithfulSailTrace, addFaithfulAddIndex, addFaithfulState,
+      addFaithfulRegs, x1, regidx_to_fin, reg_of_fin, Std.ExtDHashMap.get?_insert]
+  h_input_rd := by
+    rfl
+  h_a_lo_t := by
+    change (ZiskFv.AirsClean.FullEnsemble.mainOfTable addFaithfulAcceptedTrace.program
+          addFaithfulAcceptedTrace.mainTable).a_0 addFaithfulAddIndex.val =
+        lane_lo ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64
+          (addFaithfulSailTrace addFaithfulAddIndex)).xreg (regidx_to_fin x1))
+    exact addFaithfulAddLaneLo (fun m i => m.a_0 i)
+      (by simp [addFaithfulMainRowAt_zero, addX1Row])
+  h_a_hi_t := by
+    change (ZiskFv.AirsClean.FullEnsemble.mainOfTable addFaithfulAcceptedTrace.program
+          addFaithfulAcceptedTrace.mainTable).a_1 addFaithfulAddIndex.val =
+        lane_hi ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64
+          (addFaithfulSailTrace addFaithfulAddIndex)).xreg (regidx_to_fin x1))
+    exact addFaithfulAddLaneHi (fun m i => m.a_1 i)
+      (by simp [addFaithfulMainRowAt_zero, addX1Row])
+  h_b_lo_t := by
+    change (ZiskFv.AirsClean.FullEnsemble.mainOfTable addFaithfulAcceptedTrace.program
+          addFaithfulAcceptedTrace.mainTable).b_0 addFaithfulAddIndex.val =
+        lane_lo ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64
+          (addFaithfulSailTrace addFaithfulAddIndex)).xreg (regidx_to_fin x1))
+    exact addFaithfulAddLaneLo (fun m i => m.b_0 i)
+      (by simp [addFaithfulMainRowAt_zero, addX1Row])
+  h_b_hi_t := by
+    change (ZiskFv.AirsClean.FullEnsemble.mainOfTable addFaithfulAcceptedTrace.program
+          addFaithfulAcceptedTrace.mainTable).b_1 addFaithfulAddIndex.val =
+        lane_hi ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64
+          (addFaithfulSailTrace addFaithfulAddIndex)).xreg (regidx_to_fin x1))
+    exact addFaithfulAddLaneHi (fun m i => m.b_1 i)
+      (by simp [addFaithfulMainRowAt_zero, addX1Row])
+  h_pc_bridge := by
+    rw [addFaithfulAcceptedTrace_mainTable_eq]
+    change ((ZiskFv.AirsClean.FullEnsemble.mainOfTable addFaithfulProgram
+          addFaithfulMainTable).pc 0).val = _
+    simp [addFaithfulMainRowAt_zero, addX1Row, addFaithfulAddInput]
+
+def addFaithfulInputsAgree :
+    ∀ i : Fin 1, InputsAgree addFaithfulAcceptedTrace addFaithfulSailTrace i (addFaithfulZiskStep i)
+  | ⟨0, _⟩ => addFaithfulAddInputs
+
+def addFaithfulAddOutsideDefectRegion :
+    RowOutsideDefectRegion addFaithfulAcceptedTrace addFaithfulAddIndex
+      (addFaithfulZiskStep addFaithfulAddIndex) := by
+  unfold RowOutsideDefectRegion addFaithfulZiskStep MainSequentialPcDomain mainPcVal
+  rw [addFaithfulMainPc_add]
+  change 0 < GL_prime - 4
+  norm_num
+
+def addFaithfulOutsideDefectRegion :
+    ∀ i : Fin 1, RowOutsideDefectRegion addFaithfulAcceptedTrace i (addFaithfulZiskStep i)
+  | ⟨0, _⟩ => addFaithfulAddOutsideDefectRegion
+
+/-! ## The raw-program decode evidence for the one executed step -/
+
+open ZiskFv.Compliance.RawProgramBinding in
+theorem addFaithfulRawDecode :
+    RawProgramDecode_add addFaithfulAcceptedTrace addFaithfulAddIndex addFaithfulAddClaim
+      addFaithfulAddr addFaithfulRawProgram where
+  h_idx := by
+    rw [addFaithfulAcceptedTrace_mainTable_eq]
+    change 0 + 1 < addFaithfulMainTable.table.length
+    norm_num [addFaithfulMainTable, mainRowsTable, addFaithfulMainRows]
+  hrd0 := by simp [addFaithfulAddClaim, x1, regidx_to_fin]
+  hrs10 := by simp [addFaithfulAddClaim, x1, regidx_to_fin]
+  hrs20 := by simp [addFaithfulAddClaim, x1, regidx_to_fin]
+  hLine := by
+    intro j hline
+    change Fin 2 at j
+    fin_cases j
+    · refine ⟨⟨0, by decide⟩, rfl, ?_⟩
+      simp only [addFaithfulRawProgram, addFaithfulAddClaim, x1, regidx_to_fin]
+      decide
+    · rw [addFaithfulMainPc_add] at hline
+      rw [addFaithfulAcceptedTrace_program] at hline
+      simp only [addFaithfulAcceptedTrace, addFaithfulProgram, addFaithfulRow1ProgramRow,
+        RegisterMemBusBalance.addX1ProgramRow] at hline
+      exact absurd hline (by decide)
+
+open ZiskFv.Compliance.RawProgramBinding in
+def addFaithfulRawProgramDecodes :
+    ∀ i : Fin 1,
+      RawProgramDecode addFaithfulAcceptedTrace i (addFaithfulZiskStep i)
+        addFaithfulStart addFaithfulAddr addFaithfulRawProgram
+  | ⟨0, _⟩ => ⟨⟨addFaithfulRawDecode⟩⟩
+
+open ZiskFv.Compliance.RawProgramBinding in
+theorem addFaithfulPaddedRawRootSoundness :
+    ∀ i : Fin 1,
+      StepSound addFaithfulAcceptedTrace addFaithfulSailTrace i (addFaithfulZiskStep i)
+        (rowDecode_of_programDecode addFaithfulAcceptedTrace i
+          (programDecode_of_rawProgramDecode addFaithfulAcceptedTrace i (addFaithfulZiskStep i)
+            addFaithfulStart addFaithfulAddr addFaithfulRawProgram
+            addFaithfulProgramRowsBinding (addFaithfulRawProgramDecodes i))) :=
+  root_soundness 1 2 addFaithfulAcceptedTrace addFaithfulSailTrace addFaithfulZiskStep
+    addFaithfulStart addFaithfulAddr addFaithfulRawProgram addFaithfulProgramRowsBinding
+    addFaithfulRawProgramDecodes addFaithfulInputsAgree addFaithfulBootSeed
+    addFaithfulOutsideDefectRegion
+
+#print axioms addFaithfulPaddedRawRootSoundness
+
+end ZiskFv.Compliance.AddFaithfulPaddedRootSoundness

--- a/ZiskFv/Compliance/AddFaithfulPaddedWitness.lean
+++ b/ZiskFv/Compliance/AddFaithfulPaddedWitness.lean
@@ -1,0 +1,1105 @@
+import ZiskFv.Compliance.AddSpinWitness
+
+/-!
+# Faithful two-row ADD accepted trace (#320)
+
+This trace commits TWO physical Main rows, both the SAME faithful production lowering of
+`ADD x1,x1,x1` (`0x001080b3`): row 0 at line 0 (the one executed step) and row 1 at line 4
+(physically present in the Main table, not counted in `numInstructions`, but a fully valid,
+constraint-satisfying witness row in its own right, chained off row 0's final register state).
+
+Unlike `AddSpinWitness`'s self-looping-JAL padding row (whose hand-crafted fields are not the
+real production lowering of any raw JAL word), row 1 here is honestly `= romMessageOfRaw 4
+0x001080b3` — see `ZiskFv.Compliance.RawProgramBinding.addFaithfulProgramRowsBinding`. This gives
+`RawProgramDecode_add.h_idx : 0 + 1 < 2` for free and makes `ProgramRowsBinding` provable for BOTH
+committed rows via the same production-lowering fact, closing the non-vacuity gap for
+`ZiskFv.Compliance.root_soundness` (eth-act/zisk-fv#320).
+-/
+
+set_option maxRecDepth 10000
+
+open Goldilocks
+open Air.Flat
+open ZiskFv.AirsClean.FullEnsemble (fullRv64imEnsemble fullRv64imSoundEnsemble)
+open ZiskFv.AirsClean.Main
+open ZiskFv.AirsClean.ZiskInstructionRom (Program)
+open ZiskFv.Channels.MemoryBus (MemBusChannel MemBusMessage)
+open ZiskFv.Channels.MemAlignRom (MemAlignRomChannel)
+open ZiskFv.Channels.MemAlignRanges (MemAlignRangeChannel)
+open ZiskFv.Channels.OperationBus (OpBusChannel)
+open ZiskFv.Channels.SpecifiedRanges (SpecifiedRangesSliceChannel)
+open ZiskFv.Channels.ZiskRomBus (ZiskRomMessage)
+open ZiskFv.Compliance.AddSpinWitness
+open ZiskFv.Compliance.Instantiation
+open ZiskFv.Compliance.RegisterMemBusBalance
+open ZiskFv.Compliance.SingleAddWitness
+
+namespace ZiskFv.Compliance.AddFaithfulPaddedWitness
+
+/-! ## The two committed program rows and physical Main rows -/
+
+/-- Row 1's committed ROM entry: the identical faithful ADD lowering as row 0, at line 4.
+    `romMessageOfRaw`'s only dependence on its `line` argument is the `.line` field itself, so this
+    is proven `= romMessageOfRaw 4 0x001080b3` in `RawProgramBindingAddFaithfulNonvacuity.lean`. -/
+def addFaithfulRow1ProgramRow : ZiskRomMessage FGL :=
+  { RegisterMemBusBalance.addX1ProgramRow with line := 4 }
+
+def addFaithfulProgram : Program 2
+  | ⟨0, _⟩ => RegisterMemBusBalance.addX1ProgramRow
+  | ⟨1, _⟩ => addFaithfulRow1ProgramRow
+
+/-- Row 1's free columns before register-history materialization: the same operand/control
+    content as row 0 (register values are unchanged, since `ADD x1,x1,x1` with `x1 = 0` is a
+    fixed point), only `segment_l1`/`main_step` differ. -/
+@[reducible]
+def addFaithfulRow1FreeColsTemplate : MainRomFreeCols :=
+  { addX1MainFreeCols with segment_l1 := 0, main_step := 1 }
+
+@[reducible]
+def addFaithfulRow1Template : MainRowWithRom FGL :=
+  mainRomRowOf addFaithfulRow1ProgramRow addX1RomFlagBits
+    (MainRomExecKind.external false 0 0) addFaithfulRow1FreeColsTemplate
+
+/-- Row 1 reads both operands from x1, chained off row 0's final register state
+    (`addX1RowWithLast.1`). -/
+@[reducible]
+def addFaithfulRow1WithLast : MemBusMessage FGL × MainRowWithRom FGL :=
+  materializeMainRegisterRow addX1RowWithLast.1 addFaithfulRow1Template
+    [MainRegisterAccess.a, MainRegisterAccess.b, MainRegisterAccess.store]
+
+def addFaithfulRow1 : MainRowWithRom FGL := addFaithfulRow1WithLast.2
+
+@[reducible]
+def addFaithfulRow1FreeCols : MainRomFreeCols := mainRomFreeColsOfRow addFaithfulRow1
+
+def addFaithfulMainRows : List (MainRowWithRom FGL) := [addX1Row, addFaithfulRow1]
+
+theorem addFaithfulMainRows_fixed_domain :
+    addFaithfulMainRows.length <= mainFixedCapacity := by
+  norm_num [addFaithfulMainRows, mainFixedCapacity]
+
+def addFaithfulMainTable : Table FGL :=
+  mainRowsTable 2 addFaithfulProgram addFaithfulMainRows addFaithfulMainRows_fixed_domain
+
+private theorem addFaithfulMainTable_effectiveRows :
+    addFaithfulMainTable.table =
+      [ mainFixedColumns.materialize 0 (mainRawRow addX1Row)
+      , mainFixedColumns.materialize 1 (mainRawRow addFaithfulRow1) ] := by
+  simp [addFaithfulMainTable, mainRowsTable, Table.table, componentWithRomMemAndOpBus,
+    addFaithfulMainRows]
+
+@[simp] private theorem addFaithfulMainTable_length : addFaithfulMainTable.length = 2 := rfl
+
+@[simp] private theorem addFaithfulMainTable_table_length :
+    addFaithfulMainTable.table.length = 2 := by
+  rw [Table.table_length]
+  exact addFaithfulMainTable_length
+
+/-! ## The BinaryAdd and RegisterBoundary rows -/
+
+def addFaithfulBinaryAddRows : List (ZiskFv.AirsClean.BinaryAdd.BinaryAddRow FGL) :=
+  [addX1BinaryAddRow, addX1BinaryAddRow]
+
+def addFaithfulBinaryAddTable : Table FGL :=
+  binaryAddRowsTable addFaithfulBinaryAddRows
+
+theorem addFaithfulBinaryAddTable_constraints : addFaithfulBinaryAddTable.Constraints := by
+  apply binaryAddRowsTable_constraints_of_proverAssumptions
+  intro row h_row
+  simp [addFaithfulBinaryAddRows] at h_row
+  rcases h_row with rfl | rfl <;> exact ⟨0, 0, by decide, by decide, rfl⟩
+
+/-- Row 1 is the last real access to x1: the boundary reload comes from row 1's final message. -/
+def addFaithfulBoundaryRowX1 : ZiskFv.AirsClean.RegisterBoundary.RegisterBoundaryRow FGL :=
+  registerBoundaryRowFromLast 1 addFaithfulRow1WithLast.1
+
+theorem addFaithfulReloadMessage_eq :
+    ZiskFv.AirsClean.RegisterBoundary.reloadMessage addFaithfulBoundaryRowX1 =
+      cMemMessage addFaithfulRow1 := rfl
+
+def addFaithfulBoundaryRows :
+    List (ZiskFv.AirsClean.RegisterBoundary.RegisterBoundaryRow FGL) :=
+  addFaithfulBoundaryRowX1 :: (List.range 30).map (fun i => boundaryRowIdle ((i + 2 : Nat) : FGL))
+
+def addFaithfulBoundaryTable : Table FGL :=
+  registerBoundaryRowsTableOf addFaithfulBoundaryRows
+
+theorem addFaithfulBoundaryTable_constraints : addFaithfulBoundaryTable.Constraints :=
+  registerBoundaryRowsTableOf_constraints addFaithfulBoundaryRows
+
+/-! ## Main's per-row prover assumptions -/
+
+theorem addFaithfulMain_proverAssumptions_zero :
+    (componentWithRomMemAndOpBus 2 addFaithfulProgram).circuit.ProverAssumptions
+      addX1Row emptyData (ProverHint.empty FGL) := by
+  refine ⟨⟨0, by decide⟩, addX1RomFlagBits, MainRomExecKind.external false 0 0,
+    addX1MainFreeCols, ?_, ?_, ?_, ?_, ?_⟩
+  · decide
+  · simp [MainRomExecKind.Coherent, addX1RomFlagBits]
+  · simp [MainRomSourceGuard, addFaithfulProgram, addX1RomFlagBits]
+  · simp [MainRomAddressGuard, addX1RomFlagBits]
+  · rfl
+
+theorem addFaithfulMain_proverAssumptions_one :
+    (componentWithRomMemAndOpBus 2 addFaithfulProgram).circuit.ProverAssumptions
+      addFaithfulRow1 emptyData (ProverHint.empty FGL) := by
+  refine ⟨⟨1, by decide⟩, addX1RomFlagBits, MainRomExecKind.external false 0 0,
+    addFaithfulRow1FreeCols, ?_, ?_, ?_, ?_, ?_⟩
+  · decide
+  · simp [MainRomExecKind.Coherent, addX1RomFlagBits]
+  · simp [MainRomSourceGuard, addFaithfulProgram, addFaithfulRow1ProgramRow, addX1RomFlagBits]
+  · simp [MainRomAddressGuard, addX1RomFlagBits]
+  · rfl
+
+/-! ## Main's constraint-holding proof (per-row, mirroring `addSpinMain_constraintsHold_materialize`) -/
+
+private def addFaithfulProverEnvFromEnvironment (env : Environment FGL) : ProverEnvironment FGL where
+  get := env.get
+  data := env.data
+  hint := ProverHint.empty FGL
+
+private theorem addFaithfulFlatForAllWitness_of_localLength_zero
+    {env : ProverEnvironment FGL} {offset : ℕ} {ops : List (FlatOperation FGL)}
+    (h_len : FlatOperation.localLength ops = 0) :
+    FlatOperation.forAll offset
+      { witness := fun offset _ compute => env.ExtendsVector (compute env) offset }
+      ops := by
+  induction ops generalizing offset with
+  | nil => trivial
+  | cons op ops ih =>
+      cases op with
+      | witness m compute =>
+          simp [FlatOperation.localLength] at h_len
+          have h_m : m = 0 := by omega
+          have h_ops : FlatOperation.localLength ops = 0 := by omega
+          subst m
+          constructor
+          · intro i
+            exact Fin.elim0 i
+          · simpa [Nat.zero_add] using ih (offset := offset) h_ops
+      | assert e =>
+          simp [FlatOperation.localLength] at h_len
+          simpa [FlatOperation.forAll] using ih (offset := offset) h_len
+      | lookup l =>
+          simp [FlatOperation.localLength] at h_len
+          simpa [FlatOperation.forAll] using ih (offset := offset) h_len
+      | interact i =>
+          simp [FlatOperation.localLength] at h_len
+          simpa [FlatOperation.forAll] using ih (offset := offset) h_len
+
+private theorem addFaithfulUsesLocalWitnesses_of_localLength_zero
+    {env : ProverEnvironment FGL} {offset : ℕ} {ops : Operations FGL}
+    (h_len : ops.localLength = 0) :
+    env.UsesLocalWitnesses offset ops := by
+  rw [ProverEnvironment.UsesLocalWitnesses, Operations.forAllFlat]
+  induction ops using Operations.induct generalizing offset with
+  | empty => trivial
+  | witness m compute ops ih =>
+      simp [Operations.localLength] at h_len
+      have h_m : m = 0 := by omega
+      have h_ops : ops.localLength = 0 := by omega
+      subst m
+      constructor
+      · intro i
+        exact Fin.elim0 i
+      · simpa [Nat.zero_add] using ih (offset := offset) h_ops
+  | assert e ops ih =>
+      simp [Operations.localLength] at h_len
+      simpa [Operations.forAll] using ih (offset := offset) h_len
+  | lookup l ops ih =>
+      simp [Operations.localLength] at h_len
+      simpa [Operations.forAll] using ih (offset := offset) h_len
+  | interact i ops ih =>
+      simp [Operations.localLength] at h_len
+      simpa [Operations.forAll] using ih (offset := offset) h_len
+  | subcircuit s ops ih =>
+      simp [Operations.localLength] at h_len
+      have h_s : s.localLength = 0 := by omega
+      have h_ops : ops.localLength = 0 := by omega
+      constructor
+      · apply addFaithfulFlatForAllWitness_of_localLength_zero
+        rw [← s.localLength_eq]
+        exact h_s
+      · exact ih (offset := s.localLength + offset) h_ops
+
+private theorem addFaithfulMain_constraintsHold_materialize
+    (index : Nat) (row : MainRowWithRom FGL)
+    (h_segment_l1 : row.core.segment_l1 = mainFixedColumns.fixedAt 0 index)
+    (h_main_step : row.rom.main_step = mainFixedColumns.fixedAt 1 index)
+    (h_assumptions :
+      (componentWithRomMemAndOpBus 2 addFaithfulProgram).circuit.ProverAssumptions
+        row emptyData (ProverHint.empty FGL)) :
+    (componentWithRomMemAndOpBus 2 addFaithfulProgram).operations.ConstraintsHold
+      (Environment.fromArray (mainFixedColumns.materialize index (mainRawRow row)) emptyData) := by
+  let env := Environment.fromArray (mainFixedColumns.materialize index (mainRawRow row)) emptyData
+  let proverEnv := addFaithfulProverEnvFromEnvironment env
+  have h_localLength :
+      (componentWithRomMemAndOpBus 2 addFaithfulProgram).circuit.localLength
+        (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowInputVar = 0 := by
+    change (mainWithRomMemAndOpBusElaborated 2 addFaithfulProgram).localLength
+        (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowInputVar = 0
+    rfl
+  have h_env : proverEnv.UsesLocalWitnesses
+      (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowOffset
+      (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowOperations := by
+    apply addFaithfulUsesLocalWitnesses_of_localLength_zero
+    change ((componentWithRomMemAndOpBus 2 addFaithfulProgram).circuit.main
+      (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowInputVar).localLength
+        (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowOffset = 0
+    rw [(componentWithRomMemAndOpBus 2 addFaithfulProgram).circuit.localLength_eq]
+    exact h_localLength
+  have h_input_verifier : Eval.eval env
+      (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowInputVar = row := by
+    dsimp [env]
+    exact eval_mainRawRow_materialize index emptyData row h_segment_l1 h_main_step
+  have h_input : Eval.eval proverEnv
+      (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowInputVar = row := by
+    rw [ProvableType.eval_varFromOffset_prover]
+    rw [← h_input_verifier]
+    rw [ProvableType.eval_varFromOffset]
+    congr
+  have h_assumptions' :
+      (componentWithRomMemAndOpBus 2 addFaithfulProgram).circuit.ProverAssumptions
+        (Eval.eval proverEnv (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowInputVar)
+        proverEnv.data proverEnv.hint := by
+    rw [h_input]
+    simpa [proverEnv, addFaithfulProverEnvFromEnvironment, env] using h_assumptions
+  have h_full :=
+    (componentWithRomMemAndOpBus 2 addFaithfulProgram).circuit.original_full_completeness
+      (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowOffset proverEnv
+      (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowInputVar h_env h_assumptions'
+  have h_row :
+      (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowOperations.ConstraintsHold
+        (proverEnv : Environment FGL) := by
+    simpa [Component.rowOperations, Component.rowInputVar, Component.rowOffset] using h_full.1
+  simpa [proverEnv, addFaithfulProverEnvFromEnvironment, env] using
+    (Component.constraintsHold_iff (component := componentWithRomMemAndOpBus 2 addFaithfulProgram)
+      (env := (proverEnv : Environment FGL))).mpr h_row
+
+theorem addFaithfulMainTable_constraints : addFaithfulMainTable.Constraints := by
+  change ∀ arr ∈
+      [ mainFixedColumns.materialize 0 (mainRawRow addX1Row)
+      , mainFixedColumns.materialize 1 (mainRawRow addFaithfulRow1) ],
+      (componentWithRomMemAndOpBus 2 addFaithfulProgram).operations.ConstraintsHold
+        (Environment.fromArray arr emptyData)
+  intro arr h_arr
+  simp only [List.mem_cons, List.not_mem_nil, or_false] at h_arr
+  rcases h_arr with rfl | rfl
+  · exact addFaithfulMain_constraintsHold_materialize 0 addX1Row
+      (by rfl) (by rfl) addFaithfulMain_proverAssumptions_zero
+  · exact addFaithfulMain_constraintsHold_materialize 1 addFaithfulRow1
+      (by rfl) (by rfl) addFaithfulMain_proverAssumptions_one
+
+/-! ## The PC handshake between row 0 and row 1 -/
+
+theorem addFaithfulMain_pcHandshake_zero_one :
+    transitionBetween addX1Row addFaithfulRow1 := by
+  simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, addFaithfulRow1,
+    addFaithfulRow1Template, addFaithfulRow1ProgramRow, addX1Row, mainRomRowOf]
+
+@[simp] theorem addFaithfulMainTable_evalAt_zero :
+    Eval.eval
+      (addFaithfulMainTable.environmentAt ⟨0, by simp⟩)
+      (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowInputVar =
+      addX1Row := by
+  simpa [Table.environmentAt, addFaithfulMainTable, mainRowsTable] using
+    eval_mainRawRow_materialize 0 emptyData addX1Row (by rfl) (by rfl)
+
+@[simp] theorem addFaithfulMainTable_evalAt_one :
+    Eval.eval
+      (addFaithfulMainTable.environmentAt ⟨1, by simp⟩)
+      (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowInputVar =
+      addFaithfulRow1 := by
+  simpa [Table.environmentAt, addFaithfulMainTable, mainRowsTable] using
+    eval_mainRawRow_materialize 1 emptyData addFaithfulRow1 (by rfl) (by rfl)
+
+theorem addFaithfulMainTable_transitions : addFaithfulMainTable.TransitionConstraints := by
+  rw [Table.TransitionConstraints]
+  intro index
+  have h_index_lt : index.val < 2 := by
+    rw [← addFaithfulMainTable_length]
+    exact index.isLt
+  interval_cases h_index : index.val
+  · have h_index : index = ⟨0, by simp⟩ := Fin.ext (by omega)
+    subst index
+    change transitionBetween
+      (Eval.eval
+        (addFaithfulMainTable.previousEnvironment ⟨0, by simp⟩)
+        (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowInputVar)
+      (Eval.eval
+        (addFaithfulMainTable.environmentAt ⟨0, by simp⟩)
+        (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowInputVar)
+    simp only [Table.previousEnvironment]
+    rw [addFaithfulMainTable_evalAt_zero]
+    simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, addX1Row]
+  · have h_index : index = ⟨1, by simp⟩ := Fin.ext (by omega)
+    subst index
+    change transitionBetween
+      (Eval.eval
+        (addFaithfulMainTable.previousEnvironment ⟨1, by simp⟩)
+        (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowInputVar)
+      (Eval.eval
+        (addFaithfulMainTable.environmentAt ⟨1, by simp⟩)
+        (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowInputVar)
+    simp only [Table.previousEnvironment]
+    rw [addFaithfulMainTable_evalAt_zero, addFaithfulMainTable_evalAt_one]
+    exact addFaithfulMain_pcHandshake_zero_one
+
+/-! ## Witness assembly -/
+
+def addFaithfulTables : List (Table FGL) :=
+  [ addFaithfulBoundaryTable
+  , emptyComponentTable ZiskFv.AirsClean.MemAlignReadByte.component
+  , emptyComponentTable ZiskFv.AirsClean.MemAlignByte.component
+  , emptyComponentTable ZiskFv.AirsClean.MemAlign.component
+  , emptyComponentTable ZiskFv.AirsClean.MemAlignRangeSlice.component
+  , emptyComponentTable ZiskFv.AirsClean.MemAlignRomSlice.component
+  , emptyComponentTable ZiskFv.AirsClean.Mem.componentWithDualMemBus
+  , emptyComponentTable ZiskFv.AirsClean.SpecifiedRangesSlice.component
+  , emptyComponentTable ZiskFv.AirsClean.ArithDiv.component
+  , emptyComponentTable ZiskFv.AirsClean.ArithMul.componentComplete
+  , emptyComponentTable ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+  , emptyComponentTable ZiskFv.AirsClean.Binary.staticLookupComponent
+  , addFaithfulBinaryAddTable
+  , addFaithfulMainTable ]
+
+def addFaithfulNonMainTables : List (Table FGL) :=
+  [ addFaithfulBoundaryTable
+  , emptyComponentTable ZiskFv.AirsClean.MemAlignReadByte.component
+  , emptyComponentTable ZiskFv.AirsClean.MemAlignByte.component
+  , emptyComponentTable ZiskFv.AirsClean.MemAlign.component
+  , emptyComponentTable ZiskFv.AirsClean.MemAlignRangeSlice.component
+  , emptyComponentTable ZiskFv.AirsClean.MemAlignRomSlice.component
+  , emptyComponentTable ZiskFv.AirsClean.Mem.componentWithDualMemBus
+  , emptyComponentTable ZiskFv.AirsClean.SpecifiedRangesSlice.component
+  , emptyComponentTable ZiskFv.AirsClean.ArithDiv.component
+  , emptyComponentTable ZiskFv.AirsClean.ArithMul.componentComplete
+  , emptyComponentTable ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+  , emptyComponentTable ZiskFv.AirsClean.Binary.staticLookupComponent
+  , addFaithfulBinaryAddTable ]
+
+def addFaithfulEnsemble : Ensemble FGL unit :=
+  (fullRv64imEnsemble 2 addFaithfulProgram).ensemble
+
+theorem addFaithfulEnsemble_verifier :
+    addFaithfulEnsemble.verifier = .empty FGL unit :=
+  (fullRv64imSoundEnsemble 2 addFaithfulProgram).verifier_empty
+
+def addFaithfulWitness : EnsembleWitness addFaithfulEnsemble where
+  tables := addFaithfulTables
+  data := emptyData
+  publicInput := ()
+  same_length := by
+    simp [addFaithfulEnsemble, fullRv64imEnsemble, fullRv64imSoundEnsemble, addFaithfulTables,
+      SoundEnsemble.toFormal, SoundEnsemble.addFinishedChannel_tables, SoundEnsemble.addTable,
+      SoundEnsemble.empty_tables, Ensemble.addTable]
+  same_circuits := by
+    intro i hi
+    have hi' : i < 14 := by
+      simpa [addFaithfulTables] using hi
+    interval_cases i <;>
+      simp [addFaithfulEnsemble, fullRv64imEnsemble, fullRv64imSoundEnsemble, addFaithfulTables,
+        SoundEnsemble.toFormal, SoundEnsemble.addFinishedChannel_tables, SoundEnsemble.addTable,
+        SoundEnsemble.empty_tables, Ensemble.addTable, addFaithfulBoundaryTable,
+        registerBoundaryRowsTableOf, emptyComponentTable, addFaithfulBinaryAddTable,
+        binaryAddRowsTable, addFaithfulMainTable, mainRowsTable]
+  same_data := by
+    intro table h_table
+    simp [addFaithfulTables, addFaithfulBoundaryTable, registerBoundaryRowsTableOf,
+      emptyComponentTable, addFaithfulBinaryAddTable, binaryAddRowsTable,
+      addFaithfulMainTable, mainRowsTable] at h_table
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
+      rfl
+
+theorem addFaithfulWitness_tables : addFaithfulWitness.tables = addFaithfulTables := rfl
+
+theorem addFaithfulWitness_table_constraints :
+    ∀ table ∈ addFaithfulWitness.tables, table.Constraints := by
+  intro table h_table
+  rw [addFaithfulWitness_tables] at h_table
+  simp [addFaithfulTables] at h_table
+  rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+  · exact addFaithfulBoundaryTable_constraints
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlignReadByte.component
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlignByte.component
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlign.component
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlignRangeSlice.component
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.MemAlignRomSlice.component
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.Mem.componentWithDualMemBus
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.SpecifiedRangesSlice.component
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.ArithDiv.component
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.ArithMul.componentComplete
+  · exact emptyComponentTable_constraints
+      ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+  · exact emptyComponentTable_constraints ZiskFv.AirsClean.Binary.staticLookupComponent
+  · exact addFaithfulBinaryAddTable_constraints
+  · exact addFaithfulMainTable_constraints
+
+theorem addFaithfulWitness_constraints : addFaithfulWitness.Constraints :=
+  addFaithfulWitness.constraints_of_tables addFaithfulEnsemble_verifier
+    addFaithfulWitness_table_constraints
+
+theorem addFaithfulWitness_transitions : addFaithfulWitness.TransitionConstraints := by
+  intro table h_table
+  rw [EnsembleWitness.allTables, List.mem_cons] at h_table
+  rcases h_table with h_verifier | h_table
+  · subst table
+    rw [Table.TransitionConstraints]
+    intro index
+    simp [EnsembleWitness.verifierTable]
+  · rw [addFaithfulWitness_tables] at h_table
+    simp [addFaithfulTables] at h_table
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    · rw [Table.TransitionConstraints]
+      intro index
+      simp [addFaithfulBoundaryTable, registerBoundaryRowsTableOf,
+        ZiskFv.AirsClean.RegisterBoundary.component]
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignReadByte.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignByte.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlign.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignRangeSlice.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.MemAlignRomSlice.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.Mem.componentWithDualMemBus
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.SpecifiedRangesSlice.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.ArithDiv.component
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.ArithMul.componentComplete
+    · exact emptyComponentTable_transitions
+        ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+    · exact emptyComponentTable_transitions ZiskFv.AirsClean.Binary.staticLookupComponent
+    · rw [Table.TransitionConstraints]
+      intro index
+      simp [addFaithfulBinaryAddTable, binaryAddRowsTable, ZiskFv.AirsClean.BinaryAdd.component]
+    · exact addFaithfulMainTable_transitions
+
+theorem addFaithfulWitness_cyclicSuccessorTransitions :
+    addFaithfulWitness.CyclicSuccessorTransitionConstraints := by
+  intro table h_table
+  rw [EnsembleWitness.allTables, List.mem_cons] at h_table
+  rcases h_table with h_verifier | h_table
+  · subst table
+    rw [Table.CyclicSuccessorTransitionConstraints]
+    intro index
+    simp [EnsembleWitness.verifierTable]
+  · rw [addFaithfulWitness_tables] at h_table
+    simp [addFaithfulTables] at h_table
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    · rw [Table.CyclicSuccessorTransitionConstraints]
+      intro index
+      simp [addFaithfulBoundaryTable, registerBoundaryRowsTableOf,
+        ZiskFv.AirsClean.RegisterBoundary.component]
+    · exact emptyComponentTable_cyclicSuccessorTransitions
+        ZiskFv.AirsClean.MemAlignReadByte.component
+    · exact emptyComponentTable_cyclicSuccessorTransitions ZiskFv.AirsClean.MemAlignByte.component
+    · exact emptyComponentTable_cyclicSuccessorTransitions ZiskFv.AirsClean.MemAlign.component
+    · exact emptyComponentTable_cyclicSuccessorTransitions
+        ZiskFv.AirsClean.MemAlignRangeSlice.component
+    · exact emptyComponentTable_cyclicSuccessorTransitions ZiskFv.AirsClean.MemAlignRomSlice.component
+    · exact emptyComponentTable_cyclicSuccessorTransitions
+        ZiskFv.AirsClean.Mem.componentWithDualMemBus
+    · exact emptyComponentTable_cyclicSuccessorTransitions
+        ZiskFv.AirsClean.SpecifiedRangesSlice.component
+    · exact emptyComponentTable_cyclicSuccessorTransitions ZiskFv.AirsClean.ArithDiv.component
+    · exact emptyComponentTable_cyclicSuccessorTransitions
+        ZiskFv.AirsClean.ArithMul.componentComplete
+    · exact emptyComponentTable_cyclicSuccessorTransitions
+        ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+    · exact emptyComponentTable_cyclicSuccessorTransitions
+        ZiskFv.AirsClean.Binary.staticLookupComponent
+    · rw [Table.CyclicSuccessorTransitionConstraints]
+      intro index
+      simp [addFaithfulBinaryAddTable, binaryAddRowsTable, ZiskFv.AirsClean.BinaryAdd.component]
+    · rw [Table.CyclicSuccessorTransitionConstraints]
+      intro index
+      simp [addFaithfulMainTable, mainRowsTable, ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus]
+
+/-! ## Main-table identification lemmas -/
+
+private theorem not_addFaithful_main_component_of_name_ne
+    {component : Component FGL}
+    (h_name :
+      component.circuit.name ≠ (componentWithRomMemAndOpBus 2 addFaithfulProgram).circuit.name)
+    (h_component : component = componentWithRomMemAndOpBus 2 addFaithfulProgram) :
+    False :=
+  h_name (congrArg (fun component : Component FGL => component.circuit.name) h_component)
+
+private theorem not_addFaithful_main_component_of_width_ne
+    {component : Component FGL}
+    (h_width :
+      component.width ≠ (componentWithRomMemAndOpBus 2 addFaithfulProgram).width)
+    (h_component : component = componentWithRomMemAndOpBus 2 addFaithfulProgram) :
+    False :=
+  h_width (congrArg Component.width h_component)
+
+private theorem not_addFaithful_mutable_mem_component_of_name_ne
+    {component : Component FGL}
+    (h_name :
+      component.circuit.name ≠ ZiskFv.AirsClean.Mem.componentWithDualMemBus.circuit.name)
+    (h_component : component = ZiskFv.AirsClean.Mem.componentWithDualMemBus) :
+    False :=
+  h_name (congrArg (fun component : Component FGL => component.circuit.name) h_component)
+
+theorem addFaithfulWitness_main_component_cases
+    {table : Table FGL}
+    (h_table : table ∈ addFaithfulWitness.allTables)
+    (h_component : table.component = componentWithRomMemAndOpBus 2 addFaithfulProgram) :
+    table = addFaithfulMainTable := by
+  rw [EnsembleWitness.allTables, List.mem_cons] at h_table
+  rcases h_table with h_verifier | h_table
+  · subst table
+    exfalso
+    exact not_addFaithful_main_component_of_width_ne (by decide) h_component
+  · rw [addFaithfulWitness_tables] at h_table
+    simp [addFaithfulTables] at h_table
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    · exfalso
+      exact not_addFaithful_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addFaithful_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addFaithful_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addFaithful_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addFaithful_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addFaithful_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addFaithful_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addFaithful_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addFaithful_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addFaithful_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addFaithful_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addFaithful_main_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addFaithful_main_component_of_name_ne (by decide) h_component
+    · rfl
+
+private theorem addFaithfulWitness_mutable_mem_component_tables_empty (table : Table FGL)
+    (h_table : table ∈ addFaithfulWitness.allTables)
+    (h_component : table.component = ZiskFv.AirsClean.Mem.componentWithDualMemBus) :
+    table.table = [] := by
+  rw [EnsembleWitness.allTables, List.mem_cons] at h_table
+  rcases h_table with h_verifier | h_table
+  · exfalso
+    rw [h_verifier, EnsembleWitness.verifierTable_component] at h_component
+    have h_verifier_nil :=
+      ZiskFv.AirsClean.FullEnsemble.verifierTable_interactionsWith_memBus_nil 2 addFaithfulProgram
+    change Operations.interactionsWith MemBusChannel.toRaw
+      addFaithfulEnsemble.verifierTable.operations = [] at h_verifier_nil
+    rw [h_component,
+      ZiskFv.AirsClean.Mem.componentWithDualMemBus_interactionsWith_memBus] at h_verifier_nil
+    exact absurd h_verifier_nil (by simp)
+  · rw [addFaithfulWitness_tables] at h_table
+    simp [addFaithfulTables] at h_table
+    rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    · exfalso
+      exact not_addFaithful_mutable_mem_component_of_name_ne (by decide) h_component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignReadByte.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignByte.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlign.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignRangeSlice.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.MemAlignRomSlice.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.Mem.componentWithDualMemBus
+    · exact emptyComponentTable_table ZiskFv.AirsClean.SpecifiedRangesSlice.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.ArithDiv.component
+    · exact emptyComponentTable_table ZiskFv.AirsClean.ArithMul.componentComplete
+    · exact emptyComponentTable_table ZiskFv.AirsClean.BinaryExtension.shiftStaticLookupComponent
+    · exact emptyComponentTable_table ZiskFv.AirsClean.Binary.staticLookupComponent
+    · exfalso
+      exact not_addFaithful_mutable_mem_component_of_name_ne (by decide) h_component
+    · exfalso
+      exact not_addFaithful_mutable_mem_component_of_name_ne (by decide) h_component
+
+theorem addFaithfulWitness_not_mutableMemPresent :
+    ¬ MutableMemPresent addFaithfulWitness := by
+  intro h_present
+  obtain ⟨table, h_table, h_component, h_length⟩ := h_present
+  have h_empty :=
+    addFaithfulWitness_mutable_mem_component_tables_empty table h_table h_component
+  exact absurd h_length (by simp [h_empty])
+
+theorem addFaithfulWitness_main_height :
+    ∀ table ∈ addFaithfulWitness.allTables,
+      table.component = componentWithRomMemAndOpBus 2 addFaithfulProgram →
+        ∀ i : Fin 2, i.val < table.table.length := by
+  intro table h_table h_component i
+  have h_main := addFaithfulWitness_main_component_cases h_table h_component
+  subst table
+  fin_cases i <;> norm_num [addFaithfulMainTable, mainRowsTable, addFaithfulMainRows]
+
+theorem addFaithfulWitness_main_height_prefix_one :
+    ∀ table ∈ addFaithfulWitness.allTables,
+      table.component = componentWithRomMemAndOpBus 2 addFaithfulProgram →
+        ∀ i : Fin 1, i.val < table.table.length := by
+  intro table h_table h_component i
+  fin_cases i
+  exact addFaithfulWitness_main_height table h_table h_component ⟨0, by decide⟩
+
+/-! ## OpBus balance: two ADD ops, each `BinaryAdd ↔ Main` -/
+
+private theorem addFaithfulMainOpBusInteraction_eval_at
+    (env : Environment FGL) (row : MainRowWithRom FGL)
+    (h_input : Eval.eval env (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowInputVar = row) :
+    (((OpBusChannel.emitted
+        (-(componentWithRomMemAndOpBus 2 addFaithfulProgram).rowInputVar.core.is_external_op)
+        (opBusMessageExpr
+          (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowInputVar.core)).toRaw).eval env) =
+      mainOpBusInteraction row := by
+  let rowVar := (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowInputVar
+  have h_core : Eval.eval env rowVar.core = row.core := by
+    rw [ZiskFv.AirsClean.FullEnsemble.mainRowWithRom_eval_core]
+    exact congrArg MainRowWithRom.core h_input
+  have h_field := ZiskFv.AirsClean.FullEnsemble.mainRow_eval_is_external_op env rowVar.core
+  simp [mainOpBusInteraction, AbstractInteraction.eval, ChannelInteraction.toRaw]
+  constructor
+  · change Expression.eval env (-rowVar.core.is_external_op) = -row.core.is_external_op
+    simp [Expression.eval, h_field, h_core]
+  constructor
+  · have h_msg_eval :
+        Eval.eval env (opBusMessageExpr rowVar.core) = opBusMessage row.core := by
+      rw [eval_opBusMessageExpr, h_core]
+    rw [toElements_eval_toArray]
+    change (toElements (Eval.eval env (opBusMessageExpr rowVar.core))).toArray =
+      (toElements (opBusMessage row.core)).toArray
+    rw [h_msg_eval]
+  · rfl
+
+private theorem addFaithfulMainOpBusInteractionsAt
+    (env : Environment FGL) (row : MainRowWithRom FGL)
+    (h_input : Eval.eval env (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowInputVar = row) :
+    (componentWithRomMemAndOpBus 2 addFaithfulProgram).operations.interactionValuesWith
+        OpBusChannel.toRaw env = [mainOpBusInteraction row] := by
+  simp [Operations.interactionValuesWith_eq_map,
+    componentWithRomMemAndOpBus_interactionsWith_opBus]
+  exact addFaithfulMainOpBusInteraction_eval_at env row h_input
+
+theorem addFaithfulMainTable_interactionsWith_opBus :
+    addFaithfulMainTable.interactionsWith OpBusChannel.toRaw =
+      [mainOpBusInteraction addX1Row, mainOpBusInteraction addFaithfulRow1] := by
+  rw [Table.interactionsWith, addFaithfulMainTable_effectiveRows]
+  simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]
+  have h_zero :
+      addFaithfulMainTable.component.operations.interactionValuesWith
+          OpBusChannel.toRaw
+          (addFaithfulMainTable.environment
+            (mainFixedColumns.materialize 0 (mainRawRow addX1Row))) =
+        [mainOpBusInteraction addX1Row] := by
+    simpa [addFaithfulMainTable, mainRowsTable] using
+      (addFaithfulMainOpBusInteractionsAt
+        (Environment.fromArray
+          (mainFixedColumns.materialize 0 (mainRawRow addX1Row)) emptyData)
+        addX1Row
+        (eval_mainRawRow_materialize 0 emptyData addX1Row (by rfl) (by rfl)))
+  have h_one :
+      addFaithfulMainTable.component.operations.interactionValuesWith
+          OpBusChannel.toRaw
+          (addFaithfulMainTable.environment
+            (mainFixedColumns.materialize 1 (mainRawRow addFaithfulRow1))) =
+        [mainOpBusInteraction addFaithfulRow1] := by
+    simpa [addFaithfulMainTable, mainRowsTable] using
+      (addFaithfulMainOpBusInteractionsAt
+        (Environment.fromArray
+          (mainFixedColumns.materialize 1 (mainRawRow addFaithfulRow1)) emptyData)
+        addFaithfulRow1
+        (eval_mainRawRow_materialize 1 emptyData addFaithfulRow1 (by rfl) (by rfl)))
+  rw [h_zero, h_one]
+  rfl
+
+theorem addFaithfulOpBus_interactions :
+    addFaithfulWitness.tables.flatMap (·.interactionsWith OpBusChannel.toRaw) =
+      [ binaryAddOpBusInteraction addX1BinaryAddRow
+      , binaryAddOpBusInteraction addX1BinaryAddRow
+      , mainOpBusInteraction addX1Row
+      , mainOpBusInteraction addFaithfulRow1 ] := by
+  have h_registerBoundary :
+      addFaithfulBoundaryTable.interactionsWith OpBusChannel.toRaw = [] := by
+    exact ZiskFv.AirsClean.FullEnsemble.registerBoundary_table_interactionsWith_opBus_nil
+      (table := addFaithfulBoundaryTable) rfl
+  rw [addFaithfulWitness_tables]
+  simp [addFaithfulTables, h_registerBoundary, emptyComponentTable_interactionsWith,
+    addFaithfulBinaryAddTable, binaryAddRowsTable_interactionsWith_opBus,
+    addFaithfulBinaryAddRows, addFaithfulMainTable_interactionsWith_opBus]
+
+theorem addFaithfulWitness_opBus_balanced :
+    BalancedInteractions
+      (addFaithfulWitness.tables.flatMap (·.interactionsWith OpBusChannel.toRaw)) := by
+  rw [addFaithfulOpBus_interactions]
+  refine Air.Flat.balancedInteractions_of_present ?_
+    ([ binaryAddOpBusInteraction addX1BinaryAddRow
+      , binaryAddOpBusInteraction addX1BinaryAddRow
+      , mainOpBusInteraction addX1Row
+      , mainOpBusInteraction addFaithfulRow1 ].map (·.msg)) ?_ ?_
+  · left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+  · intro interaction h_interaction
+    exact List.mem_map_of_mem h_interaction
+  · intro msg h_msg
+    simp only [List.mem_map] at h_msg
+    rcases h_msg with ⟨interaction, h_interaction, rfl⟩
+    simp at h_interaction
+    rcases h_interaction with rfl | rfl | rfl | rfl <;> decide
+
+/-! ## MemBus balance: the six-message register telescope for x1, plus idle registers -/
+
+theorem addFaithfulMainTable_interactionsWith_memBus :
+    addFaithfulMainTable.interactionsWith MemBusChannel.toRaw =
+      mainValueMemBusInteractions addX1Row ++ mainValueMemBusInteractions addFaithfulRow1 := by
+  rw [Table.interactionsWith, addFaithfulMainTable_effectiveRows]
+  simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]
+  have h_zero :
+      addFaithfulMainTable.component.operations.interactionValuesWith
+          MemBusChannel.toRaw
+          (addFaithfulMainTable.environment
+            (mainFixedColumns.materialize 0 (mainRawRow addX1Row))) =
+        mainValueMemBusInteractions addX1Row := by
+    calc
+      _ = mainMemBusInteractionsAt 2 addFaithfulProgram
+          (Environment.fromArray
+            (mainFixedColumns.materialize 0 (mainRawRow addX1Row)) emptyData) := by
+        simpa [addFaithfulMainTable, mainRowsTable] using
+          (mainMemBusInteractionsAt_eq_component 2 addFaithfulProgram
+            (Environment.fromArray
+              (mainFixedColumns.materialize 0 (mainRawRow addX1Row)) emptyData))
+      _ = mainValueMemBusInteractions addX1Row :=
+        mainMemBusInteractionsAt_eq_valueLevel 2 addFaithfulProgram _ addX1Row
+          (eval_mainRawRow_materialize 0 emptyData addX1Row (by rfl) (by rfl))
+  have h_one :
+      addFaithfulMainTable.component.operations.interactionValuesWith
+          MemBusChannel.toRaw
+          (addFaithfulMainTable.environment
+            (mainFixedColumns.materialize 1 (mainRawRow addFaithfulRow1))) =
+        mainValueMemBusInteractions addFaithfulRow1 := by
+    calc
+      _ = mainMemBusInteractionsAt 2 addFaithfulProgram
+          (Environment.fromArray
+            (mainFixedColumns.materialize 1 (mainRawRow addFaithfulRow1)) emptyData) := by
+        simpa [addFaithfulMainTable, mainRowsTable] using
+          (mainMemBusInteractionsAt_eq_component 2 addFaithfulProgram
+            (Environment.fromArray
+              (mainFixedColumns.materialize 1 (mainRawRow addFaithfulRow1)) emptyData))
+      _ = mainValueMemBusInteractions addFaithfulRow1 :=
+        mainMemBusInteractionsAt_eq_valueLevel 2 addFaithfulProgram _ addFaithfulRow1
+          (eval_mainRawRow_materialize 1 emptyData addFaithfulRow1 (by rfl) (by rfl))
+  rw [h_zero, h_one]
+
+theorem addFaithfulBoundaryRows_interactions :
+    addFaithfulBoundaryRows.flatMap registerBoundaryMemBusInteractions =
+      boundaryInteractions addFaithfulBoundaryRowX1 ++ idleBoundaryInteractions := by
+  simp [addFaithfulBoundaryRows, boundaryInteractions, idleBoundaryInteractions]
+  generalize List.range 30 = indices
+  induction indices with
+  | nil => rfl
+  | cons _ _ ih => simp [ih]
+
+theorem addFaithfulMemBus_interactions :
+    addFaithfulWitness.tables.flatMap (·.interactionsWith MemBusChannel.toRaw) =
+      boundaryInteractions addFaithfulBoundaryRowX1 ++ idleBoundaryInteractions ++
+        mainValueMemBusInteractions addX1Row ++ mainValueMemBusInteractions addFaithfulRow1 := by
+  have h_nonMain :
+      addFaithfulNonMainTables.flatMap (·.interactionsWith MemBusChannel.toRaw) =
+        addFaithfulBoundaryRows.flatMap registerBoundaryMemBusInteractions := by
+    have h_registerBoundary :
+        addFaithfulBoundaryTable.interactionsWith MemBusChannel.toRaw =
+          addFaithfulBoundaryRows.flatMap registerBoundaryMemBusInteractions := by
+      simpa [addFaithfulBoundaryTable] using
+        registerBoundaryRowsTableOf_interactionsWith_memBus addFaithfulBoundaryRows
+    have h_binaryAdd :
+        addFaithfulBinaryAddTable.interactionsWith MemBusChannel.toRaw = [] := by
+      exact ZiskFv.AirsClean.FullEnsemble.binaryAdd_table_interactionsWith_memBus_nil
+        (table := addFaithfulBinaryAddTable) rfl
+    simp [addFaithfulNonMainTables, h_registerBoundary, h_binaryAdd,
+      emptyComponentTable_interactionsWith]
+  rw [addFaithfulWitness_tables]
+  rw [show addFaithfulTables = addFaithfulNonMainTables ++ [addFaithfulMainTable] from rfl]
+  simp only [List.flatMap_append, List.flatMap_cons, List.flatMap_nil, List.append_nil]
+  rw [h_nonMain, addFaithfulMainTable_interactionsWith_memBus, addFaithfulBoundaryRows_interactions]
+  simp only [List.append_assoc]
+
+def addFaithfulX1Telescope : List (Interaction FGL) :=
+  registerTelescopingInteractions
+    (ZiskFv.AirsClean.RegisterBoundary.bootMessage addFaithfulBoundaryRowX1)
+    [ aMemMessage addX1Row, bMemMessage addX1Row, cMemMessage addX1Row
+    , aMemMessage addFaithfulRow1, bMemMessage addFaithfulRow1, cMemMessage addFaithfulRow1 ]
+
+theorem addFaithfulX1Interactions_eq_telescope :
+    boundaryInteractions addFaithfulBoundaryRowX1 ++
+      mainValueMemBusInteractions addX1Row ++ mainValueMemBusInteractions addFaithfulRow1 =
+      addFaithfulX1Telescope := by
+  rw [boundaryInteractions_eq_messages, addFaithfulReloadMessage_eq]
+  simp [addFaithfulX1Telescope, registerTelescopingInteractions, registerLastMessage,
+    registerAccessChain, mainValueMemBusInteractions, mainARegPreInteraction, mainAMemInteraction,
+    mainBRegPreInteraction, mainBMemInteraction, mainCRegPreInteraction, mainCMemInteraction,
+    emittedPulledValue, Channel.pushedValue, aRegPreMessage, aMemMessage, bRegPreMessage,
+    bMemMessage, cRegPreMessage, cMemMessage, addX1Row, addFaithfulRow1,
+    addFaithfulRow1Template, mainRomRowOf, addFaithfulRow1ProgramRow,
+    addX1RomFlagBits, RegisterMemBusBalance.addX1ProgramRow, addFaithfulBoundaryRowX1,
+    ZiskFv.AirsClean.RegisterBoundary.bootMessage, registerBoundaryRowFromLast]
+
+theorem addFaithfulX1Telescope_balanced : BalancedInteractions addFaithfulX1Telescope := by
+  apply registerTelescopingInteractions_balanced
+  left
+  rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+  decide
+
+theorem addFaithfulWitness_memBus_balanced :
+    BalancedInteractions
+      (addFaithfulWitness.tables.flatMap (·.interactionsWith MemBusChannel.toRaw)) := by
+  rw [addFaithfulMemBus_interactions]
+  have h_x1 :
+      BalancedInteractions
+        (boundaryInteractions addFaithfulBoundaryRowX1 ++
+          mainValueMemBusInteractions addX1Row ++ mainValueMemBusInteractions addFaithfulRow1) := by
+    rw [addFaithfulX1Interactions_eq_telescope]
+    exact addFaithfulX1Telescope_balanced
+  have h_idle : BalancedInteractions idleBoundaryInteractions := by
+    have h_eq_paired : idleBoundaryInteractions =
+        pairedInteractions ((List.range 30).map fun i =>
+          ZiskFv.AirsClean.RegisterBoundary.bootMessage (boundaryRowIdle ((i + 2 : Nat) : FGL))) := by
+      unfold idleBoundaryInteractions
+      generalize List.range 30 = indices
+      induction indices with
+      | nil => rfl
+      | cons i rest ih =>
+          simp only [List.map_cons, List.flatMap_cons, pairedInteractions]
+          have h_head : boundaryInteractions (boundaryRowIdle ((i + 2 : Nat) : FGL)) =
+              pairedInteraction
+                (ZiskFv.AirsClean.RegisterBoundary.bootMessage
+                  (boundaryRowIdle ((i + 2 : Nat) : FGL))) := by
+            simp [boundaryInteractions, registerBoundaryMemBusInteractions,
+              registerBoundaryBootInteraction, registerBoundaryReloadInteraction,
+              pairedInteraction, boundaryRowIdle, emittedPulledValue, Channel.pushedValue]
+          rw [h_head, ih]
+          rfl
+    rw [h_eq_paired]
+    apply pairedInteractions_balanced
+    left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+  let addRows := mainValueMemBusInteractions addX1Row ++ mainValueMemBusInteractions addFaithfulRow1
+  have h_perm :
+      List.Perm
+        ((boundaryInteractions addFaithfulBoundaryRowX1 ++ idleBoundaryInteractions) ++ addRows)
+        ((boundaryInteractions addFaithfulBoundaryRowX1 ++
+            mainValueMemBusInteractions addX1Row ++ mainValueMemBusInteractions addFaithfulRow1) ++
+          idleBoundaryInteractions) := by
+    have h_swap : List.Perm (idleBoundaryInteractions ++ addRows) (addRows ++ idleBoundaryInteractions) :=
+      List.perm_append_comm
+    have h_with_boundary := List.Perm.append
+      (List.Perm.refl (boundaryInteractions addFaithfulBoundaryRowX1)) h_swap
+    simpa [addRows, List.append_assoc] using h_with_boundary
+  have h_reordered :
+      BalancedInteractions
+        ((boundaryInteractions addFaithfulBoundaryRowX1 ++
+            mainValueMemBusInteractions addX1Row ++ mainValueMemBusInteractions addFaithfulRow1) ++
+          idleBoundaryInteractions) :=
+    balancedInteractions_append_of_balanced h_x1 h_idle (by
+      left
+      rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+      decide)
+  apply balancedInteractions_of_perm h_reordered
+  simpa [addRows, List.append_assoc] using h_perm.symm
+
+/-! ## The remaining channels are all-empty for this witness -/
+
+private theorem addFaithfulRangeChannel_ne_memBus :
+    SpecifiedRangesSliceChannel.toRaw ≠ MemBusChannel.toRaw := by
+  intro h
+  have h_name := congrArg (fun raw : RawChannel FGL => raw.name) h
+  change "SpecifiedRangesSlice103" = "MemoryBus" at h_name
+  simp at h_name
+
+private theorem addFaithfulRangeChannel_ne_opBus :
+    SpecifiedRangesSliceChannel.toRaw ≠ OpBusChannel.toRaw := by
+  intro h
+  have h_name := congrArg (fun raw : RawChannel FGL => raw.name) h
+  change "SpecifiedRangesSlice103" = "OperationBus" at h_name
+  simp at h_name
+
+private theorem addFaithfulMemAlignRangeChannel_ne_memBus :
+    MemAlignRangeChannel.toRaw ≠ MemBusChannel.toRaw := by
+  intro h
+  have h_name := congrArg (fun raw : RawChannel FGL => raw.name) h
+  change "MemAlignRange107" = "MemoryBus" at h_name
+  simp at h_name
+
+private theorem addFaithfulMemAlignRangeChannel_ne_opBus :
+    MemAlignRangeChannel.toRaw ≠ OpBusChannel.toRaw := by
+  intro h
+  have h_name := congrArg (fun raw : RawChannel FGL => raw.name) h
+  change "MemAlignRange107" = "OperationBus" at h_name
+  simp at h_name
+
+private theorem addFaithfulRegisterBoundary_interactionsWith_rangeChannel_nil :
+    addFaithfulBoundaryTable.interactionsWith SpecifiedRangesSliceChannel.toRaw = [] := by
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  change SpecifiedRangesSliceChannel.toRaw ∉ [MemBusChannel.toRaw]
+  simp only [List.mem_singleton]
+  exact addFaithfulRangeChannel_ne_memBus
+
+private theorem addFaithfulBinaryAdd_interactionsWith_rangeChannel_nil :
+    addFaithfulBinaryAddTable.interactionsWith SpecifiedRangesSliceChannel.toRaw = [] := by
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  change SpecifiedRangesSliceChannel.toRaw ∉ [OpBusChannel.toRaw]
+  simp only [List.mem_singleton]
+  exact addFaithfulRangeChannel_ne_opBus
+
+private theorem addFaithfulMain_interactionsWith_rangeChannel_nil :
+    addFaithfulMainTable.interactionsWith SpecifiedRangesSliceChannel.toRaw = [] := by
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  change SpecifiedRangesSliceChannel.toRaw ∉ [MemBusChannel.toRaw, OpBusChannel.toRaw]
+  intro h
+  simp only [List.mem_cons] at h
+  rcases h with h | h
+  · exact addFaithfulRangeChannel_ne_memBus h
+  · rcases h with h | h
+    · exact addFaithfulRangeChannel_ne_opBus h
+    · simp at h
+
+theorem addFaithfulWitness_rangeChannel_balanced :
+    BalancedInteractions
+      (addFaithfulWitness.tables.flatMap (·.interactionsWith SpecifiedRangesSliceChannel.toRaw)) := by
+  rw [addFaithfulWitness_tables]
+  simp [addFaithfulTables, addFaithfulRegisterBoundary_interactionsWith_rangeChannel_nil,
+    addFaithfulBinaryAdd_interactionsWith_rangeChannel_nil,
+    addFaithfulMain_interactionsWith_rangeChannel_nil, emptyComponentTable_interactionsWith]
+  refine ⟨?_, ?_⟩
+  · left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+  · intro msg
+    simp [balanceOf]
+
+private theorem addFaithfulRegisterBoundary_interactionsWith_memAlignRangeChannel_nil :
+    addFaithfulBoundaryTable.interactionsWith MemAlignRangeChannel.toRaw = [] := by
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  change MemAlignRangeChannel.toRaw ∉ [MemBusChannel.toRaw]
+  simp only [List.mem_singleton]
+  exact addFaithfulMemAlignRangeChannel_ne_memBus
+
+private theorem addFaithfulBinaryAdd_interactionsWith_memAlignRangeChannel_nil :
+    addFaithfulBinaryAddTable.interactionsWith MemAlignRangeChannel.toRaw = [] := by
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  change MemAlignRangeChannel.toRaw ∉ [OpBusChannel.toRaw]
+  simp only [List.mem_singleton]
+  exact addFaithfulMemAlignRangeChannel_ne_opBus
+
+private theorem addFaithfulMain_interactionsWith_memAlignRangeChannel_nil :
+    addFaithfulMainTable.interactionsWith MemAlignRangeChannel.toRaw = [] := by
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  change MemAlignRangeChannel.toRaw ∉ [MemBusChannel.toRaw, OpBusChannel.toRaw]
+  intro h
+  simp only [List.mem_cons] at h
+  rcases h with h | h
+  · exact addFaithfulMemAlignRangeChannel_ne_memBus h
+  · rcases h with h | h
+    · exact addFaithfulMemAlignRangeChannel_ne_opBus h
+    · simp at h
+
+theorem addFaithfulWitness_memAlignRangeChannel_balanced :
+    BalancedInteractions
+      (addFaithfulWitness.tables.flatMap (·.interactionsWith MemAlignRangeChannel.toRaw)) := by
+  rw [addFaithfulWitness_tables]
+  simp [addFaithfulTables, addFaithfulRegisterBoundary_interactionsWith_memAlignRangeChannel_nil,
+    addFaithfulBinaryAdd_interactionsWith_memAlignRangeChannel_nil,
+    addFaithfulMain_interactionsWith_memAlignRangeChannel_nil, emptyComponentTable_interactionsWith]
+  refine ⟨?_, ?_⟩
+  · left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+  · intro msg
+    simp [balanceOf]
+
+private theorem addFaithfulRegisterBoundary_interactionsWith_memAlignRomChannel_nil :
+    addFaithfulBoundaryTable.interactionsWith MemAlignRomChannel.toRaw = [] := by
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  change MemAlignRomChannel.toRaw ∉ [MemBusChannel.toRaw]
+  intro h
+  have h' : MemAlignRomChannel.toRaw = MemBusChannel.toRaw := by
+    simpa only [List.mem_cons, List.not_mem_nil, or_false] using h
+  have h_name := congrArg (fun channel : RawChannel FGL => channel.name) h'
+  change "MemAlignRom133" = "MemoryBus" at h_name
+  simp at h_name
+
+private theorem addFaithfulBinaryAdd_interactionsWith_memAlignRomChannel_nil :
+    addFaithfulBinaryAddTable.interactionsWith MemAlignRomChannel.toRaw = [] := by
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  change MemAlignRomChannel.toRaw ∉ [OpBusChannel.toRaw]
+  intro h
+  have h' : MemAlignRomChannel.toRaw = OpBusChannel.toRaw := by
+    simpa only [List.mem_cons, List.not_mem_nil, or_false] using h
+  have h_name := congrArg (fun channel : RawChannel FGL => channel.name) h'
+  change "MemAlignRom133" = "OperationBus" at h_name
+  simp at h_name
+
+private theorem addFaithfulMain_interactionsWith_memAlignRomChannel_nil :
+    addFaithfulMainTable.interactionsWith MemAlignRomChannel.toRaw = [] := by
+  apply Table.interactionsWith_nil_of_channel_not_mem
+  change MemAlignRomChannel.toRaw ∉ [MemBusChannel.toRaw, OpBusChannel.toRaw]
+  intro h
+  have h' : MemAlignRomChannel.toRaw = MemBusChannel.toRaw ∨
+      MemAlignRomChannel.toRaw = OpBusChannel.toRaw := by
+    simpa only [List.mem_cons, List.not_mem_nil, or_false] using h
+  rcases h' with h' | h'
+  · have h_name := congrArg (fun channel : RawChannel FGL => channel.name) h'
+    change "MemAlignRom133" = "MemoryBus" at h_name
+    simp at h_name
+  · have h_name := congrArg (fun channel : RawChannel FGL => channel.name) h'
+    change "MemAlignRom133" = "OperationBus" at h_name
+    simp at h_name
+
+theorem addFaithfulWitness_memAlignRomChannel_balanced :
+    BalancedInteractions
+      (addFaithfulWitness.tables.flatMap (·.interactionsWith MemAlignRomChannel.toRaw)) := by
+  rw [addFaithfulWitness_tables]
+  simp [addFaithfulTables, addFaithfulRegisterBoundary_interactionsWith_memAlignRomChannel_nil,
+    addFaithfulBinaryAdd_interactionsWith_memAlignRomChannel_nil,
+    addFaithfulMain_interactionsWith_memAlignRomChannel_nil, emptyComponentTable_interactionsWith]
+  refine ⟨?_, ?_⟩
+  · left
+    rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
+    decide
+  · intro msg
+    simp [balanceOf]
+
+theorem addFaithfulWitness_balancedChannels : addFaithfulWitness.BalancedChannels := by
+  refine addFaithfulWitness.balancedChannels_of_tables addFaithfulEnsemble_verifier ?_
+  intro channel h_channel
+  simp [addFaithfulEnsemble, fullRv64imEnsemble, fullRv64imSoundEnsemble,
+    SoundEnsemble.toFormal, SoundEnsemble.addFinishedChannel_channels,
+    SoundEnsemble.addTable_channels, SoundEnsemble.empty_channels] at h_channel
+  rcases h_channel with rfl | rfl | rfl | rfl | rfl
+  · exact addFaithfulWitness_memAlignRangeChannel_balanced
+  · exact addFaithfulWitness_memBus_balanced
+  · exact addFaithfulWitness_opBus_balanced
+  · exact addFaithfulWitness_memAlignRomChannel_balanced
+  · exact addFaithfulWitness_rangeChannel_balanced
+
+/-! ## The accepted trace -/
+
+/-- One executed ADD step (row 0), with the physically present, honestly faithful, row-1 ADD entry
+    as padding. This is the public non-vacuity witness for `root_soundness` (#320). -/
+def addFaithfulAcceptedTrace : AcceptedZiskTrace 1 where
+  programLength := 2
+  program := addFaithfulProgram
+  witness := addFaithfulWitness
+  constraints_hold := addFaithfulWitness_constraints
+  channels_balanced := addFaithfulWitness_balancedChannels
+  mem_replay_table := fun h => absurd h addFaithfulWitness_not_mutableMemPresent
+  mem_replay_source_covers := fun h => absurd h addFaithfulWitness_not_mutableMemPresent
+  transitions_hold := addFaithfulWitness_transitions
+  cyclic_successor_transitions_hold := addFaithfulWitness_cyclicSuccessorTransitions
+  main_height := addFaithfulWitness_main_height_prefix_one
+
+theorem addFaithfulAcceptedTrace_mainTable_eq :
+    addFaithfulAcceptedTrace.mainTable = addFaithfulMainTable :=
+  addFaithfulWitness_main_component_cases
+    (by simpa [addFaithfulAcceptedTrace] using addFaithfulAcceptedTrace.mainTable_mem)
+    (by simpa [addFaithfulAcceptedTrace] using addFaithfulAcceptedTrace.mainTable_component)
+
+end ZiskFv.Compliance.AddFaithfulPaddedWitness

--- a/ZiskFv/Compliance/MemoryRawRootSoundness.lean
+++ b/ZiskFv/Compliance/MemoryRawRootSoundness.lean
@@ -1,0 +1,120 @@
+import ZiskFv.Soundness
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingMemoryNonvacuity
+
+/-!
+# Memory raw-program root soundness (non-vacuity)
+
+A concrete instantiation of `ZiskFv.Compliance.root_soundness` (eth-act/zisk-fv#320) on
+the all-empty-execution MEMORY witness (`memoryAcceptedTrace` from
+`RawProgramBindingMemoryNonvacuity.lean`, `numInstructions = 0`, `programLength = 3`),
+using the already-proven `memoryProgramRowsBinding` as the real `programBinding` premise
+— not a placeholder. This strengthens `root_soundness_instantiation_degenerate`, which
+exercises the same empty-execution shape but with no binding evidence at all.
+
+The conclusion and every per-step premise are vacuous over `Fin 0`, as expected for an
+empty execution; the point of this probe is that `programBinding` is a genuine,
+production-faithful `ProgramRowsBinding` witness, not that the conclusion is
+non-vacuous (that is #219/#220's job for the per-op soundness lemmas).
+
+`memoryAcceptedTrace_not_mutableMemPresent` re-derives (from public API only) the fact
+that the memory witness in `RawProgramBindingMemoryNonvacuity.lean` carries no mutable-Mem
+rows. The original proof of this fact (`memoryWitness_not_mutableMemPresent`) is `private`
+to that file, so it is re-derived here from `memoryAcceptedTrace.witness`'s public
+definitional content rather than duplicated by widening that file's public surface.
+-/
+
+namespace ZiskFv.Compliance.MemoryRawRootSoundness
+
+open ZiskFv.Compliance
+open ZiskFv.Compliance.RawProgramBinding
+  (memoryAcceptedTrace memoryAddr memoryRawProgram memoryStart memoryProgram
+    memoryProgramRowsBinding)
+open ZiskFv.AirsClean.FullEnsemble (fullRv64imEnsemble)
+
+/-- `memoryAcceptedTrace.witness`'s definitional content, spelled out via the same
+    public `EnsembleWitness.ofRows` constructor `RawProgramBindingMemoryNonvacuity.lean`
+    used for its (private) `memoryWitness`. Provable by `rfl`: both sides reduce to the
+    identical `EnsembleWitness.ofRows` application (the two `by`-proofs are proof-irrelevant). -/
+private theorem memoryAcceptedTrace_witness_eq :
+    memoryAcceptedTrace.witness =
+      Air.Flat.EnsembleWitness.ofRows (fullRv64imEnsemble 3 memoryProgram).ensemble
+        (fun (_ : String) (_ : ℕ) => (#[] : Array (Vector FGL _)))
+        () (fun _ => [])
+        (by intro i row hrow; simp at hrow)
+        (by intro i columns _hcolumns; simp) :=
+  rfl
+
+/-- Every mutable-Mem-component table of the memory witness is empty: the verifier table
+    is ruled out by its empty MemBus interaction list, and every provider table is empty
+    by construction (`fun _ => []`). Mirrors `memoryWitness_mutable_tables_empty` in
+    `RawProgramBindingMemoryNonvacuity.lean`, re-derived here via
+    `memoryAcceptedTrace_witness_eq` instead of that file's private `memoryWitness`. -/
+private theorem memoryAcceptedTrace_mutable_tables_empty (table : Air.Flat.Table FGL)
+    (hmem : table ∈ memoryAcceptedTrace.witness.allTables)
+    (hcomp : table.component = ZiskFv.AirsClean.Mem.componentWithDualMemBus) :
+    table.table = [] := by
+  rw [memoryAcceptedTrace_witness_eq, Air.Flat.EnsembleWitness.allTables, List.mem_cons] at hmem
+  rcases hmem with hv | ht
+  · exfalso
+    have hcomp' : (fullRv64imEnsemble 3 memoryProgram).ensemble.verifierTable =
+        ZiskFv.AirsClean.Mem.componentWithDualMemBus := by
+      subst hv
+      exact hcomp
+    have hvnil :=
+      ZiskFv.AirsClean.FullEnsemble.verifierTable_interactionsWith_memBus_nil 3 memoryProgram
+    rw [hcomp', ZiskFv.AirsClean.Mem.componentWithDualMemBus_interactionsWith_memBus] at hvnil
+    exact absurd hvnil (by simp)
+  · simp only [Air.Flat.EnsembleWitness.ofRows_tables, List.mem_ofFn] at ht
+    obtain ⟨i, rfl⟩ := ht
+    simp [Air.Flat.EnsembleWitness.tableAt, Air.Flat.Table.table]
+    split <;> rfl
+
+/-- The memory witness carries no mutable-Mem replay evidence. -/
+private theorem memoryAcceptedTrace_not_mutableMemPresent :
+    ¬ MutableMemPresent memoryAcceptedTrace.witness := by
+  intro hpresent
+  obtain ⟨table, hmem, hcomp, hlen⟩ := hpresent
+  have htable := memoryAcceptedTrace_mutable_tables_empty table hmem hcomp
+  exact absurd hlen (by simp [htable])
+
+/-- The empty Sail trace over the empty execution. -/
+def memorySailTrace : SailTrace 0 := nofun
+
+/-- The empty per-step ZisK decode family over the empty execution. -/
+def memoryZiskStep : ∀ i : Fin 0, ZiskStep memoryAcceptedTrace i := nofun
+
+/-- The boot / cross-segment memory seed for the memory witness: empty boot memory, no
+    execution-order rows, and every per-index obligation either vacuous over `Fin 0`
+    (`boot`, `step`, `placement`) or discharged by `memoryAcceptedTrace_not_mutableMemPresent`
+    (`readSoundInputs`) / `List.range_zero` (`memPresent_of_executionRows_nonempty`).
+    Mirrors `addPaddedBootSeed` (`ZiskFv/Compliance/AddSpinRootSoundness.lean:404-422`). -/
+def memoryBootSeed :
+    BootSegmentMemorySeed memoryAcceptedTrace memorySailTrace memoryZiskStep where
+  memInit := {}
+  rowsOf := fun _ => []
+  boot := fun h => absurd h (Nat.not_lt_zero _)
+  step := fun _ h => absurd h (Nat.not_lt_zero _)
+  readSoundInputs := fun h => absurd h memoryAcceptedTrace_not_mutableMemPresent
+  memPresent_of_executionRows_nonempty := by
+    intro h_ne
+    exact absurd (by simp [AcceptedZiskTrace.numInstructions]) h_ne
+  placement := fun i => i.elim0
+
+/-- `root_soundness` instantiated on the memory witness with the real, already-proven
+    `memoryProgramRowsBinding` as `programBinding` — strengthening
+    `root_soundness_instantiation_degenerate`, which uses the same empty-execution shape
+    but no binding evidence. The `∀ i : Fin 0` conclusion is vacuous, as expected for an
+    all-empty execution; the substance is that `programBinding` is genuine. -/
+theorem memoryRawRootSoundness :
+    ∀ i : Fin 0,
+      StepSound memoryAcceptedTrace memorySailTrace i (memoryZiskStep i)
+        (rowDecode_of_programDecode memoryAcceptedTrace i
+          (programDecode_of_rawProgramDecode memoryAcceptedTrace i (memoryZiskStep i)
+            memoryStart memoryAddr memoryRawProgram memoryProgramRowsBinding i.elim0)) :=
+  root_soundness 0 3 memoryAcceptedTrace memorySailTrace memoryZiskStep
+    memoryStart memoryAddr memoryRawProgram memoryProgramRowsBinding
+    (fun i => i.elim0) (fun i => i.elim0) memoryBootSeed (fun i => i.elim0)
+
+#print axioms memoryRawRootSoundness
+
+end ZiskFv.Compliance.MemoryRawRootSoundness

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBinding.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBinding.lean
@@ -95,8 +95,11 @@ def serializeExtract (line : FGL) (e : zisk_core.aeneas_extract.ZiskInstExtract)
   flags := packFlags (romFlagBitsOfExtract e)                         -- rom.rs:264
 
 /-- Independently named ROM-row transcription used at the program-image boundary.
-    Keeping it separate from `serializeExtract` makes the fidelity equation an
-    explicit checked contract rather than an implicit definitional convention. -/
+    It is a separate definition from `serializeExtract` to give that boundary its own
+    stable handle; `romRowOf_eq_serializeExtract` proves the two agree definitionally
+    (`rfl`). That catches editing one transcription without the other, but it is a
+    consistency check between two hand-written transcriptions — not a check against the
+    Rust source. -/
 def romRowOf (line : FGL) (e : zisk_core.aeneas_extract.ZiskInstExtract) :
     ZiskRomMessage FGL where
   line := line

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingAddFaithfulNonvacuity.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingAddFaithfulNonvacuity.lean
@@ -1,0 +1,121 @@
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingNonvacuity
+import ZiskFv.Compliance.AddFaithfulPaddedWitness
+
+/-!
+# Raw-program binding for the faithful two-row ADD witness (#320 non-vacuity)
+
+Both committed ROM rows of `AddFaithfulPaddedWitness.addFaithfulAcceptedTrace` are the SAME
+faithful production lowering of `add x1,x1,x1` (`0x001080b3`): row 0 at line 0, row 1 at line 4.
+`romMessageOfRaw`'s only dependence on its `line` argument is the `.line` field itself
+(`romMessageOfRaw_line_eq`), so row 1's fact is derived from the already-proven row-0 fact
+(`RawProgramBindingNonvacuity.singleAddProgramBinding`) rather than re-run through the extraction
+pipeline. This gives a genuine `ProgramRowsBinding` witness with `rawLength = 2`, closing the
+non-vacuity gap for `ZiskFv.Compliance.root_soundness` (eth-act/zisk-fv#320).
+-/
+
+open Goldilocks
+
+namespace ZiskFv.Compliance.RawProgramBinding
+
+open ZiskFv.Compliance.AddFaithfulPaddedWitness
+open ZiskFv.Compliance.SingleAddWitness
+open Aeneas Aeneas.Std Result zisk_core
+
+/-- `romMessageOfRaw`'s only dependence on its `line` argument is the `.line` field itself: the
+    underlying Aeneas lowering/serialization pipeline runs entirely off `raw`, in both the
+    successful-lowering and default-zero branches. -/
+theorem romMessageOfRaw_line_eq (line line' : FGL) (raw : BitVec 32) :
+    romMessageOfRaw line raw = { romMessageOfRaw line' raw with line := line } := by
+  unfold romMessageOfRaw
+  cases aeneas_extract.extract_transpile_rv64im_raw (ZiskFv.Compliance.Decode.toU32 raw) <;> rfl
+
+/-- Row 0's committed ROM entry is the faithful ADD lowering, re-derived (not re-proved) from
+    `singleAddProgramBinding`. -/
+theorem addX1ProgramRow_eq_romMessageOfRaw :
+    RegisterMemBusBalance.addX1ProgramRow = romMessageOfRaw 0 0x001080b3 := by
+  have h := singleAddProgramBinding.2 (⟨0, by decide⟩ : Fin singleAddAcceptedTrace.programLength)
+  simpa [singleAddAcceptedTrace, RegisterMemBusBalance.addX1Program, singleAddAddr,
+    singleAddRawProgram] using h
+
+/-- Row 1's committed ROM entry is the SAME faithful ADD lowering, at line 4. -/
+theorem addFaithfulRow1ProgramRow_eq_romMessageOfRaw :
+    addFaithfulRow1ProgramRow = romMessageOfRaw 4 0x001080b3 := by
+  unfold addFaithfulRow1ProgramRow
+  rw [addX1ProgramRow_eq_romMessageOfRaw]
+  exact (romMessageOfRaw_line_eq 4 0 0x001080b3).symm
+
+/-- The faithful ADD word never expands to two physical rows (non-JALR): every use of
+    `romMessagesOfRaw` on it has no second row, at every committed line. -/
+theorem addFaithfulRomMessagesOfRaw_snd (line : FGL) :
+    (romMessagesOfRaw line (0x001080b3 : BitVec 32)).2 = none := by
+  have hraw : (Completeness.Rv64imShapes.rawRType 0 1 1 0 1 0x33 : BitVec 32) = 0x001080b3 := by
+    decide
+  obtain ⟨ext, hext, _⟩ := transpile_add 1 1 1 (by omega) (by omega) (by omega)
+    (by omega) (by omega) (by omega)
+  rw [hraw] at hext
+  have hnon : (ZiskFv.Compliance.Decode.toU32 (0x001080b3 : BitVec 32) &&& 127#u32) ≠ 103#u32 := by
+    decide
+  unfold romMessagesOfRaw
+  rw [aeneas_extract.extract_transpile_rv64im_rows_raw, hext]
+  simp only [lift, Bind.bind, bind_ok, hnon]
+  rfl
+
+theorem addFaithfulRomMessagesOfRaw_fst (line : FGL) :
+    (romMessagesOfRaw line (0x001080b3 : BitVec 32)).1 = romMessageOfRaw line 0x001080b3 := by
+  have hraw : (Completeness.Rv64imShapes.rawRType 0 1 1 0 1 0x33 : BitVec 32) = 0x001080b3 := by
+    decide
+  obtain ⟨ext, hext, _⟩ := transpile_add 1 1 1 (by omega) (by omega) (by omega)
+    (by omega) (by omega) (by omega)
+  rw [hraw] at hext
+  have hnon : (ZiskFv.Compliance.Decode.toU32 (0x001080b3 : BitVec 32) &&& 127#u32) ≠ 103#u32 := by
+    decide
+  exact romMessagesOfRaw_fst_of_non_jalr line 0x001080b3 ext hext hnon
+
+/-! ## The raw program layout: two architectural raw words, both `add x1,x1,x1` -/
+
+/-- Identity embedding of architectural raw-word indices into physical ROM rows: both raw words
+    have exactly one physical row each (ADD is non-JALR), at the SAME physical index. -/
+def addFaithfulStart : Fin 2 → Fin addFaithfulAcceptedTrace.programLength := id
+
+def addFaithfulAddr : Fin 2 → FGL
+  | ⟨0, _⟩ => 0
+  | ⟨1, _⟩ => 4
+
+def addFaithfulRawProgram : Fin 2 → BitVec 32 := fun _ => 0x001080b3
+
+theorem addFaithfulProgramRowsBinding :
+    ProgramRowsBinding addFaithfulAcceptedTrace addFaithfulStart addFaithfulAddr
+      addFaithfulRawProgram := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
+  · intro k k' h
+    fin_cases k <;> fin_cases k' <;> revert h <;> decide
+  · intro k
+    fin_cases k <;> decide
+  · intro k
+    fin_cases k <;> decide
+  · intro k k' h
+    fin_cases k <;> fin_cases k' <;>
+      simp only [addFaithfulAddr, addFaithfulRawProgram, addFaithfulRomMessagesOfRaw_snd] <;>
+      revert h <;> decide
+  · intro k
+    fin_cases k
+    · simp only [addFaithfulStart, id_eq, addFaithfulAddr, addFaithfulRawProgram]
+      refine ⟨?_, ?_⟩
+      · rw [addFaithfulRomMessagesOfRaw_fst]
+        exact addX1ProgramRow_eq_romMessageOfRaw
+      · rw [addFaithfulRomMessagesOfRaw_snd]
+        trivial
+    · simp only [addFaithfulStart, id_eq, addFaithfulAddr, addFaithfulRawProgram]
+      refine ⟨?_, ?_⟩
+      · rw [addFaithfulRomMessagesOfRaw_fst]
+        exact addFaithfulRow1ProgramRow_eq_romMessageOfRaw
+      · rw [addFaithfulRomMessagesOfRaw_snd]
+        trivial
+  · intro j
+    fin_cases j
+    · exact ⟨⟨0, by decide⟩, Or.inl rfl⟩
+    · exact ⟨⟨1, by decide⟩, Or.inl rfl⟩
+
+#print axioms addFaithfulProgramRowsBinding
+
+end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingJalrExpansionNonvacuity.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingJalrExpansionNonvacuity.lean
@@ -1,0 +1,360 @@
+import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingControl
+import ZiskFv.Compliance.AeneasBridgeTrust.Extraction.JalrRows
+import ZiskFv.Compliance.EnsembleWitnessBuilder
+import ZiskFv.AirsClean.FullEnsemble.Balance.Classification
+
+/-!
+# Raw JALR-expansion program binding non-vacuity
+
+Every `ProgramRowsBinding` witness built so far (`singleAddProgramRowsBinding`,
+`memoryProgramRowsBinding`, `addFaithfulProgramRowsBinding`) uses raw words whose
+production lowering is a single physical ROM row, so the `some row` EXPANSION
+branch of `ProgramRowsBinding` (`RawProgramBinding.lean:169-195`) has never been
+exercised by a concrete witness. This module builds one: an all-empty execution
+trace (`numInstructions = 0`, following the `RawProgramBindingMemoryNonvacuity`
+pattern) that still commits a real, faithful two-row JALR-expansion ROM image —
+the intermediate ADD row and terminal AND row the production extractor emits for
+an unaligned JALR (`rawIType imm rs1 0 rd 0x67` with `imm % 4 ≠ 0`, the same
+encoding family `RawProgramBindingJalr.lean`'s `jalr_raw_rows` handles).
+
+This deliberately does NOT reuse `ZiskFv.Compliance.JalrSpinWitness.jalrAcceptedTrace`:
+that witness's committed rows are hand-authored placeholders that do not match the
+real production lowering (issue #334). Here the committed rows are *defined* as
+`romRowOf` applied to the real extracted rows, so faithfulness holds by
+construction, not by a separate equality proof.
+
+Sound: NO native_decide / bv_decide / new axiom / `sorry`; kernel-only closure.
+-/
+
+open Aeneas Aeneas.Std Result zisk_core
+open Goldilocks
+open Air.Flat
+open ZiskFv.Compliance.Extraction
+  (defCtx decode_i_bounds decode_extract_ok from_inst_full_fields jalr_ok
+   jalr_production_expanded_row_pins)
+
+namespace ZiskFv.Compliance.RawProgramBinding
+
+open ZiskFv.AirsClean.FullEnsemble (fullRv64imEnsemble fullRv64imSoundEnsemble)
+open ZiskFv.AirsClean.ZiskInstructionRom (Program)
+open ZiskFv.Channels.ZiskRomBus (ZiskRomMessage)
+
+set_option maxHeartbeats 8000000
+set_option maxRecDepth 10000
+
+/-! ## The raw JALR word and its two-row production lowering. -/
+
+/-- `rd = 1`, `rs1 = 2` (both nonzero), `imm = 1` (not a multiple of 4, so the
+    production extractor cannot statically prove the target is 4-aligned and
+    always emits the unaligned two-row expansion — the intermediate ADD row
+    followed by the terminal AND row). -/
+def jalrExpansionRaw : BitVec 32 :=
+  ZiskFv.Completeness.Rv64imShapes.rawIType 1 2 0 1 0x67
+
+/-- The production extractor lowers `jalrExpansionRaw` to exactly two physical
+    ROM rows. This mirrors the "unaligned" branch of `RawProgramBindingJalr`'s
+    private `jalr_raw_rows`, specialized to a concrete word and stated only for
+    the row-count fact this module needs (not the full ADD/AND field pins). -/
+theorem jalrExpansionRaw_row_count :
+    ∃ rows : aeneas_extract.Rv64imTranspileRowsExtract,
+      aeneas_extract.extract_transpile_rv64im_rows_raw
+          (ZiskFv.Compliance.Decode.toU32 jalrExpansionRaw) = ok rows ∧
+      rows.row_count = 2#u32 := by
+  unfold jalrExpansionRaw
+  set raw := ZiskFv.Completeness.Rv64imShapes.rawIType 1 2 0 1 0x67 with hrawdef
+  have hdec : aeneas_extract.rv64im_decode.decode_32_core
+        (ZiskFv.Compliance.Decode.toU32 raw) =
+      aeneas_extract.rv64im_decode.decode_i
+        (ZiskFv.Compliance.Decode.toU32 raw)
+          aeneas_extract.rv64im_decode.RiscvOpcode.Jalr false := by
+    simp only [raw, aeneas_extract.rv64im_decode.decode_32_core, lift,
+      Bind.bind, bind_ok, ZiskFv.Compliance.Decode.toU32_and127,
+      ZiskFv.Compliance.Decode.toU32_ofNat,
+      ZiskFv.Compliance.Decode.rawIType_opcode 1 2 0 1 0x67 (by norm_num)]
+  obtain ⟨decoded, hdecoded, hopd, hrdb, hrs1b, _⟩ :=
+    decode_i_bounds (ZiskFv.Compliance.Decode.toU32 raw)
+      aeneas_extract.rv64im_decode.RiscvOpcode.Jalr false
+  have hdec0 : aeneas_extract.rv64im_decode.decode_32_core
+      (ZiskFv.Compliance.Decode.toU32 raw) = .ok decoded := hdec.trans hdecoded
+  let input : riscv2zisk_single_row.Rv64imLoweringInput :=
+    { rom_address := 0#u64, rd := decoded.rd, rs1 := decoded.rs1,
+      rs2 := decoded.rs2, imm := decoded.imm }
+  obtain ⟨ctx, hctx⟩ := jalr_ok { defCtx with extract_marker := () } input
+    (by simpa only [input] using hrs1b) (by simpa only [input] using hrdb) rfl
+  have hpins := jalr_production_expanded_row_pins input ctx
+    (by simpa only [input] using hrdb) (by simpa only [input] using hrs1b) hctx
+  obtain ⟨dext, hdext⟩ := decode_extract_ok decoded
+  have hdext' := hdext
+  unfold aeneas_extract.decode_extract_from_decoded at hdext'
+  obtain ⟨_, _, hdext'⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hdext'
+  obtain ⟨_, _, hdext'⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hdext'
+  obtain ⟨_, _, hdext'⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp hdext'
+  rw [Result.ok.injEq] at hdext'
+  have hdextimm : dext.imm = decoded.imm := by rw [← hdext']
+  have hdextrd : dext.rd = decoded.rd := by rw [← hdext']
+  have hdextrs1 : dext.rs1 = decoded.rs1 := by rw [← hdext']
+  have hdextrs2 : dext.rs2 = decoded.rs2 := by rw [← hdext']
+  have himm : input.imm.bv = BitVec.signExtend 32 (BitVec.ofNat 12 1) :=
+    decode_i_rawIType_imm 1 2 0 1 0x67 (by norm_num) (by norm_num)
+      (by norm_num) (by norm_num) aeneas_extract.rv64im_decode.RiscvOpcode.Jalr decoded
+        (by simpa only [raw] using hdecoded)
+  have hlower :
+      riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+          defCtx input riscv2zisk_single_row.Rv64imSingleRowOpcode.Jalr false =
+        .ok { ctx with extract_marker := () } := by
+    change (do
+      let s ← riscv2zisk_context.Riscv2ZiskContext.jalr
+        { defCtx with extract_marker := () } input 4#u64
+      .ok { s with extract_marker := () }) = _
+    rw [hctx]
+    rfl
+  rcases hpins with haligned | hunaligned
+  · exfalso
+    obtain ⟨hrem0, _, _⟩ := haligned
+    have himmEq : input.imm = (1#i32 : Std.I32) := by
+      apply IScalar.eq_of_val_eq
+      show input.imm.bv.toInt = (1#i32 : Std.I32).val
+      rw [himm]
+      decide
+    rw [himmEq] at hrem0
+    have hrem1 : (1#i32 : Std.I32) % 4#i32 = ok 1#i32 := rfl
+    rw [hrem1] at hrem0
+    simp at hrem0
+  · obtain ⟨rem, hrem, hrem0, first, last, hfirst, hlast, hfirstPins, hlastPins⟩ := hunaligned
+    obtain ⟨lastRow, hfrom, haSrc, haHi, haLo, hbSrc, hbHi, hbLo, hwidth,
+      hop, hstore, hstoreOffset, hj1, hj2, hsetpc, hstorepc, hieo, hm32⟩ :=
+      from_inst_full_fields last.i
+    let terminal : aeneas_extract.Rv64imTranspileExtract :=
+      { accepted := true, decode := dext, row := lastRow }
+    have hterminal :
+        aeneas_extract.extract_transpile_rv64im_raw
+            (ZiskFv.Compliance.Decode.toU32 raw) = .ok terminal := by
+      rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
+      simp only [bind_ok, Bind.bind, hdext, hopd]
+      change (do
+        let input' ← riscv2zisk_single_row.Rv64imLoweringInput.new 0#u64
+          decoded.rd decoded.rs1 decoded.rs2 decoded.imm
+        let ctx' ←
+          riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+            defCtx input' riscv2zisk_single_row.Rv64imSingleRowOpcode.Jalr false
+        let zib ← core.option.Option.unwrap ctx'.extract_inst
+        let row ← aeneas_extract.ZiskInstExtract.from_inst zib.i
+        .ok ({ accepted := true, decode := dext, row := row } :
+          aeneas_extract.Rv64imTranspileExtract)) = _
+      simp only [riscv2zisk_single_row.Rv64imLoweringInput.new]
+      change (do
+        let ctx' ←
+          riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
+            defCtx input riscv2zisk_single_row.Rv64imSingleRowOpcode.Jalr false
+        let zib ← core.option.Option.unwrap ctx'.extract_inst
+        let row ← aeneas_extract.ZiskInstExtract.from_inst zib.i
+        .ok ({ accepted := true, decode := dext, row := row } :
+          aeneas_extract.Rv64imTranspileExtract)) = _
+      rw [hlower]
+      simp only [Bind.bind]
+      simp only [hlast, core.option.Option.unwrap, Result.ofOption, bind_ok]
+      rw [hfrom]
+      rfl
+    let rows : aeneas_extract.Rv64imTranspileRowsExtract :=
+      { accepted := true, decode := dext, row_count := 2#u32,
+        first_row := first, last_row := lastRow }
+    refine ⟨rows, ?_, rfl⟩
+    unfold aeneas_extract.extract_transpile_rv64im_rows_raw
+    rw [hterminal]
+    simp only [ZiskFv.Compliance.Decode.toU32_and127]
+    have hremval : rem.val ≠ 0 := by
+      intro hz
+      apply hrem0
+      apply IScalar.eq_of_val_eq
+      simpa using hz
+    have hinputNew :
+        riscv2zisk_single_row.Rv64imLoweringInput.new 0#u64 decoded.rd
+            decoded.rs1 decoded.rs2 decoded.imm = .ok input := rfl
+    have hremDecoded :
+        (decoded.imm % 4#i32 : Result Std.I32) = Result.ok rem := by
+      simpa only [input] using hrem
+    norm_num [terminal, raw, hdextrd, hdextrs1, hdextrs2, hdextimm, hrem,
+      hremDecoded, hremval, lift, Bind.bind, hinputNew, hlower, hfirst, rows,
+      core.option.Option.unwrap, Result.ofOption]
+    rw [if_pos (by decide)]
+    simp only [defCtx] at hlower
+    rw [hlower]
+    simp [hfirst]
+
+/-- The chosen production two-row extraction witness for `jalrExpansionRaw`. -/
+noncomputable def jalrExpansionRows : aeneas_extract.Rv64imTranspileRowsExtract :=
+  jalrExpansionRaw_row_count.choose
+
+theorem jalrExpansionRows_spec :
+    aeneas_extract.extract_transpile_rv64im_rows_raw
+        (ZiskFv.Compliance.Decode.toU32 jalrExpansionRaw) = ok jalrExpansionRows ∧
+    jalrExpansionRows.row_count = 2#u32 :=
+  jalrExpansionRaw_row_count.choose_spec
+
+/-! ## The committed two-row ROM image: the JALR expansion at consecutive lines. -/
+
+/-- Line `0`: 4-aligned, and `0 + 1 < GL_prime`, as required by
+    `ProgramRowsBinding`. -/
+def jalrExpansionLine : FGL := 0
+
+/-- Row 0 is *defined* as `romRowOf` applied to the production extractor's real
+    first (ADD) row — faithful by construction, not by a separate equality
+    lemma. -/
+noncomputable def jalrExpansionRow0 : ZiskRomMessage FGL :=
+  romRowOf jalrExpansionLine jalrExpansionRows.first_row
+
+/-- Row 1 (line `L + 1`, immediately after row 0) is *defined* as `romRowOf`
+    applied to the production extractor's real terminal (AND) row. -/
+noncomputable def jalrExpansionRow1 : ZiskRomMessage FGL :=
+  romRowOf (jalrExpansionLine + 1) jalrExpansionRows.last_row
+
+noncomputable def jalrExpansionProgram : Program 2
+  | ⟨0, _⟩ => jalrExpansionRow0
+  | ⟨1, _⟩ => jalrExpansionRow1
+
+/-- `romMessagesOfRaw` at `jalrExpansionLine` on `jalrExpansionRaw` returns
+    exactly the two committed rows, since the production extractor's row count
+    is `2#u32` (`jalrExpansionRows_spec`). -/
+theorem jalrExpansionRows_messages :
+    romMessagesOfRaw jalrExpansionLine jalrExpansionRaw =
+      (jalrExpansionRow0, some jalrExpansionRow1) := by
+  obtain ⟨hextract, hcount⟩ := jalrExpansionRows_spec
+  simp [romMessagesOfRaw, hextract, hcount, jalrExpansionRow0, jalrExpansionRow1]
+
+private def jalrExpansionEmptyData : ProverData FGL := fun _ _ => #[]
+
+private noncomputable def jalrExpansionWitness :
+    EnsembleWitness (fullRv64imEnsemble 2 jalrExpansionProgram).ensemble :=
+  EnsembleWitness.ofRows (fullRv64imEnsemble 2 jalrExpansionProgram).ensemble
+    jalrExpansionEmptyData () (fun _ => [])
+    (by intro i row hrow; simp at hrow)
+    (by intro i columns hcolumns; simp)
+
+private theorem jalrExpansionWitness_verifier :
+    (fullRv64imEnsemble 2 jalrExpansionProgram).ensemble.verifier = .empty FGL unit :=
+  (fullRv64imSoundEnsemble 2 jalrExpansionProgram).verifier_empty
+
+private theorem jalrExpansionWitness_mutable_tables_empty (table : Table FGL)
+    (hmem : table ∈ jalrExpansionWitness.allTables)
+    (hcomp : table.component = ZiskFv.AirsClean.Mem.componentWithDualMemBus) :
+    table.table = [] := by
+  rw [EnsembleWitness.allTables, List.mem_cons] at hmem
+  rcases hmem with hv | ht
+  · exfalso
+    rw [hv, EnsembleWitness.verifierTable_component] at hcomp
+    have hvnil :=
+      ZiskFv.AirsClean.FullEnsemble.verifierTable_interactionsWith_memBus_nil 2
+        jalrExpansionProgram
+    rw [hcomp,
+      ZiskFv.AirsClean.Mem.componentWithDualMemBus_interactionsWith_memBus] at hvnil
+    exact absurd hvnil (by simp)
+  · simp only [jalrExpansionWitness, EnsembleWitness.ofRows_tables, List.mem_ofFn] at ht
+    obtain ⟨i, rfl⟩ := ht
+    simp [EnsembleWitness.tableAt, Table.table]
+    split <;> rfl
+
+private theorem jalrExpansionWitness_not_mutableMemPresent :
+    ¬ MutableMemPresent jalrExpansionWitness := by
+  intro hpresent
+  obtain ⟨table, hmem, hcomp, hlen⟩ := hpresent
+  have htable := jalrExpansionWitness_mutable_tables_empty table hmem hcomp
+  exact absurd hlen (by simp [htable])
+
+private theorem jalrExpansionWitness_constraints : jalrExpansionWitness.Constraints := by
+  refine jalrExpansionWitness.constraints_of_tables jalrExpansionWitness_verifier ?_
+  intro t ht
+  simp only [jalrExpansionWitness, EnsembleWitness.ofRows_tables, List.mem_ofFn] at ht
+  obtain ⟨i, rfl⟩ := ht
+  simp [Air.Flat.Table.Constraints, EnsembleWitness.tableAt, Table.table]
+  split <;> simp
+
+private theorem jalrExpansionWitness_balanced : jalrExpansionWitness.BalancedChannels := by
+  refine jalrExpansionWitness.balancedChannels_of_tables jalrExpansionWitness_verifier ?_
+  intro channel _
+  have hnil : jalrExpansionWitness.tables.flatMap (·.interactionsWith channel) = [] := by
+    rw [List.flatMap_eq_nil_iff]
+    intro t ht
+    simp only [jalrExpansionWitness, EnsembleWitness.ofRows_tables, List.mem_ofFn] at ht
+    obtain ⟨i, rfl⟩ := ht
+    simp [Air.Flat.Table.interactionsWith, EnsembleWitness.tableAt, Table.table]
+    split <;> simp
+  rw [hnil]
+  exact balancedInteractions_of_present (Or.symm (Nat.eq_zero_or_pos _)) []
+    (by simp) (by simp)
+
+private theorem jalrExpansionWitness_transitions : jalrExpansionWitness.TransitionConstraints := by
+  intro table hmem
+  rw [Table.TransitionConstraints]
+  intro index
+  rw [EnsembleWitness.allTables, List.mem_cons] at hmem
+  rcases hmem with hverifier | htable
+  · subst table
+    simp [EnsembleWitness.verifierTable]
+  · simp only [jalrExpansionWitness, EnsembleWitness.ofRows_tables, List.mem_ofFn] at htable
+    obtain ⟨i, rfl⟩ := htable
+    change Fin 0 at index
+    exact Fin.elim0 index
+
+private theorem jalrExpansionWitness_cyclic :
+    jalrExpansionWitness.CyclicSuccessorTransitionConstraints := by
+  intro table hmem
+  rw [Table.CyclicSuccessorTransitionConstraints]
+  intro index
+  rw [EnsembleWitness.allTables, List.mem_cons] at hmem
+  rcases hmem with hverifier | htable
+  · subst table
+    simp [EnsembleWitness.verifierTable]
+  · simp only [jalrExpansionWitness, EnsembleWitness.ofRows_tables, List.mem_ofFn] at htable
+    obtain ⟨i, rfl⟩ := htable
+    change Fin 0 at index
+    exact Fin.elim0 index
+
+noncomputable def jalrExpansionAcceptedTrace : AcceptedZiskTrace 0 where
+  programLength := 2
+  program := jalrExpansionProgram
+  witness := jalrExpansionWitness
+  constraints_hold := jalrExpansionWitness_constraints
+  channels_balanced := jalrExpansionWitness_balanced
+  mem_replay_table := fun h => absurd h jalrExpansionWitness_not_mutableMemPresent
+  mem_replay_source_covers := fun h => absurd h jalrExpansionWitness_not_mutableMemPresent
+  transitions_hold := jalrExpansionWitness_transitions
+  cyclic_successor_transitions_hold := jalrExpansionWitness_cyclic
+  main_height := by intro table _ _ i; exact i.elim0
+
+/-! ## The `ProgramRowsBinding` witness, exercising the expansion branch. -/
+
+def jalrExpansionAddr : Fin 1 → FGL := fun _ => jalrExpansionLine
+
+def jalrExpansionRawProgram : Fin 1 → BitVec 32 := fun _ => jalrExpansionRaw
+
+/-- The sole raw word's first physical row is the ROM image's row `0`. -/
+def jalrExpansionStart : Fin 1 → Fin jalrExpansionAcceptedTrace.programLength :=
+  fun _ => ⟨0, by decide⟩
+
+theorem jalrExpansionProgramRowsBinding :
+    ProgramRowsBinding jalrExpansionAcceptedTrace jalrExpansionStart jalrExpansionAddr
+      jalrExpansionRawProgram := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
+  · intro k k' h
+    fin_cases k <;> fin_cases k' <;> revert h <;> decide
+  · intro k
+    fin_cases k <;> decide
+  · intro k
+    fin_cases k <;> decide
+  · intro k k' h
+    fin_cases k <;> fin_cases k' <;> exact absurd h (by decide)
+  · intro k
+    fin_cases k
+    simp only [jalrExpansionStart, jalrExpansionAddr, jalrExpansionRawProgram]
+    rw [jalrExpansionRows_messages]
+    exact ⟨rfl, by decide, rfl⟩
+  · intro j
+    fin_cases j
+    · exact ⟨⟨0, by decide⟩, Or.inl rfl⟩
+    · refine ⟨⟨0, by decide⟩, Or.inr ⟨jalrExpansionRow1, ?_, rfl⟩⟩
+      simp only [jalrExpansionAddr, jalrExpansionRawProgram]
+      rw [jalrExpansionRows_messages]
+
+#print axioms jalrExpansionProgramRowsBinding
+
+end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingMemoryNonvacuity.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingMemoryNonvacuity.lean
@@ -702,4 +702,101 @@ theorem memoryProgramBinding :
 
 #print axioms memoryProgramBinding
 
+/-- Identity embedding of architectural raw-word indices into physical ROM
+    rows: the 3-row memory witness has exactly one physical row per raw word
+    (SD and the two LDs are all non-JALR, so no expansion row is ever
+    produced). -/
+def memoryStart :
+    Fin memoryAcceptedTrace.programLength → Fin memoryAcceptedTrace.programLength :=
+  id
+
+/-- A committed ROM row known to differ from the all-zero default (via its
+    `flags`) must have come from the successful branch of `romMessageOfRaw`,
+    exposing the underlying `extract_transpile_rv64im_raw` witness. Avoids
+    re-deriving the full decode/lower/serialize chain a second time. -/
+private theorem memoryRomMessage_ext_of_ne_default {line : FGL} {raw : BitVec 32}
+    {msg : ZiskRomMessage FGL} (heq : msg = romMessageOfRaw line raw)
+    (hflags : msg.flags ≠ 0) :
+    ∃ ext : aeneas_extract.Rv64imTranspileExtract,
+      aeneas_extract.extract_transpile_rv64im_raw
+        (ZiskFv.Compliance.Decode.toU32 raw) = ok ext := by
+  unfold romMessageOfRaw at heq
+  split at heq
+  · rename_i ext hext
+    exact ⟨ext, hext⟩
+  · exact absurd (congrArg ZiskRomMessage.flags heq) (by simpa using hflags)
+
+theorem memoryProgramRowsBinding :
+    ProgramRowsBinding memoryAcceptedTrace memoryStart memoryAddr memoryRawProgram := by
+  have hnonSd : (ZiskFv.Compliance.Decode.toU32
+      (ZiskFv.Completeness.Rv64imShapes.rawSType 0 2 1 3) &&& 127#u32) ≠ 103#u32 := by decide
+  have hnonLdZero : (ZiskFv.Compliance.Decode.toU32
+      (ZiskFv.Completeness.Rv64imShapes.rawIType 0 1 3 3 0x03) &&& 127#u32) ≠ 103#u32 := by
+    decide
+  have hnonLdNeg : (ZiskFv.Compliance.Decode.toU32
+      (ZiskFv.Completeness.Rv64imShapes.rawIType 4088 1 3 4 0x03) &&& 127#u32) ≠ 103#u32 := by
+    decide
+  obtain ⟨extSd, hextSd⟩ := memoryRomMessage_ext_of_ne_default
+    memorySdRow_eq_romMessageOfRaw (by decide)
+  obtain ⟨extLdZero, hextLdZero⟩ := memoryRomMessage_ext_of_ne_default
+    memoryLdZeroRow_eq_romMessageOfRaw (by decide)
+  obtain ⟨extLdNeg, hextLdNeg⟩ := memoryRomMessage_ext_of_ne_default
+    memoryLdNegativeRow_eq_romMessageOfRaw (by decide)
+  have hsndSd : (romMessagesOfRaw (0 : FGL)
+      (ZiskFv.Completeness.Rv64imShapes.rawSType 0 2 1 3)).2 = none := by
+    unfold romMessagesOfRaw
+    rw [aeneas_extract.extract_transpile_rv64im_rows_raw, hextSd]
+    simp only [lift, Bind.bind, bind_ok, hnonSd]
+    rfl
+  have hsndLdZero : (romMessagesOfRaw (4 : FGL)
+      (ZiskFv.Completeness.Rv64imShapes.rawIType 0 1 3 3 0x03)).2 = none := by
+    unfold romMessagesOfRaw
+    rw [aeneas_extract.extract_transpile_rv64im_rows_raw, hextLdZero]
+    simp only [lift, Bind.bind, bind_ok, hnonLdZero]
+    rfl
+  have hsndLdNeg : (romMessagesOfRaw (8 : FGL)
+      (ZiskFv.Completeness.Rv64imShapes.rawIType 4088 1 3 4 0x03)).2 = none := by
+    unfold romMessagesOfRaw
+    rw [aeneas_extract.extract_transpile_rv64im_rows_raw, hextLdNeg]
+    simp only [lift, Bind.bind, bind_ok, hnonLdNeg]
+    rfl
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
+  · intro k k' h
+    fin_cases k <;> fin_cases k' <;> revert h <;> decide
+  · intro k
+    fin_cases k <;> decide
+  · intro k
+    fin_cases k <;> decide
+  · intro k k' h
+    fin_cases k <;> fin_cases k' <;>
+      simp only [memoryAddr, memoryRawProgram, hsndSd, hsndLdZero, hsndLdNeg] <;>
+      revert h <;> decide
+  · intro k
+    fin_cases k
+    · simp only [memoryStart, id_eq, memoryAddr, memoryRawProgram]
+      refine ⟨?_, ?_⟩
+      · rw [romMessagesOfRaw_fst_of_non_jalr _ _ extSd hextSd hnonSd]
+        exact memorySdRow_eq_romMessageOfRaw
+      · rw [hsndSd]
+        trivial
+    · simp only [memoryStart, id_eq, memoryAddr, memoryRawProgram]
+      refine ⟨?_, ?_⟩
+      · rw [romMessagesOfRaw_fst_of_non_jalr _ _ extLdZero hextLdZero hnonLdZero]
+        exact memoryLdZeroRow_eq_romMessageOfRaw
+      · rw [hsndLdZero]
+        trivial
+    · simp only [memoryStart, id_eq, memoryAddr, memoryRawProgram]
+      refine ⟨?_, ?_⟩
+      · rw [romMessagesOfRaw_fst_of_non_jalr _ _ extLdNeg hextLdNeg hnonLdNeg]
+        exact memoryLdNegativeRow_eq_romMessageOfRaw
+      · rw [hsndLdNeg]
+        trivial
+  · intro j
+    fin_cases j
+    · exact ⟨⟨0, by decide⟩, Or.inl rfl⟩
+    · exact ⟨⟨1, by decide⟩, Or.inl rfl⟩
+    · exact ⟨⟨2, by decide⟩, Or.inl rfl⟩
+
+#print axioms memoryProgramRowsBinding
+
 end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingNonvacuity.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingNonvacuity.lean
@@ -225,4 +225,54 @@ theorem singleAddProgramBinding :
 
 #print axioms singleAddProgramBinding
 
+/-- Identity embedding of architectural raw-word indices into physical ROM
+    rows: the single-ADD witness has one raw word and one physical row. -/
+def singleAddStart :
+    Fin singleAddAcceptedTrace.programLength → Fin singleAddAcceptedTrace.programLength :=
+  id
+
+theorem singleAddProgramRowsBinding :
+    ProgramRowsBinding singleAddAcceptedTrace singleAddStart singleAddAddr
+      singleAddRawProgram := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
+  · intro k k' h
+    fin_cases k
+    fin_cases k'
+    simp at h
+  · intro k
+    fin_cases k
+    decide
+  · intro k
+    fin_cases k
+    decide
+  · intro k k' h
+    fin_cases k
+    fin_cases k'
+    simp at h
+  · intro k
+    fin_cases k
+    simp only [singleAddStart, id_eq, singleAddAddr, singleAddRawProgram]
+    obtain ⟨ext, hext, hstatic⟩ := transpile_add 1 1 1 (by omega) (by omega) (by omega)
+      (by omega) (by omega) (by omega)
+    have hraw : (Completeness.Rv64imShapes.rawRType 0 1 1 0 1 0x33 : BitVec 32)
+        = 0x001080b3 := by decide
+    rw [hraw] at hext
+    have hnon : (ZiskFv.Compliance.Decode.toU32 (0x001080b3 : BitVec 32) &&& 127#u32)
+        ≠ 103#u32 := by decide
+    have hsnd : (romMessagesOfRaw (0 : FGL) (0x001080b3 : BitVec 32)).2 = none := by
+      unfold romMessagesOfRaw
+      rw [aeneas_extract.extract_transpile_rv64im_rows_raw, hext]
+      simp only [lift, Bind.bind, bind_ok, hnon]
+      rfl
+    refine ⟨?_, ?_⟩
+    · rw [romMessagesOfRaw_fst_of_non_jalr _ _ ext hext hnon]
+      exact singleAddProgramBinding.2 _
+    · rw [hsnd]
+      trivial
+  · intro j
+    fin_cases j
+    exact ⟨⟨0, Nat.zero_lt_one⟩, Or.inl rfl⟩
+
+#print axioms singleAddProgramRowsBinding
+
 end ZiskFv.Compliance.RawProgramBinding

--- a/trust/consistency/root_soundness_instantiation_addfaithful_raw.lean
+++ b/trust/consistency/root_soundness_instantiation_addfaithful_raw.lean
@@ -1,0 +1,3 @@
+import ZiskFv.Compliance.AddFaithfulPaddedRootSoundness
+
+#print axioms ZiskFv.Compliance.AddFaithfulPaddedRootSoundness.addFaithfulPaddedRawRootSoundness

--- a/trust/consistency/root_soundness_instantiation_memory_raw.lean
+++ b/trust/consistency/root_soundness_instantiation_memory_raw.lean
@@ -1,0 +1,3 @@
+import ZiskFv.Compliance.MemoryRawRootSoundness
+
+#print axioms ZiskFv.Compliance.MemoryRawRootSoundness.memoryRawRootSoundness


### PR DESCRIPTION
## Summary

Closes the #320 non-vacuity gap at the raw-program `root_soundness` entrypoint. Phase 9 (#313–#318) gave `root_soundness` two premises — `programBinding : ProgramRowsBinding …` and `rawProgramDecodes : ∀ i, RawProgramDecode …` — that **no witness in the tree satisfied**. An `A → B` theorem compiles and passes every gate whether or not `A` is inhabited, so the endpoint could have been vacuously true with nothing detecting it. This PR constructs the missing witnesses, all with **0 new axioms** and no `sorry`/`native_decide`/other trust markers.

## What's here (each verified: `lake build` green, `#print axioms` clean)

**Step 1 — `ProgramRowsBinding` is inhabited** (`RawProgramBindingNonvacuity.lean`, `RawProgramBindingMemoryNonvacuity.lean`)
- `singleAddProgramRowsBinding` (1-row) and `memoryProgramRowsBinding` (3-row), both against committed rows *proven equal* to the real production lowering (`romMessageOfRaw`).

**Step 2 — the two-row `some row` expansion branch** (`RawProgramBindingJalrExpansionNonvacuity.lean`)
- `jalrExpansionProgramRowsBinding`: the first witness to exercise `ProgramRowsBinding`'s expansion arm (`RawProgramBinding.lean:185-195`). An all-empty-execution accepted trace committing a **real** production two-row JALR lowering (`rawIType 1 2 0 1 0x67`, `imm % 4 ≠ 0` forces the unaligned two-row branch) at consecutive lines; both rows are defined as `romRowOf` of the actual extracted `first_row`/`last_row`. Does **not** reuse the placeholder `JalrSpinWitness` (see #334).

**Step 3 — a non-vacuous `root_soundness` instantiation** (`AddFaithfulPaddedWitness.lean`, `RawProgramBindingAddFaithfulNonvacuity.lean`, `AddFaithfulPaddedRootSoundness.lean`)
- `addFaithfulPaddedRawRootSoundness := root_soundness 1 2 …`: the first instantiation with a **real executed step** (`numInstructions = 1`, `i : Fin 1`) lifted through `programDecode_of_rawProgramDecode` via an honest `RawProgramDecode_add` + `ProgramRowsBinding`. Built on a purpose-made accepted 2-row trace (one executed `ADD x1,x1,x1` at pc0, a faithful `ADD` successor row at pc4 — both proven `= romMessageOfRaw 0x001080b3`), so `RawProgramDecode_add.h_idx` (`0+1 < 2`) is satisfiable. Trace acceptance is genuine (`channels_balanced` proven).
- `MemoryRawRootSoundness.lean` — `memoryRawRootSoundness`: `root_soundness` on the memory trace (empty execution) with the real `memoryProgramRowsBinding`, strengthening `root_soundness_instantiation_degenerate`.

Two `trust/consistency/root_soundness_instantiation_*` probes register the new instantiations with the V2 gate.

**Fold-in:** the `romRowOf_eq_serializeExtract` docstring is corrected — the equation holds definitionally (`rfl`), a consistency check between two transcriptions, not a check against the Rust source (it previously overclaimed).

## Related

Filed #334 during this work: most spin-trace witnesses hand-author committed ROM rows with a placeholder `ind_width := 8` that isn't the production lowering — benign for the decode-level proofs, but why the existing JALR trace can't serve here. Out of scope for this PR.

## Test plan
- [x] `lake build` green (full graph, ~9150 jobs)
- [x] `trust/scripts/check-all.sh` — V1 19/19 (module reachability incl. both new probes, shrinkage floor 0 axioms, etc.)
- [x] `trust/scripts/check-all-semantic.sh` — V2 ALL CHECKS PASSED
- [x] `#print axioms` of both new `root_soundness` instantiations is **byte-identical** to `#print axioms root_soundness` (0 new axioms, no `sorryAx`); the binding witnesses close over `propext`/`Classical.choice`/`Quot.sound` only
- [x] grep for `sorry`/`admit`/`axiom`/`opaque`/`native_decide`/`@[extern]`/`@[implemented_by]` across all new files: zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
