### PR TITLE
chore: clear the mechanical lake build warnings (948 -> 137)

### DIFF
--- a/ZiskFv/AirsClean/FullEnsemble/Balance/Classification.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/Classification.lean
@@ -770,10 +770,7 @@ theorem memAlignReadByte_table_interactionsWith_registerStepRange_nil
   have h_not :
       ZiskFv.Channels.SpecifiedRanges.RegisterStepRangeChannel.toRaw ∉ ZiskFv.AirsClean.MemAlignReadByte.component.circuit.channels := by
     simp [circuit_norm, ZiskFv.AirsClean.MemAlignReadByte.component, ZiskFv.AirsClean.MemAlignReadByte.circuit,
-      ZiskFv.Channels.SpecifiedRanges.RegisterStepRangeChannel, MemBusChannel, OpBusChannel,
-      ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel,
-      ZiskFv.Channels.MemAlignRom.MemAlignRomChannel,
-      ZiskFv.Channels.SpecifiedRanges.SpecifiedRangesSliceChannel]
+      ZiskFv.Channels.SpecifiedRanges.RegisterStepRangeChannel, MemBusChannel]
   apply Table.interactionsWith_nil_of_channel_not_mem
   rw [h_component]
   exact h_not
@@ -786,10 +783,7 @@ theorem memAlignByte_table_interactionsWith_registerStepRange_nil
   have h_not :
       ZiskFv.Channels.SpecifiedRanges.RegisterStepRangeChannel.toRaw ∉ ZiskFv.AirsClean.MemAlignByte.component.circuit.channels := by
     simp [circuit_norm, ZiskFv.AirsClean.MemAlignByte.component, ZiskFv.AirsClean.MemAlignByte.circuit,
-      ZiskFv.Channels.SpecifiedRanges.RegisterStepRangeChannel, MemBusChannel, OpBusChannel,
-      ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel,
-      ZiskFv.Channels.MemAlignRom.MemAlignRomChannel,
-      ZiskFv.Channels.SpecifiedRanges.SpecifiedRangesSliceChannel]
+      ZiskFv.Channels.SpecifiedRanges.RegisterStepRangeChannel, MemBusChannel]
   apply Table.interactionsWith_nil_of_channel_not_mem
   rw [h_component]
   exact h_not
@@ -830,10 +824,8 @@ theorem memAlignRangeSlice_table_interactionsWith_registerStepRange_nil
   have h_not :
       ZiskFv.Channels.SpecifiedRanges.RegisterStepRangeChannel.toRaw ∉ ZiskFv.AirsClean.MemAlignRangeSlice.component.circuit.channels := by
     simp [circuit_norm, ZiskFv.AirsClean.MemAlignRangeSlice.component, ZiskFv.AirsClean.MemAlignRangeSlice.circuit,
-      ZiskFv.Channels.SpecifiedRanges.RegisterStepRangeChannel, MemBusChannel, OpBusChannel,
-      ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel,
-      ZiskFv.Channels.MemAlignRom.MemAlignRomChannel,
-      ZiskFv.Channels.SpecifiedRanges.SpecifiedRangesSliceChannel]
+      ZiskFv.Channels.SpecifiedRanges.RegisterStepRangeChannel,
+      ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel]
   apply Table.interactionsWith_nil_of_channel_not_mem
   rw [h_component]
   exact h_not
@@ -846,10 +838,8 @@ theorem memAlignRomSlice_table_interactionsWith_registerStepRange_nil
   have h_not :
       ZiskFv.Channels.SpecifiedRanges.RegisterStepRangeChannel.toRaw ∉ ZiskFv.AirsClean.MemAlignRomSlice.component.circuit.channels := by
     simp [circuit_norm, ZiskFv.AirsClean.MemAlignRomSlice.component, ZiskFv.AirsClean.MemAlignRomSlice.circuit,
-      ZiskFv.Channels.SpecifiedRanges.RegisterStepRangeChannel, MemBusChannel, OpBusChannel,
-      ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel,
-      ZiskFv.Channels.MemAlignRom.MemAlignRomChannel,
-      ZiskFv.Channels.SpecifiedRanges.SpecifiedRangesSliceChannel]
+      ZiskFv.Channels.SpecifiedRanges.RegisterStepRangeChannel,
+      ZiskFv.Channels.MemAlignRom.MemAlignRomChannel]
   apply Table.interactionsWith_nil_of_channel_not_mem
   rw [h_component]
   exact h_not
@@ -862,9 +852,7 @@ theorem specifiedRangesSlice_table_interactionsWith_registerStepRange_nil
   have h_not :
       ZiskFv.Channels.SpecifiedRanges.RegisterStepRangeChannel.toRaw ∉ ZiskFv.AirsClean.SpecifiedRangesSlice.component.circuit.channels := by
     simp [circuit_norm, ZiskFv.AirsClean.SpecifiedRangesSlice.component, ZiskFv.AirsClean.SpecifiedRangesSlice.circuit,
-      ZiskFv.Channels.SpecifiedRanges.RegisterStepRangeChannel, MemBusChannel, OpBusChannel,
-      ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel,
-      ZiskFv.Channels.MemAlignRom.MemAlignRomChannel,
+      ZiskFv.Channels.SpecifiedRanges.RegisterStepRangeChannel,
       ZiskFv.Channels.SpecifiedRanges.SpecifiedRangesSliceChannel]
   apply Table.interactionsWith_nil_of_channel_not_mem
   rw [h_component]
@@ -878,10 +866,7 @@ theorem arithDiv_table_interactionsWith_registerStepRange_nil
   have h_not :
       ZiskFv.Channels.SpecifiedRanges.RegisterStepRangeChannel.toRaw ∉ ZiskFv.AirsClean.ArithDiv.component.circuit.channels := by
     simp [circuit_norm, ZiskFv.AirsClean.ArithDiv.component, ZiskFv.AirsClean.ArithDiv.circuit,
-      ZiskFv.Channels.SpecifiedRanges.RegisterStepRangeChannel, MemBusChannel, OpBusChannel,
-      ZiskFv.Channels.MemAlignRanges.MemAlignRangeChannel,
-      ZiskFv.Channels.MemAlignRom.MemAlignRomChannel,
-      ZiskFv.Channels.SpecifiedRanges.SpecifiedRangesSliceChannel]
+      ZiskFv.Channels.SpecifiedRanges.RegisterStepRangeChannel]
   apply Table.interactionsWith_nil_of_channel_not_mem
   rw [h_component]
   exact h_not

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusRowBridges.lean
@@ -3469,7 +3469,7 @@ private lemma main_rowInput_a_src_reg_eval
   simp only [ProvableStruct.eval_eq_eval, ProvableStruct.eval,
     ProvableStruct.fromComponents, ProvableStruct.components,
     ProvableStruct.toComponents, ProvableStruct.eval.go,
-    ProvableType.eval_field, Expression.eval]
+    ProvableType.eval_field]
 
 private lemma main_rowInput_b_src_reg_eval
     (env : Environment FGL) (row : Var ZiskFv.AirsClean.Main.MainRowWithRom FGL) :
@@ -3477,7 +3477,7 @@ private lemma main_rowInput_b_src_reg_eval
   simp only [ProvableStruct.eval_eq_eval, ProvableStruct.eval,
     ProvableStruct.fromComponents, ProvableStruct.components,
     ProvableStruct.toComponents, ProvableStruct.eval.go,
-    ProvableType.eval_field, Expression.eval]
+    ProvableType.eval_field]
 
 private lemma main_rowInput_store_reg_eval
     (env : Environment FGL) (row : Var ZiskFv.AirsClean.Main.MainRowWithRom FGL) :
@@ -3485,7 +3485,7 @@ private lemma main_rowInput_store_reg_eval
   simp only [ProvableStruct.eval_eq_eval, ProvableStruct.eval,
     ProvableStruct.fromComponents, ProvableStruct.components,
     ProvableStruct.toComponents, ProvableStruct.eval.go,
-    ProvableType.eval_field, Expression.eval]
+    ProvableType.eval_field]
 
 /-- A boolean column is `0` or `1`. -/
 private lemma zero_or_one_of_booleanity {col : FGL} (h : col * (1 - col) = 0) :

--- a/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusSourceExclusivity.lean
+++ b/ZiskFv/AirsClean/FullEnsemble/Balance/MemBusSourceExclusivity.lean
@@ -77,7 +77,7 @@ theorem main_rom_eval
     simp only [ProvableStruct.eval_eq_eval, ProvableStruct.eval,
       ProvableStruct.fromComponents, ProvableStruct.components,
       ProvableStruct.toComponents, ProvableStruct.eval.go,
-      ProvableType.eval_field, Expression.eval]
+      ProvableType.eval_field]
 
 /-! ## Main's three current accesses, at `mem_op = 4`
 

--- a/ZiskFv/AirsClean/RegisterBoundary.lean
+++ b/ZiskFv/AirsClean/RegisterBoundary.lean
@@ -223,7 +223,7 @@ theorem eval_rawRow_materialize_reg (index : Nat) (data : ProverData FGL)
   simp_all [registerBoundaryFixedColumns, IndexedFixedColumns.materialize,
     IndexedFixedColumns.fixedAt, registerBoundaryFixedLayout, registerBoundaryFixedValues,
     rawRow, Environment.fromArray, ProvableStruct.eval_eq_eval, ProvableStruct.eval,
-    ProvableStruct.varFromOffset_eq_varFromOffset, ProvableType.eval_field,
+    ProvableStruct.varFromOffset_eq_varFromOffset,
     ProvableStruct.varFromOffset, ProvableStruct.fromComponents, ProvableStruct.components,
     ProvableStruct.toComponents, ProvableStruct.eval.go, Expression.eval,
     ProvableStruct.varFromOffset.go, explicit_provable_type, circuit_norm]
@@ -285,11 +285,11 @@ theorem reg_of_materialize (index : Nat) (raw : Array FGL) (data : ProverData FG
       (Environment.fromArray (registerBoundaryFixedColumns.materialize index raw) data)
       component.rowInputVar).reg
       = registerBoundaryFixedColumns.fixedAt 0 index := by
-  simp [Air.Flat.Component.rowInputVar, component,
+  simp [Air.Flat.Component.rowInputVar,
     registerBoundaryFixedColumns, IndexedFixedColumns.materialize,
     registerBoundaryFixedLayout, Environment.fromArray,
     ProvableStruct.eval_eq_eval, ProvableStruct.eval,
-    ProvableStruct.varFromOffset_eq_varFromOffset, ProvableType.eval_field,
+    ProvableStruct.varFromOffset_eq_varFromOffset,
     ProvableStruct.varFromOffset, ProvableStruct.fromComponents, ProvableStruct.components,
     ProvableStruct.toComponents, ProvableStruct.eval.go, Expression.eval,
     ProvableStruct.varFromOffset.go, explicit_provable_type, circuit_norm]

--- a/ZiskFv/Bits/PackedBitVec/SignedChunkLift.lean
+++ b/ZiskFv/Bits/PackedBitVec/SignedChunkLift.lean
@@ -2245,7 +2245,7 @@ lemma abs_euclidean_to_signed_euclidean_div_rem_zero_quotient_exception
     rcases h_nr_pin with hpin | hD
   all_goals try norm_num at hpin
   all_goals try subst D
-  all_goals norm_num at h_chain ⊢ <;> nlinarith
+  all_goals norm_num at h_chain ⊢ ; nlinarith
 
 /-! ## Part 9.W — Abs-Euclidean → signed-Euclidean linker (DIVW / REMW)
 

--- a/ZiskFv/Compliance/AddAddiSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/AddAddiSpinRootSoundness.lean
@@ -633,8 +633,8 @@ def addAddiSpinLaneBridge : ∀ i : Fin 3,
     all_goals
       rw [addAddiSpinAcceptedTrace_mainTable_eq, addAddiSpinAcceptedTrace_program,
         addAddiSpinMainRowAt_two] at hsrc
-      simp [addAddiSpinJalIndex, addAddiSpinJalRow, addSpinJalRow,
-        addSpinJalFreeCols, addAddiSpinJalProgramRow, addSpinJalBits,
+      simp [addAddiSpinJalRow, addSpinJalRow,
+        addSpinJalBits,
         ZiskFv.AirsClean.Main.mainRomRowOf] at hsrc
 
 /-- The two root PC premises for this witness: boot agreement, and the Sail-internal retire law.

--- a/ZiskFv/Compliance/AddAddiSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/AddAddiSpinRootSoundness.lean
@@ -139,7 +139,7 @@ private theorem addAddiSpinMainPc_addi :
   change (ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinProgram
       addAddiSpinMainTable).pc 1 = 4
   simp [addAddiSpinMainRowAt_one, addAddiSpinAddiRow, addAddiSpinAddiProgramRow,
-    addAddiSpinAddiBits, addAddiSpinAddiFreeCols, ZiskFv.AirsClean.Main.mainRomRowOf]
+    addAddiSpinAddiBits, ZiskFv.AirsClean.Main.mainRomRowOf]
 
 private theorem addAddiSpinMainPc_jal :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinAcceptedTrace.program
@@ -438,7 +438,7 @@ def addAddiSpinAddiInputs :
     change ((ZiskFv.AirsClean.FullEnsemble.mainOfTable addAddiSpinProgram
       addAddiSpinMainTable).pc 1).val = _
     simp [addAddiSpinMainRowAt_one, addAddiSpinAddiRow, addAddiSpinAddiProgramRow,
-      addAddiSpinAddiBits, addAddiSpinAddiFreeCols,
+      addAddiSpinAddiBits,
       ZiskFv.AirsClean.Main.mainRomRowOf, addAddiSpinAddiInput]
 
 def addAddiSpinJalInputs :
@@ -559,7 +559,7 @@ def addAddiSpinLaneBridge : ∀ i : Fin 3,
         rw [addAddiSpinAcceptedTrace_mainTable_eq, addAddiSpinAcceptedTrace_program] at hoff
         rw [addAddiSpinMainRowAt_zero] at hoff
         fin_cases r <;> simp [addAddiSpinAddRow, addX1Row,
-          Transpiler.wrap_to_regidx, Transpiler.regidxOfBitVec5, x1, regidx_to_fin] at hoff ⊢
+          Transpiler.wrap_to_regidx, x1, regidx_to_fin] at hoff ⊢
       rw [hre]
       simpa [addAddiSpinAddIndex] using addAddiSpinLaneLo addAddiSpinAddIndex
         (fun m i => m.a_0 i) (by simp [addAddiSpinAddIndex, addAddiSpinMainRowAt_zero,
@@ -569,7 +569,7 @@ def addAddiSpinLaneBridge : ∀ i : Fin 3,
         rw [addAddiSpinAcceptedTrace_mainTable_eq, addAddiSpinAcceptedTrace_program] at hoff
         rw [addAddiSpinMainRowAt_zero] at hoff
         fin_cases r <;> simp [addAddiSpinAddRow, addX1Row,
-          Transpiler.wrap_to_regidx, Transpiler.regidxOfBitVec5, x1, regidx_to_fin] at hoff ⊢
+          Transpiler.wrap_to_regidx, x1, regidx_to_fin] at hoff ⊢
       rw [hre]
       simpa [addAddiSpinAddIndex] using addAddiSpinLaneHi addAddiSpinAddIndex
         (fun m i => m.a_1 i) (by simp [addAddiSpinAddIndex, addAddiSpinMainRowAt_zero,
@@ -579,7 +579,7 @@ def addAddiSpinLaneBridge : ∀ i : Fin 3,
         rw [addAddiSpinAcceptedTrace_mainTable_eq, addAddiSpinAcceptedTrace_program] at hoff
         rw [addAddiSpinMainRowAt_zero] at hoff
         fin_cases r <;> simp [addAddiSpinAddRow, addX1Row,
-          Transpiler.wrap_to_regidx, Transpiler.regidxOfBitVec5, x1, regidx_to_fin] at hoff ⊢
+          Transpiler.wrap_to_regidx, x1, regidx_to_fin] at hoff ⊢
       rw [hre]
       simpa [addAddiSpinAddIndex] using addAddiSpinLaneLo addAddiSpinAddIndex
         (fun m i => m.b_0 i) (by simp [addAddiSpinAddIndex, addAddiSpinMainRowAt_zero,
@@ -589,7 +589,7 @@ def addAddiSpinLaneBridge : ∀ i : Fin 3,
         rw [addAddiSpinAcceptedTrace_mainTable_eq, addAddiSpinAcceptedTrace_program] at hoff
         rw [addAddiSpinMainRowAt_zero] at hoff
         fin_cases r <;> simp [addAddiSpinAddRow, addX1Row,
-          Transpiler.wrap_to_regidx, Transpiler.regidxOfBitVec5, x1, regidx_to_fin] at hoff ⊢
+          Transpiler.wrap_to_regidx, x1, regidx_to_fin] at hoff ⊢
       rw [hre]
       simpa [addAddiSpinAddIndex] using addAddiSpinLaneHi addAddiSpinAddIndex
         (fun m i => m.b_1 i) (by simp [addAddiSpinAddIndex, addAddiSpinMainRowAt_zero,
@@ -601,7 +601,7 @@ def addAddiSpinLaneBridge : ∀ i : Fin 3,
         rw [addAddiSpinMainRowAt_one] at hoff
         fin_cases r <;> simp [addAddiSpinAddiRow, addAddiSpinAddiProgramRow,
           addAddiSpinAddiBits, ZiskFv.AirsClean.Main.mainRomRowOf,
-          Transpiler.wrap_to_regidx, Transpiler.regidxOfBitVec5, x1, regidx_to_fin] at hoff ⊢
+          Transpiler.wrap_to_regidx, x1, regidx_to_fin] at hoff ⊢
       rw [hre]
       simpa [addAddiSpinAddiIndex] using addAddiSpinLaneLo addAddiSpinAddiIndex
         (fun m i => m.a_0 i) (by simp [addAddiSpinAddiIndex, addAddiSpinMainRowAt_one,
@@ -613,7 +613,7 @@ def addAddiSpinLaneBridge : ∀ i : Fin 3,
         rw [addAddiSpinMainRowAt_one] at hoff
         fin_cases r <;> simp [addAddiSpinAddiRow, addAddiSpinAddiProgramRow,
           addAddiSpinAddiBits, ZiskFv.AirsClean.Main.mainRomRowOf,
-          Transpiler.wrap_to_regidx, Transpiler.regidxOfBitVec5, x1, regidx_to_fin] at hoff ⊢
+          Transpiler.wrap_to_regidx, x1, regidx_to_fin] at hoff ⊢
       rw [hre]
       simpa [addAddiSpinAddiIndex] using addAddiSpinLaneHi addAddiSpinAddiIndex
         (fun m i => m.a_1 i) (by simp [addAddiSpinAddiIndex, addAddiSpinMainRowAt_one,
@@ -633,9 +633,9 @@ def addAddiSpinLaneBridge : ∀ i : Fin 3,
     all_goals
       rw [addAddiSpinAcceptedTrace_mainTable_eq, addAddiSpinAcceptedTrace_program,
         addAddiSpinMainRowAt_two] at hsrc
-      simpa [addAddiSpinJalIndex, addAddiSpinJalRow, addSpinJalRow,
+      simp [addAddiSpinJalIndex, addAddiSpinJalRow, addSpinJalRow,
         addSpinJalFreeCols, addAddiSpinJalProgramRow, addSpinJalBits,
-        ZiskFv.AirsClean.Main.mainRomRowOf] using hsrc
+        ZiskFv.AirsClean.Main.mainRomRowOf] at hsrc
 
 /-- The two root PC premises for this witness: boot agreement, and the Sail-internal retire law.
     `sailRetireChain_of_inputsAgree` builds the latter from the per-row `InputsAgree` family this

--- a/ZiskFv/Compliance/AddAddiSpinWitness.lean
+++ b/ZiskFv/Compliance/AddAddiSpinWitness.lean
@@ -544,9 +544,7 @@ private theorem addAddiSpinMain_pcHandshake_jal_jal :
         ⟨0, by simp⟩)
       (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar =
       addAddiSpinAddRow := by
-  simpa [Table.environmentAt] using
-    addAddiSpinMainTable_eval_rowInputVar_zero
-      (by simp)
+  simp [Table.environmentAt]
 
 @[simp] theorem addAddiSpinMainTable_evalAt_one :
     Eval.eval
@@ -554,9 +552,7 @@ private theorem addAddiSpinMain_pcHandshake_jal_jal :
         ⟨1, by simp⟩)
       (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar =
       addAddiSpinAddiRow := by
-  simpa [Table.environmentAt] using
-    addAddiSpinMainTable_eval_rowInputVar_one
-      (by simp)
+  simp [Table.environmentAt]
 
 @[simp] theorem addAddiSpinMainTable_evalAt_two :
     Eval.eval
@@ -564,9 +560,7 @@ private theorem addAddiSpinMain_pcHandshake_jal_jal :
         ⟨2, by simp⟩)
       (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar =
       addAddiSpinJalRow 2 := by
-  simpa [Table.environmentAt] using
-    addAddiSpinMainTable_eval_rowInputVar_two
-      (by simp)
+  simp [Table.environmentAt]
 
 @[simp] theorem addAddiSpinMainTable_evalAt_three :
     Eval.eval
@@ -574,9 +568,7 @@ private theorem addAddiSpinMain_pcHandshake_jal_jal :
         ⟨3, by simp⟩)
       (componentWithRomMemAndOpBus 3 addAddiSpinProgram).rowInputVar =
       addAddiSpinJalRow 3 := by
-  simpa [Table.environmentAt] using
-    addAddiSpinMainTable_eval_rowInputVar_three
-      (by simp)
+  simp [Table.environmentAt]
 
 theorem addAddiSpinMainTable_transitions : addAddiSpinMainTable.TransitionConstraints := by
   rw [Table.TransitionConstraints]
@@ -1384,7 +1376,7 @@ theorem addAddiSpinMainTable_interactionsWith_memBus :
         addAddiSpinMainMemBusInteractionsAt_eq_valueLevel _ (addAddiSpinJalRow 3)
           (eval_mainRawRow_materialize 3 emptyData (addAddiSpinJalRow 3) (by rfl) (by rfl))
   rw [h_add, h_addi, h_jal_two, h_jal_three]
-  simpa only [List.append_assoc]
+  simp only [List.append_assoc]
 
 private theorem addAddiSpinJalMemBusInteractions_balanced (step : FGL) :
     BalancedInteractions (addAddiSpinMainValueMemBusInteractions (addAddiSpinJalRow step)) := by
@@ -1392,7 +1384,7 @@ private theorem addAddiSpinJalMemBusInteractions_balanced (step : FGL) :
   · intro interaction h_interaction
     simp [addAddiSpinMainValueMemBusInteractions, mainValueMemBusInteractions] at h_interaction
     rcases h_interaction with rfl | rfl | rfl | rfl | rfl | rfl <;>
-      simp [addAddiSpinMainValueMemBusInteractions, mainValueMemBusInteractions,
+      simp [
         mainARegPreInteraction, mainAMemInteraction, mainBRegPreInteraction,
         mainBMemInteraction, mainCRegPreInteraction, mainCMemInteraction, addAddiSpinJalRow,
         addSpinJalRow, addSpinJalProgramRow, addSpinJalBits, mainRomRowOf]

--- a/ZiskFv/Compliance/AddFaithfulPaddedRootSoundness.lean
+++ b/ZiskFv/Compliance/AddFaithfulPaddedRootSoundness.lean
@@ -259,7 +259,7 @@ theorem addFaithfulRawDecode :
       decide
     · rw [addFaithfulMainPc_add] at hline
       rw [addFaithfulAcceptedTrace_program] at hline
-      simp only [addFaithfulAcceptedTrace, addFaithfulProgram, addFaithfulRow1ProgramRow,
+      simp only [addFaithfulProgram, addFaithfulRow1ProgramRow,
         RegisterMemBusBalance.addX1ProgramRow] at hline
       exact absurd hline (by decide)
 

--- a/ZiskFv/Compliance/AddFaithfulPaddedWitness.lean
+++ b/ZiskFv/Compliance/AddFaithfulPaddedWitness.lean
@@ -107,7 +107,7 @@ theorem addFaithfulBinaryAddTable_constraints : addFaithfulBinaryAddTable.Constr
   apply binaryAddRowsTable_constraints_of_proverAssumptions
   intro row h_row
   simp [addFaithfulBinaryAddRows] at h_row
-  rcases h_row with rfl | rfl <;> exact ⟨0, 0, by decide, by decide, rfl⟩
+  rcases h_row with rfl | rfl ; exact ⟨0, 0, by decide, by decide, rfl⟩
 
 /-- Row 1 is the last real access to x1: the boundary reload comes from row 1's final message. -/
 def addFaithfulBoundaryRowX1 : ZiskFv.AirsClean.RegisterBoundary.RegisterBoundaryRow FGL :=

--- a/ZiskFv/Compliance/AddSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/AddSpinRootSoundness.lean
@@ -124,7 +124,7 @@ private theorem addSpinMainPc_jal :
   change (ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
       addSpinMainTable).pc 1 = 4
   simp [addSpinMainRowAt_one, addSpinJalRow, addSpinJalProgramRow, addSpinJalBits,
-    addSpinJalFreeCols, ZiskFv.AirsClean.Main.mainRomRowOf]
+    ZiskFv.AirsClean.Main.mainRomRowOf]
 
 private theorem addSpinReadX1_add :
     read_xreg (regidx_to_fin x1) (addSpinSailTrace addSpinAddIndex) =
@@ -307,7 +307,7 @@ def addSpinJalInputs :
     change ((ZiskFv.AirsClean.FullEnsemble.mainOfTable addSpinProgram
           addSpinMainTable).pc 1).val = _
     simp [addSpinMainRowAt_one, addSpinJalRow, addSpinJalProgramRow, addSpinJalBits,
-      addSpinJalFreeCols, ZiskFv.AirsClean.Main.mainRomRowOf, addSpinJalInput]
+      ZiskFv.AirsClean.Main.mainRomRowOf, addSpinJalInput]
   h_input_rd := by
     rfl
   h_input_pc := by
@@ -389,7 +389,7 @@ def addSpinRowsAligned :
   intro j h
   have h' : j + 1 < 2 := h
   have hj : j < 2 - 1 := by omega
-  interval_cases j <;> rfl
+  interval_cases j ; rfl
 
 set_option maxHeartbeats 4000000 in
 def addSpinLaneBridge : ∀ i : Fin 2,
@@ -402,7 +402,7 @@ def addSpinLaneBridge : ∀ i : Fin 2,
         rw [addSpinAcceptedTrace_mainTable_eq, addSpinAcceptedTrace_program] at hoff
         rw [addSpinMainRowAt_zero] at hoff
         fin_cases r <;> simp [addSpinAddRow, addX1Row,
-          Transpiler.wrap_to_regidx, Transpiler.regidxOfBitVec5, x1, regidx_to_fin] at hoff ⊢
+          Transpiler.wrap_to_regidx, x1, regidx_to_fin] at hoff ⊢
       rw [hre]
       simpa [addSpinAddIndex] using addSpinAddLaneLo (fun m i => m.a_0 i)
         (by simp [addSpinMainRowAt_zero, addSpinAddRow, addX1Row])
@@ -411,7 +411,7 @@ def addSpinLaneBridge : ∀ i : Fin 2,
         rw [addSpinAcceptedTrace_mainTable_eq, addSpinAcceptedTrace_program] at hoff
         rw [addSpinMainRowAt_zero] at hoff
         fin_cases r <;> simp [addSpinAddRow, addX1Row,
-          Transpiler.wrap_to_regidx, Transpiler.regidxOfBitVec5, x1, regidx_to_fin] at hoff ⊢
+          Transpiler.wrap_to_regidx, x1, regidx_to_fin] at hoff ⊢
       rw [hre]
       simpa [addSpinAddIndex] using addSpinAddLaneHi (fun m i => m.a_1 i)
         (by simp [addSpinMainRowAt_zero, addSpinAddRow, addX1Row])
@@ -420,7 +420,7 @@ def addSpinLaneBridge : ∀ i : Fin 2,
         rw [addSpinAcceptedTrace_mainTable_eq, addSpinAcceptedTrace_program] at hoff
         rw [addSpinMainRowAt_zero] at hoff
         fin_cases r <;> simp [addSpinAddRow, addX1Row,
-          Transpiler.wrap_to_regidx, Transpiler.regidxOfBitVec5, x1, regidx_to_fin] at hoff ⊢
+          Transpiler.wrap_to_regidx, x1, regidx_to_fin] at hoff ⊢
       rw [hre]
       simpa [addSpinAddIndex] using addSpinAddLaneLo (fun m i => m.b_0 i)
         (by simp [addSpinMainRowAt_zero, addSpinAddRow, addX1Row])
@@ -429,7 +429,7 @@ def addSpinLaneBridge : ∀ i : Fin 2,
         rw [addSpinAcceptedTrace_mainTable_eq, addSpinAcceptedTrace_program] at hoff
         rw [addSpinMainRowAt_zero] at hoff
         fin_cases r <;> simp [addSpinAddRow, addX1Row,
-          Transpiler.wrap_to_regidx, Transpiler.regidxOfBitVec5, x1, regidx_to_fin] at hoff ⊢
+          Transpiler.wrap_to_regidx, x1, regidx_to_fin] at hoff ⊢
       rw [hre]
       simpa [addSpinAddIndex] using addSpinAddLaneHi (fun m i => m.b_1 i)
         (by simp [addSpinMainRowAt_zero, addSpinAddRow, addX1Row])
@@ -437,8 +437,8 @@ def addSpinLaneBridge : ∀ i : Fin 2,
     all_goals
       rw [addSpinAcceptedTrace_mainTable_eq, addSpinAcceptedTrace_program] at hsrc
       rw [addSpinMainRowAt_one] at hsrc
-      simpa [addSpinJalRow, addSpinJalProgramRow, addSpinJalBits,
-        ZiskFv.AirsClean.Main.mainRomRowOf] using hsrc
+      simp [addSpinJalRow, addSpinJalProgramRow, addSpinJalBits,
+        ZiskFv.AirsClean.Main.mainRomRowOf] at hsrc
 
 /-- The two root PC premises for this witness: boot agreement, and the Sail-internal retire law.
     `sailRetireChain_of_inputsAgree` builds the latter from the per-row `InputsAgree` family this
@@ -712,7 +712,7 @@ def addPaddedLaneBridge : ∀ i : Fin 1,
       rw [addPaddedAcceptedTrace_mainTable_eq, addPaddedAcceptedTrace_program] at hoff
       rw [addSpinMainRowAt_zero] at hoff
       fin_cases r <;> simp [addSpinAddRow, addX1Row,
-        Transpiler.wrap_to_regidx, Transpiler.regidxOfBitVec5, x1, regidx_to_fin] at hoff ⊢
+        Transpiler.wrap_to_regidx, x1, regidx_to_fin] at hoff ⊢
     rw [hre]
     simpa [addPaddedAddIndex] using addPaddedAddLaneLo (fun m i => m.a_0 i)
       (by simp [addSpinMainRowAt_zero, addSpinAddRow, addX1Row])
@@ -721,7 +721,7 @@ def addPaddedLaneBridge : ∀ i : Fin 1,
       rw [addPaddedAcceptedTrace_mainTable_eq, addPaddedAcceptedTrace_program] at hoff
       rw [addSpinMainRowAt_zero] at hoff
       fin_cases r <;> simp [addSpinAddRow, addX1Row,
-        Transpiler.wrap_to_regidx, Transpiler.regidxOfBitVec5, x1, regidx_to_fin] at hoff ⊢
+        Transpiler.wrap_to_regidx, x1, regidx_to_fin] at hoff ⊢
     rw [hre]
     simpa [addPaddedAddIndex] using addPaddedAddLaneHi (fun m i => m.a_1 i)
       (by simp [addSpinMainRowAt_zero, addSpinAddRow, addX1Row])
@@ -730,7 +730,7 @@ def addPaddedLaneBridge : ∀ i : Fin 1,
       rw [addPaddedAcceptedTrace_mainTable_eq, addPaddedAcceptedTrace_program] at hoff
       rw [addSpinMainRowAt_zero] at hoff
       fin_cases r <;> simp [addSpinAddRow, addX1Row,
-        Transpiler.wrap_to_regidx, Transpiler.regidxOfBitVec5, x1, regidx_to_fin] at hoff ⊢
+        Transpiler.wrap_to_regidx, x1, regidx_to_fin] at hoff ⊢
     rw [hre]
     simpa [addPaddedAddIndex] using addPaddedAddLaneLo (fun m i => m.b_0 i)
       (by simp [addSpinMainRowAt_zero, addSpinAddRow, addX1Row])
@@ -739,7 +739,7 @@ def addPaddedLaneBridge : ∀ i : Fin 1,
       rw [addPaddedAcceptedTrace_mainTable_eq, addPaddedAcceptedTrace_program] at hoff
       rw [addSpinMainRowAt_zero] at hoff
       fin_cases r <;> simp [addSpinAddRow, addX1Row,
-        Transpiler.wrap_to_regidx, Transpiler.regidxOfBitVec5, x1, regidx_to_fin] at hoff ⊢
+        Transpiler.wrap_to_regidx, x1, regidx_to_fin] at hoff ⊢
     rw [hre]
     simpa [addPaddedAddIndex] using addPaddedAddLaneHi (fun m i => m.b_1 i)
       (by simp [addSpinMainRowAt_zero, addSpinAddRow, addX1Row])

--- a/ZiskFv/Compliance/AddSpinWitness.lean
+++ b/ZiskFv/Compliance/AddSpinWitness.lean
@@ -412,9 +412,7 @@ theorem addSpinMainTable_constraints : addSpinMainTable.Constraints := by
         ⟨0, by simp⟩)
       (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar =
       addSpinAddRow := by
-  simpa [Table.environmentAt] using
-    addSpinMainTable_eval_rowInputVar_zero
-      (by simp)
+  simp [Table.environmentAt]
 
 @[simp] theorem addSpinMainTable_evalAt_one :
     Eval.eval
@@ -422,9 +420,7 @@ theorem addSpinMainTable_constraints : addSpinMainTable.Constraints := by
         ⟨1, by simp⟩)
       (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar =
       addSpinJalRow 1 := by
-  simpa [Table.environmentAt] using
-    addSpinMainTable_eval_rowInputVar_one
-      (by simp)
+  simp [Table.environmentAt]
 
 @[simp] theorem addSpinMainTable_evalAt_two :
     Eval.eval
@@ -432,9 +428,7 @@ theorem addSpinMainTable_constraints : addSpinMainTable.Constraints := by
         ⟨2, by simp⟩)
       (componentWithRomMemAndOpBus 2 addSpinProgram).rowInputVar =
       addSpinJalRow 2 := by
-  simpa [Table.environmentAt] using
-    addSpinMainTable_eval_rowInputVar_two
-      (by simp)
+  simp [Table.environmentAt]
 
 theorem addSpinMainTable_transitions : addSpinMainTable.TransitionConstraints := by
   rw [Table.TransitionConstraints]
@@ -1132,7 +1126,7 @@ theorem addSpinMainTable_interactionsWith_memBus :
         mainMemBusInteractionsAt_eq_valueLevel 2 addSpinProgram _ (addSpinJalRow 2)
           (eval_mainRawRow_materialize 2 emptyData (addSpinJalRow 2) (by rfl) (by rfl))
   rw [h_zero, h_one, h_two]
-  simpa only [List.append_assoc]
+  simp only [List.append_assoc]
 
 theorem addSpinAddMainMemBusInteractions_eq :
     mainValueMemBusInteractions addSpinAddRow =

--- a/ZiskFv/Compliance/AeneasBridgeTrust/Extraction/JalrRows.lean
+++ b/ZiskFv/Compliance/AeneasBridgeTrust/Extraction/JalrRows.lean
@@ -148,8 +148,8 @@ private theorem src_b_reg_false_main_pins
     (try subst z) <;>
     (try cases h) <;>
     simp_all [hregFrom, hregTo, hnotAbove, haboveFalse] <;>
-      (try have : False := (not_lt_of_ge hnotAbove) (by assumption); contradiction) <;>
-      try decide <;> try scalar_tac <;> try omega
+      (try have : False := (not_lt_of_ge hnotAbove) (by assumption); contradiction)
+  try decide <;> try scalar_tac <;> try omega
 
 set_option maxHeartbeats 8000000 in
 theorem jalr_production_expanded_row_pins

--- a/ZiskFv/Compliance/ConstructionAdd.lean
+++ b/ZiskFv/Compliance/ConstructionAdd.lean
@@ -205,9 +205,7 @@ theorem main_add_packed_result_of_static_provider
       (ZiskFv.AirsClean.Binary.validOfRow row) 0 out h_core h_carry_bool
   have hflag : m.flag i = 0 := by
     have hm := h_match
-    simp only [matches_entry, opBus_row_Main,
-      ZiskFv.AirsClean.Binary.opBusMessage,
-      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry] at hm
+    simp only [matches_entry, opBus_row_Main] at hm
     exact hm.2.2.2.2.2.2.2.2.1.trans hcarry
   obtain ⟨hc0, hc1⟩ :=
     ZiskFv.EquivCore.Bridge.Binary.main_c_lanes_carryfree_of_match
@@ -263,9 +261,7 @@ theorem main_add_packed_result_of_binaryadd_provider
       (ZiskFv.AirsClean.BinaryAdd.b_chunks_in_range_of_component_spec_facts row h_facts)
       (ZiskFv.AirsClean.BinaryAdd.c_chunks_in_range_of_component_spec_facts row h_facts)
   have hm := h_match
-  simp only [matches_entry, opBus_row_Main,
-    ZiskFv.AirsClean.BinaryAdd.opBusMessage,
-    ZiskFv.Channels.OperationBus.OpBusMessage.toEntry] at hm
+  simp only [matches_entry, opBus_row_Main] at hm
   obtain ⟨_, _, ha0, ha1, hb0, hb1, hc0, hc1, _, _, _, _⟩ := hm
   obtain ⟨_, _, _, _, hc0_lt, hc1_lt, hc2_lt, hc3_lt⟩ := h_facts.2.2
   have hc_lo_lt :

--- a/ZiskFv/Compliance/DivSpinRootSoundness/AddiInputs.lean
+++ b/ZiskFv/Compliance/DivSpinRootSoundness/AddiInputs.lean
@@ -17,10 +17,10 @@ private def divSpinAddiInput
     (h_imm : input.imm = claim.imm)
     (h_pc : (divSpinSailTrace index).regs.get? Register.PC = .some input.PC)
     (h_rd : input.rd = regidx_to_fin claim.rd)
-    (h_a0 :
+    (_h_a0 :
       (divSpinMainRows[index.val]'(by change index.val < 5; omega)).core.a_0 =
         lane_lo input.r1_val)
-    (h_a1 :
+    (_h_a1 :
       (divSpinMainRows[index.val]'(by change index.val < 5; omega)).core.a_1 =
         lane_hi input.r1_val)
     (h_pc_bridge : (((4 * index.val : Nat) : FGL).val) = input.PC.toNat) :

--- a/ZiskFv/Compliance/DivSpinRootSoundness/Decode.lean
+++ b/ZiskFv/Compliance/DivSpinRootSoundness/Decode.lean
@@ -91,7 +91,7 @@ theorem divSpinReadX0 (i : Fin 4) :
       EStateM.Result.ok (0#64) (divSpinSailTrace i) := by
   fin_cases i <;>
     simp [divSpinSailTrace, divSpinState, divSpinRegs, x0, x1, x2, x3,
-      regidx_to_fin, read_xreg, reg_of_fin, Std.ExtDHashMap.get?_insert]
+      regidx_to_fin, read_xreg, reg_of_fin]
 
 theorem divSpinReadX1Div :
     read_xreg (regidx_to_fin x1) (divSpinSailTrace divSpinDivIndex) =

--- a/ZiskFv/Compliance/DivSpinRootSoundness/ProgramDecodes.lean
+++ b/ZiskFv/Compliance/DivSpinRootSoundness/ProgramDecodes.lean
@@ -109,12 +109,8 @@ def divSpinDivProgramDecode :
         (divSpinAcceptedMainRowAt divSpinDivIndex)).symm
     · simp [divSpinAcceptedMainRowAt, divSpinDivIndex, divSpinMainRows,
         divSpinDivRow, divSpinDivRowTemplate, mainRomRowOf,
-        withMainRegisterPrevious, busSub, Pilot.execRowOf,
-        ZiskFv.Airs.MemoryBus.matches_memory_entry,
-        ZiskFv.AirsClean.Main.cMemMessage,
-        ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry,
-        AbstractInteraction.eval, ChannelInteraction.toRaw, Channel.emitted,
-        Expression.eval]
+        withMainRegisterPrevious,
+        ZiskFv.Airs.MemoryBus.matches_memory_entry]
   bounds := by
     constructor <;>
       norm_num [busSub, Pilot.execRowOf, divSpinAcceptedTrace_mainTable_eq,

--- a/ZiskFv/Compliance/DivSpinWitness/Constraints.lean
+++ b/ZiskFv/Compliance/DivSpinWitness/Constraints.lean
@@ -30,25 +30,20 @@ theorem divSpinMain_pcHandshake_addi_x1_x2 :
     transitionBetween divSpinAddiX1Row divSpinAddiX2Row := by
   simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween,
     divSpinAddiX1Row, divSpinAddiX2Row,
-    divSpinAddiX1RowWithLast, divSpinAddiX2RowWithLast,
     divSpinAddiX1RowTemplate, divSpinAddiX2RowTemplate,
     divSpinAddiX1ProgramRow, divSpinAddiX2ProgramRow, divSpinAddiBits,
-    divSpinAddiFree, divSpinAddiBits, ZiskFv.Compliance.SdLdSpinWitness.addiX0Bits,
+    divSpinAddiBits, ZiskFv.Compliance.SdLdSpinWitness.addiX0Bits,
     mainRomRowOf,
-    ZiskFv.Compliance.RegisterMemBusBalance.materializeMainRegisterRow,
-    ZiskFv.Compliance.RegisterMemBusBalance.materializeMainRegisterAccesses,
     ZiskFv.Compliance.RegisterMemBusBalance.withMainRegisterPrevious]
 
 theorem divSpinMain_pcHandshake_addi_x2_div :
     transitionBetween divSpinAddiX2Row divSpinDivRow := by
   simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween,
-    divSpinAddiX2Row, divSpinAddiX2RowWithLast,
+    divSpinAddiX2Row,
     divSpinAddiX2RowTemplate, divSpinDivRow, divSpinDivRowTemplate,
     divSpinAddiX2ProgramRow, divSpinDivProgramRow, divSpinAddiBits,
-    divSpinDivBits, divSpinAddiFree, divSpinAddiBits,
+    divSpinDivBits, divSpinAddiBits,
     ZiskFv.Compliance.SdLdSpinWitness.addiX0Bits, mainRomRowOf,
-    ZiskFv.Compliance.RegisterMemBusBalance.materializeMainRegisterRow,
-    ZiskFv.Compliance.RegisterMemBusBalance.materializeMainRegisterAccesses,
     ZiskFv.Compliance.RegisterMemBusBalance.withMainRegisterPrevious]
 
 theorem divSpinMain_pcHandshake_div_jal :
@@ -56,7 +51,6 @@ theorem divSpinMain_pcHandshake_div_jal :
   simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween,
     divSpinDivRow, divSpinJalRow,
     divSpinJalProgramRow, divSpinDivProgramRow, divSpinDivBits,
-    ZiskFv.Compliance.AddSpinWitness.addSpinJalRow,
     ZiskFv.Compliance.AddSpinWitness.addSpinJalProgramRow,
     ZiskFv.Compliance.AddSpinWitness.addSpinJalBits, mainRomRowOf]
 
@@ -66,7 +60,7 @@ theorem divSpinMain_pcHandshake_jal_jal :
     divSpinJalRow, divSpinJalProgramRow,
     ZiskFv.Compliance.AddSpinWitness.addSpinJalProgramRow,
     ZiskFv.Compliance.AddSpinWitness.addSpinJalBits,
-    ZiskFv.Compliance.AddSpinWitness.addSpinJalFreeCols, mainRomRowOf]
+    mainRomRowOf]
   ring
 
 theorem divSpinAddiX1Main_proverAssumptions :
@@ -80,11 +74,9 @@ theorem divSpinAddiX1Main_proverAssumptions :
   · simp [MainRomSourceGuard, divSpinProgram, divSpinAddiX1ProgramRow,
       divSpinAddiBits]
   · simp [MainRomAddressGuard, divSpinAddiBits]
-  · simp [divSpinAddiX1Row, divSpinAddiX1RowWithLast,
+  · simp [divSpinAddiX1Row,
       divSpinAddiX1RowTemplate, divSpinProgram, divSpinAddiX1ProgramRow,
-      divSpinAddiBits, mainRomRowOf, divSpinAddiFree, divSpinRegisterInitial,
-      ZiskFv.Compliance.RegisterMemBusBalance.materializeMainRegisterRow,
-      ZiskFv.Compliance.RegisterMemBusBalance.materializeMainRegisterAccesses,
+      divSpinAddiBits, mainRomRowOf,
       ZiskFv.Compliance.RegisterMemBusBalance.withMainRegisterPrevious]
 
 theorem divSpinAddiX2Main_proverAssumptions :
@@ -98,11 +90,9 @@ theorem divSpinAddiX2Main_proverAssumptions :
   · simp [MainRomSourceGuard, divSpinProgram, divSpinAddiX2ProgramRow,
       divSpinAddiBits]
   · simp [MainRomAddressGuard, divSpinAddiBits]
-  · simp [divSpinAddiX2Row, divSpinAddiX2RowWithLast,
+  · simp [divSpinAddiX2Row,
       divSpinAddiX2RowTemplate, divSpinProgram, divSpinAddiX2ProgramRow,
-      divSpinAddiBits, mainRomRowOf, divSpinAddiFree, divSpinRegisterInitial,
-      ZiskFv.Compliance.RegisterMemBusBalance.materializeMainRegisterRow,
-      ZiskFv.Compliance.RegisterMemBusBalance.materializeMainRegisterAccesses,
+      divSpinAddiBits, mainRomRowOf,
       ZiskFv.Compliance.RegisterMemBusBalance.withMainRegisterPrevious]
 
 theorem divSpinDivMain_proverAssumptions :
@@ -128,7 +118,7 @@ theorem divSpinDivMain_proverAssumptions :
       divSpinDivBits]
   · simp [MainRomAddressGuard, divSpinDivBits]
   · simp [divSpinDivRow, divSpinDivRowTemplate, divSpinProgram,
-      divSpinDivProgramRow, divSpinDivBits, mainRomRowOf, divSpinRegisterInitial,
+      divSpinDivProgramRow, divSpinDivBits, mainRomRowOf,
       ZiskFv.Compliance.RegisterMemBusBalance.withMainRegisterPrevious]
 
 theorem divSpinJalMain_proverAssumptions (step : FGL) :
@@ -149,7 +139,7 @@ theorem divSpinJalMain_proverAssumptions (step : FGL) :
   · simp [divSpinJalRow, divSpinProgram, divSpinJalProgramRow,
       ZiskFv.Compliance.AddSpinWitness.addSpinJalProgramRow,
       ZiskFv.Compliance.AddSpinWitness.addSpinJalBits,
-      ZiskFv.Compliance.AddSpinWitness.addSpinJalFreeCols, mainRomRowOf]
+      mainRomRowOf]
 
 private theorem divSpinMain_constraintsHold_materialize
     (index : Nat) (row : MainRowWithRom FGL)
@@ -185,16 +175,16 @@ theorem divSpinMainTable_constraints : divSpinMainTable.Constraints := by
   simp only [List.mem_cons, List.not_mem_nil, or_false] at h_arr
   rcases h_arr with rfl | rfl | rfl | rfl | rfl
   · exact divSpinMain_constraintsHold_materialize 0 divSpinAddiX1Row
-      (by simp [divSpinAddiX1Row, divSpinAddiX1RowWithLast,
-        divSpinAddiX1RowTemplate, mainRomRowOf, divSpinAddiFree])
-      (by simp [divSpinAddiX1Row, divSpinAddiX1RowWithLast,
-        divSpinAddiX1RowTemplate, mainRomRowOf, divSpinAddiFree])
+      (by simp [divSpinAddiX1Row,
+        divSpinAddiX1RowTemplate, mainRomRowOf])
+      (by simp [divSpinAddiX1Row,
+        divSpinAddiX1RowTemplate, mainRomRowOf])
       divSpinAddiX1Main_proverAssumptions
   · exact divSpinMain_constraintsHold_materialize 1 divSpinAddiX2Row
-      (by simp [divSpinAddiX2Row, divSpinAddiX2RowWithLast,
-        divSpinAddiX2RowTemplate, mainRomRowOf, divSpinAddiFree])
-      (by simp [divSpinAddiX2Row, divSpinAddiX2RowWithLast,
-        divSpinAddiX2RowTemplate, mainRomRowOf, divSpinAddiFree])
+      (by simp [divSpinAddiX2Row,
+        divSpinAddiX2RowTemplate, mainRomRowOf])
+      (by simp [divSpinAddiX2Row,
+        divSpinAddiX2RowTemplate, mainRomRowOf])
       divSpinAddiX2Main_proverAssumptions
   · exact divSpinMain_constraintsHold_materialize 2 divSpinDivRow
       (by simp [divSpinDivRow, divSpinDivRowTemplate, mainRomRowOf])
@@ -224,10 +214,8 @@ theorem divSpinMainTable_transitions : divSpinMainTable.TransitionConstraints :=
           (mainFixedColumns.materialize 0 (mainRawRow divSpinAddiX1Row)) emptyData)
         (varFromOffset MainRowWithRom 0))
     rw [eval_mainRawRow_materialize 0 emptyData divSpinAddiX1Row
-      (by simp [divSpinAddiX1Row, divSpinAddiX1RowTemplate, mainRomRowOf,
-        divSpinAddiFree])
-      (by simp [divSpinAddiX1Row, divSpinAddiX1RowTemplate, mainRomRowOf,
-        divSpinAddiFree])]
+      (by simp [divSpinAddiX1Row, divSpinAddiX1RowTemplate, mainRomRowOf])
+      (by simp [divSpinAddiX1Row, divSpinAddiX1RowTemplate, mainRomRowOf])]
     simp [Table.previousEnvironment, divSpinMainTable, mainRowsTable,
       divSpinMainRows, transitionBetween, sourceCCopyBetween, pcHandshakeBetween,
       divSpinAddiX1Row, divSpinAddiX1RowWithLast, divSpinAddiX1RowTemplate,
@@ -243,15 +231,11 @@ theorem divSpinMainTable_transitions : divSpinMainTable.TransitionConstraints :=
           (mainFixedColumns.materialize 1 (mainRawRow divSpinAddiX2Row)) emptyData)
         (varFromOffset MainRowWithRom 0))
     rw [eval_mainRawRow_materialize 0 emptyData divSpinAddiX1Row
-        (by simp [divSpinAddiX1Row, divSpinAddiX1RowTemplate, mainRomRowOf,
-          divSpinAddiFree])
-        (by simp [divSpinAddiX1Row, divSpinAddiX1RowTemplate, mainRomRowOf,
-          divSpinAddiFree]),
+        (by simp [divSpinAddiX1Row, divSpinAddiX1RowTemplate, mainRomRowOf])
+        (by simp [divSpinAddiX1Row, divSpinAddiX1RowTemplate, mainRomRowOf]),
       eval_mainRawRow_materialize 1 emptyData divSpinAddiX2Row
-        (by simp [divSpinAddiX2Row, divSpinAddiX2RowTemplate, mainRomRowOf,
-          divSpinAddiFree])
-        (by simp [divSpinAddiX2Row, divSpinAddiX2RowTemplate, mainRomRowOf,
-          divSpinAddiFree])]
+        (by simp [divSpinAddiX2Row, divSpinAddiX2RowTemplate, mainRomRowOf])
+        (by simp [divSpinAddiX2Row, divSpinAddiX2RowTemplate, mainRomRowOf])]
     exact divSpinMain_pcHandshake_addi_x1_x2
   · change transitionBetween
       (Eval.eval
@@ -263,10 +247,8 @@ theorem divSpinMainTable_transitions : divSpinMainTable.TransitionConstraints :=
           (mainFixedColumns.materialize 2 (mainRawRow divSpinDivRow)) emptyData)
         (varFromOffset MainRowWithRom 0))
     rw [eval_mainRawRow_materialize 1 emptyData divSpinAddiX2Row
-        (by simp [divSpinAddiX2Row, divSpinAddiX2RowTemplate, mainRomRowOf,
-          divSpinAddiFree])
-        (by simp [divSpinAddiX2Row, divSpinAddiX2RowTemplate, mainRomRowOf,
-          divSpinAddiFree]),
+        (by simp [divSpinAddiX2Row, divSpinAddiX2RowTemplate, mainRomRowOf])
+        (by simp [divSpinAddiX2Row, divSpinAddiX2RowTemplate, mainRomRowOf]),
       eval_mainRawRow_materialize 2 emptyData divSpinDivRow
         (by simp [divSpinDivRow, divSpinDivRowTemplate, mainRomRowOf])
         (by simp [divSpinDivRow, divSpinDivRowTemplate, mainRomRowOf])]

--- a/ZiskFv/Compliance/DivSpinWitness/Definitions.lean
+++ b/ZiskFv/Compliance/DivSpinWitness/Definitions.lean
@@ -377,7 +377,7 @@ theorem divSpinBinaryAddTable_constraints : divSpinBinaryAddTable.Constraints :=
   apply
     ZiskFv.Compliance.Instantiation.binaryAddRowsTable_constraints_of_proverAssumptions
   intro row h_row
-  simp [divSpinBinaryAddTable, divSpinBinaryAddRows] at h_row
+  simp [divSpinBinaryAddRows] at h_row
   rcases h_row with rfl | rfl
   · exact ⟨0, 6, by decide, by decide, rfl⟩
   · exact ⟨0, 2, by decide, by decide, rfl⟩
@@ -651,9 +651,8 @@ private theorem divSpinMain_constraints (offset : ℕ) :
     | apply divSpinConstraintsHold_assertZero
       simp only [Expression.eval, h_a0, h_a1, h_a2, h_a3, h_b0, h_b1, h_b2, h_b3,
         h_c0, h_c1, h_c2, h_c3, h_d0, h_d1, h_d2, h_d3, h_na, h_nb, h_nr, h_np,
-        h_sext, h_m32, h_div, h_div0, h_overflow, h_mainDiv, h_mainMul, h_signed,
-        h_rangeAB, h_rangeCD, h_op, h_busRes, h_mult, h_cy0, h_cy1, h_cy2, h_cy3,
-        h_cy4, h_cy5, h_cy6, h_fab, h_nafb, h_nbfa, h_inv]
+        h_m32, h_div, h_cy0, h_cy1, h_cy2, h_cy3,
+        h_cy4, h_cy5, h_cy6, h_fab, h_nafb, h_nbfa]
       norm_num [divSpinArithRow, divSpinArithDivRow,
         ZiskFv.AirsClean.ArithDiv.arithDivRowOf, divSpinArithDivFree,
         divSpinDividend, divSpinDivisor,
@@ -692,11 +691,8 @@ private theorem divSpinMainWithArithTable_constraints (offset : ℕ) :
   repeat' apply divSpinConstraintsHold_bind
   all_goals first
     | apply divSpinConstraintsHold_assertZero
-      simp only [Expression.eval, h_a0, h_a1, h_a2, h_a3, h_b0, h_b1, h_b2, h_b3,
-        h_c0, h_c1, h_c2, h_c3, h_d0, h_d1, h_d2, h_d3, h_na, h_nb, h_nr, h_np,
-        h_sext, h_m32, h_div, h_div0, h_overflow, h_mainDiv, h_mainMul, h_signed,
-        h_rangeAB, h_rangeCD, h_op, h_busRes, h_mult, h_cy0, h_cy1, h_cy2, h_cy3,
-        h_cy4, h_cy5, h_cy6, h_fab, h_nafb, h_nbfa, h_inv]
+      simp only [Expression.eval, h_a2, h_a3, h_c2, h_c3, h_d2, h_d3,
+        h_sext, h_m32, h_mainDiv, h_mainMul, h_busRes]
       norm_num [divSpinArithRow, divSpinArithDivRow,
         ZiskFv.AirsClean.ArithDiv.arithDivRowOf, divSpinArithDivFree,
         divSpinDividend, divSpinDivisor,
@@ -713,17 +709,14 @@ private theorem divSpinMainWithArithTable_constraints (offset : ℕ) :
         ZiskFv.Airs.ArithCarryChainCompleteness.cc6,
         ZiskFv.Airs.ArithCarryChainCompleteness.chunk16]
     | apply divSpinConstraintsHold_staticLookup
-      simp only [ProvableStruct.eval_eq_eval, ProvableStruct.eval,
-        ProvableStruct.fromComponents, ProvableStruct.components,
-        ProvableStruct.toComponents, ProvableStruct.eval.go, ProvableType.eval_field,
-        ProvableType.eval_fields, CircuitType.eval_expr, CircuitType.eval_var_field,
+      simp only [ProvableType.eval_field,
+        ProvableType.eval_fields,
         Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil,
-        Expression.eval, eval_add,
+        Expression.eval,
         h_a0, h_a1, h_a2, h_a3, h_b0, h_b1, h_b2, h_b3, h_c0, h_c1, h_c2, h_c3,
         h_d0, h_d1, h_d2, h_d3, h_na, h_nb, h_nr, h_np, h_sext, h_m32, h_div,
         h_div0, h_overflow, h_mainDiv, h_mainMul, h_signed, h_rangeAB, h_rangeCD,
-        h_op, h_busRes, h_mult, h_cy0, h_cy1, h_cy2, h_cy3, h_cy4, h_cy5, h_cy6,
-        h_fab, h_nafb, h_nbfa, h_inv]
+        h_op, h_cy0, h_cy1, h_cy2, h_cy3, h_cy4, h_cy5, h_cy6]
       first
       | exact divSpinArithTableSpec
       | exact divSpinRange30Spec
@@ -773,10 +766,9 @@ private theorem divSpinSharedMain_constraints (offset : ℕ) :
   all_goals
     apply divSpinConstraintsHold_assertZero
     simp only [Expression.eval, h_a0, h_a1, h_a2, h_a3, h_b0, h_b1, h_b2, h_b3,
-      h_c0, h_c1, h_c2, h_c3, h_d0, h_d1, h_d2, h_d3, h_na, h_nb, h_nr, h_np,
+      h_c0, h_c1, h_c2, h_c3, h_d2, h_d3, h_na, h_nb, h_nr, h_np,
       h_sext, h_m32, h_div, h_div0, h_overflow, h_mainDiv, h_mainMul, h_signed,
-      h_rangeAB, h_rangeCD, h_op, h_busRes, h_mult, h_cy0, h_cy1, h_cy2, h_cy3,
-      h_cy4, h_cy5, h_cy6, h_fab, h_nafb, h_nbfa, h_inv]
+      h_busRes, h_inv]
     norm_num [divSpinArithRow, divSpinArithDivRow,
       ZiskFv.AirsClean.ArithDiv.arithDivRowOf, divSpinArithDivFree,
       divSpinDividend, divSpinDivisor,

--- a/ZiskFv/Compliance/DivSpinWitness/MemBusPermutation.lean
+++ b/ZiskFv/Compliance/DivSpinWitness/MemBusPermutation.lean
@@ -52,7 +52,7 @@ private theorem chronological_perm_histories {α : Type}
   refine List.Perm.cons b3 <| List.Perm.cons r3 <|
     (move_front c3p idle [c3m]).trans (List.Perm.cons c3p ?_)
   refine (move_front c3m idle []).trans (List.Perm.cons c3m ?_)
-  simpa using List.Perm.refl idle
+  simp
 
 theorem divSpinMemBusNonzeroChronological_perm_core :
     List.Perm divSpinMemBusNonzeroChronological divSpinMemBusCore := by

--- a/ZiskFv/Compliance/DivSpinWitness/MemBusReduced.lean
+++ b/ZiskFv/Compliance/DivSpinWitness/MemBusReduced.lean
@@ -89,7 +89,7 @@ theorem divSpinMemBusNonzero_filter :
       (mainValueMemBusInteractions divSpinAddiX1Row).filter (·.mult ≠ 0) =
         [mainCRegPreInteraction divSpinAddiX1Row,
           mainCMemInteraction divSpinAddiX1Row] := by
-    simp [mainValueMemBusInteractions, divSpinAddiX1Row, divSpinAddiX1RowWithLast,
+    simp [mainValueMemBusInteractions, divSpinAddiX1Row,
       divSpinAddiX1RowTemplate, mainRomRowOf, divSpinAddiBits,
       ZiskFv.Compliance.SdLdSpinWitness.addiX0Bits,
       mainARegPreInteraction, mainAMemInteraction, mainBRegPreInteraction,
@@ -98,7 +98,7 @@ theorem divSpinMemBusNonzero_filter :
       (mainValueMemBusInteractions divSpinAddiX2Row).filter (·.mult ≠ 0) =
         [mainCRegPreInteraction divSpinAddiX2Row,
           mainCMemInteraction divSpinAddiX2Row] := by
-    simp [mainValueMemBusInteractions, divSpinAddiX2Row, divSpinAddiX2RowWithLast,
+    simp [mainValueMemBusInteractions, divSpinAddiX2Row,
       divSpinAddiX2RowTemplate, mainRomRowOf, divSpinAddiBits,
       ZiskFv.Compliance.SdLdSpinWitness.addiX0Bits,
       mainARegPreInteraction, mainAMemInteraction, mainBRegPreInteraction,

--- a/ZiskFv/Compliance/DivSpinWitness/OpBusChunks.lean
+++ b/ZiskFv/Compliance/DivSpinWitness/OpBusChunks.lean
@@ -39,7 +39,7 @@ theorem divSpinOpBusTables0_flatMap :
   simp only [divSpinOpBusTables0, List.flatMap_cons, List.flatMap_nil,
     List.append_nil, divSpinBoundaryTable_opBusInteractions,
     divSpinMemAlignReadByte_opBus_nil, divSpinMemAlignByte_opBus_nil,
-    divSpinMemAlign_opBus_nil, List.nil_append]
+    divSpinMemAlign_opBus_nil]
 
 theorem divSpinOpBusTables1_flatMap :
     divSpinOpBusTables1.flatMap (·.interactionsWith OpBusChannel.toRaw) = [] := by
@@ -47,7 +47,7 @@ theorem divSpinOpBusTables1_flatMap :
     List.append_nil, divSpinMemAlignRangeSlice_opBus_nil,
     divSpinMemAlignRomSlice_opBus_nil, divSpinMem_opBus_nil,
     registerStepRangeRowsTable_interactionsWith_opBus_nil,
-    divSpinSpecifiedRangesSlice_opBus_nil, List.nil_append]
+    divSpinSpecifiedRangesSlice_opBus_nil]
 
 theorem divSpinOpBusTables2_flatMap :
     divSpinOpBusTables2.flatMap (·.interactionsWith OpBusChannel.toRaw) =

--- a/ZiskFv/Compliance/DivSpinWitness/OpBusPairBase.lean
+++ b/ZiskFv/Compliance/DivSpinWitness/OpBusPairBase.lean
@@ -18,7 +18,7 @@ theorem divSpinOpBusPair_balanced
     simp only [List.mem_cons, List.not_mem_nil, or_false] at h_interaction
     rcases h_interaction with rfl | rfl
     · simp
-    · simpa [h_msg_eq]
+    · simp [h_msg_eq]
   · intro msg h_present
     simp only [List.mem_singleton] at h_present
     subst msg

--- a/ZiskFv/Compliance/DivSpinWitness/OpBusWitnessPerm.lean
+++ b/ZiskFv/Compliance/DivSpinWitness/OpBusWitnessPerm.lean
@@ -40,7 +40,7 @@ theorem divSpinWitnessOpBus_perm :
   simp only [List.flatMap_append]
   rw [divSpinOpBusTables0_flatMap, divSpinOpBusTables1_flatMap,
     divSpinOpBusTables2_flatMap, divSpinOpBusTables3_flatMap]
-  simp only [List.nil_append, List.append_assoc]
+  simp only [List.nil_append]
   unfold divSpinReorderedOpBusInteractions
   exact divSpinTenPerm _ _ _ _ _ _ _ _ _ _
 

--- a/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
+++ b/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
@@ -222,7 +222,7 @@ def mainSingleRowTable
     intro arr h_arr
     simp [mainRowArray] at h_arr
     subst arr
-    simpa [mainRowArray, componentWithRomMemAndOpBus] using mainRawRow_size row
+    simp [mainRowArray, componentWithRomMemAndOpBus]
   fixed_domain := by
     intro columns h_columns
     have h_columns' : columns = mainFixedColumns := by
@@ -237,7 +237,7 @@ private theorem mainSingleRowTable_effectiveRows
   simp [mainSingleRowTable, Table.table, mainRowArray, componentWithRomMemAndOpBus]
 
 def mainSingleRowTableEnvironment
-    (length : ℕ) (program : Program length) (row : MainRowWithRom FGL) : Environment FGL :=
+    (length : ℕ) (_program : Program length) (row : MainRowWithRom FGL) : Environment FGL :=
   Environment.fromArray (mainFixedColumns.materialize 0 (mainRawRow row)) emptyData
 
 theorem mainSingleRowTable_rowInput
@@ -1045,8 +1045,8 @@ theorem registerStepRangeComponentInteraction_eval
       registerStepRangeInteraction v := by
   simp [registerStepRangeInteraction, AbstractInteraction.eval, ChannelInteraction.toRaw,
     ZiskFv.Channels.SpecifiedRanges.registerStepMessage, toElements_eval_toArray,
-    circuit_norm, Table.environment, registerStepRangeRowsTable, registerStepRangeRowArray,
-    Component.rowInputVar, Component.rowOffset,
+    circuit_norm, Table.environment, registerStepRangeRowArray,
+    Component.rowInputVar,
     ZiskFv.AirsClean.RegisterStepRangeSlice.component]
 
 /-- The bus-102 provider emits exactly one push per row, carrying that row's value. -/
@@ -1354,8 +1354,7 @@ def memSingleRowTable (row : ZiskFv.AirsClean.Mem.MemRow FGL) : Table FGL where
     intro arr h_arr
     simp [memRowArray] at h_arr
     subst arr
-    simpa [memRowArray, ZiskFv.AirsClean.Mem.componentWithDualMemBus] using
-      ZiskFv.AirsClean.Mem.memRawRow_size row
+    simp [memRowArray, ZiskFv.AirsClean.Mem.componentWithDualMemBus]
   fixed_domain := by
     intro columns h_columns
     have h_columns' : columns = ZiskFv.AirsClean.Mem.memFixedColumns := by
@@ -1429,7 +1428,7 @@ theorem memRowsTable_constraints_of_proverAssumptions
         (rows.map (ZiskFv.AirsClean.Mem.memRawRowWithProverData data))).get index =
         ZiskFv.AirsClean.Mem.memFixedColumns.materialize rowsIndex.val
           (ZiskFv.AirsClean.Mem.memRawRowWithProverData data (rows.get rowsIndex)) := by
-    simpa [List.mapIdx_eq_ofFn, rowsIndex]
+    simp [List.mapIdx_eq_ofFn, rowsIndex]
   rw [h_effective] at h_arr
   subst arr
   exact component_constraintsHold_of_proverAssumptions_at_data

--- a/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
+++ b/ZiskFv/Compliance/Instantiation/ConcreteRowReductions.lean
@@ -222,7 +222,7 @@ def mainSingleRowTable
     intro arr h_arr
     simp [mainRowArray] at h_arr
     subst arr
-    simp [mainRowArray, componentWithRomMemAndOpBus]
+    simp [componentWithRomMemAndOpBus]
   fixed_domain := by
     intro columns h_columns
     have h_columns' : columns = mainFixedColumns := by
@@ -1202,7 +1202,7 @@ def binarySingleRowTable (row : ZiskFv.AirsClean.Binary.BinaryRow FGL) : Table F
     simp [binaryRowArray] at h_arr
     subst arr
     rw [binaryStaticLookup_component_rawWidth]
-    simp [binaryRowArray]
+    simp
   fixed_domain := by
     intro columns h_columns
     simp [ZiskFv.AirsClean.Binary.staticLookupComponent] at h_columns
@@ -1354,7 +1354,7 @@ def memSingleRowTable (row : ZiskFv.AirsClean.Mem.MemRow FGL) : Table FGL where
     intro arr h_arr
     simp [memRowArray] at h_arr
     subst arr
-    simp [memRowArray, ZiskFv.AirsClean.Mem.componentWithDualMemBus]
+    simp [ZiskFv.AirsClean.Mem.componentWithDualMemBus]
   fixed_domain := by
     intro columns h_columns
     have h_columns' : columns = ZiskFv.AirsClean.Mem.memFixedColumns := by

--- a/ZiskFv/Compliance/JalrSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/JalrSpinRootSoundness.lean
@@ -186,7 +186,7 @@ private theorem setupMainPc :
     (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
       jalrAcceptedTrace.program jalrAcceptedTrace.mainTable 0).core.pc = 0
   rw [mainRawAt_setup]
-  simp [jalrSetupRow, jalrSetupRowWithLast, jalrSetupRowTemplate,
+  simp [jalrSetupRow, jalrSetupRowTemplate,
     jalrSetupProgramRow, jalrSetupBits, ZiskFv.AirsClean.Main.mainRomRowOf]
 
 private theorem jalrMainPc :
@@ -196,7 +196,7 @@ private theorem jalrMainPc :
     (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
       jalrAcceptedTrace.program jalrAcceptedTrace.mainTable 1).core.pc = 4
   rw [mainRawAt_start]
-  simp [jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
+  simp [jalrAddRow, jalrAddRowTemplate,
     jalrAddProgramRow, jalrAddBits, ZiskFv.AirsClean.Main.mainRomRowOf]
 
 private theorem jalrAndMainPc :
@@ -290,13 +290,13 @@ def jalrProgramDecode :
         fin_cases j
         · exfalso
           have hfalse : (0 : FGL) = 4 := by
-            simpa [jalrAcceptedTrace, jalrProgram, jalrSetupProgramRow] using hline
+            simp [jalrAcceptedTrace, jalrProgram, jalrSetupProgramRow] at hline
           have := congrArg Fin.val hfalse
           norm_num at this
         · simp [jalrAcceptedTrace, jalrProgram, jalrAddProgramRow, jalrClaim]
         · exfalso
           have hfalse : (5 : FGL) = 4 := by
-            simpa [jalrAcceptedTrace, jalrProgram, jalrAndProgramRow] using hline
+            simp [jalrAcceptedTrace, jalrProgram, jalrAndProgramRow] at hline
           have := congrArg Fin.val hfalse
           norm_num at this
       h_prog_and := by
@@ -308,12 +308,12 @@ def jalrProgramDecode :
         fin_cases j
         · exfalso
           have hfalse : (0 : FGL) = 5 := by
-            simpa [jalrAcceptedTrace, jalrProgram, jalrSetupProgramRow] using hline
+            simp [jalrAcceptedTrace, jalrProgram, jalrSetupProgramRow] at hline
           have := congrArg Fin.val hfalse
           norm_num at this
         · exfalso
           have hfalse : (4 : FGL) = 5 := by
-            simpa [jalrAcceptedTrace, jalrProgram, jalrAddProgramRow] using hline
+            simp [jalrAcceptedTrace, jalrProgram, jalrAddProgramRow] at hline
           have := congrArg Fin.val hfalse
           norm_num at this
         · simp [jalrAcceptedTrace, jalrProgram, jalrAndProgramRow, jalrClaim,
@@ -364,7 +364,7 @@ def setupProgramDecode :
       rw [setupMainPc] at hline
       exfalso
       have hfalse : (4 : FGL) = 0 := by
-        simpa [jalrAcceptedTrace, jalrProgram, jalrAddProgramRow] using hline
+        simp [jalrAcceptedTrace, jalrProgram, jalrAddProgramRow] at hline
       exact absurd (congrArg Fin.val hfalse) (by norm_num)
     · change (jalrAcceptedTrace.program
           (⟨2, by norm_num [jalrAcceptedTrace]⟩ :
@@ -374,7 +374,7 @@ def setupProgramDecode :
       rw [setupMainPc] at hline
       exfalso
       have hfalse : (5 : FGL) = 0 := by
-        simpa [jalrAcceptedTrace, jalrProgram, jalrAndProgramRow] using hline
+        simp [jalrAcceptedTrace, jalrProgram, jalrAndProgramRow] at hline
       exact absurd (congrArg Fin.val hfalse) (by norm_num)
   h_prog := by
     intro j hline
@@ -391,7 +391,7 @@ def setupProgramDecode :
       rw [setupMainPc] at hline
       exfalso
       have hfalse : (4 : FGL) = 0 := by
-        simpa [jalrAcceptedTrace, jalrProgram, jalrAddProgramRow] using hline
+        simp [jalrAcceptedTrace, jalrProgram, jalrAddProgramRow] at hline
       have := congrArg Fin.val hfalse
       norm_num at this
     · change (jalrAcceptedTrace.program
@@ -402,7 +402,7 @@ def setupProgramDecode :
       rw [setupMainPc] at hline
       exfalso
       have hfalse : (5 : FGL) = 0 := by
-        simpa [jalrAcceptedTrace, jalrProgram, jalrAndProgramRow] using hline
+        simp [jalrAcceptedTrace, jalrProgram, jalrAndProgramRow] at hline
       have := congrArg Fin.val hfalse
       norm_num at this
 
@@ -518,7 +518,7 @@ def jalrRowsAligned :
   intro j h
   have h' : j + 1 < 2 := h
   have hj : j < 2 - 1 := by omega
-  interval_cases j <;> rfl
+  interval_cases j ; rfl
 
 def jalrLaneBridge : ∀ i : Fin 2,
     LaneBridge jalrAcceptedTrace (sailTrace i) i.val := by
@@ -527,23 +527,23 @@ def jalrLaneBridge : ∀ i : Fin 2,
   · constructor <;> intro _ _ hsrc _ <;> exfalso
     all_goals
       simp only [mainRawAt_setup] at hsrc
-      simpa [jalrSetupRow, jalrSetupRowWithLast, jalrSetupRowTemplate,
-        jalrSetupProgramRow, jalrSetupBits, ZiskFv.AirsClean.Main.mainRomRowOf] using hsrc
+      simp [jalrSetupRow, jalrSetupRowWithLast, jalrSetupRowTemplate,
+        jalrSetupProgramRow, jalrSetupBits, ZiskFv.AirsClean.Main.mainRomRowOf] at hsrc
   · constructor
     · intro _ _ hsrc _
       simp only [mainRawAt_start] at hsrc
-      simpa [jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
-        jalrAddProgramRow, jalrAddBits, ZiskFv.AirsClean.Main.mainRomRowOf] using hsrc
+      simp [jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
+        jalrAddProgramRow, jalrAddBits, ZiskFv.AirsClean.Main.mainRomRowOf] at hsrc
     · intro _ _ hsrc _
       simp only [mainRawAt_start] at hsrc
-      simpa [jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
-        jalrAddProgramRow, jalrAddBits, ZiskFv.AirsClean.Main.mainRomRowOf] using hsrc
+      simp [jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
+        jalrAddProgramRow, jalrAddBits, ZiskFv.AirsClean.Main.mainRomRowOf] at hsrc
     · intro r _ _ hoff
       have hre : r = regidx_to_fin x1 := by
         simp only [mainRawAt_start] at hoff
-        fin_cases r <;> simp [jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
+        fin_cases r <;> simp [jalrAddRow, jalrAddRowTemplate,
           jalrAddProgramRow, jalrAddBits, ZiskFv.AirsClean.Main.mainRomRowOf,
-          Transpiler.wrap_to_regidx, Transpiler.regidxOfBitVec5, x1, regidx_to_fin] at hoff ⊢
+          Transpiler.wrap_to_regidx, x1, regidx_to_fin] at hoff ⊢
       rw [hre, ZiskFv.AirsClean.FullEnsemble.mainOfTable_b_0]
       change (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
         jalrAcceptedTrace.program jalrAcceptedTrace.mainTable 1).core.b_0 = _
@@ -560,9 +560,9 @@ def jalrLaneBridge : ∀ i : Fin 2,
     · intro r _ _ hoff
       have hre : r = regidx_to_fin x1 := by
         simp only [mainRawAt_start] at hoff
-        fin_cases r <;> simp [jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
+        fin_cases r <;> simp [jalrAddRow, jalrAddRowTemplate,
           jalrAddProgramRow, jalrAddBits, ZiskFv.AirsClean.Main.mainRomRowOf,
-          Transpiler.wrap_to_regidx, Transpiler.regidxOfBitVec5, x1, regidx_to_fin] at hoff ⊢
+          Transpiler.wrap_to_regidx, x1, regidx_to_fin] at hoff ⊢
       rw [hre, ZiskFv.AirsClean.FullEnsemble.mainOfTable_b_1]
       change (ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero
         jalrAcceptedTrace.program jalrAcceptedTrace.mainTable 1).core.b_1 = _

--- a/ZiskFv/Compliance/JalrSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/JalrSpinRootSoundness.lean
@@ -527,16 +527,16 @@ def jalrLaneBridge : ∀ i : Fin 2,
   · constructor <;> intro _ _ hsrc _ <;> exfalso
     all_goals
       simp only [mainRawAt_setup] at hsrc
-      simp [jalrSetupRow, jalrSetupRowWithLast, jalrSetupRowTemplate,
+      simp [jalrSetupRow, jalrSetupRowTemplate,
         jalrSetupProgramRow, jalrSetupBits, ZiskFv.AirsClean.Main.mainRomRowOf] at hsrc
   · constructor
     · intro _ _ hsrc _
       simp only [mainRawAt_start] at hsrc
-      simp [jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
+      simp [jalrAddRow, jalrAddRowTemplate,
         jalrAddProgramRow, jalrAddBits, ZiskFv.AirsClean.Main.mainRomRowOf] at hsrc
     · intro _ _ hsrc _
       simp only [mainRawAt_start] at hsrc
-      simp [jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
+      simp [jalrAddRow, jalrAddRowTemplate,
         jalrAddProgramRow, jalrAddBits, ZiskFv.AirsClean.Main.mainRomRowOf] at hsrc
     · intro r _ _ hoff
       have hre : r = regidx_to_fin x1 := by

--- a/ZiskFv/Compliance/JalrSpinWitness.lean
+++ b/ZiskFv/Compliance/JalrSpinWitness.lean
@@ -206,35 +206,29 @@ private theorem jalrMainTable_effectiveRows :
 theorem jalrTransition_add_and :
     transitionBetween jalrAddRow jalrAndRow := by
   simp [transitionBetween, pcHandshakeBetween, sourceCCopyBetween,
-    jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
-    jalrAndRow, jalrAndRowWithLast, jalrAndRowTemplate,
+    jalrAddRow, jalrAddRowTemplate,
+    jalrAndRow, jalrAndRowTemplate,
     jalrAddProgramRow, jalrAndProgramRow, jalrAddBits, jalrAndBits,
-    jalrFreeCols, jalrRegisterInitial, mainRomRowOf,
-    materializeMainRegisterRow, materializeMainRegisterAccesses,
-    withMainRegisterPrevious, boundaryRowIdle,
-    ZiskFv.AirsClean.RegisterBoundary.bootMessage]
+    mainRomRowOf,
+    withMainRegisterPrevious]
 
 theorem jalrTransition_setup_add :
     transitionBetween jalrSetupRow jalrAddRow := by
   simp [transitionBetween, pcHandshakeBetween, sourceCCopyBetween,
-    jalrSetupRow, jalrSetupRowWithLast, jalrSetupRowTemplate,
-    jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
+    jalrSetupRow, jalrSetupRowTemplate,
+    jalrAddRow, jalrAddRowTemplate,
     jalrSetupProgramRow, jalrAddProgramRow, jalrSetupBits, jalrAddBits,
-    jalrFreeCols, jalrRegisterInitial, mainRomRowOf,
-    materializeMainRegisterRow, materializeMainRegisterAccesses,
-    withMainRegisterPrevious, boundaryRowIdle,
-    ZiskFv.AirsClean.RegisterBoundary.bootMessage]
+    mainRomRowOf,
+    withMainRegisterPrevious]
 
 theorem jalrTransition_and_successor :
     transitionBetween jalrAndRow jalrSuccessorRow := by
   simp [transitionBetween, pcHandshakeBetween, sourceCCopyBetween,
-    jalrAndRow, jalrAndRowWithLast, jalrAndRowTemplate,
-    jalrSuccessorRow, jalrSuccessorRowWithLast, jalrSuccessorRowTemplate,
+    jalrAndRow, jalrAndRowTemplate,
+    jalrSuccessorRow, jalrSuccessorRowTemplate,
     jalrAndProgramRow, jalrAddProgramRow, jalrAndBits, jalrAddBits,
-    jalrFreeCols, jalrRegisterInitial, mainRomRowOf,
-    materializeMainRegisterRow, materializeMainRegisterAccesses,
-    withMainRegisterPrevious, boundaryRowIdle,
-    ZiskFv.AirsClean.RegisterBoundary.bootMessage]
+    mainRomRowOf,
+    withMainRegisterPrevious]
 
 def jalrBoundaryRowX1 :
   ZiskFv.AirsClean.RegisterBoundary.RegisterBoundaryRow FGL :=
@@ -351,10 +345,8 @@ theorem jalrSetupMain_proverAssumptions :
   · simp [MainRomExecKind.Coherent, jalrSetupBits]
   · simp [MainRomSourceGuard, jalrProgram, jalrSetupProgramRow, jalrSetupBits]
   · simp [MainRomAddressGuard, jalrSetupBits]
-  · simp [jalrSetupRow, jalrSetupRowWithLast, jalrSetupRowTemplate,
+  · simp [jalrSetupRow, jalrSetupRowTemplate,
       jalrProgram, jalrSetupProgramRow, jalrSetupBits, mainRomRowOf,
-      jalrFreeCols, jalrRegisterInitial,
-      materializeMainRegisterRow, materializeMainRegisterAccesses,
       withMainRegisterPrevious]
 
 theorem jalrAddMain_proverAssumptions :
@@ -367,10 +359,8 @@ theorem jalrAddMain_proverAssumptions :
   · simp [MainRomExecKind.Coherent, jalrAddBits]
   · simp [MainRomSourceGuard, jalrProgram, jalrAddProgramRow, jalrAddBits]
   · simp [MainRomAddressGuard, jalrAddBits]
-  · simp [jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
+  · simp [jalrAddRow, jalrAddRowTemplate,
       jalrProgram, jalrAddProgramRow, jalrAddBits, mainRomRowOf,
-      jalrFreeCols, jalrRegisterInitial,
-      materializeMainRegisterRow, materializeMainRegisterAccesses,
       withMainRegisterPrevious]
 
 theorem jalrAndMain_proverAssumptions :
@@ -383,10 +373,8 @@ theorem jalrAndMain_proverAssumptions :
   · simp [MainRomExecKind.Coherent, jalrAndBits]
   · simp [MainRomSourceGuard, jalrProgram, jalrAndProgramRow, jalrAndBits]
   · simp [MainRomAddressGuard, jalrAndBits]
-  · simp [jalrAndRow, jalrAndRowWithLast, jalrAndRowTemplate,
+  · simp [jalrAndRow, jalrAndRowTemplate,
       jalrProgram, jalrAndProgramRow, jalrAndBits, mainRomRowOf,
-      jalrFreeCols, jalrRegisterInitial,
-      materializeMainRegisterRow, materializeMainRegisterAccesses,
       withMainRegisterPrevious]
 
 theorem jalrSuccessorMain_proverAssumptions :
@@ -398,10 +386,8 @@ theorem jalrSuccessorMain_proverAssumptions :
   · simp [MainRomExecKind.Coherent, jalrAddBits]
   · simp [MainRomSourceGuard, jalrProgram, jalrAddProgramRow, jalrAddBits]
   · simp [MainRomAddressGuard, jalrAddBits]
-  · simp [jalrSuccessorRow, jalrSuccessorRowWithLast, jalrSuccessorRowTemplate,
+  · simp [jalrSuccessorRow, jalrSuccessorRowTemplate,
       jalrProgram, jalrAddProgramRow, jalrAddBits, mainRomRowOf,
-      jalrFreeCols, jalrRegisterInitial,
-      materializeMainRegisterRow, materializeMainRegisterAccesses,
       withMainRegisterPrevious]
 
 private theorem jalrMain_constraintsHold_materialize
@@ -502,11 +488,11 @@ theorem jalrBoundaryTable_constraints : jalrBoundaryTable.Constraints :=
       (Environment.fromArray (mainFixedColumns.materialize _ (mainRawRow _)) emptyData)
       (varFromOffset MainRowWithRom 0) = _ <;>
     apply eval_mainRawRow_materialize <;>
-    simp [jalrMainRows, jalrSetupRow, jalrSetupRowWithLast, jalrSetupRowTemplate,
-      jalrAddRow, jalrAddRowWithLast, jalrAddRowTemplate,
-      jalrAndRow, jalrAndRowWithLast, jalrAndRowTemplate, jalrSuccessorRow,
-      jalrSuccessorRowWithLast, jalrSuccessorRowTemplate,
-      mainRomRowOf, jalrFreeCols, jalrRegisterInitial] <;> rfl
+    simp [jalrSetupRow, jalrSetupRowTemplate,
+      jalrAddRow, jalrAddRowTemplate,
+      jalrAndRow, jalrAndRowTemplate, jalrSuccessorRow,
+      jalrSuccessorRowTemplate,
+      mainRomRowOf, jalrRegisterInitial] <;> rfl
 
 theorem jalrMainTable_transitions : jalrMainTable.TransitionConstraints := by
   rw [Table.TransitionConstraints]
@@ -519,8 +505,8 @@ theorem jalrMainTable_transitions : jalrMainTable.TransitionConstraints := by
   fin_cases index
   · simp [Table.previousEnvironment, jalrMainRows, transitionBetween,
       pcHandshakeBetween, sourceCCopyBetween, jalrSetupRow,
-      jalrSetupRowWithLast, jalrSetupRowTemplate, mainRomRowOf,
-      jalrFreeCols, jalrRegisterInitial]
+      jalrSetupRowTemplate, mainRomRowOf,
+      jalrRegisterInitial]
   · simpa [Table.previousEnvironment, jalrMainRows] using jalrTransition_setup_add
   · simpa [Table.previousEnvironment, jalrMainRows] using jalrTransition_add_and
   · simpa [Table.previousEnvironment, jalrMainRows] using

--- a/ZiskFv/Compliance/MainTableUniqueness.lean
+++ b/ZiskFv/Compliance/MainTableUniqueness.lean
@@ -76,7 +76,7 @@ theorem rawWidth_memAlignByte :
 
 theorem rawWidth_memAlign :
     (MemAlign.component : Component FGL).rawWidth = 30 := by
-  simp only [MemAlign.component, GeneralFormalCircuit.size_eq, circuit_norm, MemAlign.circuit]
+  simp only [MemAlign.component, circuit_norm, MemAlign.circuit]
 
 theorem rawWidth_memAlignRangeSlice :
     (MemAlignRangeSlice.component : Component FGL).rawWidth = 1 := by
@@ -141,7 +141,7 @@ theorem ensemble_rawWidths {length : ℕ} (program : Program length) :
       = [0, 3, 10, 16, 30, 1, 6, 17, 1, 1, 43, 44, 29, 39, 10, 41] := by
   simp only [fullRv64imEnsemble, fullRv64imSoundEnsemble, SoundEnsemble.toFormal,
     Ensemble.allTables, SoundEnsemble.addTable_tables, SoundEnsemble.addFinishedChannel_tables,
-    List.map_cons, List.map_nil, SoundEnsemble.empty, Ensemble.verifierTable,
+    List.map_cons, SoundEnsemble.empty, Ensemble.verifierTable,
     rawWidth_main, rawWidth_registerBoundary, rawWidth_memAlignReadByte, rawWidth_memAlignByte,
     rawWidth_memAlign, rawWidth_memAlignRangeSlice, rawWidth_memAlignRomSlice, rawWidth_mem,
     rawWidth_registerStepRangeSlice, rawWidth_specifiedRangesSlice, rawWidth_arithDiv,

--- a/ZiskFv/Compliance/MemBusSlotSeparation.lean
+++ b/ZiskFv/Compliance/MemBusSlotSeparation.lean
@@ -127,7 +127,7 @@ theorem memBus_mult_eq_neg_three_of_msg_eq_bMem_mem_op_five
     {length : ℕ} {program : Program length}
     {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
     (h_constraints : witness.Constraints) (h_specs : witness.Spec)
-    {tblRef : Table FGL} (h_tblRef : tblRef ∈ witness.allTables)
+    {tblRef : Table FGL} (_h_tblRef : tblRef ∈ witness.allTables)
     (h_compRef : tblRef.component = componentWithRomMemAndOpBus length program)
     {rRef : Array FGL} (h_rRef : rRef ∈ tblRef.table)
     (h_ref_op : (eval (tblRef.environment rRef)
@@ -154,7 +154,7 @@ theorem memBus_mult_eq_neg_two_of_msg_eq_cMem_mem_op_five
     {length : ℕ} {program : Program length}
     {witness : EnsembleWitness (fullRv64imEnsemble length program).ensemble}
     (h_constraints : witness.Constraints) (h_specs : witness.Spec)
-    {tblRef : Table FGL} (h_tblRef : tblRef ∈ witness.allTables)
+    {tblRef : Table FGL} (_h_tblRef : tblRef ∈ witness.allTables)
     (h_compRef : tblRef.component = componentWithRomMemAndOpBus length program)
     {rRef : Array FGL} (h_rRef : rRef ∈ tblRef.table)
     (h_ref_op : (eval (tblRef.environment rRef)
@@ -537,7 +537,7 @@ set_option maxHeartbeats 1000000 in
 theorem exists_boundaryWalk_of_fuel
     {n : Nat} (trace : AcceptedZiskTrace n) :
     ∀ (fuel : ℕ) {table : Table FGL}, table ∈ trace.witness.allTables →
-      ∀ (h_component : table.component =
+      ∀ (_h_component : table.component =
           componentWithRomMemAndOpBus trace.programLength trace.program),
         ∀ {row : Array FGL}, row ∈ table.table → ∀ (s : RegSlot),
           s.selector (eval (table.environment row)

--- a/ZiskFv/Compliance/RegisterPushCounting.lean
+++ b/ZiskFv/Compliance/RegisterPushCounting.lean
@@ -47,7 +47,7 @@ theorem sum_mult_eq_pushCount_sub_pullCount {l : List (Interaction FGL)}
         fun i hi => h i (List.mem_cons_of_mem _ hi)
       have h_a := h a List.mem_cons_self
       rcases h_a with h_a | h_a | h_a <;>
-        simp [List.countP_cons, h_a, h_zero_one, h_zero_neg, h_one_neg, h_neg_one, ih h_t] <;>
+        simp [h_a, h_zero_one, h_zero_neg, h_one_neg, h_neg_one, ih h_t] <;>
         ring
 
 /-! ## Two rows contribute two positions
@@ -105,14 +105,14 @@ private theorem two_le_countP_of_two_indices {β : Type _} (P : β → Bool) :
           have h_tail : 1 ≤ t.countP P :=
             List.countP_pos_iff.mpr ⟨t[k], List.getElem_mem h_k, by simpa using h_j⟩
           have h_head : P a = true := by simpa using h_i
-          simp only [h_head, cond_true, if_true]
+          simp only [h_head, if_true]
           omega
       | (k + 1), 0 =>
           have h_k : k < t.length := by simpa using hi
           have h_tail : 1 ≤ t.countP P :=
             List.countP_pos_iff.mpr ⟨t[k], List.getElem_mem h_k, by simpa using h_i⟩
           have h_head : P a = true := by simpa using h_j
-          simp only [h_head, cond_true, if_true]
+          simp only [h_head, if_true]
           omega
       | (k + 1), (m + 1) =>
           have := ih k m (by simpa using hi) (by simpa using hj) (by omega)
@@ -338,7 +338,7 @@ private theorem countP_le_one_of_unique_index {β : Type _} (P : β → Bool) :
             (by simpa using h_i) (by simpa using h_j)
           omega)
         simp only [Bool.not_eq_true] at h_a
-        simp [h_a] <;> omega
+        simp [h_a] ; omega
 
 /-- **One row pulls a given message at most once.** Of Main's six memory-bus emissions the three
     register-pre pushes ride at a boolean selector, so never at `-1`; the three current accesses
@@ -400,7 +400,7 @@ theorem row_memBus_pullCount_le_one {length : ℕ} {program : Program length} {t
   intro i j hi hj h_i h_j
   simp only [List.length_map, List.length_cons, List.length_nil] at hi hj
   interval_cases i <;> interval_cases j <;>
-    simp_all [Bool.and_eq_true, decide_eq_true_iff]
+    simp_all [Bool.and_eq_true]
 
 /-- **A pull in a Main row is one of the three current accesses.** The three register-pre pushes
     ride at a boolean selector, so a `-1` interaction can only be a current access. This is the
@@ -582,7 +582,7 @@ theorem registerBoundaryTable_pullCount_le_one
       RegisterBoundary.registerBoundaryFixedColumns,
       RegisterBoundary.registerBoundaryFixedValues,
       RegisterBoundary.registerBoundaryCapacity, Nat.mod_eq_of_lt h_i31,
-      Nat.mod_eq_of_lt h_j31, dif_pos] at h_ptr
+      Nat.mod_eq_of_lt h_j31] at h_ptr
     have h_prime : GL_prime = 18446744069414584321 := rfl
     have h_nat := nat_eq_of_cast_eq (a := i + 1) (b := j + 1) (by omega) (by omega) h_ptr
     omega
@@ -612,7 +612,7 @@ theorem exists_mainRead_of_table_pull {n : ℕ} (trace : AcceptedZiskTrace n)
     (List.countP_pos_iff.mpr ⟨x, h_xarr, h_px⟩)
 
 /-- A boundary table with a pull at a message has a row whose boot carries it. -/
-theorem exists_boot_of_table_pull {n : ℕ} (trace : AcceptedZiskTrace n)
+theorem exists_boot_of_table_pull {n : ℕ} (_trace : AcceptedZiskTrace n)
     {table : Table FGL} (h_component : table.component = RegisterBoundary.component)
     {msg : Array FGL}
     (h_pos : 0 < (table.interactionsWith ZiskFv.Channels.MemoryBus.MemBusChannel.toRaw).countP

--- a/ZiskFv/Compliance/RegisterValueTelescope.lean
+++ b/ZiskFv/Compliance/RegisterValueTelescope.lean
@@ -170,12 +170,12 @@ theorem memBus_mem_op_three_counterpart
     · have h_op := h_op_of_pulled h_eval
       rw [memBusMessage_eval_mem_op] at h_op
       have h_lit : (1 : FGL) = 3 := by
-        simpa [ZiskFv.AirsClean.MemAlignReadByte.memReadMessageExpr, Expression.eval] using h_op
+        simp [ZiskFv.AirsClean.MemAlignReadByte.memReadMessageExpr, Expression.eval] at h_op
       exact absurd h_lit (by decide)
     · have h_op := h_op_of_pushed h_eval
       rw [ZiskFv.AirsClean.MemAlignReadByte.eval_memBusMessageExpr] at h_op
       have h_lit : (1 : FGL) = 3 := by
-        simpa [ZiskFv.AirsClean.MemAlignReadByte.memBusMessage] using h_op
+        simp [ZiskFv.AirsClean.MemAlignReadByte.memBusMessage] at h_op
       exact absurd h_lit (by decide)
   -- MemAlignByte carries `1` or `1 + is_write`.
   · exfalso
@@ -187,7 +187,7 @@ theorem memBus_mem_op_three_counterpart
     · have h_op := h_op_of_pulled h_eval
       rw [memBusMessage_eval_mem_op] at h_op
       have h_lit : (1 : FGL) = 3 := by
-        simpa [ZiskFv.AirsClean.MemAlignByte.memReadMessageExpr, Expression.eval] using h_op
+        simp [ZiskFv.AirsClean.MemAlignByte.memReadMessageExpr, Expression.eval] at h_op
       exact absurd h_lit (by decide)
     · have h_spec := h_rowSpec r h_r
       rw [h_mab, ZiskFv.AirsClean.MemAlignByte.component_spec,
@@ -249,7 +249,7 @@ theorem memBus_mem_op_three_counterpart
     · have h_op := h_op_of_emitted h_eval
       rw [ZiskFv.AirsClean.Mem.eval_memBusDualMessageExpr] at h_op
       have h_lit : (1 : FGL) = 3 := by
-        simpa [ZiskFv.AirsClean.Mem.memBusDualMessage] using h_op
+        simp [ZiskFv.AirsClean.Mem.memBusDualMessage] at h_op
       exact absurd h_lit (by decide)
   · exfalso
     have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
@@ -385,12 +385,12 @@ theorem memBus_mem_op_three_table_component
     · have h_op := h_op_of_pulled h_eval
       rw [memBusMessage_eval_mem_op] at h_op
       have h_lit : (1 : FGL) = 3 := by
-        simpa [ZiskFv.AirsClean.MemAlignReadByte.memReadMessageExpr, Expression.eval] using h_op
+        simp [ZiskFv.AirsClean.MemAlignReadByte.memReadMessageExpr, Expression.eval] at h_op
       exact absurd h_lit (by decide)
     · have h_op := h_op_of_pushed h_eval
       rw [ZiskFv.AirsClean.MemAlignReadByte.eval_memBusMessageExpr] at h_op
       have h_lit : (1 : FGL) = 3 := by
-        simpa [ZiskFv.AirsClean.MemAlignReadByte.memBusMessage] using h_op
+        simp [ZiskFv.AirsClean.MemAlignReadByte.memBusMessage] at h_op
       exact absurd h_lit (by decide)
   -- MemAlignByte carries `1` or `1 + is_write`.
   · exfalso
@@ -402,7 +402,7 @@ theorem memBus_mem_op_three_table_component
     · have h_op := h_op_of_pulled h_eval
       rw [memBusMessage_eval_mem_op] at h_op
       have h_lit : (1 : FGL) = 3 := by
-        simpa [ZiskFv.AirsClean.MemAlignByte.memReadMessageExpr, Expression.eval] using h_op
+        simp [ZiskFv.AirsClean.MemAlignByte.memReadMessageExpr, Expression.eval] at h_op
       exact absurd h_lit (by decide)
     · have h_spec := h_rowSpec r h_r
       rw [h_mab, ZiskFv.AirsClean.MemAlignByte.component_spec,
@@ -464,7 +464,7 @@ theorem memBus_mem_op_three_table_component
     · have h_op := h_op_of_emitted h_eval
       rw [ZiskFv.AirsClean.Mem.eval_memBusDualMessageExpr] at h_op
       have h_lit : (1 : FGL) = 3 := by
-        simpa [ZiskFv.AirsClean.Mem.memBusDualMessage] using h_op
+        simp [ZiskFv.AirsClean.Mem.memBusDualMessage] at h_op
       exact absurd h_lit (by decide)
   · exfalso
     have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
@@ -704,7 +704,7 @@ theorem backward_step_lt
       componentWithRomMemAndOpBus trace.programLength trace.program)
     {row : Array FGL} (h_row : row ∈ table.table) (s : RegSlot)
     (h_sel : s.selector (eval (table.environment row) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar) = 1)
-    {tbl : Table FGL} (h_tbl : tbl ∈ trace.witness.allTables)
+    {tbl : Table FGL} (_h_tbl : tbl ∈ trace.witness.allTables)
     (h_comp : tbl.component = componentWithRomMemAndOpBus trace.programLength trace.program)
     {r : Array FGL} (h_r : r ∈ tbl.table) (t : RegSlot)
     (h_eq : t.readMessage (eval (tbl.environment r) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar)
@@ -774,7 +774,7 @@ set_option maxHeartbeats 1000000 in
 theorem exists_bootAnchored_of_fuel
     {n : Nat} (trace : AcceptedZiskTrace n) :
     ∀ (fuel : ℕ) {table : Table FGL}, table ∈ trace.witness.allTables →
-      ∀ (h_component : table.component =
+      ∀ (_h_component : table.component =
           componentWithRomMemAndOpBus trace.programLength trace.program),
         ∀ {row : Array FGL}, row ∈ table.table → ∀ (s : RegSlot),
           s.selector (eval (table.environment row) (componentWithRomMemAndOpBus trace.programLength trace.program).rowInputVar) = 1 →
@@ -866,7 +866,7 @@ def RegWalkStep.AnswersRegPre (p q : RegWalkStep) : Prop :=
 theorem exists_bootWalk_of_fuel
     {n : Nat} (trace : AcceptedZiskTrace n) :
     ∀ (fuel : ℕ) {table : Table FGL}, table ∈ trace.witness.allTables →
-      ∀ (h_component : table.component =
+      ∀ (_h_component : table.component =
           componentWithRomMemAndOpBus trace.programLength trace.program),
         ∀ {row : Array FGL}, row ∈ table.table → ∀ (s : RegSlot),
           s.selector (eval (table.environment row)

--- a/ZiskFv/Compliance/RegisterValueTelescope.lean
+++ b/ZiskFv/Compliance/RegisterValueTelescope.lean
@@ -170,12 +170,12 @@ theorem memBus_mem_op_three_counterpart
     · have h_op := h_op_of_pulled h_eval
       rw [memBusMessage_eval_mem_op] at h_op
       have h_lit : (1 : FGL) = 3 := by
-        simp [ZiskFv.AirsClean.MemAlignReadByte.memReadMessageExpr, Expression.eval] at h_op
+        simp [Expression.eval] at h_op
       exact absurd h_lit (by decide)
     · have h_op := h_op_of_pushed h_eval
       rw [ZiskFv.AirsClean.MemAlignReadByte.eval_memBusMessageExpr] at h_op
       have h_lit : (1 : FGL) = 3 := by
-        simp [ZiskFv.AirsClean.MemAlignReadByte.memBusMessage] at h_op
+        simp at h_op
       exact absurd h_lit (by decide)
   -- MemAlignByte carries `1` or `1 + is_write`.
   · exfalso
@@ -187,7 +187,7 @@ theorem memBus_mem_op_three_counterpart
     · have h_op := h_op_of_pulled h_eval
       rw [memBusMessage_eval_mem_op] at h_op
       have h_lit : (1 : FGL) = 3 := by
-        simp [ZiskFv.AirsClean.MemAlignByte.memReadMessageExpr, Expression.eval] at h_op
+        simp [Expression.eval] at h_op
       exact absurd h_lit (by decide)
     · have h_spec := h_rowSpec r h_r
       rw [h_mab, ZiskFv.AirsClean.MemAlignByte.component_spec,
@@ -249,7 +249,7 @@ theorem memBus_mem_op_three_counterpart
     · have h_op := h_op_of_emitted h_eval
       rw [ZiskFv.AirsClean.Mem.eval_memBusDualMessageExpr] at h_op
       have h_lit : (1 : FGL) = 3 := by
-        simp [ZiskFv.AirsClean.Mem.memBusDualMessage] at h_op
+        simp at h_op
       exact absurd h_lit (by decide)
   · exfalso
     have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=
@@ -385,12 +385,12 @@ theorem memBus_mem_op_three_table_component
     · have h_op := h_op_of_pulled h_eval
       rw [memBusMessage_eval_mem_op] at h_op
       have h_lit : (1 : FGL) = 3 := by
-        simp [ZiskFv.AirsClean.MemAlignReadByte.memReadMessageExpr, Expression.eval] at h_op
+        simp [Expression.eval] at h_op
       exact absurd h_lit (by decide)
     · have h_op := h_op_of_pushed h_eval
       rw [ZiskFv.AirsClean.MemAlignReadByte.eval_memBusMessageExpr] at h_op
       have h_lit : (1 : FGL) = 3 := by
-        simp [ZiskFv.AirsClean.MemAlignReadByte.memBusMessage] at h_op
+        simp at h_op
       exact absurd h_lit (by decide)
   -- MemAlignByte carries `1` or `1 + is_write`.
   · exfalso
@@ -402,7 +402,7 @@ theorem memBus_mem_op_three_table_component
     · have h_op := h_op_of_pulled h_eval
       rw [memBusMessage_eval_mem_op] at h_op
       have h_lit : (1 : FGL) = 3 := by
-        simp [ZiskFv.AirsClean.MemAlignByte.memReadMessageExpr, Expression.eval] at h_op
+        simp [Expression.eval] at h_op
       exact absurd h_lit (by decide)
     · have h_spec := h_rowSpec r h_r
       rw [h_mab, ZiskFv.AirsClean.MemAlignByte.component_spec,
@@ -464,7 +464,7 @@ theorem memBus_mem_op_three_table_component
     · have h_op := h_op_of_emitted h_eval
       rw [ZiskFv.AirsClean.Mem.eval_memBusDualMessageExpr] at h_op
       have h_lit : (1 : FGL) = 3 := by
-        simp [ZiskFv.AirsClean.Mem.memBusDualMessage] at h_op
+        simp at h_op
       exact absurd h_lit (by decide)
   · exfalso
     have h_nil : table.interactionsWith MemBusChannel.toRaw = [] :=

--- a/ZiskFv/Compliance/RegisterWalk.lean
+++ b/ZiskFv/Compliance/RegisterWalk.lean
@@ -231,7 +231,7 @@ open ZiskFv.Channels.MemoryBus (MemBusChannel)
     index, and this is the bridge. -/
 theorem exists_index_of_mem_mainTable
     {length : Nat} {program : Program length} {table : Table FGL}
-    (h_component :
+    (_h_component :
       table.component = ZiskFv.AirsClean.Main.componentWithRomMemAndOpBus length program)
     {row : Array FGL} (h_row : row ∈ table.table) :
     ∃ index, ∃ _h : index < table.table.length,

--- a/ZiskFv/Compliance/SdLdMemTable.lean
+++ b/ZiskFv/Compliance/SdLdMemTable.lean
@@ -106,7 +106,7 @@ theorem sdLdMemRows_proverAssumptions (index : Fin sdLdMemRows.length) :
     componentWithDualMemBus.circuit.ProverAssumptions (sdLdMemRows.get index)
       sdLdMemData (ProverHint.empty FGL) := by
   have h_index : index.val < 2 := by
-    simpa [sdLdMemRows] using index.isLt
+    simp [sdLdMemRows]
   interval_cases h : index.val
   · have h_eq : index = ⟨0, by simp [sdLdMemRows]⟩ := Fin.ext (by omega)
     subst index
@@ -415,7 +415,7 @@ theorem sdLdMemTable_transitions : sdLdMemTable.TransitionConstraints := by
         ZiskFv.Airs.Mem.direct_gsum_distance_end_0,
         ZiskFv.Airs.Mem.direct_gsum_distance_end_1,
         ZiskFv.Airs.Mem.gsum_accumulator_delta, sdMemRow, memRowOf,
-        memReadSameAddrOf, memValueOf] <;> decide
+        memReadSameAddrOf, memValueOf] ; decide
   · have h_eq : index = ⟨1, by simp⟩ := Fin.ext (by omega)
     subst index
     let previous := sdLdMemTable.previousEnvironment ⟨1, by simp⟩
@@ -449,7 +449,7 @@ theorem sdLdMemTable_transitions : sdLdMemTable.TransitionConstraints := by
         ZiskFv.Airs.Mem.direct_gsum_distance_end_0,
         ZiskFv.Airs.Mem.direct_gsum_distance_end_1,
         ZiskFv.Airs.Mem.gsum_accumulator_delta, sdMemRow, ldMemRow, memRowOf,
-        memReadSameAddrOf, memValueOf] <;> decide
+        memReadSameAddrOf, memValueOf] ; decide
 
 /-- The full `mem.pil` generated surface (segment 0--23 and permutation
 24--33) is available from this table's ordinary constraints and indexed

--- a/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
@@ -183,9 +183,7 @@ private theorem sdLdMainRowAt (i : Fin 7) :
       rw [sdLdMainTable_length]
       omega⟩)
       (componentWithRomMemAndOpBus 7 sdLdProgram).rowInputVar = _
-  simpa [sdLdMainRows] using sdLdMainTable_evalAt ⟨i.val, by
-    rw [sdLdMainTable_length]
-    omega⟩
+  simp [sdLdMainRows]
 
 private theorem sdLdMainPc (i : Fin 7) :
     (ZiskFv.AirsClean.FullEnsemble.mainOfTable sdLdAcceptedTrace.program
@@ -199,10 +197,10 @@ private theorem sdLdMainPc (i : Fin 7) :
   rw [congrArg (fun row => row.core.pc) (sdLdMainRowAt i)]
   fin_cases i <;>
     simp [sdLdMainRows, sdLdAddiX1A0Row,
-    sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate, sdLdSlliX1Row,
-    sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate, sdLdAddiX1EightRow,
-    sdLdAddiX1EightRowWithLast, sdLdAddiX1EightRowTemplate, sdLdAddiX2Row,
-    sdLdAddiX2RowWithLast, sdLdAddiX2RowTemplate, sdLdSdRow, sdLdSdRowTemplate,
+    sdLdAddiX1A0RowTemplate, sdLdSlliX1Row,
+    sdLdSlliX1RowTemplate, sdLdAddiX1EightRow,
+    sdLdAddiX1EightRowTemplate, sdLdAddiX2Row,
+    sdLdAddiX2RowTemplate, sdLdSdRow, sdLdSdRowTemplate,
     sdLdLdRow, sdLdLdRowTemplate, sdLdJalRow, mainRomRowOf,
     sdLdAddiX1A0ProgramRow, sdLdSlliX1ProgramRow, sdLdAddiX1EightProgramRow,
     sdLdAddiX2ProgramRow, sdLdSdProgramRow, sdLdLdProgramRow, sdLdJalProgramRow]
@@ -433,8 +431,7 @@ private theorem sdLdReadX0 (i : Fin 7) :
       EStateM.Result.ok (0#64) (sdLdSailTrace i) := by
   fin_cases i <;>
     simp [sdLdSailTrace, sdLdState, sdLdRegs, x0, x1, x2, x3,
-      regidx_to_fin, read_xreg, reg_of_fin, sdLdStoredMem,
-      Std.ExtDHashMap.get?_insert]
+      regidx_to_fin, read_xreg, reg_of_fin, sdLdStoredMem]
 
 private theorem sdLdAcceptedMainRowAt (i : Fin 7) :
     ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero sdLdAcceptedTrace.program
@@ -464,7 +461,7 @@ private theorem sdLdReadX1 (i : Fin 7) :
       EStateM.Result.ok
         ([0#64, 160#64, 2684354560#64, 2684354568#64,
           2684354568#64, 2684354568#64, 2684354568#64][i.val]'(by
-            simpa using i.isLt))
+            simp))
         (sdLdSailTrace i) := by
   fin_cases i <;>
     simp [sdLdSailTrace, sdLdState, sdLdRegs, x1, x2, x3, regidx_to_fin,
@@ -615,13 +612,12 @@ def sdLdLdInputs :
     unfold PureSpec.ld_state_assumptions
     simp [sdLdLdClaim, sdLdLdInput, sdLdSailTrace, sdLdLdIndex, sdLdState, sdLdRegs,
       sdLdStoredMem, sdLdInitialMem, sdLdAcceptedReplayRows, sdMemRow,
-      ZiskFv.AirsClean.Mem.memBusMessage, ZiskFv.AirsClean.Mem.memRowOf,
+      ZiskFv.AirsClean.Mem.memRowOf,
       ZiskFv.AirsClean.Mem.memValueOf,
       ZiskFv.Channels.MemoryBus.MemBusMessage.toEntry,
       ZiskFv.ZiskCircuit.MemTrace.writeMemoryOfEntry,
       ZiskFv.ZiskCircuit.MemTrace.zeroMemoryOfRows,
       ZiskFv.ZiskCircuit.MemTrace.zeroMemoryOfEntry,
-      ZiskFv.ZiskCircuit.MemTrace.zeroedMemoryEntryOfEntry,
       ZiskFv.Channels.MemoryBusBytes.byteAt,
       x1, x2, x3, regidx_to_fin, reg_of_fin,
       LeanRV64D.Functions.rX_bits, LeanRV64D.Functions.rX,

--- a/ZiskFv/Compliance/SdLdSpinWitness.lean
+++ b/ZiskFv/Compliance/SdLdSpinWitness.lean
@@ -225,66 +225,46 @@ def sdLdMainRows : List (MainRowWithRom FGL) :=
 theorem sdLdMain_pc_addi_slli :
     transitionBetween sdLdAddiX1A0Row sdLdSlliX1Row := by
   simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdAddiX1A0Row,
-    sdLdAddiX1A0RowWithLast,
-    sdLdAddiX1A0RowTemplate, sdLdSlliX1Row, sdLdSlliX1RowWithLast,
+    sdLdAddiX1A0RowTemplate, sdLdSlliX1Row,
     sdLdSlliX1RowTemplate, sdLdAddiX1A0ProgramRow, sdLdSlliX1ProgramRow,
-    addiX0Bits, addiX1Bits, mainRomRowOf, sdLdFreeCols,
-    mainRomFreeColsWithRegisterPrevious, materializeMainRegisterRow,
-    materializeMainRegisterAccesses, withMainRegisterPrevious,
-    ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
+    addiX0Bits, addiX1Bits, mainRomRowOf, withMainRegisterPrevious]
 
 theorem sdLdMain_pc_slli_addi :
     transitionBetween sdLdSlliX1Row sdLdAddiX1EightRow := by
   simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdSlliX1Row,
-    sdLdSlliX1RowWithLast,
-    sdLdSlliX1RowTemplate, sdLdAddiX1EightRow, sdLdAddiX1EightRowWithLast,
+    sdLdSlliX1RowTemplate, sdLdAddiX1EightRow,
     sdLdAddiX1EightRowTemplate, sdLdSlliX1ProgramRow, sdLdAddiX1EightProgramRow,
-    addiX1Bits, mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious,
-    materializeMainRegisterRow, materializeMainRegisterAccesses, withMainRegisterPrevious,
-    ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
+    addiX1Bits, mainRomRowOf, withMainRegisterPrevious]
 
 theorem sdLdMain_pc_addi_addi :
     transitionBetween sdLdAddiX1EightRow sdLdAddiX2Row := by
   simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdAddiX1EightRow,
-    sdLdAddiX1EightRowWithLast,
-    sdLdAddiX1EightRowTemplate, sdLdAddiX2Row, sdLdAddiX2RowWithLast,
+    sdLdAddiX1EightRowTemplate, sdLdAddiX2Row,
     sdLdAddiX2RowTemplate, sdLdAddiX1EightProgramRow, sdLdAddiX2ProgramRow,
-    addiX0Bits, addiX1Bits, mainRomRowOf, sdLdFreeCols,
-    mainRomFreeColsWithRegisterPrevious, materializeMainRegisterRow,
-    materializeMainRegisterAccesses, withMainRegisterPrevious,
-    ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
+    addiX0Bits, addiX1Bits, mainRomRowOf, withMainRegisterPrevious]
 
 theorem sdLdMain_pc_addi_sd :
     transitionBetween sdLdAddiX2Row sdLdSdRow := by
   simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdAddiX2Row,
-    sdLdAddiX2RowWithLast,
     sdLdAddiX2RowTemplate, sdLdSdRow, sdLdSdRowTemplate, sdLdAddiX2ProgramRow,
-    sdLdSdProgramRow, addiX0Bits, sdLdSdBits, mainRomRowOf, sdLdFreeCols,
-    mainRomFreeColsWithRegisterPrevious, materializeMainRegisterRow,
-    materializeMainRegisterAccesses, withMainRegisterPrevious,
-    ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
+    sdLdSdProgramRow, addiX0Bits, sdLdSdBits, mainRomRowOf, withMainRegisterPrevious]
 
 theorem sdLdMain_pc_sd_ld : transitionBetween sdLdSdRow sdLdLdRow := by
   simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdSdRow,
     sdLdSdRowTemplate, sdLdLdRow,
     sdLdLdRowTemplate, sdLdSdProgramRow, sdLdLdProgramRow, sdLdSdBits, sdLdLdBits,
-    mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious,
-    materializeMainRegisterRow, materializeMainRegisterAccesses, withMainRegisterPrevious,
-    ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
+    mainRomRowOf, withMainRegisterPrevious]
 
 theorem sdLdMain_pc_ld_jal : transitionBetween sdLdLdRow (sdLdJalRow 6) := by
   simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdLdRow,
     sdLdLdRowTemplate, sdLdJalRow,
     sdLdLdProgramRow, sdLdJalProgramRow, sdLdLdBits, AddSpinWitness.addSpinJalBits,
-    mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious,
-    materializeMainRegisterRow, materializeMainRegisterAccesses, withMainRegisterPrevious,
-    ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
+    mainRomRowOf, withMainRegisterPrevious]
 
 theorem sdLdMain_pc_jal_jal : transitionBetween (sdLdJalRow 6) (sdLdJalRow 7) := by
   simp [transitionBetween, sourceCCopyBetween, pcHandshakeBetween, sdLdJalRow,
     sdLdJalProgramRow, AddSpinWitness.addSpinJalBits,
-    mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious,
-    ZiskFv.AirsClean.RegisterBoundary.bootMessage, boundaryRowIdle]
+    mainRomRowOf]
   ring
 
 def sdLdProgram : Program 7
@@ -597,54 +577,44 @@ theorem sdLdMainTableWithData_constraints (data : ProverData FGL)
   simp only [List.mem_cons, List.not_mem_nil, or_false] at h_arr
   rcases h_arr with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
   · exact sdLdMain_constraintsHold_materialize data 0 sdLdAddiX1A0Row
-      (by simp [sdLdAddiX1A0Row, sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate,
-        mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
-      (by simp [sdLdAddiX1A0Row, sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate,
-        mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
+      (by simp [sdLdAddiX1A0Row, sdLdAddiX1A0RowTemplate,
+        mainRomRowOf])
+      (by simp [sdLdAddiX1A0Row, sdLdAddiX1A0RowTemplate,
+        mainRomRowOf])
       (h_assumptions sdLdAddiX1A0Row (by simp [sdLdMainRows]))
   · exact sdLdMain_constraintsHold_materialize data 1 sdLdSlliX1Row
-      (by simp [sdLdSlliX1Row, sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate,
-        mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
-      (by simp [sdLdSlliX1Row, sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate,
-        mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
+      (by simp [sdLdSlliX1Row, sdLdSlliX1RowTemplate,
+        mainRomRowOf])
+      (by simp [sdLdSlliX1Row, sdLdSlliX1RowTemplate,
+        mainRomRowOf])
       (h_assumptions sdLdSlliX1Row (by simp [sdLdMainRows]))
   · exact sdLdMain_constraintsHold_materialize data 2 sdLdAddiX1EightRow
-      (by simp [sdLdAddiX1EightRow, sdLdAddiX1EightRowWithLast,
-        sdLdAddiX1EightRowTemplate, mainRomRowOf, sdLdFreeCols,
-        mainRomFreeColsWithRegisterPrevious])
-      (by simp [sdLdAddiX1EightRow, sdLdAddiX1EightRowWithLast,
-        sdLdAddiX1EightRowTemplate, mainRomRowOf, sdLdFreeCols,
-        mainRomFreeColsWithRegisterPrevious])
+      (by simp [sdLdAddiX1EightRow,
+        sdLdAddiX1EightRowTemplate, mainRomRowOf])
+      (by simp [sdLdAddiX1EightRow,
+        sdLdAddiX1EightRowTemplate, mainRomRowOf])
       (h_assumptions sdLdAddiX1EightRow (by simp [sdLdMainRows]))
   · exact sdLdMain_constraintsHold_materialize data 3 sdLdAddiX2Row
-      (by simp [sdLdAddiX2Row, sdLdAddiX2RowWithLast, sdLdAddiX2RowTemplate,
-        mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
-      (by simp [sdLdAddiX2Row, sdLdAddiX2RowWithLast, sdLdAddiX2RowTemplate,
-        mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
+      (by simp [sdLdAddiX2Row, sdLdAddiX2RowTemplate,
+        mainRomRowOf])
+      (by simp [sdLdAddiX2Row, sdLdAddiX2RowTemplate,
+        mainRomRowOf])
       (h_assumptions sdLdAddiX2Row (by simp [sdLdMainRows]))
   · exact sdLdMain_constraintsHold_materialize data 4 sdLdSdRow
-      (by simp [sdLdSdRow, sdLdSdRowTemplate, mainRomRowOf, sdLdFreeCols,
-        mainRomFreeColsWithRegisterPrevious])
-      (by simp [sdLdSdRow, sdLdSdRowTemplate, mainRomRowOf, sdLdFreeCols,
-        mainRomFreeColsWithRegisterPrevious])
+      (by simp [sdLdSdRow, sdLdSdRowTemplate, mainRomRowOf])
+      (by simp [sdLdSdRow, sdLdSdRowTemplate, mainRomRowOf])
       (h_assumptions sdLdSdRow (by simp [sdLdMainRows]))
   · exact sdLdMain_constraintsHold_materialize data 5 sdLdLdRow
-      (by simp [sdLdLdRow, sdLdLdRowTemplate, mainRomRowOf, sdLdFreeCols,
-        mainRomFreeColsWithRegisterPrevious])
-      (by simp [sdLdLdRow, sdLdLdRowTemplate, mainRomRowOf, sdLdFreeCols,
-        mainRomFreeColsWithRegisterPrevious])
+      (by simp [sdLdLdRow, sdLdLdRowTemplate, mainRomRowOf])
+      (by simp [sdLdLdRow, sdLdLdRowTemplate, mainRomRowOf])
       (h_assumptions sdLdLdRow (by simp [sdLdMainRows]))
   · exact sdLdMain_constraintsHold_materialize data 6 (sdLdJalRow 6)
-      (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
-        mainRomFreeColsWithRegisterPrevious])
-      (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
-        mainRomFreeColsWithRegisterPrevious])
+      (by simp [sdLdJalRow, mainRomRowOf])
+      (by simp [sdLdJalRow, mainRomRowOf])
       (h_assumptions (sdLdJalRow 6) (by simp [sdLdMainRows]))
   · exact sdLdMain_constraintsHold_materialize data 7 (sdLdJalRow 7)
-      (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
-        mainRomFreeColsWithRegisterPrevious])
-      (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
-        mainRomFreeColsWithRegisterPrevious])
+      (by simp [sdLdJalRow, mainRomRowOf])
+      (by simp [sdLdJalRow, mainRomRowOf])
       (h_assumptions (sdLdJalRow 7) (by simp [sdLdMainRows]))
 
 theorem sdLdMainTable_constraints : sdLdMainTable.Constraints := by
@@ -678,12 +648,12 @@ theorem sdLdMainTable_constraints : sdLdMainTable.Constraints := by
       (Environment.fromArray (mainFixedColumns.materialize _ (mainRawRow _)) sdLdMemData)
       (varFromOffset MainRowWithRom 0) = _ <;>
     apply eval_mainRawRow_materialize <;>
-    simp [sdLdAddiX1A0Row, sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate,
-      sdLdSlliX1Row, sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate,
-      sdLdAddiX1EightRow, sdLdAddiX1EightRowWithLast, sdLdAddiX1EightRowTemplate,
-      sdLdAddiX2Row, sdLdAddiX2RowWithLast, sdLdAddiX2RowTemplate,
+    simp [sdLdAddiX1A0Row, sdLdAddiX1A0RowTemplate,
+      sdLdSlliX1Row, sdLdSlliX1RowTemplate,
+      sdLdAddiX1EightRow, sdLdAddiX1EightRowTemplate,
+      sdLdAddiX2Row, sdLdAddiX2RowTemplate,
       sdLdSdRow, sdLdSdRowTemplate, sdLdLdRow, sdLdLdRowTemplate, sdLdJalRow,
-      mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious]
+      mainRomRowOf]
 
 theorem sdLdMainTable_transitions : sdLdMainTable.TransitionConstraints := by
   rw [Table.TransitionConstraints]
@@ -696,8 +666,7 @@ theorem sdLdMainTable_transitions : sdLdMainTable.TransitionConstraints := by
   fin_cases index
   · simp [Table.previousEnvironment, sdLdMainRows, transitionBetween, sourceCCopyBetween,
       pcHandshakeBetween, sdLdAddiX1A0Row,
-      sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate, mainRomRowOf,
-      sdLdFreeCols, mainRomFreeColsWithRegisterPrevious]
+      sdLdAddiX1A0RowTemplate, mainRomRowOf]
   · simpa [Table.previousEnvironment, sdLdMainRows] using sdLdMain_pc_addi_slli
   · simpa [Table.previousEnvironment, sdLdMainRows] using sdLdMain_pc_slli_addi
   · simpa [Table.previousEnvironment, sdLdMainRows] using sdLdMain_pc_addi_addi
@@ -947,7 +916,7 @@ def sdLdWitness : EnsembleWitness sdLdEnsemble where
       registerBoundaryRowsTableOf, emptyComponentTable,
       sdLdMemTable, memRowsTable, sdLdSpecifiedRangesTable, sdLdBinaryExtensionTable,
       binaryExtensionShiftStaticRowsTable, sdLdBinaryAddTable, binaryAddRowsTable,
-      sdLdMainTable, AddSpinWitness.mainRowsTable] at h_table
+      sdLdMainTable] at h_table
     rcases h_table with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl |
       rfl | rfl | rfl | rfl <;> rfl
 
@@ -1106,7 +1075,7 @@ private theorem sdLdEmptyTableWithData_transitions (component : Component FGL) :
   intro index
   have h_length :
       (sdLdTableWithData (emptyComponentTable component)).length = 0 := by
-    simp [sdLdTableWithData, emptyComponentTable, Table.length, Table.table]
+    simp [sdLdTableWithData, emptyComponentTable, Table.length]
   exact Fin.elim0 (Fin.cast h_length index)
 
 private theorem sdLdEmptyTableWithData_cyclicSuccessorTransitions (component : Component FGL) :
@@ -1116,7 +1085,7 @@ private theorem sdLdEmptyTableWithData_cyclicSuccessorTransitions (component : C
   intro index
   have h_length :
       (sdLdTableWithData (emptyComponentTable component)).length = 0 := by
-    simp [sdLdTableWithData, emptyComponentTable, Table.length, Table.table]
+    simp [sdLdTableWithData, emptyComponentTable, Table.length]
   exact Fin.elim0 (Fin.cast h_length index)
 
 theorem sdLdWitness_transitions : sdLdWitness.TransitionConstraints := by
@@ -1404,7 +1373,7 @@ private theorem sdLdTables_interactionsWith_nil_of_ne_protocol
     simpa using h_rsr
   rw [sdLdWitness_tables]
   simp [sdLdTables, h_boundary, h_memTable, h_rangeTable, h_extension, h_binaryAdd, h_main,
-    h_stepRange, emptyComponentTable_interactionsWith]
+    h_stepRange]
 
 private theorem sdLdBalancedInteractions_nil :
     BalancedInteractions ([] : List (Interaction FGL)) := by
@@ -1550,7 +1519,7 @@ private theorem sdLdBinaryAddTable_opBusInteractions :
     ZiskFv.AirsClean.BinaryAdd.component.operations.interactionValuesWith
       OpBusChannel.toRaw (Environment.fromArray arr sdLdMemData)) = _
   simp_rw [List.flatMap_map]
-  simp [binaryAddRowArray, Environment.fromInput, sdLdBinaryAddOpBus_row]
+  simp [binaryAddRowArray, sdLdBinaryAddOpBus_row]
 
 private theorem sdLdBinaryExtensionTable_opBusInteractions :
     (sdLdTableWithData sdLdBinaryExtensionTable).interactionsWith OpBusChannel.toRaw =
@@ -1637,54 +1606,44 @@ private theorem sdLdMainTable_opBusInteractions :
     List.mapIdx_nil, List.flatMap_cons, List.flatMap_nil, List.append_nil]
   rw [sdLdMainOpBusInteractionsAt _ sdLdAddiX1A0Row
       (eval_mainRawRow_materialize 0 sdLdMemData sdLdAddiX1A0Row
-        (by simp [sdLdAddiX1A0Row, sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate,
-          mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
-        (by simp [sdLdAddiX1A0Row, sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate,
-          mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])),
+        (by simp [sdLdAddiX1A0Row, sdLdAddiX1A0RowTemplate,
+          mainRomRowOf])
+        (by simp [sdLdAddiX1A0Row, sdLdAddiX1A0RowTemplate,
+          mainRomRowOf])),
     sdLdMainOpBusInteractionsAt _ sdLdSlliX1Row
       (eval_mainRawRow_materialize 1 sdLdMemData sdLdSlliX1Row
-        (by simp [sdLdSlliX1Row, sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate,
-          mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
-        (by simp [sdLdSlliX1Row, sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate,
-          mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])),
+        (by simp [sdLdSlliX1Row, sdLdSlliX1RowTemplate,
+          mainRomRowOf])
+        (by simp [sdLdSlliX1Row, sdLdSlliX1RowTemplate,
+          mainRomRowOf])),
     sdLdMainOpBusInteractionsAt _ sdLdAddiX1EightRow
       (eval_mainRawRow_materialize 2 sdLdMemData sdLdAddiX1EightRow
-        (by simp [sdLdAddiX1EightRow, sdLdAddiX1EightRowWithLast,
-          sdLdAddiX1EightRowTemplate, mainRomRowOf, sdLdFreeCols,
-          mainRomFreeColsWithRegisterPrevious])
-        (by simp [sdLdAddiX1EightRow, sdLdAddiX1EightRowWithLast,
-          sdLdAddiX1EightRowTemplate, mainRomRowOf, sdLdFreeCols,
-          mainRomFreeColsWithRegisterPrevious])),
+        (by simp [sdLdAddiX1EightRow,
+          sdLdAddiX1EightRowTemplate, mainRomRowOf])
+        (by simp [sdLdAddiX1EightRow,
+          sdLdAddiX1EightRowTemplate, mainRomRowOf])),
     sdLdMainOpBusInteractionsAt _ sdLdAddiX2Row
       (eval_mainRawRow_materialize 3 sdLdMemData sdLdAddiX2Row
-        (by simp [sdLdAddiX2Row, sdLdAddiX2RowWithLast, sdLdAddiX2RowTemplate,
-          mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
-        (by simp [sdLdAddiX2Row, sdLdAddiX2RowWithLast, sdLdAddiX2RowTemplate,
-          mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])),
+        (by simp [sdLdAddiX2Row, sdLdAddiX2RowTemplate,
+          mainRomRowOf])
+        (by simp [sdLdAddiX2Row, sdLdAddiX2RowTemplate,
+          mainRomRowOf])),
     sdLdMainOpBusInteractionsAt _ sdLdSdRow
       (eval_mainRawRow_materialize 4 sdLdMemData sdLdSdRow
-        (by simp [sdLdSdRow, sdLdSdRowTemplate, mainRomRowOf, sdLdFreeCols,
-          mainRomFreeColsWithRegisterPrevious])
-        (by simp [sdLdSdRow, sdLdSdRowTemplate, mainRomRowOf, sdLdFreeCols,
-          mainRomFreeColsWithRegisterPrevious])),
+        (by simp [sdLdSdRow, sdLdSdRowTemplate, mainRomRowOf])
+        (by simp [sdLdSdRow, sdLdSdRowTemplate, mainRomRowOf])),
     sdLdMainOpBusInteractionsAt _ sdLdLdRow
       (eval_mainRawRow_materialize 5 sdLdMemData sdLdLdRow
-        (by simp [sdLdLdRow, sdLdLdRowTemplate, mainRomRowOf, sdLdFreeCols,
-          mainRomFreeColsWithRegisterPrevious])
-        (by simp [sdLdLdRow, sdLdLdRowTemplate, mainRomRowOf, sdLdFreeCols,
-          mainRomFreeColsWithRegisterPrevious])),
+        (by simp [sdLdLdRow, sdLdLdRowTemplate, mainRomRowOf])
+        (by simp [sdLdLdRow, sdLdLdRowTemplate, mainRomRowOf])),
     sdLdMainOpBusInteractionsAt _ (sdLdJalRow 6)
       (eval_mainRawRow_materialize 6 sdLdMemData (sdLdJalRow 6)
-        (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
-          mainRomFreeColsWithRegisterPrevious])
-        (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
-          mainRomFreeColsWithRegisterPrevious])),
+        (by simp [sdLdJalRow, mainRomRowOf])
+        (by simp [sdLdJalRow, mainRomRowOf])),
     sdLdMainOpBusInteractionsAt _ (sdLdJalRow 7)
       (eval_mainRawRow_materialize 7 sdLdMemData (sdLdJalRow 7)
-        (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
-          mainRomFreeColsWithRegisterPrevious])
-        (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
-          mainRomFreeColsWithRegisterPrevious]))]
+        (by simp [sdLdJalRow, mainRomRowOf])
+        (by simp [sdLdJalRow, mainRomRowOf]))]
   rfl
 
 theorem sdLdMainTable_registerStepRangeInteractions :
@@ -1703,54 +1662,44 @@ theorem sdLdMainTable_registerStepRangeInteractions :
     List.mapIdx_nil, List.flatMap_cons, List.flatMap_nil, List.append_nil]
   rw [mainRegisterStepInteractionsAt 7 sdLdProgram _ sdLdAddiX1A0Row
       (eval_mainRawRow_materialize 0 sdLdMemData sdLdAddiX1A0Row
-        (by simp [sdLdAddiX1A0Row, sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate,
-          mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
-        (by simp [sdLdAddiX1A0Row, sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate,
-          mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])),
+        (by simp [sdLdAddiX1A0Row, sdLdAddiX1A0RowTemplate,
+          mainRomRowOf])
+        (by simp [sdLdAddiX1A0Row, sdLdAddiX1A0RowTemplate,
+          mainRomRowOf])),
     mainRegisterStepInteractionsAt 7 sdLdProgram _ sdLdSlliX1Row
       (eval_mainRawRow_materialize 1 sdLdMemData sdLdSlliX1Row
-        (by simp [sdLdSlliX1Row, sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate,
-          mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
-        (by simp [sdLdSlliX1Row, sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate,
-          mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])),
+        (by simp [sdLdSlliX1Row, sdLdSlliX1RowTemplate,
+          mainRomRowOf])
+        (by simp [sdLdSlliX1Row, sdLdSlliX1RowTemplate,
+          mainRomRowOf])),
     mainRegisterStepInteractionsAt 7 sdLdProgram _ sdLdAddiX1EightRow
       (eval_mainRawRow_materialize 2 sdLdMemData sdLdAddiX1EightRow
-        (by simp [sdLdAddiX1EightRow, sdLdAddiX1EightRowWithLast,
-          sdLdAddiX1EightRowTemplate, mainRomRowOf, sdLdFreeCols,
-          mainRomFreeColsWithRegisterPrevious])
-        (by simp [sdLdAddiX1EightRow, sdLdAddiX1EightRowWithLast,
-          sdLdAddiX1EightRowTemplate, mainRomRowOf, sdLdFreeCols,
-          mainRomFreeColsWithRegisterPrevious])),
+        (by simp [sdLdAddiX1EightRow,
+          sdLdAddiX1EightRowTemplate, mainRomRowOf])
+        (by simp [sdLdAddiX1EightRow,
+          sdLdAddiX1EightRowTemplate, mainRomRowOf])),
     mainRegisterStepInteractionsAt 7 sdLdProgram _ sdLdAddiX2Row
       (eval_mainRawRow_materialize 3 sdLdMemData sdLdAddiX2Row
-        (by simp [sdLdAddiX2Row, sdLdAddiX2RowWithLast, sdLdAddiX2RowTemplate,
-          mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])
-        (by simp [sdLdAddiX2Row, sdLdAddiX2RowWithLast, sdLdAddiX2RowTemplate,
-          mainRomRowOf, sdLdFreeCols, mainRomFreeColsWithRegisterPrevious])),
+        (by simp [sdLdAddiX2Row, sdLdAddiX2RowTemplate,
+          mainRomRowOf])
+        (by simp [sdLdAddiX2Row, sdLdAddiX2RowTemplate,
+          mainRomRowOf])),
     mainRegisterStepInteractionsAt 7 sdLdProgram _ sdLdSdRow
       (eval_mainRawRow_materialize 4 sdLdMemData sdLdSdRow
-        (by simp [sdLdSdRow, sdLdSdRowTemplate, mainRomRowOf, sdLdFreeCols,
-          mainRomFreeColsWithRegisterPrevious])
-        (by simp [sdLdSdRow, sdLdSdRowTemplate, mainRomRowOf, sdLdFreeCols,
-          mainRomFreeColsWithRegisterPrevious])),
+        (by simp [sdLdSdRow, sdLdSdRowTemplate, mainRomRowOf])
+        (by simp [sdLdSdRow, sdLdSdRowTemplate, mainRomRowOf])),
     mainRegisterStepInteractionsAt 7 sdLdProgram _ sdLdLdRow
       (eval_mainRawRow_materialize 5 sdLdMemData sdLdLdRow
-        (by simp [sdLdLdRow, sdLdLdRowTemplate, mainRomRowOf, sdLdFreeCols,
-          mainRomFreeColsWithRegisterPrevious])
-        (by simp [sdLdLdRow, sdLdLdRowTemplate, mainRomRowOf, sdLdFreeCols,
-          mainRomFreeColsWithRegisterPrevious])),
+        (by simp [sdLdLdRow, sdLdLdRowTemplate, mainRomRowOf])
+        (by simp [sdLdLdRow, sdLdLdRowTemplate, mainRomRowOf])),
     mainRegisterStepInteractionsAt 7 sdLdProgram _ (sdLdJalRow 6)
       (eval_mainRawRow_materialize 6 sdLdMemData (sdLdJalRow 6)
-        (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
-          mainRomFreeColsWithRegisterPrevious])
-        (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
-          mainRomFreeColsWithRegisterPrevious])),
+        (by simp [sdLdJalRow, mainRomRowOf])
+        (by simp [sdLdJalRow, mainRomRowOf])),
     mainRegisterStepInteractionsAt 7 sdLdProgram _ (sdLdJalRow 7)
       (eval_mainRawRow_materialize 7 sdLdMemData (sdLdJalRow 7)
-        (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
-          mainRomFreeColsWithRegisterPrevious])
-        (by simp [sdLdJalRow, mainRomRowOf, sdLdFreeCols,
-          mainRomFreeColsWithRegisterPrevious]))]
+        (by simp [sdLdJalRow, mainRomRowOf])
+        (by simp [sdLdJalRow, mainRomRowOf]))]
 
 
 private theorem sdLdWitness_opBusInteractions :
@@ -2212,8 +2161,7 @@ private theorem sdLdMemBusNonzero_filter :
         simp only [List.flatMap_cons, List.filter_append]
         rw [ih]
         simp [registerBoundaryMemBusInteractions, registerBoundaryBootInteraction,
-          registerBoundaryReloadInteraction, RegisterMemBusBalance.emittedPulledValue,
-          Channel.pushedValue]
+          registerBoundaryReloadInteraction]
   have h_boundary :
       (sdLdBoundaryRows.flatMap registerBoundaryMemBusInteractions).filter
           (fun interaction => !decide (interaction.mult = 0)) =
@@ -2247,7 +2195,7 @@ private theorem sdLdMemBusNonzero_filter :
         [mainCRegPreInteraction sdLdAddiX1A0Row,
           mainCMemInteraction sdLdAddiX1A0Row] := by
     simp [AddSpinWitness.mainValueMemBusInteractions, sdLdAddiX1A0Row,
-      sdLdAddiX1A0RowWithLast, sdLdAddiX1A0RowTemplate, mainRomRowOf,
+      sdLdAddiX1A0RowTemplate, mainRomRowOf,
       addiX0Bits, mainARegPreInteraction, mainAMemInteraction,
       mainBRegPreInteraction, mainBMemInteraction, mainCRegPreInteraction,
       mainCMemInteraction]
@@ -2259,7 +2207,7 @@ private theorem sdLdMemBusNonzero_filter :
         , mainCRegPreInteraction sdLdSlliX1Row
         , mainCMemInteraction sdLdSlliX1Row ] := by
     simp [AddSpinWitness.mainValueMemBusInteractions, sdLdSlliX1Row,
-      sdLdSlliX1RowWithLast, sdLdSlliX1RowTemplate, mainRomRowOf, addiX1Bits,
+      sdLdSlliX1RowTemplate, mainRomRowOf, addiX1Bits,
       mainARegPreInteraction, mainAMemInteraction, mainBRegPreInteraction,
       mainBMemInteraction, mainCRegPreInteraction, mainCMemInteraction]
   have h_addi_eight :
@@ -2270,7 +2218,7 @@ private theorem sdLdMemBusNonzero_filter :
         , mainCRegPreInteraction sdLdAddiX1EightRow
         , mainCMemInteraction sdLdAddiX1EightRow ] := by
     simp [AddSpinWitness.mainValueMemBusInteractions, sdLdAddiX1EightRow,
-      sdLdAddiX1EightRowWithLast, sdLdAddiX1EightRowTemplate, mainRomRowOf,
+      sdLdAddiX1EightRowTemplate, mainRomRowOf,
       addiX1Bits, mainARegPreInteraction, mainAMemInteraction,
       mainBRegPreInteraction, mainBMemInteraction, mainCRegPreInteraction,
       mainCMemInteraction]
@@ -2279,7 +2227,7 @@ private theorem sdLdMemBusNonzero_filter :
           (fun interaction => !decide (interaction.mult = 0)) =
         [mainCRegPreInteraction sdLdAddiX2Row, mainCMemInteraction sdLdAddiX2Row] := by
     simp [AddSpinWitness.mainValueMemBusInteractions, sdLdAddiX2Row,
-      sdLdAddiX2RowWithLast, sdLdAddiX2RowTemplate, mainRomRowOf, addiX0Bits,
+      sdLdAddiX2RowTemplate, mainRomRowOf, addiX0Bits,
       mainARegPreInteraction, mainAMemInteraction, mainBRegPreInteraction,
       mainBMemInteraction, mainCRegPreInteraction, mainCMemInteraction]
   have h_sd :
@@ -2313,9 +2261,8 @@ private theorem sdLdMemBusNonzero_filter :
       AddSpinWitness.addSpinJalBits, mainARegPreInteraction, mainAMemInteraction,
       mainBRegPreInteraction, mainBMemInteraction, mainCRegPreInteraction,
       mainCMemInteraction]
-  simp only [sdLdMemBusInteractions, List.filter_append, h_boundary, h_mem,
-    sdLdMainRows, List.flatMap_cons, List.flatMap_nil, List.append_nil,
-    h_addi_a0, h_slli, h_addi_eight, h_addi_x2, h_sd, h_ld, h_jal]
+  simp only [sdLdMemBusInteractions, List.filter_append,
+    sdLdMainRows, List.flatMap_cons, List.flatMap_nil, List.append_nil]
   rfl
 
 private theorem sdLdMemBusNonzeroChronological_perm_core :
@@ -2509,7 +2456,7 @@ theorem sdLdWitness_registerStepRange_interactions :
       [2, 1, 1, 1, 1, 14, 5, 2, 3, 22] sdLdMemData
   rw [sdLdWitness_tables]
   simp [sdLdTables, h_boundary, h_mem, h_extension, h_add, h_ranges, h_provider,
-    emptyComponentTable_interactionsWith, sdLdMainTable_registerStepRangeInteractions]
+    sdLdMainTable_registerStepRangeInteractions]
 
 set_option maxRecDepth 20000 in
 /-- Bus-102 balance. Ten of the twenty-four pulls are active and the provider supplies exactly

--- a/ZiskFv/Compliance/SingleAddWitness.lean
+++ b/ZiskFv/Compliance/SingleAddWitness.lean
@@ -620,11 +620,7 @@ theorem singleAddWitness_rangeChannel_balanced :
     binaryAddRowsTable_interactionsWith_rangeChannel_nil,
     mainSingleRowTable_interactionsWith_rangeChannel_nil,
     emptyComponentTable_interactionsWith,
-    registerStepRangeRowsTable_interactionsWith_rangeChannel_nil,
-    registerStepRangeRowsTable_interactionsWith_memAlignRangeChannel_nil,
-    registerStepRangeRowsTable_interactionsWith_memBus_nil,
-    registerStepRangeRowsTable_interactionsWith_opBus_nil,
-    registerStepRangeRowsTable_interactionsWith_memAlignRomChannel_nil]
+    registerStepRangeRowsTable_interactionsWith_rangeChannel_nil]
   refine ⟨?_, ?_⟩
   · left
     rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
@@ -672,11 +668,7 @@ theorem singleAddWitness_memAlignRangeChannel_balanced :
     binaryAddRowsTable_interactionsWith_memAlignRangeChannel_nil,
     mainSingleRowTable_interactionsWith_memAlignRangeChannel_nil,
     emptyComponentTable_interactionsWith,
-    registerStepRangeRowsTable_interactionsWith_rangeChannel_nil,
-    registerStepRangeRowsTable_interactionsWith_memAlignRangeChannel_nil,
-    registerStepRangeRowsTable_interactionsWith_memBus_nil,
-    registerStepRangeRowsTable_interactionsWith_opBus_nil,
-    registerStepRangeRowsTable_interactionsWith_memAlignRomChannel_nil]
+    registerStepRangeRowsTable_interactionsWith_memAlignRangeChannel_nil]
   refine ⟨?_, ?_⟩
   · left
     rw [show ringChar FGL = GL_prime from ringChar.eq FGL GL_prime]
@@ -737,10 +729,6 @@ theorem singleAddWitness_memAlignRomChannel_balanced :
     binaryAddRowsTable_interactionsWith_memAlignRomChannel_nil,
     mainSingleRowTable_interactionsWith_memAlignRomChannel_nil,
     emptyComponentTable_interactionsWith,
-    registerStepRangeRowsTable_interactionsWith_rangeChannel_nil,
-    registerStepRangeRowsTable_interactionsWith_memAlignRangeChannel_nil,
-    registerStepRangeRowsTable_interactionsWith_memBus_nil,
-    registerStepRangeRowsTable_interactionsWith_opBus_nil,
     registerStepRangeRowsTable_interactionsWith_memAlignRomChannel_nil]
   refine ⟨?_, ?_⟩
   · left

--- a/ZiskFv/Compliance/TraceLevelExport/ChainedSailTrace.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/ChainedSailTrace.lean
@@ -128,7 +128,7 @@ theorem chainedSailStates_retire
       = some (cast (by simp [RegisterType]) v) := by
   rw [chainedSailStates, dif_pos h, retirePC]
   rw [h_next]
-  simp [Std.ExtDHashMap.get?_insert]
+  simp
 
 
 /-! ## Why this unblocks `RegAgree`
@@ -194,7 +194,7 @@ theorem chainedSailTrace_retireChain
     = post.regs.get? Register.nextPC
   rw [chainedSailStates, dif_pos (Nat.lt_of_succ_lt h), h_post, retirePC]
   cases h_next : post.regs.get? Register.nextPC with
-  | none => simp [Std.ExtDHashMap.get?_erase, h_next]
-  | some v => simp [Std.ExtDHashMap.get?_insert]
+  | none => simp
+  | some v => simp
 
 end ZiskFv.Compliance

--- a/ZiskFv/Compliance/TraceLevelExport/LaneBridge.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/LaneBridge.lean
@@ -68,13 +68,13 @@ theorem a_lo_of_laneBridge
       Transpiler.ind r)
     (h_src_imm : (mainTableRowAtOrZero trace.program trace.mainTable k).rom.a_src_imm =
       ZiskFv.AirsClean.boolF (decide (r = 0)))
-    (h_imm1 : (mainTableRowAtOrZero trace.program trace.mainTable k).rom.a_imm1 = 0) :
+    (_h_imm1 : (mainTableRowAtOrZero trace.program trace.mainTable k).rom.a_imm1 = 0) :
     (mainOfTable trace.program trace.mainTable).a_0 k =
       ZiskFv.Trusted.lane_lo
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 state).xreg r) := by
   by_cases hr : (r : Fin 32) = 0
   · subst hr
-    simp only [ne_eq, not_true_eq_false, decide_false, decide_true,
+    simp only [decide_true,
       ZiskFv.AirsClean.boolF] at h_src_imm
     have ⟨hss1, _, _, _⟩ := hSS
     rw [h_src_imm] at hss1
@@ -106,7 +106,7 @@ theorem a_hi_of_laneBridge
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 state).xreg r) := by
   by_cases hr : (r : Fin 32) = 0
   · subst hr
-    simp only [ne_eq, not_true_eq_false, decide_false, decide_true,
+    simp only [decide_true,
       ZiskFv.AirsClean.boolF] at h_src_imm
     have ⟨_, hss2, _, _⟩ := hSS
     rw [h_src_imm, h_imm1] at hss2
@@ -131,13 +131,13 @@ theorem b_lo_of_laneBridge
       Transpiler.ind r)
     (h_src_imm : (mainTableRowAtOrZero trace.program trace.mainTable k).rom.b_src_imm =
       ZiskFv.AirsClean.boolF (decide (r = 0)))
-    (h_imm1 : (mainTableRowAtOrZero trace.program trace.mainTable k).rom.b_imm1 = 0) :
+    (_h_imm1 : (mainTableRowAtOrZero trace.program trace.mainTable k).rom.b_imm1 = 0) :
     (mainOfTable trace.program trace.mainTable).b_0 k =
       ZiskFv.Trusted.lane_lo
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 state).xreg r) := by
   by_cases hr : (r : Fin 32) = 0
   · subst hr
-    simp only [ne_eq, not_true_eq_false, decide_false, decide_true,
+    simp only [decide_true,
       ZiskFv.AirsClean.boolF] at h_src_imm
     have ⟨_, _, hss3, _⟩ := hSS
     rw [h_src_imm] at hss3
@@ -169,7 +169,7 @@ theorem b_hi_of_laneBridge
         ((ZiskFv.EquivCore.Bridge.SailStateBridge.sail_to_rv64 state).xreg r) := by
   by_cases hr : (r : Fin 32) = 0
   · subst hr
-    simp only [ne_eq, not_true_eq_false, decide_false, decide_true,
+    simp only [decide_true,
       ZiskFv.AirsClean.boolF] at h_src_imm
     have ⟨_, _, _, hss4⟩ := hSS
     rw [h_src_imm, h_imm1] at hss4

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingControl.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingControl.lean
@@ -110,7 +110,7 @@ private theorem store_reg_raw_index_iff_any
   split_ifs at h <;>
     first
     | (rw [Result.ok.injEq] at h; subst h
-       simp [hstore, zisk_inst.STORE_REG] <;> scalar_tac)
+       simp [hstore, zisk_inst.STORE_REG] ; scalar_tac)
     | (rw [Result.ok.injEq] at h; subst h
        simp [zisk_inst.STORE_REG] <;> scalar_tac)
     | (exfalso; scalar_tac)
@@ -415,7 +415,7 @@ private theorem rawJType_rd (imm rd : Nat) (hrd : rd < 32) :
     ZiskFv.Compliance.Decode.tbf (show 111 < 2 ^ 7 by norm_num) (by omega)
   simp [e7, h12, h20, h21, h31, h6f, show 7 + i - 7 = i from by omega]
 
-private theorem rawIType_rd (imm rs1 funct3 rd opcode : Nat) (hrd : rd < 32) (hf3 : funct3 < 8)
+private theorem rawIType_rd (imm rs1 funct3 rd opcode : Nat) (hrd : rd < 32) (_hf3 : funct3 < 8)
     (hop : opcode < 128) :
     ((ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 funct3 rd opcode) &&& 3968#32) >>> 7
       = BitVec.ofNat 32 rd := by
@@ -1297,7 +1297,7 @@ theorem jal_decode_fields_of_binding (rd imm : Nat) (hrd : rd < 32) (hrd0 : rd �
 `op` / `flags`, plus the genuine operand-side JALR witnesses (`flag` / a-mask /
 c-mask / offset bridge / even / no-wrap) as caller hypotheses. -/
 
-theorem transpile_jalr (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrd0 : rd ≠ 0) :
+theorem transpile_jalr (rd rs1 imm : Nat) (hrd : rd < 32) (_hrs1 : rs1 < 32) (hrd0 : rd ≠ 0) :
     ∃ ext, extract_transpile_rv64im_raw
         (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 0 rd 0x67)) = ok ext
       ∧ ext.row.op = 14#u8 ∧ ext.row.is_external_op = true ∧ ext.row.m32 = false
@@ -1830,7 +1830,7 @@ private theorem decode_j_rawJType_imm
 /-! ## Branch-family `ProgramDecode` bundles. -/
 
 local macro "branch_program_decode" nm:ident "," f3:term "," rop:term ","
-    neg:term : command => do
+    _neg:term : command => do
   let s := nm.getId.toString
   let rawName := Lean.mkIdent (Lean.Name.mkSimple ("RawProgramDecode_" ++ s))
   let ctorName := Lean.mkIdent (Lean.Name.mkSimple ("ProgramDecode_" ++ s ++ "_from_rawProgram"))

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingCopyb.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingCopyb.lean
@@ -121,7 +121,7 @@ private theorem and32505856_shr20 (x : BitVec 32) : (x &&& 32505856#32) >>> 20 =
   have := and_shr_reorder x 20 (by norm_num); simpa using this
 
 theorem rawRType_rd (funct7 rs2 rs1 funct3 rd opcode : Nat) (hrd : rd < 32)
-    (hf3 : funct3 < 8) (hop : opcode < 128) :
+    (_hf3 : funct3 < 8) (hop : opcode < 128) :
     ((rawRType funct7 rs2 rs1 funct3 rd opcode) &&& 3968#32) >>> 7 = BitVec.ofNat 32 rd := by
   rw [and3968_shr7]
   simp only [rawRType, rawOfNat32]
@@ -174,7 +174,7 @@ theorem copyb_rawRType_rs2 (funct7 rs2 rs1 funct3 rd opcode : Nat) (hrs2 : rs2 <
   simp [e25, e20, e15, e12, e7, hrs1', hf3', hrd', hop', show 20 + i - 20 = i from by omega]
 
 theorem rawIType_rd' (imm rs1 funct3 rd opcode : Nat) (hrd : rd < 32)
-    (hf3 : funct3 < 8) (hop : opcode < 128) :
+    (_hf3 : funct3 < 8) (hop : opcode < 128) :
     ((rawIType imm rs1 funct3 rd opcode) &&& 3968#32) >>> 7 = BitVec.ofNat 32 rd := by
   rw [and3968_shr7]
   simp only [rawIType, rawOfNat32]
@@ -816,7 +816,7 @@ theorem transpile_add (rd rs1 rs2 : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs2
     rw [hrdbv]
     change (((rawRType 0 rs2 rs1 0 rd 0x33) &&& 3968#32) >>> 7).toNat = rd
     rw [rawRType_rd 0 rs2 rs1 0 rd 0x33 hrd (by norm_num) (by norm_num)]
-    simp [UScalar.val, BitVec.toNat_ofNat, Nat.mod_eq_of_lt] <;> omega
+    simp [UScalar.val, BitVec.toNat_ofNat, Nat.mod_eq_of_lt] ; omega
   · intro d hd
     obtain ⟨d', hd', _, hrs1bv, _⟩ :=
       copyb_decode_r_fields (toU32 (rawRType 0 rs2 rs1 0 rd 0x33)) RiscvOpcode.Add
@@ -825,7 +825,7 @@ theorem transpile_add (rd rs1 rs2 : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs2
     rw [hrs1bv]
     change (((rawRType 0 rs2 rs1 0 rd 0x33) &&& 1015808#32) >>> 15).toNat = rs1
     rw [copyb_rawRType_rs1 0 rs2 rs1 0 rd 0x33 hrs1 (by norm_num) hrd (by norm_num)]
-    simp [UScalar.val, BitVec.toNat_ofNat, Nat.mod_eq_of_lt] <;> omega
+    simp [UScalar.val, BitVec.toNat_ofNat, Nat.mod_eq_of_lt] ; omega
   · intro d hd
     obtain ⟨d', hd', _, _, hrs2bv⟩ :=
       copyb_decode_r_fields (toU32 (rawRType 0 rs2 rs1 0 rd 0x33)) RiscvOpcode.Add
@@ -834,7 +834,7 @@ theorem transpile_add (rd rs1 rs2 : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs2
     rw [hrs2bv]
     change (((rawRType 0 rs2 rs1 0 rd 0x33) &&& 32505856#32) >>> 20).toNat = rs2
     rw [copyb_rawRType_rs2 0 rs2 rs1 0 rd 0x33 hrs2 hrs1 (by norm_num) hrd (by norm_num)]
-    simp [UScalar.val, BitVec.toNat_ofNat, Nat.mod_eq_of_lt] <;> omega
+    simp [UScalar.val, BitVec.toNat_ofNat, Nat.mod_eq_of_lt] ; omega
   · simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
       ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
       ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_shr25,
@@ -910,7 +910,7 @@ theorem transpile_or (rd rs1 rs2 : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs2 
     rw [hrdbv]
     change (((rawRType 0 rs2 rs1 6 rd 0x33) &&& 3968#32) >>> 7).toNat = rd
     rw [rawRType_rd 0 rs2 rs1 6 rd 0x33 hrd (by norm_num) (by norm_num)]
-    simp [UScalar.val, BitVec.toNat_ofNat, Nat.mod_eq_of_lt] <;> omega
+    simp [UScalar.val, BitVec.toNat_ofNat, Nat.mod_eq_of_lt] ; omega
   · intro d hd
     obtain ⟨d', hd', _, hrs1bv, _⟩ :=
       copyb_decode_r_fields (toU32 (rawRType 0 rs2 rs1 6 rd 0x33)) RiscvOpcode.Or
@@ -919,7 +919,7 @@ theorem transpile_or (rd rs1 rs2 : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs2 
     rw [hrs1bv]
     change (((rawRType 0 rs2 rs1 6 rd 0x33) &&& 1015808#32) >>> 15).toNat = rs1
     rw [copyb_rawRType_rs1 0 rs2 rs1 6 rd 0x33 hrs1 (by norm_num) hrd (by norm_num)]
-    simp [UScalar.val, BitVec.toNat_ofNat, Nat.mod_eq_of_lt] <;> omega
+    simp [UScalar.val, BitVec.toNat_ofNat, Nat.mod_eq_of_lt] ; omega
   · intro d hd
     obtain ⟨d', hd', _, _, hrs2bv⟩ :=
       copyb_decode_r_fields (toU32 (rawRType 0 rs2 rs1 6 rd 0x33)) RiscvOpcode.Or
@@ -928,7 +928,7 @@ theorem transpile_or (rd rs1 rs2 : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs2 
     rw [hrs2bv]
     change (((rawRType 0 rs2 rs1 6 rd 0x33) &&& 32505856#32) >>> 20).toNat = rs2
     rw [copyb_rawRType_rs2 0 rs2 rs1 6 rd 0x33 hrs2 hrs1 (by norm_num) hrd (by norm_num)]
-    simp [UScalar.val, BitVec.toNat_ofNat, Nat.mod_eq_of_lt] <;> omega
+    simp [UScalar.val, BitVec.toNat_ofNat, Nat.mod_eq_of_lt] ; omega
   · simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
       ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,
       ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_shr25,

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingImmediate.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingImmediate.lean
@@ -95,7 +95,7 @@ private theorem and3968_shr7 (x : BitVec 32) :
 /-- The decoder's `rd` field (`inst &&& 3968 >>> 7`, bits [7,11]) of an `rawIType`
     word recovers `rd` for `rd < 32`. -/
 private theorem rawIType_rd (imm rs1 funct3 rd opcode : Nat) (hrd : rd < 32)
-    (hf3 : funct3 < 8) (hop : opcode < 128) :
+    (_hf3 : funct3 < 8) (hop : opcode < 128) :
     ((ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 funct3 rd opcode) &&& 3968#32) >>> 7
       = BitVec.ofNat 32 rd := by
   rw [and3968_shr7]
@@ -959,7 +959,7 @@ theorem transpile_addiw (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hr
       change d'.rd.bv.toNat = rd
       rw [show d'.rd.bv = BitVec.ofNat 32 rd from by
         rw [hrdbv']; exact rawIType_rd imm rs1 0 rd 0x1b hrd (by norm_num) (by norm_num)]
-      simp [UScalar.val, BitVec.toNat_ofNat, Nat.mod_eq_of_lt] <;> omega)
+      simp [UScalar.val, BitVec.toNat_ofNat, Nat.mod_eq_of_lt] ; omega)
     (by
       intro d hd
       obtain ⟨d', hd', _, _, _, _, hrs1bv'⟩ := decode_i_bounds _ RiscvOpcode.Addiw false
@@ -969,7 +969,7 @@ theorem transpile_addiw (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hr
       rw [show d'.rs1.bv = BitVec.ofNat 32 rs1 from by
         rw [hrs1bv']; exact rawIType_rs1 imm rs1 0 rd 0x1b hrs1
           (by norm_num) hrd (by norm_num)]
-      simp [UScalar.val, BitVec.toNat_ofNat, Nat.mod_eq_of_lt] <;> omega)
+      simp [UScalar.val, BitVec.toNat_ofNat, Nat.mod_eq_of_lt] ; omega)
     (fun input => input.rd ≠ 0#u32) ?_ rfl ?_ ?_ rfl rfl rfl (by intro h; cases h) (by intro h; cases h)
   · simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
       ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_and7,

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingJalr.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingJalr.lean
@@ -27,7 +27,7 @@ private theorem signExtend64_signExtend32 (v : BitVec 12) :
   intro k
   by_cases hk : k < 64
   · interval_cases k <;>
-      simp [BitVec.getLsbD_signExtend, BitVec.getElem_signExtend,
+      simp [BitVec.getElem_signExtend,
         BitVec.msb_signExtend]
   · simp [BitVec.getLsbD_signExtend, hk]
 
@@ -37,7 +37,7 @@ private theorem jalr_signExtend64_signExtend32 (v : BitVec 12) :
   intro k
   by_cases hk : k < 64
   · interval_cases k <;>
-      simp [BitVec.getLsbD_signExtend, BitVec.getElem_signExtend,
+      simp [BitVec.getElem_signExtend,
         BitVec.msb_signExtend]
   · simp [BitVec.getLsbD_signExtend, hk]
 
@@ -62,7 +62,7 @@ private theorem jalr_immediate_rom_value
     rw [hdimm, jalr_signExtend64_signExtend32]
   apply BitVec.eq_of_toNat_eq
   rw [BitVec.toNat_ofNat]
-  simp only [romRowOf, sourceImmediate, hsrc, if_pos, UScalar.val]
+  simp only [romRowOf, hsrc, if_pos, UScalar.val]
   have hloBound : row.a_offset_imm0.bv.toNat < 2 ^ 32 := by
     rw [show row.a_offset_imm0.bv.toNat =
       (IScalar.hcast UScalarTy.U64 d.imm).val % 4294967296 by
@@ -149,7 +149,7 @@ private theorem jalr_raw_rows
       aeneas_extract.rv64im_decode.decode_i
         (ZiskFv.Compliance.Decode.toU32 raw)
           aeneas_extract.rv64im_decode.RiscvOpcode.Jalr false := by
-    simp only [raw, aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc,
+    simp only [raw, aeneas_extract.rv64im_decode.decode_32_core, lift,
       Bind.bind, bind_ok, ZiskFv.Compliance.Decode.toU32_and127,
       ZiskFv.Compliance.Decode.toU32_ofNat,
       ZiskFv.Compliance.Decode.rawIType_opcode imm rs1 0 rd 0x67 (by norm_num)]
@@ -229,7 +229,7 @@ private theorem jalr_raw_rows
         let row ← aeneas_extract.ZiskInstExtract.from_inst zib.i
         .ok ({ accepted := true, decode := dext, row := row } :
           aeneas_extract.Rv64imTranspileExtract)) = _
-      simp only [riscv2zisk_single_row.Rv64imLoweringInput.new, bind_ok]
+      simp only [riscv2zisk_single_row.Rv64imLoweringInput.new]
       change (do
         let ctx' ←
           riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
@@ -281,7 +281,7 @@ private theorem jalr_raw_rows
         let row ← aeneas_extract.ZiskInstExtract.from_inst zib.i
         .ok ({ accepted := true, decode := dext, row := row } :
           aeneas_extract.Rv64imTranspileExtract)) = _
-      simp only [riscv2zisk_single_row.Rv64imLoweringInput.new, bind_ok]
+      simp only [riscv2zisk_single_row.Rv64imLoweringInput.new]
       change (do
         let ctx' ←
           riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input
@@ -321,7 +321,7 @@ private theorem jalr_raw_rows
       rw [if_pos (by decide)]
       simp only [defCtx] at hlower
       rw [hlower]
-      simp [Bind.bind, hfirst, rows]
+      simp [hfirst]
     · unfold JalrUnalignedSuccessorRowPins JalrDestinationPins at hlastPins ⊢
       simpa [rows, hbSrc, hbHi, hbLo, hop, hstore, hstoreOffset, hstoreUseSp,
         hj1, hj2, hsetpc, hstorepc, hieo, hm32] using hlastPins
@@ -582,7 +582,7 @@ noncomputable def ProgramDecode_jalr_from_rawProgram {n rawLength : Nat}
             rw [← hrd]
             exact congrArg UScalar.val hzero.1
           have hstoreZero := congrArg IScalar.val hzero.2.2.1
-          simp [hmsg, romRowOf, hop, hj1, hj2, hzero, bits, hrdZero,
+          simp [hmsg, romRowOf, hop, hj1, hj2, bits, hrdZero,
             himmInt, hstoreZero]
         · have hrdNonzero : (regidx_to_fin c.rd).val ≠ 0 := by
             intro hzero
@@ -597,8 +597,8 @@ noncomputable def ProgramDecode_jalr_from_rawProgram {n rawLength : Nat}
               lt_trans (regidx_to_fin c.rd).isLt (by norm_num)
             apply Fin.ext
             simp [hstoreVal, hcast_u32_i64_val, hrd, Transpiler.ind, hrdPrime]
-          simp [hmsg, romRowOf, hop, hj1, hj2, hnonzero, bits, hrdNonzero,
-            hrd, himmInt, hstoreOffset]
+          simp [hmsg, romRowOf, hop, hj1, hj2, bits, hrdNonzero,
+            himmInt, hstoreOffset]
   | unaligned evidence =>
       obtain ⟨raw, hrawEncoded, hcert, hOffset, hidx, hflagAdd, hflag, haLo, haHi,
         hc1, heven, hnonneg, hlt, hLineAdd, hLineAnd⟩ := evidence
@@ -720,7 +720,7 @@ noncomputable def ProgramDecode_jalr_from_rawProgram {n rawLength : Nat}
               exact decide_eq_false (by
                 intro heq
                 have hbad := hz.2.1.symm.trans heq
-                simpa [zisk_inst.SRC_IMM, zisk_inst.SRC_REG] using hbad)
+                simp [zisk_inst.SRC_IMM, zisk_inst.SRC_REG] at hbad)
             · change input.rs1 ≠ 0#u32 ∧ rows.first_row.b_src = zisk_inst.SRC_REG ∧
                   rows.first_row.b_use_sp_imm1 = 0#u64 ∧
                   rows.first_row.b_offset_imm0 = UScalar.cast UScalarTy.U64 input.rs1 at hn
@@ -828,8 +828,8 @@ noncomputable def ProgramDecode_jalr_from_rawProgram {n rawLength : Nat}
               rw [← haddr]
             have himmRow := jalr_immediate_rom_value c.imm input himmC
               rows.first_row haddASrc haddHi haddLo
-            simp [hmsg, romRowOf, haddOp, haddJ2, haddASrc, haddHi, haddLo,
-              addBits, himm, himmRow]
+            simp [hmsg, romRowOf, haddOp, haddJ2, haddASrc, haddHi,
+              addBits, himmRow]
           h_prog_and := by
             intro j hline
             obtain ⟨k, hj, haddr, hraw⟩ := hLineAnd j hline
@@ -859,7 +859,7 @@ noncomputable def ProgramDecode_jalr_from_rawProgram {n rawLength : Nat}
                 exact congrArg UScalar.val hz.1
               have hstoreZero := congrArg IScalar.val hz.2.2.1
               simp [hmsg, romRowOf, handOp, handJ1, handJ2,
-                hz, andBits, hrdZero, hstoreZero]
+                hz, andBits, hrdZero]
             · change input.rd ≠ 0#u32 ∧ rows.last_row.store = zisk_inst.STORE_REG ∧
                   rows.last_row.store_offset = UScalar.hcast IScalarTy.I64 input.rd ∧
                   rows.last_row.store_use_sp = false ∧ rows.last_row.store_pc = true at hn
@@ -877,7 +877,7 @@ noncomputable def ProgramDecode_jalr_from_rawProgram {n rawLength : Nat}
                 apply Fin.ext
                 simp [hstoreVal, hcast_u32_i64_val, hrd, Transpiler.ind, hrdPrime]
               simp [hmsg, romRowOf, handOp, handJ1, handJ2,
-                hn, andBits, hrdNonzero, hstoreOffset]
+                hn, andBits, hrdNonzero]
               simpa only [hstoreVal] using hstoreOffset }
 
 end ZiskFv.Compliance.RawProgramBinding

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingJalrExpansionNonvacuity.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingJalrExpansionNonvacuity.lean
@@ -336,13 +336,13 @@ theorem jalrExpansionProgramRowsBinding :
       jalrExpansionRawProgram := by
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
   · intro k k' h
-    fin_cases k <;> fin_cases k' <;> revert h <;> decide
+    fin_cases k ; fin_cases k' ; revert h ; decide
   · intro k
-    fin_cases k <;> decide
+    fin_cases k ; decide
   · intro k
-    fin_cases k <;> decide
+    fin_cases k ; decide
   · intro k k' h
-    fin_cases k <;> fin_cases k' <;> exact absurd h (by decide)
+    fin_cases k ; fin_cases k' ; exact absurd h (by decide)
   · intro k
     fin_cases k
     simp only [jalrExpansionStart, jalrExpansionAddr, jalrExpansionRawProgram]

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingLoadStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingLoadStore.lean
@@ -916,7 +916,7 @@ store_op sw, 2, RiscvOpcode.Sw, riscv2zisk_single_row.Rv64imSingleRowOpcode.Sw, 
     `ind_width` column (the SD width column is not a decode pin), so SD threads only
     op/jmp1/jmp2/flags via the register field bridge. -/
 
-theorem transpile_sd (rs1 rs2 imm : Nat) (hrs1 : rs1 < 32) (hrs2 : rs2 < 32) :
+theorem transpile_sd (rs1 rs2 imm : Nat) (_hrs1 : rs1 < 32) (_hrs2 : rs2 < 32) :
     ∃ ext, extract_transpile_rv64im_raw
         (toU32 (ZiskFv.Completeness.Rv64imShapes.rawSType imm rs2 rs1 3)) = ok ext
       ∧ ext.row.op = 1#u8 ∧ ext.row.is_external_op = false ∧ ext.row.m32 = false

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingMemoryNonvacuity.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingMemoryNonvacuity.lean
@@ -207,7 +207,7 @@ private theorem operandFields_store_ind (self z : zisk_inst_builder.ZiskInstBuil
 
 private theorem operandFields_j (self z : zisk_inst_builder.ZiskInstBuilder)
     (j1 j2 : Std.I64) (h : self.j j1 j2 = ok z) : operandFields self z := by
-  simp only [zisk_inst_builder.ZiskInstBuilder.j, bind_ok, Bind.bind] at h
+  simp only [zisk_inst_builder.ZiskInstBuilder.j] at h
   rw [Result.ok.injEq] at h
   subst z
   exact ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
@@ -224,7 +224,7 @@ private theorem op_zisk_copyb_precompiled (self z : zisk_inst_builder.ZiskInstBu
     zisk_ops.ZiskOp.op_type, zisk_ops.ZiskOp.code, zisk_ops.ZiskOp.is_m32,
     zisk_ops.ZiskOp.input_size, core.convert.IntoFrom.into,
     zisk_inst.ZiskOperationType.Insts.CoreConvertFromOpType.from, Bind.bind] at h
-  simp only [bind_ok, Bind.bind] at h
+  simp only [bind_ok] at h
   rw [Result.ok.injEq] at h
   subst z
   norm_num [memoryLdZeroRow, romMessageOfRaw]
@@ -249,7 +249,7 @@ private theorem precompiled_pres_store_ind (self z : zisk_inst_builder.ZiskInstB
 private theorem precompiled_pres_j (self z : zisk_inst_builder.ZiskInstBuilder)
     (j1 j2 : Std.I64) (h : self.j j1 j2 = ok z) :
     z.i.is_precompiled = self.i.is_precompiled := by
-  simp only [zisk_inst_builder.ZiskInstBuilder.j, Bind.bind] at h
+  simp only [zisk_inst_builder.ZiskInstBuilder.j] at h
   rw [Result.ok.injEq] at h
   subst z
   rfl
@@ -265,7 +265,7 @@ theorem memorySdRow_eq_romMessageOfRaw :
     rw [show aeneas_extract.rv64im_decode.decode_32_core raw =
         aeneas_extract.rv64im_decode.decode_s raw
           aeneas_extract.rv64im_decode.RiscvOpcode.Sd by
-      simp only [raw, aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc,
+      simp only [raw, aeneas_extract.rv64im_decode.decode_32_core, lift,
         Bind.bind, bind_ok, ZiskFv.Compliance.Decode.toU32_and127,
         ZiskFv.Compliance.Decode.toU32_and7, ZiskFv.Compliance.Decode.toU32_shr12,
         ZiskFv.Compliance.Decode.toU32_ofNat,
@@ -321,7 +321,7 @@ theorem memorySdRow_eq_romMessageOfRaw :
       zisk_ops.ZiskOp.CopyB 8#u64 4#u64 8#u64 ctx ind_width_set8 hctx
   have hctxFields := hctx
   simp only [riscv2zisk_context.Riscv2ZiskContext.store_op_typed,
-    Bind.bind, bind_ok] at hctxFields
+    Bind.bind] at hctxFields
   obtain ⟨ctxBase, hctxBase, hctxFields⟩ :=
     ZiskFv.Compliance.Extraction.bind_eq_ok_imp hctxFields
   rw [Result.ok.injEq] at hctxFields
@@ -370,7 +370,7 @@ theorem memorySdRow_eq_romMessageOfRaw :
     rw [(ZiskFv.Compliance.Extraction.build_eq z6 z7 hz7)]
     exact hpre6.trans (hpre5.trans hpre4)
   simp only [zisk_inst_builder.ZiskInstBuilder.new_for_rv64im_lowering,
-    zisk_inst_builder.ZiskInstBuilder.new, input, ← hdecoded, Result.ok.injEq] at hz0
+    zisk_inst_builder.ZiskInstBuilder.new, input] at hz0
   have hz1Saved := hz1
   norm_num [input, ← hdecoded, zisk_inst_builder.ZiskInstBuilder.src_a_reg,
     zisk_inst_builder.ZiskInstBuilder.src_a_imm, zisk_registers.REGS_IN_MAIN_FROM,
@@ -451,16 +451,7 @@ theorem memorySdRow_eq_romMessageOfRaw :
     hj2, hsetPc,
     hstorePc, hopVal, hm32Val, hotVal, hext, input, ← hdecoded, ext,
     hpre7,
-    haSrcFinal, haUseSpFinal, haOffsetFinal, hbSrcFinal, hbUseSpFinal, hbOffsetFinal,
-    hz1Saved,
-    zisk_inst_builder.ZiskInstBuilder.src_a_reg,
-    zisk_inst_builder.ZiskInstBuilder.src_a_imm,
-    zisk_inst_builder.ZiskInstBuilder.src_b_reg,
-    zisk_inst_builder.ZiskInstBuilder.src_b_imm,
-    zisk_inst_builder.ZiskInstBuilder.op_zisk,
-    zisk_inst_builder.ZiskInstBuilder.ind_width,
-    zisk_inst_builder.ZiskInstBuilder.store_ind,
-    zisk_inst_builder.ZiskInstBuilder.j]
+    haSrcFinal, haUseSpFinal, haOffsetFinal, hbSrcFinal, hbUseSpFinal, hbOffsetFinal]
   norm_num [input, ← hdecoded, zisk_inst_builder.ZiskInstBuilder.src_a_reg,
     zisk_inst_builder.ZiskInstBuilder.src_a_imm,
     zisk_inst_builder.ZiskInstBuilder.src_b_reg,
@@ -488,7 +479,7 @@ theorem memoryLdZeroRow_eq_romMessageOfRaw :
     rw [show aeneas_extract.rv64im_decode.decode_32_core raw =
         aeneas_extract.rv64im_decode.decode_i raw
           aeneas_extract.rv64im_decode.RiscvOpcode.Ld false by
-      simp only [raw, aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc,
+      simp only [raw, aeneas_extract.rv64im_decode.decode_32_core, lift,
         Bind.bind, bind_ok, ZiskFv.Compliance.Decode.toU32_and127,
         ZiskFv.Compliance.Decode.toU32_and7, ZiskFv.Compliance.Decode.toU32_shr12,
         ZiskFv.Compliance.Decode.toU32_ofNat,
@@ -576,7 +567,7 @@ theorem memoryLdZeroRow_eq_romMessageOfRaw :
     romOpcode, romFlagBitsOfExtract, ZiskFv.AirsClean.Main.packFlags, hrowASrc, hrowASp,
     hrowAOff, hrowBSrc, hrowBSp, hrowBOff, hrowWidth, hrowOp, hrowStore, hrowStoreOff,
     hrowJ1, hrowJ2, hrowSetPc, hrowStorePc, hrowExt, hrowM32, haSrc, haOffEq, haSp,
-    hbSrc, hbOff, hstoreOffEq, hstoreReg hrdne, hiw, hj1, hj2, hpre, hrowPre, hop, hext,
+    hbSrc, hbOff, hstoreOffEq, hstoreReg hrdne, hj1, hj2, hpre, hrowPre, hop, hext,
     hm32, hsetPc, hstorePc, input, ext]
   norm_num [signedOffset, sourceImmediate, ZiskFv.AirsClean.boolF, zisk_inst.SRC_IMM,
     zisk_inst.SRC_MEM, zisk_inst.SRC_IND, zisk_inst.SRC_REG, zisk_inst.STORE_MEM,
@@ -596,7 +587,7 @@ theorem memoryLdNegativeRow_eq_romMessageOfRaw :
     rw [show aeneas_extract.rv64im_decode.decode_32_core raw =
         aeneas_extract.rv64im_decode.decode_i raw
           aeneas_extract.rv64im_decode.RiscvOpcode.Ld false by
-      simp only [raw, aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc,
+      simp only [raw, aeneas_extract.rv64im_decode.decode_32_core, lift,
         Bind.bind, bind_ok, ZiskFv.Compliance.Decode.toU32_and127,
         ZiskFv.Compliance.Decode.toU32_and7, ZiskFv.Compliance.Decode.toU32_shr12,
         ZiskFv.Compliance.Decode.toU32_ofNat,
@@ -678,7 +669,7 @@ theorem memoryLdNegativeRow_eq_romMessageOfRaw :
     romOpcode, romFlagBitsOfExtract, ZiskFv.AirsClean.Main.packFlags, hrowASrc, hrowASp,
     hrowAOff, hrowBSrc, hrowBSp, hrowBOff, hrowWidth, hrowOp, hrowStore, hrowStoreOff,
     hrowJ1, hrowJ2, hrowSetPc, hrowStorePc, hrowExt, hrowM32, haSrc, haOffEq, haSp,
-    hbSrc, hbOff, hstoreOffEq, hstoreReg hrdne, hiw, hj1, hj2, hpre, hrowPre, hop, hext,
+    hbSrc, hbOff, hstoreOffEq, hstoreReg hrdne, hj1, hj2, hpre, hrowPre, hop, hext,
     hm32, hsetPc, hstorePc, input, ext]
   norm_num [signedOffset, sourceImmediate, ZiskFv.AirsClean.boolF, zisk_inst.SRC_IMM,
     zisk_inst.SRC_MEM, zisk_inst.SRC_IND, zisk_inst.SRC_REG, zisk_inst.STORE_MEM,

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingNonvacuity.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingNonvacuity.lean
@@ -69,7 +69,7 @@ private theorem createRegisterAddX1FullPins
   have ei31 := Extraction.cast_31_i64
   split_ifs at h <;> (try scalar_tac)
   all_goals
-    simp only [bind_ok, Bind.bind] at h
+    simp only [bind_ok] at h
     rw [Result.ok.injEq] at h
     subst ctx
     refine ⟨_, rfl, ?_⟩
@@ -90,7 +90,7 @@ private theorem transpileAddX1FullPins
   have hdec : aeneas_extract.rv64im_decode.decode_32_core raw =
       aeneas_extract.rv64im_decode.decode_r raw
         aeneas_extract.rv64im_decode.RiscvOpcode.Add := by
-    simp only [raw, aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc,
+    simp only [raw, aeneas_extract.rv64im_decode.decode_32_core, lift,
       Bind.bind, bind_ok, ZiskFv.Compliance.Decode.toU32_and127,
       ZiskFv.Compliance.Decode.toU32_and7, ZiskFv.Compliance.Decode.toU32_shr12,
       ZiskFv.Compliance.Decode.toU32_shr25,
@@ -164,7 +164,7 @@ private theorem transpileAddX1FullPins
   have hext' : aeneas_extract.extract_transpile_rv64im_raw raw =
       ok { accepted := true, decode := dext, row := row } := by
     rw [aeneas_extract.extract_transpile_rv64im_raw, hdec0]
-    simp only [bind_ok, Bind.bind, hdext, hopd, input,
+    simp only [bind_ok, Bind.bind, hdext, hopd,
       show aeneas_extract.lowering_opcode
         aeneas_extract.rv64im_decode.RiscvOpcode.Add =
           ok (some riscv2zisk_single_row.Rv64imSingleRowOpcode.Add) from rfl]
@@ -214,10 +214,9 @@ theorem singleAddProgramBinding :
     have haeq : ext.row.a_offset_imm0 = 1#u64 := UScalar.eq_of_val_eq hao
     have hbeq : ext.row.b_offset_imm0 = 1#u64 := UScalar.eq_of_val_eq hbo
     rw [romMessageOfRaw, hext]
-    congr 1 <;>
-      simp [RegisterMemBusBalance.addX1ProgramRow, romRowOf, signedOffset, sourceImmediate,
-        romOpcode, romFlagBitsOfExtract, ZiskFv.AirsClean.Main.packFlags,
-        ha, hau, hao, haeq, hb, hbu, hbo, hbeq, hiw, hs, hso, hip,
+    congr 1
+    simp [RegisterMemBusBalance.addX1ProgramRow, romRowOf, signedOffset, romFlagBitsOfExtract, ZiskFv.AirsClean.Main.packFlags,
+        ha, haeq, hb, hbeq, hiw, hs, hso, hip,
         hop, hie, hm32, hset, hstorepc, hj1, hj2, hcast4,
         zisk_inst.SRC_IMM, zisk_inst.SRC_MEM, zisk_inst.SRC_IND,
         zisk_inst.SRC_REG, zisk_inst.STORE_MEM, zisk_inst.STORE_IND,

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingRegister.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingRegister.lean
@@ -222,7 +222,7 @@ theorem store_reg_u32_zero_not_reg
   split_ifs at h <;>
     first
     | (rw [Result.ok.injEq] at h; subst z
-       simpa [hself, zisk_inst.STORE_REG])
+       simp [hself, zisk_inst.STORE_REG])
     | (exfalso; scalar_tac)
 
 theorem src_a_reg_pres_store (self z : zisk_inst_builder.ZiskInstBuilder)

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBitfields.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBitfields.lean
@@ -572,7 +572,7 @@ private theorem rawSType_imm_bits (imm rs2 rs1 funct3 : Nat)
       simp [BitVec.getLsbD, Nat.testBit_shiftLeft, Nat.testBit_shiftRight,
         Nat.mod_eq_of_lt himmLt, Nat.mod_eq_of_lt hhiLt, Nat.mod_eq_of_lt hshiftLt,
         show (4096 : Nat) = 2 ^ 12 by norm_num] <;>
-      first | rfl | (norm_num [Nat.testBit] <;> aesop)
+      first | rfl | (norm_num [Nat.testBit] ; aesop)
   · simp [BitVec.getLsbD, hi]
 
 private theorem rawSType_assembled_mask (v : BitVec 32) :
@@ -900,14 +900,12 @@ private theorem rawBType_imm_bits (imm rs2 rs1 funct3 : Nat)
   · interval_cases i <;>
       simp only [BitVec.getLsbD] <;>
       simp [Nat.testBit_shiftLeft, Nat.testBit_shiftRight,
-        Nat.testBit_mod_two_pow, Nat.mod_eq_of_lt himmLt, Nat.mod_eq_of_lt hshr12,
-        Nat.mod_eq_of_lt hshr11, Nat.mod_eq_of_lt hshr5, Nat.mod_eq_of_lt hshr1,
-        Nat.mod_eq_of_lt hp12, Nat.mod_eq_of_lt hp11, Nat.mod_eq_of_lt ha10,
-        Nat.mod_eq_of_lt ha4,
+        Nat.mod_eq_of_lt himmLt, Nat.mod_eq_of_lt hshr5, Nat.mod_eq_of_lt hshr1,
+        Nat.mod_eq_of_lt hp12, Nat.mod_eq_of_lt hp11,
         Nat.mod_eq_of_lt h12, Nat.mod_eq_of_lt h11, Nat.mod_eq_of_lt h10,
-        Nat.mod_eq_of_lt h4, show (8192 : Nat) = 2 ^ 13 by norm_num] <;>
-      norm_num [Nat.testBit] at halign ⊢ <;> aesop <;>
-      simp [Nat.shiftRight_eq_div_pow] at *
+        Nat.mod_eq_of_lt h4] <;>
+      norm_num [Nat.testBit] at halign ⊢ <;> aesop
+    simp [Nat.shiftRight_eq_div_pow] at *
   · simp [BitVec.getLsbD, hi]
 
 private theorem rawBType_assembled_mask (v : BitVec 32) :
@@ -1038,8 +1036,7 @@ private theorem signExtend13_of_not_sign (v : BitVec 13) (h : v[12] = false) :
   intro i
   by_cases hi : i < 32
   · interval_cases i <;>
-      simp [BitVec.getElem_signExtend, BitVec.getElem_setWidth,
-        BitVec.msb_setWidth] at h ⊢ <;> assumption
+      simp [BitVec.getElem_signExtend, BitVec.getElem_setWidth] at h ⊢ <;> assumption
   · simp [BitVec.getLsbD_signExtend, hi]
 
 private theorem signext13 (v : BitVec 13) :

--- a/ZiskFv/Compliance/TraceLevelExport/RegisterCoverageBridge.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RegisterCoverageBridge.lean
@@ -223,7 +223,7 @@ theorem cMemMessage_value_eq_lane_lo_of_bootWalk_supplier
         (mainTableRowAtOrZero trace.program trace.mainTable i.val).rom.store_reg = 1 →
         stepRegWrite (stepChannelOutput i (ziskStep i) (rowDecodes i)) ≠ none
         ∧ stepProducerRow i (ziskStep i) (rowDecodes i) = i.val)
-    (h_stepRegWrite_converse : ∀ (i : Fin n) (e : Interaction.MemoryBusEntry FGL),
+    (_h_stepRegWrite_converse : ∀ (i : Fin n) (e : Interaction.MemoryBusEntry FGL),
         i.val + 1 < n →
         stepRegWrite (stepChannelOutput i (ziskStep i) (rowDecodes i)) = some e →
         Transpiler.wrap_to_regidx e.ptr ≠ 0 →
@@ -304,7 +304,7 @@ theorem cMemMessage_value_eq_lane_hi_of_bootWalk_supplier
         (mainTableRowAtOrZero trace.program trace.mainTable i.val).rom.store_reg = 1 →
         stepRegWrite (stepChannelOutput i (ziskStep i) (rowDecodes i)) ≠ none
         ∧ stepProducerRow i (ziskStep i) (rowDecodes i) = i.val)
-    (h_stepRegWrite_converse : ∀ (i : Fin n) (e : Interaction.MemoryBusEntry FGL),
+    (_h_stepRegWrite_converse : ∀ (i : Fin n) (e : Interaction.MemoryBusEntry FGL),
         i.val + 1 < n →
         stepRegWrite (stepChannelOutput i (ziskStep i) (rowDecodes i)) = some e →
         Transpiler.wrap_to_regidx e.ptr ≠ 0 →

--- a/ZiskFv/Compliance/TraceLevelExport/RegisterFileAgreement.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RegisterFileAgreement.lean
@@ -151,8 +151,7 @@ private lemma post_eq_of_busEffect_ok_three_store
   have h_one_val : ((1 : FGL) : ℕ) = 1 := rfl
   unfold bus_effect at h_ok
   simp only [h_len, h_ex0, h_ex1, and_self, if_true, List.foldl_cons, List.foldl_nil,
-    h_m0, h_m1, h_m2, h_a0, h_a1, h_a2, h_one_ne, h_one_val, as_two_val, as_two_ne_one,
-    h_two_ne_neg_one, h_two_ne_one, if_false, if_true,
+    h_m0, h_m1, h_m2, h_a0, h_a1, h_a2, h_one_ne, h_one_val, as_two_val, if_false, if_true,
     write_xreg, Sail.writeReg, PreSail.writeReg, modify, modifyGet,
     MonadStateOf.modifyGet, EStateM.modifyGet, EStateM.Result.map] at h_ok
   cases h_ok
@@ -215,8 +214,7 @@ private lemma post_eq_of_busEffect_ok_three_load
   have h_one_val : ((1 : FGL) : ℕ) = 1 := rfl
   unfold bus_effect at h_ok
   simp only [h_len, h_ex0, h_ex1, and_self, if_true, List.foldl_cons, List.foldl_nil,
-    h_m0, h_m1, h_m2, h_a0, h_a1, h_a2, h_one_ne, h_one_val, as_two_val, as_two_ne_one,
-    h_two_ne_neg_one, if_false, if_true, dif_neg h_nz,
+    h_m0, h_m1, h_m2, h_a0, h_a1, h_a2, h_one_ne, h_one_val, as_two_val, if_false, if_true, dif_neg h_nz,
     write_xreg, Sail.writeReg, PreSail.writeReg, modify, modifyGet,
     MonadStateOf.modifyGet, EStateM.modifyGet, EStateM.Result.map] at h_ok
   cases h_ok
@@ -313,8 +311,7 @@ private lemma post_eq_of_busEffect_ok_three_x0
   unfold bus_effect at h_ok
   rcases h_a1 with h_a1 | h_a1 <;>
     · simp only [h_len, h_ex0, h_ex1, and_self, if_true, List.foldl_cons, List.foldl_nil,
-        h_m0, h_m1, h_m2, h_a0, h_a1, h_a2, h_one_ne, h_one_val, as_two_val, as_two_ne_one,
-        h_two_ne_neg_one, if_false, if_true, dif_pos h_z,
+        h_m0, h_m1, h_m2, h_a0, h_a1, h_a2, h_one_ne, h_one_val, as_two_val, if_false, if_true, dif_pos h_z,
         write_xreg, Sail.writeReg, PreSail.writeReg, modify, modifyGet,
         MonadStateOf.modifyGet, EStateM.modifyGet, EStateM.Result.map] at h_ok
       cases h_ok
@@ -486,7 +483,7 @@ theorem regAgree_succ
   rw [h_regs, h_post_regs, ziskRegFile, dif_pos h]
   have h_nextPC : reg_of_fin k ≠ Register.nextPC := reg_of_fin_neq_nextPC
   rw [Std.ExtDHashMap.get?_insert,
-    dif_neg (by simp only [beq_iff_eq, ne_eq]; exact Ne.symm h_nextPC)]
+    dif_neg (by simp only [beq_iff_eq]; exact Ne.symm h_nextPC)]
   cases h_w : stepRegWrite (stepChannelOutput (⟨j, h⟩ : Fin ziskTrace.numInstructions)
       (ziskStep ⟨j, h⟩) (rowDecode ⟨j, h⟩)) with
   | none => exact h_prev k h_k
@@ -506,7 +503,7 @@ theorem regAgree_succ
             h_eq (reg_of_fin_injective h_z h_k hc)
           dsimp only
           rw [if_neg h_z, if_neg h_eq, Std.ExtDHashMap.get?_insert,
-            dif_neg (by simp only [beq_iff_eq, ne_eq]; exact h_ne)]
+            dif_neg (by simp only [beq_iff_eq]; exact h_ne)]
           exact h_prev k h_k
 
 /-! ## The register file as "the last write"
@@ -618,7 +615,7 @@ lemma lane_lo_entryRegValue (e : Interaction.MemoryBusEntry FGL)
   have h_toNat := entryRegValue_toNat e h_v0 h_v1
   simp only [ZiskFv.Trusted.lane_lo]
   refine Fin.ext ?_
-  simp only [Fin.val_mk, h_toNat, Nat.add_mul_mod_self_right, Nat.mod_eq_of_lt h_v0]
+  simp only [h_toNat, Nat.add_mul_mod_self_right, Nat.mod_eq_of_lt h_v0]
 
 open ZiskFv.Airs.MemoryBus in
 lemma lane_hi_entryRegValue (e : Interaction.MemoryBusEntry FGL)

--- a/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RomDecodeBindingOps.lean
@@ -346,7 +346,7 @@ theorem fin_ne_zero_iff_val_ne_zero (r : Fin 32) : r ≠ 0 ↔ r.val ≠ 0 := by
     simpa using hval
   · intro h hr
     apply h
-    simpa [hr]
+    simp [hr]
 
 /-- **Immediate-source selector unpacking at a row.** Given the row's packed
     `romFlags` equals `packFlags bits`, the `b_src_imm` column equals `boolF` of

--- a/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RowDataControl.lean
@@ -47,7 +47,7 @@ This is not a decoded placement fact: it is the explicit soundness-domain condit
 branch next-PC cast. Keeping it separate from `Inputs_<branch>` leaves those input records focused
 on Sail/ZisK state and value agreement. -/
 def BranchRangeDomain (trace : AcceptedZiskTrace numInstructions)
-    (i : Fin trace.numInstructions) (pc takenOffset : BitVec 64) : Prop :=
+    (_i : Fin trace.numInstructions) (pc takenOffset : BitVec 64) : Prop :=
   0 ≤ (pc.toNat : Int) + takenOffset.toInt
     ∧ (pc.toNat : Int) + takenOffset.toInt < GL_prime
     ∧ pc.toNat < GL_prime - 4

--- a/ZiskFv/Regression/SignedDivOrdinaryCounterexample.lean
+++ b/ZiskFv/Regression/SignedDivOrdinaryCounterexample.lean
@@ -273,9 +273,8 @@ private theorem mainConstraints (offset : ℕ) :
     | apply constraintsHold_assertZero
       simp only [Expression.eval, h_a0, h_a1, h_a2, h_a3, h_b0, h_b1, h_b2, h_b3,
         h_c0, h_c1, h_c2, h_c3, h_d0, h_d1, h_d2, h_d3, h_na, h_nb, h_nr, h_np,
-        h_sext, h_m32, h_div, h_div0, h_overflow, h_mainDiv, h_mainMul, h_signed,
-        h_rangeAB, h_rangeCD, h_op, h_busRes, h_mult, h_cy0, h_cy1, h_cy2, h_cy3,
-        h_cy4, h_cy5, h_cy6, h_fab, h_nafb, h_nbfa, h_inv]
+        h_m32, h_div, h_cy0, h_cy1, h_cy2, h_cy3,
+        h_cy4, h_cy5, h_cy6, h_fab, h_nafb, h_nbfa]
       norm_num [arithRow]
     | apply constraintsHold_interaction <;> rfl
 
@@ -311,25 +310,18 @@ private theorem mainWithArithTableConstraints (offset : ℕ) :
   repeat' apply constraintsHold_bind
   next =>
     apply constraintsHold_assertZero
-    simp only [Expression.eval, h_a0, h_a1, h_a2, h_a3, h_b0, h_b1, h_b2, h_b3,
-      h_c0, h_c1, h_c2, h_c3, h_d0, h_d1, h_d2, h_d3, h_na, h_nb, h_nr, h_np,
-      h_sext, h_m32, h_div, h_div0, h_overflow, h_mainDiv, h_mainMul, h_signed,
-      h_rangeAB, h_rangeCD, h_op, h_busRes, h_mult, h_cy0, h_cy1, h_cy2, h_cy3,
-      h_cy4, h_cy5, h_cy6, h_fab, h_nafb, h_nbfa, h_inv]
+    simp only [Expression.eval, h_a2, h_a3, h_c2, h_c3, h_d2, h_d3,
+      h_sext, h_m32, h_mainDiv, h_mainMul, h_busRes]
     norm_num [arithRow]
   all_goals
     apply constraintsHold_staticLookup
-    simp only [ProvableStruct.eval_eq_eval, ProvableStruct.eval,
-      ProvableStruct.fromComponents, ProvableStruct.components,
-      ProvableStruct.toComponents, ProvableStruct.eval.go, ProvableType.eval_field,
-      ProvableType.eval_fields, CircuitType.eval_expr, CircuitType.eval_var_field,
+    simp only [ProvableType.eval_field,
+      ProvableType.eval_fields,
       Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil,
-      eval_add, expressionEvalConst,
       h_a0, h_a1, h_a2, h_a3, h_b0, h_b1, h_b2, h_b3, h_c0, h_c1, h_c2, h_c3,
       h_d0, h_d1, h_d2, h_d3, h_na, h_nb, h_nr, h_np, h_sext, h_m32, h_div,
       h_div0, h_overflow, h_mainDiv, h_mainMul, h_signed, h_rangeAB, h_rangeCD,
-      h_op, h_busRes, h_mult, h_cy0, h_cy1, h_cy2, h_cy3, h_cy4, h_cy5, h_cy6,
-      h_fab, h_nafb, h_nbfa, h_inv]
+      h_op, h_cy0, h_cy1, h_cy2, h_cy3, h_cy4, h_cy5, h_cy6]
   next => exact hRom
   next => norm_num; exact hIdxA1
   next => norm_num; exact hIdxB1
@@ -366,10 +358,9 @@ private theorem sharedMainConstraints (offset : ℕ) :
   all_goals first
     | apply constraintsHold_assertZero
       simp only [Expression.eval, h_a0, h_a1, h_a2, h_a3, h_b0, h_b1, h_b2, h_b3,
-        h_c0, h_c1, h_c2, h_c3, h_d0, h_d1, h_d2, h_d3, h_na, h_nb, h_nr, h_np,
+        h_c0, h_c1, h_c2, h_c3, h_d2, h_d3, h_na, h_nb, h_nr, h_np,
         h_sext, h_m32, h_div, h_div0, h_overflow, h_mainDiv, h_mainMul, h_signed,
-        h_rangeAB, h_rangeCD, h_op, h_busRes, h_mult, h_cy0, h_cy1, h_cy2, h_cy3,
-        h_cy4, h_cy5, h_cy6, h_fab, h_nafb, h_nbfa, h_inv]
+        h_busRes, h_inv]
       norm_num [arithRow]
   all_goals
     have hDenominator : (262140 : FGL) ≠ 0 := by decide

--- a/ZiskFv/Soundness.lean
+++ b/ZiskFv/Soundness.lean
@@ -274,7 +274,7 @@ private theorem stepRegWrite_converse_aux
     simp [h_r_ne, fin32_ne_zero_of_val_ne_zero]
 
 private lemma fgl_add_val_lt_of_sum_lt {a b : FGL} {bound : ℕ}
-    (h_sum_lt : a.val + b.val < GL_prime)
+    (_h_sum_lt : a.val + b.val < GL_prime)
     (h_bound : a.val + b.val < bound) :
     (a + b).val < bound := by
   change (a.val + b.val) % GL_prime < bound
@@ -309,7 +309,7 @@ private lemma cMemMessage_chunks_of_store_pc_one
     (h_val : (m.core.pc + m.core.jmp_offset2).val < 4294967296) :
     ZiskFv.Airs.MemoryBus.memory_entry_chunks_in_range
       ((cMemMessage m).toEntry 1 1) := by
-  simp only [ZiskFv.Airs.MemoryBus.memory_entry_chunks_in_range, cMemMessage, MemBusMessage.toEntry,
+  simp only [ZiskFv.Airs.MemoryBus.memory_entry_chunks_in_range,
     h_sp]
   constructor
   · rw [one_mul, sub_add_cancel]; exact h_val
@@ -322,8 +322,7 @@ private lemma matches_entry_c_eq
       (ZiskFv.Channels.OperationBus.OpBusMessage.toEntry msg 1)) :
     m.c_0 i = msg.c_lo ∧ m.c_1 i = msg.c_hi := by
   simp only [ZiskFv.Airs.OperationBus.matches_entry,
-    ZiskFv.Airs.OperationBus.opBus_row_Main,
-    ZiskFv.Channels.OperationBus.OpBusMessage.toEntry] at h
+    ZiskFv.Airs.OperationBus.opBus_row_Main] at h
   exact ⟨h.2.2.2.2.2.2.1, h.2.2.2.2.2.2.2.1⟩
 
 private lemma fgl_two_chunks_val_lt (a b : FGL)
@@ -350,7 +349,7 @@ private lemma fgl_two_bytes_val_lt (a b : FGL)
     Nat.mod_eq_of_lt (by rw [h256v]; omega)
   have h2 : (a.val + 256 * b.val) % GL_prime = a.val + 256 * b.val :=
     Nat.mod_eq_of_lt (by omega)
-  simp only [Fin.val_add, Fin.val_mul, h256v, h1, h2]
+  simp only [Fin.val_add, Fin.val_mul, h256v]
   omega
 
 private lemma fgl_four_bytes_val_lt (a b c d : FGL)
@@ -379,12 +378,7 @@ private lemma binary_static_opBus_c_hi_lt
   have hr5 := ZiskFv.AirsClean.BinaryTable.spec_range_conditions h_spec.2.2.2.2.2.1
   have hr6 := ZiskFv.AirsClean.BinaryTable.spec_range_conditions h_spec.2.2.2.2.2.2.1
   have hr7 := ZiskFv.AirsClean.BinaryTable.spec_range_conditions h_spec.2.2.2.2.2.2.2
-  simp only [ZiskFv.Airs.Tables.BinaryTable.range_conditions,
-    ZiskFv.Channels.BinaryTable.BinaryTableMessage.toEntry,
-    ZiskFv.AirsClean.Binary.lookupMessage4Row,
-    ZiskFv.AirsClean.Binary.lookupMessage5Row,
-    ZiskFv.AirsClean.Binary.lookupMessage6Row,
-    ZiskFv.AirsClean.Binary.lookupMessage7Row] at hr4 hr5 hr6 hr7
+  simp only [ZiskFv.Airs.Tables.BinaryTable.range_conditions] at hr4 hr5 hr6 hr7
   exact fgl_four_bytes_val_lt _ _ _ _ hr4.2.2.1 hr5.2.2.1 hr6.2.2.1 hr7.2.2.1
 
 private lemma binary_static_opBus_c_lo_lt
@@ -398,12 +392,7 @@ private lemma binary_static_opBus_c_lo_lt
   have hr1 := ZiskFv.AirsClean.BinaryTable.spec_range_conditions h_spec.2.1
   have hr2 := ZiskFv.AirsClean.BinaryTable.spec_range_conditions h_spec.2.2.1
   have hr3 := ZiskFv.AirsClean.BinaryTable.spec_range_conditions h_spec.2.2.2.1
-  simp only [ZiskFv.Airs.Tables.BinaryTable.range_conditions,
-    ZiskFv.Channels.BinaryTable.BinaryTableMessage.toEntry,
-    ZiskFv.AirsClean.Binary.lookupMessage0Row,
-    ZiskFv.AirsClean.Binary.lookupMessage1Row,
-    ZiskFv.AirsClean.Binary.lookupMessage2Row,
-    ZiskFv.AirsClean.Binary.lookupMessage3Row] at hr0 hr1 hr2 hr3
+  simp only [ZiskFv.Airs.Tables.BinaryTable.range_conditions] at hr0 hr1 hr2 hr3
   exact fgl_four_bytes_carry_val_lt _ _ _ _ _ hr0.2.2.1 hr1.2.2.1 hr2.2.2.1 hr3.2.2.1 h_carry
 
 private lemma mode_pins_of_emit_op_eq_16_of_static_spec
@@ -571,7 +560,7 @@ private lemma cMemMessage_chunks_of_store_pc_zero
     (h_c1 : m.core.c_1.val < 4294967296) :
     ZiskFv.Airs.MemoryBus.memory_entry_chunks_in_range
       ((cMemMessage m).toEntry 1 1) := by
-  simp only [ZiskFv.Airs.MemoryBus.memory_entry_chunks_in_range, cMemMessage, MemBusMessage.toEntry,
+  simp only [ZiskFv.Airs.MemoryBus.memory_entry_chunks_in_range,
     h_sp]
   constructor
   · show (0 * _ + m.core.c_0).val < _; simp [h_c0]
@@ -697,7 +686,7 @@ private lemma arithMul_opBus_c_lo_lt
     have hmd0 : row.flags.main_div = 0 := by
       have h := hmm1 ▸ h_mm_md; rwa [one_mul] at h
     have h1 : (1 : FGL) - 1 - 0 = 0 := by ring
-    simp only [hmm1, hmd0, h1, zero_mul, zero_add, one_mul, mul_zero, add_zero]
+    simp only [hmm1, hmd0, h1, zero_mul, zero_add, one_mul, add_zero]
     exact fgl_two_chunks_val_lt_comm row.chunks.c_1 row.chunks.c_0
       h_chunks.2.2.2.2.2.2.2.2.2.1 h_chunks.2.2.2.2.2.2.2.2.1
 
@@ -739,7 +728,7 @@ private lemma arithMul_opBus_c_hi_lt
       have hmd0 : row.flags.main_div = 0 := by
         have h := hmm1 ▸ h_mm_md; rwa [one_mul] at h
       have h1 : (1 : FGL) - 1 - 0 = 0 := by ring
-      simp only [hmm1, hmd0, h1, zero_mul, zero_add, one_mul, mul_zero, add_zero]
+      simp only [hmm1, hmd0, h1, zero_mul, zero_add, one_mul, add_zero]
       exact fgl_two_chunks_val_lt_comm row.chunks.c_3 row.chunks.c_2
         h_chunks.2.2.2.2.2.2.2.2.2.2.2.1 h_chunks.2.2.2.2.2.2.2.2.2.2.1
   · simp only [hm32, sub_self, zero_mul, add_zero]
@@ -870,8 +859,7 @@ private lemma binExt_shift_entry_range
   have h_row_spec := hspec providerRow hpr
   rw [hcomp, shiftStaticLookupComponent_spec] at h_row_spec
   have h_op_eq := hmatch.2.1
-  simp only [ZiskFv.Airs.OperationBus.opBus_row_Main,
-    ZiskFv.Channels.OperationBus.OpBusMessage.toEntry, opBusMessage] at h_op_eq
+  simp only [ZiskFv.Airs.OperationBus.opBus_row_Main] at h_op_eq
   rw [h_op_eq] at h_main_op
   have h_c_lt := binExt_shift_opBus_c_lt theRow h_row_spec.2.1 h_main_op
   exact entry_range_of_provider_match i h_sp hmatch h_c_lt.1 h_c_lt.2
@@ -1004,14 +992,12 @@ private lemma copyb_entry_range_of_e1_range
   have h_op_row : row.core.op = ZiskFv.Trusted.OP_COPYB := by
     simpa [row, mainOfTable_op] using h_main_op
   have h_bc0 : row.core.b_0 = row.core.c_0 := by
-    simp only [ZiskFv.Airs.Main.internal_op1_copies_b0,
-      ZiskFv.AirsClean.Main.validOfRow] at h_copy0
+    simp only [ZiskFv.Airs.Main.internal_op1_copies_b0] at h_copy0
     rw [h_active_row, h_op_row] at h_copy0
     norm_num [ZiskFv.Trusted.OP_COPYB] at h_copy0 ⊢
     linear_combination h_copy0
   have h_bc1 : row.core.b_1 = row.core.c_1 := by
-    simp only [ZiskFv.Airs.Main.internal_op1_copies_b1,
-      ZiskFv.AirsClean.Main.validOfRow] at h_copy1
+    simp only [ZiskFv.Airs.Main.internal_op1_copies_b1] at h_copy1
     rw [h_active_row, h_op_row] at h_copy1
     norm_num [ZiskFv.Trusted.OP_COPYB] at h_copy1 ⊢
     linear_combination h_copy1
@@ -1020,7 +1006,7 @@ private lemma copyb_entry_range_of_e1_range
           ZiskFv.Airs.MemoryBus.memory_entry_lo e1
       ∧ (mainOfTable trace.program trace.mainTable).b_1 i.val =
           ZiskFv.Airs.MemoryBus.memory_entry_hi e1 := by
-    simp [e1, busLd, mainRowWithRomLd, mainOfTable_b_0, mainOfTable_b_1]
+    simp [e1, mainRowWithRomLd, mainOfTable_b_0, mainOfTable_b_1]
   apply cMemMessage_chunks_of_store_pc_zero row h_sp
   · rw [← h_bc0, show row.core.b_0 = e1.value_0 from h_emit.1]
     exact h_e1_range.1
@@ -1054,14 +1040,12 @@ private lemma copyb_narrow_entry_range
   have h_op_row : row.core.op = ZiskFv.Trusted.OP_COPYB := by
     simpa [row, mainOfTable_op] using h_main_op
   have h_bc0 : row.core.b_0 = row.core.c_0 := by
-    simp only [ZiskFv.Airs.Main.internal_op1_copies_b0,
-      ZiskFv.AirsClean.Main.validOfRow] at h_copy0
+    simp only [ZiskFv.Airs.Main.internal_op1_copies_b0] at h_copy0
     rw [h_active_row, h_op_row] at h_copy0
     norm_num [ZiskFv.Trusted.OP_COPYB] at h_copy0 ⊢
     linear_combination h_copy0
   have h_bc1 : row.core.b_1 = row.core.c_1 := by
-    simp only [ZiskFv.Airs.Main.internal_op1_copies_b1,
-      ZiskFv.AirsClean.Main.validOfRow] at h_copy1
+    simp only [ZiskFv.Airs.Main.internal_op1_copies_b1] at h_copy1
     rw [h_active_row, h_op_row] at h_copy1
     norm_num [ZiskFv.Trusted.OP_COPYB] at h_copy1 ⊢
     linear_combination h_copy1
@@ -1071,7 +1055,7 @@ private lemma copyb_narrow_entry_range
       ∧ (mainOfTable trace.program trace.mainTable).b_1 i.val =
           ZiskFv.Airs.MemoryBus.memory_entry_hi e1
       ∧ e1.as = 2 ∧ e1.multiplicity = -1 := by
-    simp [e1, busLd, mainRowWithRomLd, mainOfTable_b_0, mainOfTable_b_1]
+    simp [e1, mainRowWithRomLd, mainOfTable_b_0, mainOfTable_b_1]
   have h_zero :=
     ZiskFv.Airs.MemoryBus.MemAlignBridge.memalign_subdoubleword_load_high_bytes_zero
       (mainOfTable trace.program trace.mainTable) align.mab align.marb align.ma i.val e1
@@ -1133,7 +1117,7 @@ private theorem stepRegWrite_entry_range_aux
       simp only [mainOfTable_pc] at this; exact this
     have h_bound := hAvoid.h_pc_offset_lt_2_32
       (BitVec.ofNat 64 (mainTableRowAtOrZero trace.program trace.mainTable i.val).core.pc.val)
-      (by unfold mainPcVal; simp only [mainOfTable_pc, BitVec.toNat_ofNat, Nat.mod_eq_of_lt]; omega)
+      (by unfold mainPcVal; simp only [mainOfTable_pc, BitVec.toNat_ofNat]; omega)
     simp only [BitVec.toNat_add, BitVec.toNat_ofNat] at h_bound
     exact fgl_add_val_lt_of_sum_lt (by omega) (by omega)
   | auipc c =>
@@ -1217,7 +1201,7 @@ private theorem stepRegWrite_entry_range_aux
         simp only [mainOfTable_pc] at h_pcv
         have h_bound := hAvoid.h_pc_offset_lt_2_32
           (BitVec.ofNat 64 (mainTableRowAtOrZero trace.program trace.mainTable i.val).core.pc.val)
-          (by unfold mainPcVal; simp only [mainOfTable_pc, BitVec.toNat_ofNat, Nat.mod_eq_of_lt]; omega)
+          (by unfold mainPcVal; simp only [mainOfTable_pc, BitVec.toNat_ofNat]; omega)
         simp only [BitVec.toNat_add, BitVec.toNat_ofNat] at h_bound
         exact fgl_add_val_lt_of_sum_lt (by omega) (by omega)
       · -- unaligned (2-row): rows.finish = i+1, jmp2 = 3
@@ -1253,7 +1237,7 @@ private theorem stepRegWrite_entry_range_aux
           simp only [mainOfTable_pc] at h_pcv
           have h_bound := hAvoid.h_pc_offset_lt_2_32
             (BitVec.ofNat 64 (mainTableRowAtOrZero trace.program trace.mainTable i.val).core.pc.val)
-            (by unfold mainPcVal; simp only [mainOfTable_pc, BitVec.toNat_ofNat, Nat.mod_eq_of_lt]; omega)
+            (by unfold mainPcVal; simp only [mainOfTable_pc, BitVec.toNat_ofNat]; omega)
           simp only [BitVec.toNat_add, BitVec.toNat_ofNat] at h_bound
           have h_sum : ((mainTableRowAtOrZero trace.program trace.mainTable i.val).core.pc
               + 1 + 3 : FGL) = (mainTableRowAtOrZero trace.program trace.mainTable i.val).core.pc
@@ -1298,7 +1282,7 @@ private theorem stepRegWrite_entry_range_aux
         have h_ts : (3 : FGL) + (rd.rows.finish.val : FGL) * 4
             = 3 + (i.val : FGL) * 4 := by
           have := congrArg Interaction.MemoryBusEntry.timestamp h_inj
-          simp only [MemBusMessage.toEntry, cMemMessage, h_ms_f, h_ms_i] at this
+          simp only [h_ms_f, h_ms_i] at this
           exact this
         rw [h_fi_eq] at h_ts
         have h_cancel : (↑(i.val + 1) : FGL) = (↑i.val : FGL) :=
@@ -1322,9 +1306,7 @@ private theorem stepRegWrite_entry_range_aux
     have h_core := ZiskFv.AirsClean.Binary.core_every_row_of_spec _ h_row.1
     have h_wf := ZiskFv.AirsClean.Binary.static_table_wf_facts_of_spec_facts _ h_spec_facts
     have h_op_eq := hmatch.2.1
-    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main,
-      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
-      ZiskFv.AirsClean.Binary.opBusMessage] at h_op_eq
+    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main] at h_op_eq
     rw [h_op] at h_op_eq
     have h_pins := ZiskFv.EquivCore.Bridge.Binary.logic_row_mode_pins_of_emit_op_lt_16_of_static_spec
       _ h_spec_facts 14 (by norm_num) h_core h_op_eq.symm
@@ -1346,9 +1328,7 @@ private theorem stepRegWrite_entry_range_aux
     have h_core := ZiskFv.AirsClean.Binary.core_every_row_of_spec _ h_row.1
     have h_wf := ZiskFv.AirsClean.Binary.static_table_wf_facts_of_spec_facts _ h_spec_facts
     have h_op_eq := hmatch.2.1
-    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main,
-      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
-      ZiskFv.AirsClean.Binary.opBusMessage] at h_op_eq
+    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main] at h_op_eq
     rw [h_op] at h_op_eq
     have h_pins := ZiskFv.EquivCore.Bridge.Binary.logic_row_mode_pins_of_emit_op_lt_16_of_static_spec
       _ h_spec_facts 15 (by norm_num) h_core h_op_eq.symm
@@ -1370,9 +1350,7 @@ private theorem stepRegWrite_entry_range_aux
     have h_core := ZiskFv.AirsClean.Binary.core_every_row_of_spec _ h_row.1
     have h_wf := ZiskFv.AirsClean.Binary.static_table_wf_facts_of_spec_facts _ h_spec_facts
     have h_op_eq := hmatch.2.1
-    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main,
-      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
-      ZiskFv.AirsClean.Binary.opBusMessage] at h_op_eq
+    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main] at h_op_eq
     rw [h_op] at h_op_eq
     have h_pins := mode_pins_of_emit_op_eq_16_of_static_spec
       _ h_spec_facts h_core h_op_eq.symm
@@ -1394,9 +1372,7 @@ private theorem stepRegWrite_entry_range_aux
     have h_core := ZiskFv.AirsClean.Binary.core_every_row_of_spec _ h_row.1
     have h_wf := ZiskFv.AirsClean.Binary.static_table_wf_facts_of_spec_facts _ h_spec_facts
     have h_op_eq := hmatch.2.1
-    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main,
-      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
-      ZiskFv.AirsClean.Binary.opBusMessage] at h_op_eq
+    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main] at h_op_eq
     rw [h_op] at h_op_eq
     have h_pins := ZiskFv.EquivCore.Bridge.Binary.logic_row_mode_pins_of_emit_op_lt_16_of_static_spec
       _ h_spec_facts 14 (by norm_num) h_core h_op_eq.symm
@@ -1418,9 +1394,7 @@ private theorem stepRegWrite_entry_range_aux
     have h_core := ZiskFv.AirsClean.Binary.core_every_row_of_spec _ h_row.1
     have h_wf := ZiskFv.AirsClean.Binary.static_table_wf_facts_of_spec_facts _ h_spec_facts
     have h_op_eq := hmatch.2.1
-    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main,
-      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
-      ZiskFv.AirsClean.Binary.opBusMessage] at h_op_eq
+    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main] at h_op_eq
     rw [h_op] at h_op_eq
     have h_pins := ZiskFv.EquivCore.Bridge.Binary.logic_row_mode_pins_of_emit_op_lt_16_of_static_spec
       _ h_spec_facts 15 (by norm_num) h_core h_op_eq.symm
@@ -1442,9 +1416,7 @@ private theorem stepRegWrite_entry_range_aux
     have h_core := ZiskFv.AirsClean.Binary.core_every_row_of_spec _ h_row.1
     have h_wf := ZiskFv.AirsClean.Binary.static_table_wf_facts_of_spec_facts _ h_spec_facts
     have h_op_eq := hmatch.2.1
-    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main,
-      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
-      ZiskFv.AirsClean.Binary.opBusMessage] at h_op_eq
+    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main] at h_op_eq
     rw [h_op] at h_op_eq
     have h_pins := mode_pins_of_emit_op_eq_16_of_static_spec
       _ h_spec_facts h_core h_op_eq.symm
@@ -1466,9 +1438,7 @@ private theorem stepRegWrite_entry_range_aux
     have h_core := ZiskFv.AirsClean.Binary.core_every_row_of_spec _ h_row.1
     have h_wf := ZiskFv.AirsClean.Binary.static_table_wf_facts_of_spec_facts _ h_spec_facts
     have h_op_eq := hmatch.2.1
-    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main,
-      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
-      ZiskFv.AirsClean.Binary.opBusMessage] at h_op_eq
+    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main] at h_op_eq
     rw [h_op] at h_op_eq
     have h_carry := binary_static_add_sub_entry_range _ h_spec_facts h_core h_wf
       11 (by norm_num) h_op_eq.symm (Or.inr rfl)
@@ -1489,9 +1459,7 @@ private theorem stepRegWrite_entry_range_aux
       have h_core := ZiskFv.AirsClean.Binary.core_every_row_of_spec _ h_row.1
       have h_wf := ZiskFv.AirsClean.Binary.static_table_wf_facts_of_spec_facts _ h_spec_facts
       have h_op_eq := hmatch.2.1
-      simp only [ZiskFv.Airs.OperationBus.opBus_row_Main,
-        ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
-        ZiskFv.AirsClean.Binary.opBusMessage] at h_op_eq
+      simp only [ZiskFv.Airs.OperationBus.opBus_row_Main] at h_op_eq
       rw [h_op] at h_op_eq
       have h_carry := binary_static_add_sub_entry_range _ h_spec_facts h_core h_wf
         10 (by norm_num) h_op_eq.symm (Or.inl rfl)
@@ -1513,9 +1481,7 @@ private theorem stepRegWrite_entry_range_aux
       have h_core := ZiskFv.AirsClean.Binary.core_every_row_of_spec _ h_row.1
       have h_wf := ZiskFv.AirsClean.Binary.static_table_wf_facts_of_spec_facts _ h_spec_facts
       have h_op_eq := hmatch.2.1
-      simp only [ZiskFv.Airs.OperationBus.opBus_row_Main,
-        ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
-        ZiskFv.AirsClean.Binary.opBusMessage] at h_op_eq
+      simp only [ZiskFv.Airs.OperationBus.opBus_row_Main] at h_op_eq
       rw [h_op] at h_op_eq
       have h_carry := binary_static_add_sub_entry_range _ h_spec_facts h_core h_wf
         10 (by norm_num) h_op_eq.symm (Or.inl rfl)
@@ -1536,9 +1502,7 @@ private theorem stepRegWrite_entry_range_aux
     have h_core := ZiskFv.AirsClean.Binary.core_every_row_of_spec _ h_row.1
     have h_wf := ZiskFv.AirsClean.Binary.static_table_wf_facts_of_spec_facts _ h_spec_facts
     have h_op_eq := hmatch.2.1
-    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main,
-      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
-      ZiskFv.AirsClean.Binary.opBusMessage] at h_op_eq
+    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main] at h_op_eq
     rw [h_op] at h_op_eq
     exact entry_range_of_provider_match i h_sp hmatch
       (binary_static_compare_c_lo_lt _ h_spec_facts h_core h_wf 7 (by norm_num) h_op_eq.symm
@@ -1559,9 +1523,7 @@ private theorem stepRegWrite_entry_range_aux
     have h_core := ZiskFv.AirsClean.Binary.core_every_row_of_spec _ h_row.1
     have h_wf := ZiskFv.AirsClean.Binary.static_table_wf_facts_of_spec_facts _ h_spec_facts
     have h_op_eq := hmatch.2.1
-    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main,
-      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
-      ZiskFv.AirsClean.Binary.opBusMessage] at h_op_eq
+    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main] at h_op_eq
     rw [h_op] at h_op_eq
     exact entry_range_of_provider_match i h_sp hmatch
       (binary_static_compare_c_lo_lt _ h_spec_facts h_core h_wf 6 (by norm_num) h_op_eq.symm
@@ -1582,9 +1544,7 @@ private theorem stepRegWrite_entry_range_aux
     have h_core := ZiskFv.AirsClean.Binary.core_every_row_of_spec _ h_row.1
     have h_wf := ZiskFv.AirsClean.Binary.static_table_wf_facts_of_spec_facts _ h_spec_facts
     have h_op_eq := hmatch.2.1
-    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main,
-      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
-      ZiskFv.AirsClean.Binary.opBusMessage] at h_op_eq
+    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main] at h_op_eq
     rw [h_op] at h_op_eq
     exact entry_range_of_provider_match i h_sp hmatch
       (binary_static_compare_c_lo_lt _ h_spec_facts h_core h_wf 7 (by norm_num) h_op_eq.symm
@@ -1605,9 +1565,7 @@ private theorem stepRegWrite_entry_range_aux
     have h_core := ZiskFv.AirsClean.Binary.core_every_row_of_spec _ h_row.1
     have h_wf := ZiskFv.AirsClean.Binary.static_table_wf_facts_of_spec_facts _ h_spec_facts
     have h_op_eq := hmatch.2.1
-    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main,
-      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
-      ZiskFv.AirsClean.Binary.opBusMessage] at h_op_eq
+    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main] at h_op_eq
     rw [h_op] at h_op_eq
     exact entry_range_of_provider_match i h_sp hmatch
       (binary_static_compare_c_lo_lt _ h_spec_facts h_core h_wf 6 (by norm_num) h_op_eq.symm
@@ -1628,9 +1586,7 @@ private theorem stepRegWrite_entry_range_aux
     have h_core := ZiskFv.AirsClean.Binary.core_every_row_of_spec _ h_row.1
     have h_wf := ZiskFv.AirsClean.Binary.static_table_wf_facts_of_spec_facts _ h_spec_facts
     have h_op_eq := hmatch.2.1
-    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main,
-      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
-      ZiskFv.AirsClean.Binary.opBusMessage] at h_op_eq
+    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main] at h_op_eq
     rw [h_op] at h_op_eq
     have h_carry := binary_static_w_mode_carry_7_zero _ h_spec_facts h_core h_wf
       26 h_op_eq.symm (Or.inl rfl)
@@ -1650,9 +1606,7 @@ private theorem stepRegWrite_entry_range_aux
     have h_core := ZiskFv.AirsClean.Binary.core_every_row_of_spec _ h_row.1
     have h_wf := ZiskFv.AirsClean.Binary.static_table_wf_facts_of_spec_facts _ h_spec_facts
     have h_op_eq := hmatch.2.1
-    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main,
-      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
-      ZiskFv.AirsClean.Binary.opBusMessage] at h_op_eq
+    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main] at h_op_eq
     rw [h_op] at h_op_eq
     have h_carry := binary_static_w_mode_carry_7_zero _ h_spec_facts h_core h_wf
       27 h_op_eq.symm (Or.inr rfl)
@@ -1672,9 +1626,7 @@ private theorem stepRegWrite_entry_range_aux
     have h_core := ZiskFv.AirsClean.Binary.core_every_row_of_spec _ h_row.1
     have h_wf := ZiskFv.AirsClean.Binary.static_table_wf_facts_of_spec_facts _ h_spec_facts
     have h_op_eq := hmatch.2.1
-    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main,
-      ZiskFv.Channels.OperationBus.OpBusMessage.toEntry,
-      ZiskFv.AirsClean.Binary.opBusMessage] at h_op_eq
+    simp only [ZiskFv.Airs.OperationBus.opBus_row_Main] at h_op_eq
     rw [h_op] at h_op_eq
     have h_carry := binary_static_w_mode_carry_7_zero _ h_spec_facts h_core h_wf
       26 h_op_eq.symm (Or.inl rfl)


### PR DESCRIPTION
## What this is

`lake build` on `main` at `08db1645` is green and emits 955 warnings. 7 come from pinned
dependencies (Aeneas `sorry`, LeanRV64D deprecations); the other 948 are Lean 4.28 linter
noise in 55 files under `ZiskFv/`. None reports a failed goal, and nothing enforces them —
there is no `warningAsError` and no CI job greps a build log for `warning:`.

The noise hides any *new* warning a future change introduces. This PR clears the four
script-fixable classes. A follow-up PR does the tactic-class ones by hand.

Precedent: PR #216 (`8d08d05f`) cleared 245 warnings this way.

## Result

| Class | before | after |
|---|---|---|
| `linter.unusedSimpArgs` | 696 | 6 |
| `linter.unnecessarySimpa` | 51 | 0 |
| `linter.unusedVariables` | 25 | 0 |
| `linter.unnecessarySeqFocus` | 28 | 1 |
| `linter.unusedTactic` | 84 | 75 |
| `linter.unreachableTactic` | 63 | 54 |
| non-terminal `aesop` | 1 | 1 |
| **in-tree total** | **948** | **137** |

`unusedTactic` and `unreachableTactic` fell by 9 each as a side effect; the rest of those
are the follow-up PR's job.

## How the edits were made

**By compiler-reported position, never by text search.** Each warning carries an exact
`file:LINE:COL` (1-indexed line, 0-indexed codepoint column) pointing at the offending
token. A scratch Python fixer read the build log and edited exactly there.

That matters because these idioms are copy-pasted across sibling lemmas and roughly half
the sibling copies are still live. `(try simp only [bind_ok] at h)` appears 9 times in the
`RawProgramBinding*` family: dead at `RawProgramBindingRegister.lean:313`, `:336` and
`RawProgramBindingLoadStore.lean:301`, `:317`, but doing real work at `Register.lean:237`,
`:273`, `:355` and `LoadStore.lean:352`, `:473`. A `sed` sweep would have broken the live
ones.

It also avoids a second trap: these linters ignore `norm_num [...]` argument lists
entirely. `sdLdFreeCols` occurs 73 times in `SdLdSpinWitness.lean` with 57 flagged; the 7
unflagged ones at lines 366, 382, 399, 415, 431, 1253, 1268 sit in `norm_num` lists, so
they are *unverified*, not known-dead. Positional editing never touches them.

Removing an argument can unmask another, so the fixer ran to a fixpoint: two passes.

Per-class rules:

- `unusedSimpArgs` — from the reported column, scan forward balancing `[]`/`()`/`⟨⟩` to the
  next top-level `,` or `]`, delete that span. Scanning beats matching the reported name,
  because a complex argument may be pretty-printed rather than echoed verbatim. Deletion
  spans are widened so they leave no trailing whitespace and no whitespace-only line, and
  never reflow surviving text onto a different line.
- `unnecessarySimpa` — `simpa .. using h` → `simp .. at h` (token replacement, using the
  hypothesis name the message itself supplies). 13 sites of the `simpa .. using <term>`
  form, where the fix is `simp ..` and the term is dropped, were done by hand.
- `unnecessarySeqFocus` — `<;>` → sequential tactic at the chain head's column.
- `unusedVariables` — binder prefixed with `_`.

## Left alone on purpose

**`ZiskFv/AirsClean/MemAlign/Circuit.lean:258` — a linter false positive.** The linter says
this `<;>` is unnecessary. It is not: `cases isBoot <;> cases phase` leaves several goals,
so sequencing `simp_all` instead of distributing it leaves the `completeness` proof with
unsolved goals. Applied, failed the build, reverted. This is the one surviving
`unnecessarySeqFocus`.

**6 `simp only [X]` calls whose single argument is dead.** Dropping it leaves
`simp only []`, which still beta/eta/proj reduces and so is not obviously deletable. PR
#216 produced exactly this residue and it is still on main in `ConstructionDivu.lean:360`,
`ConstructionDivuw.lean:209`, `ConstructionRemu.lean:337`, `ConstructionRemuw.lean:207`.
Not repeating that without a human decision. The sites are
`RegisterPushCounting.lean:573`, `:670`, `RegisterCoverageBridge.lean:554`, `:774`, `:998`,
and `Soundness.lean:525`.

Where the dead argument was the only one of a *plain* `simp [X]`, the whole bracket goes
and the call becomes `simp` / `simp at h` — exactly equivalent, no residue. 8 such sites.

## Scope and safety

- Diff is `.lean` files under `ZiskFv/` only. No `set_option`, no `axiom`/`opaque`/`sorry`,
  no `native_decide`, no theorem statement, no validator field, no generated artifact, no
  trust file.
- No file touched is CODEOWNERS-protected, is `ZiskFv/Compliance.lean` or a
  `ZiskFv/Compliance/Dispatch/*` file (which `trust/scripts/check-clean-integration.py`
  greps for `exact` steps), or is `ZiskFv/Compliance/RowProvenance.lean` (whose hash keys a
  no-prefix-fallback CI cache).
- Deletion only, never reflow, so `check-locality.sh`'s line-initial keyword scan cannot
  gain a match.
- `tools/mirror-roundtrip/check_mirrors.py` counts textual mentions of `AirsClean` mirror
  predicates *inside proofs* and hard-fails at zero. None of the 197 distinct dead argument
  names is a `survey.CLASSIFICATION` declaration, and the check was re-run after each pass.

## Verification

```
lake build                                   0 errors
trust/scripts/check-all.sh                   20/20
trust/scripts/check-all-semantic.sh          20/20
tools/mirror-roundtrip/check_mirrors.py      176/176, 0 unreachable mirror
git diff --check                             clean
```

Lines over 100 columns: 542 before, 543 after.
