### PR TITLE
Freeze the public endpoints in-build; fix three drifted doc claims

### DIFF
--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -224,6 +224,10 @@ import ZiskFv.Completeness.Aspirational
 import ZiskFv.Completeness.Rv64im.SailDecode
 import ZiskFv.Completeness.Rv64im.SailDecode.ZiskClassifyMatch
 import ZiskFv.Completeness
+-- The audit surface: re-states nothing, but freezes the statement and the axiom
+-- closure of each public endpoint as `#guard_msgs` golden tests, so drift in what
+-- is claimed or trusted breaks `lake build` rather than a separate gate run.
+import ZiskFv.Audit
 -- Checked defect reproductions. Imported so `lake build` actually compiles them:
 -- a regression that is not in the build graph is a regression that never runs, and
 -- `trust/defects.md` cites this one as evidence for

--- a/ZiskFv/Audit.lean
+++ b/ZiskFv/Audit.lean
@@ -1,0 +1,214 @@
+import ZiskFv.Soundness
+import ZiskFv.Completeness
+
+/-!
+# `ZiskFv.Audit` — the audit surface
+
+One file an auditor can open to read off, without chasing into any other module:
+
+1. the soundness endpoint and the completeness endpoints, with their full types;
+2. the exact axiom closure of each — the machine-checked trust ledger;
+3. both of the above frozen as golden tests, so that a stray `sorry`, a newly
+   introduced trusted premise, or a silent change to what is *claimed* breaks
+   `lake build` rather than passing review unnoticed.
+
+This file re-states nothing new: it only `#check`s and `#print axioms` theorems
+proven elsewhere and pins their output. Updating a snapshot below is a deliberate
+change to the public audit surface and must be explained in the PR that does it.
+
+## Relation to the trust gate
+
+`trust/scripts/check-strong-export-{binders,closure}.sh` already freeze
+`root_soundness`' binder list and its `ZiskFv.*` project-axiom closure. This file
+is not a replacement for them; it adds three things they do not cover:
+
+* it fires during `lake build`, not in a separate olean-consuming script run;
+* it pins the *full* closure (Lean kernel axioms and the Sail-translated
+  primitives included), not only the `ZiskFv.*` entries;
+* it covers the completeness endpoints, which have no script gate at all.
+
+## Narrative boundary
+
+* `trust/trusted-base.md` — the narrative trust boundary: extraction
+  assumptions, the conditional Aeneas and memory-seed inputs, and the current
+  ledgers under `trust/generated/`.
+* `trust/defects.md` — the enumerated known defects excluded from the soundness
+  scope (`RowOutsideDefectRegion`) and the completeness decode gap
+  (`knownDecodeGap`).
+
+## The endpoints
+
+* `ZiskFv.Compliance.root_soundness` (`ZiskFv/Soundness.lean`) — the advertised
+  soundness endpoint. Every state transition of an `AcceptedZiskTrace` that
+  avoids the enumerated defects agrees with the Sail RV64IM model.
+  `ZiskFv.Compliance.zisk_riscv_compliant_program_bus` is the *internal* per-arm
+  channel-balance lemma it consumes, not the endpoint.
+* `ZiskFv.Completeness.sail_executable_within_supported_decode_shape` — the one
+  unconditional completeness fact in this build: every Sail-executable RV64IM
+  raw word lands in the hand-written `SupportedDecodeShape` enumeration. It
+  asserts nothing about ZisK.
+* `ZiskFv.Completeness.skeletal_root_completeness` — the end-to-end acceptance
+  statement, honestly conditional on the five ZisK obligation predicates until
+  the Aeneas bridge lands.
+
+## Trusted extraction (outside the Lean axiom ledger)
+
+* Sail-to-Lean extraction for the official `riscv/sail-riscv` semantics.
+* ZisK RV64IM circuit-to-Lean extraction from the flake-pinned ZisK/PIL inputs.
+-/
+
+/-! ## Statement snapshots (frozen)
+
+A change here means the *claim* changed; update a snapshot only in the PR that
+deliberately changes what an endpoint states. -/
+
+open ZiskFv.Compliance in
+/--
+info: root_soundness : ∀ (numInstructions rawLength : ℕ) (ziskTrace : AcceptedZiskTrace numInstructions)
+  (sailTrace : SailTrace numInstructions) (ziskStep : (i : Fin numInstructions) → ZiskStep ziskTrace i)
+  (start : Fin rawLength → Fin ziskTrace.programLength) (addr : Fin rawLength → Fin 18446744069414584321)
+  (rawProgram : Fin rawLength → BitVec 32)
+  (programBinding : RawProgramBinding.ProgramRowsBinding ziskTrace start addr rawProgram)
+  (rawProgramDecodes : (i : Fin numInstructions) → RawProgramDecode ziskTrace i (ziskStep i) start addr rawProgram)
+  (inputsAgree : (i : Fin numInstructions) → InputsAgree ziskTrace sailTrace i (ziskStep i))
+  (bootSeed : BootSegmentMemorySeed ziskTrace sailTrace ziskStep),
+  (∀ (i : Fin numInstructions), RowOutsideDefectRegion ziskTrace i (ziskStep i)) →
+    ∀ (i : Fin numInstructions),
+      StepSound ziskTrace sailTrace i (ziskStep i)
+        (rowDecode_of_programDecode ziskTrace i
+          (programDecode_of_rawProgramDecode ziskTrace i (ziskStep i) start addr rawProgram programBinding
+            (rawProgramDecodes i)))
+-/
+#guard_msgs (whitespace := lax) in
+#check @root_soundness
+
+open ZiskFv.Completeness in
+/--
+info: sail_executable_within_supported_decode_shape : ∀ (state : SailDecode.SailState) (raw : SailDecode.RawInstruction),
+  SailDecode.IsaExtensionsEnabled state →
+    SailDecode.SailRv64imExecutableRawIn state raw → Rv64imShapes.SupportedDecodeShape raw
+-/
+#guard_msgs (whitespace := lax) in
+#check @sail_executable_within_supported_decode_shape
+
+open ZiskFv.Completeness in
+/--
+info: skeletal_root_completeness : ∀ (state : SailDecode.SailState),
+  SailDecode.IsaExtensionsEnabled state →
+    ∀ (z : OutstandingZiskPredicates),
+      z.decoderAcceptsInShape →
+        z.loweringTotal → z.rowTotal → z.opcodeTotal → z.soundnessContract → EventualCompleteness state z
+-/
+#guard_msgs (whitespace := lax) in
+#check @skeletal_root_completeness
+
+/-! ## Axiom-closure snapshots (frozen)
+
+Each `#print axioms` is pinned. A stray `sorry` (which would add `sorryAx`) or a
+newly introduced trusted premise anywhere below an endpoint changes this output
+and breaks the build. The `riscv_*` / reservation / `plat_term_write` /
+`get_16_random_bits` entries are the trusted Sail-extraction primitives; the
+remaining `propext` / `Classical.choice` / `Quot.sound` / `Lean.ofReduceBool` /
+`Lean.trustCompiler` entries are the standard permitted Lean axioms. -/
+
+/--
+info: 'ZiskFv.Compliance.root_soundness' depends on axioms: [cancel_reservation,
+ get_16_random_bits,
+ load_reservation,
+ match_reservation,
+ plat_term_write,
+ propext,
+ riscv_f16Add,
+ riscv_f16Div,
+ riscv_f16Eq,
+ riscv_f16Le,
+ riscv_f16Le_quiet,
+ riscv_f16Lt,
+ riscv_f16Lt_quiet,
+ riscv_f16Mul,
+ riscv_f16MulAdd,
+ riscv_f16Sqrt,
+ riscv_f16Sub,
+ riscv_f16ToF32,
+ riscv_f16ToF64,
+ riscv_f16ToI32,
+ riscv_f16ToI64,
+ riscv_f16ToUi32,
+ riscv_f16ToUi64,
+ riscv_f16roundToInt,
+ riscv_f32Add,
+ riscv_f32Div,
+ riscv_f32Eq,
+ riscv_f32Le,
+ riscv_f32Le_quiet,
+ riscv_f32Lt,
+ riscv_f32Lt_quiet,
+ riscv_f32Mul,
+ riscv_f32MulAdd,
+ riscv_f32Sqrt,
+ riscv_f32Sub,
+ riscv_f32ToBF16,
+ riscv_f32ToF16,
+ riscv_f32ToF64,
+ riscv_f32ToI32,
+ riscv_f32ToI64,
+ riscv_f32ToUi32,
+ riscv_f32ToUi64,
+ riscv_f32roundToInt,
+ riscv_f64Add,
+ riscv_f64Div,
+ riscv_f64Eq,
+ riscv_f64Le,
+ riscv_f64Le_quiet,
+ riscv_f64Lt,
+ riscv_f64Lt_quiet,
+ riscv_f64Mul,
+ riscv_f64MulAdd,
+ riscv_f64Sqrt,
+ riscv_f64Sub,
+ riscv_f64ToF16,
+ riscv_f64ToF32,
+ riscv_f64ToI32,
+ riscv_f64ToI64,
+ riscv_f64ToUi32,
+ riscv_f64ToUi64,
+ riscv_f64roundToInt,
+ riscv_i32ToF16,
+ riscv_i32ToF32,
+ riscv_i32ToF64,
+ riscv_i64ToF16,
+ riscv_i64ToF32,
+ riscv_i64ToF64,
+ riscv_ui32ToF16,
+ riscv_ui32ToF32,
+ riscv_ui32ToF64,
+ riscv_ui64ToF16,
+ riscv_ui64ToF32,
+ riscv_ui64ToF64,
+ Classical.choice,
+ Lean.ofReduceBool,
+ Lean.trustCompiler,
+ Quot.sound]
+-/
+#guard_msgs (whitespace := lax) in
+#print axioms ZiskFv.Compliance.root_soundness
+
+/--
+info: 'ZiskFv.Completeness.sail_executable_within_supported_decode_shape' depends on axioms: [propext,
+ Classical.choice,
+ Lean.ofReduceBool,
+ Lean.trustCompiler,
+ Quot.sound]
+-/
+#guard_msgs (whitespace := lax) in
+#print axioms ZiskFv.Completeness.sail_executable_within_supported_decode_shape
+
+/--
+info: 'ZiskFv.Completeness.skeletal_root_completeness' depends on axioms: [propext,
+ Classical.choice,
+ Lean.ofReduceBool,
+ Lean.trustCompiler,
+ Quot.sound]
+-/
+#guard_msgs (whitespace := lax) in
+#print axioms ZiskFv.Completeness.skeletal_root_completeness

--- a/ZiskFv/Audit.lean
+++ b/ZiskFv/Audit.lean
@@ -107,9 +107,17 @@ info: skeletal_root_completeness : ∀ (state : SailDecode.SailState),
 Each `#print axioms` is pinned. A stray `sorry` (which would add `sorryAx`) or a
 newly introduced trusted premise anywhere below an endpoint changes this output
 and breaks the build. The `riscv_*` / reservation / `plat_term_write` /
-`get_16_random_bits` entries are the trusted Sail-extraction primitives; the
-remaining `propext` / `Classical.choice` / `Quot.sound` / `Lean.ofReduceBool` /
-`Lean.trustCompiler` entries are the standard permitted Lean axioms. -/
+`get_16_random_bits` entries are the trusted Sail-extraction primitives, and
+`propext` / `Classical.choice` / `Quot.sound` are the standard Lean axioms.
+
+`Lean.ofReduceBool` / `Lean.trustCompiler` are neither: they are the
+compiler-evaluation axioms emitted by `native_decide`, which
+`trust/scripts/check-generated-axiom-allowlist.sh` rejects in the generated
+ledgers and which issue #75 tracks for elimination. Their presence records the
+existing `native_decide` surface; it is not a permitted baseline. Note the
+corresponding blind spot: because they are already listed, a *newly* introduced
+`native_decide` under an endpoint leaves these snapshots byte-identical, so this
+file does not gate that particular trust expansion. -/
 
 /--
 info: 'ZiskFv.Compliance.root_soundness' depends on axioms: [cancel_reservation,

--- a/ZiskFv/Compliance/README.md
+++ b/ZiskFv/Compliance/README.md
@@ -13,9 +13,9 @@ plus the per-arm `OpEnvelope` glue that the global theorem in
   the channel-balance form. `ZiskFv/Equivalence/<Op>.lean` is a thin
   re-export *above* this wrapper, not an input to it — the dependency
   runs `EquivCore → Wrappers → Equivalence`. The wrapper's parameter
-  surface is the *minimal* caller-burden remaining after discharge; that
-  surface is drift-guarded by
-  `trust/generated/baseline-wrapper-caller-burden.txt`.
+  surface is the *minimal* caller-burden remaining after discharge; there
+  is no generated ledger pinning it today, so a new caller-supplied
+  hypothesis is caught only by review.
 
 The global theorem `zisk_riscv_compliant_program_bus` lives in
 `ZiskFv/Compliance.lean` (the file at the level above this folder).

--- a/ZiskFv/Compliance/README.md
+++ b/ZiskFv/Compliance/README.md
@@ -1,21 +1,35 @@
 # `ZiskFv/Compliance/`
 
 The trust-ledger discharge layer for each of the 63 RV64IM opcodes,
-plus the per-arm `OpEnvelope` dispatch glue that the global theorem
-in `ZiskFv/Compliance.lean` (one level up) case-splits on.
+plus the per-arm `OpEnvelope` glue that the global theorem in
+`ZiskFv/Compliance.lean` (one level up) proves.
 
 - **`Wrappers/<Op>.lean`** — 63 wrappers (one per opcode). Each
-  takes the canonical `equiv_<OP>` theorem (in `ZiskFv/Equivalence/`)
-  and discharges its **promise hypotheses** using explicit route facts,
+  imports the **core** `equiv_<OP>` theorem from
+  `ZiskFv/EquivCore/<Op>.lean` (the `execute = bus_effect` form) and
+  discharges its **promise hypotheses** using explicit route facts,
   row/provider evidence, the remaining non-row-shape trust ledger entries,
-  and pure-Lean derivations. The wrapper's parameter surface is the
-  *minimal* caller-burden remaining after discharge; that surface
-  is drift-guarded by `trust/generated/baseline-wrapper-caller-burden.txt`.
+  and pure-Lean derivations, producing `ZiskFv.Compliance.equiv_<OP>` in
+  the channel-balance form. `ZiskFv/Equivalence/<Op>.lean` is a thin
+  re-export *above* this wrapper, not an input to it — the dependency
+  runs `EquivCore → Wrappers → Equivalence`. The wrapper's parameter
+  surface is the *minimal* caller-burden remaining after discharge; that
+  surface is drift-guarded by
+  `trust/generated/baseline-wrapper-caller-burden.txt`.
 
-The uber theorem `zisk_riscv_compliant_program_bus` lives in
-`ZiskFv/Compliance.lean` (the file at the level above this folder)
-and uses an `OpEnvelope` sum type (63 arms, one per RV64IM opcode)
-to dispatch each opcode to its `Wrappers/<Op>` wrapper.
+The global theorem `zisk_riscv_compliant_program_bus` lives in
+`ZiskFv/Compliance.lean` (the file at the level above this folder).
+`OpEnvelope` is an inductive with one arm per opcode, but its `exec_eq`
+conclusion is *not* a case-returning dispatch: it is a conjunction of the
+ten per-family `exec_eq_<family>` statements, of which exactly one fires
+with a real channel-balance statement for any given arm while the rest
+are `True`. The ten `Compliance/Dispatch/<family>.lean` files each prove
+their family's conjunct.
+
+`zisk_riscv_compliant_program_bus` is an **internal** per-arm
+channel-balance lemma, not the advertised endpoint; the public soundness
+endpoint is `ZiskFv.Compliance.root_soundness` in `ZiskFv/Soundness.lean`,
+which consumes it.
 
 To audit a single opcode's trust closure, read
 `Compliance/Wrappers/<Op>.lean` together with the canonical

--- a/ZiskFv/EquivCore/README.md
+++ b/ZiskFv/EquivCore/README.md
@@ -1,8 +1,9 @@
-# `ZiskFv/Equivalence/`
+# `ZiskFv/EquivCore/`
 
-Per-opcode canonical equivalence theorems. The 63 top-level files
-(`Add.lean`, `Addi.lean`, …, `Xori.lean`, one per RV64IM opcode)
-each contain the **canonical** `equiv_<OP>` theorem:
+Per-opcode **core** equivalence theorems — the bottom of the per-opcode
+tower. The 63 top-level files (`Add.lean`, `Addi.lean`, …, `Xori.lean`,
+one per RV64IM opcode) each contain the `equiv_<OP>` theorem in its
+`execute = bus_effect` form:
 
 ```lean
 equiv_<OP> :
@@ -24,16 +25,24 @@ by deriving their cross-entry rd-value byte equations from circuit
 witnesses in `ZiskCircuit/LoadDerivation.lean` and
 `ZiskCircuit/SextLoadBridge.lean`).
 
-Each canonical theorem is wrapped by a `ZiskFv.Compliance.equiv_<OP>`
+Each core theorem is consumed by a `ZiskFv.Compliance.equiv_<OP>`
 theorem in `ZiskFv/Compliance/Wrappers/<Op>.lean`, which discharges
 the promise hypotheses from the trust ledger; the global theorem
-chains those wrappers via `OpEnvelope`.
+chains those wrappers via `OpEnvelope`. `ZiskFv/Equivalence/<Op>.lean`
+sits *above* the wrapper as a thin re-export, so the dependency runs
+bottom-up:
+
+```text
+EquivCore/<Op>  →  Compliance/Wrappers/<Op>  →  Equivalence/<Op>
+```
 
 ## Subdirectories
 
 - **`Bridge/`** — cross-AIR equivalence machinery shared across many
   opcodes: arith, binary, binary-add, binary-extension, mem,
   control-flow, sail-state-bridge, state-bridge.
+- **`Promises/`** — the per-family promise bundles the core theorems
+  take as hypotheses, plus their helper lemmas.
 - **`WriteValueProofs/`** — shared rd-value derivations factored
   across opcode families that share a derivation pattern: arith,
   binary-compare, binary-logic, binary-shift, jump+utype, mul/div/rem

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -19,10 +19,12 @@ ZiskFv.Compliance.root_soundness
 
 `ZiskFv.Compliance.zisk_riscv_compliant_program_bus` is the **internal**
 per-arm channel-balance lemma that `root_soundness` consumes; it is audited
-alongside the endpoint but is not the claim. Both statements, and their axiom
-closure, together with the completeness endpoints, are additionally frozen
-*in-build* by `ZiskFv/Audit.lean` — the script gates below need oleans and a
-separate run, the golden tests there fail during `lake build` itself.
+alongside the endpoint but is not the claim. The statement and full axiom
+closure of `root_soundness`, and of the two completeness endpoints, are
+additionally frozen *in-build* by `ZiskFv/Audit.lean`: the script gates below
+need oleans and a separate run, whereas those golden tests fail during
+`lake build` itself. `zisk_riscv_compliant_program_bus` is not pinned there —
+it is covered by the script gates only.
 
 Current generated counts:
 

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -11,23 +11,32 @@ The intended soundness claim is:
 > extraction are trusted, every state transition accepted by the modeled ZisK
 > RV64IM circuits is a valid RISC-V state transition.
 
-The global Lean theorem is:
+The advertised Lean endpoint is:
 
 ```text
-ZiskFv.Compliance.zisk_riscv_compliant_program_bus
+ZiskFv.Compliance.root_soundness
 ```
+
+`ZiskFv.Compliance.zisk_riscv_compliant_program_bus` is the **internal**
+per-arm channel-balance lemma that `root_soundness` consumes; it is audited
+alongside the endpoint but is not the claim. Both statements, and their axiom
+closure, together with the completeness endpoints, are additionally frozen
+*in-build* by `ZiskFv/Audit.lean` — the script gates below need oleans and a
+separate run, the golden tests there fail during `lake build` itself.
 
 Current generated counts:
 
-| Surface                                                                | Count | Ledger                                                                                       |
-| ---                                                                    | ---:  | ---                                                                                          |
-| Source Lean trust declarations                                         | 0     | [`generated/baseline-axioms.txt`](generated/baseline-axioms.txt)                             |
-| Transitive project-axiom closure of `zisk_riscv_compliant_program_bus` | 0     | [`generated/baseline-zisk-riscv-compliant.txt`](generated/baseline-zisk-riscv-compliant.txt) |
+| Surface                                                                | Count | Ledger                                                                                             |
+| ---                                                                    | ---:  | ---                                                                                                |
+| Source Lean trust declarations                                         | 0     | [`generated/baseline-axioms.txt`](generated/baseline-axioms.txt)                                   |
+| Transitive project-axiom closure of `root_soundness`                   | 0     | [`generated/baseline-strong-export-closure.txt`](generated/baseline-strong-export-closure.txt)     |
+| Transitive project-axiom closure of `zisk_riscv_compliant_program_bus` | 0     | [`generated/baseline-zisk-riscv-compliant.txt`](generated/baseline-zisk-riscv-compliant.txt)       |
 
-The source trust ledger currently contains no project axioms. The global theorem
-also has no transitive project-axiom closure. The former Aeneas row-lowering and
-memory-state load bridge axioms are now visible conditional inputs:
-`env.aeneasBridgeTrust` and `env.memoryTimelineEvidence` on the global theorem.
+The source trust ledger currently contains no project axioms. Neither the
+endpoint nor the internal global theorem has a transitive project-axiom closure.
+The former Aeneas row-lowering and memory-state load bridge axioms are now
+visible conditional inputs: `env.aeneasBridgeTrust` and
+`env.memoryTimelineEvidence` on the internal global theorem.
 
 The extraction assumptions are part of the project premise but outside the
 Lean axiom ledger:


### PR DESCRIPTION
## What

Salvage of [#257](https://github.com/eth-act/zisk-fv/pull/257) (closed — stranded on the abandoned `refactor-plan-docs` → `aristotle-portability` stack), rebased onto `main` and scoped down to the two pieces that stand on their own.

### `ZiskFv/Audit.lean` (new, imported from `ZiskFv.lean`)

Re-states nothing. It `#check`s and `#print axioms` the three public endpoints — `root_soundness`, `sail_executable_within_supported_decode_shape`, `skeletal_root_completeness` — and freezes both outputs as `#guard_msgs` golden tests. A stray `sorry` (which would add `sorryAx`), a newly introduced trusted premise, or a silent change to what is *claimed* now breaks `lake build`.

This deliberately overlaps with, and does **not** replace, `check-strong-export-{binders,closure}.sh`, which already freeze `root_soundness`' binder list and its `ZiskFv.*` closure. It adds three things those do not cover:

- it fires during `lake build`, not in a separate olean-consuming script run;
- it pins the **full** closure — the Sail-translated primitives and Lean kernel axioms included — not only the `ZiskFv.*` entries;
- it covers the **completeness** endpoints, which have no script gate today.

The snapshots are generated against this tip, not carried over from #257 (whose `root_soundness` snapshot predates the raw-program binders from #313–#318/#335).

### Doc drift

All three defects verified still present on `main`:

- **`ZiskFv/EquivCore/README.md`** was titled `` `ZiskFv/Equivalence/` `` and described the wrong directory with the dependency direction inverted. Checked against imports (`Wrappers/Add.lean` imports `EquivCore.Add`; `Equivalence/Add.lean` imports `Compliance.Wrappers.Add`), it runs `EquivCore → Compliance/Wrappers → Equivalence`. Also adds the missing `Promises/` subdirectory.
- **`ZiskFv/Compliance/README.md`** called `OpEnvelope.exec_eq` a "sum type … to dispatch" that the global theorem "case-splits on". It is a conjunction of the ten per-family `exec_eq_<family>` conjuncts, exactly one of which fires per arm — as `ZiskFv/Compliance.lean:21-23,79-93` already documents correctly. Also records that `zisk_riscv_compliant_program_bus` is internal and `root_soundness` is the endpoint.
- **`trust/trusted-base.md`** § Claim still advertised `zisk_riscv_compliant_program_bus` as *the* global theorem. Now names `root_soundness` as the endpoint, labels the other internal, and adds the existing `baseline-strong-export-closure.txt` row to the counts table.

## Not included

`skeletal_root_completeness → root_completeness` and the `ZiskCompletenessObligations` bundling from #257. Proof-identical rename plus binder repackaging across ~12 files, with no proof content. Better done when the Aeneas bridge actually makes the theorem unconditional.

## Trust boundary

Unchanged. No theorem statement, proof, or premise was touched; no `axiom`/`opaque`/`sorry`/`native_decide` added. The counts in `trusted-base.md` are the existing generated ledgers, re-pointed — not new claims.

## Verification

- full `lake build` ✓ (9152 jobs; the one `unusedSimpArgs` warning in `DivSpinRootSoundness/ProgramDecodes.lean` is pre-existing on `main`)
- `trust/scripts/check-all.sh` — 19/19 ✓
- `trust/scripts/check-all-semantic.sh` — 19/19 ✓

Note that CI on `main` was red for an unrelated reason until just now: the `zisk` submodule gitlink `9ca88b5b` (bumped in #316) was never pushed to `codygunton/zisk`, so `actions/checkout` failed on every job of every push since #318. Fixed by pushing the missing commits; unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
