### PR TITLE
#342: source exclusivity from balance, and the register walk terminates at the boundary

### DIFF
--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -195,6 +195,7 @@ import ZiskFv.Compliance.RegisterMemBusBalance
 import ZiskFv.AirsClean.FullEnsemble.Balance.MemBusSourceExclusivity
 import ZiskFv.Compliance.Instantiation.ConcreteRowReductions
 import ZiskFv.Compliance.RegisterWalk
+import ZiskFv.Compliance.MemBusSlotSeparation
 import ZiskFv.Compliance.SingleAddWitness
 import ZiskFv.Compliance.AddSpinWitness
 import ZiskFv.Compliance.AddSpinRootSoundness

--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -192,6 +192,7 @@ import ZiskFv.Compliance.TraceLevelExport.RawProgramBindingJalrExpansionNonvacui
 import ZiskFv.Compliance
 import ZiskFv.Compliance.EnsembleWitnessBuilder
 import ZiskFv.Compliance.RegisterMemBusBalance
+import ZiskFv.AirsClean.FullEnsemble.Balance.MemBusSourceExclusivity
 import ZiskFv.Compliance.Instantiation.ConcreteRowReductions
 import ZiskFv.Compliance.RegisterWalk
 import ZiskFv.Compliance.SingleAddWitness

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusSourceExclusivity.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusSourceExclusivity.lean
@@ -63,7 +63,7 @@ private lemma zero_or_one_of_val_lt_two {x : FGL} (h : x.val < 2) : x = 0 ∨ x 
   · exact Or.inr (by apply Fin.ext; simp [h_val])
 
 /-- Push `Expression.eval` through a Main row variable's ROM projections. -/
-private lemma main_rom_eval
+theorem main_rom_eval
     (env : Environment FGL) (row : Var MainRowWithRom FGL) :
     Expression.eval env row.rom.a_src_mem = (eval env row).rom.a_src_mem
   ∧ Expression.eval env row.rom.a_src_reg = (eval env row).rom.a_src_reg

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusSourceExclusivity.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusSourceExclusivity.lean
@@ -604,4 +604,74 @@ theorem main_not_a_src_mem_and_a_src_reg
     · exact absurd h_char (by decide)
   omega
 
+
+/-- **A register-reading row does not also read memory on the a side.** Immediate from
+    `main_not_a_src_mem_and_a_src_reg` plus booleanity. -/
+theorem main_a_src_mem_eq_zero_of_a_src_reg
+    {length : ℕ} {program : Program length}
+    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
+    (h_balanced : witness.BalancedChannels)
+    (h_constraints : witness.Constraints) (h_specs : witness.Spec)
+    {table : Table FGL} (h_table : table ∈ witness.allTables)
+    (h_component : table.component = componentWithRomMemAndOpBus length program)
+    {row : Array FGL} (h_row : row ∈ table.table)
+    (h_src_reg : (eval (table.environment row)
+      (componentWithRomMemAndOpBus length program).rowInputVar).rom.a_src_reg = 1) :
+    (eval (table.environment row)
+      (componentWithRomMemAndOpBus length program).rowInputVar).rom.a_src_mem = 0 := by
+  obtain ⟨b_a_mem, -⟩ := main_source_flags_boolean h_component (h_constraints table h_table) h_row
+  rcases zero_or_one_of_bool b_a_mem with h | h
+  · exact h
+  · exact absurd (main_not_a_src_mem_and_a_src_reg h_balanced h_constraints h_specs h_table
+      h_component h_row h h_src_reg) (by simp)
+
+/-- **The a-side access of a register-reading row is a genuine `-1` pull at `mem_op = 3`.**
+
+    This is the shape Clean's `exists_push_of_pull` consumes, so it is what lets the register walk
+    take another step from a supplying row rather than stopping there. Both halves come from
+    exclusivity: the multiplicity is `-(0 + 1)` and the opcode is `0 + 3 * 1`. -/
+theorem main_aMem_pull_of_a_src_reg
+    {length : ℕ} {program : Program length}
+    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
+    (h_balanced : witness.BalancedChannels)
+    (h_constraints : witness.Constraints) (h_specs : witness.Spec)
+    {table : Table FGL} (h_table : table ∈ witness.allTables)
+    (h_component : table.component = componentWithRomMemAndOpBus length program)
+    {row : Array FGL} (h_row : row ∈ table.table)
+    (h_src_reg : (eval (table.environment row)
+      (componentWithRomMemAndOpBus length program).rowInputVar).rom.a_src_reg = 1) :
+    (((MemBusChannel.emitted
+      (-((componentWithRomMemAndOpBus length program).rowInputVar.rom.a_src_mem
+        + (componentWithRomMemAndOpBus length program).rowInputVar.rom.a_src_reg))
+      (ZiskFv.AirsClean.Main.aMemMessageExpr
+        (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw).eval
+      (table.environment row)).mult = -1
+    ∧ (eval (table.environment row)
+        (ZiskFv.AirsClean.Main.aMemMessageExpr
+          (componentWithRomMemAndOpBus length program).rowInputVar)).mem_op = 3 := by
+  have h_src_mem := main_a_src_mem_eq_zero_of_a_src_reg h_balanced h_constraints h_specs
+    h_table h_component h_row h_src_reg
+  obtain ⟨e_a_mem, e_a_reg, -⟩ :=
+    main_rom_eval (table.environment row) (componentWithRomMemAndOpBus length program).rowInputVar
+  constructor
+  · rw [memBus_emitted_eval_mult]
+    have h_eval :
+        Expression.eval (table.environment row)
+          (-((componentWithRomMemAndOpBus length program).rowInputVar.rom.a_src_mem
+            + (componentWithRomMemAndOpBus length program).rowInputVar.rom.a_src_reg))
+        = -((eval (table.environment row)
+              (componentWithRomMemAndOpBus length program).rowInputVar).rom.a_src_mem
+            + (eval (table.environment row)
+              (componentWithRomMemAndOpBus length program).rowInputVar).rom.a_src_reg) := by
+      simp only [Expression.eval, e_a_mem, e_a_reg]; ring
+    rw [h_eval, h_src_mem, h_src_reg]
+    norm_num
+  · rw [ZiskFv.AirsClean.Main.eval_aMemMessageExpr]
+    change (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.a_src_mem
+      + 3 * (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.a_src_reg = 3
+    rw [h_src_mem, h_src_reg]
+    norm_num
+
 end ZiskFv.AirsClean.FullEnsemble

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusSourceExclusivity.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusSourceExclusivity.lean
@@ -56,6 +56,12 @@ private lemma zero_or_one_of_bool {col : FGL} (h : col * (1 - col) = 0) : col = 
       simpa [sub_eq_add_neg] using hneg
     linear_combination this
 
+/-- A field element whose `val` is below `2` is `0` or `1`. -/
+private lemma zero_or_one_of_val_lt_two {x : FGL} (h : x.val < 2) : x = 0 ∨ x = 1 := by
+  interval_cases h_val : x.val
+  · exact Or.inl (by apply Fin.ext; simp [h_val])
+  · exact Or.inr (by apply Fin.ext; simp [h_val])
+
 /-- Push `Expression.eval` through a Main row variable's ROM projections. -/
 private lemma main_rom_eval
     (env : Environment FGL) (row : Var MainRowWithRom FGL) :
@@ -266,16 +272,39 @@ whose `mem_op` is `4` rides at multiplicity `-2`.
 This is the whole content of the exclusivity argument. The reference is a Main a-side current access
 on a row that sets both `a_src_mem` and `a_src_reg`; the conclusion says nothing else in the
 ensemble can offset it. -/
-theorem memBus_mult_eq_neg_two_of_msg_eq_mem_op_four
+theorem memBus_mult_eq_of_msg_eq_mem_op_high
     {length : ℕ} {program : Program length}
     {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
     (h_constraints : witness.Constraints) (h_specs : witness.Spec)
+    {k m : FGL} (h_k1 : k ≠ 1) (h_k2 : k ≠ 2) (h_k3 : k ≠ 3)
+    (h_slot_a : ∀ {env : Environment FGL} {row : Var MainRowWithRom FGL},
+      (eval env row).rom.a_src_mem * (1 - (eval env row).rom.a_src_mem) = 0 →
+      (eval env row).rom.a_src_reg * (1 - (eval env row).rom.a_src_reg) = 0 →
+      (eval env (ZiskFv.AirsClean.Main.aMemMessageExpr row)).mem_op = k →
+      (((MemBusChannel.emitted (-(row.rom.a_src_mem + row.rom.a_src_reg))
+        (ZiskFv.AirsClean.Main.aMemMessageExpr row)).toRaw).eval env).mult = m)
+    (h_slot_b : ∀ {env : Environment FGL} {row : Var MainRowWithRom FGL},
+      (eval env row).rom.b_src_mem * (1 - (eval env row).rom.b_src_mem) = 0 →
+      (eval env row).rom.b_src_ind * (1 - (eval env row).rom.b_src_ind) = 0 →
+      (eval env row).rom.b_src_reg * (1 - (eval env row).rom.b_src_reg) = 0 →
+      (eval env (ZiskFv.AirsClean.Main.bMemMessageExpr row)).mem_op = k →
+      (((MemBusChannel.emitted
+        (-(row.rom.b_src_mem + row.rom.b_src_ind + row.rom.b_src_reg))
+        (ZiskFv.AirsClean.Main.bMemMessageExpr row)).toRaw).eval env).mult = m)
+    (h_slot_c : ∀ {env : Environment FGL} {row : Var MainRowWithRom FGL},
+      (eval env row).rom.store_mem * (1 - (eval env row).rom.store_mem) = 0 →
+      (eval env row).rom.store_ind * (1 - (eval env row).rom.store_ind) = 0 →
+      (eval env row).rom.store_reg * (1 - (eval env row).rom.store_reg) = 0 →
+      (eval env (ZiskFv.AirsClean.Main.cMemMessageExpr row)).mem_op = k →
+      (((MemBusChannel.emitted
+        (-(row.rom.store_mem + row.rom.store_ind + row.rom.store_reg))
+        (ZiskFv.AirsClean.Main.cMemMessageExpr row)).toRaw).eval env).mult = m)
     {refEnv : Environment FGL} {refMult : Expression FGL}
     {refMsg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)}
-    (h_ref_op : (eval refEnv refMsg).mem_op = 4)
+    (h_ref_op : (eval refEnv refMsg).mem_op = k)
     {j : Interaction FGL} (h_j : j ∈ witness.interactionsWith MemBusChannel.toRaw)
     (h_msg : j.msg = (((MemBusChannel.emitted refMult refMsg).toRaw).eval refEnv).msg) :
-    j.mult = -2 := by
+    j.mult = m := by
   rw [EnsembleWitness.mem_interactionsWith] at h_j
   obtain ⟨table, h_table, h_mem_table⟩ := h_j
   have h_component_mem :
@@ -287,7 +316,7 @@ theorem memBus_mult_eq_neg_two_of_msg_eq_mem_op_four
       ∀ {env : Environment FGL} {m : Expression FGL}
         {msg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)},
         j = ((MemBusChannel.emitted m msg).toRaw).eval env →
-          (eval env msg).mem_op = 4 := by
+          (eval env msg).mem_op = k := by
     intro env m msg h_eval
     have h_raw :
         (((MemBusChannel.emitted m msg).toRaw).eval env).msg =
@@ -299,7 +328,7 @@ theorem memBus_mult_eq_neg_two_of_msg_eq_mem_op_four
       ∀ {env : Environment FGL}
         {msg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)},
         j = ((MemBusChannel.pushed msg).toRaw).eval env →
-          (eval env msg).mem_op = 4 := by
+          (eval env msg).mem_op = k := by
     intro env msg h_eval
     have h_raw :
         (((MemBusChannel.pushed msg).toRaw).eval env).msg =
@@ -311,7 +340,7 @@ theorem memBus_mult_eq_neg_two_of_msg_eq_mem_op_four
       ∀ {env : Environment FGL}
         {msg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)},
         j = ((MemBusChannel.pulled msg).toRaw).eval env →
-          (eval env msg).mem_op = 4 := by
+          (eval env msg).mem_op = k := by
     intro env msg h_eval
     have h_raw :
         (((MemBusChannel.pulled msg).toRaw).eval env).msg =
@@ -337,14 +366,14 @@ theorem memBus_mult_eq_neg_two_of_msg_eq_mem_op_four
       ⟨row, _h_row, h_eval⟩ | ⟨row, _h_row, h_eval⟩
     · have h_op := h_op_of_emitted h_eval
       rw [ZiskFv.AirsClean.RegisterBoundary.eval_bootMessageExpr] at h_op
-      have h_lit : (3 : FGL) = 4 := by
+      have h_lit : (3 : FGL) = k := by
         simpa [ZiskFv.AirsClean.RegisterBoundary.bootMessage] using h_op
-      exact absurd h_lit (by decide)
+      exact h_k3 h_lit.symm
     · have h_op := h_op_of_emitted h_eval
       rw [ZiskFv.AirsClean.RegisterBoundary.eval_reloadMessageExpr] at h_op
-      have h_lit : (3 : FGL) = 4 := by
+      have h_lit : (3 : FGL) = k := by
         simpa [ZiskFv.AirsClean.RegisterBoundary.reloadMessage] using h_op
-      exact absurd h_lit (by decide)
+      exact h_k3 h_lit.symm
   -- MemAlignReadByte: both emissions carry the literal `1`.
   · exfalso
     rcases exists_memBus_row_eval_of_pair_interactionsWith
@@ -354,14 +383,14 @@ theorem memBus_mult_eq_neg_two_of_msg_eq_mem_op_four
       ⟨row, _h_row, h_eval⟩ | ⟨row, _h_row, h_eval⟩
     · have h_op := h_op_of_pulled h_eval
       rw [memBusMessage_eval_mem_op] at h_op
-      have h_lit : (1 : FGL) = 4 := by
+      have h_lit : (1 : FGL) = k := by
         simpa [ZiskFv.AirsClean.MemAlignReadByte.memReadMessageExpr, Expression.eval] using h_op
-      exact absurd h_lit (by decide)
+      exact h_k1 h_lit.symm
     · have h_op := h_op_of_pushed h_eval
       rw [ZiskFv.AirsClean.MemAlignReadByte.eval_memBusMessageExpr] at h_op
-      have h_lit : (1 : FGL) = 4 := by
+      have h_lit : (1 : FGL) = k := by
         simpa [ZiskFv.AirsClean.MemAlignReadByte.memBusMessage] using h_op
-      exact absurd h_lit (by decide)
+      exact h_k1 h_lit.symm
   -- MemAlignByte: the read carries `1`, the write-back `1 + is_write` for a bounded `is_write`.
   · exfalso
     have h_rowSpec := h_specs table h_table
@@ -372,21 +401,24 @@ theorem memBus_mult_eq_neg_two_of_msg_eq_mem_op_four
       ⟨row, h_row, h_eval⟩ | ⟨row, h_row, h_eval⟩
     · have h_op := h_op_of_pulled h_eval
       rw [memBusMessage_eval_mem_op] at h_op
-      have h_lit : (1 : FGL) = 4 := by
+      have h_lit : (1 : FGL) = k := by
         simpa [ZiskFv.AirsClean.MemAlignByte.memReadMessageExpr, Expression.eval] using h_op
-      exact absurd h_lit (by decide)
+      exact h_k1 h_lit.symm
     · have h_spec := h_rowSpec row h_row
       rw [h_mab, ZiskFv.AirsClean.MemAlignByte.component_spec,
         component_rowInput_eq_eval_rowInputVar] at h_spec
       have h_isw := h_spec.2.2.2.2.2.2.2
       have h_op := h_op_of_pushed h_eval
       rw [ZiskFv.AirsClean.MemAlignByte.eval_memBusMessageExpr] at h_op
-      have h_isw_three :
-          (eval (table.environment row)
-            ZiskFv.AirsClean.MemAlignByte.component.rowInputVar).is_write = 3 := by
-        linear_combination h_op
-      rw [h_isw_three] at h_isw
-      exact absurd h_isw (by decide)
+      change 1 + (eval (table.environment row)
+        ZiskFv.AirsClean.MemAlignByte.component.rowInputVar).is_write = k at h_op
+      rcases zero_or_one_of_val_lt_two (by simpa using h_isw) with h0 | h1
+      · rw [h0] at h_op
+        have h_lit : (1 : FGL) = k := by rw [← h_op]; ring
+        exact h_k1 h_lit.symm
+      · rw [h1] at h_op
+        have h_lit : (2 : FGL) = k := by rw [← h_op]; norm_num
+        exact h_k2 h_lit.symm
   -- MemAlign: `mem_op = wr + 1` with `wr` boolean.
   · exfalso
     have h_rowSpec := h_specs table h_table
@@ -401,12 +433,15 @@ theorem memBus_mult_eq_neg_two_of_msg_eq_mem_op_four
     have h_wr := h_spec.1
     have h_op := h_op_of_emitted h_eval
     rw [ZiskFv.AirsClean.MemAlign.eval_memBusMessageExpr] at h_op
-    have h_wr_three :
-        (eval (table.environment row)
-          ZiskFv.AirsClean.MemAlign.component.rowInputVar).wr = 3 := by
-      linear_combination h_op
-    rw [h_wr_three] at h_wr
-    exact absurd h_wr (by decide)
+    change (eval (table.environment row)
+      ZiskFv.AirsClean.MemAlign.component.rowInputVar).wr + 1 = k at h_op
+    rcases zero_or_one_of_bool h_wr with h0 | h1
+    · rw [h0] at h_op
+      have h_lit : (1 : FGL) = k := by rw [← h_op]; ring
+      exact h_k1 h_lit.symm
+    · rw [h1] at h_op
+      have h_lit : (2 : FGL) = k := by rw [← h_op]; norm_num
+      exact h_k2 h_lit.symm
   · exfalso
     have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
       memAlignRangeSlice_table_interactionsWith_memBus_nil h_memAlignRange
@@ -430,17 +465,20 @@ theorem memBus_mult_eq_neg_two_of_msg_eq_mem_op_four
       have h_wr := h_rowSpec'.2.2.2.2.1
       have h_op := h_op_of_emitted h_eval
       rw [ZiskFv.AirsClean.Mem.eval_memBusMessageExpr] at h_op
-      have h_wr_three :
-          (eval (table.environment row)
-            ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar).wr = 3 := by
-        linear_combination h_op
-      rw [h_wr_three] at h_wr
-      exact absurd h_wr (by decide)
+      change (eval (table.environment row)
+        ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar).wr + 1 = k at h_op
+      rcases zero_or_one_of_bool h_wr with h0 | h1
+      · rw [h0] at h_op
+        have h_lit : (1 : FGL) = k := by rw [← h_op]; ring
+        exact h_k1 h_lit.symm
+      · rw [h1] at h_op
+        have h_lit : (2 : FGL) = k := by rw [← h_op]; norm_num
+        exact h_k2 h_lit.symm
     · have h_op := h_op_of_emitted h_eval
       rw [ZiskFv.AirsClean.Mem.eval_memBusDualMessageExpr] at h_op
-      have h_lit : (1 : FGL) = 4 := by
+      have h_lit : (1 : FGL) = k := by
         simpa [ZiskFv.AirsClean.Mem.memBusDualMessage] using h_op
-      exact absurd h_lit (by decide)
+      exact h_k1 h_lit.symm
   · exfalso
     have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
       specifiedRangesSlice_table_interactionsWith_memBus_nil h_ranges
@@ -476,27 +514,49 @@ theorem memBus_mult_eq_neg_two_of_msg_eq_mem_op_four
     obtain ⟨b_a_mem, b_a_reg, b_b_mem, b_b_ind, b_b_reg, b_c_mem, b_c_ind, b_c_reg⟩ :=
       main_source_flags_boolean h_main (h_constraints table h_table) h_row
     rcases h_branch with h_eval | h_eval | h_eval | h_eval | h_eval | h_eval
-    · exact absurd (by
-        have h_op := h_op_of_emitted h_eval
-        rw [ZiskFv.AirsClean.Main.eval_aRegPreMessageExpr] at h_op
-        simpa [ZiskFv.AirsClean.Main.aRegPreMessage] using h_op : (3 : FGL) = 4) (by decide)
+    · exfalso
+      have h_op := h_op_of_emitted h_eval
+      rw [ZiskFv.AirsClean.Main.eval_aRegPreMessageExpr] at h_op
+      have h_lit : (3 : FGL) = k := by
+        simpa [ZiskFv.AirsClean.Main.aRegPreMessage] using h_op
+      exact h_k3 h_lit.symm
     · rw [h_eval]
-      exact main_aMem_mult_eq_neg_two_of_mem_op_four b_a_mem b_a_reg (h_op_of_emitted h_eval)
-    · exact absurd (by
-        have h_op := h_op_of_emitted h_eval
-        rw [ZiskFv.AirsClean.Main.eval_bRegPreMessageExpr] at h_op
-        simpa [ZiskFv.AirsClean.Main.bRegPreMessage] using h_op : (3 : FGL) = 4) (by decide)
+      exact h_slot_a b_a_mem b_a_reg (h_op_of_emitted h_eval)
+    · exfalso
+      have h_op := h_op_of_emitted h_eval
+      rw [ZiskFv.AirsClean.Main.eval_bRegPreMessageExpr] at h_op
+      have h_lit : (3 : FGL) = k := by
+        simpa [ZiskFv.AirsClean.Main.bRegPreMessage] using h_op
+      exact h_k3 h_lit.symm
     · rw [h_eval]
-      exact main_bMem_mult_eq_neg_two_of_mem_op_four b_b_mem b_b_ind b_b_reg
-        (h_op_of_emitted h_eval)
-    · exact absurd (by
-        have h_op := h_op_of_emitted h_eval
-        rw [ZiskFv.AirsClean.Main.eval_cRegPreMessageExpr] at h_op
-        simpa [ZiskFv.AirsClean.Main.cRegPreMessage] using h_op : (3 : FGL) = 4) (by decide)
+      exact h_slot_b b_b_mem b_b_ind b_b_reg (h_op_of_emitted h_eval)
+    · exfalso
+      have h_op := h_op_of_emitted h_eval
+      rw [ZiskFv.AirsClean.Main.eval_cRegPreMessageExpr] at h_op
+      have h_lit : (3 : FGL) = k := by
+        simpa [ZiskFv.AirsClean.Main.cRegPreMessage] using h_op
+      exact h_k3 h_lit.symm
     · rw [h_eval]
-      exact main_cMem_mult_eq_neg_two_of_mem_op_four b_c_mem b_c_ind b_c_reg
-        (h_op_of_emitted h_eval)
+      exact h_slot_c b_c_mem b_c_ind b_c_reg (h_op_of_emitted h_eval)
 
+
+/-- The `mem_op = 4` instance: all three Main current accesses ride at `-2` there. -/
+theorem memBus_mult_eq_neg_two_of_msg_eq_mem_op_four
+    {length : ℕ} {program : Program length}
+    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
+    (h_constraints : witness.Constraints) (h_specs : witness.Spec)
+    {refEnv : Environment FGL} {refMult : Expression FGL}
+    {refMsg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)}
+    (h_ref_op : (eval refEnv refMsg).mem_op = 4)
+    {j : Interaction FGL} (h_j : j ∈ witness.interactionsWith MemBusChannel.toRaw)
+    (h_msg : j.msg = (((MemBusChannel.emitted refMult refMsg).toRaw).eval refEnv).msg) :
+    j.mult = -2 :=
+  memBus_mult_eq_of_msg_eq_mem_op_high h_constraints h_specs
+    (by decide) (by decide) (by decide)
+    (fun h1 h2 h3 => main_aMem_mult_eq_neg_two_of_mem_op_four h1 h2 h3)
+    (fun h1 h2 h3 h4 => main_bMem_mult_eq_neg_two_of_mem_op_four h1 h2 h3 h4)
+    (fun h1 h2 h3 h4 => main_cMem_mult_eq_neg_two_of_mem_op_four h1 h2 h3 h4)
+    h_ref_op h_j h_msg
 
 /-! ## The exclusivity, from balance -/
 
@@ -506,6 +566,48 @@ private lemma natCast_eq_zero_of_lt_prime {c : ℕ} (h_lt : c < GL_prime) (h : (
     c = 0 := by
   have h_dvd : GL_prime ∣ c := (ZMod.natCast_eq_zero_iff c GL_prime).mp h
   exact Nat.eq_zero_of_dvd_of_lt h_dvd h_lt
+
+
+/-- **A message whose every interaction rides at one nonzero multiplicity cannot balance.**
+
+    The balance at that message is `m * count`; `count` is at least one because the witnessing
+    interaction is itself counted, and below the modulus because the whole interaction list is. With
+    `m` invertible that product cannot vanish. -/
+theorem no_balanced_message_with_constant_nonzero_mult
+    {length : ℕ} {program : Program length}
+    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
+    (h_balanced : witness.BalancedChannels)
+    {m : FGL} (h_m : m ≠ 0)
+    {I : Interaction FGL} (h_I : I ∈ witness.interactionsWith MemBusChannel.toRaw)
+    (h_I_mult : I.mult = m)
+    (h_all : ∀ i ∈ witness.interactionsWith MemBusChannel.toRaw,
+      i.msg = I.msg → i.mult ≠ 0 → i.mult = m) :
+    False := by
+  have h_balance := memBus_balanced_of_witness witness h_balanced
+  have h_zero := h_balance.2 I.msg
+  rw [balanceOf_eq_of_mult_or_zero h_all] at h_zero
+  set count : ℕ :=
+    (witness.interactionsWith MemBusChannel.toRaw).countP
+      (fun i => i.msg = I.msg && i.mult ≠ 0) with h_count
+  have h_count_pos : 0 < count := by
+    rw [h_count, List.countP_pos_iff]
+    exact ⟨I, h_I, by simp [h_I_mult, h_m]⟩
+  have h_count_lt : count < ringChar FGL ∨ ringChar FGL = 0 := by
+    rcases count_lt_ringChar_of_balancedInteractions (msg := I.msg) h_balance with h | h
+    · exact Or.inl (lt_of_le_of_lt (List.countP_and_left_le _ _ _) h)
+    · exact Or.inr h
+  have h_cast : ((count : ℕ) : FGL) = 0 := by
+    rcases mul_eq_zero.mp h_zero with h | h
+    · exact absurd h h_m
+    · exact h
+  rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime] at h_count_lt
+  have h_count_zero : count = 0 := by
+    rcases h_count_lt with h_lt | h_char
+    · exact natCast_eq_zero_of_lt_prime h_lt h_cast
+    · exact absurd h_char (by decide)
+  omega
+
+
 
 
 /-- A Main row's a-side current access really is one of the witness's memory-bus interactions. -/
@@ -673,5 +775,90 @@ theorem main_aMem_pull_of_a_src_reg
         (componentWithRomMemAndOpBus length program).rowInputVar).rom.a_src_reg = 3
     rw [h_src_mem, h_src_reg]
     norm_num
+
+
+/-! ## `mem_op = 7`: only the store-side current access can reach it
+
+`a_src_mem + 3 * a_src_reg` tops out at `4` and `(b_src_mem + b_src_ind) + 3 * b_src_reg` at `5`, so
+at `7` the a- and b-side hypotheses are vacuous. The store side reaches `7` only at
+`store_mem = store_ind = 1, store_reg = 1`, where its multiplicity is `-3`. -/
+
+theorem main_aMem_mult_of_mem_op_seven
+    {env : Environment FGL} {row : Var MainRowWithRom FGL}
+    (h_mem : (eval env row).rom.a_src_mem * (1 - (eval env row).rom.a_src_mem) = 0)
+    (h_reg : (eval env row).rom.a_src_reg * (1 - (eval env row).rom.a_src_reg) = 0)
+    (h_op : (eval env (ZiskFv.AirsClean.Main.aMemMessageExpr row)).mem_op = 7) :
+    (((MemBusChannel.emitted (-(row.rom.a_src_mem + row.rom.a_src_reg))
+      (ZiskFv.AirsClean.Main.aMemMessageExpr row)).toRaw).eval env).mult = -3 := by
+  exfalso
+  rw [ZiskFv.AirsClean.Main.eval_aMemMessageExpr] at h_op
+  change (eval env row).rom.a_src_mem + 3 * (eval env row).rom.a_src_reg = 7 at h_op
+  rcases zero_or_one_of_bool h_mem with h1 | h1 <;>
+    rcases zero_or_one_of_bool h_reg with h2 | h2 <;>
+      rw [h1, h2] at h_op <;> norm_num at h_op <;> exact absurd h_op (by decide)
+
+theorem main_bMem_mult_of_mem_op_seven
+    {env : Environment FGL} {row : Var MainRowWithRom FGL}
+    (h_mem : (eval env row).rom.b_src_mem * (1 - (eval env row).rom.b_src_mem) = 0)
+    (h_ind : (eval env row).rom.b_src_ind * (1 - (eval env row).rom.b_src_ind) = 0)
+    (h_reg : (eval env row).rom.b_src_reg * (1 - (eval env row).rom.b_src_reg) = 0)
+    (h_op : (eval env (ZiskFv.AirsClean.Main.bMemMessageExpr row)).mem_op = 7) :
+    (((MemBusChannel.emitted
+      (-(row.rom.b_src_mem + row.rom.b_src_ind + row.rom.b_src_reg))
+      (ZiskFv.AirsClean.Main.bMemMessageExpr row)).toRaw).eval env).mult = -3 := by
+  exfalso
+  rw [ZiskFv.AirsClean.Main.eval_bMemMessageExpr] at h_op
+  change ((eval env row).rom.b_src_mem + (eval env row).rom.b_src_ind)
+    + 3 * (eval env row).rom.b_src_reg = 7 at h_op
+  rcases zero_or_one_of_bool h_mem with h1 | h1 <;>
+    rcases zero_or_one_of_bool h_ind with h2 | h2 <;>
+      rcases zero_or_one_of_bool h_reg with h3 | h3 <;>
+        rw [h1, h2, h3] at h_op <;> norm_num at h_op <;> exact absurd h_op (by decide)
+
+theorem main_cMem_mult_of_mem_op_seven
+    {env : Environment FGL} {row : Var MainRowWithRom FGL}
+    (h_mem : (eval env row).rom.store_mem * (1 - (eval env row).rom.store_mem) = 0)
+    (h_ind : (eval env row).rom.store_ind * (1 - (eval env row).rom.store_ind) = 0)
+    (h_reg : (eval env row).rom.store_reg * (1 - (eval env row).rom.store_reg) = 0)
+    (h_op : (eval env (ZiskFv.AirsClean.Main.cMemMessageExpr row)).mem_op = 7) :
+    (((MemBusChannel.emitted
+      (-(row.rom.store_mem + row.rom.store_ind + row.rom.store_reg))
+      (ZiskFv.AirsClean.Main.cMemMessageExpr row)).toRaw).eval env).mult = -3 := by
+  rw [ZiskFv.AirsClean.Main.eval_cMemMessageExpr] at h_op
+  change 2 * ((eval env row).rom.store_mem + (eval env row).rom.store_ind)
+    + 3 * (eval env row).rom.store_reg = 7 at h_op
+  obtain ⟨-, -, -, -, -, h_c_mem, h_c_ind, h_c_reg⟩ := main_rom_eval env row
+  rw [memBus_emitted_eval_mult]
+  have h_eval :
+      Expression.eval env (-(row.rom.store_mem + row.rom.store_ind + row.rom.store_reg))
+      = -((eval env row).rom.store_mem + (eval env row).rom.store_ind
+          + (eval env row).rom.store_reg) := by
+    simp only [Expression.eval, h_c_mem, h_c_ind, h_c_reg]; ring
+  rw [h_eval]
+  rcases zero_or_one_of_bool h_mem with h1 | h1 <;>
+    rcases zero_or_one_of_bool h_ind with h2 | h2 <;>
+      rcases zero_or_one_of_bool h_reg with h3 | h3 <;>
+        rw [h1, h2, h3] at h_op ⊢ <;> norm_num at h_op ⊢ <;>
+          first
+            | rfl
+            | exact absurd h_op (by decide)
+
+/-- The `mem_op = 7` instance of the classification. -/
+theorem memBus_mult_eq_neg_three_of_msg_eq_mem_op_seven
+    {length : ℕ} {program : Program length}
+    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
+    (h_constraints : witness.Constraints) (h_specs : witness.Spec)
+    {refEnv : Environment FGL} {refMult : Expression FGL}
+    {refMsg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)}
+    (h_ref_op : (eval refEnv refMsg).mem_op = 7)
+    {j : Interaction FGL} (h_j : j ∈ witness.interactionsWith MemBusChannel.toRaw)
+    (h_msg : j.msg = (((MemBusChannel.emitted refMult refMsg).toRaw).eval refEnv).msg) :
+    j.mult = -3 :=
+  memBus_mult_eq_of_msg_eq_mem_op_high h_constraints h_specs
+    (by decide) (by decide) (by decide)
+    (fun h1 h2 h3 => main_aMem_mult_of_mem_op_seven h1 h2 h3)
+    (fun h1 h2 h3 h4 => main_bMem_mult_of_mem_op_seven h1 h2 h3 h4)
+    (fun h1 h2 h3 h4 => main_cMem_mult_of_mem_op_seven h1 h2 h3 h4)
+    h_ref_op h_j h_msg
 
 end ZiskFv.AirsClean.FullEnsemble

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusSourceExclusivity.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusSourceExclusivity.lean
@@ -277,10 +277,13 @@ theorem memBus_mult_eq_of_msg_eq_mem_op_high
     {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
     (h_constraints : witness.Constraints) (h_specs : witness.Spec)
     {k m : FGL} (h_k1 : k ≠ 1) (h_k2 : k ≠ 2) (h_k3 : k ≠ 3)
+    {refEnv : Environment FGL} {refMult : Expression FGL}
+    {refMsg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)}
     (h_slot_a : ∀ {env : Environment FGL} {row : Var MainRowWithRom FGL},
       (eval env row).rom.a_src_mem * (1 - (eval env row).rom.a_src_mem) = 0 →
       (eval env row).rom.a_src_reg * (1 - (eval env row).rom.a_src_reg) = 0 →
       (eval env (ZiskFv.AirsClean.Main.aMemMessageExpr row)).mem_op = k →
+      eval env (ZiskFv.AirsClean.Main.aMemMessageExpr row) = eval refEnv refMsg →
       (((MemBusChannel.emitted (-(row.rom.a_src_mem + row.rom.a_src_reg))
         (ZiskFv.AirsClean.Main.aMemMessageExpr row)).toRaw).eval env).mult = m)
     (h_slot_b : ∀ {env : Environment FGL} {row : Var MainRowWithRom FGL},
@@ -288,6 +291,7 @@ theorem memBus_mult_eq_of_msg_eq_mem_op_high
       (eval env row).rom.b_src_ind * (1 - (eval env row).rom.b_src_ind) = 0 →
       (eval env row).rom.b_src_reg * (1 - (eval env row).rom.b_src_reg) = 0 →
       (eval env (ZiskFv.AirsClean.Main.bMemMessageExpr row)).mem_op = k →
+      eval env (ZiskFv.AirsClean.Main.bMemMessageExpr row) = eval refEnv refMsg →
       (((MemBusChannel.emitted
         (-(row.rom.b_src_mem + row.rom.b_src_ind + row.rom.b_src_reg))
         (ZiskFv.AirsClean.Main.bMemMessageExpr row)).toRaw).eval env).mult = m)
@@ -296,11 +300,10 @@ theorem memBus_mult_eq_of_msg_eq_mem_op_high
       (eval env row).rom.store_ind * (1 - (eval env row).rom.store_ind) = 0 →
       (eval env row).rom.store_reg * (1 - (eval env row).rom.store_reg) = 0 →
       (eval env (ZiskFv.AirsClean.Main.cMemMessageExpr row)).mem_op = k →
+      eval env (ZiskFv.AirsClean.Main.cMemMessageExpr row) = eval refEnv refMsg →
       (((MemBusChannel.emitted
         (-(row.rom.store_mem + row.rom.store_ind + row.rom.store_reg))
         (ZiskFv.AirsClean.Main.cMemMessageExpr row)).toRaw).eval env).mult = m)
-    {refEnv : Environment FGL} {refMult : Expression FGL}
-    {refMsg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)}
     (h_ref_op : (eval refEnv refMsg).mem_op = k)
     {j : Interaction FGL} (h_j : j ∈ witness.interactionsWith MemBusChannel.toRaw)
     (h_msg : j.msg = (((MemBusChannel.emitted refMult refMsg).toRaw).eval refEnv).msg) :
@@ -312,18 +315,24 @@ theorem memBus_mult_eq_of_msg_eq_mem_op_high
     EnsembleWitness.mem_allTables_component_of_mem_allTables h_table
   -- Every emission of the row this interaction comes from carries its own `mem_op`; matching the
   -- reference message forces that value to be `4`.
-  have h_op_of_emitted :
-      ∀ {env : Environment FGL} {m : Expression FGL}
+  have h_full_of_emitted :
+      ∀ {env : Environment FGL} {mm : Expression FGL}
         {msg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)},
-        j = ((MemBusChannel.emitted m msg).toRaw).eval env →
-          (eval env msg).mem_op = k := by
-    intro env m msg h_eval
+        j = ((MemBusChannel.emitted mm msg).toRaw).eval env →
+          eval env msg = eval refEnv refMsg := by
+    intro env mm msg h_eval
     have h_raw :
-        (((MemBusChannel.emitted m msg).toRaw).eval env).msg =
+        (((MemBusChannel.emitted mm msg).toRaw).eval env).msg =
           (((MemBusChannel.emitted refMult refMsg).toRaw).eval refEnv).msg := by
       rw [← h_eval]; exact h_msg
-    have := memBusMessage_mem_op_eq_of_eval_emitted_provider_msg_eq (h_msg := h_raw)
-    rw [this, h_ref_op]
+    exact memBusMessage_eq_of_eval_emitted_provider_msg_eq (h_msg := h_raw)
+  have h_op_of_emitted :
+      ∀ {env : Environment FGL} {mm : Expression FGL}
+        {msg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)},
+        j = ((MemBusChannel.emitted mm msg).toRaw).eval env →
+          (eval env msg).mem_op = k := by
+    intro env mm msg h_eval
+    rw [h_full_of_emitted h_eval, h_ref_op]
   have h_op_of_pushed :
       ∀ {env : Environment FGL}
         {msg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)},
@@ -521,7 +530,7 @@ theorem memBus_mult_eq_of_msg_eq_mem_op_high
         simpa [ZiskFv.AirsClean.Main.aRegPreMessage] using h_op
       exact h_k3 h_lit.symm
     · rw [h_eval]
-      exact h_slot_a b_a_mem b_a_reg (h_op_of_emitted h_eval)
+      exact h_slot_a b_a_mem b_a_reg (h_op_of_emitted h_eval) (h_full_of_emitted h_eval)
     · exfalso
       have h_op := h_op_of_emitted h_eval
       rw [ZiskFv.AirsClean.Main.eval_bRegPreMessageExpr] at h_op
@@ -529,7 +538,7 @@ theorem memBus_mult_eq_of_msg_eq_mem_op_high
         simpa [ZiskFv.AirsClean.Main.bRegPreMessage] using h_op
       exact h_k3 h_lit.symm
     · rw [h_eval]
-      exact h_slot_b b_b_mem b_b_ind b_b_reg (h_op_of_emitted h_eval)
+      exact h_slot_b b_b_mem b_b_ind b_b_reg (h_op_of_emitted h_eval) (h_full_of_emitted h_eval)
     · exfalso
       have h_op := h_op_of_emitted h_eval
       rw [ZiskFv.AirsClean.Main.eval_cRegPreMessageExpr] at h_op
@@ -537,7 +546,7 @@ theorem memBus_mult_eq_of_msg_eq_mem_op_high
         simpa [ZiskFv.AirsClean.Main.cRegPreMessage] using h_op
       exact h_k3 h_lit.symm
     · rw [h_eval]
-      exact h_slot_c b_c_mem b_c_ind b_c_reg (h_op_of_emitted h_eval)
+      exact h_slot_c b_c_mem b_c_ind b_c_reg (h_op_of_emitted h_eval) (h_full_of_emitted h_eval)
 
 
 /-- The `mem_op = 4` instance: all three Main current accesses ride at `-2` there. -/
@@ -553,9 +562,9 @@ theorem memBus_mult_eq_neg_two_of_msg_eq_mem_op_four
     j.mult = -2 :=
   memBus_mult_eq_of_msg_eq_mem_op_high h_constraints h_specs
     (by decide) (by decide) (by decide)
-    (fun h1 h2 h3 => main_aMem_mult_eq_neg_two_of_mem_op_four h1 h2 h3)
-    (fun h1 h2 h3 h4 => main_bMem_mult_eq_neg_two_of_mem_op_four h1 h2 h3 h4)
-    (fun h1 h2 h3 h4 => main_cMem_mult_eq_neg_two_of_mem_op_four h1 h2 h3 h4)
+    (fun h1 h2 h3 _ => main_aMem_mult_eq_neg_two_of_mem_op_four h1 h2 h3)
+    (fun h1 h2 h3 h4 _ => main_bMem_mult_eq_neg_two_of_mem_op_four h1 h2 h3 h4)
+    (fun h1 h2 h3 h4 _ => main_cMem_mult_eq_neg_two_of_mem_op_four h1 h2 h3 h4)
     h_ref_op h_j h_msg
 
 /-! ## The exclusivity, from balance -/
@@ -856,9 +865,9 @@ theorem memBus_mult_eq_neg_three_of_msg_eq_mem_op_seven
     j.mult = -3 :=
   memBus_mult_eq_of_msg_eq_mem_op_high h_constraints h_specs
     (by decide) (by decide) (by decide)
-    (fun h1 h2 h3 => main_aMem_mult_of_mem_op_seven h1 h2 h3)
-    (fun h1 h2 h3 h4 => main_bMem_mult_of_mem_op_seven h1 h2 h3 h4)
-    (fun h1 h2 h3 h4 => main_cMem_mult_of_mem_op_seven h1 h2 h3 h4)
+    (fun h1 h2 h3 _ => main_aMem_mult_of_mem_op_seven h1 h2 h3)
+    (fun h1 h2 h3 h4 _ => main_bMem_mult_of_mem_op_seven h1 h2 h3 h4)
+    (fun h1 h2 h3 h4 _ => main_cMem_mult_of_mem_op_seven h1 h2 h3 h4)
     h_ref_op h_j h_msg
 
 

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusSourceExclusivity.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusSourceExclusivity.lean
@@ -1,0 +1,607 @@
+import ZiskFv.AirsClean.FullEnsemble.Balance.RegisterChainBridges
+
+/-!
+# Main's operand-source flags are exclusive, and balance is what proves it
+
+Main's a-side operand is either a memory read (`a_src_mem`) or a register read (`a_src_reg`). The
+component asserts only that each flag is **boolean** (`Main/Constraints.lean:252,259`); nothing in it
+says they cannot both be set. Yet the register walk in `ZiskFv/Compliance/RegisterWalk.lean` needs
+exactly that: it can only follow a supply step to a row whose own access is a `mem_op = 3` **pull**,
+and Clean's `exists_push_of_pull` fires only at multiplicity exactly `-1`, i.e. at
+`a_src_mem + a_src_reg = 1`.
+
+This module proves the exclusivity from `BalancedChannels` alone.
+
+The argument is a multiplicity count, not a decode fact:
+
+* `Air.Flat.BalancedInteractions` is **message-exact** — `∀ msg, balanceOf interactions msg = 0`,
+  summing multiplicities over interactions carrying that exact message array. It is not a
+  challenge-mixed sum, so a single message can be reasoned about on its own.
+* A row with both a-side flags set emits its a-side current access with
+  `mem_op = a_src_mem + 3 * a_src_reg = 4`.
+* **No memory-bus emission in the ensemble carries `mem_op = 4` at a non-negative multiplicity.**
+  Main's three register-pre pushes are the only positive ones and they carry the literal `3`; the
+  Mem, MemAlign, MemAlignByte and MemAlignReadByte messages carry `1` or `wr + 1` with `wr` boolean;
+  `RegisterBoundary` carries the literal `3`. Main's three *current* accesses are all pulls
+  (`Main/Constraints.lean:436,441,446`), and at `mem_op = 4` booleanity pins each to `-2`.
+* So the balance at that message is `-2 * count` with `count ≥ 1` and `count < GL_prime`, which
+  cannot vanish.
+-/
+
+namespace ZiskFv.AirsClean.FullEnsemble
+
+open Goldilocks
+open Air.Flat
+open ZiskFv.Channels.MemoryBus (MemBusChannel)
+open ZiskFv.AirsClean.ZiskInstructionRom (Program)
+open ZiskFv.AirsClean.Main (MainRowWithRom componentWithRomMemAndOpBus)
+
+/-! ## Reading a raw memory-bus interaction -/
+
+/-- The multiplicity of an emitted memory-bus interaction is its multiplicity expression,
+    evaluated. -/
+theorem memBus_emitted_eval_mult
+    (env : Environment FGL) (mult : Expression FGL)
+    (msg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)) :
+    (((MemBusChannel.emitted mult msg).toRaw).eval env).mult = Expression.eval env mult :=
+  rfl
+
+/-- A boolean column is `0` or `1`. -/
+private lemma zero_or_one_of_bool {col : FGL} (h : col * (1 - col) = 0) : col = 0 ∨ col = 1 := by
+  rcases mul_eq_zero.mp h with h0 | h1
+  · exact Or.inl h0
+  · refine Or.inr ?_
+    have : col - 1 = 0 := by
+      have hneg := congrArg Neg.neg h1
+      simpa [sub_eq_add_neg] using hneg
+    linear_combination this
+
+/-- Push `Expression.eval` through a Main row variable's ROM projections. -/
+private lemma main_rom_eval
+    (env : Environment FGL) (row : Var MainRowWithRom FGL) :
+    Expression.eval env row.rom.a_src_mem = (eval env row).rom.a_src_mem
+  ∧ Expression.eval env row.rom.a_src_reg = (eval env row).rom.a_src_reg
+  ∧ Expression.eval env row.rom.b_src_mem = (eval env row).rom.b_src_mem
+  ∧ Expression.eval env row.rom.b_src_ind = (eval env row).rom.b_src_ind
+  ∧ Expression.eval env row.rom.b_src_reg = (eval env row).rom.b_src_reg
+  ∧ Expression.eval env row.rom.store_mem = (eval env row).rom.store_mem
+  ∧ Expression.eval env row.rom.store_ind = (eval env row).rom.store_ind
+  ∧ Expression.eval env row.rom.store_reg = (eval env row).rom.store_reg := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
+    simp only [ProvableStruct.eval_eq_eval, ProvableStruct.eval,
+      ProvableStruct.fromComponents, ProvableStruct.components,
+      ProvableStruct.toComponents, ProvableStruct.eval.go,
+      ProvableType.eval_field, Expression.eval]
+
+/-! ## Main's three current accesses, at `mem_op = 4`
+
+Each is a pull whose multiplicity is the negated selector sum, and at `mem_op = 4` booleanity leaves
+exactly one assignment of the selectors — one that pins the multiplicity to `-2`. -/
+
+/-- The a-side current access rides at `-2` when its `mem_op` is `4`. -/
+theorem main_aMem_mult_eq_neg_two_of_mem_op_four
+    {env : Environment FGL} {row : Var MainRowWithRom FGL}
+    (h_mem : (eval env row).rom.a_src_mem * (1 - (eval env row).rom.a_src_mem) = 0)
+    (h_reg : (eval env row).rom.a_src_reg * (1 - (eval env row).rom.a_src_reg) = 0)
+    (h_op : (eval env (ZiskFv.AirsClean.Main.aMemMessageExpr row)).mem_op = 4) :
+    (((MemBusChannel.emitted (-(row.rom.a_src_mem + row.rom.a_src_reg))
+      (ZiskFv.AirsClean.Main.aMemMessageExpr row)).toRaw).eval env).mult = -2 := by
+  rw [ZiskFv.AirsClean.Main.eval_aMemMessageExpr] at h_op
+  change (eval env row).rom.a_src_mem + 3 * (eval env row).rom.a_src_reg = 4 at h_op
+  obtain ⟨h_a_mem, h_a_reg, -⟩ := main_rom_eval env row
+  rw [memBus_emitted_eval_mult]
+  have h_eval : Expression.eval env (-(row.rom.a_src_mem + row.rom.a_src_reg))
+      = -((eval env row).rom.a_src_mem + (eval env row).rom.a_src_reg) := by
+    simp only [Expression.eval, h_a_mem, h_a_reg]; ring
+  rw [h_eval]
+  rcases zero_or_one_of_bool h_mem with h1 | h1 <;>
+    rcases zero_or_one_of_bool h_reg with h2 | h2 <;>
+      rw [h1, h2] at h_op ⊢ <;> norm_num at h_op ⊢
+  · exact absurd h_op (by decide)
+  · exact absurd h_op (by decide)
+  · exact absurd h_op (by decide)
+
+/-- The b-side current access rides at `-2` when its `mem_op` is `4`. -/
+theorem main_bMem_mult_eq_neg_two_of_mem_op_four
+    {env : Environment FGL} {row : Var MainRowWithRom FGL}
+    (h_mem : (eval env row).rom.b_src_mem * (1 - (eval env row).rom.b_src_mem) = 0)
+    (h_ind : (eval env row).rom.b_src_ind * (1 - (eval env row).rom.b_src_ind) = 0)
+    (h_reg : (eval env row).rom.b_src_reg * (1 - (eval env row).rom.b_src_reg) = 0)
+    (h_op : (eval env (ZiskFv.AirsClean.Main.bMemMessageExpr row)).mem_op = 4) :
+    (((MemBusChannel.emitted
+      (-(row.rom.b_src_mem + row.rom.b_src_ind + row.rom.b_src_reg))
+      (ZiskFv.AirsClean.Main.bMemMessageExpr row)).toRaw).eval env).mult = -2 := by
+  rw [ZiskFv.AirsClean.Main.eval_bMemMessageExpr] at h_op
+  change ((eval env row).rom.b_src_mem + (eval env row).rom.b_src_ind)
+    + 3 * (eval env row).rom.b_src_reg = 4 at h_op
+  obtain ⟨-, -, h_b_mem, h_b_ind, h_b_reg, -⟩ := main_rom_eval env row
+  rw [memBus_emitted_eval_mult]
+  have h_eval :
+      Expression.eval env (-(row.rom.b_src_mem + row.rom.b_src_ind + row.rom.b_src_reg))
+      = -((eval env row).rom.b_src_mem + (eval env row).rom.b_src_ind
+          + (eval env row).rom.b_src_reg) := by
+    simp only [Expression.eval, h_b_mem, h_b_ind, h_b_reg]; ring
+  rw [h_eval]
+  rcases zero_or_one_of_bool h_mem with h1 | h1 <;>
+    rcases zero_or_one_of_bool h_ind with h2 | h2 <;>
+      rcases zero_or_one_of_bool h_reg with h3 | h3 <;>
+        rw [h1, h2, h3] at h_op ⊢ <;> norm_num at h_op ⊢ <;>
+          first
+            | rfl
+            | exact absurd h_op (by decide)
+
+/-- The store-side current access rides at `-2` when its `mem_op` is `4`. -/
+theorem main_cMem_mult_eq_neg_two_of_mem_op_four
+    {env : Environment FGL} {row : Var MainRowWithRom FGL}
+    (h_mem : (eval env row).rom.store_mem * (1 - (eval env row).rom.store_mem) = 0)
+    (h_ind : (eval env row).rom.store_ind * (1 - (eval env row).rom.store_ind) = 0)
+    (h_reg : (eval env row).rom.store_reg * (1 - (eval env row).rom.store_reg) = 0)
+    (h_op : (eval env (ZiskFv.AirsClean.Main.cMemMessageExpr row)).mem_op = 4) :
+    (((MemBusChannel.emitted
+      (-(row.rom.store_mem + row.rom.store_ind + row.rom.store_reg))
+      (ZiskFv.AirsClean.Main.cMemMessageExpr row)).toRaw).eval env).mult = -2 := by
+  rw [ZiskFv.AirsClean.Main.eval_cMemMessageExpr] at h_op
+  change 2 * ((eval env row).rom.store_mem + (eval env row).rom.store_ind)
+    + 3 * (eval env row).rom.store_reg = 4 at h_op
+  obtain ⟨-, -, -, -, -, h_c_mem, h_c_ind, h_c_reg⟩ := main_rom_eval env row
+  rw [memBus_emitted_eval_mult]
+  have h_eval :
+      Expression.eval env (-(row.rom.store_mem + row.rom.store_ind + row.rom.store_reg))
+      = -((eval env row).rom.store_mem + (eval env row).rom.store_ind
+          + (eval env row).rom.store_reg) := by
+    simp only [Expression.eval, h_c_mem, h_c_ind, h_c_reg]; ring
+  rw [h_eval]
+  rcases zero_or_one_of_bool h_mem with h1 | h1 <;>
+    rcases zero_or_one_of_bool h_ind with h2 | h2 <;>
+      rcases zero_or_one_of_bool h_reg with h3 | h3 <;>
+        rw [h1, h2, h3] at h_op ⊢ <;> norm_num at h_op ⊢ <;>
+          first
+            | rfl
+            | exact absurd h_op (by decide)
+
+
+/-- Projecting `mem_op` commutes with evaluating a memory-bus message. -/
+theorem memBusMessage_eval_mem_op
+    (env : Environment FGL)
+    (msg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)) :
+    (eval env msg).mem_op = Expression.eval env msg.mem_op := by
+  simp only [ProvableStruct.eval_eq_eval, ProvableStruct.eval,
+    ProvableStruct.fromComponents, ProvableStruct.components,
+    ProvableStruct.toComponents, ProvableStruct.eval.go,
+    ProvableType.eval_field]
+
+/-- `mem_op` projection for a *pulled* memory-bus interaction, the `MemAlignByte` /
+`MemAlignReadByte` read shape. Mirrors the `pushed` and `emitted` variants in
+`MemBusRowBridges`. -/
+theorem memBusMessage_mem_op_eq_of_eval_pulled_provider_msg_eq
+    {mainMsg providerMsg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)}
+    {mainMult : Expression FGL}
+    {mainEnv providerEnv : Environment FGL}
+    (h_msg :
+      (((MemBusChannel.pulled providerMsg).toRaw).eval providerEnv).msg =
+        (((MemBusChannel.emitted mainMult mainMsg).toRaw).eval mainEnv).msg) :
+    (eval providerEnv providerMsg).mem_op = (eval mainEnv mainMsg).mem_op := by
+  have h_vec :
+      Vector.map (Expression.eval providerEnv) (toElements providerMsg) =
+        Vector.map (Expression.eval mainEnv) (toElements mainMsg) := by
+    apply Vector.toArray_injective
+    simpa [ChannelInteraction.toRaw, AbstractInteraction.eval] using h_msg
+  have h_eval : eval providerEnv providerMsg = eval mainEnv mainMsg := by
+    have h_from := congrArg
+      (fun xs => (fromElements xs :
+        ZiskFv.Channels.MemoryBus.MemBusMessage FGL)) h_vec
+    simpa [ProvableType.fromElements_eval_toElements] using h_from
+  exact congrArg ZiskFv.Channels.MemoryBus.MemBusMessage.mem_op h_eval
+
+/-- Main's eight operand-source flags are boolean at any row satisfying the component's
+constraints. -/
+theorem main_source_flags_boolean
+    {length : ℕ} {program : Program length}
+    {table : Table FGL} {row : Array FGL}
+    (h_component : table.component = componentWithRomMemAndOpBus length program)
+    (h_constraints : table.Constraints) (h_row : row ∈ table.table) :
+    (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.a_src_mem
+      * (1 - (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.a_src_mem) = 0
+  ∧ (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.a_src_reg
+      * (1 - (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.a_src_reg) = 0
+  ∧ (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_mem
+      * (1 - (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_mem) = 0
+  ∧ (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_ind
+      * (1 - (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_ind) = 0
+  ∧ (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_reg
+      * (1 - (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_reg) = 0
+  ∧ (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_mem
+      * (1 - (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_mem) = 0
+  ∧ (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_ind
+      * (1 - (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_ind) = 0
+  ∧ (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_reg
+      * (1 - (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_reg) = 0 := by
+  have h_holds :
+      (componentWithRomMemAndOpBus length program).operations.ConstraintsHold
+        (table.environment row) := by
+    have := h_constraints row h_row
+    rwa [h_component] at this
+  obtain ⟨-, -, -, -, h_a_mem, -, -, h_b_mem, h_c_mem, h_c_ind, h_b_ind, h_a_reg, h_b_reg,
+    h_c_reg⟩ :=
+    ZiskFv.AirsClean.Main.romBoolSpec_of_componentWithRomMemAndOpBus_constraints
+      length program (table.environment row) h_holds
+  obtain ⟨e_a_mem, e_a_reg, e_b_mem, e_b_ind, e_b_reg, e_c_mem, e_c_ind, e_c_reg⟩ :=
+    main_rom_eval (table.environment row) (componentWithRomMemAndOpBus length program).rowInputVar
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · simpa [Expression.eval, sub_eq_add_neg, e_a_mem] using h_a_mem
+  · simpa [Expression.eval, sub_eq_add_neg, e_a_reg] using h_a_reg
+  · simpa [Expression.eval, sub_eq_add_neg, e_b_mem] using h_b_mem
+  · simpa [Expression.eval, sub_eq_add_neg, e_b_ind] using h_b_ind
+  · simpa [Expression.eval, sub_eq_add_neg, e_b_reg] using h_b_reg
+  · simpa [Expression.eval, sub_eq_add_neg, e_c_mem] using h_c_mem
+  · simpa [Expression.eval, sub_eq_add_neg, e_c_ind] using h_c_ind
+  · simpa [Expression.eval, sub_eq_add_neg, e_c_reg] using h_c_reg
+
+/-! ## No other emission in the ensemble reaches `mem_op = 4`
+
+Main's three register-pre pushes carry the literal `3`; `RegisterBoundary`'s boot and reload carry
+the literal `3`; `MemAlignReadByte` carries `1`; `MemAlign`, `MemAlignByte` and `Mem` carry `wr + 1`
+or `1 + is_write` for a flag their own `Spec` pins to `{0, 1}`. Each case below reads the provider's
+`mem_op` off the shared message and contradicts `4`. -/
+
+/-- Every memory-bus interaction of the witness carrying the same message as a reference emission
+whose `mem_op` is `4` rides at multiplicity `-2`.
+
+This is the whole content of the exclusivity argument. The reference is a Main a-side current access
+on a row that sets both `a_src_mem` and `a_src_reg`; the conclusion says nothing else in the
+ensemble can offset it. -/
+theorem memBus_mult_eq_neg_two_of_msg_eq_mem_op_four
+    {length : ℕ} {program : Program length}
+    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
+    (h_constraints : witness.Constraints) (h_specs : witness.Spec)
+    {refEnv : Environment FGL} {refMult : Expression FGL}
+    {refMsg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)}
+    (h_ref_op : (eval refEnv refMsg).mem_op = 4)
+    {j : Interaction FGL} (h_j : j ∈ witness.interactionsWith MemBusChannel.toRaw)
+    (h_msg : j.msg = (((MemBusChannel.emitted refMult refMsg).toRaw).eval refEnv).msg) :
+    j.mult = -2 := by
+  rw [EnsembleWitness.mem_interactionsWith] at h_j
+  obtain ⟨table, h_table, h_mem_table⟩ := h_j
+  have h_component_mem :
+      table.component ∈ (fullRv64imEnsemble length program).ensemble.allTables :=
+    EnsembleWitness.mem_allTables_component_of_mem_allTables h_table
+  -- Every emission of the row this interaction comes from carries its own `mem_op`; matching the
+  -- reference message forces that value to be `4`.
+  have h_op_of_emitted :
+      ∀ {env : Environment FGL} {m : Expression FGL}
+        {msg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)},
+        j = ((MemBusChannel.emitted m msg).toRaw).eval env →
+          (eval env msg).mem_op = 4 := by
+    intro env m msg h_eval
+    have h_raw :
+        (((MemBusChannel.emitted m msg).toRaw).eval env).msg =
+          (((MemBusChannel.emitted refMult refMsg).toRaw).eval refEnv).msg := by
+      rw [← h_eval]; exact h_msg
+    have := memBusMessage_mem_op_eq_of_eval_emitted_provider_msg_eq (h_msg := h_raw)
+    rw [this, h_ref_op]
+  have h_op_of_pushed :
+      ∀ {env : Environment FGL}
+        {msg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)},
+        j = ((MemBusChannel.pushed msg).toRaw).eval env →
+          (eval env msg).mem_op = 4 := by
+    intro env msg h_eval
+    have h_raw :
+        (((MemBusChannel.pushed msg).toRaw).eval env).msg =
+          (((MemBusChannel.emitted refMult refMsg).toRaw).eval refEnv).msg := by
+      rw [← h_eval]; exact h_msg
+    have := memBusMessage_mem_op_eq_of_eval_pushed_provider_msg_eq (h_msg := h_raw)
+    rw [this, h_ref_op]
+  have h_op_of_pulled :
+      ∀ {env : Environment FGL}
+        {msg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)},
+        j = ((MemBusChannel.pulled msg).toRaw).eval env →
+          (eval env msg).mem_op = 4 := by
+    intro env msg h_eval
+    have h_raw :
+        (((MemBusChannel.pulled msg).toRaw).eval env).msg =
+          (((MemBusChannel.emitted refMult refMsg).toRaw).eval refEnv).msg := by
+      rw [← h_eval]; exact h_msg
+    have := memBusMessage_mem_op_eq_of_eval_pulled_provider_msg_eq (h_msg := h_raw)
+    rw [this, h_ref_op]
+  rcases component_mem_fullRv64im_cases h_component_mem with
+    h_verifier | h_regBoundary | h_marb | h_mab | h_memAlign | h_memAlignRange | h_memAlignRom |
+    h_mem | h_ranges | h_regRange | h_arithDiv | h_arithMul | h_binExt | h_binary | h_binaryAdd |
+    h_main
+  -- Components with no memory-bus interactions at all.
+  · exfalso
+    have h_nil : table.interactionsWith MemBusChannel.toRaw = [] := by
+      have h_ops_nil :
+          table.component.operations.interactionsWith MemBusChannel.toRaw = [] := by
+        simpa [h_verifier] using verifierTable_interactionsWith_memBus_nil length program
+      simp [Table.interactionsWith, Operations.interactionValuesWith_eq_map, h_ops_nil]
+    simp [h_nil] at h_mem_table
+  -- RegisterBoundary: both emissions carry the literal `3`.
+  · exfalso
+    rcases exists_registerBoundary_mem_row_eval_of_interaction_mem h_regBoundary h_mem_table with
+      ⟨row, _h_row, h_eval⟩ | ⟨row, _h_row, h_eval⟩
+    · have h_op := h_op_of_emitted h_eval
+      rw [ZiskFv.AirsClean.RegisterBoundary.eval_bootMessageExpr] at h_op
+      have h_lit : (3 : FGL) = 4 := by
+        simpa [ZiskFv.AirsClean.RegisterBoundary.bootMessage] using h_op
+      exact absurd h_lit (by decide)
+    · have h_op := h_op_of_emitted h_eval
+      rw [ZiskFv.AirsClean.RegisterBoundary.eval_reloadMessageExpr] at h_op
+      have h_lit : (3 : FGL) = 4 := by
+        simpa [ZiskFv.AirsClean.RegisterBoundary.reloadMessage] using h_op
+      exact absurd h_lit (by decide)
+  -- MemAlignReadByte: both emissions carry the literal `1`.
+  · exfalso
+    rcases exists_memBus_row_eval_of_pair_interactionsWith
+        (by simpa [h_marb] using
+          ZiskFv.AirsClean.MemAlignReadByte.component_interactionsWith_memBus)
+        h_mem_table with
+      ⟨row, _h_row, h_eval⟩ | ⟨row, _h_row, h_eval⟩
+    · have h_op := h_op_of_pulled h_eval
+      rw [memBusMessage_eval_mem_op] at h_op
+      have h_lit : (1 : FGL) = 4 := by
+        simpa [ZiskFv.AirsClean.MemAlignReadByte.memReadMessageExpr, Expression.eval] using h_op
+      exact absurd h_lit (by decide)
+    · have h_op := h_op_of_pushed h_eval
+      rw [ZiskFv.AirsClean.MemAlignReadByte.eval_memBusMessageExpr] at h_op
+      have h_lit : (1 : FGL) = 4 := by
+        simpa [ZiskFv.AirsClean.MemAlignReadByte.memBusMessage] using h_op
+      exact absurd h_lit (by decide)
+  -- MemAlignByte: the read carries `1`, the write-back `1 + is_write` for a bounded `is_write`.
+  · exfalso
+    have h_rowSpec := h_specs table h_table
+    rcases exists_memBus_row_eval_of_pair_interactionsWith
+        (by simpa [h_mab] using
+          ZiskFv.AirsClean.MemAlignByte.component_interactionsWith_memBus)
+        h_mem_table with
+      ⟨row, h_row, h_eval⟩ | ⟨row, h_row, h_eval⟩
+    · have h_op := h_op_of_pulled h_eval
+      rw [memBusMessage_eval_mem_op] at h_op
+      have h_lit : (1 : FGL) = 4 := by
+        simpa [ZiskFv.AirsClean.MemAlignByte.memReadMessageExpr, Expression.eval] using h_op
+      exact absurd h_lit (by decide)
+    · have h_spec := h_rowSpec row h_row
+      rw [h_mab, ZiskFv.AirsClean.MemAlignByte.component_spec,
+        component_rowInput_eq_eval_rowInputVar] at h_spec
+      have h_isw := h_spec.2.2.2.2.2.2.2
+      have h_op := h_op_of_pushed h_eval
+      rw [ZiskFv.AirsClean.MemAlignByte.eval_memBusMessageExpr] at h_op
+      have h_isw_three :
+          (eval (table.environment row)
+            ZiskFv.AirsClean.MemAlignByte.component.rowInputVar).is_write = 3 := by
+        linear_combination h_op
+      rw [h_isw_three] at h_isw
+      exact absurd h_isw (by decide)
+  -- MemAlign: `mem_op = wr + 1` with `wr` boolean.
+  · exfalso
+    have h_rowSpec := h_specs table h_table
+    obtain ⟨row, h_row, h_eval⟩ :=
+      exists_memBus_row_eval_of_singleton_interactionsWith
+        (by simpa [h_memAlign] using
+          ZiskFv.AirsClean.MemAlign.component_interactionsWith_memBus)
+        h_mem_table
+    have h_spec := h_rowSpec row h_row
+    rw [h_memAlign, ZiskFv.AirsClean.MemAlign.component_spec,
+      component_rowInput_eq_eval_rowInputVar] at h_spec
+    have h_wr := h_spec.1
+    have h_op := h_op_of_emitted h_eval
+    rw [ZiskFv.AirsClean.MemAlign.eval_memBusMessageExpr] at h_op
+    have h_wr_three :
+        (eval (table.environment row)
+          ZiskFv.AirsClean.MemAlign.component.rowInputVar).wr = 3 := by
+      linear_combination h_op
+    rw [h_wr_three] at h_wr
+    exact absurd h_wr (by decide)
+  · exfalso
+    have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
+      memAlignRangeSlice_table_interactionsWith_memBus_nil h_memAlignRange
+    simp [h_nil] at h_mem_table
+  · exfalso
+    have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
+      memAlignRomSlice_table_interactionsWith_memBus_nil h_memAlignRom
+    simp [h_nil] at h_mem_table
+  -- Mem: the primary emission is `wr + 1` with `wr` boolean, the dual emission is the literal `1`.
+  · exfalso
+    have h_rowSpec := h_specs table h_table
+    rcases exists_memBus_row_eval_of_pair_interactionsWith
+        (by simpa [h_mem] using
+          ZiskFv.AirsClean.Mem.componentWithDualMemBus_interactionsWith_memBus)
+        h_mem_table with
+      ⟨row, h_row, h_eval⟩ | ⟨row, h_row, h_eval⟩
+    · have h_spec := h_rowSpec row h_row
+      rw [h_mem] at h_spec
+      have h_rowSpec' := ZiskFv.AirsClean.Mem.spec_of_componentWithDualMemBus_spec _ h_spec
+      rw [component_rowInput_eq_eval_rowInputVar] at h_rowSpec'
+      have h_wr := h_rowSpec'.2.2.2.2.1
+      have h_op := h_op_of_emitted h_eval
+      rw [ZiskFv.AirsClean.Mem.eval_memBusMessageExpr] at h_op
+      have h_wr_three :
+          (eval (table.environment row)
+            ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar).wr = 3 := by
+        linear_combination h_op
+      rw [h_wr_three] at h_wr
+      exact absurd h_wr (by decide)
+    · have h_op := h_op_of_emitted h_eval
+      rw [ZiskFv.AirsClean.Mem.eval_memBusDualMessageExpr] at h_op
+      have h_lit : (1 : FGL) = 4 := by
+        simpa [ZiskFv.AirsClean.Mem.memBusDualMessage] using h_op
+      exact absurd h_lit (by decide)
+  · exfalso
+    have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
+      specifiedRangesSlice_table_interactionsWith_memBus_nil h_ranges
+    simp [h_nil] at h_mem_table
+  · exfalso
+    have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
+      registerStepRangeSlice_table_interactionsWith_memBus_nil h_regRange
+    simp [h_nil] at h_mem_table
+  · exfalso
+    have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
+      arithDiv_table_interactionsWith_memBus_nil h_arithDiv
+    simp [h_nil] at h_mem_table
+  · exfalso
+    have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
+      arithMul_table_interactionsWith_memBus_nil h_arithMul
+    simp [h_nil] at h_mem_table
+  · exfalso
+    have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
+      staticBinaryExtension_table_interactionsWith_memBus_nil h_binExt
+    simp [h_nil] at h_mem_table
+  · exfalso
+    have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
+      staticBinary_table_interactionsWith_memBus_nil h_binary
+    simp [h_nil] at h_mem_table
+  · exfalso
+    have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
+      binaryAdd_table_interactionsWith_memBus_nil h_binaryAdd
+    simp [h_nil] at h_mem_table
+  -- Main: the three register-pre pushes carry `3`; the three current accesses are pulls that
+  -- booleanity pins to `-2` once their `mem_op` is `4`.
+  · obtain ⟨row, h_row, h_branch⟩ :=
+      exists_main_mem_row_eval_of_interaction_mem h_main h_mem_table
+    obtain ⟨b_a_mem, b_a_reg, b_b_mem, b_b_ind, b_b_reg, b_c_mem, b_c_ind, b_c_reg⟩ :=
+      main_source_flags_boolean h_main (h_constraints table h_table) h_row
+    rcases h_branch with h_eval | h_eval | h_eval | h_eval | h_eval | h_eval
+    · exact absurd (by
+        have h_op := h_op_of_emitted h_eval
+        rw [ZiskFv.AirsClean.Main.eval_aRegPreMessageExpr] at h_op
+        simpa [ZiskFv.AirsClean.Main.aRegPreMessage] using h_op : (3 : FGL) = 4) (by decide)
+    · rw [h_eval]
+      exact main_aMem_mult_eq_neg_two_of_mem_op_four b_a_mem b_a_reg (h_op_of_emitted h_eval)
+    · exact absurd (by
+        have h_op := h_op_of_emitted h_eval
+        rw [ZiskFv.AirsClean.Main.eval_bRegPreMessageExpr] at h_op
+        simpa [ZiskFv.AirsClean.Main.bRegPreMessage] using h_op : (3 : FGL) = 4) (by decide)
+    · rw [h_eval]
+      exact main_bMem_mult_eq_neg_two_of_mem_op_four b_b_mem b_b_ind b_b_reg
+        (h_op_of_emitted h_eval)
+    · exact absurd (by
+        have h_op := h_op_of_emitted h_eval
+        rw [ZiskFv.AirsClean.Main.eval_cRegPreMessageExpr] at h_op
+        simpa [ZiskFv.AirsClean.Main.cRegPreMessage] using h_op : (3 : FGL) = 4) (by decide)
+    · rw [h_eval]
+      exact main_cMem_mult_eq_neg_two_of_mem_op_four b_c_mem b_c_ind b_c_reg
+        (h_op_of_emitted h_eval)
+
+
+/-! ## The exclusivity, from balance -/
+
+/-- A natural number below the modulus that casts to `0` in the field is `0`. This is what turns
+`-2 * count = 0` into `count = 0`. -/
+private lemma natCast_eq_zero_of_lt_prime {c : ℕ} (h_lt : c < GL_prime) (h : (c : FGL) = 0) :
+    c = 0 := by
+  have h_dvd : GL_prime ∣ c := (ZMod.natCast_eq_zero_iff c GL_prime).mp h
+  exact Nat.eq_zero_of_dvd_of_lt h_dvd h_lt
+
+
+/-- A Main row's a-side current access really is one of the witness's memory-bus interactions. -/
+theorem main_aMem_interaction_mem_witness
+    {length : ℕ} {program : Program length}
+    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
+    {table : Table FGL} (h_table : table ∈ witness.allTables)
+    (h_component : table.component = componentWithRomMemAndOpBus length program)
+    {row : Array FGL} (h_row : row ∈ table.table) :
+    (((MemBusChannel.emitted
+      (-((componentWithRomMemAndOpBus length program).rowInputVar.rom.a_src_mem
+        + (componentWithRomMemAndOpBus length program).rowInputVar.rom.a_src_reg))
+      (ZiskFv.AirsClean.Main.aMemMessageExpr
+        (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw).eval
+      (table.environment row))
+      ∈ witness.interactionsWith MemBusChannel.toRaw := by
+  rw [EnsembleWitness.mem_interactionsWith]
+  refine ⟨table, h_table, ?_⟩
+  rw [Table.interactionsWith]
+  refine List.mem_flatMap.mpr ⟨row, h_row, ?_⟩
+  rw [Operations.interactionValuesWith_eq_map, h_component,
+    ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus_interactionsWith_memBus]
+  simp
+
+set_option maxHeartbeats 1000000 in
+/-- **Main's a-side operand sources are exclusive, and `BalancedChannels` is what proves it.**
+
+    A row setting both `a_src_mem` and `a_src_reg` emits its a-side current access at
+    `mem_op = 4` and multiplicity `-2`. By `memBus_mult_eq_neg_two_of_msg_eq_mem_op_four`, every
+    interaction of the witness carrying that same message also rides at `-2`, so the balance at that
+    message is `-2 * count` with `count ≥ 1`. Since `count` is below the field characteristic and
+    `2` is invertible, that cannot vanish.
+
+    No decode fact and no ROM binding is used: the flags are pinned by the multiplicity ledger
+    alone. -/
+theorem main_not_a_src_mem_and_a_src_reg
+    {length : ℕ} {program : Program length}
+    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
+    (h_balanced : witness.BalancedChannels)
+    (h_constraints : witness.Constraints) (h_specs : witness.Spec)
+    {table : Table FGL} (h_table : table ∈ witness.allTables)
+    (h_component : table.component = componentWithRomMemAndOpBus length program)
+    {row : Array FGL} (h_row : row ∈ table.table)
+    (h_src_mem : (eval (table.environment row)
+      (componentWithRomMemAndOpBus length program).rowInputVar).rom.a_src_mem = 1)
+    (h_src_reg : (eval (table.environment row)
+      (componentWithRomMemAndOpBus length program).rowInputVar).rom.a_src_reg = 1) :
+    False := by
+  set env := table.environment row with h_env
+  set rowVar := (componentWithRomMemAndOpBus length program).rowInputVar with h_rowVar
+  set refMult : Expression FGL := -(rowVar.rom.a_src_mem + rowVar.rom.a_src_reg) with h_refMult
+  set refMsg := ZiskFv.AirsClean.Main.aMemMessageExpr rowVar with h_refMsg
+  set I := (((MemBusChannel.emitted refMult refMsg).toRaw).eval env) with h_I
+  -- the reference message sits at `mem_op = 4`
+  have h_ref_op : (eval env refMsg).mem_op = 4 := by
+    rw [h_refMsg, ZiskFv.AirsClean.Main.eval_aMemMessageExpr]
+    change (eval env rowVar).rom.a_src_mem + 3 * (eval env rowVar).rom.a_src_reg = 4
+    rw [h_src_mem, h_src_reg]
+    norm_num
+  have h_I_mem : I ∈ witness.interactionsWith MemBusChannel.toRaw :=
+    main_aMem_interaction_mem_witness h_table h_component h_row
+  have h_I_mult : I.mult = -2 :=
+    main_aMem_mult_eq_neg_two_of_mem_op_four
+      (by rw [h_src_mem]; ring) (by rw [h_src_reg]; ring) h_ref_op
+  -- every interaction on that message rides at `-2`
+  have h_all :
+      ∀ i ∈ witness.interactionsWith MemBusChannel.toRaw,
+        i.msg = I.msg → i.mult ≠ 0 → i.mult = -2 := by
+    intro i h_i h_msg _
+    exact memBus_mult_eq_neg_two_of_msg_eq_mem_op_four h_constraints h_specs h_ref_op h_i h_msg
+  have h_balance := memBus_balanced_of_witness witness h_balanced
+  have h_zero := h_balance.2 I.msg
+  rw [balanceOf_eq_of_mult_or_zero h_all] at h_zero
+  set count : ℕ :=
+    (witness.interactionsWith MemBusChannel.toRaw).countP
+      (fun i => i.msg = I.msg && i.mult ≠ 0) with h_count
+  -- the reference interaction itself is counted
+  have h_count_pos : 0 < count := by
+    rw [h_count, List.countP_pos_iff]
+    exact ⟨I, h_I_mem, by simp [h_I_mult]⟩
+  -- and the count is below the characteristic
+  have h_count_lt : count < ringChar FGL ∨ ringChar FGL = 0 := by
+    rcases count_lt_ringChar_of_balancedInteractions (msg := I.msg) h_balance with h | h
+    · exact Or.inl (lt_of_le_of_lt (List.countP_and_left_le _ _ _) h)
+    · exact Or.inr h
+  -- `-2 * count = 0` with `2` invertible forces `count = 0`
+  have h_cast : ((count : ℕ) : FGL) = 0 := by
+    have h2 : (-2 : FGL) ≠ 0 := by decide
+    rcases mul_eq_zero.mp h_zero with h | h
+    · exact absurd h h2
+    · exact h
+  rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime] at h_count_lt
+  have h_count_zero : count = 0 := by
+    rcases h_count_lt with h_lt | h_char
+    · exact natCast_eq_zero_of_lt_prime h_lt h_cast
+    · exact absurd h_char (by decide)
+  omega
+
+end ZiskFv.AirsClean.FullEnsemble

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusSourceExclusivity.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusSourceExclusivity.lean
@@ -861,4 +861,66 @@ theorem memBus_mult_eq_neg_three_of_msg_eq_mem_op_seven
     (fun h1 h2 h3 h4 => main_cMem_mult_of_mem_op_seven h1 h2 h3 h4)
     h_ref_op h_j h_msg
 
+
+/-- A Main row's store-side current access is one of the witness's memory-bus interactions. -/
+theorem main_cMem_interaction_mem_witness
+    {length : ℕ} {program : Program length}
+    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
+    {table : Table FGL} (h_table : table ∈ witness.allTables)
+    (h_component : table.component = componentWithRomMemAndOpBus length program)
+    {row : Array FGL} (h_row : row ∈ table.table) :
+    (((MemBusChannel.emitted
+      (-((componentWithRomMemAndOpBus length program).rowInputVar.rom.store_mem
+        + (componentWithRomMemAndOpBus length program).rowInputVar.rom.store_ind
+        + (componentWithRomMemAndOpBus length program).rowInputVar.rom.store_reg))
+      (ZiskFv.AirsClean.Main.cMemMessageExpr
+        (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw).eval
+      (table.environment row))
+      ∈ witness.interactionsWith MemBusChannel.toRaw := by
+  rw [EnsembleWitness.mem_interactionsWith]
+  refine ⟨table, h_table, ?_⟩
+  rw [Table.interactionsWith]
+  refine List.mem_flatMap.mpr ⟨row, h_row, ?_⟩
+  rw [Operations.interactionValuesWith_eq_map, h_component,
+    ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus_interactionsWith_memBus]
+  simp
+
+set_option maxHeartbeats 1000000 in
+/-- **A store-side register write is not also an indirect memory store.** The three store selectors
+    cannot all be set: that row would emit its store-side access at `mem_op = 7`, and by the
+    classification every interaction on that message rides at `-3`, so the balance there is
+    `-3 * count` with `count ≥ 1`. -/
+theorem main_not_store_mem_and_store_ind_and_store_reg
+    {length : ℕ} {program : Program length}
+    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
+    (h_balanced : witness.BalancedChannels)
+    (h_constraints : witness.Constraints) (h_specs : witness.Spec)
+    {table : Table FGL} (h_table : table ∈ witness.allTables)
+    (h_component : table.component = componentWithRomMemAndOpBus length program)
+    {row : Array FGL} (h_row : row ∈ table.table)
+    (h_store_mem : (eval (table.environment row)
+      (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_mem = 1)
+    (h_store_ind : (eval (table.environment row)
+      (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_ind = 1)
+    (h_store_reg : (eval (table.environment row)
+      (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_reg = 1) :
+    False := by
+  set env := table.environment row with h_env
+  set rowVar := (componentWithRomMemAndOpBus length program).rowInputVar with h_rowVar
+  set refMult : Expression FGL :=
+    -(rowVar.rom.store_mem + rowVar.rom.store_ind + rowVar.rom.store_reg) with h_refMult
+  set refMsg := ZiskFv.AirsClean.Main.cMemMessageExpr rowVar with h_refMsg
+  have h_ref_op : (eval env refMsg).mem_op = 7 := by
+    rw [h_refMsg, ZiskFv.AirsClean.Main.eval_cMemMessageExpr]
+    change 2 * ((eval env rowVar).rom.store_mem + (eval env rowVar).rom.store_ind)
+      + 3 * (eval env rowVar).rom.store_reg = 7
+    rw [h_store_mem, h_store_ind, h_store_reg]
+    norm_num
+  refine no_balanced_message_with_constant_nonzero_mult h_balanced (m := -3) (by decide)
+    (main_cMem_interaction_mem_witness h_table h_component h_row) ?_ ?_
+  · exact main_cMem_mult_of_mem_op_seven
+      (by rw [h_store_mem]; ring) (by rw [h_store_ind]; ring) (by rw [h_store_reg]; ring) h_ref_op
+  · intro i h_i h_msg _
+    exact memBus_mult_eq_neg_three_of_msg_eq_mem_op_seven h_constraints h_specs h_ref_op h_i h_msg
+
 end ZiskFv.AirsClean.FullEnsemble

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusSourceExclusivity.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusSourceExclusivity.lean
@@ -47,7 +47,7 @@ theorem memBus_emitted_eval_mult
   rfl
 
 /-- A boolean column is `0` or `1`. -/
-private lemma zero_or_one_of_bool {col : FGL} (h : col * (1 - col) = 0) : col = 0 ∨ col = 1 := by
+theorem zero_or_one_of_bool {col : FGL} (h : col * (1 - col) = 0) : col = 0 ∨ col = 1 := by
   rcases mul_eq_zero.mp h with h0 | h1
   · exact Or.inl h0
   · refine Or.inr ?_
@@ -279,31 +279,82 @@ theorem memBus_mult_eq_of_msg_eq_mem_op_high
     {k m : FGL} (h_k1 : k ≠ 1) (h_k2 : k ≠ 2) (h_k3 : k ≠ 3)
     {refEnv : Environment FGL} {refMult : Expression FGL}
     {refMsg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)}
-    (h_slot_a : ∀ {env : Environment FGL} {row : Var MainRowWithRom FGL},
-      (eval env row).rom.a_src_mem * (1 - (eval env row).rom.a_src_mem) = 0 →
-      (eval env row).rom.a_src_reg * (1 - (eval env row).rom.a_src_reg) = 0 →
-      (eval env (ZiskFv.AirsClean.Main.aMemMessageExpr row)).mem_op = k →
-      eval env (ZiskFv.AirsClean.Main.aMemMessageExpr row) = eval refEnv refMsg →
-      (((MemBusChannel.emitted (-(row.rom.a_src_mem + row.rom.a_src_reg))
-        (ZiskFv.AirsClean.Main.aMemMessageExpr row)).toRaw).eval env).mult = m)
-    (h_slot_b : ∀ {env : Environment FGL} {row : Var MainRowWithRom FGL},
-      (eval env row).rom.b_src_mem * (1 - (eval env row).rom.b_src_mem) = 0 →
-      (eval env row).rom.b_src_ind * (1 - (eval env row).rom.b_src_ind) = 0 →
-      (eval env row).rom.b_src_reg * (1 - (eval env row).rom.b_src_reg) = 0 →
-      (eval env (ZiskFv.AirsClean.Main.bMemMessageExpr row)).mem_op = k →
-      eval env (ZiskFv.AirsClean.Main.bMemMessageExpr row) = eval refEnv refMsg →
+    (h_slot_a : ∀ {tbl : Table FGL} {r : Array FGL},
+      tbl ∈ witness.allTables →
+      tbl.component = componentWithRomMemAndOpBus length program →
+      r ∈ tbl.table →
+      (eval (tbl.environment r)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.a_src_mem
+        * (1 - (eval (tbl.environment r)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.a_src_mem) = 0 →
+      (eval (tbl.environment r)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.a_src_reg
+        * (1 - (eval (tbl.environment r)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.a_src_reg) = 0 →
+      (eval (tbl.environment r) (ZiskFv.AirsClean.Main.aMemMessageExpr
+        (componentWithRomMemAndOpBus length program).rowInputVar)).mem_op = k →
+      eval (tbl.environment r) (ZiskFv.AirsClean.Main.aMemMessageExpr
+        (componentWithRomMemAndOpBus length program).rowInputVar) = eval refEnv refMsg →
       (((MemBusChannel.emitted
-        (-(row.rom.b_src_mem + row.rom.b_src_ind + row.rom.b_src_reg))
-        (ZiskFv.AirsClean.Main.bMemMessageExpr row)).toRaw).eval env).mult = m)
-    (h_slot_c : ∀ {env : Environment FGL} {row : Var MainRowWithRom FGL},
-      (eval env row).rom.store_mem * (1 - (eval env row).rom.store_mem) = 0 →
-      (eval env row).rom.store_ind * (1 - (eval env row).rom.store_ind) = 0 →
-      (eval env row).rom.store_reg * (1 - (eval env row).rom.store_reg) = 0 →
-      (eval env (ZiskFv.AirsClean.Main.cMemMessageExpr row)).mem_op = k →
-      eval env (ZiskFv.AirsClean.Main.cMemMessageExpr row) = eval refEnv refMsg →
+        (-((componentWithRomMemAndOpBus length program).rowInputVar.rom.a_src_mem
+          + (componentWithRomMemAndOpBus length program).rowInputVar.rom.a_src_reg))
+        (ZiskFv.AirsClean.Main.aMemMessageExpr
+          (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw).eval
+        (tbl.environment r)).mult = m)
+    (h_slot_b : ∀ {tbl : Table FGL} {r : Array FGL},
+      tbl ∈ witness.allTables →
+      tbl.component = componentWithRomMemAndOpBus length program →
+      r ∈ tbl.table →
+      (eval (tbl.environment r)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_mem
+        * (1 - (eval (tbl.environment r)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_mem) = 0 →
+      (eval (tbl.environment r)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_ind
+        * (1 - (eval (tbl.environment r)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_ind) = 0 →
+      (eval (tbl.environment r)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_reg
+        * (1 - (eval (tbl.environment r)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_reg) = 0 →
+      (eval (tbl.environment r) (ZiskFv.AirsClean.Main.bMemMessageExpr
+        (componentWithRomMemAndOpBus length program).rowInputVar)).mem_op = k →
+      eval (tbl.environment r) (ZiskFv.AirsClean.Main.bMemMessageExpr
+        (componentWithRomMemAndOpBus length program).rowInputVar) = eval refEnv refMsg →
       (((MemBusChannel.emitted
-        (-(row.rom.store_mem + row.rom.store_ind + row.rom.store_reg))
-        (ZiskFv.AirsClean.Main.cMemMessageExpr row)).toRaw).eval env).mult = m)
+        (-((componentWithRomMemAndOpBus length program).rowInputVar.rom.b_src_mem
+          + (componentWithRomMemAndOpBus length program).rowInputVar.rom.b_src_ind
+          + (componentWithRomMemAndOpBus length program).rowInputVar.rom.b_src_reg))
+        (ZiskFv.AirsClean.Main.bMemMessageExpr
+          (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw).eval
+        (tbl.environment r)).mult = m)
+    (h_slot_c : ∀ {tbl : Table FGL} {r : Array FGL},
+      tbl ∈ witness.allTables →
+      tbl.component = componentWithRomMemAndOpBus length program →
+      r ∈ tbl.table →
+      (eval (tbl.environment r)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_mem
+        * (1 - (eval (tbl.environment r)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_mem) = 0 →
+      (eval (tbl.environment r)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_ind
+        * (1 - (eval (tbl.environment r)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_ind) = 0 →
+      (eval (tbl.environment r)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_reg
+        * (1 - (eval (tbl.environment r)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_reg) = 0 →
+      (eval (tbl.environment r) (ZiskFv.AirsClean.Main.cMemMessageExpr
+        (componentWithRomMemAndOpBus length program).rowInputVar)).mem_op = k →
+      eval (tbl.environment r) (ZiskFv.AirsClean.Main.cMemMessageExpr
+        (componentWithRomMemAndOpBus length program).rowInputVar) = eval refEnv refMsg →
+      (((MemBusChannel.emitted
+        (-((componentWithRomMemAndOpBus length program).rowInputVar.rom.store_mem
+          + (componentWithRomMemAndOpBus length program).rowInputVar.rom.store_ind
+          + (componentWithRomMemAndOpBus length program).rowInputVar.rom.store_reg))
+        (ZiskFv.AirsClean.Main.cMemMessageExpr
+          (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw).eval
+        (tbl.environment r)).mult = m)
     (h_ref_op : (eval refEnv refMsg).mem_op = k)
     {j : Interaction FGL} (h_j : j ∈ witness.interactionsWith MemBusChannel.toRaw)
     (h_msg : j.msg = (((MemBusChannel.emitted refMult refMsg).toRaw).eval refEnv).msg) :
@@ -530,7 +581,8 @@ theorem memBus_mult_eq_of_msg_eq_mem_op_high
         simpa [ZiskFv.AirsClean.Main.aRegPreMessage] using h_op
       exact h_k3 h_lit.symm
     · rw [h_eval]
-      exact h_slot_a b_a_mem b_a_reg (h_op_of_emitted h_eval) (h_full_of_emitted h_eval)
+      exact h_slot_a h_table h_main h_row b_a_mem b_a_reg (h_op_of_emitted h_eval)
+        (h_full_of_emitted h_eval)
     · exfalso
       have h_op := h_op_of_emitted h_eval
       rw [ZiskFv.AirsClean.Main.eval_bRegPreMessageExpr] at h_op
@@ -538,7 +590,8 @@ theorem memBus_mult_eq_of_msg_eq_mem_op_high
         simpa [ZiskFv.AirsClean.Main.bRegPreMessage] using h_op
       exact h_k3 h_lit.symm
     · rw [h_eval]
-      exact h_slot_b b_b_mem b_b_ind b_b_reg (h_op_of_emitted h_eval) (h_full_of_emitted h_eval)
+      exact h_slot_b h_table h_main h_row b_b_mem b_b_ind b_b_reg (h_op_of_emitted h_eval)
+        (h_full_of_emitted h_eval)
     · exfalso
       have h_op := h_op_of_emitted h_eval
       rw [ZiskFv.AirsClean.Main.eval_cRegPreMessageExpr] at h_op
@@ -546,7 +599,8 @@ theorem memBus_mult_eq_of_msg_eq_mem_op_high
         simpa [ZiskFv.AirsClean.Main.cRegPreMessage] using h_op
       exact h_k3 h_lit.symm
     · rw [h_eval]
-      exact h_slot_c b_c_mem b_c_ind b_c_reg (h_op_of_emitted h_eval) (h_full_of_emitted h_eval)
+      exact h_slot_c h_table h_main h_row b_c_mem b_c_ind b_c_reg (h_op_of_emitted h_eval)
+        (h_full_of_emitted h_eval)
 
 
 /-- The `mem_op = 4` instance: all three Main current accesses ride at `-2` there. -/
@@ -562,9 +616,9 @@ theorem memBus_mult_eq_neg_two_of_msg_eq_mem_op_four
     j.mult = -2 :=
   memBus_mult_eq_of_msg_eq_mem_op_high h_constraints h_specs
     (by decide) (by decide) (by decide)
-    (fun h1 h2 h3 _ => main_aMem_mult_eq_neg_two_of_mem_op_four h1 h2 h3)
-    (fun h1 h2 h3 h4 _ => main_bMem_mult_eq_neg_two_of_mem_op_four h1 h2 h3 h4)
-    (fun h1 h2 h3 h4 _ => main_cMem_mult_eq_neg_two_of_mem_op_four h1 h2 h3 h4)
+    (fun _ _ _ h1 h2 h3 _ => main_aMem_mult_eq_neg_two_of_mem_op_four h1 h2 h3)
+    (fun _ _ _ h1 h2 h3 h4 _ => main_bMem_mult_eq_neg_two_of_mem_op_four h1 h2 h3 h4)
+    (fun _ _ _ h1 h2 h3 h4 _ => main_cMem_mult_eq_neg_two_of_mem_op_four h1 h2 h3 h4)
     h_ref_op h_j h_msg
 
 /-! ## The exclusivity, from balance -/
@@ -865,9 +919,9 @@ theorem memBus_mult_eq_neg_three_of_msg_eq_mem_op_seven
     j.mult = -3 :=
   memBus_mult_eq_of_msg_eq_mem_op_high h_constraints h_specs
     (by decide) (by decide) (by decide)
-    (fun h1 h2 h3 _ => main_aMem_mult_of_mem_op_seven h1 h2 h3)
-    (fun h1 h2 h3 h4 _ => main_bMem_mult_of_mem_op_seven h1 h2 h3 h4)
-    (fun h1 h2 h3 h4 _ => main_cMem_mult_of_mem_op_seven h1 h2 h3 h4)
+    (fun _ _ _ h1 h2 h3 _ => main_aMem_mult_of_mem_op_seven h1 h2 h3)
+    (fun _ _ _ h1 h2 h3 h4 _ => main_bMem_mult_of_mem_op_seven h1 h2 h3 h4)
+    (fun _ _ _ h1 h2 h3 h4 _ => main_cMem_mult_of_mem_op_seven h1 h2 h3 h4)
     h_ref_op h_j h_msg
 
 
@@ -931,5 +985,103 @@ theorem main_not_store_mem_and_store_ind_and_store_reg
       (by rw [h_store_mem]; ring) (by rw [h_store_ind]; ring) (by rw [h_store_reg]; ring) h_ref_op
   · intro i h_i h_msg _
     exact memBus_mult_eq_neg_three_of_msg_eq_mem_op_seven h_constraints h_specs h_ref_op h_i h_msg
+
+
+/-! ## `mem_op = 5`: reachable by the b-side and the store-side, at different multiplicities -/
+
+/-- The a-side current access cannot reach `mem_op = 5`: `a_src_mem + 3 * a_src_reg` tops out at
+`4`. -/
+theorem main_aMem_mem_op_ne_five
+    {env : Environment FGL} {row : Var MainRowWithRom FGL}
+    (h_mem : (eval env row).rom.a_src_mem * (1 - (eval env row).rom.a_src_mem) = 0)
+    (h_reg : (eval env row).rom.a_src_reg * (1 - (eval env row).rom.a_src_reg) = 0)
+    (h_op : (eval env (ZiskFv.AirsClean.Main.aMemMessageExpr row)).mem_op = 5) :
+    False := by
+  rw [ZiskFv.AirsClean.Main.eval_aMemMessageExpr] at h_op
+  change (eval env row).rom.a_src_mem + 3 * (eval env row).rom.a_src_reg = 5 at h_op
+  rcases zero_or_one_of_bool h_mem with h1 | h1 <;>
+    rcases zero_or_one_of_bool h_reg with h2 | h2 <;>
+      rw [h1, h2] at h_op <;> norm_num at h_op <;> exact absurd h_op (by decide)
+
+/-- The b-side current access rides at `-3` when its `mem_op` is `5`. -/
+theorem main_bMem_mult_of_mem_op_five
+    {env : Environment FGL} {row : Var MainRowWithRom FGL}
+    (h_mem : (eval env row).rom.b_src_mem * (1 - (eval env row).rom.b_src_mem) = 0)
+    (h_ind : (eval env row).rom.b_src_ind * (1 - (eval env row).rom.b_src_ind) = 0)
+    (h_reg : (eval env row).rom.b_src_reg * (1 - (eval env row).rom.b_src_reg) = 0)
+    (h_op : (eval env (ZiskFv.AirsClean.Main.bMemMessageExpr row)).mem_op = 5) :
+    (((MemBusChannel.emitted
+      (-(row.rom.b_src_mem + row.rom.b_src_ind + row.rom.b_src_reg))
+      (ZiskFv.AirsClean.Main.bMemMessageExpr row)).toRaw).eval env).mult = -3 := by
+  rw [ZiskFv.AirsClean.Main.eval_bMemMessageExpr] at h_op
+  change ((eval env row).rom.b_src_mem + (eval env row).rom.b_src_ind)
+    + 3 * (eval env row).rom.b_src_reg = 5 at h_op
+  obtain ⟨-, -, h_b_mem, h_b_ind, h_b_reg, -⟩ := main_rom_eval env row
+  rw [memBus_emitted_eval_mult]
+  have h_eval :
+      Expression.eval env (-(row.rom.b_src_mem + row.rom.b_src_ind + row.rom.b_src_reg))
+      = -((eval env row).rom.b_src_mem + (eval env row).rom.b_src_ind
+          + (eval env row).rom.b_src_reg) := by
+    simp only [Expression.eval, h_b_mem, h_b_ind, h_b_reg]; ring
+  rw [h_eval]
+  rcases zero_or_one_of_bool h_mem with h1 | h1 <;>
+    rcases zero_or_one_of_bool h_ind with h2 | h2 <;>
+      rcases zero_or_one_of_bool h_reg with h3 | h3 <;>
+        rw [h1, h2, h3] at h_op ⊢ <;> norm_num at h_op ⊢ <;>
+          first
+            | rfl
+            | exact absurd h_op (by decide)
+
+/-- The store-side current access rides at `-2` when its `mem_op` is `5`. -/
+theorem main_cMem_mult_of_mem_op_five
+    {env : Environment FGL} {row : Var MainRowWithRom FGL}
+    (h_mem : (eval env row).rom.store_mem * (1 - (eval env row).rom.store_mem) = 0)
+    (h_ind : (eval env row).rom.store_ind * (1 - (eval env row).rom.store_ind) = 0)
+    (h_reg : (eval env row).rom.store_reg * (1 - (eval env row).rom.store_reg) = 0)
+    (h_op : (eval env (ZiskFv.AirsClean.Main.cMemMessageExpr row)).mem_op = 5) :
+    (((MemBusChannel.emitted
+      (-(row.rom.store_mem + row.rom.store_ind + row.rom.store_reg))
+      (ZiskFv.AirsClean.Main.cMemMessageExpr row)).toRaw).eval env).mult = -2 := by
+  rw [ZiskFv.AirsClean.Main.eval_cMemMessageExpr] at h_op
+  change 2 * ((eval env row).rom.store_mem + (eval env row).rom.store_ind)
+    + 3 * (eval env row).rom.store_reg = 5 at h_op
+  obtain ⟨-, -, -, -, -, h_c_mem, h_c_ind, h_c_reg⟩ := main_rom_eval env row
+  rw [memBus_emitted_eval_mult]
+  have h_eval :
+      Expression.eval env (-(row.rom.store_mem + row.rom.store_ind + row.rom.store_reg))
+      = -((eval env row).rom.store_mem + (eval env row).rom.store_ind
+          + (eval env row).rom.store_reg) := by
+    simp only [Expression.eval, h_c_mem, h_c_ind, h_c_reg]; ring
+  rw [h_eval]
+  rcases zero_or_one_of_bool h_mem with h1 | h1 <;>
+    rcases zero_or_one_of_bool h_ind with h2 | h2 <;>
+      rcases zero_or_one_of_bool h_reg with h3 | h3 <;>
+        rw [h1, h2, h3] at h_op ⊢ <;> norm_num at h_op ⊢ <;>
+          first
+            | rfl
+            | exact absurd h_op (by decide)
+
+/-- A Main row's b-side current access is one of the witness's memory-bus interactions. -/
+theorem main_bMem_interaction_mem_witness
+    {length : ℕ} {program : Program length}
+    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
+    {table : Table FGL} (h_table : table ∈ witness.allTables)
+    (h_component : table.component = componentWithRomMemAndOpBus length program)
+    {row : Array FGL} (h_row : row ∈ table.table) :
+    (((MemBusChannel.emitted
+      (-((componentWithRomMemAndOpBus length program).rowInputVar.rom.b_src_mem
+        + (componentWithRomMemAndOpBus length program).rowInputVar.rom.b_src_ind
+        + (componentWithRomMemAndOpBus length program).rowInputVar.rom.b_src_reg))
+      (ZiskFv.AirsClean.Main.bMemMessageExpr
+        (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw).eval
+      (table.environment row))
+      ∈ witness.interactionsWith MemBusChannel.toRaw := by
+  rw [EnsembleWitness.mem_interactionsWith]
+  refine ⟨table, h_table, ?_⟩
+  rw [Table.interactionsWith]
+  refine List.mem_flatMap.mpr ⟨row, h_row, ?_⟩
+  rw [Operations.interactionValuesWith_eq_map, h_component,
+    ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus_interactionsWith_memBus]
+  simp
 
 end ZiskFv.AirsClean.FullEnsemble

--- a/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
+++ b/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
@@ -2161,6 +2161,13 @@ def memMessageExpr : RegSlot → Var MainRowWithRom FGL →
   | .b, row => ZiskFv.AirsClean.Main.bMemMessageExpr row
   | .c, row => ZiskFv.AirsClean.Main.cMemMessageExpr row
 
+/-- The multiplicity this slot's current access rides at: the negated sum of its source
+selectors (`Main/Constraints.lean:436,441,446`). Every slot's current access is a pull. -/
+def memMult : RegSlot → Var MainRowWithRom FGL → Expression FGL
+  | .a, row => -(row.rom.a_src_mem + row.rom.a_src_reg)
+  | .b, row => -(row.rom.b_src_mem + row.rom.b_src_ind + row.rom.b_src_reg)
+  | .c, row => -(row.rom.store_mem + row.rom.store_ind + row.rom.store_reg)
+
 /-- The read message's timestamp is the slot's read timestamp. -/
 theorem eval_memMessageExpr_timestamp (s : RegSlot) (env : Environment FGL)
     (row : Var MainRowWithRom FGL) :

--- a/ZiskFv/Compliance/MemBusSlotSeparation.lean
+++ b/ZiskFv/Compliance/MemBusSlotSeparation.lean
@@ -1,4 +1,5 @@
 import ZiskFv.Compliance.RegisterWalk
+import ZiskFv.AirsClean.FullEnsemble.Balance.MemBusSourceExclusivity
 
 /-!
 # Main's three memory-bus slots never share a message
@@ -18,7 +19,7 @@ below `2^24`, no wraparound can occur, and the residue mod `4` is an invariant o
 
 namespace ZiskFv.Compliance
 
-open Air.Flat (Table)
+open Air.Flat
 open ZiskFv.AirsClean.FullEnsemble
 open ZiskFv.AirsClean.ZiskInstructionRom (Program)
 open ZiskFv.AirsClean.Main (MainRowWithRom componentWithRomMemAndOpBus)
@@ -71,5 +72,248 @@ theorem slot_timestamp_ne
   have h_val := congrArg Fin.val h
   rw [slot_timestamp_val h_k₁ h_i₁, slot_timestamp_val h_k₂ h_i₂] at h_val
   omega
+
+
+/-- The b-side and store-side current accesses of any two Main rows carry different messages: their
+timestamps are `2 + 4 * index` and `3 + 4 * index`, which never coincide. -/
+theorem cMem_message_ne_bMem_message
+    {length : ℕ} {program : Program length} {tblC tblB : Table FGL}
+    (h_compC : tblC.component = componentWithRomMemAndOpBus length program)
+    (h_compB : tblB.component = componentWithRomMemAndOpBus length program)
+    {rC rB : Array FGL} (h_rC : rC ∈ tblC.table) (h_rB : rB ∈ tblB.table)
+    (h : eval (tblC.environment rC)
+          (ZiskFv.AirsClean.Main.cMemMessageExpr
+            (componentWithRomMemAndOpBus length program).rowInputVar)
+        = eval (tblB.environment rB)
+          (ZiskFv.AirsClean.Main.bMemMessageExpr
+            (componentWithRomMemAndOpBus length program).rowInputVar)) :
+    False := by
+  obtain ⟨iC, h_iC, h_msC⟩ := exists_main_step_index_of_mem h_compC h_rC
+  obtain ⟨iB, h_iB, h_msB⟩ := exists_main_step_index_of_mem h_compB h_rB
+  have h_ts := congrArg ZiskFv.Channels.MemoryBus.MemBusMessage.timestamp h
+  rw [ZiskFv.AirsClean.Main.eval_cMemMessageExpr,
+    ZiskFv.AirsClean.Main.eval_bMemMessageExpr] at h_ts
+  change 3 + (eval (tblC.environment rC)
+      (componentWithRomMemAndOpBus length program).rowInputVar).rom.main_step * 4
+    = 2 + (eval (tblB.environment rB)
+      (componentWithRomMemAndOpBus length program).rowInputVar).rom.main_step * 4 at h_ts
+  rw [h_msC, h_msB] at h_ts
+  refine slot_timestamp_ne (k₁ := 3) (k₂ := 2) (by norm_num) (by norm_num) (by norm_num)
+    h_iC h_iB ?_
+  simpa using h_ts
+
+
+/-- The store-side twin of `cMem_message_ne_bMem_message`. -/
+theorem bMem_message_ne_cMem_message
+    {length : ℕ} {program : Program length} {tblB tblC : Table FGL}
+    (h_compB : tblB.component = componentWithRomMemAndOpBus length program)
+    (h_compC : tblC.component = componentWithRomMemAndOpBus length program)
+    {rB rC : Array FGL} (h_rB : rB ∈ tblB.table) (h_rC : rC ∈ tblC.table)
+    (h : eval (tblB.environment rB)
+          (ZiskFv.AirsClean.Main.bMemMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)
+        = eval (tblC.environment rC)
+          (ZiskFv.AirsClean.Main.cMemMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)) :
+    False :=
+  cMem_message_ne_bMem_message h_compC h_compB h_rC h_rB h.symm
+
+/-! ## The `mem_op = 5` instances
+
+With the slots separated, the multiplicity *is* constant once the reference slot is fixed: every
+interaction carrying a b-side current's message is itself a b-side current (`-3`), and every
+interaction carrying a store-side current's message is itself a store-side current (`-2`). -/
+
+/-- Reference: a b-side current access at `mem_op = 5`. -/
+theorem memBus_mult_eq_neg_three_of_msg_eq_bMem_mem_op_five
+    {length : ℕ} {program : Program length}
+    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
+    (h_constraints : witness.Constraints) (h_specs : witness.Spec)
+    {tblRef : Table FGL} (h_tblRef : tblRef ∈ witness.allTables)
+    (h_compRef : tblRef.component = componentWithRomMemAndOpBus length program)
+    {rRef : Array FGL} (h_rRef : rRef ∈ tblRef.table)
+    (h_ref_op : (eval (tblRef.environment rRef)
+      (ZiskFv.AirsClean.Main.bMemMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)).mem_op = 5)
+    {j : Interaction FGL} (h_j : j ∈ witness.interactionsWith MemBusChannel.toRaw)
+    (h_msg : j.msg =
+      (((MemBusChannel.emitted
+        (-((componentWithRomMemAndOpBus length program).rowInputVar.rom.b_src_mem
+          + (componentWithRomMemAndOpBus length program).rowInputVar.rom.b_src_ind
+          + (componentWithRomMemAndOpBus length program).rowInputVar.rom.b_src_reg))
+        (ZiskFv.AirsClean.Main.bMemMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw).eval
+        (tblRef.environment rRef)).msg) :
+    j.mult = -3 :=
+  memBus_mult_eq_of_msg_eq_mem_op_high h_constraints h_specs
+    (by decide) (by decide) (by decide)
+    (fun _ _ _ h1 h2 h3 _ => (main_aMem_mem_op_ne_five h1 h2 h3).elim)
+    (fun _ _ _ h1 h2 h3 h4 _ => main_bMem_mult_of_mem_op_five h1 h2 h3 h4)
+    (fun _ h_comp h_row _ _ _ _ h_full =>
+      (cMem_message_ne_bMem_message h_comp h_compRef h_row h_rRef h_full).elim)
+    h_ref_op h_j h_msg
+
+/-- Reference: a store-side current access at `mem_op = 5`. -/
+theorem memBus_mult_eq_neg_two_of_msg_eq_cMem_mem_op_five
+    {length : ℕ} {program : Program length}
+    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
+    (h_constraints : witness.Constraints) (h_specs : witness.Spec)
+    {tblRef : Table FGL} (h_tblRef : tblRef ∈ witness.allTables)
+    (h_compRef : tblRef.component = componentWithRomMemAndOpBus length program)
+    {rRef : Array FGL} (h_rRef : rRef ∈ tblRef.table)
+    (h_ref_op : (eval (tblRef.environment rRef)
+      (ZiskFv.AirsClean.Main.cMemMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)).mem_op = 5)
+    {j : Interaction FGL} (h_j : j ∈ witness.interactionsWith MemBusChannel.toRaw)
+    (h_msg : j.msg =
+      (((MemBusChannel.emitted
+        (-((componentWithRomMemAndOpBus length program).rowInputVar.rom.store_mem
+          + (componentWithRomMemAndOpBus length program).rowInputVar.rom.store_ind
+          + (componentWithRomMemAndOpBus length program).rowInputVar.rom.store_reg))
+        (ZiskFv.AirsClean.Main.cMemMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw).eval
+        (tblRef.environment rRef)).msg) :
+    j.mult = -2 :=
+  memBus_mult_eq_of_msg_eq_mem_op_high h_constraints h_specs
+    (by decide) (by decide) (by decide)
+    (fun _ _ _ h1 h2 h3 _ => (main_aMem_mem_op_ne_five h1 h2 h3).elim)
+    (fun _ h_comp h_row _ _ _ _ h_full =>
+      (bMem_message_ne_cMem_message h_comp h_compRef h_row h_rRef h_full).elim)
+    (fun _ _ _ h1 h2 h3 h4 _ => main_cMem_mult_of_mem_op_five h1 h2 h3 h4)
+    h_ref_op h_j h_msg
+
+
+/-! ## Exclusivity for the remaining two slots
+
+With `mem_op = 4`, `5` and `7` all covered, every flag combination that would put two sources on one
+slot is ruled out. -/
+
+set_option maxHeartbeats 1000000 in
+/-- **A b-side register read is not also a memory or indirect read.** -/
+theorem main_b_src_mem_and_ind_zero_of_b_src_reg
+    {length : ℕ} {program : Program length}
+    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
+    (h_balanced : witness.BalancedChannels)
+    (h_constraints : witness.Constraints) (h_specs : witness.Spec)
+    {table : Table FGL} (h_table : table ∈ witness.allTables)
+    (h_component : table.component = componentWithRomMemAndOpBus length program)
+    {row : Array FGL} (h_row : row ∈ table.table)
+    (h_reg : (eval (table.environment row)
+      (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_reg = 1) :
+    (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_mem = 0
+      ∧ (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_ind = 0 := by
+  obtain ⟨-, -, b_mem, b_ind, b_reg, -⟩ :=
+    main_source_flags_boolean h_component (h_constraints table h_table) h_row
+  rcases zero_or_one_of_bool b_mem with h_m | h_m <;>
+    rcases zero_or_one_of_bool b_ind with h_i | h_i
+  · exact ⟨h_m, h_i⟩
+  · exfalso
+    have h_op : (eval (table.environment row)
+        (ZiskFv.AirsClean.Main.bMemMessageExpr
+          (componentWithRomMemAndOpBus length program).rowInputVar)).mem_op = 4 := by
+      rw [ZiskFv.AirsClean.Main.eval_bMemMessageExpr]
+      change ((eval (table.environment row)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_mem
+        + (eval (table.environment row)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_ind)
+        + 3 * (eval (table.environment row)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_reg = 4
+      rw [h_m, h_i, h_reg]; norm_num
+    exact no_balanced_message_with_constant_nonzero_mult h_balanced (m := -2) (by decide)
+      (main_bMem_interaction_mem_witness h_table h_component h_row)
+      (main_bMem_mult_eq_neg_two_of_mem_op_four b_mem b_ind b_reg h_op)
+      (fun i h_i' h_msg _ =>
+        memBus_mult_eq_neg_two_of_msg_eq_mem_op_four h_constraints h_specs h_op h_i' h_msg)
+  · exfalso
+    have h_op : (eval (table.environment row)
+        (ZiskFv.AirsClean.Main.bMemMessageExpr
+          (componentWithRomMemAndOpBus length program).rowInputVar)).mem_op = 4 := by
+      rw [ZiskFv.AirsClean.Main.eval_bMemMessageExpr]
+      change ((eval (table.environment row)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_mem
+        + (eval (table.environment row)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_ind)
+        + 3 * (eval (table.environment row)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_reg = 4
+      rw [h_m, h_i, h_reg]; norm_num
+    exact no_balanced_message_with_constant_nonzero_mult h_balanced (m := -2) (by decide)
+      (main_bMem_interaction_mem_witness h_table h_component h_row)
+      (main_bMem_mult_eq_neg_two_of_mem_op_four b_mem b_ind b_reg h_op)
+      (fun i h_i' h_msg _ =>
+        memBus_mult_eq_neg_two_of_msg_eq_mem_op_four h_constraints h_specs h_op h_i' h_msg)
+  · exfalso
+    have h_op : (eval (table.environment row)
+        (ZiskFv.AirsClean.Main.bMemMessageExpr
+          (componentWithRomMemAndOpBus length program).rowInputVar)).mem_op = 5 := by
+      rw [ZiskFv.AirsClean.Main.eval_bMemMessageExpr]
+      change ((eval (table.environment row)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_mem
+        + (eval (table.environment row)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_ind)
+        + 3 * (eval (table.environment row)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_reg = 5
+      rw [h_m, h_i, h_reg]; norm_num
+    exact no_balanced_message_with_constant_nonzero_mult h_balanced (m := -3) (by decide)
+      (main_bMem_interaction_mem_witness h_table h_component h_row)
+      (main_bMem_mult_of_mem_op_five b_mem b_ind b_reg h_op)
+      (fun i h_i' h_msg _ =>
+        memBus_mult_eq_neg_three_of_msg_eq_bMem_mem_op_five h_constraints h_specs h_table
+          h_component h_row h_op h_i' h_msg)
+
+set_option maxHeartbeats 1000000 in
+/-- **A store-side register write is not also a memory or indirect store.** -/
+theorem main_store_mem_and_ind_zero_of_store_reg
+    {length : ℕ} {program : Program length}
+    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
+    (h_balanced : witness.BalancedChannels)
+    (h_constraints : witness.Constraints) (h_specs : witness.Spec)
+    {table : Table FGL} (h_table : table ∈ witness.allTables)
+    (h_component : table.component = componentWithRomMemAndOpBus length program)
+    {row : Array FGL} (h_row : row ∈ table.table)
+    (h_reg : (eval (table.environment row)
+      (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_reg = 1) :
+    (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_mem = 0
+      ∧ (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_ind = 0 := by
+  obtain ⟨-, -, -, -, -, c_mem, c_ind, c_reg⟩ :=
+    main_source_flags_boolean h_component (h_constraints table h_table) h_row
+  rcases zero_or_one_of_bool c_mem with h_m | h_m <;>
+    rcases zero_or_one_of_bool c_ind with h_i | h_i
+  · exact ⟨h_m, h_i⟩
+  · exfalso
+    have h_op : (eval (table.environment row)
+        (ZiskFv.AirsClean.Main.cMemMessageExpr
+          (componentWithRomMemAndOpBus length program).rowInputVar)).mem_op = 5 := by
+      rw [ZiskFv.AirsClean.Main.eval_cMemMessageExpr]
+      change 2 * ((eval (table.environment row)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_mem
+        + (eval (table.environment row)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_ind)
+        + 3 * (eval (table.environment row)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_reg = 5
+      rw [h_m, h_i, h_reg]; norm_num
+    exact no_balanced_message_with_constant_nonzero_mult h_balanced (m := -2) (by decide)
+      (main_cMem_interaction_mem_witness h_table h_component h_row)
+      (main_cMem_mult_of_mem_op_five c_mem c_ind c_reg h_op)
+      (fun i h_i' h_msg _ =>
+        memBus_mult_eq_neg_two_of_msg_eq_cMem_mem_op_five h_constraints h_specs h_table
+          h_component h_row h_op h_i' h_msg)
+  · exfalso
+    have h_op : (eval (table.environment row)
+        (ZiskFv.AirsClean.Main.cMemMessageExpr
+          (componentWithRomMemAndOpBus length program).rowInputVar)).mem_op = 5 := by
+      rw [ZiskFv.AirsClean.Main.eval_cMemMessageExpr]
+      change 2 * ((eval (table.environment row)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_mem
+        + (eval (table.environment row)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_ind)
+        + 3 * (eval (table.environment row)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_reg = 5
+      rw [h_m, h_i, h_reg]; norm_num
+    exact no_balanced_message_with_constant_nonzero_mult h_balanced (m := -2) (by decide)
+      (main_cMem_interaction_mem_witness h_table h_component h_row)
+      (main_cMem_mult_of_mem_op_five c_mem c_ind c_reg h_op)
+      (fun i h_i' h_msg _ =>
+        memBus_mult_eq_neg_two_of_msg_eq_cMem_mem_op_five h_constraints h_specs h_table
+          h_component h_row h_op h_i' h_msg)
+  · exact absurd (main_not_store_mem_and_store_ind_and_store_reg h_balanced h_constraints h_specs
+      h_table h_component h_row h_m h_i h_reg) (by simp)
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/MemBusSlotSeparation.lean
+++ b/ZiskFv/Compliance/MemBusSlotSeparation.lean
@@ -316,4 +316,258 @@ theorem main_store_mem_and_ind_zero_of_store_reg
   · exact absurd (main_not_store_mem_and_store_ind_and_store_reg h_balanced h_constraints h_specs
       h_table h_component h_row h_m h_i h_reg) (by simp)
 
+
+/-! ## Every register access is a pull
+
+The payoff of exclusivity, stated uniformly over the three slots: a row whose slot selector is set
+emits that slot's current access at multiplicity exactly `-1` and opcode exactly `3`. That is what
+Clean's `exists_push_of_pull` consumes, so the register walk can step from such a row rather than
+stopping at it. -/
+
+open ZiskFv.Compliance.Instantiation (RegSlot)
+
+set_option maxHeartbeats 1000000 in
+/-- **A register access is a `-1` pull at `mem_op = 3`, on every slot.** -/
+theorem regSlot_mem_pull_of_selector
+    {length : ℕ} {program : Program length}
+    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
+    (h_balanced : witness.BalancedChannels)
+    (h_constraints : witness.Constraints) (h_specs : witness.Spec)
+    {table : Table FGL} (h_table : table ∈ witness.allTables)
+    (h_component : table.component = componentWithRomMemAndOpBus length program)
+    {row : Array FGL} (h_row : row ∈ table.table)
+    (s : RegSlot)
+    (h_sel : s.selector (eval (table.environment row)
+      (componentWithRomMemAndOpBus length program).rowInputVar) = 1) :
+    (((MemBusChannel.emitted
+      (s.memMult (componentWithRomMemAndOpBus length program).rowInputVar)
+      (s.memMessageExpr
+        (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw).eval
+      (table.environment row)).mult = -1
+    ∧ (eval (table.environment row)
+        (s.memMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)).mem_op = 3 := by
+  cases s
+  · exact main_aMem_pull_of_a_src_reg h_balanced h_constraints h_specs h_table h_component h_row
+      h_sel
+  · have h_sel' : (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_reg = 1 := h_sel
+    obtain ⟨h_m, h_i⟩ := main_b_src_mem_and_ind_zero_of_b_src_reg h_balanced h_constraints h_specs
+      h_table h_component h_row h_sel'
+    obtain ⟨-, -, e_b_mem, e_b_ind, e_b_reg, -⟩ :=
+      main_rom_eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar
+    constructor
+    · rw [RegSlot.memMult, memBus_emitted_eval_mult]
+      have h_eval :
+          Expression.eval (table.environment row)
+            (-((componentWithRomMemAndOpBus length program).rowInputVar.rom.b_src_mem
+              + (componentWithRomMemAndOpBus length program).rowInputVar.rom.b_src_ind
+              + (componentWithRomMemAndOpBus length program).rowInputVar.rom.b_src_reg))
+          = -((eval (table.environment row)
+                (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_mem
+              + (eval (table.environment row)
+                (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_ind
+              + (eval (table.environment row)
+                (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_reg) := by
+        simp only [Expression.eval, e_b_mem, e_b_ind, e_b_reg]; ring
+      rw [h_eval, h_m, h_i, h_sel']; norm_num
+    · rw [RegSlot.memMessageExpr, ZiskFv.AirsClean.Main.eval_bMemMessageExpr]
+      change ((eval (table.environment row)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_mem
+        + (eval (table.environment row)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_ind)
+        + 3 * (eval (table.environment row)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_reg = 3
+      rw [h_m, h_i, h_sel']; norm_num
+  · have h_sel' : (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_reg = 1 := h_sel
+    obtain ⟨h_m, h_i⟩ := main_store_mem_and_ind_zero_of_store_reg h_balanced h_constraints h_specs
+      h_table h_component h_row h_sel'
+    obtain ⟨-, -, -, -, -, e_c_mem, e_c_ind, e_c_reg⟩ :=
+      main_rom_eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar
+    constructor
+    · rw [RegSlot.memMult, memBus_emitted_eval_mult]
+      have h_eval :
+          Expression.eval (table.environment row)
+            (-((componentWithRomMemAndOpBus length program).rowInputVar.rom.store_mem
+              + (componentWithRomMemAndOpBus length program).rowInputVar.rom.store_ind
+              + (componentWithRomMemAndOpBus length program).rowInputVar.rom.store_reg))
+          = -((eval (table.environment row)
+                (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_mem
+              + (eval (table.environment row)
+                (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_ind
+              + (eval (table.environment row)
+                (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_reg) := by
+        simp only [Expression.eval, e_c_mem, e_c_ind, e_c_reg]; ring
+      rw [h_eval, h_m, h_i, h_sel']; norm_num
+    · rw [RegSlot.memMessageExpr, ZiskFv.AirsClean.Main.eval_cMemMessageExpr]
+      change 2 * ((eval (table.environment row)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_mem
+        + (eval (table.environment row)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_ind)
+        + 3 * (eval (table.environment row)
+          (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_reg = 3
+      rw [h_m, h_i, h_sel']; norm_num
+
+
+/-! ## One step of the walk, between witness sites -/
+
+open ZiskFv.Compliance.Instantiation (RegSupplies RegWalkStep readTimestamp_lt_of_regSupplies)
+
+/-- A slot's current access really is one of its table's memory-bus interactions. -/
+theorem regSlot_mem_interaction_mem_table
+    {length : ℕ} {program : Program length} {table : Table FGL}
+    (h_component : table.component = componentWithRomMemAndOpBus length program)
+    {row : Array FGL} (h_row : row ∈ table.table) (s : RegSlot) :
+    (((MemBusChannel.emitted
+      (s.memMult (componentWithRomMemAndOpBus length program).rowInputVar)
+      (s.memMessageExpr
+        (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw).eval
+      (table.environment row))
+      ∈ table.interactionsWith MemBusChannel.toRaw := by
+  rw [Table.interactionsWith]
+  refine List.mem_flatMap.mpr ⟨row, h_row, ?_⟩
+  rw [Operations.interactionValuesWith_eq_map, h_component,
+    ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus_interactionsWith_memBus]
+  cases s <;> simp [RegSlot.memMult, RegSlot.memMessageExpr]
+
+/-- The no-wrap bound for a row given by membership rather than index. -/
+theorem regSlot_timestamp_bound_of_mem
+    {length : ℕ} {program : Program length} {table : Table FGL}
+    (h_component : table.component = componentWithRomMemAndOpBus length program)
+    {row : Array FGL} (h_row : row ∈ table.table) (s : RegSlot) :
+    (s.readTimestamp (eval (table.environment row)
+      (componentWithRomMemAndOpBus length program).rowInputVar)).val < 2 ^ 40 := by
+  obtain ⟨index, h_index, h_rowAt⟩ := exists_index_of_mem_mainTable h_component h_row
+  rw [h_rowAt]
+  exact regSlot_timestamp_bound_of_mainTable h_component h_index s
+
+/-- **One step of the register walk, between witness sites.**
+
+    A row whose slot selector is set has its register read supplied either by the
+    `RegisterBoundary`, or by another witness site whose own read happens **strictly later**. Every
+    input is discharged: the `-1` pull shape from source exclusivity, the branch split from
+    `channels_balanced`, the descent from the bus-102 slice, and the no-wrap bound from the Main
+    table's fixed-column capacity. -/
+theorem site_step
+    {n : Nat} (trace : AcceptedZiskTrace n)
+    {table : Table FGL} (h_table : table ∈ trace.witness.allTables)
+    (h_component : table.component =
+      componentWithRomMemAndOpBus trace.programLength trace.program)
+    {row : Array FGL} (h_row : row ∈ table.table) (s : RegSlot)
+    (h_sel : s.selector (eval (table.environment row)
+      (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar) = 1)
+    {multiplicity as : FGL} :
+    ActiveMainRegisterBoundaryProviderRowMatchSpec trace.program trace.witness table row
+        (((MemBusChannel.emitted
+          (s.memMult
+            (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)
+          (s.memMessageExpr
+            (componentWithRomMemAndOpBus trace.programLength
+              trace.program).rowInputVar)).toRaw).eval (table.environment row))
+        (s.memMessageExpr
+          (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)
+        multiplicity as
+      ∨ ∃ q : RegWalkStep, IsActiveWitnessMainRow trace q
+          ∧ (s.readTimestamp (eval (table.environment row)
+              (componentWithRomMemAndOpBus trace.programLength
+                trace.program).rowInputVar)).val < q.timestamp.val := by
+  obtain ⟨h_pull, h_op⟩ := regSlot_mem_pull_of_selector trace.channels_balanced
+    trace.constraints_hold trace.spec_holds h_table h_component h_row s h_sel
+  rcases registerRead_counterpart_of_witnessTable trace h_table h_row
+      (regSlot_mem_interaction_mem_table h_component h_row s) rfl h_pull h_op
+      (multiplicity := multiplicity) (as := as) with h_boundary | ⟨q, h_q, h_ts⟩
+  · exact Or.inl h_boundary
+  · refine Or.inr ⟨q, h_q, ?_⟩
+    have h_supplies :
+        RegSupplies s q.2 (eval (table.environment row)
+          (componentWithRomMemAndOpBus trace.programLength
+            trace.program).rowInputVar) q.1 := by
+      show q.2.prevStep q.1 = s.readTimestamp _
+      rw [h_ts, RegSlot.eval_memMessageExpr_timestamp]
+    exact readTimestamp_lt_of_regSupplies h_supplies
+      (regSlot_descent_of_witnessMainRow trace h_q)
+      (regSlot_timestamp_bound_of_mem h_component h_row s)
+
+
+/-! ## Termination: the walk ends at the `RegisterBoundary`
+
+Each supply step strictly increases the read timestamp, and every read timestamp is below `2^40`.
+So following the counterparts cannot go on forever: after finitely many steps the counterpart is no
+longer another Main row, and the only remaining memory-bus provider at `mem_op = 3` is the
+`RegisterBoundary`. -/
+
+/-- A witness site whose own register read is supplied by the `RegisterBoundary`. -/
+def BoundarySuppliedSite {n : Nat} (trace : AcceptedZiskTrace n) (multiplicity as : FGL) : Prop :=
+  ∃ table ∈ trace.witness.allTables,
+    ∃ _h_comp : table.component =
+        componentWithRomMemAndOpBus trace.programLength trace.program,
+      ∃ row ∈ table.table, ∃ s : RegSlot,
+        s.selector (eval (table.environment row)
+          (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar) = 1
+        ∧ ActiveMainRegisterBoundaryProviderRowMatchSpec trace.program trace.witness table row
+            (((MemBusChannel.emitted
+              (s.memMult
+                (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)
+              (s.memMessageExpr
+                (componentWithRomMemAndOpBus trace.programLength
+                  trace.program).rowInputVar)).toRaw).eval (table.environment row))
+            (s.memMessageExpr
+              (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)
+            multiplicity as
+
+set_option maxHeartbeats 1000000 in
+/-- **The walk terminates.** From any witness site, following supply counterparts reaches a site
+    whose read is supplied by the `RegisterBoundary`. The measure is `2 ^ 40 - readTimestamp`, which
+    strictly decreases at every step because each step moves strictly later in time, and which is
+    well-founded because every read timestamp is below `2 ^ 40`. -/
+theorem exists_boundarySuppliedSite_of_fuel
+    {n : Nat} (trace : AcceptedZiskTrace n) (multiplicity as : FGL) :
+    ∀ (fuel : ℕ) {table : Table FGL}, table ∈ trace.witness.allTables →
+      ∀ (h_component : table.component =
+          componentWithRomMemAndOpBus trace.programLength trace.program),
+        ∀ {row : Array FGL}, row ∈ table.table → ∀ (s : RegSlot),
+          s.selector (eval (table.environment row)
+            (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar) = 1 →
+          2 ^ 40 - (s.readTimestamp (eval (table.environment row)
+            (componentWithRomMemAndOpBus trace.programLength
+              trace.program).rowInputVar)).val ≤ fuel →
+          BoundarySuppliedSite trace multiplicity as := by
+  intro fuel
+  induction fuel with
+  | zero =>
+      intro table h_table h_component row h_row s h_sel h_fuel
+      exact absurd (regSlot_timestamp_bound_of_mem h_component h_row s) (by omega)
+  | succ fuel ih =>
+      intro table h_table h_component row h_row s h_sel h_fuel
+      rcases site_step trace h_table h_component h_row s h_sel
+          (multiplicity := multiplicity) (as := as) with h_boundary | ⟨q, h_q, h_lt⟩
+      · exact ⟨table, h_table, h_component, row, h_row, s, h_sel, h_boundary⟩
+      · obtain ⟨tbl, h_tbl, h_comp, index, h_index, h_rowAt, h_active⟩ := h_q
+        have h_get : q.1 = eval (tbl.environment (tbl.table.get ⟨index, h_index⟩))
+            (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar := by
+          rw [h_rowAt]
+          exact mainTableRowAtOrZero_get trace.program tbl ⟨index, h_index⟩
+        refine ih h_tbl h_comp (List.get_mem tbl.table ⟨index, h_index⟩) q.2 ?_ ?_
+        · rw [← h_get]; exact h_active
+        · have h_bound := regSlot_timestamp_bound_of_mem h_comp
+            (List.get_mem tbl.table ⟨index, h_index⟩) q.2
+          rw [← h_get] at h_bound ⊢
+          have : q.timestamp.val = (q.2.readTimestamp q.1).val := rfl
+          omega
+
+/-- **Termination, with the measure supplied.** Every witness site's walk reaches the boundary. -/
+theorem exists_boundarySuppliedSite
+    {n : Nat} (trace : AcceptedZiskTrace n) (multiplicity as : FGL)
+    {table : Table FGL} (h_table : table ∈ trace.witness.allTables)
+    (h_component : table.component =
+      componentWithRomMemAndOpBus trace.programLength trace.program)
+    {row : Array FGL} (h_row : row ∈ table.table) (s : RegSlot)
+    (h_sel : s.selector (eval (table.environment row)
+      (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar) = 1) :
+    BoundarySuppliedSite trace multiplicity as :=
+  exists_boundarySuppliedSite_of_fuel trace multiplicity as (2 ^ 40) h_table h_component h_row s
+    h_sel (by omega)
+
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/MemBusSlotSeparation.lean
+++ b/ZiskFv/Compliance/MemBusSlotSeparation.lean
@@ -1,0 +1,75 @@
+import ZiskFv.Compliance.RegisterWalk
+
+/-!
+# Main's three memory-bus slots never share a message
+
+`MemBusSourceExclusivity` rules out an operand-source flag combination by showing that the
+multiplicity of every interaction carrying the offending message is one fixed nonzero value. That
+works at `mem_op = 4` and `mem_op = 7`, where only one shape of Main emission can occur. It fails at
+`mem_op = 5`, which **two** shapes reach: a b-side current access rides at `-3` there and a
+store-side current access at `-2`.
+
+The message itself separates them, through its timestamp. Main's three accesses happen at
+`1 + main_step * 4`, `2 + main_step * 4` and `3 + main_step * 4`
+(`Main/Constraints.lean:363,376,389`), `main_step` is the row index, and the table's own
+fixed-column schema caps that index at `mainFixedCapacity = 2^22`. So every access timestamp is
+below `2^24`, no wraparound can occur, and the residue mod `4` is an invariant of the slot.
+-/
+
+namespace ZiskFv.Compliance
+
+open Air.Flat (Table)
+open ZiskFv.AirsClean.FullEnsemble
+open ZiskFv.AirsClean.ZiskInstructionRom (Program)
+open ZiskFv.AirsClean.Main (MainRowWithRom componentWithRomMemAndOpBus)
+open ZiskFv.Channels.MemoryBus (MemBusChannel)
+
+/-- Every row of a Main-component table carries its own index in `main_step`, and that index is
+below the component's fixed-column capacity. -/
+theorem exists_main_step_index_of_mem
+    {length : ℕ} {program : Program length} {table : Table FGL}
+    (h_component : table.component = componentWithRomMemAndOpBus length program)
+    {row : Array FGL} (h_row : row ∈ table.table) :
+    ∃ index : ℕ, index < ZiskFv.AirsClean.Main.mainFixedCapacity ∧
+      (eval (table.environment row)
+        (componentWithRomMemAndOpBus length program).rowInputVar).rom.main_step
+        = (index : FGL) := by
+  obtain ⟨index, h_index, h_rowAt⟩ := exists_index_of_mem_mainTable h_component h_row
+  refine ⟨index, main_index_lt_mainFixedCapacity h_component h_index, ?_⟩
+  rw [h_rowAt]
+  exact (mainStepIndexFixedFacts_of_component_fixedColumns
+    (numInstructions := table.table.length) program table h_component
+    (fun i => i.isLt)).main_step_eq_index ⟨index, h_index⟩
+
+/-- An access timestamp `k + 4 * index` with `k ≤ 3` and `index < 2^22` evaluates without wrapping,
+so its `val` is the integer `k + 4 * index`. -/
+theorem slot_timestamp_val
+    {k index : ℕ} (h_k : k ≤ 3) (h_index : index < ZiskFv.AirsClean.Main.mainFixedCapacity) :
+    ((k : FGL) + (index : FGL) * 4).val = k + 4 * index := by
+  have h_cap : index < 4194304 := by
+    simpa [ZiskFv.AirsClean.Main.mainFixedCapacity] using h_index
+  have h_prime : GL_prime = 18446744069414584321 := rfl
+  have h_k_cast : ((k : ℕ) : FGL).val = k := by
+    rw [Fin.val_natCast, Nat.mod_eq_of_lt (by omega)]
+  have h_i_cast : ((index : ℕ) : FGL).val = index := by
+    rw [Fin.val_natCast, Nat.mod_eq_of_lt (by omega)]
+  have h_mul : ((index : FGL) * 4).val = index * 4 := by
+    rw [Fin.val_mul, h_i_cast]
+    exact Nat.mod_eq_of_lt (by omega)
+  rw [Fin.val_add, h_k_cast, h_mul, Nat.mod_eq_of_lt (by omega)]
+  omega
+
+/-- **Two of Main's slots never read at the same time.** The offsets `1`, `2`, `3` sit in distinct
+residues mod `4`, and no wraparound can move between them. -/
+theorem slot_timestamp_ne
+    {k₁ k₂ index₁ index₂ : ℕ}
+    (h_k₁ : k₁ ≤ 3) (h_k₂ : k₂ ≤ 3) (h_ne : k₁ ≠ k₂)
+    (h_i₁ : index₁ < ZiskFv.AirsClean.Main.mainFixedCapacity)
+    (h_i₂ : index₂ < ZiskFv.AirsClean.Main.mainFixedCapacity) :
+    ((k₁ : FGL) + (index₁ : FGL) * 4) ≠ ((k₂ : FGL) + (index₂ : FGL) * 4) := by
+  intro h
+  have h_val := congrArg Fin.val h
+  rw [slot_timestamp_val h_k₁ h_i₁, slot_timestamp_val h_k₂ h_i₂] at h_val
+  omega
+
+end ZiskFv.Compliance

--- a/ZiskFv/Compliance/RegisterWalk.lean
+++ b/ZiskFv/Compliance/RegisterWalk.lean
@@ -266,28 +266,30 @@ theorem exists_index_of_mem_mainTable
 
     The activity conjunct is what makes the second branch usable — it is exactly the premise the
     bus-102 descent needs. -/
-theorem registerRead_counterpart_of_trace
+theorem registerRead_counterpart_of_witnessTable
     {n : Nat} (trace : AcceptedZiskTrace n)
-    {mainRow : Array FGL} (h_mainRow : mainRow ∈ trace.mainTable.table)
+    {mainTable : Table FGL} (h_mainTable : mainTable ∈ trace.witness.allTables)
+    {mainRow : Array FGL} (h_mainRow : mainRow ∈ mainTable.table)
     {mainInteraction : Interaction FGL}
     (h_mainInteraction :
-      mainInteraction ∈ trace.mainTable.interactionsWith MemBusChannel.toRaw)
+      mainInteraction ∈ mainTable.interactionsWith MemBusChannel.toRaw)
     {mainMult : Expression FGL}
     {mainMsg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)}
     (h_mainEval :
       mainInteraction =
         ((MemBusChannel.emitted mainMult mainMsg).toRaw).eval
-          (trace.mainTable.environment mainRow))
+          (mainTable.environment mainRow))
     (h_pull : mainInteraction.mult = -1)
-    (h_mem_op : (eval (trace.mainTable.environment mainRow) mainMsg).mem_op = 3)
+    (h_mem_op : (eval (mainTable.environment mainRow) mainMsg).mem_op = 3)
     {multiplicity as : FGL} :
-    ActiveMainRegisterBoundaryProviderRowMatchSpec trace.program trace.witness trace.mainTable
+    ActiveMainRegisterBoundaryProviderRowMatchSpec trace.program trace.witness mainTable
         mainRow mainInteraction mainMsg multiplicity as
       ∨ ∃ p : RegWalkStep, IsActiveWitnessMainRow trace p
-          ∧ p.2.prevStep p.1 = (eval (trace.mainTable.environment mainRow) mainMsg).timestamp := by
+          ∧ p.2.prevStep p.1 = (eval (mainTable.environment mainRow) mainMsg).timestamp := by
   have h_match :=
-    (trace.activeMainMemProviderRowMatchSpec_of_active_main_eval
-      h_mainRow h_mainInteraction h_mainEval h_pull (multiplicity := multiplicity) (as := as)).2
+    (ZiskFv.AirsClean.FullEnsemble.activeMainMemProviderRowMatchSpec_of_active_main_eval
+      trace.witness trace.channels_balanced trace.spec_holds h_mainTable h_mainRow
+      h_mainInteraction h_mainEval h_pull (multiplicity := multiplicity) (as := as)).2
   rcases activeMainRegisterProviderRowMatchSpec_of_main_mem_op_three
       h_mainEval h_mem_op h_match with h_self | h_boundary
   · refine Or.inr ?_
@@ -360,7 +362,7 @@ theorem registerRead_supplied_by_boundary_or_strictly_later_row
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
           trace.programLength trace.program).rowInputVar :=
     mainTableRowAtOrZero_get trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-  rcases registerRead_counterpart_of_trace trace
+  rcases registerRead_counterpart_of_witnessTable trace trace.mainTable_mem
       (List.get_mem trace.mainTable.table ⟨i.val, trace.mainTable_index i⟩)
       h_mainInteraction h_mainEval h_pull h_mem_op (multiplicity := multiplicity) (as := as) with
     h_boundary | ⟨p, h_site, h_ts⟩

--- a/trust/consistency/register_walk_acyclic.lean
+++ b/trust/consistency/register_walk_acyclic.lean
@@ -1,4 +1,5 @@
 import ZiskFv.Compliance.RegisterWalk
+import ZiskFv.Compliance.MemBusSlotSeparation
 
 /-!
 # Register walk acyclicity (issue #342)
@@ -25,6 +26,7 @@ namespace ZiskFv.TrustConsistency
 
 open ZiskFv.Compliance
 open ZiskFv.Compliance.Instantiation (RegSlot RegSupplies RegWalkStep)
+open Air.Flat
 
 /-- #342's concrete two-row witness is impossible on an accepted trace. -/
 theorem register_walk_no_two_cycle
@@ -62,12 +64,52 @@ theorem register_walk_timestamps_nodup_on_witness_rows
     (steps.map RegWalkStep.timestamp).Nodup :=
   regSupplies_chain_timestamps_nodup_of_witnessRows trace steps h_sites h_chain
 
+/-- Termination: from any witness site the walk reaches a site whose register read is supplied by
+    the `RegisterBoundary`. -/
+theorem register_walk_terminates_at_boundary
+    {n : Nat} (trace : AcceptedZiskTrace n) (multiplicity as : FGL)
+    {table : Air.Flat.Table FGL} (h_table : table ∈ trace.witness.allTables)
+    (h_component : table.component =
+      ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.programLength trace.program)
+    {row : Array FGL} (h_row : row ∈ table.table) (s : RegSlot)
+    (h_sel : s.selector (eval (table.environment row)
+      (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+        trace.programLength trace.program).rowInputVar) = 1) :
+    BoundarySuppliedSite trace multiplicity as :=
+  exists_boundarySuppliedSite trace multiplicity as h_table h_component h_row s h_sel
+
+/-- Source exclusivity, the fact termination rests on: every Main register access is a `-1` pull. -/
+theorem register_access_is_a_pull
+    {length : ℕ} {program : ZiskFv.AirsClean.ZiskInstructionRom.Program length}
+    {witness : Air.Flat.EnsembleWitness
+      (ZiskFv.AirsClean.FullEnsemble.fullRv64imEnsemble length program).ensemble}
+    (h_balanced : witness.BalancedChannels)
+    (h_constraints : witness.Constraints) (h_specs : witness.Spec)
+    {table : Air.Flat.Table FGL} (h_table : table ∈ witness.allTables)
+    (h_component : table.component =
+      ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program)
+    {row : Array FGL} (h_row : row ∈ table.table) (s : RegSlot)
+    (h_sel : s.selector (eval (table.environment row)
+      (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program).rowInputVar) = 1) :
+    (((ZiskFv.Channels.MemoryBus.MemBusChannel.emitted
+      (s.memMult (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program).rowInputVar)
+      (s.memMessageExpr
+        (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+          length program).rowInputVar)).toRaw).eval (table.environment row)).mult = -1
+    ∧ (eval (table.environment row)
+        (s.memMessageExpr
+          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+            length program).rowInputVar)).mem_op = 3 :=
+  regSlot_mem_pull_of_selector h_balanced h_constraints h_specs h_table h_component h_row s h_sel
+
+#print axioms register_walk_terminates_at_boundary
+#print axioms register_access_is_a_pull
 #print axioms register_walk_timestamps_nodup_on_witness_rows
 #print axioms register_walk_no_two_cycle
 #print axioms register_walk_timestamps_nodup
 #print axioms register_walk_non_vacuous
 #print axioms ZiskFv.Compliance.addX1Row_walk_timestamps_nodup
-#print axioms ZiskFv.Compliance.registerRead_counterpart_of_trace
+#print axioms ZiskFv.Compliance.registerRead_counterpart_of_witnessTable
 #print axioms ZiskFv.Compliance.registerRead_supplied_by_boundary_or_strictly_later_row
 #print axioms ZiskFv.Compliance.regSlot_descent_of_trace
 #print axioms ZiskFv.Compliance.regSlot_timestamp_bound_of_trace

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -671,16 +671,39 @@ distances are the `[0, 0, 0]` that `singleAddWitness`'s provider list records. E
 result in `RegisterWalk.lean` is an implication out of `RegSupplies`, so an empty relation
 would make them hold without saying anything about ZisK.
 
-**What this still does not give.** Acyclicity bounds the walk from below, not above. Nothing yet
-forces a register chain to *reach* `RegisterBoundary.bootMessage`, for two separate reasons.
-First, the `main.pil:447` gap above is unchanged, so the boundary can still self-pair at
-timestamp `0`. Second, iterating the supply step needs the supplying row's own access to be a
-`mem_op = 3` **pull**, i.e. `a_src_mem + a_src_reg = 1`, because `exists_push_of_pull` fires only
-at multiplicity exactly `-1`. Main's constraints give **booleanity only**
-(`Main/Constraints.lean:252,259`); no exclusivity constraint exists in the component, so `(1, 1)`
-is admissible in the model and the pull would ride at `-2` with `mem_op = 4`. Ruling that out means
-pinning `rom_flags` to a decoded instruction — the committed-program decode bridge (#172, on top of
-#164's proven decoder), a different axis from this range slice.
+**Update (#342, source exclusivity).** The second obstacle above is gone, and it did **not** need
+the decode bridge. `ZiskFv/AirsClean/FullEnsemble/Balance/MemBusSourceExclusivity.lean` proves the
+operand-source flags exclusive from `BalancedChannels` alone.
+
+`Air.Flat.BalancedInteractions` is **message-exact** — `∀ msg, balanceOf interactions msg = 0`, not
+a challenge-mixed sum — so one message can be reasoned about on its own. A row setting two a-side
+source flags emits its a-side current access at `mem_op = 4`, and
+`memBus_mult_eq_of_msg_eq_mem_op_high` shows every memory-bus interaction of the witness carrying
+that message rides at `-2`: Main's three register-pre pushes are the only positive emissions and
+carry the literal `3`; `RegisterBoundary` carries `3`; `MemAlignReadByte` carries `1`; `MemAlign`,
+`MemAlignByte` and `Mem` carry `wr + 1` or `1 + is_write` for a flag their own `Spec` pins to
+`{0, 1}`; and Main's three *current* accesses are all pulls that booleanity pins to `-2` there. The
+balance is then `-2 * count` with `count ≥ 1` and `count < GL_prime`, which cannot vanish
+(`no_balanced_message_with_constant_nonzero_mult`).
+
+So `main_not_a_src_mem_and_a_src_reg` holds, and with it `main_aMem_pull_of_a_src_reg`: a
+register-reading row's a-side access is a genuine `-1` pull at `mem_op = 3`, which is the shape
+`exists_push_of_pull` consumes. The same argument at `mem_op = 7` gives
+`main_not_store_mem_and_store_ind_and_store_reg`. No new premise, no decode fact; axiom closure is
+the three standard axioms.
+
+**What this still does not give.** Acyclicity bounds the walk from below, not above, and two things
+still stand between that and termination at `RegisterBoundary.bootMessage`.
+
+First, the remaining b-side and store-side flag combinations land at `mem_op = 5`, where the
+multiplicity is not constant across slots — a b-side current rides at `-3`, a store-side current at
+`-2` — so the classification above does not apply as stated. The message **timestamp** separates
+them: the three slots sit at `1, 2, 3 + 4 * main_step`, `main_step` is the row index, and the Main
+table's own fixed-column capacity caps it at `2^22`, so no wraparound can move between residue
+classes mod `4`. That instance is not yet built.
+
+Second, the `main.pil:447` gap above is unchanged, so the boundary can still self-pair at
+timestamp `0`.
 This slice does **not** claim register/memory access-ordering soundness. The
 cross-segment continuation terms (`MAIN_CONTINUATION_ID` block and
 `main.pil:454`'s `sel:(1-main_last_segment)` continuation pull) are out of scope

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -707,17 +707,29 @@ constant once the reference slot is fixed, giving
 
 So **every** Main register access is a genuine `-1` pull at `mem_op = 3`.
 
-**What this still does not give.** Termination remains open, for two reasons.
+**Update (termination).** The walk now provably ends at the boundary.
+`exists_boundarySuppliedSite`: from any witness site — a Main row with an active register slot —
+following supply counterparts reaches a site whose own register read is supplied by
+`RegisterBoundary`.
 
-First, `registerRead_counterpart_of_trace` is stated on `trace.mainTable`, while the provider it
-returns is any witness table carrying Main's component. Iterating the walk therefore needs
-*uniqueness* of the Main table in the witness. That is derivable in principle —
-`EnsembleWitness.allTables_map_component` pins the component list — but it requires distinguishing
-Main from the other fifteen components, which are structure values with no cheap decidable equality.
-It is **not** proved yet, and it is not an assumption anywhere.
+Three things make it go through. `regSlot_mem_pull_of_selector` turns source exclusivity into the
+`-1`-pull shape on all three slots, so the counterpart classification applies to a *supplying* row
+in turn and not only to the consumer. `registerRead_counterpart_of_witnessTable` restates that
+classification over any witness table carrying Main's component — the underlying ensemble lemma
+already quantified over an arbitrary table, so no uniqueness-of-the-Main-table argument is needed.
+And `exists_boundarySuppliedSite_of_fuel` is an induction on `2 ^ 40 - readTimestamp`: the measure
+strictly decreases because each supply step moves strictly later in time, and it is well-founded
+because every read timestamp is below `2 ^ 40` — from the Main table's own fixed-column capacity,
+not from a premise about segment length.
 
-Second, the `main.pil:447` gap above is unchanged, so the boundary can still self-pair at
-timestamp `0`.
+No new premise, no decode fact, no assumption about the number of Main tables. Axiom closure is the
+three standard axioms.
+
+**What this still does not give.** The `main.pil:447` gap above is unchanged: the reload timestamp
+is free, so the boundary can self-pair at timestamp `0`. Termination says the walk *reaches* the
+boundary; pinning **which** boundary message it lands on — and so anchoring the value telescope at
+`bootMessage`'s literal `(ts 0, value 0)` — is that separate gap, and it is what #330 Phase 4 needs
+next.
 This slice does **not** claim register/memory access-ordering soundness. The
 cross-segment continuation terms (`MAIN_CONTINUATION_ID` block and
 `main.pil:454`'s `sel:(1-main_last_segment)` continuation pull) are out of scope

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -695,12 +695,26 @@ the three standard axioms.
 **What this still does not give.** Acyclicity bounds the walk from below, not above, and two things
 still stand between that and termination at `RegisterBoundary.bootMessage`.
 
-First, the remaining b-side and store-side flag combinations land at `mem_op = 5`, where the
-multiplicity is not constant across slots — a b-side current rides at `-3`, a store-side current at
-`-2` — so the classification above does not apply as stated. The message **timestamp** separates
-them: the three slots sit at `1, 2, 3 + 4 * main_step`, `main_step` is the row index, and the Main
-table's own fixed-column capacity caps it at `2^22`, so no wraparound can move between residue
-classes mod `4`. That instance is not yet built.
+**Update (all three slots).** `ZiskFv/Compliance/MemBusSlotSeparation.lean` finishes the argument.
+The remaining b-side and store-side combinations land at `mem_op = 5`, where the multiplicity is
+*not* constant across slots — a b-side current rides at `-3`, a store-side current at `-2` — so the
+classification does not apply directly. The message **timestamp** separates them
+(`cMem_message_ne_bMem_message`): the three slots access at `1, 2, 3 + 4 * main_step`, `main_step`
+is the row index, and the Main table's own fixed-column capacity caps it at `2^22`, so nothing wraps
+and the residue mod `4` is an invariant of the slot. With the slots separated the multiplicity is
+constant once the reference slot is fixed, giving
+`main_b_src_mem_and_ind_zero_of_b_src_reg` and `main_store_mem_and_ind_zero_of_store_reg`.
+
+So **every** Main register access is a genuine `-1` pull at `mem_op = 3`.
+
+**What this still does not give.** Termination remains open, for two reasons.
+
+First, `registerRead_counterpart_of_trace` is stated on `trace.mainTable`, while the provider it
+returns is any witness table carrying Main's component. Iterating the walk therefore needs
+*uniqueness* of the Main table in the witness. That is derivable in principle —
+`EnsembleWitness.allTables_map_component` pins the component list — but it requires distinguishing
+Main from the other fifteen components, which are structure values with no cheap decidable equality.
+It is **not** proved yet, and it is not an assumption anywhere.
 
 Second, the `main.pil:447` gap above is unchanged, so the boundary can still self-pair at
 timestamp `0`.


### PR DESCRIPTION
Third instalment on #342, after #345 (model the bus-102 descent) and #346 (walk it — cycles
excluded). This one proves **termination**, and along the way removes an obstacle I had wrongly
attributed to a different axis.

## What this PR proves

**`exists_boundarySuppliedSite`** — from any witness site (a Main row with an active register slot),
following supply counterparts reaches a site whose own register read is supplied by
`RegisterBoundary`.

Three steps, each discharged from `AcceptedZiskTrace` with no new premise.

### 1. Operand-source exclusivity, from `BalancedChannels` alone

The walk can only step from a supplying row if that row's own access is a `mem_op = 3` **pull**:
Clean's `exists_push_of_pull` fires only at multiplicity exactly `-1`. Main asserts **booleanity
only** for the source flags (`Main/Constraints.lean:252,259`) and no exclusivity constraint exists in
the component.

`Air.Flat.BalancedInteractions` is **message-exact** — `∀ msg, balanceOf interactions msg = 0`,
summing multiplicities over interactions carrying that exact message array. It is not a
challenge-mixed sum, so a single message can be reasoned about on its own. A row putting two sources
on one slot emits its current access at an opcode nothing else can offset:

| emitter | `mem_op` it can carry |
|---|---|
| Main, three register-pre pushes (the only positive multiplicities) | literal `3` |
| `RegisterBoundary` boot / reload | literal `3` |
| `MemAlignReadByte` | literal `1` |
| `MemAlign`, `Mem` | `wr + 1`, `wr` boolean by their own `Spec` |
| `MemAlignByte` | `1 + is_write`, bounded by its own `Spec` |
| Main, three **current** accesses — all pulls | `0…7` |

So the balance at that message is `m * count` with `count ≥ 1` and `count < GL_prime`, which cannot
vanish (`no_balanced_message_with_constant_nonzero_mult`).

- `mem_op = 4` → `main_not_a_src_mem_and_a_src_reg`
- `mem_op = 7` → `main_not_store_mem_and_store_ind_and_store_reg`
- `mem_op = 5` is reached by **two** emissions at **different** multiplicities (`-3` b-side, `-2`
  store-side), so the count argument does not apply directly. The message **timestamp** separates
  them (`cMem_message_ne_bMem_message`): the slots access at `1, 2, 3 + 4 * main_step`, `main_step`
  is the row index, and the table's own fixed-column schema caps it at `mainFixedCapacity = 2^22`,
  so nothing wraps and the residue mod `4` is an invariant of the slot. That gives
  `main_b_src_mem_and_ind_zero_of_b_src_reg` and `main_store_mem_and_ind_zero_of_store_reg`.

`memBus_mult_eq_of_msg_eq_mem_op_high` does the component case split **once**, parameterized by the
reference opcode `k ∉ {1,2,3}` — exactly what clears the table above — and by the multiplicity the
three Main current accesses share there.

### 2. Hence every register access is a `-1` pull at `mem_op = 3`

`regSlot_mem_pull_of_selector`, on all three slots. That is the shape `exists_push_of_pull` consumes,
so the counterpart classification applies to a **supplying** row in turn, not only to the consumer.

### 3. Hence the walk terminates

`registerRead_counterpart_of_witnessTable` restates the classification over any witness table
carrying Main's component. The underlying ensemble lemma
(`activeMainMemProviderRowMatchSpec_of_active_main_eval`) already quantified over an arbitrary
`mainTable ∈ witness.allTables`; only the trace-level wrapper had specialized it. So **no Main-table
uniqueness argument is needed.**

`exists_boundarySuppliedSite_of_fuel` is then an induction on `2 ^ 40 − readTimestamp`. The measure
strictly decreases because each supply step moves strictly later in time (#346), and it is
well-founded because every read timestamp is below `2 ^ 40` — from the Main table's own fixed-column
capacity, **not** from any premise about segment length.

## Two claims from earlier PRs that this retracts

- On #346 I said exclusivity required the committed-program decode bridge (#172). **It does not** —
  it follows from balance.
- I then said termination required Main-table uniqueness in the witness. **It does not** — see
  step 3. I had taken a trace-level wrapper's specialization as essential without checking the
  ensemble lemma underneath.

Both corrections are recorded on #342.

## Trust boundary

No new trust markers: no `axiom` / `opaque` / `sorry` / `native_decide` or equivalent. Axiom closure
of every new theorem is `[propext, Classical.choice, Quot.sound]`; `slot_timestamp_ne` needs only
`[propext, Quot.sound]`. V2 check 19 now also certifies `register_walk_terminates_at_boundary` and
`register_access_is_a_pull`. `trust/trusted-base.md` is updated in the same change, including what
is *not* delivered.

## What remains — one gap, and it is a different constraint

`main.pil:447`'s reload-timestamp range check is still unmodelled, so the `RegisterBoundary` reload
timestamp is free and the boundary can self-pair at timestamp `0`. Termination says the walk
*reaches* the boundary; pinning **which** boundary message it lands on — and so anchoring the value
telescope at `bootMessage`'s literal `(ts 0, value 0)` — is that separate gap.

Ordering is also not agreement: carrying the register *value* along the chain, and so building
#330's 116 `h_a_*_t` / `h_b_*_t` fields instead of assuming them, is #330 Phase 4.

## Verification

Gates on `42756aeb`: `lake build` 9163 jobs, V1 20/20, V2 20/20, no `sorry` under `ZiskFv/`. Details
in the comments below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
