### PR TITLE
#342 follow-up: record the register walk's path, and tighten check 19

### DIFF
--- a/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusSourceExclusivity.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusSourceExclusivity.lean
@@ -735,39 +735,12 @@ theorem main_not_a_src_mem_and_a_src_reg
   have h_I_mult : I.mult = -2 :=
     main_aMem_mult_eq_neg_two_of_mem_op_four
       (by rw [h_src_mem]; ring) (by rw [h_src_reg]; ring) h_ref_op
-  -- every interaction on that message rides at `-2`
-  have h_all :
-      ∀ i ∈ witness.interactionsWith MemBusChannel.toRaw,
-        i.msg = I.msg → i.mult ≠ 0 → i.mult = -2 := by
-    intro i h_i h_msg _
-    exact memBus_mult_eq_neg_two_of_msg_eq_mem_op_four h_constraints h_specs h_ref_op h_i h_msg
-  have h_balance := memBus_balanced_of_witness witness h_balanced
-  have h_zero := h_balance.2 I.msg
-  rw [balanceOf_eq_of_mult_or_zero h_all] at h_zero
-  set count : ℕ :=
-    (witness.interactionsWith MemBusChannel.toRaw).countP
-      (fun i => i.msg = I.msg && i.mult ≠ 0) with h_count
-  -- the reference interaction itself is counted
-  have h_count_pos : 0 < count := by
-    rw [h_count, List.countP_pos_iff]
-    exact ⟨I, h_I_mem, by simp [h_I_mult]⟩
-  -- and the count is below the characteristic
-  have h_count_lt : count < ringChar FGL ∨ ringChar FGL = 0 := by
-    rcases count_lt_ringChar_of_balancedInteractions (msg := I.msg) h_balance with h | h
-    · exact Or.inl (lt_of_le_of_lt (List.countP_and_left_le _ _ _) h)
-    · exact Or.inr h
-  -- `-2 * count = 0` with `2` invertible forces `count = 0`
-  have h_cast : ((count : ℕ) : FGL) = 0 := by
-    have h2 : (-2 : FGL) ≠ 0 := by decide
-    rcases mul_eq_zero.mp h_zero with h | h
-    · exact absurd h h2
-    · exact h
-  rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime] at h_count_lt
-  have h_count_zero : count = 0 := by
-    rcases h_count_lt with h_lt | h_char
-    · exact natCast_eq_zero_of_lt_prime h_lt h_cast
-    · exact absurd h_char (by decide)
-  omega
+  -- every interaction on that message rides at `-2`, so the balance is `-2 * count` with
+  -- `count ≥ 1`, which cannot vanish
+  refine no_balanced_message_with_constant_nonzero_mult h_balanced (m := -2) (by decide)
+    h_I_mem h_I_mult ?_
+  intro i h_i h_msg _
+  exact memBus_mult_eq_neg_two_of_msg_eq_mem_op_four h_constraints h_specs h_ref_op h_i h_msg
 
 
 /-- **A register-reading row does not also read memory on the a side.** Immediate from

--- a/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
+++ b/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
@@ -2190,7 +2190,10 @@ end RegSlot
 
 /-- `(provider, sp)` supplies `(consumer, sc)`'s register read: the provider slot's register-pre
 push carries the consumer slot's read timestamp. This is exactly what
-`selfMemProvider_registerPre_timestamp_of_mem_op_three` concludes from balance. -/
+`selfMemProvider_registerPre_timestamp_of_mem_op_three` concludes from balance.
+
+Read the argument order as *consumer first*: `RegSupplies sc sp consumer provider` is a fact about
+`consumer`'s read, and `provider` is what answers it. -/
 def RegSupplies (sc sp : RegSlot) (consumer provider : MainRowWithRom FGL) : Prop :=
   sp.prevStep provider = sc.readTimestamp consumer
 
@@ -2203,8 +2206,9 @@ def RegWalkStep.timestamp (p : RegWalkStep) : FGL := p.2.readTimestamp p.1
 /-- The bus-102 distance a walk step's slot range-checks. -/
 def RegWalkStep.distance (p : RegWalkStep) : FGL := p.2.distance p.1
 
-/-- The supply relation lifted to walk steps. -/
-def RegWalkStep.Supplies (p q : RegWalkStep) : Prop := RegSupplies p.2 q.2 p.1 q.1
+/-- The supply relation lifted to walk steps: `p.SuppliedBy q` says `q`'s register-pre push answers
+`p`'s register read. The walk therefore runs consumer-to-provider, which is *forwards* in time. -/
+def RegWalkStep.SuppliedBy (p q : RegWalkStep) : Prop := RegSupplies p.2 q.2 p.1 q.1
 
 /-- **One supply step moves strictly later in time.** The provider's own bus-102 pull bounds
 `<slot>_mem_step - <slot>_reg_prev_mem_step - 1`, and the supply link identifies that predecessor
@@ -2251,7 +2255,7 @@ theorem regSupplies_chain_timestamps_nodup
     (h_descent : ∀ p ∈ steps,
       ZiskFv.AirsClean.RangeTables.rangeTable24.Spec p.distance)
     (h_bounds : ∀ p ∈ steps, p.timestamp.val < 2 ^ 40)
-    (h_chain : List.IsChain RegWalkStep.Supplies steps) :
+    (h_chain : List.IsChain RegWalkStep.SuppliedBy steps) :
     (steps.map RegWalkStep.timestamp).Nodup := by
   have h_mono : List.IsChain
       (fun p q : RegWalkStep => p.timestamp.val < q.timestamp.val) steps := by

--- a/ZiskFv/Compliance/MemBusSlotSeparation.lean
+++ b/ZiskFv/Compliance/MemBusSlotSeparation.lean
@@ -443,13 +443,40 @@ theorem regSlot_timestamp_bound_of_mem
   rw [h_rowAt]
   exact regSlot_timestamp_bound_of_mainTable h_component h_index s
 
+/-- A walk step whose own register read is answered by the `RegisterBoundary`.
+
+    `ActiveMainRegisterBoundaryProviderRowMatchSpec` ignores its trailing `multiplicity` and `as`
+    arguments — both are `_`-bound in its definition — so this predicate passes `0` for each and is
+    independent of them. Carrying them here would be two parameters that mean nothing. -/
+def BoundarySuppliedAt {n : Nat} (trace : AcceptedZiskTrace n) (p : RegWalkStep) : Prop :=
+  ∃ table ∈ trace.witness.allTables,
+    ∃ _h_comp : table.component =
+        componentWithRomMemAndOpBus trace.programLength trace.program,
+      ∃ row ∈ table.table,
+        p.1 = eval (table.environment row)
+            (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar
+        ∧ p.2.selector p.1 = 1
+        ∧ ActiveMainRegisterBoundaryProviderRowMatchSpec trace.program trace.witness table row
+            (((MemBusChannel.emitted
+              (p.2.memMult
+                (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)
+              (p.2.memMessageExpr
+                (componentWithRomMemAndOpBus trace.programLength
+                  trace.program).rowInputVar)).toRaw).eval (table.environment row))
+            (p.2.memMessageExpr
+              (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)
+            0 0
+
 /-- **One step of the register walk, between witness sites.**
 
     A row whose slot selector is set has its register read supplied either by the
-    `RegisterBoundary`, or by another witness site whose own read happens **strictly later**. Every
-    input is discharged: the `-1` pull shape from source exclusivity, the branch split from
-    `channels_balanced`, the descent from the bus-102 slice, and the no-wrap bound from the Main
-    table's fixed-column capacity. -/
+    `RegisterBoundary`, or by another witness site that **supplies** it and whose own read happens
+    strictly later. Every input is discharged: the `-1` pull shape from source exclusivity, the
+    branch split from `channels_balanced`, the descent from the bus-102 slice, and the no-wrap bound
+    from the Main table's fixed-column capacity.
+
+    The supply link is part of the conclusion, not just the timestamp inequality, so iterating this
+    step builds a chain rather than an unrelated sequence of sites. -/
 theorem site_step
     {n : Nat} (trace : AcceptedZiskTrace n)
     {table : Table FGL} (h_table : table ∈ trace.witness.allTables)
@@ -457,19 +484,15 @@ theorem site_step
       componentWithRomMemAndOpBus trace.programLength trace.program)
     {row : Array FGL} (h_row : row ∈ table.table) (s : RegSlot)
     (h_sel : s.selector (eval (table.environment row)
-      (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar) = 1)
-    {multiplicity as : FGL} :
-    ActiveMainRegisterBoundaryProviderRowMatchSpec trace.program trace.witness table row
-        (((MemBusChannel.emitted
-          (s.memMult
-            (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)
-          (s.memMessageExpr
-            (componentWithRomMemAndOpBus trace.programLength
-              trace.program).rowInputVar)).toRaw).eval (table.environment row))
-        (s.memMessageExpr
-          (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)
-        multiplicity as
+      (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar) = 1) :
+    BoundarySuppliedAt trace
+        (eval (table.environment row)
+          (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar, s)
       ∨ ∃ q : RegWalkStep, IsActiveWitnessMainRow trace q
+          ∧ RegWalkStep.SuppliedBy
+              (eval (table.environment row)
+                (componentWithRomMemAndOpBus trace.programLength
+                  trace.program).rowInputVar, s) q
           ∧ (s.readTimestamp (eval (table.environment row)
               (componentWithRomMemAndOpBus trace.programLength
                 trace.program).rowInputVar)).val < q.timestamp.val := by
@@ -477,18 +500,18 @@ theorem site_step
     trace.constraints_hold trace.spec_holds h_table h_component h_row s h_sel
   rcases registerRead_counterpart_of_witnessTable trace h_table h_row
       (regSlot_mem_interaction_mem_table h_component h_row s) rfl h_pull h_op
-      (multiplicity := multiplicity) (as := as) with h_boundary | ⟨q, h_q, h_ts⟩
-  · exact Or.inl h_boundary
-  · refine Or.inr ⟨q, h_q, ?_⟩
-    have h_supplies :
+      (multiplicity := 0) (as := 0) with h_boundary | ⟨q, h_q, h_ts⟩
+  · exact Or.inl ⟨table, h_table, h_component, row, h_row, rfl, h_sel, h_boundary⟩
+  · have h_supplies :
         RegSupplies s q.2 (eval (table.environment row)
           (componentWithRomMemAndOpBus trace.programLength
             trace.program).rowInputVar) q.1 := by
       show q.2.prevStep q.1 = s.readTimestamp _
       rw [h_ts, RegSlot.eval_memMessageExpr_timestamp]
-    exact readTimestamp_lt_of_regSupplies h_supplies
-      (regSlot_descent_of_witnessMainRow trace h_q)
-      (regSlot_timestamp_bound_of_mem h_component h_row s)
+    exact Or.inr ⟨q, h_q, h_supplies,
+      readTimestamp_lt_of_regSupplies h_supplies
+        (regSlot_descent_of_witnessMainRow trace h_q)
+        (regSlot_timestamp_bound_of_mem h_component h_row s)⟩
 
 
 /-! ## Termination: the walk ends at the `RegisterBoundary`
@@ -496,34 +519,23 @@ theorem site_step
 Each supply step strictly increases the read timestamp, and every read timestamp is below `2^40`.
 So following the counterparts cannot go on forever: after finitely many steps the counterpart is no
 longer another Main row, and the only remaining memory-bus provider at `mem_op = 3` is the
-`RegisterBoundary`. -/
+`RegisterBoundary`.
 
-/-- A witness site whose own register read is supplied by the `RegisterBoundary`. -/
-def BoundarySuppliedSite {n : Nat} (trace : AcceptedZiskTrace n) (multiplicity as : FGL) : Prop :=
-  ∃ table ∈ trace.witness.allTables,
-    ∃ _h_comp : table.component =
-        componentWithRomMemAndOpBus trace.programLength trace.program,
-      ∃ row ∈ table.table, ∃ s : RegSlot,
-        s.selector (eval (table.environment row)
-          (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar) = 1
-        ∧ ActiveMainRegisterBoundaryProviderRowMatchSpec trace.program trace.witness table row
-            (((MemBusChannel.emitted
-              (s.memMult
-                (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)
-              (s.memMessageExpr
-                (componentWithRomMemAndOpBus trace.programLength
-                  trace.program).rowInputVar)).toRaw).eval (table.environment row))
-            (s.memMessageExpr
-              (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)
-            multiplicity as
+The result records the **path**, not just the fact that some boundary-supplied site exists. A bare
+existential would not say that *this* site's read is the one traced back to the boundary, and
+transporting a register value along the telescope needs the intermediate steps. -/
 
 set_option maxHeartbeats 1000000 in
-/-- **The walk terminates.** From any witness site, following supply counterparts reaches a site
-    whose read is supplied by the `RegisterBoundary`. The measure is `2 ^ 40 - readTimestamp`, which
-    strictly decreases at every step because each step moves strictly later in time, and which is
-    well-founded because every read timestamp is below `2 ^ 40`. -/
-theorem exists_boundarySuppliedSite_of_fuel
-    {n : Nat} (trace : AcceptedZiskTrace n) (multiplicity as : FGL) :
+/-- **The walk terminates, and here is the walk.** From any witness site, following supply
+    counterparts produces a finite chain that starts at that site and ends at a site whose read is
+    supplied by the `RegisterBoundary`. Every step of the chain is itself a witness site.
+
+    The measure is `2 ^ 40 - readTimestamp`, which strictly decreases at every step because each
+    step moves strictly later in time, and which is well-founded because every read timestamp is
+    below `2 ^ 40` — from the Main table's own fixed-column capacity, not from a premise about
+    segment length. -/
+theorem exists_boundaryWalk_of_fuel
+    {n : Nat} (trace : AcceptedZiskTrace n) :
     ∀ (fuel : ℕ) {table : Table FGL}, table ∈ trace.witness.allTables →
       ∀ (h_component : table.component =
           componentWithRomMemAndOpBus trace.programLength trace.program),
@@ -533,7 +545,14 @@ theorem exists_boundarySuppliedSite_of_fuel
           2 ^ 40 - (s.readTimestamp (eval (table.environment row)
             (componentWithRomMemAndOpBus trace.programLength
               trace.program).rowInputVar)).val ≤ fuel →
-          BoundarySuppliedSite trace multiplicity as := by
+          ∃ path : List RegWalkStep, ∃ last : RegWalkStep,
+            path.head? = some
+                (eval (table.environment row)
+                  (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar, s)
+              ∧ path.getLast? = some last
+              ∧ (∀ q ∈ path, IsActiveWitnessMainRow trace q)
+              ∧ List.IsChain RegWalkStep.SuppliedBy path
+              ∧ BoundarySuppliedAt trace last := by
   intro fuel
   induction fuel with
   | zero =>
@@ -541,33 +560,93 @@ theorem exists_boundarySuppliedSite_of_fuel
       exact absurd (regSlot_timestamp_bound_of_mem h_component h_row s) (by omega)
   | succ fuel ih =>
       intro table h_table h_component row h_row s h_sel h_fuel
-      rcases site_step trace h_table h_component h_row s h_sel
-          (multiplicity := multiplicity) (as := as) with h_boundary | ⟨q, h_q, h_lt⟩
-      · exact ⟨table, h_table, h_component, row, h_row, s, h_sel, h_boundary⟩
+      have h_start := isActiveWitnessMainRow_of_mem trace h_table h_component h_row s h_sel
+      rcases site_step trace h_table h_component h_row s h_sel with
+        h_boundary | ⟨q, h_q, h_sup, h_lt⟩
+      · refine ⟨[(eval (table.environment row)
+            (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar, s)],
+          _, rfl, rfl, ?_, List.isChain_singleton _, h_boundary⟩
+        intro p hp
+        rw [List.mem_singleton] at hp
+        exact hp ▸ h_start
       · obtain ⟨tbl, h_tbl, h_comp, index, h_index, h_rowAt, h_active⟩ := h_q
         have h_get : q.1 = eval (tbl.environment (tbl.table.get ⟨index, h_index⟩))
             (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar := by
           rw [h_rowAt]
           exact mainTableRowAtOrZero_get trace.program tbl ⟨index, h_index⟩
-        refine ih h_tbl h_comp (List.get_mem tbl.table ⟨index, h_index⟩) q.2 ?_ ?_
-        · rw [← h_get]; exact h_active
-        · have h_bound := regSlot_timestamp_bound_of_mem h_comp
-            (List.get_mem tbl.table ⟨index, h_index⟩) q.2
-          rw [← h_get] at h_bound ⊢
-          have : q.timestamp.val = (q.2.readTimestamp q.1).val := rfl
-          omega
+        obtain ⟨path, last, h_head, h_last, h_sites, h_chain, h_bd⟩ :=
+          ih h_tbl h_comp (List.get_mem tbl.table ⟨index, h_index⟩) q.2
+            (by rw [← h_get]; exact h_active)
+            (by
+              have h_bound := regSlot_timestamp_bound_of_mem h_comp
+                (List.get_mem tbl.table ⟨index, h_index⟩) q.2
+              rw [← h_get] at h_bound ⊢
+              have : q.timestamp.val = (q.2.readTimestamp q.1).val := rfl
+              omega)
+        have h_q_eq : (eval (tbl.environment (tbl.table.get ⟨index, h_index⟩))
+            (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar, q.2)
+              = q := by
+          rw [← h_get]; rfl
+        rw [h_q_eq] at h_head
+        match path, h_head with
+        | a :: rest, h_head =>
+            have h_a : a = q := by simpa using h_head
+            subst h_a
+            refine ⟨(eval (table.environment row)
+                (componentWithRomMemAndOpBus trace.programLength
+                  trace.program).rowInputVar, s) :: a :: rest,
+              last, rfl, by simpa using h_last, ?_, ?_, h_bd⟩
+            · intro p hp
+              rcases List.mem_cons.mp hp with rfl | hp
+              · exact h_start
+              · exact h_sites p hp
+            · exact List.isChain_cons_cons.mpr ⟨h_sup, h_chain⟩
 
-/-- **Termination, with the measure supplied.** Every witness site's walk reaches the boundary. -/
-theorem exists_boundarySuppliedSite
-    {n : Nat} (trace : AcceptedZiskTrace n) (multiplicity as : FGL)
+/-- **Termination, with the measure supplied.** Every witness site starts a chain that ends at the
+    boundary. -/
+theorem exists_boundaryWalk
+    {n : Nat} (trace : AcceptedZiskTrace n)
     {table : Table FGL} (h_table : table ∈ trace.witness.allTables)
     (h_component : table.component =
       componentWithRomMemAndOpBus trace.programLength trace.program)
     {row : Array FGL} (h_row : row ∈ table.table) (s : RegSlot)
     (h_sel : s.selector (eval (table.environment row)
       (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar) = 1) :
-    BoundarySuppliedSite trace multiplicity as :=
-  exists_boundarySuppliedSite_of_fuel trace multiplicity as (2 ^ 40) h_table h_component h_row s
-    h_sel (by omega)
+    ∃ path : List RegWalkStep, ∃ last : RegWalkStep,
+      path.head? = some
+          (eval (table.environment row)
+            (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar, s)
+        ∧ path.getLast? = some last
+        ∧ (∀ q ∈ path, IsActiveWitnessMainRow trace q)
+        ∧ List.IsChain RegWalkStep.SuppliedBy path
+        ∧ BoundarySuppliedAt trace last :=
+  exists_boundaryWalk_of_fuel trace (2 ^ 40) h_table h_component h_row s h_sel (by omega)
+
+/-- The bare existence statement: *some* witness site is boundary-supplied. This is the weak
+    corollary of `exists_boundaryWalk`; prefer the path version, which says that the site you
+    started from is the one traced back. -/
+theorem exists_boundarySuppliedSite
+    {n : Nat} (trace : AcceptedZiskTrace n)
+    {table : Table FGL} (h_table : table ∈ trace.witness.allTables)
+    (h_component : table.component =
+      componentWithRomMemAndOpBus trace.programLength trace.program)
+    {row : Array FGL} (h_row : row ∈ table.table) (s : RegSlot)
+    (h_sel : s.selector (eval (table.environment row)
+      (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar) = 1) :
+    ∃ p : RegWalkStep, BoundarySuppliedAt trace p := by
+  obtain ⟨_, last, _, _, _, _, h_bd⟩ :=
+    exists_boundaryWalk trace h_table h_component h_row s h_sel
+  exact ⟨last, h_bd⟩
+
+/-- The chain `exists_boundaryWalk` builds is a genuine walk: its read timestamps do not repeat, so
+    it never revisits a site's read. This is `regSupplies_chain_timestamps_nodup_of_witnessRows`
+    applied to the path, and it is what makes "the walk reaches the boundary" a statement about a
+    finite acyclic path rather than about an arbitrary sequence. -/
+theorem boundaryWalk_timestamps_nodup
+    {n : Nat} (trace : AcceptedZiskTrace n) (path : List RegWalkStep)
+    (h_sites : ∀ q ∈ path, IsActiveWitnessMainRow trace q)
+    (h_chain : List.IsChain RegWalkStep.SuppliedBy path) :
+    (path.map RegWalkStep.timestamp).Nodup :=
+  regSupplies_chain_timestamps_nodup_of_witnessRows trace path h_sites h_chain
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/RegisterWalk.lean
+++ b/ZiskFv/Compliance/RegisterWalk.lean
@@ -23,9 +23,11 @@ This module discharges them from an `AcceptedZiskTrace` and nothing else:
 
 The result is `regSupplies_chain_timestamps_nodup_of_trace`: on an accepted trace, a chain of
 register supply steps visits no read timestamp twice. This is the Main-side half of #342. It rules
-out the disjoint cycle that balance alone permits; it does not yet pin the chain's *end* at
-`RegisterBoundary.bootMessage`, which is what `main.pil:447` does and which
-`ZiskFv/AirsClean/RegisterBoundary.lean` still omits.
+out the disjoint cycle that balance alone permits.
+
+`ZiskFv/Compliance/MemBusSlotSeparation.lean` then walks the chain to the `RegisterBoundary`. What
+neither file does is pin *which* boundary message the chain lands on: that is `main.pil:447`, which
+`ZiskFv/AirsClean/RegisterBoundary.lean` still omits (#348).
 -/
 
 namespace ZiskFv.Compliance
@@ -151,35 +153,14 @@ noncomputable def traceWalkStep (trace : AcceptedZiskTrace n) (p : Fin n × RegS
     RegWalkStep :=
   (mainTableRowAtOrZero trace.program trace.mainTable p.1.val, p.2)
 
-/-- **One supply step on an accepted trace moves strictly later in time**, with both inputs derived
-    from the trace rather than assumed: the descent from channel balance, the no-wrap bound from the
-    Main table's fixed-column capacity. -/
-theorem traceWalkStep_timestamp_lt_of_supplies
-    (trace : AcceptedZiskTrace n) {p q : Fin n × RegSlot}
-    (h_active : q.2.selector (traceWalkStep trace q).1 = 1)
-    (h_supplies : (traceWalkStep trace p).Supplies (traceWalkStep trace q)) :
-    (traceWalkStep trace p).timestamp.val < (traceWalkStep trace q).timestamp.val :=
-  readTimestamp_lt_of_regSupplies h_supplies
-    (regSlot_descent_of_trace trace q.1 q.2 h_active)
-    (regSlot_timestamp_bound_of_trace trace p.1 p.2)
-
-/-- **No step of an accepted trace supplies its own register read.** The smallest case of #342's
-    witness, refuted with no hypothesis beyond the trace itself and the slot being active. -/
-theorem not_traceWalkStep_supplies_self
-    (trace : AcceptedZiskTrace n) (p : Fin n × RegSlot)
-    (h_active : p.2.selector (traceWalkStep trace p).1 = 1) :
-    ¬ RegSupplies p.2 p.2 (traceWalkStep trace p).1 (traceWalkStep trace p).1 :=
-  not_regSupplies_self (regSlot_descent_of_trace trace p.1 p.2 h_active)
-    (regSlot_timestamp_bound_of_trace trace p.1 p.2)
-
 /-- **#342's concrete witness is impossible on an accepted trace.** Two Main rows whose register-pre
     pushes carry each other's read timestamps cannot both occur, for any pair of slots. -/
 theorem not_traceWalkStep_two_cycle
     (trace : AcceptedZiskTrace n) (p q : Fin n × RegSlot)
     (h_active_p : p.2.selector (traceWalkStep trace p).1 = 1)
     (h_active_q : q.2.selector (traceWalkStep trace q).1 = 1)
-    (h_pq : (traceWalkStep trace p).Supplies (traceWalkStep trace q))
-    (h_qp : (traceWalkStep trace q).Supplies (traceWalkStep trace p)) : False :=
+    (h_pq : (traceWalkStep trace p).SuppliedBy (traceWalkStep trace q))
+    (h_qp : (traceWalkStep trace q).SuppliedBy (traceWalkStep trace p)) : False :=
   not_regSupplies_two_cycle
     (regSlot_descent_of_trace trace p.1 p.2 h_active_p)
     (regSlot_descent_of_trace trace q.1 q.2 h_active_q)
@@ -200,7 +181,7 @@ theorem not_traceWalkStep_two_cycle
 theorem regSupplies_chain_timestamps_nodup_of_trace
     (trace : AcceptedZiskTrace n) (steps : List (Fin n × RegSlot))
     (h_active : ∀ p ∈ steps, p.2.selector (traceWalkStep trace p).1 = 1)
-    (h_chain : List.IsChain RegWalkStep.Supplies (steps.map (traceWalkStep trace))) :
+    (h_chain : List.IsChain RegWalkStep.SuppliedBy (steps.map (traceWalkStep trace))) :
     ((steps.map (traceWalkStep trace)).map RegWalkStep.timestamp).Nodup := by
   refine regSupplies_chain_timestamps_nodup _ ?_ ?_ h_chain
   · intro w hw
@@ -233,10 +214,12 @@ theorem regSlot_timestamp_bound_of_witnessMainRow
 
 /-! ## From balance to the supply relation
 
-Everything above takes the supply relation as given. This last section derives it: on an accepted
-trace, the counterpart of a Main register read is *either* the `RegisterBoundary` (boot or reload)
-*or* another Main row's register-pre push, and in the second case that row's own register access
-happens strictly later. -/
+Everything above takes the supply relation as given. This section derives it: on an accepted trace,
+the counterpart of a Main register read is *either* the `RegisterBoundary` (boot or reload) *or*
+another Main row's register-pre push, whose slot is itself active.
+
+The read's `-1`-pull shape is still a hypothesis here. `ZiskFv/Compliance/MemBusSlotSeparation.lean`
+discharges it from source exclusivity and assembles the walk (`site_step`, `exists_boundaryWalk`). -/
 
 open ZiskFv.AirsClean.FullEnsemble (ActiveMainRegisterBoundaryProviderRowMatchSpec
   activeMainRegisterProviderRowMatchSpec_of_main_mem_op_three
@@ -312,86 +295,42 @@ theorem registerRead_counterpart_of_witnessTable
             h_rowAt, h_sel⟩, h_ts⟩
   · exact Or.inl h_boundary
 
-/-- **The supply step, entirely from the accepted trace.**
-
-    A register read on a Main row is supplied either by the `RegisterBoundary`, or by a Main row
-    whose own register access is at a **strictly later** timestamp. Nothing is assumed: the branch
-    split comes from `channels_balanced`, the provider's slot activity from its counterpart
-    multiplicity plus Main's selector booleanity, the descent from the bus-102 range slice, and the
-    no-wrap bound from the Main table's fixed-column capacity.
-
-    This is what rules out the disjoint register cycle that #342 exhibits. A cycle would be a closed
-    walk of supply steps, and every supply step strictly increases the read timestamp. -/
-theorem registerRead_supplied_by_boundary_or_strictly_later_row
+/-- A row given by membership, with its slot selector set, is a walk site. The counterpart
+    classification hands rows back by membership while `IsActiveWitnessMainRow` names them by index;
+    this is that direction of `exists_index_of_mem_mainTable`. -/
+theorem isActiveWitnessMainRow_of_mem
     {n : Nat} (trace : AcceptedZiskTrace n)
-    (i : Fin n) (sc : RegSlot)
-    {mainInteraction : Interaction FGL}
-    (h_mainInteraction :
-      mainInteraction ∈ trace.mainTable.interactionsWith MemBusChannel.toRaw)
-    {mainMult : Expression FGL}
-    (h_mainEval :
-      mainInteraction =
-        ((MemBusChannel.emitted mainMult
-          (sc.memMessageExpr
-            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-              trace.programLength trace.program).rowInputVar)).toRaw).eval
-          (trace.mainTable.environment
-            (trace.mainTable.table.get ⟨i.val, trace.mainTable_index i⟩)))
-    (h_pull : mainInteraction.mult = -1)
-    (h_mem_op :
-      (eval (trace.mainTable.environment
-          (trace.mainTable.table.get ⟨i.val, trace.mainTable_index i⟩))
-        (sc.memMessageExpr
-          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            trace.programLength trace.program).rowInputVar)).mem_op = 3)
-    {multiplicity as : FGL} :
-    ActiveMainRegisterBoundaryProviderRowMatchSpec trace.program trace.witness trace.mainTable
-        (trace.mainTable.table.get ⟨i.val, trace.mainTable_index i⟩) mainInteraction
-        (sc.memMessageExpr
-          (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-            trace.programLength trace.program).rowInputVar)
-        multiplicity as
-      ∨ ∃ p : RegWalkStep, IsActiveWitnessMainRow trace p
-          ∧ RegSupplies sc p.2 (mainTableRowAtOrZero trace.program trace.mainTable i.val) p.1
-          ∧ (sc.readTimestamp
-                (mainTableRowAtOrZero trace.program trace.mainTable i.val)).val
-              < p.timestamp.val := by
-  have h_row : mainTableRowAtOrZero trace.program trace.mainTable i.val
-      = eval (trace.mainTable.environment
-          (trace.mainTable.table.get ⟨i.val, trace.mainTable_index i⟩))
+    {table : Table FGL} (h_table : table ∈ trace.witness.allTables)
+    (h_component : table.component =
+      ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.programLength trace.program)
+    {row : Array FGL} (h_row : row ∈ table.table) (s : RegSlot)
+    (h_sel : s.selector (eval (table.environment row)
+      (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+        trace.programLength trace.program).rowInputVar) = 1) :
+    IsActiveWitnessMainRow trace
+      (eval (table.environment row)
         (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
-          trace.programLength trace.program).rowInputVar :=
-    mainTableRowAtOrZero_get trace.program trace.mainTable ⟨i.val, trace.mainTable_index i⟩
-  rcases registerRead_counterpart_of_witnessTable trace trace.mainTable_mem
-      (List.get_mem trace.mainTable.table ⟨i.val, trace.mainTable_index i⟩)
-      h_mainInteraction h_mainEval h_pull h_mem_op (multiplicity := multiplicity) (as := as) with
-    h_boundary | ⟨p, h_site, h_ts⟩
-  · exact Or.inl h_boundary
-  · have h_supplies :
-        RegSupplies sc p.2 (mainTableRowAtOrZero trace.program trace.mainTable i.val) p.1 := by
-      show p.2.prevStep p.1 = sc.readTimestamp _
-      rw [h_ts, RegSlot.eval_memMessageExpr_timestamp, ← h_row]
-    exact Or.inr ⟨p, h_site, h_supplies,
-      readTimestamp_lt_of_regSupplies h_supplies
-        (regSlot_descent_of_witnessMainRow trace h_site)
-        (regSlot_timestamp_bound_of_trace trace i sc)⟩
+          trace.programLength trace.program).rowInputVar, s) := by
+  obtain ⟨index, h_index, h_rowAt⟩ := exists_index_of_mem_mainTable h_component h_row
+  exact ⟨table, h_table, h_component, index, h_index, h_rowAt, h_sel⟩
 
 /-! ## The chain result, on the rows the classification actually produces
 
 `regSupplies_chain_timestamps_nodup_of_trace` above is indexed by `Fin n`, so it only speaks about
-executed steps. `registerRead_counterpart_of_trace` produces providers out of `witness.allTables`,
-which may be padding rows past the executed prefix. This section states the chain result over
-`IsActiveWitnessMainRow`, the shape the classification returns, so the two compose. -/
+executed steps. `registerRead_counterpart_of_witnessTable` produces providers out of
+`witness.allTables`, which may be padding rows past the executed prefix. This section states the
+chain result over `IsActiveWitnessMainRow`, the shape the classification returns, so the two
+compose. -/
 
 /-- **No cycle, over exactly the rows the counterpart classification produces.**
 
     Both hypotheses of the row-local no-cycle theorem are discharged from the trace, and the walk
     steps range over every Main row of the witness rather than only the executed prefix. This is the
-    form that composes with `registerRead_supplied_by_boundary_or_strictly_later_row`. -/
+    form that consumes the path `exists_boundaryWalk` builds. -/
 theorem regSupplies_chain_timestamps_nodup_of_witnessRows
     (trace : AcceptedZiskTrace n) (steps : List RegWalkStep)
     (h_sites : ∀ p ∈ steps, IsActiveWitnessMainRow trace p)
-    (h_chain : List.IsChain RegWalkStep.Supplies steps) :
+    (h_chain : List.IsChain RegWalkStep.SuppliedBy steps) :
     (steps.map RegWalkStep.timestamp).Nodup :=
   regSupplies_chain_timestamps_nodup steps
     (fun p hp => regSlot_descent_of_witnessMainRow trace (h_sites p hp))
@@ -425,7 +364,7 @@ theorem addX1Row_regSupplies_b_c : RegSupplies RegSlot.b RegSlot.c addX1Row addX
 
 /-- The three slots of the `add x1,x1,x1` row form a genuine supply chain. -/
 theorem addX1Row_walk_isChain :
-    List.IsChain RegWalkStep.Supplies
+    List.IsChain RegWalkStep.SuppliedBy
       [(addX1Row, RegSlot.a), (addX1Row, RegSlot.b), (addX1Row, RegSlot.c)] := by
   rw [List.isChain_cons_cons]
   refine ⟨addX1Row_regSupplies_a_b, ?_⟩

--- a/trust/consistency/register_walk_acyclic.lean
+++ b/trust/consistency/register_walk_acyclic.lean
@@ -4,7 +4,9 @@ import ZiskFv.Compliance.MemBusSlotSeparation
 /-!
 # Register walk acyclicity (issue #342)
 
-Keeps the axiom closure of the #342 payoff theorems visible to the semantic trust gate.
+Pins the axiom closure of the #342 payoff theorems. V2 check 19 runs this file and *asserts* that
+every `#print axioms` report below stays inside `{propext, Classical.choice, Quot.sound}`; it does
+not merely print them.
 
 `main.pil:333-335`'s bus-102 range check bounds each Main row's register-step distance. Modelling it
 (PR #345) supplies the descent; these theorems consume it. Together they say that on an accepted
@@ -33,8 +35,8 @@ theorem register_walk_no_two_cycle
     {n : Nat} (trace : AcceptedZiskTrace n) (p q : Fin n × RegSlot)
     (h_active_p : p.2.selector (traceWalkStep trace p).1 = 1)
     (h_active_q : q.2.selector (traceWalkStep trace q).1 = 1)
-    (h_pq : (traceWalkStep trace p).Supplies (traceWalkStep trace q))
-    (h_qp : (traceWalkStep trace q).Supplies (traceWalkStep trace p)) : False :=
+    (h_pq : (traceWalkStep trace p).SuppliedBy (traceWalkStep trace q))
+    (h_qp : (traceWalkStep trace q).SuppliedBy (traceWalkStep trace p)) : False :=
   not_traceWalkStep_two_cycle trace p q h_active_p h_active_q h_pq h_qp
 
 /-- The register walk on an accepted trace visits no read timestamp twice, so it has no cycle of
@@ -42,14 +44,14 @@ theorem register_walk_no_two_cycle
 theorem register_walk_timestamps_nodup
     {n : Nat} (trace : AcceptedZiskTrace n) (steps : List (Fin n × RegSlot))
     (h_active : ∀ p ∈ steps, p.2.selector (traceWalkStep trace p).1 = 1)
-    (h_chain : List.IsChain RegWalkStep.Supplies (steps.map (traceWalkStep trace))) :
+    (h_chain : List.IsChain RegWalkStep.SuppliedBy (steps.map (traceWalkStep trace))) :
     ((steps.map (traceWalkStep trace)).map RegWalkStep.timestamp).Nodup :=
   regSupplies_chain_timestamps_nodup_of_trace trace steps h_active h_chain
 
 /-- Non-vacuity: the supply relation holds on a checked witness's real Main row, so the
     implications above are not empty. -/
 theorem register_walk_non_vacuous :
-    List.IsChain RegWalkStep.Supplies
+    List.IsChain RegWalkStep.SuppliedBy
       [(ZiskFv.Compliance.RegisterMemBusBalance.addX1Row, RegSlot.a),
        (ZiskFv.Compliance.RegisterMemBusBalance.addX1Row, RegSlot.b),
        (ZiskFv.Compliance.RegisterMemBusBalance.addX1Row, RegSlot.c)] :=
@@ -60,14 +62,16 @@ theorem register_walk_non_vacuous :
 theorem register_walk_timestamps_nodup_on_witness_rows
     {n : Nat} (trace : AcceptedZiskTrace n) (steps : List RegWalkStep)
     (h_sites : ∀ p ∈ steps, IsActiveWitnessMainRow trace p)
-    (h_chain : List.IsChain RegWalkStep.Supplies steps) :
+    (h_chain : List.IsChain RegWalkStep.SuppliedBy steps) :
     (steps.map RegWalkStep.timestamp).Nodup :=
   regSupplies_chain_timestamps_nodup_of_witnessRows trace steps h_sites h_chain
 
 /-- Termination: from any witness site the walk reaches a site whose register read is supplied by
-    the `RegisterBoundary`. -/
+    the `RegisterBoundary`, and the chain that gets there is part of the statement — it starts at
+    the site you asked about, every step of it is a witness site, and each step is supplied by the
+    next. -/
 theorem register_walk_terminates_at_boundary
-    {n : Nat} (trace : AcceptedZiskTrace n) (multiplicity as : FGL)
+    {n : Nat} (trace : AcceptedZiskTrace n)
     {table : Air.Flat.Table FGL} (h_table : table ∈ trace.witness.allTables)
     (h_component : table.component =
       ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus trace.programLength trace.program)
@@ -75,8 +79,16 @@ theorem register_walk_terminates_at_boundary
     (h_sel : s.selector (eval (table.environment row)
       (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
         trace.programLength trace.program).rowInputVar) = 1) :
-    BoundarySuppliedSite trace multiplicity as :=
-  exists_boundarySuppliedSite trace multiplicity as h_table h_component h_row s h_sel
+    ∃ path : List RegWalkStep, ∃ last : RegWalkStep,
+      path.head? = some
+          (eval (table.environment row)
+            (ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus
+              trace.programLength trace.program).rowInputVar, s)
+        ∧ path.getLast? = some last
+        ∧ (∀ q ∈ path, IsActiveWitnessMainRow trace q)
+        ∧ List.IsChain RegWalkStep.SuppliedBy path
+        ∧ BoundarySuppliedAt trace last :=
+  exists_boundaryWalk trace h_table h_component h_row s h_sel
 
 /-- Source exclusivity, the fact termination rests on: every Main register access is a `-1` pull. -/
 theorem register_access_is_a_pull
@@ -110,7 +122,9 @@ theorem register_access_is_a_pull
 #print axioms register_walk_non_vacuous
 #print axioms ZiskFv.Compliance.addX1Row_walk_timestamps_nodup
 #print axioms ZiskFv.Compliance.registerRead_counterpart_of_witnessTable
-#print axioms ZiskFv.Compliance.registerRead_supplied_by_boundary_or_strictly_later_row
+#print axioms ZiskFv.Compliance.site_step
+#print axioms ZiskFv.Compliance.exists_boundaryWalk
+#print axioms ZiskFv.Compliance.boundaryWalk_timestamps_nodup
 #print axioms ZiskFv.Compliance.regSlot_descent_of_trace
 #print axioms ZiskFv.Compliance.regSlot_timestamp_bound_of_trace
 

--- a/trust/scripts/check-all-semantic.sh
+++ b/trust/scripts/check-all-semantic.sh
@@ -45,6 +45,37 @@ run_lean_no_sorry() {
   fi
 }
 
+# Same as `run_lean_no_sorry`, and additionally *asserts* the `#print axioms` reports rather than
+# only printing them: every reported closure must sit inside the three standard Lean axioms.
+run_lean_no_sorry_std_axioms() {
+  local output status flat reports offenders
+  output="$(lake env lean "$@" 2>&1)"
+  status=$?
+  if [ -n "$output" ]; then
+    printf '%s\n' "$output"
+  fi
+  if [ "$status" -ne 0 ]; then
+    return "$status"
+  fi
+  if grep -q 'uses `sorry`' <<<"$output"; then
+    echo "Lean file unexpectedly contains sorry: $*"
+    return 1
+  fi
+  # Lean wraps long `#print axioms` reports over several lines; flatten before matching.
+  flat="$(tr '\n' ' ' <<<"$output" | tr -s ' ')"
+  reports="$(grep -oE "depends on axioms: \[[^]]*\]" <<<"$flat")"
+  if [ -z "$reports" ]; then
+    echo "No '#print axioms' report found in: $*"
+    return 1
+  fi
+  offenders="$(grep -vE "^depends on axioms: \[(propext|Classical\.choice|Quot\.sound)(, (propext|Classical\.choice|Quot\.sound))*\]$" <<<"$reports")"
+  if [ -n "$offenders" ]; then
+    echo "Axiom closure outside {propext, Classical.choice, Quot.sound} in: $*"
+    printf '%s\n' "$offenders"
+    return 1
+  fi
+}
+
 run_witnesses() {
   local ok=0
   for f in trust/consistency/completeness_witness_*.lean; do
@@ -98,8 +129,8 @@ run "15/20 global LD theorem instantiation" \
 run "16/20 root_soundness instantiation witnesses" run_root_soundness_instantiations
 run "17/20 Clean completeness witnesses" run_witnesses
 run "18/20 register MemBus balance witnesses" run_register_mem_bus_witnesses
-run "19/20 register walk acyclicity (#342)" \
-  run_lean_no_sorry trust/consistency/register_walk_acyclic.lean
+run "19/20 register walk acyclicity + termination (#342)" \
+  run_lean_no_sorry_std_axioms trust/consistency/register_walk_acyclic.lean
 run "20/20 Aeneas extraction-pin raw axiom closure (V2)" \
   "$dir/check-extraction-closure.sh"
 

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -647,10 +647,10 @@ component silent on bus 102 — so modelling 447 later will require revisiting t
 and the provider case split in `exists_registerStepRange_provider_of_pull`.
 
 **Update (#342, the walk).** The descent is now *consumed*, in
-`ZiskFv/Compliance/RegisterWalk.lean`.
-`registerRead_supplied_by_boundary_or_strictly_later_row` says a Main register read on an
-accepted trace is supplied either by the `RegisterBoundary` or by a Main row whose own
-register access sits at a **strictly later** memory-bus timestamp. Every premise is
+`ZiskFv/Compliance/RegisterWalk.lean` and `ZiskFv/Compliance/MemBusSlotSeparation.lean`.
+`site_step` says a Main register read on an accepted trace is supplied either by the
+`RegisterBoundary` or by a Main row that supplies it and whose own register access sits at
+a **strictly later** memory-bus timestamp. Every premise is
 discharged from `AcceptedZiskTrace`: the branch split from `channels_balanced`, the
 supplying row's slot activity from its counterpart multiplicity plus Main's selector
 booleanity, the descent from the bus-102 slice, and the no-wrap bound from the Main
@@ -660,8 +660,8 @@ segment-length assumption. Consequently the supply relation is acyclic
 register cycle #342 exhibits. The relation is slot-indexed on both sides, so mixed-slot
 cycles are excluded too. The chain result is stated over `IsActiveWitnessMainRow` — every Main
 row of the witness, not just the executed prefix — because a provider may be a padding row past
-that prefix, and its no-wrap bound comes from the same fixed-column capacity. V2 check 19 keeps
-the axiom closure visible
+that prefix, and its no-wrap bound comes from the same fixed-column capacity. V2 check 19 asserts
+the axiom closure of these theorems, not only their compilation
 (`trust/consistency/register_walk_acyclic.lean`); it is kernel-only and adds no project
 axioms.
 
@@ -692,8 +692,12 @@ register-reading row's a-side access is a genuine `-1` pull at `mem_op = 3`, whi
 `main_not_store_mem_and_store_ind_and_store_reg`. No new premise, no decode fact; axiom closure is
 the three standard axioms.
 
-**What this still does not give.** Acyclicity bounds the walk from below, not above, and two things
-still stand between that and termination at `RegisterBoundary.bootMessage`.
+**Scope of the count argument.** It is a *closed-world* argument over the modeled ensemble:
+`memBus_mult_eq_of_msg_eq_mem_op_high` case-splits over the sixteen components of
+`component_mem_fullRv64im_cases` and shows none of the others reaches the offending opcode. It is
+therefore exactly as strong as the ensemble's completeness with respect to the real circuit's
+memory-bus emitters. That is the standing extraction-fidelity boundary recorded elsewhere in this
+ledger, not a new assumption — but this is the first result whose whole content rests on it.
 
 **Update (all three slots).** `ZiskFv/Compliance/MemBusSlotSeparation.lean` finishes the argument.
 The remaining b-side and store-side combinations land at `mem_op = 5`, where the multiplicity is
@@ -707,17 +711,22 @@ constant once the reference slot is fixed, giving
 
 So **every** Main register access is a genuine `-1` pull at `mem_op = 3`.
 
-**Update (termination).** The walk now provably ends at the boundary.
-`exists_boundarySuppliedSite`: from any witness site — a Main row with an active register slot —
-following supply counterparts reaches a site whose own register read is supplied by
-`RegisterBoundary`.
+**Update (termination).** The walk now provably ends at the boundary, and the **path** is part of
+the statement. `exists_boundaryWalk`: from any witness site — a Main row with an active register
+slot — following supply counterparts produces a finite list of walk steps that begins at *that*
+site, in which every step is itself a witness site, each step is supplied by the next, and whose
+last step's register read is supplied by `RegisterBoundary`. `boundaryWalk_timestamps_nodup` says
+that path visits no read timestamp twice. The bare existential — *some* site is boundary-supplied —
+survives as the weak corollary `exists_boundarySuppliedSite`; it is not the statement to build on,
+because it does not connect the boundary to the read you started from, and transporting a register
+value along the telescope needs the intermediate steps.
 
 Three things make it go through. `regSlot_mem_pull_of_selector` turns source exclusivity into the
 `-1`-pull shape on all three slots, so the counterpart classification applies to a *supplying* row
 in turn and not only to the consumer. `registerRead_counterpart_of_witnessTable` restates that
 classification over any witness table carrying Main's component — the underlying ensemble lemma
 already quantified over an arbitrary table, so no uniqueness-of-the-Main-table argument is needed.
-And `exists_boundarySuppliedSite_of_fuel` is an induction on `2 ^ 40 - readTimestamp`: the measure
+And `exists_boundaryWalk_of_fuel` is an induction on `2 ^ 40 - readTimestamp`: the measure
 strictly decreases because each supply step moves strictly later in time, and it is well-founded
 because every read timestamp is below `2 ^ 40` — from the Main table's own fixed-column capacity,
 not from a premise about segment length.
@@ -729,7 +738,8 @@ three standard axioms.
 is free, so the boundary can self-pair at timestamp `0`. Termination says the walk *reaches* the
 boundary; pinning **which** boundary message it lands on — and so anchoring the value telescope at
 `bootMessage`'s literal `(ts 0, value 0)` — is that separate gap, and it is what #330 Phase 4 needs
-next.
+next. It is tracked as #348.
+
 This slice does **not** claim register/memory access-ordering soundness. The
 cross-segment continuation terms (`MAIN_CONTINUATION_ID` block and
 `main.pil:454`'s `sel:(1-main_last_segment)` continuation pull) are out of scope


### PR DESCRIPTION
Post-merge review follow-ups on #346 and #347. **No proof obligation is discharged here, and none is
weakened.** The changes strengthen one statement, delete surface that #347 superseded, make a trust
gate check what it claims to check, and correct the ledger.

I reviewed both PRs and found no correctness defect. In particular I re-checked and confirm:

* the `RegSlot` abstraction matches the circuit — read timestamps against `Main/Constraints.lean:363,376,389`,
  predecessor columns against `:400,411,422`, `memMult` against the six `MemBusChannel.emit` calls,
  booleanity against `:252,259`, and `distance_a/b/c` are `rfl` against the pre-existing
  `aRegStepDistance` family, so the new names cannot drift from the old lemmas;
* `memBus_mult_eq_of_msg_eq_mem_op_high` case-splits over **all sixteen** components of
  `component_mem_fullRv64im_cases`, not a chosen subset;
* the no-wrap bound really does come from `Table.index_lt_fixed_capacity`, so it costs no premise.

## 1. `exists_boundaryWalk` records the path

This is the one change I would not leave for later.

`exists_boundarySuppliedSite` concluded `BoundarySuppliedSite trace multiplicity as` — a bare
existential over the whole witness that never mentions the `table`/`row`/`s` you started from. So
the theorem stated *"if one active register site exists, then some active register site is
boundary-supplied"*, not *"this site's read traces back to the boundary"*. The proof does follow the
walk; only the statement discarded it. Nothing downstream could then transport a register value,
because the telescope needs the intermediate steps — and `regSupplies_chain_timestamps_nodup_of_witnessRows`
had no way to compose with it.

The fuel induction now returns the walk:

```lean
∃ path : List RegWalkStep, ∃ last : RegWalkStep,
  path.head? = some (eval (table.environment row) …rowInputVar, s)
  ∧ path.getLast? = some last
  ∧ (∀ q ∈ path, IsActiveWitnessMainRow trace q)
  ∧ List.IsChain RegWalkStep.SuppliedBy path
  ∧ BoundarySuppliedAt trace last
```

`site_step` now returns the `RegSupplies` link as well as the timestamp inequality — that is what
makes consecutive steps assemble into an `IsChain` rather than an unrelated sequence of sites.
`boundaryWalk_timestamps_nodup` applies the existing no-cycle theorem to the path, so the walk is
a finite acyclic chain, stated over exactly the rows the classification produces.

The old bare existential survives as `exists_boundarySuppliedSite`, with a docstring saying it is
the weak corollary.

## 2. `RegWalkStep.Supplies` → `RegWalkStep.SuppliedBy`

`def RegWalkStep.Supplies (p q) := RegSupplies p.2 q.2 p.1 q.1` unfolds to "**q** supplies p's
read", so `p.Supplies q` read exactly backwards under dot notation. `p.SuppliedBy q` reads right,
and the chain direction (consumer to provider, forwards in time) is now legible at each use site.
`RegSupplies` keeps its name and gains a line fixing the argument order in prose.

## 3. Two parameters that mean nothing

`ActiveMainRegisterBoundaryProviderRowMatchSpec` `_`-binds its `multiplicity` and `as` arguments.
`BoundarySuppliedSite` copied both into a new definition, and they propagated into
`exists_boundarySuppliedSite` and the trust file. `BoundarySuppliedAt` passes `0 0` and says why in
its docstring.

## 4. Superseded surface deleted

* `registerRead_supplied_by_boundary_or_strictly_later_row` — #346's headline theorem. It takes
  `h_pull : mult = -1` and `h_mem_op = 3` as **hypotheses**, which #347's `site_step` discharges
  from source exclusivity. Nothing called it. Keeping it invites a reader to build on the weaker
  form.
* `traceWalkStep_timestamp_lt_of_supplies`, `not_traceWalkStep_supplies_self` — zero uses.

`not_traceWalkStep_two_cycle` stays: the trust file consumes it.

## 5. V2 check 19 now asserts the axiom closure

`run_lean_no_sorry` fails only on a nonzero exit or ``uses `sorry` ``. The `#print axioms` reports
were printed and never asserted, so check 19 certified *compiles, no sorry* — not the closure the
PR described. `run_lean_no_sorry_std_axioms` requires every report to sit inside
`{propext, Classical.choice, Quot.sound}`, flattening Lean's line-wrapped output first (long
reports wrap over three lines, which a naive line grep gets wrong in both directions).

**Flagging explicitly:** this edits `trust/scripts/`, a protected trust-policy file. It only makes
the gate stricter — it cannot hide anything — but it is your call.

## 6. `main_not_a_src_mem_and_a_src_reg` calls its own helper

It inlined the whole body of `no_balanced_message_with_constant_nonzero_mult`, which its b-side and
store-side twins already call. −35 lines, same proof.

## 7. Ledger

* Removed an orphan sentence: *"…and two things still stand between that and termination"* — #347
  deleted the list and left the lead-in.
* Recorded that the exclusivity count is a **closed-world** argument over the modeled ensemble's
  sixteen components, so it is exactly as strong as that ensemble's completeness with respect to
  the real circuit's memory-bus emitters. That is the standing extraction-fidelity boundary, not a
  new assumption, but this is the first result whose whole content rests on it.
* Restated termination in terms of the path, and pointed the remaining `main.pil:447` gap at #348.

## Verification

On `7141d201`:

* `lake build` — 9163 jobs, green
* `trust/scripts/check-all.sh` — 20/20
* `trust/scripts/check-all-semantic.sh` — 20/20, with check 19 now asserting closures
* no `sorry` under `ZiskFv/`; no new `axiom` / `opaque` / `native_decide`
* axiom closure of every theorem in `trust/consistency/register_walk_acyclic.lean` is
  `[propext, Classical.choice, Quot.sound]`, and `register_walk_non_vacuous` is `[propext]` alone

Details in the comments below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
