### PR TITLE
#343: root_soundness generates the Sail trace, so retire stops being a premise

### DIFF
--- a/ZiskFv.lean
+++ b/ZiskFv.lean
@@ -198,6 +198,7 @@ import ZiskFv.Compliance.RegisterWalk
 import ZiskFv.Compliance.MemBusSlotSeparation
 import ZiskFv.Compliance.RegisterBoundaryAnchor
 import ZiskFv.Compliance.RegisterBoundaryAnchorNonvacuity
+import ZiskFv.Compliance.TraceLevelExport.ChainedSailTrace
 import ZiskFv.Compliance.SingleAddWitness
 import ZiskFv.Compliance.AddSpinWitness
 import ZiskFv.Compliance.AddSpinRootSoundness

--- a/ZiskFv/Audit.lean
+++ b/ZiskFv/Audit.lean
@@ -65,21 +65,23 @@ deliberately changes what an endpoint states. -/
 open ZiskFv.Compliance in
 /--
 info: root_soundness : ∀ (numInstructions rawLength : ℕ) (ziskTrace : AcceptedZiskTrace numInstructions)
-  (sailTrace : SailTrace numInstructions) (ziskStep : (i : Fin numInstructions) → ZiskStep ziskTrace i)
-  (start : Fin rawLength → Fin ziskTrace.programLength) (addr : Fin rawLength → Fin 18446744069414584321)
-  (rawProgram : Fin rawLength → BitVec 32)
+  (init : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
+  (ziskStep : (i : Fin numInstructions) → ZiskStep ziskTrace i) (start : Fin rawLength → Fin ziskTrace.programLength)
+  (addr : Fin rawLength → Fin 18446744069414584321) (rawProgram : Fin rawLength → BitVec 32)
   (programBinding : RawProgramBinding.ProgramRowsBinding ziskTrace start addr rawProgram)
   (rawProgramDecodes : (i : Fin numInstructions) → RawProgramDecode ziskTrace i (ziskStep i) start addr rawProgram)
-  (inputsAgree : (i : Fin numInstructions) → InputsAgreeCore ziskTrace sailTrace i (ziskStep i)),
-  SegmentPcChain ziskTrace sailTrace ziskStep →
+  (inputsAgree : (i : Fin numInstructions) → InputsAgreeCore ziskTrace (chainedSailTrace ziskStep init) i (ziskStep i)),
+  (0 < numInstructions →
+      ↑((ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable).pc 0) =
+        (init.regs.get? Register.PC).elim 0 BitVec.toNat) →
     (StepRowsAligned ziskTrace ziskStep fun i ↦
         rowDecode_of_programDecode ziskTrace i
           (programDecode_of_rawProgramDecode ziskTrace i (ziskStep i) start addr rawProgram programBinding
             (rawProgramDecodes i))) →
-      ∀ (bootSeed : BootSegmentMemorySeed ziskTrace sailTrace ziskStep),
+      ∀ (bootSeed : BootSegmentMemorySeed ziskTrace (chainedSailTrace ziskStep init) ziskStep),
         (∀ (i : Fin numInstructions), RowOutsideDefectRegion ziskTrace i (ziskStep i)) →
           ∀ (i : Fin numInstructions),
-            StepSound ziskTrace sailTrace i (ziskStep i)
+            StepSound ziskTrace (chainedSailTrace ziskStep init) i (ziskStep i)
               (rowDecode_of_programDecode ziskTrace i
                 (programDecode_of_rawProgramDecode ziskTrace i (ziskStep i) start addr rawProgram programBinding
                   (rawProgramDecodes i)))

--- a/ZiskFv/Compliance/AddFaithfulPaddedRootSoundness.lean
+++ b/ZiskFv/Compliance/AddFaithfulPaddedRootSoundness.lean
@@ -54,8 +54,12 @@ def addFaithfulState (pc : BitVec 64) :
     regs := addFaithfulRegs pc
     mem := {} }
 
-def addFaithfulSailTrace : SailTrace 1
-  | ⟨0, _⟩ => addFaithfulState (0#64)
+/-- The Sail side of this witness (#343). Not a hand-written family of states: the execution Sail's
+    own semantics generates from `addFaithfulState (0#64)`. A one-instruction execution has no chain
+    step, so it reduces to the initial state at its single index — but it is now the *generated*
+    trace, which is what `root_soundness` consumes. -/
+noncomputable def addFaithfulSailTrace : SailTrace 1 :=
+  chainedSailTrace addFaithfulZiskStep (addFaithfulState (0#64))
 
 theorem addFaithfulRowsOf_empty_readSound :
     MemoryBusRowsPrefixReadSound
@@ -205,7 +209,7 @@ def addFaithfulInputsAgree :
 def addFaithfulPcSeed : SegmentPcSeed addFaithfulAcceptedTrace addFaithfulSailTrace :=
   pcSeed_of_inputsAgree addFaithfulInputsAgree
 
-def addFaithfulInputsAgreeCore :
+noncomputable def addFaithfulInputsAgreeCore :
     ∀ i : Fin 1,
       InputsAgreeCore addFaithfulAcceptedTrace addFaithfulSailTrace i (addFaithfulZiskStep i) :=
   fun i => inputsAgreeCore_of_inputsAgree i (addFaithfulZiskStep i) (addFaithfulInputsAgree i)
@@ -267,15 +271,14 @@ def addFaithfulRowsAligned :
   have h' : j + 1 < 1 := h
   omega
 
-/-- The two root PC premises: boot agreement, and the Sail-internal retire law. `retire` is vacuous
-    on a one-instruction execution; `boot` is the witness's own row-0 PC agreement. -/
-def addFaithfulPcChain :
-    SegmentPcChain addFaithfulAcceptedTrace addFaithfulSailTrace addFaithfulZiskStep where
-  retire := by
-    intro j h
-    have h' : j + 1 < 1 := h
-    omega
-  boot := (pcSeed_of_inputsAgree addFaithfulInputsAgree).boot
+/-- The single root PC premise (#343): boot agreement at row `0`. The retire law that used to sit
+    beside it is no longer a premise — `root_soundness` gets it from
+    `chainedSailTrace_retireChain`. -/
+def addFaithfulPcBoot : ∀ (_ : 0 < 1),
+    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable addFaithfulAcceptedTrace.program
+        addFaithfulAcceptedTrace.mainTable).pc 0).val
+      = ((addFaithfulState (0#64)).regs.get? Register.PC).elim 0 BitVec.toNat :=
+  (pcSeed_of_inputsAgree addFaithfulInputsAgree).boot
 
 open ZiskFv.Compliance.RawProgramBinding in
 theorem addFaithfulPaddedRawRootSoundness :
@@ -285,9 +288,9 @@ theorem addFaithfulPaddedRawRootSoundness :
           (programDecode_of_rawProgramDecode addFaithfulAcceptedTrace i (addFaithfulZiskStep i)
             addFaithfulStart addFaithfulAddr addFaithfulRawProgram
             addFaithfulProgramRowsBinding (addFaithfulRawProgramDecodes i))) :=
-  root_soundness 1 2 addFaithfulAcceptedTrace addFaithfulSailTrace addFaithfulZiskStep
+  root_soundness 1 2 addFaithfulAcceptedTrace (addFaithfulState (0#64)) addFaithfulZiskStep
     addFaithfulStart addFaithfulAddr addFaithfulRawProgram addFaithfulProgramRowsBinding
-    addFaithfulRawProgramDecodes addFaithfulInputsAgreeCore addFaithfulPcChain
+    addFaithfulRawProgramDecodes addFaithfulInputsAgreeCore addFaithfulPcBoot
     addFaithfulRowsAligned addFaithfulBootSeed addFaithfulOutsideDefectRegion
 
 #print axioms addFaithfulPaddedRawRootSoundness

--- a/ZiskFv/Compliance/MemoryRawRootSoundness.lean
+++ b/ZiskFv/Compliance/MemoryRawRootSoundness.lean
@@ -77,11 +77,17 @@ private theorem memoryAcceptedTrace_not_mutableMemPresent :
   have htable := memoryAcceptedTrace_mutable_tables_empty table hmem hcomp
   exact absurd hlen (by simp [htable])
 
-/-- The empty Sail trace over the empty execution. -/
-def memorySailTrace : SailTrace 0 := nofun
-
 /-- The empty per-step ZisK decode family over the empty execution. -/
 def memoryZiskStep : ∀ i : Fin 0, ZiskStep memoryAcceptedTrace i := nofun
+
+/-- The initial Sail state this witness hands to `root_soundness` (#343). An empty execution never
+    reads it, but the theorem now takes a state rather than a trace, so it must be supplied. -/
+def memoryInit : PreSail.SequentialState RegisterType Sail.trivialChoiceSource := default
+
+/-- The Sail trace over the empty execution — generated from `memoryInit`, not hand-written. Over
+    `Fin 0` it has no inhabited index, as before. -/
+noncomputable def memorySailTrace : SailTrace 0 :=
+  chainedSailTrace memoryZiskStep memoryInit
 
 /-- The boot / cross-segment memory seed for the memory witness: empty boot memory, no
     execution-order rows, and every per-index obligation either vacuous over `Fin 0`
@@ -100,12 +106,14 @@ def memoryBootSeed :
     exact absurd (by simp [AcceptedZiskTrace.numInstructions]) h_ne
   placement := fun i => i.elim0
 
-/-- The PC premises for the empty execution. All of them are vacuous here for the same
-    reason `memoryBootSeed`'s are: there is no step `0`, and no step `j + 1`. -/
-def memoryPcChain :
-    SegmentPcChain memoryAcceptedTrace memorySailTrace memoryZiskStep where
-  retire := fun _ h => absurd h (Nat.not_lt_zero _)
-  boot := fun h => absurd h (Nat.not_lt_zero _)
+/-- The one PC premise left after #343, vacuous here for the same reason `memoryBootSeed`'s fields
+    are: the empty execution has no step `0`. The retire law that used to sit beside it is no longer
+    a premise at all — `root_soundness` derives it from `chainedSailTrace_retireChain`. -/
+def memoryPcBoot : ∀ (_ : 0 < 0),
+    ((ZiskFv.AirsClean.FullEnsemble.mainOfTable memoryAcceptedTrace.program
+        memoryAcceptedTrace.mainTable).pc 0).val
+      = (memoryInit.regs.get? Register.PC).elim 0 BitVec.toNat :=
+  fun h => absurd h (Nat.not_lt_zero _)
 
 def memoryRowsAligned :
     StepRowsAligned memoryAcceptedTrace memoryZiskStep
@@ -125,9 +133,9 @@ theorem memoryRawRootSoundness :
         (rowDecode_of_programDecode memoryAcceptedTrace i
           (programDecode_of_rawProgramDecode memoryAcceptedTrace i (memoryZiskStep i)
             memoryStart memoryAddr memoryRawProgram memoryProgramRowsBinding i.elim0)) :=
-  root_soundness 0 3 memoryAcceptedTrace memorySailTrace memoryZiskStep
+  root_soundness 0 3 memoryAcceptedTrace memoryInit memoryZiskStep
     memoryStart memoryAddr memoryRawProgram memoryProgramRowsBinding
-    (fun i => i.elim0) (fun i => i.elim0) memoryPcChain memoryRowsAligned memoryBootSeed
+    (fun i => i.elim0) (fun i => i.elim0) memoryPcBoot memoryRowsAligned memoryBootSeed
     (fun i => i.elim0)
 
 #print axioms memoryRawRootSoundness

--- a/ZiskFv/Compliance/TraceLevelExport/ChainedSailTrace.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/ChainedSailTrace.lean
@@ -17,12 +17,19 @@ This module builds the trace instead of assuming it. `chainedSailStates` runs
 
 It settles the shape: a trace generated this way satisfies `retire` definitionally, so a caller that
 supplies one is supplying an actual Sail execution rather than an arbitrary family of states with a
-promise attached.
+promise attached. `root_soundness` consumes it — that theorem takes an initial state, builds the
+trace here, and no longer carries a `SegmentPcChain` binder.
 
-It does not by itself migrate `root_soundness`. `SailTrace` is referenced by all 63 `StepSound`
-arms, every `Inputs_<op>`, and all seven accepted-trace witnesses; repointing them is the rest of
-#343. Nothing here changes a protected interface — the definitions are additive, and the existing
-`SailTrace` abbreviation is untouched.
+`stepSound_of_programDecodes` still takes an arbitrary `SailTrace`, so the five multi-step
+accepted-trace witnesses keep their hand-built state families.
+
+**Nothing below is exercised by a checked-in witness yet — say so plainly.** The two witnesses that
+instantiate `root_soundness` run at `numInstructions = 1` and `0`. `chainedSailStates … 0` is `init`
+by `rfl`, so index `0` is the caller's own state and no witness reaches index `≥ 1`. `retirePC` and
+`sailStepPost` are therefore never applied in the checked-in tree, and
+`chainedSailTrace_retireChain` is proved but never *used* by a witness. The premise reduction on
+`root_soundness` is real regardless — it is a statement-level fact — but the claim that the trace is
+"harder to inhabit" is not yet demonstrated by an instantiation that has to run Sail.
 -/
 
 namespace ZiskFv.Compliance
@@ -30,7 +37,15 @@ namespace ZiskFv.Compliance
 variable {numInstructions : ℕ}
 
 /-- **Sail's retire step, as a state function.** Copy `nextPC` into `PC`. This is the transition the
-    old `SegmentPcChain.retire` field asserted; here it is performed. -/
+    old `SegmentPcChain.retire` field asserted; here it is performed.
+
+    **The `none` branch erases `PC`, and that is a coverage cliff, not a soundness hole.** Erasing
+    makes both sides of `retire` equal to `none`, which is what lets `chainedSailTrace_retireChain`
+    hold with no side condition — the alternative needs a fact about all 63 `execute` arms. The cost
+    is that a step which leaves `nextPC` unset produces a state with no `PC` at all, and every
+    `Inputs_<op>`'s `h_input_pc` demands `.some`. So such a step makes `inputsAgree` *unsatisfiable*
+    from there on: the theorem becomes uninstantiable rather than silently matching `.elim 0`'s
+    zero. Nothing is proved about a state that never arises; a real trace is simply lost. -/
 noncomputable def retirePC
     (s : PreSail.SequentialState RegisterType Sail.trivialChoiceSource) :
     PreSail.SequentialState RegisterType Sail.trivialChoiceSource :=
@@ -39,7 +54,13 @@ noncomputable def retirePC
   | some v =>
       { s with regs := s.regs.insert Register.PC (cast (by simp [RegisterType]) v) }
 
-/-- The post-state of one Sail step, error branches kept total by staying put. -/
+/-- The post-state of one Sail step.
+
+    **Both branches return `post`**, the state the step ended in — including the error branch, where
+    `post` is the trap's post-state, not the pre-state. So a trapping step advances the chain from
+    wherever Sail left it. That is what makes this total, and it is the honest reading: the retire
+    law says nothing about a trapping step because `chainedSailTrace_retireChain`'s hypothesis is an
+    `.ok`. An earlier docstring here claimed the error branch "stays put"; it does not. -/
 noncomputable def sailStepPost
     (instr : instruction)
     (s : PreSail.SequentialState RegisterType Sail.trivialChoiceSource) :

--- a/ZiskFv/Compliance/TraceLevelExport/ChainedSailTrace.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/ChainedSailTrace.lean
@@ -76,6 +76,19 @@ noncomputable def chainedSailTrace
     SailTrace ziskTrace.numInstructions :=
   fun i => chainedSailStates ziskStep init i.val
 
+@[simp] theorem chainedSailStates_zero
+    {ziskTrace : AcceptedZiskTrace numInstructions}
+    (ziskStep : ∀ i : Fin ziskTrace.numInstructions, ZiskStep ziskTrace i)
+    (init : PreSail.SequentialState RegisterType Sail.trivialChoiceSource) :
+    chainedSailStates ziskStep init 0 = init := rfl
+
+@[simp] theorem chainedSailTrace_apply
+    {ziskTrace : AcceptedZiskTrace numInstructions}
+    (ziskStep : ∀ i : Fin ziskTrace.numInstructions, ZiskStep ziskTrace i)
+    (init : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
+    (i : Fin ziskTrace.numInstructions) :
+    chainedSailTrace ziskStep init i = chainedSailStates ziskStep init i.val := rfl
+
 /-- **`retire` holds by construction.** For a chained trace the PC at step `j + 1` *is* the `nextPC`
     the step at `j` wrote, because `chainedSailStates` performs the copy rather than assuming it.
 

--- a/ZiskFv/Compliance/TraceLevelExport/ChainedSailTrace.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/ChainedSailTrace.lean
@@ -35,7 +35,7 @@ noncomputable def retirePC
     (s : PreSail.SequentialState RegisterType Sail.trivialChoiceSource) :
     PreSail.SequentialState RegisterType Sail.trivialChoiceSource :=
   match s.regs.get? Register.nextPC with
-  | none => s
+  | none => { s with regs := s.regs.erase Register.PC }
   | some v =>
       { s with regs := s.regs.insert Register.PC (cast (by simp [RegisterType]) v) }
 
@@ -113,7 +113,7 @@ theorem retirePC_regs_of_ne
     (retirePC s).regs.get? r = s.regs.get? r := by
   rw [retirePC]
   cases h_next : s.regs.get? Register.nextPC with
-  | none => rfl
+  | none => simp [Std.ExtDHashMap.get?_erase, h_r.symm]
   | some v => simp [Std.ExtDHashMap.get?_insert, h_r.symm]
 
 /-- **The general registers at step `j + 1` are the post-state's.**
@@ -134,5 +134,33 @@ theorem chainedSailStates_regs_of_ne_pc
           (chainedSailStates ziskStep init j)).regs.get? r := by
   rw [chainedSailStates, dif_pos h]
   exact retirePC_regs_of_ne _ r h_r
+
+
+/-! ## The decisive consequence: `retire` stops being a premise
+
+`SailRetireChain.retire` is the per-step law `SegmentPcChain` assumes. On a chained trace it is a
+theorem. A caller that supplies an initial state instead of a `SailTrace` therefore owes one premise
+fewer — and this is what makes the PC arm a *reduction* rather than a restructure. -/
+
+/-- **`SailRetireChain` holds for a chained trace.** No hypothesis: the trace performs the retire. -/
+theorem chainedSailTrace_retireChain
+    {ziskTrace : AcceptedZiskTrace numInstructions}
+    (ziskStep : ∀ i : Fin ziskTrace.numInstructions, ZiskStep ziskTrace i)
+    (init : PreSail.SequentialState RegisterType Sail.trivialChoiceSource) :
+    SailRetireChain ziskTrace (chainedSailTrace ziskStep init) ziskStep := by
+  constructor
+  intro j h result post h_step
+  have h_post : sailStepPost (sailInstructionOf ⟨j, Nat.lt_of_succ_lt h⟩
+      (ziskStep ⟨j, Nat.lt_of_succ_lt h⟩)) (chainedSailStates ziskStep init j) = post := by
+    rw [sailStepPost]
+    rw [show execute_instruction (sailInstructionOf ⟨j, Nat.lt_of_succ_lt h⟩
+      (ziskStep ⟨j, Nat.lt_of_succ_lt h⟩)) (chainedSailStates ziskStep init j)
+        = .ok result post from h_step]
+  show (chainedSailStates ziskStep init (j + 1)).regs.get? Register.PC
+    = post.regs.get? Register.nextPC
+  rw [chainedSailStates, dif_pos (Nat.lt_of_succ_lt h), h_post, retirePC]
+  cases h_next : post.regs.get? Register.nextPC with
+  | none => simp [Std.ExtDHashMap.get?_erase, h_next]
+  | some v => simp [Std.ExtDHashMap.get?_insert]
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/TraceLevelExport/ChainedSailTrace.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/ChainedSailTrace.lean
@@ -96,4 +96,43 @@ theorem chainedSailStates_retire
   rw [h_next]
   simp [Std.ExtDHashMap.get?_insert]
 
+
+/-! ## Why this unblocks `RegAgree`
+
+The retire step touches `PC` and nothing else. So on a chained trace the *general* registers at step
+`j + 1` are exactly the post-state's — which is what `RegisterWriteback.lean`'s
+`regs_write_of_busEffect_ok_three` and `regs_preserved_of_busEffect_ok_three` describe.
+
+That is the link `RegAgree j → RegAgree (j + 1)` was missing. On a bare `Fin n → State` there is no
+such equation to state, let alone prove. -/
+
+/-- **Retire moves `PC` and leaves every other register alone.** -/
+theorem retirePC_regs_of_ne
+    (s : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
+    (r : Register) (h_r : r ≠ Register.PC) :
+    (retirePC s).regs.get? r = s.regs.get? r := by
+  rw [retirePC]
+  cases h_next : s.regs.get? Register.nextPC with
+  | none => rfl
+  | some v => simp [Std.ExtDHashMap.get?_insert, h_r.symm]
+
+/-- **The general registers at step `j + 1` are the post-state's.**
+
+    This is the equation `RegAgree`'s inductive step needs, and the equation a bare
+    `Fin n → SequentialState` cannot even state. Compose it with
+    `regs_write_of_busEffect_ok_three` (the destination register takes the write entry's lanes) and
+    `regs_preserved_of_busEffect_ok_three` (every other register is untouched), and the Sail side of
+    the step is complete; #330 Phase 4's `exists_bootAnchored` supplies the ZisK side. -/
+theorem chainedSailStates_regs_of_ne_pc
+    {ziskTrace : AcceptedZiskTrace numInstructions}
+    (ziskStep : ∀ i : Fin ziskTrace.numInstructions, ZiskStep ziskTrace i)
+    (init : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
+    (j : ℕ) (h : j < ziskTrace.numInstructions)
+    (r : Register) (h_r : r ≠ Register.PC) :
+    (chainedSailStates ziskStep init (j + 1)).regs.get? r
+      = (sailStepPost (sailInstructionOf ⟨j, h⟩ (ziskStep ⟨j, h⟩))
+          (chainedSailStates ziskStep init j)).regs.get? r := by
+  rw [chainedSailStates, dif_pos h]
+  exact retirePC_regs_of_ne _ r h_r
+
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/TraceLevelExport/ChainedSailTrace.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/ChainedSailTrace.lean
@@ -1,0 +1,99 @@
+import ZiskFv.Compliance.TraceLevelExport.SailRetireChain
+
+/-!
+# A `SailTrace` that Sail's own semantics generates — #343
+
+`SailTrace n` is `Fin n → PreSail.SequentialState`: a *family* of states with no relation between
+indices. Because nothing links step `j` to step `j + 1`, every cross-step law has to be **assumed**.
+`SegmentPcChain` assumes `retire`, and `SailRetireChain.lean:789` says what that costs — Phase 7 is
+a restructure, not a logical-strength reduction. #330 Phase 4 hits the same wall: `RegAgree`'s
+inductive step has nothing to stand on.
+
+This module builds the trace instead of assuming it. `chainedSailStates` runs
+`execute_instruction` at each step from an initial state and then performs Sail's **retire**: copy
+`nextPC` into `PC`. `chainedSailStates_retire` is then true **by construction**, not by hypothesis.
+
+## What this does and does not settle
+
+It settles the shape: a trace generated this way satisfies `retire` definitionally, so a caller that
+supplies one is supplying an actual Sail execution rather than an arbitrary family of states with a
+promise attached.
+
+It does not by itself migrate `root_soundness`. `SailTrace` is referenced by all 63 `StepSound`
+arms, every `Inputs_<op>`, and all seven accepted-trace witnesses; repointing them is the rest of
+#343. Nothing here changes a protected interface — the definitions are additive, and the existing
+`SailTrace` abbreviation is untouched.
+-/
+
+namespace ZiskFv.Compliance
+
+variable {numInstructions : ℕ}
+
+/-- **Sail's retire step, as a state function.** Copy `nextPC` into `PC`. This is the transition the
+    old `SegmentPcChain.retire` field asserted; here it is performed. -/
+noncomputable def retirePC
+    (s : PreSail.SequentialState RegisterType Sail.trivialChoiceSource) :
+    PreSail.SequentialState RegisterType Sail.trivialChoiceSource :=
+  match s.regs.get? Register.nextPC with
+  | none => s
+  | some v =>
+      { s with regs := s.regs.insert Register.PC (cast (by simp [RegisterType]) v) }
+
+/-- The post-state of one Sail step, error branches kept total by staying put. -/
+noncomputable def sailStepPost
+    (instr : instruction)
+    (s : PreSail.SequentialState RegisterType Sail.trivialChoiceSource) :
+    PreSail.SequentialState RegisterType Sail.trivialChoiceSource :=
+  match execute_instruction instr s with
+  | .ok _ post => post
+  | .error _ post => post
+
+
+/-- **The trace Sail's semantics generates.** Step `0` is the given initial state; step `j + 1` is
+    the post-state of executing step `j`'s instruction, followed by Sail's retire — copy `nextPC`
+    into `PC`.
+
+    Out-of-range indices stay put, which keeps the recursion total without affecting any index the
+    trace is used at. -/
+noncomputable def chainedSailStates
+    {ziskTrace : AcceptedZiskTrace numInstructions}
+    (ziskStep : ∀ i : Fin ziskTrace.numInstructions, ZiskStep ziskTrace i)
+    (init : PreSail.SequentialState RegisterType Sail.trivialChoiceSource) :
+    ℕ → PreSail.SequentialState RegisterType Sail.trivialChoiceSource
+  | 0 => init
+  | j + 1 =>
+      if h : j < ziskTrace.numInstructions then
+        retirePC (sailStepPost (sailInstructionOf ⟨j, h⟩ (ziskStep ⟨j, h⟩))
+          (chainedSailStates ziskStep init j))
+      else
+        chainedSailStates ziskStep init j
+
+/-- The chained states, packaged as a `SailTrace`. -/
+noncomputable def chainedSailTrace
+    {ziskTrace : AcceptedZiskTrace numInstructions}
+    (ziskStep : ∀ i : Fin ziskTrace.numInstructions, ZiskStep ziskTrace i)
+    (init : PreSail.SequentialState RegisterType Sail.trivialChoiceSource) :
+    SailTrace ziskTrace.numInstructions :=
+  fun i => chainedSailStates ziskStep init i.val
+
+/-- **`retire` holds by construction.** For a chained trace the PC at step `j + 1` *is* the `nextPC`
+    the step at `j` wrote, because `chainedSailStates` performs the copy rather than assuming it.
+
+    This is the whole point of #343. `SegmentPcChain.retire` is a hypothesis precisely because
+    `SailTrace` is an arbitrary family of states; on a trace Sail actually generated there is nothing
+    left to assume. -/
+theorem chainedSailStates_retire
+    {ziskTrace : AcceptedZiskTrace numInstructions}
+    (ziskStep : ∀ i : Fin ziskTrace.numInstructions, ZiskStep ziskTrace i)
+    (init : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
+    (j : ℕ) (h : j < ziskTrace.numInstructions)
+    (v : RegisterType Register.nextPC)
+    (h_next : (sailStepPost (sailInstructionOf ⟨j, h⟩ (ziskStep ⟨j, h⟩))
+        (chainedSailStates ziskStep init j)).regs.get? Register.nextPC = some v) :
+    (chainedSailStates ziskStep init (j + 1)).regs.get? Register.PC
+      = some (cast (by simp [RegisterType]) v) := by
+  rw [chainedSailStates, dif_pos h, retirePC]
+  rw [h_next]
+  simp [Std.ExtDHashMap.get?_insert]
+
+end ZiskFv.Compliance

--- a/ZiskFv/Soundness.lean
+++ b/ZiskFv/Soundness.lean
@@ -167,17 +167,28 @@ theorem stepSound_of_programDecodes
     THE SAIL SIDE IS GENERATED, NOT SUPPLIED (#343). This theorem does not take a
     `SailTrace`. It takes the initial Sail state `init` and builds the trace itself
     with `chainedSailTrace`, which runs `execute_instruction` at each step and then
-    performs Sail's retire (copy `nextPC` into `PC`). Two consequences:
+    performs Sail's retire (copy `nextPC` into `PC`). Three consequences, and the
+    third is a cost:
 
-      * The old `pcChain : SegmentPcChain …` premise is gone. Its `retire` half is now
-        the theorem `chainedSailTrace_retireChain`, applied below; only its `boot` half
-        survives, as `pcBoot`. That is a premise leaving the statement, not a premise
-        being renamed — `sailRetireChain_of_inputsAgree`'s converse no longer applies,
-        because there is nothing left to derive.
+      * The `retire` OBLIGATION left the statement; the binder did not. `pcChain :
+        SegmentPcChain …` was *replaced* by `pcBoot`, which carries only the `boot`
+        equation — the binder count is unchanged (16, per
+        `trust/generated/baseline-strong-export-binders.txt`). What is gone is
+        `SegmentPcChain`'s `retire` field, supplied below by the hypothesis-free
+        theorem `chainedSailTrace_retireChain`. `sailRetireChain_of_inputsAgree`'s
+        converse no longer applies, because there is nothing left to derive.
       * A caller can no longer choose the Sail states. Supplying `init` and then
         `inputsAgree` at `chainedSailTrace ziskStep init` means agreeing with the
         states Sail actually reaches, which is the guardrail #343 asks for: the trace
-        has to be *harder* to inhabit, not merely repackaged.
+        has to be *harder* to inhabit, not merely repackaged. Note that no checked-in
+        witness yet pays that cost — both instantiations run at `numInstructions ≤ 1`,
+        where `chainedSailStates … 0` is `init` by `rfl`, so neither reaches a chain
+        step. See `trust/trusted-base.md`.
+      * This statement is an INSTANCE of the old one, at
+        `sailTrace := chainedSailTrace ziskStep init`. So the edit both drops an
+        obligation and specializes the conclusion: a caller who wants `StepSound` at a
+        trace of their own choosing can no longer get it here. That is the intended
+        direction, but it is a specialization, not a free strengthening.
 
     `stepSound_of_programDecodes` keeps taking a `SailTrace` and a full
     `SegmentPcChain`, because the five multi-step accepted-trace witnesses target it

--- a/ZiskFv/Soundness.lean
+++ b/ZiskFv/Soundness.lean
@@ -1,4 +1,5 @@
 import ZiskFv.Compliance.TraceLevelExport
+import ZiskFv.Compliance.TraceLevelExport.ChainedSailTrace
 import ZiskFv.Compliance.TraceLevelExport.ProgramDecode
 import ZiskFv.Compliance.TraceLevelExport.RawProgramDecode
 
@@ -74,11 +75,14 @@ namespace ZiskFv.Compliance
     content collapses to `boot` alone, the other two premises are each one-sided, and
     `rowsAligned` — which the old `succ` silently did without — is now visible.
 
-    `retire` is irreducible at *this* layer for the same reason `bootSeed` is:
-    `SailTrace` is a bare `Fin n → SailState` (`Compliance/SailTrace.lean`) with no
-    chaining, so *something* must say the Sail states form an execution.  Defining
-    `SailTrace` as the sequence Sail's own semantics generates would make `retire`
-    definitional — a real strength reduction, tracked as #343.
+    `retire` is irreducible at *this* layer because `sailTrace` is an arbitrary
+    `Fin n → SailState` (`Compliance/SailTrace.lean`) with no chaining, so *something*
+    must say the Sail states form an execution.  It is **not** irreducible at the root:
+    `root_soundness` below takes an initial state instead of a trace, generates the
+    trace with `chainedSailTrace`, and obtains `retire` from
+    `chainedSailTrace_retireChain` — a theorem, not a premise (#343).  This layer keeps
+    the trace parametric because the five multi-step accepted-trace witnesses target it
+    directly with hand-built traces.
 
     `bootSeed` is the single named **cross-row memory seed** premise: the segment's
     initial memory state at segment entry, together with the one consistent
@@ -160,6 +164,25 @@ theorem stepSound_of_programDecodes
     #172; and identifying `rawProgram` with the intended compiled binary is the
     external compile/commitment boundary.
 
+    THE SAIL SIDE IS GENERATED, NOT SUPPLIED (#343). This theorem does not take a
+    `SailTrace`. It takes the initial Sail state `init` and builds the trace itself
+    with `chainedSailTrace`, which runs `execute_instruction` at each step and then
+    performs Sail's retire (copy `nextPC` into `PC`). Two consequences:
+
+      * The old `pcChain : SegmentPcChain …` premise is gone. Its `retire` half is now
+        the theorem `chainedSailTrace_retireChain`, applied below; only its `boot` half
+        survives, as `pcBoot`. That is a premise leaving the statement, not a premise
+        being renamed — `sailRetireChain_of_inputsAgree`'s converse no longer applies,
+        because there is nothing left to derive.
+      * A caller can no longer choose the Sail states. Supplying `init` and then
+        `inputsAgree` at `chainedSailTrace ziskStep init` means agreeing with the
+        states Sail actually reaches, which is the guardrail #343 asks for: the trace
+        has to be *harder* to inhabit, not merely repackaged.
+
+    `stepSound_of_programDecodes` keeps taking a `SailTrace` and a full
+    `SegmentPcChain`, because the five multi-step accepted-trace witnesses target it
+    directly with hand-built traces.
+
     NON-VACUITY (#320): witnessed. `addFaithfulPaddedRawRootSoundness`
     (`Compliance/AddFaithfulPaddedRootSoundness.lean`) instantiates this theorem on a
     one-instruction execution with the proved `addFaithfulProgramRowsBinding` and real
@@ -167,13 +190,13 @@ theorem stepSound_of_programDecodes
     `memoryRawRootSoundness` supplies a second real `ProgramRowsBinding`, on an
     empty execution. The other instantiations (`addSpin`, `addAddiSpin`, `divSpin`,
     `jalrSpin`, `sdLdSpin`) discharge the premises this theorem SHARES with
-    `stepSound_of_programDecodes` — `ziskTrace`, `ziskStep`, `inputsAgree`, `pcChain`, `rowsAligned`,
+    `stepSound_of_programDecodes` — `ziskTrace`, `ziskStep`, `inputsAgree`, `rowsAligned`,
     `bootSeed`, `hAvoidKnownBugs` — but satisfy `ProgramDecode` directly, so they
     provide no evidence for `programBinding` / `rawProgramDecodes`. -/
 theorem root_soundness
     (numInstructions rawLength : Nat)
     (ziskTrace : AcceptedZiskTrace numInstructions)
-    (sailTrace : SailTrace numInstructions)
+    (init : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
     (ziskStep : ∀ i : Fin numInstructions, ZiskStep ziskTrace i)
     (start : Fin rawLength → Fin ziskTrace.programLength)
     (addr : Fin rawLength → FGL)
@@ -183,23 +206,28 @@ theorem root_soundness
     (rawProgramDecodes : ∀ i : Fin numInstructions,
       RawProgramDecode ziskTrace i (ziskStep i) start addr rawProgram)
     (inputsAgree : ∀ i : Fin numInstructions,
-      InputsAgreeCore ziskTrace sailTrace i (ziskStep i))
-    (pcChain : SegmentPcChain ziskTrace sailTrace ziskStep)
+      InputsAgreeCore ziskTrace (chainedSailTrace ziskStep init) i (ziskStep i))
+    (pcBoot : ∀ (_ : 0 < numInstructions),
+      ((ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable).pc 0).val
+        = (init.regs.get? Register.PC).elim 0 BitVec.toNat)
     (rowsAligned : StepRowsAligned ziskTrace ziskStep
       (fun i => rowDecode_of_programDecode ziskTrace i
         (programDecode_of_rawProgramDecode ziskTrace i (ziskStep i)
           start addr rawProgram programBinding (rawProgramDecodes i))))
-    (bootSeed : BootSegmentMemorySeed ziskTrace sailTrace ziskStep)
+    (bootSeed : BootSegmentMemorySeed ziskTrace (chainedSailTrace ziskStep init) ziskStep)
     (hAvoidKnownBugs : ∀ i : Fin numInstructions,
       RowOutsideDefectRegion ziskTrace i (ziskStep i)) :
     ∀ i : Fin numInstructions,
-      StepSound ziskTrace sailTrace i (ziskStep i)
+      StepSound ziskTrace (chainedSailTrace ziskStep init) i (ziskStep i)
         (rowDecode_of_programDecode ziskTrace i
           (programDecode_of_rawProgramDecode ziskTrace i (ziskStep i)
             start addr rawProgram programBinding (rawProgramDecodes i))) :=
-  stepSound_of_programDecodes numInstructions ziskTrace sailTrace ziskStep
+  stepSound_of_programDecodes numInstructions ziskTrace (chainedSailTrace ziskStep init) ziskStep
     (fun i => programDecode_of_rawProgramDecode ziskTrace i (ziskStep i)
       start addr rawProgram programBinding (rawProgramDecodes i))
-    inputsAgree pcChain rowsAligned bootSeed hAvoidKnownBugs
+    inputsAgree
+    { toSailRetireChain := chainedSailTrace_retireChain ziskStep init
+      boot := pcBoot }
+    rowsAligned bootSeed hAvoidKnownBugs
 
 end ZiskFv.Compliance

--- a/bin/TrustGate/TypeWalk.lean
+++ b/bin/TrustGate/TypeWalk.lean
@@ -11,9 +11,22 @@ underlying forbidden Name surfaces.
 We avoid `MetaM` reduction here — naive `whnfR`-recursion explodes
 on the deeply-elaborated Sail/circuit types in `equiv_<OP>` binders.
 Instead we do an environment-side static closure: for each const
-appearing in the binder type, if its definition is `abbrev` or has
-`reducible` reducibility hint, we unfold by descending into its
+appearing in the binder type, if the environment reports it
+`@[reducible]` (which `abbrev` sets), we unfold by descending into its
 value's syntactic constants. Bounded by the env's const count.
+
+SCOPE, stated exactly, because the previous wording did not match the
+code and that mismatch cost a review round. The closure follows
+REDUCIBLE definitions only. A forbidden Name reachable from a binder
+type solely through ORDINARY (`semireducible`) definitions is not
+reported. That is deliberate: unfolding ordinary definitions makes the
+walk flag any binder mentioning anything that eventually calls the Sail
+entry points — including a premise that merely talks ABOUT a Sail-
+generated state, which is the opposite of the OUTPUT-EQ leak this
+catalog exists to catch. Direct syntactic occurrences are still caught
+by `gatherConsts` with no unfolding at all, so the aliasing dodge this
+layer was built for (`abbrev S := LeanRV64D.Functions.execute`) remains
+closed. See `trust/trusted-base.md`, "TypeWalk coverage".
 -/
 import Lean
 
@@ -39,15 +52,22 @@ partial def gatherConsts (e : Expr) (acc : NameSet) : NameSet :=
   | _               => acc
 
 /-- True iff this constant should be transparently unfolded for the
-const-closure walk: definitions whose body is itself part of the
-"shape" reviewers see. Catches `abbrev` and `@[reducible] def`. -/
-def shouldUnfold (ci : ConstantInfo) : Bool :=
+const-closure walk: definitions the elaborator itself unfolds at reducible
+transparency, which is exactly what `abbrev` and `@[reducible] def` produce.
+
+We ask the environment for the declaration's reducibility status. Reading
+`ConstantInfo.hints` instead does NOT work: `ReducibilityHints.regular n` carries a
+definition's *height*, which is positive for ordinary `def`s too, so a hints-based
+test unfolds essentially every non-recursive definition. That is far wider than
+this walk's contract — it flags a binder whose only path to a forbidden Name runs
+through ordinary, non-reducible definitions, which is not aliasing and not the
+OUTPUT-EQ class. See the coverage note in `trust/trusted-base.md`. -/
+def shouldUnfold (env : Environment) (declName : Name) (ci : ConstantInfo) : Bool :=
   match ci with
-  | .defnInfo d =>
-    match d.hints with
-    | .abbrev => true
-    | .regular n => n > 0  -- @[reducible] sets a positive depth hint
-    | .opaque => false
+  | .defnInfo _ =>
+    match getReducibilityStatusCore env declName with
+    | .reducible => true
+    | _ => false
   | _ => false
 
 /-- Compute the closure of `init` Names under reducible-definition
@@ -67,7 +87,7 @@ where
         match env.find? n with
         | none => go acc rest visited'
         | some ci =>
-          if shouldUnfold ci then
+          if shouldUnfold env n ci then
             -- Pull defn body's consts into the closure.
             let body := match ci with | .defnInfo d => d.value | _ => default
             let bodyConsts := gatherConsts body {}

--- a/trust/generated/baseline-strong-export-binders.txt
+++ b/trust/generated/baseline-strong-export-binders.txt
@@ -1,16 +1,16 @@
 0 :: numInstructions :: Nat
 1 :: rawLength :: Nat
 2 :: ziskTrace :: ZiskFv.Compliance.AcceptedZiskTrace numInstructions
-3 :: sailTrace :: ZiskFv.Compliance.SailTrace numInstructions
+3 :: init :: PreSail.SequentialState RegisterType Sail.trivialChoiceSource
 4 :: ziskStep :: (i : Fin numInstructions) → ZiskFv.Compliance.ZiskStep ziskTrace i
 5 :: start :: Fin rawLength → Fin ziskTrace.programLength
 6 :: addr :: Fin rawLength → Fin 18446744069414584321
 7 :: rawProgram :: Fin rawLength → BitVec 32
 8 :: programBinding :: ZiskFv.Compliance.RawProgramBinding.ProgramRowsBinding ziskTrace start addr rawProgram
 9 :: rawProgramDecodes :: (i : Fin numInstructions) → ZiskFv.Compliance.RawProgramDecode ziskTrace i (ziskStep i) start addr rawProgram
-10 :: inputsAgree :: (i : Fin numInstructions) → ZiskFv.Compliance.InputsAgreeCore ziskTrace sailTrace i (ziskStep i)
-11 :: pcChain :: ZiskFv.Compliance.SegmentPcChain ziskTrace sailTrace ziskStep
+10 :: inputsAgree :: (i : Fin numInstructions) → ZiskFv.Compliance.InputsAgreeCore ziskTrace (ZiskFv.Compliance.chainedSailTrace ziskStep init) i (ziskStep i)
+11 :: pcBoot :: instLTNat.lt 0 numInstructions → Eq ((ZiskFv.AirsClean.FullEnsemble.mainOfTable ziskTrace.program ziskTrace.mainTable).pc 0).val ((init.regs.get? Register.PC).elim 0 BitVec.toNat)
 12 :: rowsAligned :: ZiskFv.Compliance.StepRowsAligned ziskTrace ziskStep fun i => ZiskFv.Compliance.rowDecode_of_programDecode ziskTrace i (ZiskFv.Compliance.programDecode_of_rawProgramDecode ziskTrace i (ziskStep i) start addr rawProgram programBinding (rawProgramDecodes i))
-13 :: bootSeed :: ZiskFv.Compliance.BootSegmentMemorySeed ziskTrace sailTrace ziskStep
+13 :: bootSeed :: ZiskFv.Compliance.BootSegmentMemorySeed ziskTrace (ZiskFv.Compliance.chainedSailTrace ziskStep init) ziskStep
 14 :: hAvoidKnownBugs :: ∀ (i : Fin numInstructions), ZiskFv.Compliance.RowOutsideDefectRegion ziskTrace i (ziskStep i)
 15 :: i :: Fin numInstructions

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -574,44 +574,102 @@ Sail's own semantics generates, and that it was not done. It is done, at
 which runs `execute_instruction` at each step and then performs Sail's retire —
 copy `nextPC` into `PC`. Consequently:
 
-* **`pcChain : SegmentPcChain …` is no longer a binder of `root_soundness`.** Its
-  `retire` half is supplied inside the theorem by `chainedSailTrace_retireChain`, a
-  theorem with no hypotheses. Its `boot` half survives as the binder `pcBoot`, now
-  stated directly about `init`. The frozen statement snapshot in `ZiskFv/Audit.lean`
-  records the change.
+* **The `retire` obligation left the statement; the binder did not.** State this
+  carefully, because "the `pcChain` binder is gone" reads as a shorter premise list
+  and the audit surface says otherwise. `pcChain : SegmentPcChain …` was *replaced*
+  by `pcBoot`, which carries only the `boot` equation; the binder **count is
+  unchanged** (`trust/generated/baseline-strong-export-binders.txt`, 16 entries
+  before and after). What actually left is `SegmentPcChain`'s `retire` field,
+  supplied inside the theorem by `chainedSailTrace_retireChain`, a theorem with no
+  hypotheses. The frozen statement snapshot in `ZiskFv/Audit.lean` records the shape.
+* **The edit does two things, and both belong on the record.** It drops an
+  obligation, *and* it specializes the conclusion to chained traces: the new
+  statement is an **instance** of the old one, obtained by instantiating `sailTrace`
+  at `chainedSailTrace ziskStep init`. A caller who wants `StepSound` at a trace of
+  their own choosing can no longer get it from this theorem. That is the intended
+  direction — the states are now Sail's, not the caller's — but it is a
+  specialization, not a free strengthening.
 * **The inter-derivability caveat does not rescue the old premise here.**
   `sailRetireChain_of_inputsAgree` derives `retire` from the old per-row bundle; that
   matters when `retire` is something a caller must supply. At the root there is
   nothing to supply, so there is nothing to derive. The caveat still applies to
   `stepSound_of_programDecodes`, which deliberately keeps taking a `SailTrace` and a
   full `SegmentPcChain`.
-* **The guardrail #343 asks for is met.** A caller can no longer choose the Sail
-  states. Supplying `init` and then `inputsAgree` at `chainedSailTrace ziskStep init`
-  means agreeing with the states Sail actually reaches. The trace became harder to
-  inhabit rather than merely repackaged — which is the test that separates this from
-  the Phase 5/6/7 restructurings above.
+* **The guardrail #343 asks for is met at the level of the statement, and NOT yet
+  demonstrated by a witness.** A caller can no longer choose the Sail states:
+  `inputsAgree` is demanded at `chainedSailTrace ziskStep init`. But see
+  "Non-vacuity" below — no checked-in instantiation actually runs a chain step, so
+  "harder to inhabit" is so far a property of the statement rather than something an
+  instantiation has had to pay for.
 
 `retirePC`'s `nextPC`-absent branch **erases** `PC`, so both sides of the retire law
 are `none` there and the law needs no side condition about the 63 `execute` arms.
+That is a coverage cliff, not a soundness hole: every `Inputs_<op>`'s `h_input_pc`
+demands `.some`, so a step leaving `nextPC` unset makes `inputsAgree` unsatisfiable
+from there on — the theorem becomes uninstantiable rather than silently matching
+`.elim 0`'s zero. Nothing is proved about a state that never arises; a real trace
+would simply be lost. Ruling that out is exactly the 63-arm fact the erase branch
+avoids needing.
+
 Nothing was added to the trust boundary: the new declarations close over
 `[propext, Classical.choice, Quot.sound]`, and the ones mentioning `execute_instruction`
 close over the pre-existing Sail base (`cancel_reservation`, `riscv_f*`, …) that the
 endpoint already carried.
 
-**Non-vacuity.** `root_soundness` has exactly two instantiations, and both were
-migrated with it: `addFaithfulPaddedRawRootSoundness` (one instruction) and
-`memoryRawRootSoundness` (empty execution). Each now supplies an initial state, and
-`addFaithfulSailTrace` is the generated trace rather than a hand-written family of
-states. Their axiom closures are unchanged. The other five witnesses
-(`addSpin`, `addAddiSpin`, `divSpin`, `jalrSpin`, `sdLdSpin`) target
-`stepSound_of_programDecodes`, keep their hand-built traces, and still build `retire`
-through `sailRetireChain_of_inputsAgree` — no witness evaluates a Sail execution by
-hand. Migrating those five means deriving each hand-written state by running Sail,
-which is real work and is not claimed here.
+**Non-vacuity — and the limit on it, stated plainly.** `root_soundness` has exactly
+two instantiations, and both were migrated with it: `addFaithfulPaddedRawRootSoundness`
+(`numInstructions = 1`) and `memoryRawRootSoundness` (`numInstructions = 0`). Each now
+supplies an initial state, and `addFaithfulSailTrace` is the generated trace rather
+than a hand-written family of states. Their axiom closures are unchanged.
+
+**No checked-in witness reaches index `≥ 1`.** `chainedSailStates … 0` is `init` by
+`rfl`, so at `n ≤ 1` the only state either witness ever names is its own initial
+state. `addFaithfulInputsAgree` is therefore textually unchanged by the migration —
+only `addFaithfulInputsAgreeCore` moved, and only by gaining `noncomputable`.
+Consequently `retirePC` and `sailStepPost` are **never applied** anywhere in the
+checked-in tree, and `chainedSailTrace_retireChain` is proved but never *used* by a
+witness. The premise reduction is real regardless, being a fact about the statement;
+what is not yet shown is an instantiation that had to run Sail to satisfy
+`inputsAgree`.
+
+The other five witnesses (`addSpin`, `addAddiSpin`, `divSpin`, `jalrSpin`, `sdLdSpin`)
+target `stepSound_of_programDecodes`, keep their hand-built traces, and still build
+`retire` through `sailRetireChain_of_inputsAgree`. Migrating them — 13 chain steps —
+is what would exercise the chain, and it is not claimed here.
 
 **Scope of what #343 did NOT change.** `stepSound_of_programDecodes` keeps its
 signature, so the register fields and every other per-row premise are untouched. The
-reduction is one premise, at one theorem.
+reduction is one obligation, at one theorem.
+
+### TypeWalk coverage — deliberate narrowing, #343
+
+`bin/TrustGate/TypeWalk.lean`'s `shouldUnfold` decided which definitions the
+forbidden-Name closure walks through. It tested `ConstantInfo.hints`, treating
+`ReducibilityHints.regular n` with `n > 0` as "reducible". That is wrong: `regular n`
+carries a definition's *height*, which is positive for ordinary `def`s too, so the
+walk unfolded essentially **every** non-recursive definition — far wider than the
+module's documented contract ("`abbrev` / `@[reducible] def` chains") and wider than
+the OUTPUT-EQ policy it serves.
+
+It now asks the environment via `getReducibilityStatusCore` and unfolds only genuinely
+`@[reducible]` declarations. Both docstrings were corrected; the stated/actual gap is
+what turned an implementation bug into an apparent policy question.
+
+**This is a coverage reduction, recorded as such.** Measured, not asserted:
+
+| declaration | status | walk |
+|---|---|---|
+| `abbrev SneakySpec := LeanRV64D.Functions.execute` | reducible | unfolds — **dodge still closed** |
+| `def SneakyOrdinary := LeanRV64D.Functions.execute` | semireducible | stops — **newly missed** |
+| `ZiskFv.Compliance.SailTrace` (`abbrev`) | reducible | unfolds |
+| `chainedSailTrace` / `chainedSailStates` | semireducible | stops |
+
+So the aliasing dodge the V2 layer was built for (`abbrev S := <forbidden>`) remains
+closed, and direct syntactic occurrences never needed unfolding at all. What is newly
+missed is an *ordinary-`def`* alias of a Sail entry point used in a binder type. No
+past result is invalidated: the old behaviour over-flagged, never under-flagged.
+`trust/forbidden-types.txt` is untouched, and check 2 still passes on all 63
+canonical `equiv_<OP>` theorems.
 
 **Scope.** The PC arm only. The register fields (`h_a_*_t` / `h_b_*_t`, 116
 occurrences) stay assumed; they go through the MemBus and are the separate

--- a/trust/trusted-base.md
+++ b/trust/trusted-base.md
@@ -563,20 +563,55 @@ What it does change, and why the change is worth having:
   It binds only at steps that have a successor, so a trailing unaligned JALR — the
   shape `jalrSpinRootSoundness` uses — discharges it vacuously.
 
-**What would be a real strength reduction, and is not done.** `SailTrace` is a bare
-`Fin n → SailState` (`ZiskFv/Compliance/SailTrace.lean`) with no chaining, so
-*something* must say the Sail states form an execution — exactly the reason
-`bootSeed` is irreducible at the single-segment level. Defining `SailTrace` as the
-sequence Sail's own semantics generates from an initial state would make `retire`
-definitional and leave `boot` alone. That is a change to a protected interface used
-by all 63 arms, and it remains the open #330 follow-on.
+**The strength reduction, now done at the root — #343.** The paragraph that used to
+sit here said a real reduction would come from defining the trace as the sequence
+Sail's own semantics generates, and that it was not done. It is done, at
+`root_soundness`.
 
-**Non-vacuity.** All seven accepted-trace witnesses supply both binders and still
-instantiate `root_soundness` / `stepSound_of_programDecodes`. They build `retire`
-through `sailRetireChain_of_inputsAgree` from the per-row `InputsAgree` family they
-already prove — no witness evaluates a Sail execution by hand. The
-empty-execution memory witness and the degenerate probe get vacuous ones, as their
-`bootSeed`s already are.
+`root_soundness` no longer takes a `SailTrace` at all. It takes
+`init : PreSail.SequentialState …` and builds the trace itself with
+`chainedSailTrace` (`ZiskFv/Compliance/TraceLevelExport/ChainedSailTrace.lean`),
+which runs `execute_instruction` at each step and then performs Sail's retire —
+copy `nextPC` into `PC`. Consequently:
+
+* **`pcChain : SegmentPcChain …` is no longer a binder of `root_soundness`.** Its
+  `retire` half is supplied inside the theorem by `chainedSailTrace_retireChain`, a
+  theorem with no hypotheses. Its `boot` half survives as the binder `pcBoot`, now
+  stated directly about `init`. The frozen statement snapshot in `ZiskFv/Audit.lean`
+  records the change.
+* **The inter-derivability caveat does not rescue the old premise here.**
+  `sailRetireChain_of_inputsAgree` derives `retire` from the old per-row bundle; that
+  matters when `retire` is something a caller must supply. At the root there is
+  nothing to supply, so there is nothing to derive. The caveat still applies to
+  `stepSound_of_programDecodes`, which deliberately keeps taking a `SailTrace` and a
+  full `SegmentPcChain`.
+* **The guardrail #343 asks for is met.** A caller can no longer choose the Sail
+  states. Supplying `init` and then `inputsAgree` at `chainedSailTrace ziskStep init`
+  means agreeing with the states Sail actually reaches. The trace became harder to
+  inhabit rather than merely repackaged — which is the test that separates this from
+  the Phase 5/6/7 restructurings above.
+
+`retirePC`'s `nextPC`-absent branch **erases** `PC`, so both sides of the retire law
+are `none` there and the law needs no side condition about the 63 `execute` arms.
+Nothing was added to the trust boundary: the new declarations close over
+`[propext, Classical.choice, Quot.sound]`, and the ones mentioning `execute_instruction`
+close over the pre-existing Sail base (`cancel_reservation`, `riscv_f*`, …) that the
+endpoint already carried.
+
+**Non-vacuity.** `root_soundness` has exactly two instantiations, and both were
+migrated with it: `addFaithfulPaddedRawRootSoundness` (one instruction) and
+`memoryRawRootSoundness` (empty execution). Each now supplies an initial state, and
+`addFaithfulSailTrace` is the generated trace rather than a hand-written family of
+states. Their axiom closures are unchanged. The other five witnesses
+(`addSpin`, `addAddiSpin`, `divSpin`, `jalrSpin`, `sdLdSpin`) target
+`stepSound_of_programDecodes`, keep their hand-built traces, and still build `retire`
+through `sailRetireChain_of_inputsAgree` — no witness evaluates a Sail execution by
+hand. Migrating those five means deriving each hand-written state by running Sail,
+which is real work and is not claimed here.
+
+**Scope of what #343 did NOT change.** `stepSound_of_programDecodes` keeps its
+signature, so the register fields and every other per-row premise are untouched. The
+reduction is one premise, at one theorem.
 
 **Scope.** The PC arm only. The register fields (`h_a_*_t` / `h_b_*_t`, 116
 occurrences) stay assumed; they go through the MemBus and are the separate


### PR DESCRIPTION
Closes #343.

`root_soundness` no longer takes a `SailTrace`. It takes the initial Sail state and generates the
trace itself, so the `retire` obligation stops being a premise.

**This is the first proof obligation to actually leave `root_soundness` on the #330 line.** Phases 5,
6 and 7 were restructurings — each traded one caller-supplied premise for another of the same
strength, and `SailRetireChain.lean:789` says so on the record.

## What changed

```diff
-    (sailTrace : SailTrace numInstructions)
+    (init : PreSail.SequentialState RegisterType Sail.trivialChoiceSource)
...
-    (pcChain : SegmentPcChain ziskTrace sailTrace ziskStep)
+    (pcBoot : ∀ (_ : 0 < numInstructions),
+      ((mainOfTable ziskTrace.program ziskTrace.mainTable).pc 0).val
+        = (init.regs.get? Register.PC).elim 0 BitVec.toNat)
```

`chainedSailTrace` runs `execute_instruction` at each step and then performs Sail's retire — copy
`nextPC` into `PC`. `SegmentPcChain`'s `retire` field is supplied inside the theorem by
`chainedSailTrace_retireChain`, which takes **no hypothesis**.

**Be precise about what left.** The binder *count* is unchanged at 16: `pcChain` was **replaced** by
`pcBoot`, not removed. What left is `SegmentPcChain`'s `retire` field. And the edit does two things —
it drops that obligation *and* specializes the conclusion, since the new statement is an **instance**
of the old one at `sailTrace := chainedSailTrace ziskStep init`. A caller who wants `StepSound` at a
trace of their own choosing can no longer get it here. That is the intended direction; it is a
specialization, not a free strengthening.

One detail that made `retire` unconditional: `retirePC`'s `nextPC`-absent branch **erases** `PC`, so
both sides of the law are `none` there. Writing it the obvious way instead leaves a side condition
that would need a fact about all 63 `execute` arms. That is a coverage cliff, not a soundness hole —
`h_input_pc` demands `.some`, so an erased `PC` makes `inputsAgree` unsatisfiable rather than
silently matching `.elim 0`'s zero.

## Why this is a reduction and not another restructure

`sailRetireChain_of_inputsAgree` derives `retire` from the old per-row bundle. That converse is
exactly what made Phase 7 inter-derivable with what it replaced, and it needs `retire` to be
something a caller supplies. At the root there is nothing to supply, so there is nothing to derive.

## No witness exercises a chain step — stated, not buried

Both instantiations run at `numInstructions ≤ 1`, and `chainedSailStates … 0` is `init` by `rfl`, so
index `0` is the caller's own state. `addFaithfulInputsAgree` is textually unchanged by this PR —
only `addFaithfulInputsAgreeCore` moved, and only by gaining `noncomputable`. So **`retirePC` and
`sailStepPost` are never applied anywhere in the tree, and `chainedSailTrace_retireChain` is proved
but never used by a witness.**

The premise reduction holds regardless — it is a fact about the statement. What is *not* yet shown is
an instantiation that had to run Sail to satisfy `inputsAgree`, i.e. #343's "harder to inhabit"
guardrail demonstrated rather than argued. This is now said in both `ChainedSailTrace.lean` and
`trust/trusted-base.md`, next to the reduction claim rather than in a separate paragraph.

## The scope claim in #343 was wrong

#343 says `SailTrace` is referenced by all 63 `StepSound` arms, every `Inputs_<op>`, and all 7
witnesses, and therefore needs sign-off before starting. Against the tree:

- `InputsAgreeCore` and `StepSoundWithoutDecode` take `sailTrace` as a **parameter** and only ever
  use `sailTrace i`. The 63 arms need no edit. There are 11 `sailTrace` binder sites in total, 8 of
  them in `Dispatcher.lean`.
- Only **2** of the 7 witnesses instantiate `root_soundness`, at `n = 1` and `n = 0`. The other 5
  target `stepSound_of_programDecodes`, which deliberately keeps its signature and is untouched.

I asserted the larger figure from the issue body rather than the tree, and it is the reason this work
looked infeasible for longer than it was.

## What this does **not** do

`stepSound_of_programDecodes` still takes a `SailTrace` and a full `SegmentPcChain`. The five
multi-step witnesses (`addSpin`, `addAddiSpin`, `divSpin`, `jalrSpin`, `sdLdSpin`) keep their
hand-written state families. Migrating them means deriving each state by running Sail — 13 chain
steps — and that is what would exercise the chain. Not claimed here. The route, if picked up, is not
brute-force reduction of Sail's `execute`: the `Dispatch/` equivalences already give
`execute_instruction … = state_effect_via_channels …`, so the post-state is computable from each
witness's own bus rows via `nextPC_of_busEffect_ok` and `RegisterWriteback`'s projections.

## V2 check 6 was an implementation bug in the gate, not a policy question

The first push had check 6 failing on the two binders that mention `chainedSailTrace`. I proposed a
carve-out. **That was the wrong fix, and the review was right to reject it.**

`bin/TrustGate/TypeWalk.lean`'s `shouldUnfold` tested `ConstantInfo.hints`, treating
`ReducibilityHints.regular n` with `n > 0` as reducible. `regular n` carries a definition's *height*,
which is positive for ordinary `def`s too — so the walk unfolded essentially **every** non-recursive
definition, far wider than the module's documented contract (*"`abbrev` / `@[reducible] def`
chains"*). It now asks `getReducibilityStatusCore`. Both binders clear with
`trust/forbidden-types.txt` **untouched**, and check 2 still passes on all 63 canonical `equiv_<OP>`
theorems.

This is a coverage reduction, and it is recorded as one in `trust/trusted-base.md` ("TypeWalk
coverage"). The boundary is measured, not asserted:

| declaration | status | walk |
|---|---|---|
| `abbrev SneakySpec := LeanRV64D.Functions.execute` | reducible | unfolds — **dodge still closed** |
| `def SneakyOrdinary := LeanRV64D.Functions.execute` | semireducible | stops — **newly missed** |
| `ZiskFv.Compliance.SailTrace` (`abbrev`) | reducible | unfolds |
| `chainedSailTrace` / `chainedSailStates` | semireducible | stops |

So the aliasing dodge this layer exists to close stays closed, and direct syntactic occurrences never
needed unfolding at all. What is newly missed is an *ordinary-`def`* alias of a Sail entry point in a
binder type. The old behaviour over-flagged and never under-flagged, so no past result is
invalidated. Both docstrings were corrected — the gap between stated and actual behaviour is what
turned a bug into an apparent policy question.

`/bin/TrustGate/` and `/trust/trusted-base.md` are both CODEOWNER-protected, so this needs your ack
even though the gate is now green.

## Trust boundary

No new `axiom`, `opaque`, `sorry`, `native_decide`, or any other trust marker. No allowlist edit, and
`trust/forbidden-types.txt` is unchanged.

The new declarations close over `[propext, Classical.choice, Quot.sound]`; those mentioning
`execute_instruction` close over the pre-existing Sail base (`cancel_reservation`, `riscv_f*`, …)
that the endpoint already carried. Both witness axiom closures are unchanged.

Frozen artefacts changed **together with** the declaration, as the trust workflow requires:

- `ZiskFv/Audit.lean` — the `#guard_msgs` statement snapshot;
- `trust/generated/baseline-strong-export-binders.txt` — regenerated (16 entries, before and after);
- `trust/trusted-base.md` — the PC-arm section, whose paragraph headed *"What would be a real
  strength reduction, and is not done"* described precisely this change, plus the new "TypeWalk
  coverage" note.

## Verification

`lake build` **9166 green**, V1 **20/20**, V2 **20/20**. Logs in the comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
