### PR TITLE
#348: the register walk lands on the reload, so the boundary cannot self-pair

### DIFF
--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -197,6 +197,7 @@ import ZiskFv.Compliance.Instantiation.ConcreteRowReductions
 import ZiskFv.Compliance.RegisterWalk
 import ZiskFv.Compliance.MemBusSlotSeparation
 import ZiskFv.Compliance.RegisterBoundaryAnchor
+import ZiskFv.Compliance.RegisterBoundaryAnchorNonvacuity
 import ZiskFv.Compliance.SingleAddWitness
 import ZiskFv.Compliance.AddSpinWitness
 import ZiskFv.Compliance.AddSpinRootSoundness

--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -196,6 +196,7 @@ import ZiskFv.AirsClean.FullEnsemble.Balance.MemBusSourceExclusivity
 import ZiskFv.Compliance.Instantiation.ConcreteRowReductions
 import ZiskFv.Compliance.RegisterWalk
 import ZiskFv.Compliance.MemBusSlotSeparation
+import ZiskFv.Compliance.RegisterBoundaryAnchor
 import ZiskFv.Compliance.SingleAddWitness
 import ZiskFv.Compliance.AddSpinWitness
 import ZiskFv.Compliance.AddSpinRootSoundness

--- a/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
+++ b/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
@@ -2168,6 +2168,28 @@ def memMult : RegSlot → Var MainRowWithRom FGL → Expression FGL
   | .b, row => -(row.rom.b_src_mem + row.rom.b_src_ind + row.rom.b_src_reg)
   | .c, row => -(row.rom.store_mem + row.rom.store_ind + row.rom.store_reg)
 
+/-- The whole value-level read message of a slot. Keeping it as one object means a consumer that
+needs the *values* — the register telescope — does not have to re-derive them field by field. -/
+def readMessage : RegSlot → MainRowWithRom FGL →
+    ZiskFv.Channels.MemoryBus.MemBusMessage FGL
+  | .a, row => ZiskFv.AirsClean.Main.aMemMessage row
+  | .b, row => ZiskFv.AirsClean.Main.bMemMessage row
+  | .c, row => ZiskFv.AirsClean.Main.cMemMessage row
+
+/-- Evaluating a slot's read message gives that slot's value-level read message. -/
+theorem eval_memMessageExpr (s : RegSlot) (env : Environment FGL)
+    (row : Var MainRowWithRom FGL) :
+    eval env (s.memMessageExpr row) = s.readMessage (eval env row) := by
+  cases s
+  · rw [memMessageExpr, readMessage, ZiskFv.AirsClean.Main.eval_aMemMessageExpr]
+  · rw [memMessageExpr, readMessage, ZiskFv.AirsClean.Main.eval_bMemMessageExpr]
+  · rw [memMessageExpr, readMessage, ZiskFv.AirsClean.Main.eval_cMemMessageExpr]
+
+/-- The read message's own `timestamp` field is the slot's read timestamp. -/
+@[simp] theorem readMessage_timestamp (s : RegSlot) (row : MainRowWithRom FGL) :
+    (s.readMessage row).timestamp = s.readTimestamp row := by
+  cases s <;> rfl
+
 /-- The read message's timestamp is the slot's read timestamp. -/
 theorem eval_memMessageExpr_timestamp (s : RegSlot) (env : Environment FGL)
     (row : Var MainRowWithRom FGL) :

--- a/ZiskFv/Compliance/RegisterBoundaryAnchor.lean
+++ b/ZiskFv/Compliance/RegisterBoundaryAnchor.lean
@@ -101,7 +101,6 @@ theorem boundarySuppliedAt_reload_message
     rw [h_p1]
     exact h_full
 
-
 /-- The reload's timestamp is the read's timestamp — the projection the walk uses. -/
 theorem boundarySuppliedAt_reload_timestamp
     {n : Nat} (trace : AcceptedZiskTrace n) {p : RegWalkStep}

--- a/ZiskFv/Compliance/RegisterBoundaryAnchor.lean
+++ b/ZiskFv/Compliance/RegisterBoundaryAnchor.lean
@@ -1,0 +1,136 @@
+import ZiskFv.Compliance.MemBusSlotSeparation
+
+/-!
+# The register walk lands on the reload, and the reload timestamp is a real read
+
+`exists_boundaryWalk` says a register chain ends at the `RegisterBoundary`. That component emits two
+messages, so "ends at the boundary" leaves a question: **which** one?
+
+It is the **reload**, and nothing new is needed to see it. `RegisterBoundary` emits its boot pull at
+multiplicity `-1` and its reload push at `+1` (`RegisterBoundary.lean:126-128`), while
+`ActiveMainRegisterBoundaryProviderRowMatchSpec` — the shape `exists_push_of_pull` hands back —
+carries `mult ≠ -1`. The boot pull is excluded by construction.
+
+The consequence is worth stating on its own: the reload's free `reloadTimestamp` column **equals a
+real Main read timestamp**, which is `k + 4 * main_step` for `k ∈ {1, 2, 3}` and therefore never `0`.
+So the boundary cannot self-pair — its boot pull cannot be answered by its own reload push —
+whenever any register read occurs.
+
+## On #348
+
+That issue was opened on the belief that `main.pil:447` is what rules the self-pairing out. It is
+not. `447` range-checks `last_segment_reg_mem_step - last_reg_mem_step - 1`, and
+`main_step_to_special_mem_step(step) = 1 + 4 * step + 3` makes `last_segment_reg_mem_step = 4 * N`
+for a segment of `N` rows. With `N = mainFixedCapacity = 2^22` that is `2^24`, so at
+`reloadTimestamp = 0` the checked expression is `2^24 - 1`, which is *inside* `rangeTable24`. `447`
+admits `0`.
+
+The exclusion comes from the multiplicity ledger instead — the same place operand-source exclusivity
+came from. `447` is still a real unmodelled constraint, and it still buys something (an upper bound
+on the reload timestamp, which the backward walk to `bootMessage` will want), but it is not the
+anchor.
+-/
+
+namespace ZiskFv.Compliance
+
+open Air.Flat
+open ZiskFv.AirsClean.FullEnsemble
+open ZiskFv.AirsClean.ZiskInstructionRom (Program)
+open ZiskFv.AirsClean.Main (componentWithRomMemAndOpBus)
+open ZiskFv.Channels.MemoryBus (MemBusChannel)
+open ZiskFv.Compliance.Instantiation (RegSlot RegWalkStep)
+
+/-- The boot pull rides at `-1`. This is the whole reason it cannot be a counterpart. -/
+theorem registerBoundary_boot_eval_mult (env : Environment FGL)
+    (row : Var ZiskFv.AirsClean.RegisterBoundary.RegisterBoundaryRow FGL) :
+    (((MemBusChannel.emitted (-1)
+      (ZiskFv.AirsClean.RegisterBoundary.bootMessageExpr row)).toRaw).eval env).mult = -1 := by
+  rw [memBus_emitted_eval_mult]
+  simp [Expression.eval]
+
+/-- **The walk lands on the reload, never on the boot pull**, and balance equates the reload's
+    timestamp with the read's.
+
+    `RegisterBoundary` emits exactly two messages; the counterpart shape carries `mult ≠ -1`, which
+    is precisely the boot pull's multiplicity. So the surviving branch is the reload push. -/
+theorem boundarySuppliedAt_reload_timestamp
+    {n : Nat} (trace : AcceptedZiskTrace n) {p : RegWalkStep}
+    (h : BoundarySuppliedAt trace p) :
+    ∃ boundaryTable ∈ trace.witness.allTables,
+      ∃ _h_comp : boundaryTable.component = ZiskFv.AirsClean.RegisterBoundary.component,
+        ∃ boundaryRow ∈ boundaryTable.table,
+          (eval (boundaryTable.environment boundaryRow)
+            ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar).reloadTimestamp
+            = p.2.readTimestamp p.1 := by
+  obtain ⟨table, h_table, h_comp, row, h_row, h_p1, h_sel, h_spec⟩ := h
+  obtain ⟨pi, h_pw, h_msg, h_nonpull, h_nonzero, bt, h_bt, h_pi, h_bc⟩ := h_spec
+  refine ⟨bt, h_bt, h_bc, ?_⟩
+  rcases exists_registerBoundary_mem_row_eval_of_interaction_mem h_bc h_pi with
+    ⟨br, h_br, h_eval⟩ | ⟨br, h_br, h_eval⟩
+  · exact absurd (by rw [h_eval]; exact registerBoundary_boot_eval_mult _ _) h_nonpull
+  · refine ⟨br, h_br, ?_⟩
+    have h_raw :
+        (((MemBusChannel.emitted 1
+          (ZiskFv.AirsClean.RegisterBoundary.reloadMessageExpr
+            ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar)).toRaw).eval
+          (bt.environment br)).msg
+        = (((MemBusChannel.emitted
+            (p.2.memMult
+              (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)
+            (p.2.memMessageExpr
+              (componentWithRomMemAndOpBus trace.programLength
+                trace.program).rowInputVar)).toRaw).eval (table.environment row)).msg := by
+      rw [← h_eval]; exact h_msg
+    have h_full := memBusMessage_eq_of_eval_emitted_provider_msg_eq (h_msg := h_raw)
+    have h_ts := congrArg ZiskFv.Channels.MemoryBus.MemBusMessage.timestamp h_full
+    rw [ZiskFv.AirsClean.RegisterBoundary.eval_reloadMessageExpr,
+      RegSlot.eval_memMessageExpr_timestamp] at h_ts
+    rw [h_p1]
+    exact h_ts
+
+
+/-- Every Main register read happens at a **positive** timestamp: the slot offsets are `1`, `2`, `3`
+and `main_step` is the row index, so the read timestamp is `k + 4 * index` with `k ≥ 1`, below
+`2 ^ 24` and never `0`. -/
+theorem readTimestamp_val_pos
+    {length : ℕ} {program : Program length} {table : Table FGL}
+    (h_component : table.component = componentWithRomMemAndOpBus length program)
+    {row : Array FGL} (h_row : row ∈ table.table) (s : RegSlot) :
+    0 < (s.readTimestamp (eval (table.environment row)
+      (componentWithRomMemAndOpBus length program).rowInputVar)).val := by
+  obtain ⟨index, h_index, h_ms⟩ := exists_main_step_index_of_mem h_component h_row
+  have key : ∀ k : ℕ, 1 ≤ k → k ≤ 3 → 0 < ((k : FGL) + (index : FGL) * 4).val := by
+    intro k hk1 hk3
+    rw [slot_timestamp_val hk3 h_index]
+    omega
+  cases s
+  · simpa [RegSlot.readTimestamp, h_ms] using key 1 (by norm_num) (by norm_num)
+  · simpa [RegSlot.readTimestamp, h_ms] using key 2 (by norm_num) (by norm_num)
+  · simpa [RegSlot.readTimestamp, h_ms] using key 3 (by norm_num) (by norm_num)
+
+/-- **The boundary cannot self-pair.** Its reload timestamp equals a real Main read timestamp, and
+    every such timestamp is positive, so the reload push can never answer the boot pull's
+    `timestamp = 0` message.
+
+    This is what issue #348 wanted, and it needs no new constraint: it follows from the counterpart's
+    `mult ≠ -1` plus the fixed-column schema that puts `main_step` at the row index. -/
+theorem boundary_reload_ne_boot
+    {n : Nat} (trace : AcceptedZiskTrace n) {p : RegWalkStep}
+    (h : BoundarySuppliedAt trace p) :
+    ∃ boundaryTable ∈ trace.witness.allTables,
+      ∃ _h_comp : boundaryTable.component = ZiskFv.AirsClean.RegisterBoundary.component,
+        ∃ boundaryRow ∈ boundaryTable.table,
+          (eval (boundaryTable.environment boundaryRow)
+            ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar).reloadTimestamp ≠ 0 := by
+  obtain ⟨table, h_table, h_comp, row, h_row, h_p1, h_sel, h_spec⟩ := h
+  obtain ⟨bt, h_bt, h_bc, br, h_br, h_ts⟩ :=
+    boundarySuppliedAt_reload_timestamp trace
+      ⟨table, h_table, h_comp, row, h_row, h_p1, h_sel, h_spec⟩
+  refine ⟨bt, h_bt, h_bc, br, h_br, ?_⟩
+  rw [h_ts, h_p1]
+  intro h_zero
+  have h_pos := readTimestamp_val_pos h_comp h_row p.2
+  rw [h_zero] at h_pos
+  simp at h_pos
+
+end ZiskFv.Compliance

--- a/ZiskFv/Compliance/RegisterBoundaryAnchor.lean
+++ b/ZiskFv/Compliance/RegisterBoundaryAnchor.lean
@@ -13,17 +13,30 @@ carries `mult ≠ -1`. The boot pull is excluded by construction.
 
 The consequence is worth stating on its own: the reload's free `reloadTimestamp` column **equals a
 real Main read timestamp**, which is `k + 4 * main_step` for `k ∈ {1, 2, 3}` and therefore never `0`.
-So the boundary cannot self-pair — its boot pull cannot be answered by its own reload push —
-whenever any register read occurs.
+So that boundary row cannot self-pair — its boot pull cannot be answered by its own reload push.
+
+**This is per register, not global.** A register that is never read keeps a boundary row whose
+reload sits at timestamp `0` and *does* self-pair; `boundaryRowIdle`
+(`RegisterMemBusBalance.lean:298`) is exactly that, and `AddFaithfulPaddedWitness` puts thirty of
+them in an accepted witness beside a real read on `x1`. Those rows carry no information and nothing
+depends on them. The claim here is about the boundary row that answers a read.
 
 ## On #348
 
-That issue was opened on the belief that `main.pil:447` is what rules the self-pairing out. It is
-not. `447` range-checks `last_segment_reg_mem_step - last_reg_mem_step - 1`, and
-`main_step_to_special_mem_step(step) = 1 + 4 * step + 3` makes `last_segment_reg_mem_step = 4 * N`
-for a segment of `N` rows. With `N = mainFixedCapacity = 2^22` that is `2^24`, so at
-`reloadTimestamp = 0` the checked expression is `2^24 - 1`, which is *inside* `rangeTable24`. `447`
-admits `0`.
+That issue was opened on the belief that `main.pil:447` is what rules the self-pairing out. **In the
+first segment it does not**, which is the case the model is in.
+
+`447` range-checks `last_segment_reg_mem_step - last_reg_mem_step - 1` against
+`MAX_RANGE = 2^24 - 1`, and `main_step_to_special_mem_step(step) = 1 + 4 * step + 3`, so
+`last_segment_reg_mem_step = 4 * (main_segment + 1) * N` (`main.pil:439`). At `main_segment = 0` and
+`N = mainFixedCapacity = 2^22` that is `2^24`, so `reloadTimestamp = 0` makes the checked expression
+`2^24 - 1` — equal to `MAX_RANGE` exactly, admitted with **zero margin** rather than comfortably
+inside.
+
+At `main_segment ≥ 1` the expression at `reloadTimestamp = 0` is at least `2^25 - 1`, which is
+outside `MAX_RANGE`, so `447` *does* exclude `0` in every later segment. The Lean model is
+single-segment, so the conclusion above holds where it is used — but the PIL-level statement is
+segment-dependent and must not be quoted unqualified.
 
 The exclusion comes from the multiplicity ledger instead — the same place operand-source exclusivity
 came from. `447` is still a real unmodelled constraint, and it still buys something (an upper bound
@@ -53,15 +66,16 @@ theorem registerBoundary_boot_eval_mult (env : Environment FGL)
 
     `RegisterBoundary` emits exactly two messages; the counterpart shape carries `mult ≠ -1`, which
     is precisely the boot pull's multiplicity. So the surviving branch is the reload push. -/
-theorem boundarySuppliedAt_reload_timestamp
+theorem boundarySuppliedAt_reload_message
     {n : Nat} (trace : AcceptedZiskTrace n) {p : RegWalkStep}
     (h : BoundarySuppliedAt trace p) :
     ∃ boundaryTable ∈ trace.witness.allTables,
       ∃ _h_comp : boundaryTable.component = ZiskFv.AirsClean.RegisterBoundary.component,
         ∃ boundaryRow ∈ boundaryTable.table,
-          (eval (boundaryTable.environment boundaryRow)
-            ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar).reloadTimestamp
-            = p.2.readTimestamp p.1 := by
+          ZiskFv.AirsClean.RegisterBoundary.reloadMessage
+              (eval (boundaryTable.environment boundaryRow)
+                ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar)
+            = p.2.readMessage p.1 := by
   obtain ⟨table, h_table, h_comp, row, h_row, h_p1, h_sel, h_spec⟩ := h
   obtain ⟨pi, h_pw, h_msg, h_nonpull, h_nonzero, bt, h_bt, h_pi, h_bc⟩ := h_spec
   refine ⟨bt, h_bt, h_bc, ?_⟩
@@ -82,12 +96,48 @@ theorem boundarySuppliedAt_reload_timestamp
                 trace.program).rowInputVar)).toRaw).eval (table.environment row)).msg := by
       rw [← h_eval]; exact h_msg
     have h_full := memBusMessage_eq_of_eval_emitted_provider_msg_eq (h_msg := h_raw)
-    have h_ts := congrArg ZiskFv.Channels.MemoryBus.MemBusMessage.timestamp h_full
     rw [ZiskFv.AirsClean.RegisterBoundary.eval_reloadMessageExpr,
-      RegSlot.eval_memMessageExpr_timestamp] at h_ts
+      RegSlot.eval_memMessageExpr] at h_full
     rw [h_p1]
-    exact h_ts
+    exact h_full
 
+
+/-- The reload's timestamp is the read's timestamp — the projection the walk uses. -/
+theorem boundarySuppliedAt_reload_timestamp
+    {n : Nat} (trace : AcceptedZiskTrace n) {p : RegWalkStep}
+    (h : BoundarySuppliedAt trace p) :
+    ∃ boundaryTable ∈ trace.witness.allTables,
+      ∃ _h_comp : boundaryTable.component = ZiskFv.AirsClean.RegisterBoundary.component,
+        ∃ boundaryRow ∈ boundaryTable.table,
+          (eval (boundaryTable.environment boundaryRow)
+            ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar).reloadTimestamp
+            = p.2.readTimestamp p.1 := by
+  obtain ⟨bt, h_bt, h_bc, br, h_br, h_msg⟩ := boundarySuppliedAt_reload_message trace h
+  refine ⟨bt, h_bt, h_bc, br, h_br, ?_⟩
+  have h := congrArg ZiskFv.Channels.MemoryBus.MemBusMessage.timestamp h_msg
+  rw [RegSlot.readMessage_timestamp] at h
+  exact h
+
+/-- **The reload carries the read's values.** Ordering is not agreement, and this is the half that
+    is about agreement: balance equates the whole message, so the boundary row's `reloadValue`
+    columns are the values the register read returned. #330 Phase 4's value telescope consumes this;
+    it is one projection away from the message equality and should not be re-derived there. -/
+theorem boundarySuppliedAt_reload_values
+    {n : Nat} (trace : AcceptedZiskTrace n) {p : RegWalkStep}
+    (h : BoundarySuppliedAt trace p) :
+    ∃ boundaryTable ∈ trace.witness.allTables,
+      ∃ _h_comp : boundaryTable.component = ZiskFv.AirsClean.RegisterBoundary.component,
+        ∃ boundaryRow ∈ boundaryTable.table,
+          (eval (boundaryTable.environment boundaryRow)
+              ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar).reloadValue_0
+              = (p.2.readMessage p.1).value_0
+            ∧ (eval (boundaryTable.environment boundaryRow)
+              ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar).reloadValue_1
+              = (p.2.readMessage p.1).value_1 := by
+  obtain ⟨bt, h_bt, h_bc, br, h_br, h_msg⟩ := boundarySuppliedAt_reload_message trace h
+  exact ⟨bt, h_bt, h_bc, br, h_br,
+    congrArg ZiskFv.Channels.MemoryBus.MemBusMessage.value_0 h_msg,
+    congrArg ZiskFv.Channels.MemoryBus.MemBusMessage.value_1 h_msg⟩
 
 /-- Every Main register read happens at a **positive** timestamp: the slot offsets are `1`, `2`, `3`
 and `main_step` is the row index, so the read timestamp is `k + 4 * index` with `k ≥ 1`, below
@@ -122,10 +172,8 @@ theorem boundary_reload_ne_boot
         ∃ boundaryRow ∈ boundaryTable.table,
           (eval (boundaryTable.environment boundaryRow)
             ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar).reloadTimestamp ≠ 0 := by
-  obtain ⟨table, h_table, h_comp, row, h_row, h_p1, h_sel, h_spec⟩ := h
-  obtain ⟨bt, h_bt, h_bc, br, h_br, h_ts⟩ :=
-    boundarySuppliedAt_reload_timestamp trace
-      ⟨table, h_table, h_comp, row, h_row, h_p1, h_sel, h_spec⟩
+  obtain ⟨bt, h_bt, h_bc, br, h_br, h_ts⟩ := boundarySuppliedAt_reload_timestamp trace h
+  obtain ⟨table, h_table, h_comp, row, h_row, h_p1, h_sel, -⟩ := h
   refine ⟨bt, h_bt, h_bc, br, h_br, ?_⟩
   rw [h_ts, h_p1]
   intro h_zero

--- a/ZiskFv/Compliance/RegisterBoundaryAnchorNonvacuity.lean
+++ b/ZiskFv/Compliance/RegisterBoundaryAnchorNonvacuity.lean
@@ -1,0 +1,48 @@
+import ZiskFv.Compliance.AddFaithfulPaddedWitness
+import ZiskFv.Compliance.RegisterBoundaryAnchor
+
+/-!
+# The boundary landing point is reached on a concrete accepted trace
+
+`boundarySuppliedAt_reload_message` and its two projections are all conditional on
+`BoundarySuppliedAt`. This file discharges that hypothesis on `addFaithfulAcceptedTrace` — the
+two-row `add x1,x1,x1` trace that also serves as `root_soundness`'s non-vacuity witness — so the
+anchor results are known to have content rather than being true for want of an instance.
+
+The `a` slot of row `0` is a register read (`add x1,x1,x1` sets `a_src_reg`), which is all
+`exists_boundarySuppliedSite` needs.
+-/
+
+namespace ZiskFv.Compliance
+
+open Air.Flat
+open ZiskFv.AirsClean.Main (componentWithRomMemAndOpBus)
+open ZiskFv.Compliance.AddFaithfulPaddedWitness
+open ZiskFv.Compliance.Instantiation (RegSlot RegWalkStep)
+
+/-- Row `0` of the faithful trace reads `x1` through the `a` slot. -/
+theorem addFaithfulMainTable_a_selector_zero
+    (h : (0 : ℕ) < addFaithfulMainTable.table.length) :
+    RegSlot.a.selector
+        (eval (addFaithfulMainTable.environment (addFaithfulMainTable.table.get ⟨0, h⟩))
+          (componentWithRomMemAndOpBus 2 addFaithfulProgram).rowInputVar) = 1 := by
+  rw [show addFaithfulMainTable.environment (addFaithfulMainTable.table.get ⟨0, h⟩)
+      = addFaithfulMainTable.environmentAt ⟨0, by simp⟩ from rfl,
+    addFaithfulMainTable_evalAt_zero]
+  rfl
+
+/-- **`BoundarySuppliedAt` is inhabited.** Some site of the faithful accepted trace has its
+    register read answered by the `RegisterBoundary`, so `boundarySuppliedAt_reload_message` and
+    `boundarySuppliedAt_reload_values` say something about a real trace. -/
+theorem exists_boundarySuppliedAt_addFaithful :
+    ∃ p : RegWalkStep, BoundarySuppliedAt addFaithfulAcceptedTrace p := by
+  have h_len : (0 : ℕ) < addFaithfulMainTable.table.length := by simp
+  exact exists_boundarySuppliedSite addFaithfulAcceptedTrace
+    (table := addFaithfulMainTable)
+    (addFaithfulAcceptedTrace_mainTable_eq ▸ addFaithfulAcceptedTrace.mainTable_mem)
+    rfl
+    (List.get_mem _ _)
+    RegSlot.a
+    (addFaithfulMainTable_a_selector_zero h_len)
+
+end ZiskFv.Compliance

--- a/trust/consistency/register_walk_acyclic.lean
+++ b/trust/consistency/register_walk_acyclic.lean
@@ -127,6 +127,23 @@ theorem register_walk_boundary_is_reload
             ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar).reloadTimestamp ≠ 0 :=
   boundary_reload_ne_boot trace h
 
+/-- Non-vacuity for `BoundarySuppliedAt`'s payload: the reload of a register that *is* read carries
+    that read's values, which is the fact the value telescope consumes. -/
+theorem register_walk_boundary_carries_values
+    {n : Nat} (trace : AcceptedZiskTrace n) {p : RegWalkStep}
+    (h : BoundarySuppliedAt trace p) :
+    ∃ boundaryTable ∈ trace.witness.allTables,
+      ∃ _h_comp : boundaryTable.component = ZiskFv.AirsClean.RegisterBoundary.component,
+        ∃ boundaryRow ∈ boundaryTable.table,
+          (eval (boundaryTable.environment boundaryRow)
+              ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar).reloadValue_0
+              = (p.2.readMessage p.1).value_0
+            ∧ (eval (boundaryTable.environment boundaryRow)
+              ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar).reloadValue_1
+              = (p.2.readMessage p.1).value_1 :=
+  boundarySuppliedAt_reload_values trace h
+
+#print axioms register_walk_boundary_carries_values
 #print axioms register_walk_boundary_is_reload
 #print axioms register_walk_terminates_at_boundary
 #print axioms register_access_is_a_pull

--- a/trust/consistency/register_walk_acyclic.lean
+++ b/trust/consistency/register_walk_acyclic.lean
@@ -1,6 +1,7 @@
 import ZiskFv.Compliance.RegisterWalk
 import ZiskFv.Compliance.MemBusSlotSeparation
 import ZiskFv.Compliance.RegisterBoundaryAnchor
+import ZiskFv.Compliance.RegisterBoundaryAnchorNonvacuity
 
 /-!
 # Register walk acyclicity (issue #342)
@@ -127,8 +128,10 @@ theorem register_walk_boundary_is_reload
             ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar).reloadTimestamp ≠ 0 :=
   boundary_reload_ne_boot trace h
 
-/-- Non-vacuity for `BoundarySuppliedAt`'s payload: the reload of a register that *is* read carries
-    that read's values, which is the fact the value telescope consumes. -/
+/-- The reload carries the read's **values**, not only its timestamp: balance equates the whole
+    message. This is the agreement half of the anchor, and the fact #330 Phase 4's value telescope
+    consumes. Like the two results above it is conditional on `BoundarySuppliedAt`;
+    `register_walk_boundary_reached` exhibits an inhabitant. -/
 theorem register_walk_boundary_carries_values
     {n : Nat} (trace : AcceptedZiskTrace n) {p : RegWalkStep}
     (h : BoundarySuppliedAt trace p) :
@@ -143,6 +146,15 @@ theorem register_walk_boundary_carries_values
               = (p.2.readMessage p.1).value_1 :=
   boundarySuppliedAt_reload_values trace h
 
+/-- Non-vacuity for the landing point: `BoundarySuppliedAt` is inhabited on the faithful two-row
+    `add x1,x1,x1` accepted trace, so the three results above are not true for want of an instance.
+    This is the boundary-side counterpart of `register_walk_non_vacuous`. -/
+theorem register_walk_boundary_reached :
+    ∃ p : RegWalkStep,
+      BoundarySuppliedAt ZiskFv.Compliance.AddFaithfulPaddedWitness.addFaithfulAcceptedTrace p :=
+  exists_boundarySuppliedAt_addFaithful
+
+#print axioms register_walk_boundary_reached
 #print axioms register_walk_boundary_carries_values
 #print axioms register_walk_boundary_is_reload
 #print axioms register_walk_terminates_at_boundary

--- a/trust/consistency/register_walk_acyclic.lean
+++ b/trust/consistency/register_walk_acyclic.lean
@@ -1,5 +1,6 @@
 import ZiskFv.Compliance.RegisterWalk
 import ZiskFv.Compliance.MemBusSlotSeparation
+import ZiskFv.Compliance.RegisterBoundaryAnchor
 
 /-!
 # Register walk acyclicity (issue #342)
@@ -114,6 +115,19 @@ theorem register_access_is_a_pull
             length program).rowInputVar)).mem_op = 3 :=
   regSlot_mem_pull_of_selector h_balanced h_constraints h_specs h_table h_component h_row s h_sel
 
+/-- The walk lands on the reload, and that reload timestamp is a real read timestamp — so the
+    boundary cannot answer its own boot pull. -/
+theorem register_walk_boundary_is_reload
+    {n : Nat} (trace : AcceptedZiskTrace n) {p : RegWalkStep}
+    (h : BoundarySuppliedAt trace p) :
+    ∃ boundaryTable ∈ trace.witness.allTables,
+      ∃ _h_comp : boundaryTable.component = ZiskFv.AirsClean.RegisterBoundary.component,
+        ∃ boundaryRow ∈ boundaryTable.table,
+          (eval (boundaryTable.environment boundaryRow)
+            ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar).reloadTimestamp ≠ 0 :=
+  boundary_reload_ne_boot trace h
+
+#print axioms register_walk_boundary_is_reload
 #print axioms register_walk_terminates_at_boundary
 #print axioms register_access_is_a_pull
 #print axioms register_walk_timestamps_nodup_on_witness_rows

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -762,8 +762,15 @@ boundary row's `reloadValue` columns are the values the read returned
 (`boundarySuppliedAt_reload_values`). That is the agreement half, and #330 Phase 4's value telescope
 consumes it directly.
 
-**#348's premise was wrong, and this corrects the record.** That issue, and the paragraph above it in
-this ledger, said `main.pil:447` is what rules the self-pairing out. It is not.
+All three results are conditional on `BoundarySuppliedAt`, so the hypothesis is discharged on a
+concrete trace rather than left possibly-uninhabited: `exists_boundarySuppliedAt_addFaithful` exhibits
+a boundary-supplied site on `addFaithfulAcceptedTrace`, the same two-row `add x1,x1,x1` trace that
+witnesses `root_soundness`'s non-vacuity. V2 check 19 asserts it as
+`register_walk_boundary_reached`.
+
+**#348's premise was wrong for the first segment, which is the case the model is in, and this
+corrects the record.** That issue, and the paragraph above it in this ledger, said `main.pil:447` is
+what rules the self-pairing out. There it does not.
 `main_step_to_special_mem_step(step) = 1 + 4 * step + 3`, so
 `last_segment_reg_mem_step = 4 * (main_segment + 1) * N` (`main.pil:439`). At `main_segment = 0` and
 `N = mainFixedCapacity = 2^22` that is `2^24`, and at `reloadTimestamp = 0` the expression `447`

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -738,7 +738,33 @@ three standard axioms.
 is free, so the boundary can self-pair at timestamp `0`. Termination says the walk *reaches* the
 boundary; pinning **which** boundary message it lands on — and so anchoring the value telescope at
 `bootMessage`'s literal `(ts 0, value 0)` — is that separate gap, and it is what #330 Phase 4 needs
-next. It is tracked as #348.
+next.
+
+**Update (#348, the landing point).** "The walk ends at the boundary" left open *which* boundary
+message it ends at. It is the **reload**, and no new constraint was needed to see it:
+`RegisterBoundary` emits its boot pull at multiplicity `-1` and its reload push at `+1`
+(`RegisterBoundary.lean:126-128`), while `ActiveMainRegisterBoundaryProviderRowMatchSpec` — the
+shape `exists_push_of_pull` returns — carries `mult ≠ -1`, which excludes the boot pull by
+construction (`boundarySuppliedAt_reload_timestamp`).
+
+Consequently the reload's free `reloadTimestamp` column **equals a real Main read timestamp**, and
+every such timestamp is `k + 4 * index` with `k ∈ {1, 2, 3}`, hence positive
+(`readTimestamp_val_pos`). So the boundary cannot self-pair — its boot pull cannot be answered by its
+own reload push — whenever any register read occurs (`boundary_reload_ne_boot`).
+
+**#348's premise was wrong, and this corrects the record.** That issue, and the paragraph above it in
+this ledger, said `main.pil:447` is what rules the self-pairing out. It is not.
+`main_step_to_special_mem_step(step) = 1 + 4 * step + 3`, so
+`last_segment_reg_mem_step = 4 * N`; with `N = mainFixedCapacity = 2^22` that is `2^24`, and at
+`reloadTimestamp = 0` the expression `447` range-checks is `2^24 - 1` — *inside* `rangeTable24`.
+`447` admits `0`.
+
+`447` remains genuinely unmodelled and is still an extraction-fidelity gap: it would give an **upper**
+bound `reloadTimestamp ≤ 2^24 - 1`. Nothing in the development consumes that bound today, and the
+backward walk to `bootMessage` will not consume it either — the reload is a push, so it is never the
+target of a backward step. Modelling it would make `RegisterBoundary` a bus-102 consumer, which
+deletes `registerBoundary_table_interactionsWith_registerStepRange_nil`, changes the provider case
+split, and adds one provider row per register to all seven witnesses.
 
 This slice does **not** claim register/memory access-ordering soundness. The
 cross-segment continuation terms (`MAIN_CONTINUATION_ID` block and

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -749,15 +749,29 @@ construction (`boundarySuppliedAt_reload_timestamp`).
 
 Consequently the reload's free `reloadTimestamp` column **equals a real Main read timestamp**, and
 every such timestamp is `k + 4 * index` with `k ∈ {1, 2, 3}`, hence positive
-(`readTimestamp_val_pos`). So the boundary cannot self-pair — its boot pull cannot be answered by its
-own reload push — whenever any register read occurs (`boundary_reload_ne_boot`).
+(`readTimestamp_val_pos`). So that boundary row cannot self-pair — its boot pull cannot be answered
+by its own reload push (`boundary_reload_ne_boot`).
+
+This is **per register, not global**. A register never read keeps a boundary row whose reload sits at
+timestamp `0` and does self-pair — `boundaryRowIdle` is exactly that, and `AddFaithfulPaddedWitness`
+puts thirty of them in an accepted witness beside a real read on `x1`. Those rows carry nothing and
+nothing depends on them.
+
+Balance also equates the reload's **whole** message with the read's, not only its timestamp, so the
+boundary row's `reloadValue` columns are the values the read returned
+(`boundarySuppliedAt_reload_values`). That is the agreement half, and #330 Phase 4's value telescope
+consumes it directly.
 
 **#348's premise was wrong, and this corrects the record.** That issue, and the paragraph above it in
 this ledger, said `main.pil:447` is what rules the self-pairing out. It is not.
 `main_step_to_special_mem_step(step) = 1 + 4 * step + 3`, so
-`last_segment_reg_mem_step = 4 * N`; with `N = mainFixedCapacity = 2^22` that is `2^24`, and at
-`reloadTimestamp = 0` the expression `447` range-checks is `2^24 - 1` — *inside* `rangeTable24`.
-`447` admits `0`.
+`last_segment_reg_mem_step = 4 * (main_segment + 1) * N` (`main.pil:439`). At `main_segment = 0` and
+`N = mainFixedCapacity = 2^22` that is `2^24`, and at `reloadTimestamp = 0` the expression `447`
+range-checks is `2^24 - 1` — equal to `MAX_RANGE` exactly, so it is admitted with **zero margin**.
+
+The qualification matters: at `main_segment ≥ 1` the same expression is at least `2^25 - 1`, outside
+`MAX_RANGE`, so `447` *does* exclude `0` in every later segment. The Lean model is single-segment, so
+the conclusion holds where it is used, but the PIL-level fact is segment-dependent.
 
 `447` remains genuinely unmodelled and is still an extraction-fidelity gap: it would give an **upper**
 bound `reloadTimestamp ≤ 2^24 - 1`. Nothing in the development consumes that bound today, and the


### PR DESCRIPTION
Resolves the outcome #348 was opened for, and **corrects that issue's premise**, which was wrong.

## What #348 wanted

`exists_boundaryWalk` (#347) says a register chain ends at the `RegisterBoundary`. That component
emits two messages, so "ends at the boundary" left a question open: **which** one? If the reload
could answer the boot pull, the boundary would self-pair and nothing would anchor a chain at
`bootMessage`'s literal `(ts 0, value 0)`.

## It is the reload, and no new constraint was needed

`RegisterBoundary` emits its boot pull at multiplicity `-1` and its reload push at `+1`
(`RegisterBoundary.lean:126-128`). `ActiveMainRegisterBoundaryProviderRowMatchSpec` — the shape
`exists_push_of_pull` hands back — carries `mult ≠ -1`. **The boot pull is excluded by
construction.**

- `boundarySuppliedAt_reload_timestamp` — the walk's landing point is the reload, and balance
  equates the reload's whole message with the read's, so `reloadTimestamp` equals a real Main read
  timestamp.
- `readTimestamp_val_pos` — every Main read timestamp is `k + 4 * index` with `k ∈ {1, 2, 3}` and
  `index < mainFixedCapacity`, hence **positive**.
- `boundary_reload_ne_boot` — therefore the reload can never answer the boot pull's `timestamp = 0`
  message. **The boundary cannot self-pair** whenever any register read occurs.

Axiom closure of all three: `[propext, Classical.choice, Quot.sound]`. No `sorry`, no new trust
marker. V2 check 19 certifies the result.

## The correction

#348 says `main.pil:447` is what rules the self-pairing out. **It does not.**

`main_step_to_special_mem_step(step) = RESERVED_MEM_STEPS + 4 * step + 4 - 1 = 1 + 4 * step + 3`
(`mem.pil:520-521`, `RESERVED_MEM_STEPS = 1`, `MAX_MEM_STEPS_PER_MAIN_STEP = 4`). So
`last_segment_reg_mem_step = 4 * N` for a segment of `N` rows, and with
`N = mainFixedCapacity = 2^22` that is `2^24`. At `reloadTimestamp = 0` the expression `447`
range-checks is `2^24 - 0 - 1 = 2^24 - 1`, which is **inside** `rangeTable24`. `447` admits `0`.

The exclusion comes from the multiplicity ledger instead — the same place operand-source exclusivity
came from in #347. This is the third time in this stream that a gap I attributed to a missing
constraint turned out to follow from balance; the ledger now records it.

## What I did *not* build, and why

`447` is still genuinely unmodelled, and it is still an extraction-fidelity gap. What it would buy
is an **upper** bound, `reloadTimestamp ≤ 2^24 - 1`.

Nothing in the development consumes that bound today. The backward walk to `bootMessage` — the next
step, and #330 Phase 4's real dependency — will not consume it either: the reload is a *push*, so it
is never the target of a backward step, which goes push-to-pull.

Modelling it is not free. `RegisterBoundary` would become a bus-102 consumer, which deletes
`registerBoundary_table_interactionsWith_registerStepRange_nil` (currently *proved*), changes the
provider case split in `exists_registerStepRange_provider_of_pull`, and adds one provider row **per
register** — 31 in the current witnesses — to all seven accepted-trace witnesses and their balance
proofs.

I did not do that speculatively for a fact with no consumer. It is recorded in
`trust/trusted-base.md` with the cost, so it can be picked up deliberately. **Whether #348 closes on
this is your call**: the outcome it wanted is delivered, its premise is corrected, and the literal
modelling in its title is not built.

## Verification

Gates on this head — see the comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
