### PR TITLE
#330 Phase 4 (ZisK half): the register value telescope reaches bootMessage

### DIFF
--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -198,6 +198,7 @@ import ZiskFv.Compliance.RegisterWalk
 import ZiskFv.Compliance.MemBusSlotSeparation
 import ZiskFv.Compliance.RegisterBoundaryAnchor
 import ZiskFv.Compliance.RegisterBoundaryAnchorNonvacuity
+import ZiskFv.Compliance.RegisterValueTelescope
 import ZiskFv.Compliance.SingleAddWitness
 import ZiskFv.Compliance.AddSpinWitness
 import ZiskFv.Compliance.AddSpinRootSoundness

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusSourceExclusivity.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusSourceExclusivity.lean
@@ -57,7 +57,7 @@ theorem zero_or_one_of_bool {col : FGL} (h : col * (1 - col) = 0) : col = 0 ∨ 
     linear_combination this
 
 /-- A field element whose `val` is below `2` is `0` or `1`. -/
-private lemma zero_or_one_of_val_lt_two {x : FGL} (h : x.val < 2) : x = 0 ∨ x = 1 := by
+theorem zero_or_one_of_val_lt_two {x : FGL} (h : x.val < 2) : x = 0 ∨ x = 1 := by
   interval_cases h_val : x.val
   · exact Or.inl (by apply Fin.ext; simp [h_val])
   · exact Or.inr (by apply Fin.ext; simp [h_val])

--- a/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
+++ b/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
@@ -2200,6 +2200,28 @@ theorem eval_regPreMessageExpr_mem_op (s : RegSlot) (env : Environment FGL)
   · rw [regPreMessageExpr, ZiskFv.AirsClean.Main.eval_bRegPreMessageExpr]
   · rw [regPreMessageExpr, ZiskFv.AirsClean.Main.eval_cRegPreMessageExpr]
 
+/-- The whole value-level register-pre message of a slot. Its value lanes are the row's **own**
+operand values, which is why matching it against `bootMessage` pins those values to `0`. -/
+def regPreMessage : RegSlot → MainRowWithRom FGL →
+    ZiskFv.Channels.MemoryBus.MemBusMessage FGL
+  | .a, row => ZiskFv.AirsClean.Main.aRegPreMessage row
+  | .b, row => ZiskFv.AirsClean.Main.bRegPreMessage row
+  | .c, row => ZiskFv.AirsClean.Main.cRegPreMessage row
+
+/-- Evaluating a slot's register-pre message gives that slot's value-level message. -/
+theorem eval_regPreMessageExpr (s : RegSlot) (env : Environment FGL)
+    (row : Var MainRowWithRom FGL) :
+    eval env (s.regPreMessageExpr row) = s.regPreMessage (eval env row) := by
+  cases s
+  · rw [regPreMessageExpr, regPreMessage, ZiskFv.AirsClean.Main.eval_aRegPreMessageExpr]
+  · rw [regPreMessageExpr, regPreMessage, ZiskFv.AirsClean.Main.eval_bRegPreMessageExpr]
+  · rw [regPreMessageExpr, regPreMessage, ZiskFv.AirsClean.Main.eval_cRegPreMessageExpr]
+
+/-- The register-pre message's own `timestamp` field is the slot's predecessor column. -/
+@[simp] theorem regPreMessage_timestamp (s : RegSlot) (row : MainRowWithRom FGL) :
+    (s.regPreMessage row).timestamp = s.prevStep row := by
+  cases s <;> rfl
+
 /-- The whole value-level read message of a slot. Keeping it as one object means a consumer that
 needs the *values* — the register telescope — does not have to re-derive them field by field. -/
 def readMessage : RegSlot → MainRowWithRom FGL →

--- a/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
+++ b/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
@@ -2168,6 +2168,38 @@ def memMult : RegSlot → Var MainRowWithRom FGL → Expression FGL
   | .b, row => -(row.rom.b_src_mem + row.rom.b_src_ind + row.rom.b_src_reg)
   | .c, row => -(row.rom.store_mem + row.rom.store_ind + row.rom.store_reg)
 
+/-- The slot's register-pre *push* message — the one that answers an earlier access
+(`Main/Constraints.lean:396,407,418`). The backward walk follows these. -/
+def regPreMessageExpr : RegSlot → Var MainRowWithRom FGL →
+    ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)
+  | .a, row => ZiskFv.AirsClean.Main.aRegPreMessageExpr row
+  | .b, row => ZiskFv.AirsClean.Main.bRegPreMessageExpr row
+  | .c, row => ZiskFv.AirsClean.Main.cRegPreMessageExpr row
+
+/-- The multiplicity the slot's register-pre push rides at: its own selector. -/
+def selectorExpr : RegSlot → Var MainRowWithRom FGL → Expression FGL
+  | .a, row => row.rom.a_src_reg
+  | .b, row => row.rom.b_src_reg
+  | .c, row => row.rom.store_reg
+
+/-- The register-pre message's timestamp is the slot's free predecessor column. -/
+theorem eval_regPreMessageExpr_timestamp (s : RegSlot) (env : Environment FGL)
+    (row : Var MainRowWithRom FGL) :
+    (eval env (s.regPreMessageExpr row)).timestamp = s.prevStep (eval env row) := by
+  cases s
+  · rw [regPreMessageExpr, ZiskFv.AirsClean.Main.eval_aRegPreMessageExpr]; rfl
+  · rw [regPreMessageExpr, ZiskFv.AirsClean.Main.eval_bRegPreMessageExpr]; rfl
+  · rw [regPreMessageExpr, ZiskFv.AirsClean.Main.eval_cRegPreMessageExpr]; rfl
+
+/-- Every register-pre message carries `mem_op = 3`; the literal is in the emission itself. -/
+theorem eval_regPreMessageExpr_mem_op (s : RegSlot) (env : Environment FGL)
+    (row : Var MainRowWithRom FGL) :
+    (eval env (s.regPreMessageExpr row)).mem_op = 3 := by
+  cases s
+  · rw [regPreMessageExpr, ZiskFv.AirsClean.Main.eval_aRegPreMessageExpr]
+  · rw [regPreMessageExpr, ZiskFv.AirsClean.Main.eval_bRegPreMessageExpr]
+  · rw [regPreMessageExpr, ZiskFv.AirsClean.Main.eval_cRegPreMessageExpr]
+
 /-- The whole value-level read message of a slot. Keeping it as one object means a consumer that
 needs the *values* — the register telescope — does not have to re-derive them field by field. -/
 def readMessage : RegSlot → MainRowWithRom FGL →

--- a/ZiskFv/Compliance/RegisterValueTelescope.lean
+++ b/ZiskFv/Compliance/RegisterValueTelescope.lean
@@ -348,4 +348,188 @@ theorem regSlot_selector_of_mem_op_three
           rw [h1, h2, h3] at h_op <;> exact absurd h_op (by decide)
     · exact h3
 
+
+/-- A slot's register-pre push really is one of the witness's memory-bus interactions. -/
+theorem regSlot_regPre_interaction_mem_witness
+    {length : ℕ} {program : Program length}
+    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
+    {table : Table FGL} (h_table : table ∈ witness.allTables)
+    (h_component : table.component = componentWithRomMemAndOpBus length program)
+    {row : Array FGL} (h_row : row ∈ table.table) (s : RegSlot) :
+    (((MemBusChannel.emitted (s.selectorExpr (componentWithRomMemAndOpBus length program).rowInputVar) (s.regPreMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw).eval
+      (table.environment row)) ∈ witness.interactionsWith MemBusChannel.toRaw := by
+  rw [EnsembleWitness.mem_interactionsWith]
+  refine ⟨table, h_table, ?_⟩
+  rw [Table.interactionsWith]
+  refine List.mem_flatMap.mpr ⟨row, h_row, ?_⟩
+  rw [Operations.interactionValuesWith_eq_map, h_component,
+    ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus_interactionsWith_memBus]
+  cases s <;> simp [RegSlot.selectorExpr, RegSlot.regPreMessageExpr]
+
+/-- An active slot's register-pre push rides at `+1`. -/
+theorem regSlot_regPre_mult_one
+    {length : ℕ} {program : Program length}
+    {table : Table FGL} {row : Array FGL}
+    (s : RegSlot) (h_sel : s.selector (eval (table.environment row) (componentWithRomMemAndOpBus length program).rowInputVar) = 1) :
+    (((MemBusChannel.emitted (s.selectorExpr (componentWithRomMemAndOpBus length program).rowInputVar) (s.regPreMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw).eval
+      (table.environment row)).mult = 1 := by
+  obtain ⟨-, e_a_reg, -, -, e_b_reg, -, -, e_c_reg⟩ :=
+    main_rom_eval (table.environment row) (componentWithRomMemAndOpBus length program).rowInputVar
+  rw [memBus_emitted_eval_mult]
+  cases s
+  · rw [RegSlot.selectorExpr, e_a_reg]; exact h_sel
+  · rw [RegSlot.selectorExpr, e_b_reg]; exact h_sel
+  · rw [RegSlot.selectorExpr, e_c_reg]; exact h_sel
+
+/-- **One backward step.** An active slot's register-pre push is answered either by
+    `bootMessage` — which pins that slot's predecessor timestamp *and its operand values* to `0` —
+    or by an earlier register read, whose own slot is active and whose read timestamp is the
+    predecessor timestamp, hence **strictly below** this row's own access.
+
+    The strict decrease is the bus-102 descent, so the measure that terminates the backward walk is
+    the read timestamp itself. -/
+theorem backward_step
+    {n : Nat} (trace : AcceptedZiskTrace n)
+    {table : Table FGL} (h_table : table ∈ trace.witness.allTables)
+    (h_component : table.component =
+      componentWithRomMemAndOpBus trace.programLength trace.program)
+    {row : Array FGL} (h_row : row ∈ table.table) (s : RegSlot)
+    (h_sel : s.selector (eval (table.environment row)
+      (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar) = 1) :
+    (∃ btbl ∈ trace.witness.allTables,
+        ∃ _h : btbl.component = ZiskFv.AirsClean.RegisterBoundary.component,
+          ∃ br ∈ btbl.table,
+            s.regPreMessage (eval (table.environment row)
+                (componentWithRomMemAndOpBus trace.programLength
+                  trace.program).rowInputVar)
+              = ZiskFv.AirsClean.RegisterBoundary.bootMessage
+                (eval (btbl.environment br)
+                  ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar))
+      ∨ (∃ tbl ∈ trace.witness.allTables,
+          ∃ _h : tbl.component =
+              componentWithRomMemAndOpBus trace.programLength trace.program,
+            ∃ r ∈ tbl.table, ∃ t : RegSlot,
+              t.selector (eval (tbl.environment r)
+                  (componentWithRomMemAndOpBus trace.programLength
+                    trace.program).rowInputVar) = 1
+              ∧ t.readMessage (eval (tbl.environment r)
+                  (componentWithRomMemAndOpBus trace.programLength
+                    trace.program).rowInputVar)
+                = s.regPreMessage (eval (table.environment row)
+                  (componentWithRomMemAndOpBus trace.programLength
+                    trace.program).rowInputVar)) := by
+  have h_mem := regSlot_regPre_interaction_mem_witness h_table h_component h_row s
+  have h_mult := regSlot_regPre_mult_one (table := table) (row := row) s h_sel
+  obtain ⟨b, h_b, h_bmsg, h_b0, h_b1⟩ :=
+    exists_pull_of_push_memBus trace.channels_balanced h_mem h_mult
+  have h_ref_op : (eval (table.environment row) (s.regPreMessageExpr
+      (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)).mem_op = 3 :=
+    RegSlot.eval_regPreMessageExpr_mem_op s _ _
+  rcases memBus_mem_op_three_counterpart trace.constraints_hold trace.spec_holds h_ref_op h_b
+      h_bmsg h_b0 h_b1 with
+    ⟨tbl, h_tbl, h_comp, r, h_r, t, h_eval⟩ | ⟨btbl, h_btbl, h_bcomp, br, h_br, h_eval⟩
+  · refine Or.inr ⟨tbl, h_tbl, h_comp, r, h_r, t, ?_, ?_⟩
+    · refine regSlot_selector_of_mem_op_three h_comp (trace.constraints_hold tbl h_tbl) h_r t ?_
+      have h_raw :
+          (((MemBusChannel.emitted (t.memMult
+            (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)
+            (t.memMessageExpr
+              (componentWithRomMemAndOpBus trace.programLength
+                trace.program).rowInputVar)).toRaw).eval (tbl.environment r)).msg
+          = (((MemBusChannel.emitted (s.selectorExpr
+              (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)
+              (s.regPreMessageExpr
+                (componentWithRomMemAndOpBus trace.programLength
+                  trace.program).rowInputVar)).toRaw).eval (table.environment row)).msg := by
+        rw [← h_eval]; exact h_bmsg
+      rw [memBusMessage_mem_op_eq_of_eval_emitted_provider_msg_eq (h_msg := h_raw)]
+      exact h_ref_op
+    · have h_raw :
+          (((MemBusChannel.emitted (t.memMult
+            (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)
+            (t.memMessageExpr
+              (componentWithRomMemAndOpBus trace.programLength
+                trace.program).rowInputVar)).toRaw).eval (tbl.environment r)).msg
+          = (((MemBusChannel.emitted (s.selectorExpr
+              (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)
+              (s.regPreMessageExpr
+                (componentWithRomMemAndOpBus trace.programLength
+                  trace.program).rowInputVar)).toRaw).eval (table.environment row)).msg := by
+        rw [← h_eval]; exact h_bmsg
+      have h_full := memBusMessage_eq_of_eval_emitted_provider_msg_eq (h_msg := h_raw)
+      rwa [RegSlot.eval_memMessageExpr, RegSlot.eval_regPreMessageExpr] at h_full
+  · refine Or.inl ⟨btbl, h_btbl, h_bcomp, br, h_br, ?_⟩
+    have h_raw :
+        (((MemBusChannel.emitted (-1)
+          (ZiskFv.AirsClean.RegisterBoundary.bootMessageExpr
+            ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar)).toRaw).eval
+          (btbl.environment br)).msg
+        = (((MemBusChannel.emitted (s.selectorExpr
+            (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)
+            (s.regPreMessageExpr
+              (componentWithRomMemAndOpBus trace.programLength
+                trace.program).rowInputVar)).toRaw).eval (table.environment row)).msg := by
+      rw [← h_eval]; exact h_bmsg
+    have h_full := memBusMessage_eq_of_eval_emitted_provider_msg_eq (h_msg := h_raw)
+    rw [ZiskFv.AirsClean.RegisterBoundary.eval_bootMessageExpr,
+      RegSlot.eval_regPreMessageExpr] at h_full
+    exact h_full.symm
+
+
+/-- **The backward step strictly decreases the read timestamp.**
+
+    The predecessor column is a free witness column, so nothing bounds it *a priori* — the bound
+    arrives with the step. Once the answering read is identified, its own timestamp is `k + 4 * index`
+    and so below `2 ^ 40`, and the bus-102 descent then puts it strictly below this row's access.
+    That is the measure the backward walk terminates on. -/
+theorem backward_step_lt
+    {n : Nat} (trace : AcceptedZiskTrace n)
+    {table : Table FGL} (h_table : table ∈ trace.witness.allTables)
+    (h_component : table.component =
+      componentWithRomMemAndOpBus trace.programLength trace.program)
+    {row : Array FGL} (h_row : row ∈ table.table) (s : RegSlot)
+    (h_sel : s.selector (eval (table.environment row) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar) = 1)
+    {tbl : Table FGL} (h_tbl : tbl ∈ trace.witness.allTables)
+    (h_comp : tbl.component = componentWithRomMemAndOpBus trace.programLength trace.program)
+    {r : Array FGL} (h_r : r ∈ tbl.table) (t : RegSlot)
+    (h_eq : t.readMessage (eval (tbl.environment r) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)
+      = s.regPreMessage (eval (table.environment row) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)) :
+    (t.readTimestamp (eval (tbl.environment r) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)).val
+      < (s.readTimestamp (eval (table.environment row) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)).val := by
+  have h_ts : t.readTimestamp (eval (tbl.environment r) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)
+      = s.prevStep (eval (table.environment row) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar) := by
+    have := congrArg ZiskFv.Channels.MemoryBus.MemBusMessage.timestamp h_eq
+    rwa [RegSlot.readMessage_timestamp, RegSlot.regPreMessage_timestamp] at this
+  have h_bound : (s.prevStep (eval (table.environment row) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)).val < 2 ^ 40 := by
+    rw [← h_ts]
+    exact regSlot_timestamp_bound_of_mem h_comp h_r t
+  have h_descent :
+      ZiskFv.AirsClean.RangeTables.rangeTable24.Spec
+        (s.distance (eval (table.environment row) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)) :=
+    ZiskFv.Compliance.Instantiation.rangeTable24_spec_distance_of_active trace.channels_balanced trace.spec_holds
+      trace.constraints_hold h_table h_row rfl h_component s h_sel
+  rw [h_ts]
+  exact ZiskFv.AirsClean.FullEnsemble.prev_val_lt_of_registerStepSpec h_descent h_bound
+
+/-- **The boot branch pins the operand values to zero.** A register-pre message's value lanes are
+    the row's *own* operand values, and `bootMessage` carries `(0, 0)`. So a slot whose predecessor
+    access is the boot pull reads a register that still holds `0` — the anchor the value telescope
+    descends to. -/
+theorem regPre_values_zero_of_boot
+    {n : Nat} (trace : AcceptedZiskTrace n)
+    {table : Table FGL} {row : Array FGL} (s : RegSlot)
+    {btbl : Table FGL} {br : Array FGL}
+    (h_eq : s.regPreMessage (eval (table.environment row) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)
+      = ZiskFv.AirsClean.RegisterBoundary.bootMessage
+        (eval (btbl.environment br)
+          ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar)) :
+    (s.regPreMessage (eval (table.environment row) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)).value_0 = 0
+      ∧ (s.regPreMessage (eval (table.environment row) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)).value_1 = 0
+      ∧ s.prevStep (eval (table.environment row) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar) = 0 := by
+  refine ⟨?_, ?_, ?_⟩
+  · exact congrArg ZiskFv.Channels.MemoryBus.MemBusMessage.value_0 h_eq
+  · exact congrArg ZiskFv.Channels.MemoryBus.MemBusMessage.value_1 h_eq
+  · have := congrArg ZiskFv.Channels.MemoryBus.MemBusMessage.timestamp h_eq
+    rwa [RegSlot.regPreMessage_timestamp] at this
+
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/RegisterValueTelescope.lean
+++ b/ZiskFv/Compliance/RegisterValueTelescope.lean
@@ -532,4 +532,87 @@ theorem regPre_values_zero_of_boot
   · have := congrArg ZiskFv.Channels.MemoryBus.MemBusMessage.timestamp h_eq
     rwa [RegSlot.regPreMessage_timestamp] at this
 
+
+/-! ## The backward walk reaches `bootMessage`
+
+Each step moves to an earlier read, and read timestamps are natural numbers, so the descent cannot
+continue forever. The measure is the read timestamp itself — decreasing, unlike the forward walk's
+`2 ^ 40 - readTimestamp`. -/
+
+/-- A slot of a witness row whose predecessor access is the boot pull, so whose operand values are
+    the register's untouched `0`. -/
+def BootAnchoredAt {n : Nat} (trace : AcceptedZiskTrace n)
+    (table : Table FGL) (row : Array FGL) (s : RegSlot) : Prop :=
+  ∃ btbl ∈ trace.witness.allTables,
+    ∃ _h : btbl.component = ZiskFv.AirsClean.RegisterBoundary.component,
+      ∃ br ∈ btbl.table,
+        s.regPreMessage (eval (table.environment row) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)
+          = ZiskFv.AirsClean.RegisterBoundary.bootMessage
+            (eval (btbl.environment br)
+              ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar)
+
+set_option maxHeartbeats 1000000 in
+/-- **The backward walk terminates at `bootMessage`.** From any active slot of any witness Main row,
+    following register-pre pushes back reaches a slot anchored at the boot pull.
+
+    The measure is the read timestamp, which `backward_step_lt` strictly decreases at every step. -/
+theorem exists_bootAnchored_of_fuel
+    {n : Nat} (trace : AcceptedZiskTrace n) :
+    ∀ (fuel : ℕ) {table : Table FGL}, table ∈ trace.witness.allTables →
+      ∀ (h_component : table.component =
+          componentWithRomMemAndOpBus trace.programLength trace.program),
+        ∀ {row : Array FGL}, row ∈ table.table → ∀ (s : RegSlot),
+          s.selector (eval (table.environment row) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar) = 1 →
+          (s.readTimestamp (eval (table.environment row) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)).val ≤ fuel →
+          ∃ tbl ∈ trace.witness.allTables,
+            ∃ _h : tbl.component =
+                componentWithRomMemAndOpBus trace.programLength trace.program,
+              ∃ r ∈ tbl.table, ∃ t : RegSlot,
+                t.selector (eval (tbl.environment r) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar) = 1
+                ∧ BootAnchoredAt trace tbl r t := by
+  intro fuel
+  induction fuel with
+  | zero =>
+      intro table h_table h_component row h_row s h_sel h_fuel
+      exact absurd (readTimestamp_val_pos h_component h_row s) (by omega)
+  | succ fuel ih =>
+      intro table h_table h_component row h_row s h_sel h_fuel
+      rcases backward_step trace h_table h_component h_row s h_sel with
+        h_boot | ⟨tbl, h_tbl, h_comp, r, h_r, t, h_tsel, h_eq⟩
+      · exact ⟨table, h_table, h_component, row, h_row, s, h_sel, h_boot⟩
+      · refine ih h_tbl h_comp h_r t h_tsel ?_
+        have h_lt := backward_step_lt trace h_table h_component h_row s h_sel h_tbl h_comp h_r t h_eq
+        omega
+
+/-- **Termination, with the measure supplied.** Every active register slot of the witness traces
+    back to a slot anchored at `bootMessage`. -/
+theorem exists_bootAnchored
+    {n : Nat} (trace : AcceptedZiskTrace n)
+    {table : Table FGL} (h_table : table ∈ trace.witness.allTables)
+    (h_component : table.component =
+      componentWithRomMemAndOpBus trace.programLength trace.program)
+    {row : Array FGL} (h_row : row ∈ table.table) (s : RegSlot)
+    (h_sel : s.selector (eval (table.environment row) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar) = 1) :
+    ∃ tbl ∈ trace.witness.allTables,
+      ∃ _h : tbl.component =
+          componentWithRomMemAndOpBus trace.programLength trace.program,
+        ∃ r ∈ tbl.table, ∃ t : RegSlot,
+          t.selector (eval (tbl.environment r) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar) = 1
+          ∧ BootAnchoredAt trace tbl r t :=
+  exists_bootAnchored_of_fuel trace
+    (s.readTimestamp (eval (table.environment row) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)).val
+    h_table h_component h_row s h_sel (by omega)
+
+/-- **The anchor, unpacked.** A boot-anchored slot's operand values are `0` and its predecessor
+    timestamp is `0`: the register is untouched. -/
+theorem bootAnchored_values_zero
+    {n : Nat} (trace : AcceptedZiskTrace n)
+    {table : Table FGL} {row : Array FGL} {s : RegSlot}
+    (h : BootAnchoredAt trace table row s) :
+    (s.regPreMessage (eval (table.environment row) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)).value_0 = 0
+      ∧ (s.regPreMessage (eval (table.environment row) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)).value_1 = 0
+      ∧ s.prevStep (eval (table.environment row) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar) = 0 := by
+  obtain ⟨btbl, h_btbl, h_bcomp, br, h_br, h_eq⟩ := h
+  exact regPre_values_zero_of_boot trace s h_eq
+
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/RegisterValueTelescope.lean
+++ b/ZiskFv/Compliance/RegisterValueTelescope.lean
@@ -297,4 +297,55 @@ theorem memBus_mem_op_three_counterpart
     · exact absurd (h_regPre RegSlot.c h_eval) not_false
     · exact Or.inl ⟨table, h_table, h_main, r, h_r, RegSlot.c, h_eval⟩
 
+
+/-! ## The backward step
+
+A register-pre push is answered by an earlier read or by `bootMessage`. When it is a read, that
+read's own slot is active — `mem_op = 3` forces it — so the walk can take its register-pre push in
+turn, and the timestamp strictly **decreases** because the bus-102 descent puts a row's predecessor
+below its own access. -/
+
+/-- A current access at `mem_op = 3` has its register selector set. For the a side that is
+`a_src_mem + 3 * a_src_reg = 3` with both flags boolean, which forces `a_src_reg = 1`. -/
+theorem regSlot_selector_of_mem_op_three
+    {length : ℕ} {program : Program length} {table : Table FGL} {row : Array FGL}
+    (h_component : table.component = componentWithRomMemAndOpBus length program)
+    (h_constraints : table.Constraints) (h_row : row ∈ table.table) (s : RegSlot)
+    (h_op : (eval (table.environment row) (s.memMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)).mem_op = 3) :
+    s.selector (eval (table.environment row) (componentWithRomMemAndOpBus length program).rowInputVar) = 1 := by
+  obtain ⟨b_a_mem, b_a_reg, b_b_mem, b_b_ind, b_b_reg, b_c_mem, b_c_ind, b_c_reg⟩ :=
+    main_source_flags_boolean h_component h_constraints h_row
+  cases s
+  · rw [RegSlot.memMessageExpr, ZiskFv.AirsClean.Main.eval_aMemMessageExpr] at h_op
+    change (eval (table.environment row) (componentWithRomMemAndOpBus length program).rowInputVar).rom.a_src_mem
+      + 3 * (eval (table.environment row) (componentWithRomMemAndOpBus length program).rowInputVar).rom.a_src_reg = 3 at h_op
+    show (eval (table.environment row) (componentWithRomMemAndOpBus length program).rowInputVar).rom.a_src_reg = 1
+    rcases zero_or_one_of_bool b_a_reg with h2 | h2
+    · exfalso
+      rcases zero_or_one_of_bool b_a_mem with h1 | h1 <;>
+        rw [h1, h2] at h_op <;> exact absurd h_op (by decide)
+    · exact h2
+  · rw [RegSlot.memMessageExpr, ZiskFv.AirsClean.Main.eval_bMemMessageExpr] at h_op
+    change ((eval (table.environment row) (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_mem
+      + (eval (table.environment row) (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_ind)
+      + 3 * (eval (table.environment row) (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_reg = 3 at h_op
+    show (eval (table.environment row) (componentWithRomMemAndOpBus length program).rowInputVar).rom.b_src_reg = 1
+    rcases zero_or_one_of_bool b_b_reg with h3 | h3
+    · exfalso
+      rcases zero_or_one_of_bool b_b_mem with h1 | h1 <;>
+        rcases zero_or_one_of_bool b_b_ind with h2 | h2 <;>
+          rw [h1, h2, h3] at h_op <;> exact absurd h_op (by decide)
+    · exact h3
+  · rw [RegSlot.memMessageExpr, ZiskFv.AirsClean.Main.eval_cMemMessageExpr] at h_op
+    change 2 * ((eval (table.environment row) (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_mem
+      + (eval (table.environment row) (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_ind)
+      + 3 * (eval (table.environment row) (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_reg = 3 at h_op
+    show (eval (table.environment row) (componentWithRomMemAndOpBus length program).rowInputVar).rom.store_reg = 1
+    rcases zero_or_one_of_bool b_c_reg with h3 | h3
+    · exfalso
+      rcases zero_or_one_of_bool b_c_mem with h1 | h1 <;>
+        rcases zero_or_one_of_bool b_c_ind with h2 | h2 <;>
+          rw [h1, h2, h3] at h_op <;> exact absurd h_op (by decide)
+    · exact h3
+
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/RegisterValueTelescope.lean
+++ b/ZiskFv/Compliance/RegisterValueTelescope.lean
@@ -76,4 +76,225 @@ theorem main_regPre_mult_zero_or_one
   · rw [RegSlot.selectorExpr, e_b_reg]; exact zero_or_one_of_bool b_b_reg
   · rw [RegSlot.selectorExpr, e_c_reg]; exact zero_or_one_of_bool b_c_reg
 
+
+/-- **What answers a register-pre push.** Every memory-bus interaction of the witness that carries a
+`mem_op = 3` message at a multiplicity outside `{0, 1}` is either a Main *current* access or the
+`RegisterBoundary` boot pull.
+
+The exclusions, in the order the case split meets them: ten components emit nothing on this bus;
+`MemAlignReadByte`, `MemAlignByte`, `MemAlign` and `Mem` carry `mem_op ∈ {1, 2}`; the boundary reload
+rides at `+1`; and Main's three register-pre pushes ride at their own selector, which is `0` or `1`.
+That last one is why `mult ≠ 0` matters as much as `mult ≠ 1`. -/
+theorem memBus_mem_op_three_counterpart
+    {length : ℕ} {program : Program length}
+    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
+    (h_constraints : witness.Constraints) (h_specs : witness.Spec)
+    {refEnv : Environment FGL} {refMult : Expression FGL}
+    {refMsg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)}
+    (h_ref_op : (eval refEnv refMsg).mem_op = 3)
+    {j : Interaction FGL} (h_j : j ∈ witness.interactionsWith MemBusChannel.toRaw)
+    (h_msg : j.msg = (((MemBusChannel.emitted refMult refMsg).toRaw).eval refEnv).msg)
+    (h_ne0 : j.mult ≠ 0) (h_ne1 : j.mult ≠ 1) :
+    (∃ tbl ∈ witness.allTables,
+        ∃ _h : tbl.component = componentWithRomMemAndOpBus length program,
+          ∃ r ∈ tbl.table, ∃ t : RegSlot,
+            j = ((MemBusChannel.emitted (t.memMult (componentWithRomMemAndOpBus length program).rowInputVar) (t.memMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw).eval
+              (tbl.environment r))
+      ∨ (∃ btbl ∈ witness.allTables,
+          ∃ _h : btbl.component = ZiskFv.AirsClean.RegisterBoundary.component,
+            ∃ br ∈ btbl.table,
+              j = ((MemBusChannel.emitted (-1)
+                (ZiskFv.AirsClean.RegisterBoundary.bootMessageExpr
+                  ZiskFv.AirsClean.RegisterBoundary.component.rowInputVar)).toRaw).eval
+                (btbl.environment br)) := by
+  rw [EnsembleWitness.mem_interactionsWith] at h_j
+  obtain ⟨table, h_table, h_mem_table⟩ := h_j
+  have h_component_mem :
+      table.component ∈ (fullRv64imEnsemble length program).ensemble.allTables :=
+    EnsembleWitness.mem_allTables_component_of_mem_allTables h_table
+  have h_op_of_emitted :
+      ∀ {env : Environment FGL} {mm : Expression FGL}
+        {msg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)},
+        j = ((MemBusChannel.emitted mm msg).toRaw).eval env →
+          (eval env msg).mem_op = 3 := by
+    intro env mm msg h_eval
+    have h_raw :
+        (((MemBusChannel.emitted mm msg).toRaw).eval env).msg =
+          (((MemBusChannel.emitted refMult refMsg).toRaw).eval refEnv).msg := by
+      rw [← h_eval]; exact h_msg
+    rw [memBusMessage_eq_of_eval_emitted_provider_msg_eq (h_msg := h_raw), h_ref_op]
+  have h_op_of_pushed :
+      ∀ {env : Environment FGL}
+        {msg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)},
+        j = ((MemBusChannel.pushed msg).toRaw).eval env →
+          (eval env msg).mem_op = 3 := by
+    intro env msg h_eval
+    have h_raw :
+        (((MemBusChannel.pushed msg).toRaw).eval env).msg =
+          (((MemBusChannel.emitted refMult refMsg).toRaw).eval refEnv).msg := by
+      rw [← h_eval]; exact h_msg
+    rw [memBusMessage_mem_op_eq_of_eval_pushed_provider_msg_eq (h_msg := h_raw), h_ref_op]
+  have h_op_of_pulled :
+      ∀ {env : Environment FGL}
+        {msg : ZiskFv.Channels.MemoryBus.MemBusMessage (Expression FGL)},
+        j = ((MemBusChannel.pulled msg).toRaw).eval env →
+          (eval env msg).mem_op = 3 := by
+    intro env msg h_eval
+    have h_raw :
+        (((MemBusChannel.pulled msg).toRaw).eval env).msg =
+          (((MemBusChannel.emitted refMult refMsg).toRaw).eval refEnv).msg := by
+      rw [← h_eval]; exact h_msg
+    rw [memBusMessage_mem_op_eq_of_eval_pulled_provider_msg_eq (h_msg := h_raw), h_ref_op]
+  rcases component_mem_fullRv64im_cases h_component_mem with
+    h_verifier | h_regBoundary | h_marb | h_mab | h_memAlign | h_memAlignRange | h_memAlignRom |
+    h_mem | h_ranges | h_regRange | h_arithDiv | h_arithMul | h_binExt | h_binary | h_binaryAdd |
+    h_main
+  · exfalso
+    have h_nil : table.interactionsWith MemBusChannel.toRaw = [] := by
+      have h_ops_nil :
+          table.component.operations.interactionsWith MemBusChannel.toRaw = [] := by
+        simpa [h_verifier] using verifierTable_interactionsWith_memBus_nil length program
+      simp [Table.interactionsWith, Operations.interactionValuesWith_eq_map, h_ops_nil]
+    simp [h_nil] at h_mem_table
+  -- RegisterBoundary: boot survives, reload rides at `+1`.
+  · rcases exists_registerBoundary_mem_row_eval_of_interaction_mem h_regBoundary h_mem_table with
+      ⟨br, h_br, h_eval⟩ | ⟨br, h_br, h_eval⟩
+    · exact Or.inr ⟨table, h_table, h_regBoundary, br, h_br, h_eval⟩
+    · exact absurd (by rw [h_eval, memBus_emitted_eval_mult]; simp [Expression.eval]) h_ne1
+  -- MemAlignReadByte carries `1`.
+  · exfalso
+    rcases exists_memBus_row_eval_of_pair_interactionsWith
+        (by simpa [h_marb] using
+          ZiskFv.AirsClean.MemAlignReadByte.component_interactionsWith_memBus)
+        h_mem_table with ⟨r, h_r, h_eval⟩ | ⟨r, h_r, h_eval⟩
+    · have h_op := h_op_of_pulled h_eval
+      rw [memBusMessage_eval_mem_op] at h_op
+      have h_lit : (1 : FGL) = 3 := by
+        simpa [ZiskFv.AirsClean.MemAlignReadByte.memReadMessageExpr, Expression.eval] using h_op
+      exact absurd h_lit (by decide)
+    · have h_op := h_op_of_pushed h_eval
+      rw [ZiskFv.AirsClean.MemAlignReadByte.eval_memBusMessageExpr] at h_op
+      have h_lit : (1 : FGL) = 3 := by
+        simpa [ZiskFv.AirsClean.MemAlignReadByte.memBusMessage] using h_op
+      exact absurd h_lit (by decide)
+  -- MemAlignByte carries `1` or `1 + is_write`.
+  · exfalso
+    have h_rowSpec := h_specs table h_table
+    rcases exists_memBus_row_eval_of_pair_interactionsWith
+        (by simpa [h_mab] using
+          ZiskFv.AirsClean.MemAlignByte.component_interactionsWith_memBus)
+        h_mem_table with ⟨r, h_r, h_eval⟩ | ⟨r, h_r, h_eval⟩
+    · have h_op := h_op_of_pulled h_eval
+      rw [memBusMessage_eval_mem_op] at h_op
+      have h_lit : (1 : FGL) = 3 := by
+        simpa [ZiskFv.AirsClean.MemAlignByte.memReadMessageExpr, Expression.eval] using h_op
+      exact absurd h_lit (by decide)
+    · have h_spec := h_rowSpec r h_r
+      rw [h_mab, ZiskFv.AirsClean.MemAlignByte.component_spec,
+        component_rowInput_eq_eval_rowInputVar] at h_spec
+      have h_isw := h_spec.2.2.2.2.2.2.2
+      have h_op := h_op_of_pushed h_eval
+      rw [ZiskFv.AirsClean.MemAlignByte.eval_memBusMessageExpr] at h_op
+      change 1 + (eval (table.environment r)
+        ZiskFv.AirsClean.MemAlignByte.component.rowInputVar).is_write = 3 at h_op
+      rcases zero_or_one_of_val_lt_two (by simpa using h_isw) with h0 | h1
+      · rw [h0] at h_op; exact absurd (by rw [← h_op]; ring : (1 : FGL) = 3) (by decide)
+      · rw [h1] at h_op; exact absurd (by rw [← h_op]; norm_num : (2 : FGL) = 3) (by decide)
+  -- MemAlign carries `wr + 1`.
+  · exfalso
+    have h_rowSpec := h_specs table h_table
+    obtain ⟨r, h_r, h_eval⟩ :=
+      exists_memBus_row_eval_of_singleton_interactionsWith
+        (by simpa [h_memAlign] using
+          ZiskFv.AirsClean.MemAlign.component_interactionsWith_memBus)
+        h_mem_table
+    have h_spec := h_rowSpec r h_r
+    rw [h_memAlign, ZiskFv.AirsClean.MemAlign.component_spec,
+      component_rowInput_eq_eval_rowInputVar] at h_spec
+    have h_wr := h_spec.1
+    have h_op := h_op_of_emitted h_eval
+    rw [ZiskFv.AirsClean.MemAlign.eval_memBusMessageExpr] at h_op
+    change (eval (table.environment r)
+      ZiskFv.AirsClean.MemAlign.component.rowInputVar).wr + 1 = 3 at h_op
+    rcases zero_or_one_of_bool h_wr with h0 | h1
+    · rw [h0] at h_op; exact absurd (by rw [← h_op]; ring : (1 : FGL) = 3) (by decide)
+    · rw [h1] at h_op; exact absurd (by rw [← h_op]; norm_num : (2 : FGL) = 3) (by decide)
+  · exfalso
+    have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
+      memAlignRangeSlice_table_interactionsWith_memBus_nil h_memAlignRange
+    simp [h_nil] at h_mem_table
+  · exfalso
+    have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
+      memAlignRomSlice_table_interactionsWith_memBus_nil h_memAlignRom
+    simp [h_nil] at h_mem_table
+  -- Mem carries `wr + 1` and `1`.
+  · exfalso
+    have h_rowSpec := h_specs table h_table
+    rcases exists_memBus_row_eval_of_pair_interactionsWith
+        (by simpa [h_mem] using
+          ZiskFv.AirsClean.Mem.componentWithDualMemBus_interactionsWith_memBus)
+        h_mem_table with ⟨r, h_r, h_eval⟩ | ⟨r, h_r, h_eval⟩
+    · have h_spec := h_rowSpec r h_r
+      rw [h_mem] at h_spec
+      have h_rowSpec' := ZiskFv.AirsClean.Mem.spec_of_componentWithDualMemBus_spec _ h_spec
+      rw [component_rowInput_eq_eval_rowInputVar] at h_rowSpec'
+      have h_wr := h_rowSpec'.2.2.2.2.1
+      have h_op := h_op_of_emitted h_eval
+      rw [ZiskFv.AirsClean.Mem.eval_memBusMessageExpr] at h_op
+      change (eval (table.environment r)
+        ZiskFv.AirsClean.Mem.componentWithDualMemBus.rowInputVar).wr + 1 = 3 at h_op
+      rcases zero_or_one_of_bool h_wr with h0 | h1
+      · rw [h0] at h_op; exact absurd (by rw [← h_op]; ring : (1 : FGL) = 3) (by decide)
+      · rw [h1] at h_op; exact absurd (by rw [← h_op]; norm_num : (2 : FGL) = 3) (by decide)
+    · have h_op := h_op_of_emitted h_eval
+      rw [ZiskFv.AirsClean.Mem.eval_memBusDualMessageExpr] at h_op
+      have h_lit : (1 : FGL) = 3 := by
+        simpa [ZiskFv.AirsClean.Mem.memBusDualMessage] using h_op
+      exact absurd h_lit (by decide)
+  · exfalso
+    have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
+      specifiedRangesSlice_table_interactionsWith_memBus_nil h_ranges
+    simp [h_nil] at h_mem_table
+  · exfalso
+    have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
+      registerStepRangeSlice_table_interactionsWith_memBus_nil h_regRange
+    simp [h_nil] at h_mem_table
+  · exfalso
+    have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
+      arithDiv_table_interactionsWith_memBus_nil h_arithDiv
+    simp [h_nil] at h_mem_table
+  · exfalso
+    have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
+      arithMul_table_interactionsWith_memBus_nil h_arithMul
+    simp [h_nil] at h_mem_table
+  · exfalso
+    have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
+      staticBinaryExtension_table_interactionsWith_memBus_nil h_binExt
+    simp [h_nil] at h_mem_table
+  · exfalso
+    have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
+      staticBinary_table_interactionsWith_memBus_nil h_binary
+    simp [h_nil] at h_mem_table
+  · exfalso
+    have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
+      binaryAdd_table_interactionsWith_memBus_nil h_binaryAdd
+    simp [h_nil] at h_mem_table
+  -- Main: the three register-pre pushes ride at their selector, in `{0, 1}`; the three current
+  -- accesses survive.
+  · obtain ⟨r, h_r, h_branch⟩ := exists_main_mem_row_eval_of_interaction_mem h_main h_mem_table
+    have h_regPre : ∀ t : RegSlot,
+        j = ((MemBusChannel.emitted (t.selectorExpr (componentWithRomMemAndOpBus length program).rowInputVar)
+          (t.regPreMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw).eval (table.environment r) → False := by
+      intro t h_eval
+      rcases main_regPre_mult_zero_or_one h_main (h_constraints table h_table) h_r t with h0 | h1
+      · exact h_ne0 (by rw [h_eval]; exact h0)
+      · exact h_ne1 (by rw [h_eval]; exact h1)
+    rcases h_branch with h_eval | h_eval | h_eval | h_eval | h_eval | h_eval
+    · exact absurd (h_regPre RegSlot.a h_eval) not_false
+    · exact Or.inl ⟨table, h_table, h_main, r, h_r, RegSlot.a, h_eval⟩
+    · exact absurd (h_regPre RegSlot.b h_eval) not_false
+    · exact Or.inl ⟨table, h_table, h_main, r, h_r, RegSlot.b, h_eval⟩
+    · exact absurd (h_regPre RegSlot.c h_eval) not_false
+    · exact Or.inl ⟨table, h_table, h_main, r, h_r, RegSlot.c, h_eval⟩
+
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/RegisterValueTelescope.lean
+++ b/ZiskFv/Compliance/RegisterValueTelescope.lean
@@ -1,0 +1,47 @@
+import ZiskFv.Compliance.RegisterBoundaryAnchor
+
+/-!
+# The backward walk: carrying a register value back to `bootMessage`
+
+#342 established the **forward** walk. From a register read, `exists_push_of_pull` finds the
+register-pre push that answers it, and that push belongs to a row whose own access is strictly
+later; iterating reaches the `RegisterBoundary` reload.
+
+Ordering is not agreement. #330 Phase 4 needs the **value**, and for that the walk has to run the
+other way: from a row's register-pre push, find the *pull* it answers. That pull is an earlier read,
+or `bootMessage`'s literal `(timestamp 0, value 0)`. Following it back and carrying the message
+equality at each step is what turns "the operand column holds some value" into "the operand column
+holds the value the register was last written with".
+
+Clean gives `exists_push_of_pull` but no converse. `balanceOf` is symmetric in the sign, so the
+converse is the same argument at `mult = 1`, and
+`no_balanced_message_with_constant_nonzero_mult` already packages the arithmetic.
+-/
+
+namespace ZiskFv.Compliance
+
+open Air.Flat
+open ZiskFv.AirsClean.FullEnsemble
+open ZiskFv.AirsClean.ZiskInstructionRom (Program)
+open ZiskFv.AirsClean.Main (componentWithRomMemAndOpBus)
+open ZiskFv.Channels.MemoryBus (MemBusChannel)
+open ZiskFv.Compliance.Instantiation (RegSlot RegWalkStep)
+
+/-- **The converse of `exists_push_of_pull`, on the memory bus.**
+
+    A push must be answered too: an interaction riding at `+1` forces another interaction with the
+    same message whose multiplicity is neither `0` nor `1`. Clean states only the pull direction;
+    `balanceOf` is sign-symmetric, so this is the same count argument at `m = 1`. -/
+theorem exists_pull_of_push_memBus
+    {length : ℕ} {program : Program length}
+    {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
+    (h_balanced : witness.BalancedChannels)
+    {a : Interaction FGL} (h_a : a ∈ witness.interactionsWith MemBusChannel.toRaw)
+    (h_push : a.mult = 1) :
+    ∃ b ∈ witness.interactionsWith MemBusChannel.toRaw,
+      b.msg = a.msg ∧ b.mult ≠ 0 ∧ b.mult ≠ 1 := by
+  by_contra! h_none
+  exact no_balanced_message_with_constant_nonzero_mult h_balanced (m := 1) one_ne_zero h_a h_push
+    (fun i h_i h_msg h_ne => h_none i h_i h_msg h_ne)
+
+end ZiskFv.Compliance

--- a/ZiskFv/Compliance/RegisterValueTelescope.lean
+++ b/ZiskFv/Compliance/RegisterValueTelescope.lean
@@ -44,4 +44,36 @@ theorem exists_pull_of_push_memBus
   exact no_balanced_message_with_constant_nonzero_mult h_balanced (m := 1) one_ne_zero h_a h_push
     (fun i h_i h_msg h_ne => h_none i h_i h_msg h_ne)
 
+
+/-! ## What answers a register-pre push
+
+At `mem_op = 3` the memory bus carries six shapes: Main's three current accesses (pulls), Main's
+three register-pre pushes, and the `RegisterBoundary` boot pull and reload push. A counterpart with
+`mult ∉ {0, 1}` can only be one of the two pulls.
+
+The `mult ≠ 0` clause is not decoration. A register-pre push on an **inactive** slot rides at
+multiplicity `0` — it is a phantom emission that carries a message but contributes nothing to the
+balance — and idle slots are everywhere in the witnesses. `mult ≠ 0` is what stops such a phantom
+from answering a read, exactly as `mult ≠ -1` stopped the boot pull in the forward direction. -/
+
+/-- Main's register-pre push rides at its own selector, which booleanity pins to `0` or `1`. -/
+theorem main_regPre_mult_zero_or_one
+    {length : ℕ} {program : Program length}
+    {table : Table FGL} {row : Array FGL}
+    (h_component : table.component = componentWithRomMemAndOpBus length program)
+    (h_constraints : table.Constraints) (h_row : row ∈ table.table) (s : RegSlot) :
+    (((MemBusChannel.emitted (s.selectorExpr (componentWithRomMemAndOpBus length program).rowInputVar) (s.regPreMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw).eval
+      (table.environment row)).mult = 0
+    ∨ (((MemBusChannel.emitted (s.selectorExpr (componentWithRomMemAndOpBus length program).rowInputVar) (s.regPreMessageExpr (componentWithRomMemAndOpBus length program).rowInputVar)).toRaw).eval
+      (table.environment row)).mult = 1 := by
+  obtain ⟨b_a_mem, b_a_reg, b_b_mem, b_b_ind, b_b_reg, b_c_mem, b_c_ind, b_c_reg⟩ :=
+    main_source_flags_boolean h_component h_constraints h_row
+  obtain ⟨e_a_mem, e_a_reg, e_b_mem, e_b_ind, e_b_reg, e_c_mem, e_c_ind, e_c_reg⟩ :=
+    main_rom_eval (table.environment row) (componentWithRomMemAndOpBus length program).rowInputVar
+  rw [memBus_emitted_eval_mult]
+  cases s
+  · rw [RegSlot.selectorExpr, e_a_reg]; exact zero_or_one_of_bool b_a_reg
+  · rw [RegSlot.selectorExpr, e_b_reg]; exact zero_or_one_of_bool b_b_reg
+  · rw [RegSlot.selectorExpr, e_c_reg]; exact zero_or_one_of_bool b_c_reg
+
 end ZiskFv.Compliance


### PR DESCRIPTION
#330 Phase 4, ZisK half. Stacked on #350 (`348-boundary-anchor`).

Ordering is not agreement. #342 proved the register walk is acyclic and terminates; this carries the
**value** along it, back to a register that still holds `0`.

## The direction the plan never fixed

The forward walk of #342/#347 ends at the `RegisterBoundary` **reload**. The value telescope has to
run the other way — from a row's register-pre push, find the *pull* it answers — and that is a
different walk on a **decreasing** measure, not a reuse of `exists_boundaryWalk_of_fuel`. The plan
now says so.

## What this proves

**`exists_bootAnchored`** — from any active register slot of any witness Main row, following
register-pre pushes back reaches a slot whose predecessor access is the boot pull.
**`bootAnchored_values_zero`** — that slot's operand values are `0` and its predecessor timestamp is
`0`.

The pieces:

- **`exists_pull_of_push_memBus`** — Clean ships `exists_push_of_pull` and no converse. `balanceOf`
  is sign-symmetric, so the converse is the same count argument at `m = 1`, and
  `no_balanced_message_with_constant_nonzero_mult` already had the arithmetic.
- **`memBus_mem_op_three_counterpart`** — the sixteen-component split. A `mem_op = 3` counterpart at
  multiplicity outside `{0, 1}` is a Main current access or the boot pull. Ten components emit
  nothing on this bus; the Mem/MemAlign family carries `mem_op ∈ {1, 2}`; the reload rides at `+1`;
  and Main's three register-pre pushes ride at their own selector.
- **`main_regPre_mult_zero_or_one`** — that last exclusion. **`mult ≠ 0` is load-bearing**: a
  register-pre push on an *inactive* slot is a phantom emission at multiplicity `0` carrying a real
  message, and idle slots are everywhere in the witnesses. It does here what `mult ≠ -1` did for the
  boot pull going forwards.
- **`regSlot_selector_of_mem_op_three`** — a `mem_op = 3` read has its own register selector set
  (`a_src_mem + 3 · a_src_reg = 3` with both boolean forces `a_src_reg = 1`), which is what lets the
  walk take *that* row's register-pre push in turn.
- **`backward_step_lt`** — the strict decrease. Worth saying why it could not come earlier: the
  predecessor column is a **free witness column**, so nothing bounds it *a priori*. The bound
  arrives *with* the step — once the answering read is identified, its timestamp is `k + 4 · index`
  and so below `2 ^ 40`, and the bus-102 descent then puts it strictly below this row's access.

Axiom closure of everything new: `[propext, Classical.choice, Quot.sound]`. No `sorry`, no new trust
marker, no new premise.

## How the chain carries writes

Worth recording, because it looks wrong at first. The a- and b-side register-pre messages carry the
row's **own** operand values, so along an a-side chain the value is *constant* — correct, reads do
not write. The store side is where it changes: `cRegPreMessage` carries `store_reg_prev_value` while
`cMemMessage` carries the new store value. So a write is exactly the link where the chain's value
steps, and the per-step message equality already threads it. Nothing extra was needed.

## What this does **not** do — the honest split

The 116 fields are cross-machine:

```
h_a_lo_t : m.a_0 r_main = lane_lo ((sail_to_rv64 state).xreg (regidx_to_fin r1))
```

This PR delivers the **ZisK half**: the `a_0` column traces back through message equalities to a
register that still holds `0`, with writes threaded along the way. It says nothing about Sail's
`xreg`.

The remaining half is the cross-machine induction the plan describes: widen Phase 7's
`stepSound_of_programDecodes` invariant from `PcAgree j` to `PcAgree j ∧ RegAgree j`, with the step
being writeback preservation off `StepSound j`'s post-state, and a `regs`-projection lemma in the
shape of `nextPC_of_busEffect_ok`. That is not built here.

**The bargain, stated in advance as the plan requires.** `RegAgree 0` becomes a new named boot
premise, in the same class as `SegmentPcChain.boot` and `BootSegmentMemorySeed`. Phase 4 is a real
reduction **only if** the 116 per-row fields go away and that one boot equation replaces them. I
have not reached the point where that exchange is decidable, so nothing in this PR claims it — and
`root_soundness`'s statement is untouched.

## Verification

Gates in the comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
