### PR TITLE
#342: walk the register telescope — cycles excluded on an accepted trace

### DIFF
--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -193,6 +193,7 @@ import ZiskFv.Compliance
 import ZiskFv.Compliance.EnsembleWitnessBuilder
 import ZiskFv.Compliance.RegisterMemBusBalance
 import ZiskFv.Compliance.Instantiation.ConcreteRowReductions
+import ZiskFv.Compliance.RegisterWalk
 import ZiskFv.Compliance.SingleAddWitness
 import ZiskFv.Compliance.AddSpinWitness
 import ZiskFv.Compliance.AddSpinRootSoundness

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean
@@ -3455,4 +3455,224 @@ theorem selfMemProvider_registerPre_timestamp_of_mem_op_three
       (not_activeMainSelfCMemProviderRowMatchSpec_of_main_mem_op_three
         h_constraints h_mainEval h_main_mem_op)
 
+/-! ### The provider's own slot is active
+
+`selfMemProvider_registerPre_timestamp_of_mem_op_three` identifies *which* message supplied the
+read, but the bus-102 descent is only guaranteed for a slot whose selector is `1` -- an inactive
+slot pulls at multiplicity `0` and carries no range fact. The selector is recoverable: a register-pre
+push rides at multiplicity `<slot>_reg`, `exists_push_of_pull` hands back a counterpart with
+`mult ≠ 0`, and Main's own constraints make that selector boolean. -/
+
+private lemma main_rowInput_a_src_reg_eval
+    (env : Environment FGL) (row : Var ZiskFv.AirsClean.Main.MainRowWithRom FGL) :
+    Expression.eval env row.rom.a_src_reg = (eval env row).rom.a_src_reg := by
+  simp only [ProvableStruct.eval_eq_eval, ProvableStruct.eval,
+    ProvableStruct.fromComponents, ProvableStruct.components,
+    ProvableStruct.toComponents, ProvableStruct.eval.go,
+    ProvableType.eval_field, Expression.eval]
+
+private lemma main_rowInput_b_src_reg_eval
+    (env : Environment FGL) (row : Var ZiskFv.AirsClean.Main.MainRowWithRom FGL) :
+    Expression.eval env row.rom.b_src_reg = (eval env row).rom.b_src_reg := by
+  simp only [ProvableStruct.eval_eq_eval, ProvableStruct.eval,
+    ProvableStruct.fromComponents, ProvableStruct.components,
+    ProvableStruct.toComponents, ProvableStruct.eval.go,
+    ProvableType.eval_field, Expression.eval]
+
+private lemma main_rowInput_store_reg_eval
+    (env : Environment FGL) (row : Var ZiskFv.AirsClean.Main.MainRowWithRom FGL) :
+    Expression.eval env row.rom.store_reg = (eval env row).rom.store_reg := by
+  simp only [ProvableStruct.eval_eq_eval, ProvableStruct.eval,
+    ProvableStruct.fromComponents, ProvableStruct.components,
+    ProvableStruct.toComponents, ProvableStruct.eval.go,
+    ProvableType.eval_field, Expression.eval]
+
+/-- A boolean column is `0` or `1`. -/
+private lemma zero_or_one_of_booleanity {col : FGL} (h : col * (1 - col) = 0) :
+    col = 0 ∨ col = 1 := by
+  obtain ⟨d, hd⟩ := bool_of_booleanity h
+  cases d
+  · exact Or.inl (by simpa [ZiskFv.AirsClean.boolF] using hd)
+  · exact Or.inr (by simpa [ZiskFv.AirsClean.boolF] using hd)
+
+/-- The a-side register-pre push rides at multiplicity `a_src_reg`. -/
+private lemma main_a_reg_pre_eval_mult
+    (env : Environment FGL) (row : Var ZiskFv.AirsClean.Main.MainRowWithRom FGL) :
+    (((MemBusChannel.emitted row.rom.a_src_reg
+      (ZiskFv.AirsClean.Main.aRegPreMessageExpr row)).toRaw).eval env).mult
+      = (eval env row).rom.a_src_reg := by
+  change env row.rom.a_src_reg = (eval env row).rom.a_src_reg
+  exact main_rowInput_a_src_reg_eval env row
+
+/-- The b-side register-pre push rides at multiplicity `b_src_reg`. -/
+private lemma main_b_reg_pre_eval_mult
+    (env : Environment FGL) (row : Var ZiskFv.AirsClean.Main.MainRowWithRom FGL) :
+    (((MemBusChannel.emitted row.rom.b_src_reg
+      (ZiskFv.AirsClean.Main.bRegPreMessageExpr row)).toRaw).eval env).mult
+      = (eval env row).rom.b_src_reg := by
+  change env row.rom.b_src_reg = (eval env row).rom.b_src_reg
+  exact main_rowInput_b_src_reg_eval env row
+
+/-- The store-side register-pre push rides at multiplicity `store_reg`. -/
+private lemma main_c_reg_pre_eval_mult
+    (env : Environment FGL) (row : Var ZiskFv.AirsClean.Main.MainRowWithRom FGL) :
+    (((MemBusChannel.emitted row.rom.store_reg
+      (ZiskFv.AirsClean.Main.cRegPreMessageExpr row)).toRaw).eval env).mult
+      = (eval env row).rom.store_reg := by
+  change env row.rom.store_reg = (eval env row).rom.store_reg
+  exact main_rowInput_store_reg_eval env row
+
+/-- Main's three register selectors are boolean at any row satisfying the component's constraints. -/
+private lemma main_reg_selectors_boolean
+    {length : ℕ} {program : Program length}
+    {table : Table FGL} {row : Array FGL}
+    (h_component :
+      table.component = ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program)
+    (h_constraints : table.Constraints)
+    (h_row : row ∈ table.table) :
+    (eval (table.environment row)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program).rowInputVar).rom.a_src_reg
+        * (1 - (eval (table.environment row)
+          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar).rom.a_src_reg) = 0
+      ∧ (eval (table.environment row)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          length program).rowInputVar).rom.b_src_reg
+        * (1 - (eval (table.environment row)
+          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar).rom.b_src_reg) = 0
+      ∧ (eval (table.environment row)
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          length program).rowInputVar).rom.store_reg
+        * (1 - (eval (table.environment row)
+          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar).rom.store_reg) = 0 := by
+  have h_holds :
+      (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program).operations.ConstraintsHold
+        (table.environment row) := by
+    have := h_constraints row h_row
+    rwa [h_component] at this
+  obtain ⟨-, -, -, -, -, -, -, -, -, -, -, h_a, h_b, h_c⟩ :=
+    ZiskFv.AirsClean.Main.romBoolSpec_of_componentWithRomMemAndOpBus_constraints
+      length program (table.environment row) h_holds
+  refine ⟨?_, ?_, ?_⟩
+  · simpa [Expression.eval, sub_eq_add_neg, main_rowInput_a_src_reg_eval] using h_a
+  · simpa [Expression.eval, sub_eq_add_neg, main_rowInput_b_src_reg_eval] using h_b
+  · simpa [Expression.eval, sub_eq_add_neg, main_rowInput_store_reg_eval] using h_c
+
+/-- **The supply step, with the provider's slot proved active.**
+
+Strengthens `selfMemProvider_registerPre_timestamp_of_mem_op_three`: besides naming which
+register-pre push supplied the read, it establishes that push's selector is `1`. That is the
+premise `rangeTable24_spec_<slot>RegStepDistance_of_active` needs, so the caller can compose the
+bus-102 descent on the provider row without assuming anything about it.
+
+The selector comes from the counterpart's multiplicity. A register-pre push rides at
+`+<slot>_reg`, `exists_push_of_pull` returns it with `mult ≠ 0`, and Main's constraints make the
+selector boolean -- so it is `1`. -/
+theorem selfMemProvider_registerPre_active_of_mem_op_three
+    {length : ℕ} {program : Program length}
+    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
+    {mainTable : Table FGL}
+    {mainRow : Array FGL}
+    {mainInteraction : Interaction FGL}
+    {mainMult : Expression FGL}
+    {mainMsg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)}
+    {multiplicity as : FGL}
+    (h_mainEval :
+      mainInteraction =
+        ((MemBusChannel.emitted mainMult mainMsg).toRaw).eval
+          (mainTable.environment mainRow))
+    (h_main_mem_op :
+      (eval (mainTable.environment mainRow) mainMsg).mem_op = 3)
+    (h_constraints : witness.Constraints)
+    (h_self : ActiveMainSelfMemProviderRowMatchSpec program witness mainTable
+      mainRow mainInteraction mainMsg multiplicity as) :
+    ∃ providerTable ∈ witness.allTables, ∃ providerRow ∈ providerTable.table,
+      providerTable.component =
+          ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program
+        ∧ (((eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+                length program).rowInputVar).rom.a_src_reg = 1
+            ∧ (eval (providerTable.environment providerRow)
+                (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+                  length program).rowInputVar).rom.a_reg_prev_mem_step
+              = (eval (mainTable.environment mainRow) mainMsg).timestamp)
+          ∨ ((eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+                length program).rowInputVar).rom.b_src_reg = 1
+            ∧ (eval (providerTable.environment providerRow)
+                (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+                  length program).rowInputVar).rom.b_reg_prev_mem_step
+              = (eval (mainTable.environment mainRow) mainMsg).timestamp)
+          ∨ ((eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+                length program).rowInputVar).rom.store_reg = 1
+            ∧ (eval (providerTable.environment providerRow)
+                (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+                  length program).rowInputVar).rom.store_reg_prev_mem_step
+              = (eval (mainTable.environment mainRow) mainMsg).timestamp)) := by
+  obtain ⟨providerInteraction, h_provider_witness, h_msg, h_nonpull, h_nonzero,
+    providerTable, h_providerTable, h_providerInteraction,
+    providerRow, h_providerRow, h_providerSpec, h_providerComponent, h_match⟩ := h_self
+  obtain ⟨h_bool_a, h_bool_b, h_bool_c⟩ :=
+    main_reg_selectors_boolean h_providerComponent
+      (h_constraints providerTable h_providerTable) h_providerRow
+  refine ⟨providerTable, h_providerTable, providerRow, h_providerRow, h_providerComponent, ?_⟩
+  rcases h_match with h_a_reg | h_a_mem | h_b_reg | h_b_mem | h_c_reg | h_c_mem
+  · refine Or.inl ⟨?_, ?_⟩
+    · have h_mult : providerInteraction.mult
+          = (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+                length program).rowInputVar).rom.a_src_reg := by
+        rw [h_a_reg.1]
+        exact main_a_reg_pre_eval_mult _ _
+      rcases zero_or_one_of_booleanity h_bool_a with h | h
+      · exact absurd (h_mult.trans h) h_nonzero
+      · exact h
+    · have h_ts := (memBusMessage_timestamp_eq_of_entry_match h_a_reg.2).symm
+      rwa [ZiskFv.AirsClean.Main.eval_aRegPreMessageExpr,
+        ZiskFv.AirsClean.Main.aRegPreMessage] at h_ts
+  · exact absurd ⟨providerInteraction, h_provider_witness, h_msg, h_nonpull, h_nonzero,
+      providerTable, h_providerTable, h_providerInteraction,
+      providerRow, h_providerRow, h_providerSpec, h_providerComponent, h_a_mem⟩
+      (not_activeMainSelfAMemProviderRowMatchSpec_of_main_mem_op_three
+        h_constraints h_mainEval h_main_mem_op)
+  · refine Or.inr (Or.inl ⟨?_, ?_⟩)
+    · have h_mult : providerInteraction.mult
+          = (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+                length program).rowInputVar).rom.b_src_reg := by
+        rw [h_b_reg.1]
+        exact main_b_reg_pre_eval_mult _ _
+      rcases zero_or_one_of_booleanity h_bool_b with h | h
+      · exact absurd (h_mult.trans h) h_nonzero
+      · exact h
+    · have h_ts := (memBusMessage_timestamp_eq_of_entry_match h_b_reg.2).symm
+      rwa [ZiskFv.AirsClean.Main.eval_bRegPreMessageExpr,
+        ZiskFv.AirsClean.Main.bRegPreMessage] at h_ts
+  · exact absurd ⟨providerInteraction, h_provider_witness, h_msg, h_nonpull, h_nonzero,
+      providerTable, h_providerTable, h_providerInteraction,
+      providerRow, h_providerRow, h_providerSpec, h_providerComponent, h_b_mem⟩
+      (not_activeMainSelfBMemProviderRowMatchSpec_of_main_mem_op_three
+        h_constraints h_mainEval h_main_mem_op)
+  · refine Or.inr (Or.inr ⟨?_, ?_⟩)
+    · have h_mult : providerInteraction.mult
+          = (eval (providerTable.environment providerRow)
+              (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+                length program).rowInputVar).rom.store_reg := by
+        rw [h_c_reg.1]
+        exact main_c_reg_pre_eval_mult _ _
+      rcases zero_or_one_of_booleanity h_bool_c with h | h
+      · exact absurd (h_mult.trans h) h_nonzero
+      · exact h
+    · have h_ts := (memBusMessage_timestamp_eq_of_entry_match h_c_reg.2).symm
+      rwa [ZiskFv.AirsClean.Main.eval_cRegPreMessageExpr,
+        ZiskFv.AirsClean.Main.cRegPreMessage] at h_ts
+  · exact absurd ⟨providerInteraction, h_provider_witness, h_msg, h_nonpull, h_nonzero,
+      providerTable, h_providerTable, h_providerInteraction,
+      providerRow, h_providerRow, h_providerSpec, h_providerComponent, h_c_mem⟩
+      (not_activeMainSelfCMemProviderRowMatchSpec_of_main_mem_op_three
+        h_constraints h_mainEval h_main_mem_op)
+
 end ZiskFv.AirsClean.FullEnsemble

--- a/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
+++ b/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
@@ -2105,4 +2105,92 @@ theorem registerRead_timestamp_lt_provider_access
   refine ZiskFv.AirsClean.FullEnsemble.prev_val_lt_of_registerStepSpec ?_ h_bound
   simpa [aRegStepDistance, h_prev] using h_descent
 
+/-! ## The register walk, on concrete rows
+
+`registerChain_nodup_of_descent` is the order-theoretic half: it assumes a chain relation on an
+abstract list. What follows states the chain relation on *real Main rows* -- `r₂` supplies `r₁`'s
+a-side register read exactly when `r₂`'s `a_reg_prev_mem_step` is `r₁`'s read timestamp -- and
+derives the strict increase from the bus-102 descent rather than assuming it.
+-/
+
+/-- The a-side read timestamp of a Main row: `a_mem_step = 1 + main_step * 4`. -/
+def aReadTimestamp (row : MainRowWithRom FGL) : FGL :=
+  1 + row.rom.main_step * 4
+
+/-- `provider` supplies `consumer`'s a-side register read: the provider row's register-pre push
+carries the consumer's read timestamp, which is what
+`selfMemProvider_registerPre_timestamp_of_mem_op_three` concludes from balance. -/
+def ARegSupplies (consumer provider : MainRowWithRom FGL) : Prop :=
+  provider.rom.a_reg_prev_mem_step = aReadTimestamp consumer
+
+/-- **One supply step moves strictly later in time.** The provider's own bus-102 pull bounds
+`a_mem_step - a_reg_prev_mem_step - 1`, and the link identifies that predecessor with the
+consumer's read, so the consumer reads strictly before the provider accesses. -/
+theorem aReadTimestamp_lt_of_supplies
+    {consumer provider : MainRowWithRom FGL}
+    (h_supplies : ARegSupplies consumer provider)
+    (h_descent :
+      ZiskFv.AirsClean.RangeTables.rangeTable24.Spec (aRegStepDistance provider))
+    (h_bound : (aReadTimestamp consumer).val < 2 ^ 40) :
+    (aReadTimestamp consumer).val < (aReadTimestamp provider).val := by
+  refine ZiskFv.AirsClean.FullEnsemble.prev_val_lt_of_registerStepSpec ?_ h_bound
+  simpa [aRegStepDistance, aReadTimestamp, ARegSupplies] using
+    (h_supplies ▸ h_descent : ZiskFv.AirsClean.RangeTables.rangeTable24.Spec
+      (aReadTimestamp provider - aReadTimestamp consumer - 1))
+
+/-- **No row supplies its own register read.** The direct refutation of the shape #342 was opened
+about, at its smallest: a self-loop would make a timestamp strictly precede itself. -/
+theorem not_aRegSupplies_self
+    {row : MainRowWithRom FGL}
+    (h_descent : ZiskFv.AirsClean.RangeTables.rangeTable24.Spec (aRegStepDistance row))
+    (h_bound : (aReadTimestamp row).val < 2 ^ 40) :
+    ¬ ARegSupplies row row := by
+  intro h_supplies
+  exact absurd (aReadTimestamp_lt_of_supplies h_supplies h_descent h_bound) (lt_irrefl _)
+
+/-- **No two-row cycle.** This is exactly the witness in #342's body: two rows on one register
+pointing at each other's timestamps. Each supply step moves strictly later, so a two-cycle would
+put a timestamp strictly before itself. -/
+theorem not_aRegSupplies_two_cycle
+    {r₁ r₂ : MainRowWithRom FGL}
+    (h_descent₁ : ZiskFv.AirsClean.RangeTables.rangeTable24.Spec (aRegStepDistance r₁))
+    (h_descent₂ : ZiskFv.AirsClean.RangeTables.rangeTable24.Spec (aRegStepDistance r₂))
+    (h_bound₁ : (aReadTimestamp r₁).val < 2 ^ 40)
+    (h_bound₂ : (aReadTimestamp r₂).val < 2 ^ 40)
+    (h₁₂ : ARegSupplies r₁ r₂) (h₂₁ : ARegSupplies r₂ r₁) : False := by
+  have h_lt₁ := aReadTimestamp_lt_of_supplies h₁₂ h_descent₂ h_bound₁
+  have h_lt₂ := aReadTimestamp_lt_of_supplies h₂₁ h_descent₁ h_bound₂
+  exact absurd (h_lt₁.trans h_lt₂) (lt_irrefl _)
+
+/-- **No cycle of any length.** A chain of supply steps visits no row timestamp twice, so the
+register partition cannot close a loop. The chain relation here is the concrete one on Main rows,
+and the strict increase at each step comes from that row's own bus-102 descent. -/
+theorem aRegSupplies_chain_timestamps_nodup
+    (rows : List (MainRowWithRom FGL))
+    (h_descent : ∀ r ∈ rows,
+      ZiskFv.AirsClean.RangeTables.rangeTable24.Spec (aRegStepDistance r))
+    (h_bounds : ∀ r ∈ rows, (aReadTimestamp r).val < 2 ^ 40)
+    (h_chain : List.IsChain ARegSupplies rows) :
+    (rows.map aReadTimestamp).Nodup := by
+  have h_mono : List.IsChain (fun a b => (aReadTimestamp a).val < (aReadTimestamp b).val) rows := by
+    induction rows with
+    | nil => simp
+    | cons a rest ih =>
+        cases rest with
+        | nil => simp
+        | cons b rest' =>
+            rw [List.isChain_cons_cons] at h_chain
+            rw [List.isChain_cons_cons]
+            refine ⟨aReadTimestamp_lt_of_supplies h_chain.1 (h_descent b (by simp))
+                (h_bounds a (by simp)), ?_⟩
+            exact ih (fun r hr => h_descent r (by simp [hr]))
+              (fun r hr => h_bounds r (by simp [hr])) h_chain.2
+  haveI : Trans (fun a b : MainRowWithRom FGL => (aReadTimestamp a).val < (aReadTimestamp b).val)
+      (fun a b : MainRowWithRom FGL => (aReadTimestamp a).val < (aReadTimestamp b).val)
+      (fun a b : MainRowWithRom FGL => (aReadTimestamp a).val < (aReadTimestamp b).val) :=
+    ⟨fun h1 h2 => Nat.lt_trans h1 h2⟩
+  have h_pairwise := h_mono.pairwise
+  rw [List.Nodup, List.pairwise_map]
+  exact h_pairwise.imp (fun {a b} h h_eq => absurd (congrArg Fin.val h_eq) (Nat.ne_of_lt h))
+
 end ZiskFv.Compliance.Instantiation

--- a/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
+++ b/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
@@ -2108,72 +2108,147 @@ theorem registerRead_timestamp_lt_provider_access
 /-! ## The register walk, on concrete rows
 
 `registerChain_nodup_of_descent` is the order-theoretic half: it assumes a chain relation on an
-abstract list. What follows states the chain relation on *real Main rows* -- `r₂` supplies `r₁`'s
-a-side register read exactly when `r₂`'s `a_reg_prev_mem_step` is `r₁`'s read timestamp -- and
-derives the strict increase from the bus-102 descent rather than assuming it.
--/
+abstract list. What follows states the chain relation on *real Main rows* -- one row supplies
+another's register read exactly when its free predecessor-step column holds that read's timestamp
+-- and derives the strict increase from the bus-102 descent rather than assuming it.
 
-/-- The a-side read timestamp of a Main row: `a_mem_step = 1 + main_step * 4`. -/
-def aReadTimestamp (row : MainRowWithRom FGL) : FGL :=
-  1 + row.rom.main_step * 4
+All three register slots share one MemBus at `mem_op = 3`, so a supply step may cross slots: row
+`r₁`'s a-side read can be supplied by row `r₂`'s store-side register-pre push. The relation is
+therefore indexed by the slot on each side, and the cycle results below rule out mixed-slot cycles
+as well as same-slot ones. -/
 
-/-- `provider` supplies `consumer`'s a-side register read: the provider row's register-pre push
-carries the consumer's read timestamp, which is what
+/-- One of Main's three register slots. Each owns a memory-bus read timestamp, a free
+predecessor-access witness column, and a selector; `main.pil:333-335` range-checks one distance per
+slot. -/
+inductive RegSlot where
+  | a
+  | b
+  | c
+  deriving DecidableEq, Repr
+
+namespace RegSlot
+
+/-- The slot's memory-bus read timestamp (`Main/Constraints.lean:363,376,389`). -/
+def readTimestamp : RegSlot → MainRowWithRom FGL → FGL
+  | .a, row => 1 + row.rom.main_step * 4
+  | .b, row => 2 + row.rom.main_step * 4
+  | .c, row => 3 + row.rom.main_step * 4
+
+/-- The slot's free predecessor-access witness column, pushed as the register-pre message's
+timestamp (`Main/Constraints.lean:400,411,422`). No constraint in the Main component pins it; that
+is the whole reason #342 exists. -/
+def prevStep : RegSlot → MainRowWithRom FGL → FGL
+  | .a, row => row.rom.a_reg_prev_mem_step
+  | .b, row => row.rom.b_reg_prev_mem_step
+  | .c, row => row.rom.store_reg_prev_mem_step
+
+/-- The slot's register selector, which gates both the `mem_op = 3` memory access and the bus-102
+pull. -/
+def selector : RegSlot → MainRowWithRom FGL → FGL
+  | .a, row => row.rom.a_src_reg
+  | .b, row => row.rom.b_src_reg
+  | .c, row => row.rom.store_reg
+
+/-- The distance `main.pil:333-335` range-checks for this slot. -/
+def distance (s : RegSlot) (row : MainRowWithRom FGL) : FGL :=
+  s.readTimestamp row - s.prevStep row - 1
+
+/-- The memory-bus *read* message this slot emits, at `mem_op = 3` when the slot is a register
+access (`Main/Constraints.lean:359,372,385`). -/
+def memMessageExpr : RegSlot → Var MainRowWithRom FGL →
+    ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)
+  | .a, row => ZiskFv.AirsClean.Main.aMemMessageExpr row
+  | .b, row => ZiskFv.AirsClean.Main.bMemMessageExpr row
+  | .c, row => ZiskFv.AirsClean.Main.cMemMessageExpr row
+
+/-- The read message's timestamp is the slot's read timestamp. -/
+theorem eval_memMessageExpr_timestamp (s : RegSlot) (env : Environment FGL)
+    (row : Var MainRowWithRom FGL) :
+    (eval env (s.memMessageExpr row)).timestamp = s.readTimestamp (eval env row) := by
+  cases s
+  · rw [memMessageExpr, ZiskFv.AirsClean.Main.eval_aMemMessageExpr]; rfl
+  · rw [memMessageExpr, ZiskFv.AirsClean.Main.eval_bMemMessageExpr]; rfl
+  · rw [memMessageExpr, ZiskFv.AirsClean.Main.eval_cMemMessageExpr]; rfl
+
+@[simp] theorem distance_a (row : MainRowWithRom FGL) :
+    RegSlot.a.distance row = aRegStepDistance row := rfl
+
+@[simp] theorem distance_b (row : MainRowWithRom FGL) :
+    RegSlot.b.distance row = bRegStepDistance row := rfl
+
+@[simp] theorem distance_c (row : MainRowWithRom FGL) :
+    RegSlot.c.distance row = cRegStepDistance row := rfl
+
+end RegSlot
+
+/-- `(provider, sp)` supplies `(consumer, sc)`'s register read: the provider slot's register-pre
+push carries the consumer slot's read timestamp. This is exactly what
 `selfMemProvider_registerPre_timestamp_of_mem_op_three` concludes from balance. -/
-def ARegSupplies (consumer provider : MainRowWithRom FGL) : Prop :=
-  provider.rom.a_reg_prev_mem_step = aReadTimestamp consumer
+def RegSupplies (sc sp : RegSlot) (consumer provider : MainRowWithRom FGL) : Prop :=
+  sp.prevStep provider = sc.readTimestamp consumer
+
+/-- A step of the walk: one Main row together with the register slot being followed. -/
+abbrev RegWalkStep := MainRowWithRom FGL × RegSlot
+
+/-- The timestamp at which a walk step reads its register. -/
+def RegWalkStep.timestamp (p : RegWalkStep) : FGL := p.2.readTimestamp p.1
+
+/-- The bus-102 distance a walk step's slot range-checks. -/
+def RegWalkStep.distance (p : RegWalkStep) : FGL := p.2.distance p.1
+
+/-- The supply relation lifted to walk steps. -/
+def RegWalkStep.Supplies (p q : RegWalkStep) : Prop := RegSupplies p.2 q.2 p.1 q.1
 
 /-- **One supply step moves strictly later in time.** The provider's own bus-102 pull bounds
-`a_mem_step - a_reg_prev_mem_step - 1`, and the link identifies that predecessor with the
-consumer's read, so the consumer reads strictly before the provider accesses. -/
-theorem aReadTimestamp_lt_of_supplies
-    {consumer provider : MainRowWithRom FGL}
-    (h_supplies : ARegSupplies consumer provider)
+`<slot>_mem_step - <slot>_reg_prev_mem_step - 1`, and the supply link identifies that predecessor
+with the consumer's read, so the consumer reads strictly before the provider accesses. -/
+theorem readTimestamp_lt_of_regSupplies
+    {sc sp : RegSlot} {consumer provider : MainRowWithRom FGL}
+    (h_supplies : RegSupplies sc sp consumer provider)
     (h_descent :
-      ZiskFv.AirsClean.RangeTables.rangeTable24.Spec (aRegStepDistance provider))
-    (h_bound : (aReadTimestamp consumer).val < 2 ^ 40) :
-    (aReadTimestamp consumer).val < (aReadTimestamp provider).val := by
-  refine ZiskFv.AirsClean.FullEnsemble.prev_val_lt_of_registerStepSpec ?_ h_bound
-  simpa [aRegStepDistance, aReadTimestamp, ARegSupplies] using
-    (h_supplies ▸ h_descent : ZiskFv.AirsClean.RangeTables.rangeTable24.Spec
-      (aReadTimestamp provider - aReadTimestamp consumer - 1))
+      ZiskFv.AirsClean.RangeTables.rangeTable24.Spec (sp.distance provider))
+    (h_bound : (sc.readTimestamp consumer).val < 2 ^ 40) :
+    (sc.readTimestamp consumer).val < (sp.readTimestamp provider).val := by
+  rw [RegSlot.distance, h_supplies] at h_descent
+  exact ZiskFv.AirsClean.FullEnsemble.prev_val_lt_of_registerStepSpec h_descent h_bound
 
 /-- **No row supplies its own register read.** The direct refutation of the shape #342 was opened
 about, at its smallest: a self-loop would make a timestamp strictly precede itself. -/
-theorem not_aRegSupplies_self
-    {row : MainRowWithRom FGL}
-    (h_descent : ZiskFv.AirsClean.RangeTables.rangeTable24.Spec (aRegStepDistance row))
-    (h_bound : (aReadTimestamp row).val < 2 ^ 40) :
-    ¬ ARegSupplies row row := by
+theorem not_regSupplies_self
+    {s : RegSlot} {row : MainRowWithRom FGL}
+    (h_descent : ZiskFv.AirsClean.RangeTables.rangeTable24.Spec (s.distance row))
+    (h_bound : (s.readTimestamp row).val < 2 ^ 40) :
+    ¬ RegSupplies s s row row := by
   intro h_supplies
-  exact absurd (aReadTimestamp_lt_of_supplies h_supplies h_descent h_bound) (lt_irrefl _)
+  exact absurd (readTimestamp_lt_of_regSupplies h_supplies h_descent h_bound) (lt_irrefl _)
 
-/-- **No two-row cycle.** This is exactly the witness in #342's body: two rows on one register
-pointing at each other's timestamps. Each supply step moves strictly later, so a two-cycle would
-put a timestamp strictly before itself. -/
-theorem not_aRegSupplies_two_cycle
-    {r₁ r₂ : MainRowWithRom FGL}
-    (h_descent₁ : ZiskFv.AirsClean.RangeTables.rangeTable24.Spec (aRegStepDistance r₁))
-    (h_descent₂ : ZiskFv.AirsClean.RangeTables.rangeTable24.Spec (aRegStepDistance r₂))
-    (h_bound₁ : (aReadTimestamp r₁).val < 2 ^ 40)
-    (h_bound₂ : (aReadTimestamp r₂).val < 2 ^ 40)
-    (h₁₂ : ARegSupplies r₁ r₂) (h₂₁ : ARegSupplies r₂ r₁) : False := by
-  have h_lt₁ := aReadTimestamp_lt_of_supplies h₁₂ h_descent₂ h_bound₁
-  have h_lt₂ := aReadTimestamp_lt_of_supplies h₂₁ h_descent₁ h_bound₂
+/-- **No two-step cycle.** This is exactly the witness in #342's body: two rows pointing at each
+other's timestamps. Each supply step moves strictly later, so a two-cycle would put a timestamp
+strictly before itself. The slots are independent, so a mixed-slot two-cycle is ruled out too. -/
+theorem not_regSupplies_two_cycle
+    {s₁ s₂ : RegSlot} {r₁ r₂ : MainRowWithRom FGL}
+    (h_descent₁ : ZiskFv.AirsClean.RangeTables.rangeTable24.Spec (s₁.distance r₁))
+    (h_descent₂ : ZiskFv.AirsClean.RangeTables.rangeTable24.Spec (s₂.distance r₂))
+    (h_bound₁ : (s₁.readTimestamp r₁).val < 2 ^ 40)
+    (h_bound₂ : (s₂.readTimestamp r₂).val < 2 ^ 40)
+    (h₁₂ : RegSupplies s₁ s₂ r₁ r₂) (h₂₁ : RegSupplies s₂ s₁ r₂ r₁) : False := by
+  have h_lt₁ := readTimestamp_lt_of_regSupplies h₁₂ h_descent₂ h_bound₁
+  have h_lt₂ := readTimestamp_lt_of_regSupplies h₂₁ h_descent₁ h_bound₂
   exact absurd (h_lt₁.trans h_lt₂) (lt_irrefl _)
 
-/-- **No cycle of any length.** A chain of supply steps visits no row timestamp twice, so the
-register partition cannot close a loop. The chain relation here is the concrete one on Main rows,
-and the strict increase at each step comes from that row's own bus-102 descent. -/
-theorem aRegSupplies_chain_timestamps_nodup
-    (rows : List (MainRowWithRom FGL))
-    (h_descent : ∀ r ∈ rows,
-      ZiskFv.AirsClean.RangeTables.rangeTable24.Spec (aRegStepDistance r))
-    (h_bounds : ∀ r ∈ rows, (aReadTimestamp r).val < 2 ^ 40)
-    (h_chain : List.IsChain ARegSupplies rows) :
-    (rows.map aReadTimestamp).Nodup := by
-  have h_mono : List.IsChain (fun a b => (aReadTimestamp a).val < (aReadTimestamp b).val) rows := by
-    induction rows with
+/-- **No cycle of any length.** A chain of supply steps visits no read timestamp twice, so the
+register partition cannot close a loop. The chain relation is the concrete one on Main rows, and the
+strict increase at each step comes from that step's own bus-102 descent. -/
+theorem regSupplies_chain_timestamps_nodup
+    (steps : List RegWalkStep)
+    (h_descent : ∀ p ∈ steps,
+      ZiskFv.AirsClean.RangeTables.rangeTable24.Spec p.distance)
+    (h_bounds : ∀ p ∈ steps, p.timestamp.val < 2 ^ 40)
+    (h_chain : List.IsChain RegWalkStep.Supplies steps) :
+    (steps.map RegWalkStep.timestamp).Nodup := by
+  have h_mono : List.IsChain
+      (fun p q : RegWalkStep => p.timestamp.val < q.timestamp.val) steps := by
+    induction steps with
     | nil => simp
     | cons a rest ih =>
         cases rest with
@@ -2181,16 +2256,47 @@ theorem aRegSupplies_chain_timestamps_nodup
         | cons b rest' =>
             rw [List.isChain_cons_cons] at h_chain
             rw [List.isChain_cons_cons]
-            refine ⟨aReadTimestamp_lt_of_supplies h_chain.1 (h_descent b (by simp))
+            refine ⟨readTimestamp_lt_of_regSupplies h_chain.1 (h_descent b (by simp))
                 (h_bounds a (by simp)), ?_⟩
             exact ih (fun r hr => h_descent r (by simp [hr]))
               (fun r hr => h_bounds r (by simp [hr])) h_chain.2
-  haveI : Trans (fun a b : MainRowWithRom FGL => (aReadTimestamp a).val < (aReadTimestamp b).val)
-      (fun a b : MainRowWithRom FGL => (aReadTimestamp a).val < (aReadTimestamp b).val)
-      (fun a b : MainRowWithRom FGL => (aReadTimestamp a).val < (aReadTimestamp b).val) :=
+  haveI : Trans (fun p q : RegWalkStep => p.timestamp.val < q.timestamp.val)
+      (fun p q : RegWalkStep => p.timestamp.val < q.timestamp.val)
+      (fun p q : RegWalkStep => p.timestamp.val < q.timestamp.val) :=
     ⟨fun h1 h2 => Nat.lt_trans h1 h2⟩
   have h_pairwise := h_mono.pairwise
   rw [List.Nodup, List.pairwise_map]
   exact h_pairwise.imp (fun {a b} h h_eq => absurd (congrArg Fin.val h_eq) (Nat.ne_of_lt h))
+
+/-- **The slot-generic descent.** Each slot's active-selector bus-102 pull forces its own distance
+into `rangeTable24`; this collects the three per-slot lemmas into one statement the walk can use
+without case-splitting at every call site. -/
+theorem rangeTable24_spec_distance_of_active
+    {length : ℕ} {program : ZiskFv.AirsClean.ZiskInstructionRom.Program length}
+    {witness : Air.Flat.EnsembleWitness
+      (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble length program).ensemble}
+    (h_balanced : witness.BalancedChannels)
+    (h_specs : witness.Spec)
+    (h_constraints : witness.Constraints)
+    {mainTable : Table FGL}
+    (h_mainTable : mainTable ∈ witness.allTables)
+    {rowArray : Array FGL} (h_rowArray : rowArray ∈ mainTable.table)
+    {row : MainRowWithRom FGL}
+    (h_input :
+      eval (mainTable.environment rowArray)
+        (componentWithRomMemAndOpBus length program).rowInputVar = row)
+    (h_component : mainTable.component = componentWithRomMemAndOpBus length program)
+    (s : RegSlot) (h_active : s.selector row = 1) :
+    ZiskFv.AirsClean.RangeTables.rangeTable24.Spec (s.distance row) := by
+  cases s with
+  | a =>
+      simpa using rangeTable24_spec_aRegStepDistance_of_active h_balanced h_specs h_constraints
+        h_mainTable h_rowArray h_input h_component h_active
+  | b =>
+      simpa using rangeTable24_spec_bRegStepDistance_of_active h_balanced h_specs h_constraints
+        h_mainTable h_rowArray h_input h_component h_active
+  | c =>
+      simpa using rangeTable24_spec_cRegStepDistance_of_active h_balanced h_specs h_constraints
+        h_mainTable h_rowArray h_input h_component h_active
 
 end ZiskFv.Compliance.Instantiation

--- a/ZiskFv/Compliance/RegisterWalk.lean
+++ b/ZiskFv/Compliance/RegisterWalk.lean
@@ -3,6 +3,7 @@ import ZiskFv.Compliance.AcceptedZiskTrace.Spec
 import ZiskFv.Compliance.AcceptedZiskTrace.MemProviders
 import ZiskFv.AirsClean.FullEnsemble.Balance.RegisterChainBridges
 import ZiskFv.Compliance.Instantiation.ConcreteRowReductions
+import ZiskFv.Compliance.RegisterMemBusBalance
 
 /-!
 # The register walk on an accepted trace
@@ -322,5 +323,78 @@ theorem registerRead_supplied_by_boundary_or_strictly_later_row
       · exact rangeTable24_spec_distance_of_active trace.channels_balanced trace.spec_holds
           trace.constraints_hold h_providerTable h_providerRow rfl h_providerComponent sp h_sel
       · exact regSlot_timestamp_bound_of_trace trace i sc
+
+/-! ## Non-vacuity
+
+The supply relation is inhabited, and by a row of a checked witness rather than a hand-built one.
+On the `add x1,x1,x1` row all three register slots are active and the accesses run at timestamps
+`1`, `2`, `3`, so within that single row the b-slot supplies the a-slot's read and the store-slot
+supplies the b-slot's read. That is a legal configuration, not a cycle: it is exactly the
+strictly-increasing walk the theorems above describe, and the same row is what
+`singleAddWitness`'s bus-102 provider list `[0, 0, 0]` records.
+
+This matters because every result in this file is an implication out of `RegSupplies`. If the
+relation were empty the implications would hold vacuously and prove nothing about ZisK. -/
+
+open ZiskFv.Compliance.RegisterMemBusBalance (addX1Row)
+
+/-- The `add x1,x1,x1` row's b-slot supplies its own a-slot register read: `b_reg_prev_mem_step`
+    is `1`, which is the a-slot's read timestamp. -/
+theorem addX1Row_regSupplies_a_b : RegSupplies RegSlot.a RegSlot.b addX1Row addX1Row := by
+  show addX1Row.rom.b_reg_prev_mem_step = 1 + addX1Row.rom.main_step * 4
+  decide
+
+/-- The `add x1,x1,x1` row's store-slot supplies its own b-slot register read. -/
+theorem addX1Row_regSupplies_b_c : RegSupplies RegSlot.b RegSlot.c addX1Row addX1Row := by
+  show addX1Row.rom.store_reg_prev_mem_step = 2 + addX1Row.rom.main_step * 4
+  decide
+
+/-- The three slots of the `add x1,x1,x1` row form a genuine supply chain. -/
+theorem addX1Row_walk_isChain :
+    List.IsChain RegWalkStep.Supplies
+      [(addX1Row, RegSlot.a), (addX1Row, RegSlot.b), (addX1Row, RegSlot.c)] := by
+  rw [List.isChain_cons_cons]
+  refine ⟨addX1Row_regSupplies_a_b, ?_⟩
+  rw [List.isChain_cons_cons]
+  exact ⟨addX1Row_regSupplies_b_c, List.isChain_singleton _⟩
+
+/-- The `add x1,x1,x1` row's three bus-102 distances are all `0`, so each is in `rangeTable24`. -/
+theorem addX1Row_descent (s : RegSlot) :
+    ZiskFv.AirsClean.RangeTables.rangeTable24.Spec (s.distance addX1Row) := by
+  cases s
+  · show (RegSlot.a.distance addX1Row).val < 2 ^ 24; decide
+  · show (RegSlot.b.distance addX1Row).val < 2 ^ 24; decide
+  · show (RegSlot.c.distance addX1Row).val < 2 ^ 24; decide
+
+/-- The `add x1,x1,x1` row's three read timestamps are `1`, `2`, `3`. -/
+theorem addX1Row_timestamp_bound (s : RegSlot) : (s.readTimestamp addX1Row).val < 2 ^ 40 := by
+  cases s
+  · show (RegSlot.a.readTimestamp addX1Row).val < 2 ^ 40; decide
+  · show (RegSlot.b.readTimestamp addX1Row).val < 2 ^ 40; decide
+  · show (RegSlot.c.readTimestamp addX1Row).val < 2 ^ 40; decide
+
+/-- The general no-cycle theorem, applied to that chain: its read timestamps are `1`, `2`, `3` and
+    they do not repeat. Non-vacuous instantiation of `regSupplies_chain_timestamps_nodup`. -/
+theorem addX1Row_walk_timestamps_nodup :
+    ([(addX1Row, RegSlot.a), (addX1Row, RegSlot.b), (addX1Row, RegSlot.c)].map
+      RegWalkStep.timestamp).Nodup :=
+  regSupplies_chain_timestamps_nodup _
+    (fun p hp => by
+      rcases List.mem_cons.mp hp with rfl | hp
+      · exact addX1Row_descent RegSlot.a
+      rcases List.mem_cons.mp hp with rfl | hp
+      · exact addX1Row_descent RegSlot.b
+      rcases List.mem_cons.mp hp with rfl | hp
+      · exact addX1Row_descent RegSlot.c
+      · exact absurd hp (by simp))
+    (fun p hp => by
+      rcases List.mem_cons.mp hp with rfl | hp
+      · exact addX1Row_timestamp_bound RegSlot.a
+      rcases List.mem_cons.mp hp with rfl | hp
+      · exact addX1Row_timestamp_bound RegSlot.b
+      rcases List.mem_cons.mp hp with rfl | hp
+      · exact addX1Row_timestamp_bound RegSlot.c
+      · exact absurd hp (by simp))
+    addX1Row_walk_isChain
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/RegisterWalk.lean
+++ b/ZiskFv/Compliance/RegisterWalk.lean
@@ -109,13 +109,42 @@ theorem regSlot_descent_of_trace
     ((mainTableRowAtOrZero_get trace.program trace.mainTable ⟨i.val, h_index⟩).symm)
     trace.mainTable_component s h_active
 
-/-- The no-wrap bound for a trace's Main row, derived from the fixed schema. -/
+/-- **The no-wrap bound for any in-range Main row**, not only the executed steps.
+
+    The walk's providers come out of `witness.allTables` and need not be indexed by `Fin n` — a
+    padding row can carry a register-pre push exactly as an executed row can. So the bound has to
+    cover every row of a Main-component table, and it does: `main_step` is indexed fixed data and
+    the table's own `fixed_domain` caps the index at `mainFixedCapacity = 2^22`. -/
+theorem regSlot_timestamp_bound_of_mainTable
+    {length : Nat} {program : Program length} {table : Table FGL}
+    (h_component :
+      table.component = ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program)
+    {index : Nat} (h_index : index < table.table.length) (s : RegSlot) :
+    (s.readTimestamp (mainTableRowAtOrZero program table index)).val < 2 ^ 40 :=
+  readTimestamp_val_lt_of_main_step_eq_index
+    ((mainStepIndexFixedFacts_of_component_fixedColumns
+      (numInstructions := table.table.length) program table h_component
+      (fun i => i.isLt)).main_step_eq_index ⟨index, h_index⟩)
+    (main_index_lt_mainFixedCapacity h_component h_index) s
+
+/-- The no-wrap bound at an executed step, the special case the trace-indexed results use. -/
 theorem regSlot_timestamp_bound_of_trace
     (trace : AcceptedZiskTrace n) (i : Fin n) (s : RegSlot) :
     (s.readTimestamp (mainTableRowAtOrZero trace.program trace.mainTable i.val)).val < 2 ^ 40 :=
-  readTimestamp_val_lt_of_main_step_eq_index
-    (trace.mainTable_main_step_index_fixed.main_step_eq_index i)
-    (main_index_lt_mainFixedCapacity trace.mainTable_component (trace.mainTable_index i)) s
+  regSlot_timestamp_bound_of_mainTable trace.mainTable_component (trace.mainTable_index i) s
+
+/-- **A walk step that really occurs in the witness**: some Main-component table of the witness, an
+    in-range row of it, and a slot whose register selector is set.
+
+    This is the shape the counterpart classification below *produces*, so it is the shape the chain
+    results must consume. Indexing walk steps by `Fin n` would only cover executed steps, while a
+    provider may be any row of the table — including a padding row past the executed prefix. -/
+def IsActiveWitnessMainRow (trace : AcceptedZiskTrace n) (p : RegWalkStep) : Prop :=
+  ∃ table ∈ trace.witness.allTables,
+    table.component =
+        ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.programLength trace.program
+      ∧ ∃ index, ∃ _h : index < table.table.length,
+          p.1 = mainTableRowAtOrZero trace.program table index ∧ p.2.selector p.1 = 1
 
 /-- A walk step named by an executed step index and a register slot. -/
 noncomputable def traceWalkStep (trace : AcceptedZiskTrace n) (p : Fin n × RegSlot) :
@@ -181,6 +210,27 @@ theorem regSupplies_chain_timestamps_nodup_of_trace
     obtain ⟨p, hp, rfl⟩ := List.mem_map.mp hw
     exact regSlot_timestamp_bound_of_trace trace p.1 p.2
 
+/-- The descent for any active in-range row of any Main-component table of the witness. -/
+theorem regSlot_descent_of_witnessMainRow
+    (trace : AcceptedZiskTrace n) {p : RegWalkStep} (h_site : IsActiveWitnessMainRow trace p) :
+    ZiskFv.AirsClean.RangeTables.rangeTable24.Spec p.distance := by
+  obtain ⟨table, h_table, h_component, index, h_index, h_row, h_active⟩ := h_site
+  show ZiskFv.AirsClean.RangeTables.rangeTable24.Spec (p.2.distance p.1)
+  rw [h_row] at h_active ⊢
+  exact rangeTable24_spec_distance_of_active trace.channels_balanced trace.spec_holds
+    trace.constraints_hold h_table (List.get_mem table.table ⟨index, h_index⟩)
+    ((mainTableRowAtOrZero_get trace.program table ⟨index, h_index⟩).symm)
+    h_component p.2 h_active
+
+/-- The no-wrap bound for any in-range row of any Main-component table of the witness. -/
+theorem regSlot_timestamp_bound_of_witnessMainRow
+    (trace : AcceptedZiskTrace n) {p : RegWalkStep} (h_site : IsActiveWitnessMainRow trace p) :
+    p.timestamp.val < 2 ^ 40 := by
+  obtain ⟨table, h_table, h_component, index, h_index, h_row, h_active⟩ := h_site
+  show (p.2.readTimestamp p.1).val < 2 ^ 40
+  rw [h_row]
+  exact regSlot_timestamp_bound_of_mainTable h_component h_index p.2
+
 /-! ## From balance to the supply relation
 
 Everything above takes the supply relation as given. This last section derives it: on an accepted
@@ -192,6 +242,22 @@ open ZiskFv.AirsClean.FullEnsemble (ActiveMainRegisterBoundaryProviderRowMatchSp
   activeMainRegisterProviderRowMatchSpec_of_main_mem_op_three
   selfMemProvider_registerPre_active_of_mem_op_three)
 open ZiskFv.Channels.MemoryBus (MemBusChannel)
+
+/-- A member row of a Main-component table is that table's `mainTableRowAtOrZero` at some in-range
+    index. The classification returns rows by membership; `IsActiveWitnessMainRow` names them by
+    index, and this is the bridge. -/
+theorem exists_index_of_mem_mainTable
+    {length : Nat} {program : Program length} {table : Table FGL}
+    (h_component :
+      table.component = ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program)
+    {row : Array FGL} (h_row : row ∈ table.table) :
+    ∃ index, ∃ _h : index < table.table.length,
+      eval (table.environment row)
+          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program).rowInputVar
+        = mainTableRowAtOrZero program table index := by
+  obtain ⟨⟨index, h_index⟩, h_get⟩ := List.get_of_mem h_row
+  refine ⟨index, h_index, ?_⟩
+  rw [mainTableRowAtOrZero_get program table ⟨index, h_index⟩, h_get]
 
 /-- **The counterpart of a register read, classified.** From `channels_balanced` alone: a Main
     memory-bus pull at `mem_op = 3` is supplied either by the `RegisterBoundary` or by another Main
@@ -217,18 +283,8 @@ theorem registerRead_counterpart_of_trace
     {multiplicity as : FGL} :
     ActiveMainRegisterBoundaryProviderRowMatchSpec trace.program trace.witness trace.mainTable
         mainRow mainInteraction mainMsg multiplicity as
-      ∨ ∃ providerTable ∈ trace.witness.allTables, ∃ providerRow ∈ providerTable.table,
-          providerTable.component =
-              ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                trace.programLength trace.program
-            ∧ ∃ sp : RegSlot,
-                sp.selector (eval (providerTable.environment providerRow)
-                    (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                      trace.programLength trace.program).rowInputVar) = 1
-                  ∧ sp.prevStep (eval (providerTable.environment providerRow)
-                      (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                        trace.programLength trace.program).rowInputVar)
-                    = (eval (trace.mainTable.environment mainRow) mainMsg).timestamp := by
+      ∨ ∃ p : RegWalkStep, IsActiveWitnessMainRow trace p
+          ∧ p.2.prevStep p.1 = (eval (trace.mainTable.environment mainRow) mainMsg).timestamp := by
   have h_match :=
     (trace.activeMainMemProviderRowMatchSpec_of_active_main_eval
       h_mainRow h_mainInteraction h_mainEval h_pull (multiplicity := multiplicity) (as := as)).2
@@ -239,11 +295,19 @@ theorem registerRead_counterpart_of_trace
       h_branch⟩ :=
       selfMemProvider_registerPre_active_of_mem_op_three h_mainEval h_mem_op
         trace.constraints_hold h_self
-    refine ⟨providerTable, h_providerTable, providerRow, h_providerRow, h_providerComponent, ?_⟩
-    rcases h_branch with ⟨h_sel, h_ts⟩ | ⟨h_sel, h_ts⟩ | ⟨h_sel, h_ts⟩
-    · exact ⟨RegSlot.a, h_sel, h_ts⟩
-    · exact ⟨RegSlot.b, h_sel, h_ts⟩
-    · exact ⟨RegSlot.c, h_sel, h_ts⟩
+    obtain ⟨index, h_index, h_rowAt⟩ :=
+      exists_index_of_mem_mainTable h_providerComponent h_providerRow
+    refine
+      match h_branch with
+      | Or.inl ⟨h_sel, h_ts⟩ =>
+          ⟨(_, RegSlot.a), ⟨providerTable, h_providerTable, h_providerComponent, index, h_index,
+            h_rowAt, h_sel⟩, h_ts⟩
+      | Or.inr (Or.inl ⟨h_sel, h_ts⟩) =>
+          ⟨(_, RegSlot.b), ⟨providerTable, h_providerTable, h_providerComponent, index, h_index,
+            h_rowAt, h_sel⟩, h_ts⟩
+      | Or.inr (Or.inr ⟨h_sel, h_ts⟩) =>
+          ⟨(_, RegSlot.c), ⟨providerTable, h_providerTable, h_providerComponent, index, h_index,
+            h_rowAt, h_sel⟩, h_ts⟩
   · exact Or.inl h_boundary
 
 /-- **The supply step, entirely from the accepted trace.**
@@ -285,22 +349,11 @@ theorem registerRead_supplied_by_boundary_or_strictly_later_row
           (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
             trace.programLength trace.program).rowInputVar)
         multiplicity as
-      ∨ ∃ providerTable ∈ trace.witness.allTables, ∃ providerRow ∈ providerTable.table,
-          ∃ _ : providerTable.component =
-              ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                trace.programLength trace.program,
-            ∃ sp : RegSlot,
-              RegSupplies sc sp
-                  (mainTableRowAtOrZero trace.program trace.mainTable i.val)
-                  (eval (providerTable.environment providerRow)
-                    (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                      trace.programLength trace.program).rowInputVar)
-                ∧ (sc.readTimestamp
-                      (mainTableRowAtOrZero trace.program trace.mainTable i.val)).val
-                    < (sp.readTimestamp
-                      (eval (providerTable.environment providerRow)
-                        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-                          trace.programLength trace.program).rowInputVar)).val := by
+      ∨ ∃ p : RegWalkStep, IsActiveWitnessMainRow trace p
+          ∧ RegSupplies sc p.2 (mainTableRowAtOrZero trace.program trace.mainTable i.val) p.1
+          ∧ (sc.readTimestamp
+                (mainTableRowAtOrZero trace.program trace.mainTable i.val)).val
+              < p.timestamp.val := by
   have h_row : mainTableRowAtOrZero trace.program trace.mainTable i.val
       = eval (trace.mainTable.environment
           (trace.mainTable.table.get ⟨i.val, trace.mainTable_index i⟩))
@@ -310,19 +363,38 @@ theorem registerRead_supplied_by_boundary_or_strictly_later_row
   rcases registerRead_counterpart_of_trace trace
       (List.get_mem trace.mainTable.table ⟨i.val, trace.mainTable_index i⟩)
       h_mainInteraction h_mainEval h_pull h_mem_op (multiplicity := multiplicity) (as := as) with
-    h_boundary | ⟨providerTable, h_providerTable, providerRow, h_providerRow,
-      h_providerComponent, sp, h_sel, h_ts⟩
+    h_boundary | ⟨p, h_site, h_ts⟩
   · exact Or.inl h_boundary
-  · refine Or.inr ⟨providerTable, h_providerTable, providerRow, h_providerRow,
-      h_providerComponent, sp, ?_, ?_⟩
-    · show sp.prevStep _ = sc.readTimestamp _
+  · have h_supplies :
+        RegSupplies sc p.2 (mainTableRowAtOrZero trace.program trace.mainTable i.val) p.1 := by
+      show p.2.prevStep p.1 = sc.readTimestamp _
       rw [h_ts, RegSlot.eval_memMessageExpr_timestamp, ← h_row]
-    · refine readTimestamp_lt_of_regSupplies (sc := sc) (sp := sp) ?_ ?_ ?_
-      · show sp.prevStep _ = sc.readTimestamp _
-        rw [h_ts, RegSlot.eval_memMessageExpr_timestamp, ← h_row]
-      · exact rangeTable24_spec_distance_of_active trace.channels_balanced trace.spec_holds
-          trace.constraints_hold h_providerTable h_providerRow rfl h_providerComponent sp h_sel
-      · exact regSlot_timestamp_bound_of_trace trace i sc
+    exact Or.inr ⟨p, h_site, h_supplies,
+      readTimestamp_lt_of_regSupplies h_supplies
+        (regSlot_descent_of_witnessMainRow trace h_site)
+        (regSlot_timestamp_bound_of_trace trace i sc)⟩
+
+/-! ## The chain result, on the rows the classification actually produces
+
+`regSupplies_chain_timestamps_nodup_of_trace` above is indexed by `Fin n`, so it only speaks about
+executed steps. `registerRead_counterpart_of_trace` produces providers out of `witness.allTables`,
+which may be padding rows past the executed prefix. This section states the chain result over
+`IsActiveWitnessMainRow`, the shape the classification returns, so the two compose. -/
+
+/-- **No cycle, over exactly the rows the counterpart classification produces.**
+
+    Both hypotheses of the row-local no-cycle theorem are discharged from the trace, and the walk
+    steps range over every Main row of the witness rather than only the executed prefix. This is the
+    form that composes with `registerRead_supplied_by_boundary_or_strictly_later_row`. -/
+theorem regSupplies_chain_timestamps_nodup_of_witnessRows
+    (trace : AcceptedZiskTrace n) (steps : List RegWalkStep)
+    (h_sites : ∀ p ∈ steps, IsActiveWitnessMainRow trace p)
+    (h_chain : List.IsChain RegWalkStep.Supplies steps) :
+    (steps.map RegWalkStep.timestamp).Nodup :=
+  regSupplies_chain_timestamps_nodup steps
+    (fun p hp => regSlot_descent_of_witnessMainRow trace (h_sites p hp))
+    (fun p hp => regSlot_timestamp_bound_of_witnessMainRow trace (h_sites p hp))
+    h_chain
 
 /-! ## Non-vacuity
 

--- a/ZiskFv/Compliance/RegisterWalk.lean
+++ b/ZiskFv/Compliance/RegisterWalk.lean
@@ -1,0 +1,326 @@
+import ZiskFv.Compliance.AcceptedZiskTrace.MainTable
+import ZiskFv.Compliance.AcceptedZiskTrace.Spec
+import ZiskFv.Compliance.AcceptedZiskTrace.MemProviders
+import ZiskFv.AirsClean.FullEnsemble.Balance.RegisterChainBridges
+import ZiskFv.Compliance.Instantiation.ConcreteRowReductions
+
+/-!
+# The register walk on an accepted trace
+
+`ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean` states the supply relation on Main
+rows and proves that one supply step moves strictly later in time, given that step's bus-102
+descent and a no-wrap bound on the consumer's read timestamp. Both of those are hypotheses there.
+
+This module discharges them from an `AcceptedZiskTrace` and nothing else:
+
+* the **descent** comes from `rangeTable24_spec_distance_of_active`, which reads it off the
+  witness's channel balance (`main.pil:333-335`, bus 102);
+* the **no-wrap bound** comes from the Main table's own fixed-column capacity. `main_step` is
+  indexed fixed data of capacity `mainFixedCapacity = 2^22`
+  (`ZiskFv/AirsClean/Main/Circuit.lean:787`), so every read timestamp is below `2^24`. It is
+  **not** a premise about segment length.
+
+The result is `regSupplies_chain_timestamps_nodup_of_trace`: on an accepted trace, a chain of
+register supply steps visits no read timestamp twice. This is the Main-side half of #342. It rules
+out the disjoint cycle that balance alone permits; it does not yet pin the chain's *end* at
+`RegisterBoundary.bootMessage`, which is what `main.pil:447` does and which
+`ZiskFv/AirsClean/RegisterBoundary.lean` still omits.
+-/
+
+namespace ZiskFv.Compliance
+
+open Air.Flat (Table)
+open ZiskFv.AirsClean.FullEnsemble (mainTableRowAtOrZero mainTableRowAtOrZero_get)
+open ZiskFv.AirsClean.ZiskInstructionRom (Program)
+open ZiskFv.Compliance.Instantiation (RegSlot RegSupplies RegWalkStep
+  rangeTable24_spec_distance_of_active readTimestamp_lt_of_regSupplies not_regSupplies_self
+  not_regSupplies_two_cycle regSupplies_chain_timestamps_nodup)
+
+variable {n : Nat}
+
+/-- Any in-range Main row index is below the component's fixed-column capacity.
+
+    This is `Table.index_lt_fixed_capacity` specialized to Main's indexed fixed schema. The bound is
+    intrinsic to the table carrier, so it costs no premise. -/
+theorem main_index_lt_mainFixedCapacity
+    {length : Nat} {program : Program length} {table : Table FGL}
+    (h_component :
+      table.component = ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program)
+    {index : Nat} (h_index : index < table.table.length) :
+    index < ZiskFv.AirsClean.Main.mainFixedCapacity := by
+  cases table with
+  | mk component rawRows data raw_uniform_width fixed_domain =>
+    change component =
+      ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program at h_component
+    subst component
+    let table : Table FGL :=
+      { component := ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program
+        rawRows := rawRows
+        data := data
+        raw_uniform_width := raw_uniform_width
+        fixed_domain := fixed_domain }
+    change index < table.table.length at h_index
+    have h_columns :
+        table.component.fixedColumns = some ZiskFv.AirsClean.Main.mainFixedColumns := by
+      rfl
+    have h_raw_index : index < table.length := by
+      simpa only [Table.table_length] using h_index
+    have h_capacity : index < ZiskFv.AirsClean.Main.mainFixedColumns.capacity :=
+      Table.index_lt_fixed_capacity table ZiskFv.AirsClean.Main.mainFixedColumns h_columns
+        ⟨index, h_raw_index⟩
+    simpa [ZiskFv.AirsClean.Main.mainFixedColumns] using h_capacity
+
+/-- **Every register read timestamp is far below the field's wrap point.**
+
+    `main_step` is the row index, and the Main component's fixed schema caps the index at
+    `mainFixedCapacity = 2^22`, so `k + main_step * 4 < 2^24` for `k ∈ {1, 2, 3}`. The `2^40` form
+    is what `prev_val_lt_of_registerStepSpec` consumes. -/
+theorem readTimestamp_val_lt_of_main_step_eq_index
+    {row : ZiskFv.AirsClean.Main.MainRowWithRom FGL} {index : Nat}
+    (h_step : row.rom.main_step = (index : FGL))
+    (h_index : index < ZiskFv.AirsClean.Main.mainFixedCapacity)
+    (s : RegSlot) :
+    (s.readTimestamp row).val < 2 ^ 40 := by
+  have h_capacity : index < 4194304 := by
+    simpa [ZiskFv.AirsClean.Main.mainFixedCapacity] using h_index
+  have h_prime : GL_prime = 18446744069414584321 := rfl
+  have h_cast : ((index : FGL)).val = index := by
+    rw [Fin.val_natCast, Nat.mod_eq_of_lt (by omega)]
+  have h_mul : ((index : FGL) * 4).val = index * 4 := by
+    rw [Fin.val_mul, h_cast]
+    exact Nat.mod_eq_of_lt (by omega)
+  cases s <;>
+    simp only [RegSlot.readTimestamp, h_step, Fin.val_add, h_mul] <;>
+      · rw [Nat.mod_eq_of_lt (by omega)]
+        omega
+
+/-- The bus-102 descent for one slot of one executed step, read off the trace's channel balance. -/
+theorem regSlot_descent_of_trace
+    (trace : AcceptedZiskTrace n) (i : Fin n) (s : RegSlot)
+    (h_active :
+      s.selector (mainTableRowAtOrZero trace.program trace.mainTable i.val) = 1) :
+    ZiskFv.AirsClean.RangeTables.rangeTable24.Spec
+      (s.distance (mainTableRowAtOrZero trace.program trace.mainTable i.val)) := by
+  have h_index : i.val < trace.mainTable.table.length := trace.mainTable_index i
+  refine rangeTable24_spec_distance_of_active trace.channels_balanced trace.spec_holds
+    trace.constraints_hold trace.mainTable_mem
+    (List.get_mem trace.mainTable.table ⟨i.val, h_index⟩)
+    ((mainTableRowAtOrZero_get trace.program trace.mainTable ⟨i.val, h_index⟩).symm)
+    trace.mainTable_component s h_active
+
+/-- The no-wrap bound for a trace's Main row, derived from the fixed schema. -/
+theorem regSlot_timestamp_bound_of_trace
+    (trace : AcceptedZiskTrace n) (i : Fin n) (s : RegSlot) :
+    (s.readTimestamp (mainTableRowAtOrZero trace.program trace.mainTable i.val)).val < 2 ^ 40 :=
+  readTimestamp_val_lt_of_main_step_eq_index
+    (trace.mainTable_main_step_index_fixed.main_step_eq_index i)
+    (main_index_lt_mainFixedCapacity trace.mainTable_component (trace.mainTable_index i)) s
+
+/-- A walk step named by an executed step index and a register slot. -/
+noncomputable def traceWalkStep (trace : AcceptedZiskTrace n) (p : Fin n × RegSlot) :
+    RegWalkStep :=
+  (mainTableRowAtOrZero trace.program trace.mainTable p.1.val, p.2)
+
+/-- **One supply step on an accepted trace moves strictly later in time**, with both inputs derived
+    from the trace rather than assumed: the descent from channel balance, the no-wrap bound from the
+    Main table's fixed-column capacity. -/
+theorem traceWalkStep_timestamp_lt_of_supplies
+    (trace : AcceptedZiskTrace n) {p q : Fin n × RegSlot}
+    (h_active : q.2.selector (traceWalkStep trace q).1 = 1)
+    (h_supplies : (traceWalkStep trace p).Supplies (traceWalkStep trace q)) :
+    (traceWalkStep trace p).timestamp.val < (traceWalkStep trace q).timestamp.val :=
+  readTimestamp_lt_of_regSupplies h_supplies
+    (regSlot_descent_of_trace trace q.1 q.2 h_active)
+    (regSlot_timestamp_bound_of_trace trace p.1 p.2)
+
+/-- **No step of an accepted trace supplies its own register read.** The smallest case of #342's
+    witness, refuted with no hypothesis beyond the trace itself and the slot being active. -/
+theorem not_traceWalkStep_supplies_self
+    (trace : AcceptedZiskTrace n) (p : Fin n × RegSlot)
+    (h_active : p.2.selector (traceWalkStep trace p).1 = 1) :
+    ¬ RegSupplies p.2 p.2 (traceWalkStep trace p).1 (traceWalkStep trace p).1 :=
+  not_regSupplies_self (regSlot_descent_of_trace trace p.1 p.2 h_active)
+    (regSlot_timestamp_bound_of_trace trace p.1 p.2)
+
+/-- **#342's concrete witness is impossible on an accepted trace.** Two Main rows whose register-pre
+    pushes carry each other's read timestamps cannot both occur, for any pair of slots. -/
+theorem not_traceWalkStep_two_cycle
+    (trace : AcceptedZiskTrace n) (p q : Fin n × RegSlot)
+    (h_active_p : p.2.selector (traceWalkStep trace p).1 = 1)
+    (h_active_q : q.2.selector (traceWalkStep trace q).1 = 1)
+    (h_pq : (traceWalkStep trace p).Supplies (traceWalkStep trace q))
+    (h_qp : (traceWalkStep trace q).Supplies (traceWalkStep trace p)) : False :=
+  not_regSupplies_two_cycle
+    (regSlot_descent_of_trace trace p.1 p.2 h_active_p)
+    (regSlot_descent_of_trace trace q.1 q.2 h_active_q)
+    (regSlot_timestamp_bound_of_trace trace p.1 p.2)
+    (regSlot_timestamp_bound_of_trace trace q.1 q.2)
+    h_pq h_qp
+
+/-- **The register walk on an accepted trace has no cycle of any length.**
+
+    Quantified over the trace: every hypothesis except the chain itself and the per-step selector is
+    discharged from `AcceptedZiskTrace`. A chain of supply steps visits no read timestamp twice, so
+    the pairing that channel balance certifies cannot decompose into the boundary path plus a
+    disjoint cycle *among Main rows*.
+
+    **What this does not do.** It bounds the chain from below, not from above: nothing here forces
+    the chain to reach `RegisterBoundary.bootMessage`. That anchor is `main.pil:447`, which the
+    modeled `RegisterBoundary` still omits. -/
+theorem regSupplies_chain_timestamps_nodup_of_trace
+    (trace : AcceptedZiskTrace n) (steps : List (Fin n × RegSlot))
+    (h_active : ∀ p ∈ steps, p.2.selector (traceWalkStep trace p).1 = 1)
+    (h_chain : List.IsChain RegWalkStep.Supplies (steps.map (traceWalkStep trace))) :
+    ((steps.map (traceWalkStep trace)).map RegWalkStep.timestamp).Nodup := by
+  refine regSupplies_chain_timestamps_nodup _ ?_ ?_ h_chain
+  · intro w hw
+    obtain ⟨p, hp, rfl⟩ := List.mem_map.mp hw
+    exact regSlot_descent_of_trace trace p.1 p.2 (h_active p hp)
+  · intro w hw
+    obtain ⟨p, hp, rfl⟩ := List.mem_map.mp hw
+    exact regSlot_timestamp_bound_of_trace trace p.1 p.2
+
+/-! ## From balance to the supply relation
+
+Everything above takes the supply relation as given. This last section derives it: on an accepted
+trace, the counterpart of a Main register read is *either* the `RegisterBoundary` (boot or reload)
+*or* another Main row's register-pre push, and in the second case that row's own register access
+happens strictly later. -/
+
+open ZiskFv.AirsClean.FullEnsemble (ActiveMainRegisterBoundaryProviderRowMatchSpec
+  activeMainRegisterProviderRowMatchSpec_of_main_mem_op_three
+  selfMemProvider_registerPre_active_of_mem_op_three)
+open ZiskFv.Channels.MemoryBus (MemBusChannel)
+
+/-- **The counterpart of a register read, classified.** From `channels_balanced` alone: a Main
+    memory-bus pull at `mem_op = 3` is supplied either by the `RegisterBoundary` or by another Main
+    row, and in the second case the supplying row's slot is *active* and its free
+    `<slot>_reg_prev_mem_step` column holds this read's timestamp.
+
+    The activity conjunct is what makes the second branch usable — it is exactly the premise the
+    bus-102 descent needs. -/
+theorem registerRead_counterpart_of_trace
+    {n : Nat} (trace : AcceptedZiskTrace n)
+    {mainRow : Array FGL} (h_mainRow : mainRow ∈ trace.mainTable.table)
+    {mainInteraction : Interaction FGL}
+    (h_mainInteraction :
+      mainInteraction ∈ trace.mainTable.interactionsWith MemBusChannel.toRaw)
+    {mainMult : Expression FGL}
+    {mainMsg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)}
+    (h_mainEval :
+      mainInteraction =
+        ((MemBusChannel.emitted mainMult mainMsg).toRaw).eval
+          (trace.mainTable.environment mainRow))
+    (h_pull : mainInteraction.mult = -1)
+    (h_mem_op : (eval (trace.mainTable.environment mainRow) mainMsg).mem_op = 3)
+    {multiplicity as : FGL} :
+    ActiveMainRegisterBoundaryProviderRowMatchSpec trace.program trace.witness trace.mainTable
+        mainRow mainInteraction mainMsg multiplicity as
+      ∨ ∃ providerTable ∈ trace.witness.allTables, ∃ providerRow ∈ providerTable.table,
+          providerTable.component =
+              ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+                trace.programLength trace.program
+            ∧ ∃ sp : RegSlot,
+                sp.selector (eval (providerTable.environment providerRow)
+                    (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+                      trace.programLength trace.program).rowInputVar) = 1
+                  ∧ sp.prevStep (eval (providerTable.environment providerRow)
+                      (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+                        trace.programLength trace.program).rowInputVar)
+                    = (eval (trace.mainTable.environment mainRow) mainMsg).timestamp := by
+  have h_match :=
+    (trace.activeMainMemProviderRowMatchSpec_of_active_main_eval
+      h_mainRow h_mainInteraction h_mainEval h_pull (multiplicity := multiplicity) (as := as)).2
+  rcases activeMainRegisterProviderRowMatchSpec_of_main_mem_op_three
+      h_mainEval h_mem_op h_match with h_self | h_boundary
+  · refine Or.inr ?_
+    obtain ⟨providerTable, h_providerTable, providerRow, h_providerRow, h_providerComponent,
+      h_branch⟩ :=
+      selfMemProvider_registerPre_active_of_mem_op_three h_mainEval h_mem_op
+        trace.constraints_hold h_self
+    refine ⟨providerTable, h_providerTable, providerRow, h_providerRow, h_providerComponent, ?_⟩
+    rcases h_branch with ⟨h_sel, h_ts⟩ | ⟨h_sel, h_ts⟩ | ⟨h_sel, h_ts⟩
+    · exact ⟨RegSlot.a, h_sel, h_ts⟩
+    · exact ⟨RegSlot.b, h_sel, h_ts⟩
+    · exact ⟨RegSlot.c, h_sel, h_ts⟩
+  · exact Or.inl h_boundary
+
+/-- **The supply step, entirely from the accepted trace.**
+
+    A register read on a Main row is supplied either by the `RegisterBoundary`, or by a Main row
+    whose own register access is at a **strictly later** timestamp. Nothing is assumed: the branch
+    split comes from `channels_balanced`, the provider's slot activity from its counterpart
+    multiplicity plus Main's selector booleanity, the descent from the bus-102 range slice, and the
+    no-wrap bound from the Main table's fixed-column capacity.
+
+    This is what rules out the disjoint register cycle that #342 exhibits. A cycle would be a closed
+    walk of supply steps, and every supply step strictly increases the read timestamp. -/
+theorem registerRead_supplied_by_boundary_or_strictly_later_row
+    {n : Nat} (trace : AcceptedZiskTrace n)
+    (i : Fin n) (sc : RegSlot)
+    {mainInteraction : Interaction FGL}
+    (h_mainInteraction :
+      mainInteraction ∈ trace.mainTable.interactionsWith MemBusChannel.toRaw)
+    {mainMult : Expression FGL}
+    (h_mainEval :
+      mainInteraction =
+        ((MemBusChannel.emitted mainMult
+          (sc.memMessageExpr
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              trace.programLength trace.program).rowInputVar)).toRaw).eval
+          (trace.mainTable.environment
+            (trace.mainTable.table.get ⟨i.val, trace.mainTable_index i⟩)))
+    (h_pull : mainInteraction.mult = -1)
+    (h_mem_op :
+      (eval (trace.mainTable.environment
+          (trace.mainTable.table.get ⟨i.val, trace.mainTable_index i⟩))
+        (sc.memMessageExpr
+          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            trace.programLength trace.program).rowInputVar)).mem_op = 3)
+    {multiplicity as : FGL} :
+    ActiveMainRegisterBoundaryProviderRowMatchSpec trace.program trace.witness trace.mainTable
+        (trace.mainTable.table.get ⟨i.val, trace.mainTable_index i⟩) mainInteraction
+        (sc.memMessageExpr
+          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            trace.programLength trace.program).rowInputVar)
+        multiplicity as
+      ∨ ∃ providerTable ∈ trace.witness.allTables, ∃ providerRow ∈ providerTable.table,
+          ∃ _ : providerTable.component =
+              ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+                trace.programLength trace.program,
+            ∃ sp : RegSlot,
+              RegSupplies sc sp
+                  (mainTableRowAtOrZero trace.program trace.mainTable i.val)
+                  (eval (providerTable.environment providerRow)
+                    (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+                      trace.programLength trace.program).rowInputVar)
+                ∧ (sc.readTimestamp
+                      (mainTableRowAtOrZero trace.program trace.mainTable i.val)).val
+                    < (sp.readTimestamp
+                      (eval (providerTable.environment providerRow)
+                        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+                          trace.programLength trace.program).rowInputVar)).val := by
+  have h_row : mainTableRowAtOrZero trace.program trace.mainTable i.val
+      = eval (trace.mainTable.environment
+          (trace.mainTable.table.get ⟨i.val, trace.mainTable_index i⟩))
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          trace.programLength trace.program).rowInputVar :=
+    mainTableRowAtOrZero_get trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
+  rcases registerRead_counterpart_of_trace trace
+      (List.get_mem trace.mainTable.table ⟨i.val, trace.mainTable_index i⟩)
+      h_mainInteraction h_mainEval h_pull h_mem_op (multiplicity := multiplicity) (as := as) with
+    h_boundary | ⟨providerTable, h_providerTable, providerRow, h_providerRow,
+      h_providerComponent, sp, h_sel, h_ts⟩
+  · exact Or.inl h_boundary
+  · refine Or.inr ⟨providerTable, h_providerTable, providerRow, h_providerRow,
+      h_providerComponent, sp, ?_, ?_⟩
+    · show sp.prevStep _ = sc.readTimestamp _
+      rw [h_ts, RegSlot.eval_memMessageExpr_timestamp, ← h_row]
+    · refine readTimestamp_lt_of_regSupplies (sc := sc) (sp := sp) ?_ ?_ ?_
+      · show sp.prevStep _ = sc.readTimestamp _
+        rw [h_ts, RegSlot.eval_memMessageExpr_timestamp, ← h_row]
+      · exact rangeTable24_spec_distance_of_active trace.channels_balanced trace.spec_holds
+          trace.constraints_hold h_providerTable h_providerRow rfl h_providerComponent sp h_sel
+      · exact regSlot_timestamp_bound_of_trace trace i sc
+
+end ZiskFv.Compliance

--- a/trust/consistency/register_walk_acyclic.lean
+++ b/trust/consistency/register_walk_acyclic.lean
@@ -44,8 +44,19 @@ theorem register_walk_timestamps_nodup
     ((steps.map (traceWalkStep trace)).map RegWalkStep.timestamp).Nodup :=
   regSupplies_chain_timestamps_nodup_of_trace trace steps h_active h_chain
 
+/-- Non-vacuity: the supply relation holds on a checked witness's real Main row, so the
+    implications above are not empty. -/
+theorem register_walk_non_vacuous :
+    List.IsChain RegWalkStep.Supplies
+      [(ZiskFv.Compliance.RegisterMemBusBalance.addX1Row, RegSlot.a),
+       (ZiskFv.Compliance.RegisterMemBusBalance.addX1Row, RegSlot.b),
+       (ZiskFv.Compliance.RegisterMemBusBalance.addX1Row, RegSlot.c)] :=
+  addX1Row_walk_isChain
+
 #print axioms register_walk_no_two_cycle
 #print axioms register_walk_timestamps_nodup
+#print axioms register_walk_non_vacuous
+#print axioms ZiskFv.Compliance.addX1Row_walk_timestamps_nodup
 #print axioms ZiskFv.Compliance.registerRead_counterpart_of_trace
 #print axioms ZiskFv.Compliance.registerRead_supplied_by_boundary_or_strictly_later_row
 #print axioms ZiskFv.Compliance.regSlot_descent_of_trace

--- a/trust/consistency/register_walk_acyclic.lean
+++ b/trust/consistency/register_walk_acyclic.lean
@@ -53,6 +53,16 @@ theorem register_walk_non_vacuous :
        (ZiskFv.Compliance.RegisterMemBusBalance.addX1Row, RegSlot.c)] :=
   addX1Row_walk_isChain
 
+/-- The chain result stated over exactly the rows the counterpart classification produces —
+    every Main row of the witness, not only the executed prefix. -/
+theorem register_walk_timestamps_nodup_on_witness_rows
+    {n : Nat} (trace : AcceptedZiskTrace n) (steps : List RegWalkStep)
+    (h_sites : ∀ p ∈ steps, IsActiveWitnessMainRow trace p)
+    (h_chain : List.IsChain RegWalkStep.Supplies steps) :
+    (steps.map RegWalkStep.timestamp).Nodup :=
+  regSupplies_chain_timestamps_nodup_of_witnessRows trace steps h_sites h_chain
+
+#print axioms register_walk_timestamps_nodup_on_witness_rows
 #print axioms register_walk_no_two_cycle
 #print axioms register_walk_timestamps_nodup
 #print axioms register_walk_non_vacuous

--- a/trust/consistency/register_walk_acyclic.lean
+++ b/trust/consistency/register_walk_acyclic.lean
@@ -1,0 +1,54 @@
+import ZiskFv.Compliance.RegisterWalk
+
+/-!
+# Register walk acyclicity (issue #342)
+
+Keeps the axiom closure of the #342 payoff theorems visible to the semantic trust gate.
+
+`main.pil:333-335`'s bus-102 range check bounds each Main row's register-step distance. Modelling it
+(PR #345) supplies the descent; these theorems consume it. Together they say that on an accepted
+trace the register supply relation strictly increases the memory-bus read timestamp, so the pairing
+that `channels_balanced` certifies cannot contain a cycle among Main rows — the exact configuration
+`#342` exhibits as a counterexample to the unmodelled circuit.
+
+Every premise is discharged from `AcceptedZiskTrace`:
+
+* the branch split from `channels_balanced`;
+* the supplying row's slot activity from its counterpart multiplicity plus Main's own selector
+  booleanity;
+* the descent from the bus-102 provider slice;
+* the no-wrap bound from the Main table's fixed-column capacity (`mainFixedCapacity = 2^22`), not
+  from an assumption about segment length.
+-/
+
+namespace ZiskFv.TrustConsistency
+
+open ZiskFv.Compliance
+open ZiskFv.Compliance.Instantiation (RegSlot RegSupplies RegWalkStep)
+
+/-- #342's concrete two-row witness is impossible on an accepted trace. -/
+theorem register_walk_no_two_cycle
+    {n : Nat} (trace : AcceptedZiskTrace n) (p q : Fin n × RegSlot)
+    (h_active_p : p.2.selector (traceWalkStep trace p).1 = 1)
+    (h_active_q : q.2.selector (traceWalkStep trace q).1 = 1)
+    (h_pq : (traceWalkStep trace p).Supplies (traceWalkStep trace q))
+    (h_qp : (traceWalkStep trace q).Supplies (traceWalkStep trace p)) : False :=
+  not_traceWalkStep_two_cycle trace p q h_active_p h_active_q h_pq h_qp
+
+/-- The register walk on an accepted trace visits no read timestamp twice, so it has no cycle of
+    any length. -/
+theorem register_walk_timestamps_nodup
+    {n : Nat} (trace : AcceptedZiskTrace n) (steps : List (Fin n × RegSlot))
+    (h_active : ∀ p ∈ steps, p.2.selector (traceWalkStep trace p).1 = 1)
+    (h_chain : List.IsChain RegWalkStep.Supplies (steps.map (traceWalkStep trace))) :
+    ((steps.map (traceWalkStep trace)).map RegWalkStep.timestamp).Nodup :=
+  regSupplies_chain_timestamps_nodup_of_trace trace steps h_active h_chain
+
+#print axioms register_walk_no_two_cycle
+#print axioms register_walk_timestamps_nodup
+#print axioms ZiskFv.Compliance.registerRead_counterpart_of_trace
+#print axioms ZiskFv.Compliance.registerRead_supplied_by_boundary_or_strictly_later_row
+#print axioms ZiskFv.Compliance.regSlot_descent_of_trace
+#print axioms ZiskFv.Compliance.regSlot_timestamp_bound_of_trace
+
+end ZiskFv.TrustConsistency

--- a/trust/scripts/check-all-semantic.sh
+++ b/trust/scripts/check-all-semantic.sh
@@ -72,33 +72,35 @@ run_register_mem_bus_witnesses() {
   return $ok
 }
 
-run "1/19 axiom-deps baseline (V2)"        "$dir/check-axiom-deps.sh"
-run "2/19 forbidden types (V2)"            "$dir/check-no-output-eq-v2.sh"
-run "3/19 closure vs baseline-axioms (V2)" "$dir/check-closure-vs-baseline.sh"
-run "4/19 global theorem binders (V2)"     "$dir/check-global-theorem-binders.sh"
-run "5/19 strong-export axiom closure (V2)" "$dir/check-strong-export-closure.sh"
-run "6/19 strong-export binders + forbidden types (V2)" "$dir/check-strong-export-binders.sh"
-run "7/19 consistency false probe rejected" reject_false_probe
-run "8/19 MemAlign narrow-load lane constraint repro" \
+run "1/20 axiom-deps baseline (V2)"        "$dir/check-axiom-deps.sh"
+run "2/20 forbidden types (V2)"            "$dir/check-no-output-eq-v2.sh"
+run "3/20 closure vs baseline-axioms (V2)" "$dir/check-closure-vs-baseline.sh"
+run "4/20 global theorem binders (V2)"     "$dir/check-global-theorem-binders.sh"
+run "5/20 strong-export axiom closure (V2)" "$dir/check-strong-export-closure.sh"
+run "6/20 strong-export binders + forbidden types (V2)" "$dir/check-strong-export-binders.sh"
+run "7/20 consistency false probe rejected" reject_false_probe
+run "8/20 MemAlign narrow-load lane constraint repro" \
   run_lean_no_sorry trust/consistency/memalign_narrow_load_lane_defect.lean
-run "9/19 signed-DIV quotient-sign defect repro" \
+run "9/20 signed-DIV quotient-sign defect repro" \
   run_lean_no_sorry trust/consistency/arith_div_quotient_sign_defect.lean
-run "10/19 Sail memory timeline witness" \
+run "10/20 Sail memory timeline witness" \
   run_lean_no_sorry trust/consistency/load_byte_agreement_witness.lean
-run "11/19 memory timeline construction witness" \
+run "11/20 memory timeline construction witness" \
   run_lean_no_sorry trust/consistency/memory_timeline_construction_witness.lean
-run "12/19 memory prefix alignment witness" \
+run "12/20 memory prefix alignment witness" \
   run_lean_no_sorry trust/consistency/memory_prefix_alignment_witness.lean
-run "13/19 SD/LD Mem-prefix constructibility" \
+run "13/20 SD/LD Mem-prefix constructibility" \
   run_lean_no_sorry trust/consistency/memory_prefix_sd_ld_mem_table.lean
-run "14/19 global ADD theorem instantiation" \
+run "14/20 global ADD theorem instantiation" \
   run_lean_no_sorry trust/consistency/global_theorem_instantiation_add.lean
-run "15/19 global LD theorem instantiation" \
+run "15/20 global LD theorem instantiation" \
   run_lean_no_sorry trust/consistency/global_theorem_instantiation_ld.lean
-run "16/19 root_soundness instantiation witnesses" run_root_soundness_instantiations
-run "17/19 Clean completeness witnesses" run_witnesses
-run "18/19 register MemBus balance witnesses" run_register_mem_bus_witnesses
-run "19/19 Aeneas extraction-pin raw axiom closure (V2)" \
+run "16/20 root_soundness instantiation witnesses" run_root_soundness_instantiations
+run "17/20 Clean completeness witnesses" run_witnesses
+run "18/20 register MemBus balance witnesses" run_register_mem_bus_witnesses
+run "19/20 register walk acyclicity (#342)" \
+  run_lean_no_sorry trust/consistency/register_walk_acyclic.lean
+run "20/20 Aeneas extraction-pin raw axiom closure (V2)" \
   "$dir/check-extraction-closure.sh"
 
 if [ $overall -eq 0 ]; then

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -658,7 +658,10 @@ table's own fixed-column capacity (`mainFixedCapacity = 2^22`) rather than from 
 segment-length assumption. Consequently the supply relation is acyclic
 (`regSupplies_chain_timestamps_nodup_of_trace`), which is what excludes the disjoint
 register cycle #342 exhibits. The relation is slot-indexed on both sides, so mixed-slot
-cycles are excluded too. V2 check 19 keeps the axiom closure visible
+cycles are excluded too. The chain result is stated over `IsActiveWitnessMainRow` — every Main
+row of the witness, not just the executed prefix — because a provider may be a padding row past
+that prefix, and its no-wrap bound comes from the same fixed-column capacity. V2 check 19 keeps
+the axiom closure visible
 (`trust/consistency/register_walk_acyclic.lean`); it is kernel-only and adds no project
 axioms.
 

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -668,9 +668,16 @@ distances are the `[0, 0, 0]` that `singleAddWitness`'s provider list records. E
 result in `RegisterWalk.lean` is an implication out of `RegSupplies`, so an empty relation
 would make them hold without saying anything about ZisK.
 
-**What this still does not give.** Acyclicity bounds the walk from below, not above. The
-`main.pil:447` gap above is unchanged, so nothing yet forces a register chain to *reach*
-`RegisterBoundary.bootMessage`; the boundary can still self-pair at timestamp `0`.
+**What this still does not give.** Acyclicity bounds the walk from below, not above. Nothing yet
+forces a register chain to *reach* `RegisterBoundary.bootMessage`, for two separate reasons.
+First, the `main.pil:447` gap above is unchanged, so the boundary can still self-pair at
+timestamp `0`. Second, iterating the supply step needs the supplying row's own access to be a
+`mem_op = 3` **pull**, i.e. `a_src_mem + a_src_reg = 1`, because `exists_push_of_pull` fires only
+at multiplicity exactly `-1`. Main's constraints give **booleanity only**
+(`Main/Constraints.lean:252,259`); no exclusivity constraint exists in the component, so `(1, 1)`
+is admissible in the model and the pull would ride at `-2` with `mem_op = 4`. Ruling that out means
+pinning `rom_flags` to a decoded instruction — the committed-program decode bridge (#172, on top of
+#164's proven decoder), a different axis from this range slice.
 This slice does **not** claim register/memory access-ordering soundness. The
 cross-segment continuation terms (`MAIN_CONTINUATION_ID` block and
 `main.pil:454`'s `sel:(1-main_last_segment)` continuation pull) are out of scope

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -645,6 +645,26 @@ free witness column. `main.pil:447`'s reload-timestamp check remains **unmodelle
 `registerBoundary_table_interactionsWith_registerStepRange_nil` currently *proves* that
 component silent on bus 102 — so modelling 447 later will require revisiting that lemma
 and the provider case split in `exists_registerStepRange_provider_of_pull`.
+
+**Update (#342, the walk).** The descent is now *consumed*, in
+`ZiskFv/Compliance/RegisterWalk.lean`.
+`registerRead_supplied_by_boundary_or_strictly_later_row` says a Main register read on an
+accepted trace is supplied either by the `RegisterBoundary` or by a Main row whose own
+register access sits at a **strictly later** memory-bus timestamp. Every premise is
+discharged from `AcceptedZiskTrace`: the branch split from `channels_balanced`, the
+supplying row's slot activity from its counterpart multiplicity plus Main's selector
+booleanity, the descent from the bus-102 slice, and the no-wrap bound from the Main
+table's own fixed-column capacity (`mainFixedCapacity = 2^22`) rather than from a
+segment-length assumption. Consequently the supply relation is acyclic
+(`regSupplies_chain_timestamps_nodup_of_trace`), which is what excludes the disjoint
+register cycle #342 exhibits. The relation is slot-indexed on both sides, so mixed-slot
+cycles are excluded too. V2 check 19 keeps the axiom closure visible
+(`trust/consistency/register_walk_acyclic.lean`); it is kernel-only and adds no project
+axioms.
+
+**What this still does not give.** Acyclicity bounds the walk from below, not above. The
+`main.pil:447` gap above is unchanged, so nothing yet forces a register chain to *reach*
+`RegisterBoundary.bootMessage`; the boundary can still self-pair at timestamp `0`.
 This slice does **not** claim register/memory access-ordering soundness. The
 cross-segment continuation terms (`MAIN_CONTINUATION_ID` block and
 `main.pil:454`'s `sel:(1-main_last_segment)` continuation pull) are out of scope

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -662,6 +662,12 @@ cycles are excluded too. V2 check 19 keeps the axiom closure visible
 (`trust/consistency/register_walk_acyclic.lean`); it is kernel-only and adds no project
 axioms.
 
+The relation is **not vacuous**: `addX1Row_walk_isChain` exhibits it on the `add x1,x1,x1`
+witness row, whose three slots read at timestamps `1`, `2`, `3` and whose bus-102
+distances are the `[0, 0, 0]` that `singleAddWitness`'s provider list records. Every
+result in `RegisterWalk.lean` is an implication out of `RegSupplies`, so an empty relation
+would make them hold without saying anything about ZisK.
+
 **What this still does not give.** Acyclicity bounds the walk from below, not above. The
 `main.pil:447` gap above is unchanged, so nothing yet forces a register chain to *reach*
 `RegisterBoundary.bootMessage`; the boundary can still self-pair at timestamp `0`.


### PR DESCRIPTION
Second half of #342. PR #345 modelled `main.pil:333-335`'s bus-102 register-step descent and derived
it from balance. This PR **uses** it: it turns the per-row range fact into a statement about the whole
register partition of an accepted trace.

**Does not close #342** on its own — see "What remains".

## The gap, restated

`a_reg_prev_mem_step` is a free witness column. Two Main rows on one register can point at each
other's read timestamps carrying a fabricated value: a closed 2-cycle touching neither boot nor
reload, with `BalancedChannels` intact. #342's body has the witness.

## What this PR proves

**`registerRead_supplied_by_boundary_or_strictly_later_row`** — on an accepted trace, a Main register
read at `mem_op = 3` is supplied *either* by the `RegisterBoundary`, *or* by a Main row whose own
register access sits at a **strictly later** memory-bus timestamp.

Every premise is discharged from `AcceptedZiskTrace`. Nothing is assumed:

| what | where it comes from |
|---|---|
| the counterpart exists and is register-side | `channels_balanced` → `activeMainMemProviderRowMatchSpec_of_active_main_eval` → `activeMainRegisterProviderRowMatchSpec_of_main_mem_op_three` |
| the supplying row's slot is **active** | its counterpart multiplicity (`≠ 0`) plus Main's own selector booleanity — new `selfMemProvider_registerPre_active_of_mem_op_three` |
| the descent on that row | the bus-102 provider slice (PR #345) |
| the no-wrap bound | the Main table's fixed-column capacity, `mainFixedCapacity = 2^22`, so every read timestamp is below `2^24` |

The last row is worth pausing on. `prev_val_lt_of_registerStepSpec` needs the predecessor timestamp
to be far from the field's wrap point, and the obvious way to get that is to assume the segment is
short. It is not assumed: `Table.index_lt_fixed_capacity` reads the bound off the table carrier
itself (`main_index_lt_mainFixedCapacity`), so it costs no premise and holds for any accepted trace.

**`regSupplies_chain_timestamps_nodup_of_trace`** — consequently the walk visits no read timestamp
twice. The pairing that balance certifies cannot decompose into the boundary path plus a disjoint
cycle among Main rows. That is the configuration #342 exhibits, and `register_walk_no_two_cycle`
refutes its exact two-row shape.

## The walk is slot-indexed on both sides

All three register slots share one MemBus at `mem_op = 3`, so a supply step can **cross** slots: row
`r₁`'s a-side read can be supplied by row `r₂`'s store-side register-pre push. The relation is
therefore `RegSupplies sc sp consumer provider`, indexed by the slot at each end, and the cycle
results exclude mixed-slot cycles too. This replaces the a-only version in this branch's first
commit, which would have left the b/store slots as separate unproved twins.

`RegSlot` collects the three slots' read timestamp, free predecessor column, selector, distance, and
memory-bus message, so the three per-slot lemmas from #345 compose into one
`rangeTable24_spec_distance_of_active` instead of being case-split at every call site.

## The chain result matches what the classification produces

`regSupplies_chain_timestamps_nodup_of_trace` is indexed by `Fin n`, so on its own it speaks only
about executed steps — while `registerRead_counterpart_of_trace` produces providers out of
`witness.allTables`, and a provider may be a **padding row past the executed prefix**. Those two did
not compose, and a chain theorem that cannot consume the classification's output is the same defect
as quantifying over an abstract list.

`IsActiveWitnessMainRow` names the shape the classification actually returns — a Main-component
table of the witness, an in-range index, a slot whose selector is set — the classification returns
it directly, and `regSupplies_chain_timestamps_nodup_of_witnessRows` consumes it. The no-wrap bound
generalizes the same way (`regSlot_timestamp_bound_of_mainTable`), because the fixed-column capacity
argument never cared whether a row was executed or padding. The `Fin n` versions remain as
corollaries.

## Non-vacuity

Every result here is an implication out of `RegSupplies`. If that relation were empty they would all
hold vacuously.

`addX1Row_walk_isChain` exhibits it on the `add x1,x1,x1` witness row — a row of a **checked**
witness, not a hand-built one. Its three slots read at timestamps `1`, `2`, `3`, so the b-slot
supplies the a-slot's read and the store-slot supplies the b-slot's. Those are exactly the
`[0, 0, 0]` bus-102 distances `singleAddWitness`'s provider list records. `addX1Row_walk_timestamps_nodup`
then instantiates the general no-cycle theorem on it.

The chain is a legal strictly-increasing walk within one row, not a cycle — which is the point: the
theorems distinguish the two.

## Trust boundary

**No new trust markers.** No `axiom` / `opaque` / `sorry` / `native_decide` or equivalent. The
non-vacuity witnesses use plain `decide`, which the kernel checks.

V2 **gains** a check rather than losing one: check 19 is the new
`trust/consistency/register_walk_acyclic.lean`, and the Aeneas extraction-pin check moves to 20/20.
Axiom closure of every new theorem is `[propext, Classical.choice, Quot.sound]`; the non-vacuity
chain is `[propext]` alone.

`trust/trusted-base.md`'s register-partition section is updated in the same change: what the descent
now delivers, and — explicitly — what it still does not.

## What remains — this PR does not close #342

1. **Termination at `RegisterBoundary.bootMessage`.** Acyclicity bounds the walk from below, not
   from above. Nothing here forces a chain to *reach* boot, and `main.pil:447`'s reload-timestamp
   check is still unmodelled, so the boundary can self-pair at timestamp `0`.

   Iterating the supply step to prove termination needs one fact this PR does not have: that the
   supplying row's own register access is itself a `mem_op = 3` **pull**, so the counterpart theorem
   applies to it in turn. That needs `a_src_mem + a_src_reg = 1`, because `exists_push_of_pull`
   only fires at multiplicity exactly `-1`.

   Main's constraints give **booleanity only** — `Constraints.lean:252,259` assert
   `a_src_mem * (1 - a_src_mem) = 0` and `a_src_reg * (1 - a_src_reg) = 0`, and there is no
   exclusivity constraint anywhere in the component (checked, not assumed). So `(1, 1)` is
   admissible in the model: the pull would ride at `-2` with `mem_op = 4`. Ruling it out means
   pinning `rom_flags` to a *decoded* instruction, which is the committed-program decode bridge
   (#172, on top of #164's proven decoder) — a different axis from the bus-102 range slice.

   Separately, `main.pil:447` stays unmodelled, so
   `registerBoundary_table_interactionsWith_registerStepRange_nil` is still load-bearing.

   I am flagging both rather than routing them anywhere.

2. **The value telescope.** Ordering is not agreement. Carrying the *value* along the chain, and so
   building #330's 116 `h_a_*_t` / `h_b_*_t` fields instead of assuming them, is #330 Phase 4 and
   sits behind (1).

## Verification

On this branch's head:

- `lake build` — see comment below
- V1 `trust/scripts/check-all.sh` — see comment below
- V2 `trust/scripts/check-all-semantic.sh` (now 20 checks) — see comment below
- no `sorry` anywhere under `ZiskFv/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
