### PR TITLE
chore: clear the remaining lake build warnings by hand (137 -> 1)

### DIFF
--- a/ZiskFv/AirsClean/ArithMul/Bridge.lean
+++ b/ZiskFv/AirsClean/ArithMul/Bridge.lean
@@ -639,7 +639,7 @@ theorem primaryOpBusMessage_toEntry_rowAt_eq_opBus_row
       ZiskFv.Airs.ArithMul.opBus_row_Arith v r := by
   simp only [OpBusMessage.toEntry, primaryOpBusMessage,
     ZiskFv.Airs.ArithMul.opBus_row_Arith, h_div, h_main_mul, h_main_div]
-  ring
+  ring_nf
 
 theorem secondaryOpBusMessage_toEntry_rowAt_eq_opBus_row
     (v : ZiskFv.Airs.ArithMul.Valid_ArithMul FGL FGL) (r : ℕ) :
@@ -666,7 +666,7 @@ theorem primaryOpBusMessage_toEntry_rowAt_eq_opBus_row_secondary
       ZiskFv.Airs.ArithMul.opBus_row_ArithMulSecondary v r := by
   simp only [OpBusMessage.toEntry, primaryOpBusMessage,
     ZiskFv.Airs.ArithMul.opBus_row_ArithMulSecondary, h_div, h_main_mul, h_main_div]
-  ring
+  ring_nf
 
 /-- The Clean Component `Spec` projected at a `Valid_ArithMul` row,
     derived **through the Clean Component**. From the AIR's MUL-mode

--- a/ZiskFv/Compliance/AddSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/AddSpinRootSoundness.lean
@@ -699,7 +699,7 @@ def addPaddedRowsAligned :
   intro j h
   have h' : j + 1 < 1 := h
   have hj : j < 1 - 1 := by omega
-  interval_cases j <;> rfl
+  interval_cases j
 
 set_option maxHeartbeats 4000000 in
 def addPaddedLaneBridge : ∀ i : Fin 1,

--- a/ZiskFv/Compliance/ConstructionDivu.lean
+++ b/ZiskFv/Compliance/ConstructionDivu.lean
@@ -221,7 +221,7 @@ theorem primaryOpBusMessage_toEntry_eq_opBus_row_ArithDiv
     ZiskFv.AirsClean.ArithMul.primaryOpBusMessage,
     ZiskFv.Airs.ArithDiv.opBus_row_ArithDiv,
     h_div, h_main_div, h_main_mul]
-  ring
+  ring_nf
 
 /-- The DIVU op-bus match transports along the ArithDiv row-native view: a
     match against the FAITHFUL muxed primary message of a concrete row carries

--- a/ZiskFv/Compliance/ConstructionRemu.lean
+++ b/ZiskFv/Compliance/ConstructionRemu.lean
@@ -108,7 +108,7 @@ theorem primaryOpBusMessage_toEntry_eq_opBus_row_ArithDivSecondary
     ZiskFv.AirsClean.ArithMul.primaryOpBusMessage,
     ZiskFv.Airs.ArithDiv.opBus_row_ArithDivSecondary,
     h_div, h_main_div, h_main_mul]
-  ring
+  ring_nf
 
 /-- The REMU op-bus match transports along the ArithDiv secondary row-native
     view: a match against the FAITHFUL muxed primary message of a concrete row

--- a/ZiskFv/Compliance/Defects.lean
+++ b/ZiskFv/Compliance/Defects.lean
@@ -332,7 +332,6 @@ def MemAlignNarrowLoadLaneShape
 @[simp] theorem no_memAlignNarrowLoadLaneShape
     (env : OpEnvelope state m r_main) : ¬ MemAlignNarrowLoadLaneShape env := by
   cases env <;> simp [MemAlignNarrowLoadLaneShape]
-  all_goals rintro ⟨_, _, h_fits, h_not_fits⟩; exact h_not_fits h_fits
 
 /-- Anti-vacuity guard for the trace-local carve-out: any selected general
     provider row whose reconstructed value fits its selected narrow width lies

--- a/ZiskFv/Compliance/JalrSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/JalrSpinRootSoundness.lean
@@ -138,8 +138,7 @@ private theorem mainAt_setup :
   rw [ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get]
   rw [setupMainGet]
   rw [jalrAcceptedTrace_mainTable_eq]
-  convert jalrMainTable_evalAt (⟨0, by decide⟩ : Fin jalrMainTable.length) using 1 <;>
-    simp [jalrMainRows]
+  convert jalrMainTable_evalAt (⟨0, by decide⟩ : Fin jalrMainTable.length) using 1
 
 private theorem mainAt_start :
     ZiskFv.Compliance.mainRowWithRomAt jalrAcceptedTrace startMainIndex =
@@ -148,8 +147,7 @@ private theorem mainAt_start :
   rw [ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get]
   rw [startMainGet]
   rw [jalrAcceptedTrace_mainTable_eq]
-  convert jalrMainTable_evalAt (⟨1, by decide⟩ : Fin jalrMainTable.length) using 1 <;>
-    simp [jalrMainRows]
+  convert jalrMainTable_evalAt (⟨1, by decide⟩ : Fin jalrMainTable.length) using 1
 
 private theorem mainAt_finish :
     ZiskFv.Compliance.mainRowWithRomAt jalrAcceptedTrace finishMainIndex =
@@ -158,8 +156,7 @@ private theorem mainAt_finish :
   rw [ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero_get]
   rw [finishMainGet]
   rw [jalrAcceptedTrace_mainTable_eq]
-  convert jalrMainTable_evalAt (⟨2, by decide⟩ : Fin jalrMainTable.length) using 1 <;>
-    simp [jalrMainRows]
+  convert jalrMainTable_evalAt (⟨2, by decide⟩ : Fin jalrMainTable.length) using 1
 
 @[simp] private theorem mainRawAt_setup :
     ZiskFv.AirsClean.FullEnsemble.mainTableRowAtOrZero

--- a/ZiskFv/Compliance/RegisterPushCounting.lean
+++ b/ZiskFv/Compliance/RegisterPushCounting.lean
@@ -570,7 +570,7 @@ theorem registerBoundaryTable_pullCount_le_one
     have h_eq := memBusMessage_eq_of_eval_emitted_provider_msg_eq (h_bi.trans h_bj.symm)
     rw [RegisterBoundary.eval_bootMessageExpr, RegisterBoundary.eval_bootMessageExpr] at h_eq
     have h_ptr := congrArg ZiskFv.Channels.MemoryBus.MemBusMessage.ptr h_eq
-    simp only [RegisterBoundary.bootMessage] at h_ptr
+    simp only [] at h_ptr
     rw [RegisterBoundary.reg_of_materialize, RegisterBoundary.reg_of_materialize] at h_ptr
     have h_cap : rawRows.length ≤ RegisterBoundary.registerBoundaryCapacity :=
       fixed_domain RegisterBoundary.registerBoundaryFixedColumns rfl
@@ -667,7 +667,7 @@ theorem mainRead_ne_boot {length : ℕ} {program : Program length} {table : Tabl
   rw [slot_timestamp_val (slotOffset_le_three s)
     (main_index_lt_mainFixedCapacity h_component h_index)] at h_val
   have h_pos : 1 ≤ slotOffset s := by cases s <;> decide
-  simp only [RegisterBoundary.bootMessage] at h_val
+  simp only [] at h_val
   omega
 
 /-- **As many pushes as pulls, at every memory-bus message whose interactions ride at `0`, `±1`.**

--- a/ZiskFv/Compliance/RegisterPushCounting.lean
+++ b/ZiskFv/Compliance/RegisterPushCounting.lean
@@ -570,7 +570,7 @@ theorem registerBoundaryTable_pullCount_le_one
     have h_eq := memBusMessage_eq_of_eval_emitted_provider_msg_eq (h_bi.trans h_bj.symm)
     rw [RegisterBoundary.eval_bootMessageExpr, RegisterBoundary.eval_bootMessageExpr] at h_eq
     have h_ptr := congrArg ZiskFv.Channels.MemoryBus.MemBusMessage.ptr h_eq
-    simp only [] at h_ptr
+    dsimp only at h_ptr
     rw [RegisterBoundary.reg_of_materialize, RegisterBoundary.reg_of_materialize] at h_ptr
     have h_cap : rawRows.length ≤ RegisterBoundary.registerBoundaryCapacity :=
       fixed_domain RegisterBoundary.registerBoundaryFixedColumns rfl
@@ -667,7 +667,7 @@ theorem mainRead_ne_boot {length : ℕ} {program : Program length} {table : Tabl
   rw [slot_timestamp_val (slotOffset_le_three s)
     (main_index_lt_mainFixedCapacity h_component h_index)] at h_val
   have h_pos : 1 ≤ slotOffset s := by cases s <;> decide
-  simp only [] at h_val
+  dsimp only at h_val
   omega
 
 /-- **As many pushes as pulls, at every memory-bus message whose interactions ride at `0`, `±1`.**

--- a/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
+++ b/ZiskFv/Compliance/SdLdSpinRootSoundness.lean
@@ -290,7 +290,6 @@ def sdLdSlliProgramDecode :
     norm_num [sdLdAcceptedTrace, sdLdProgram, sdLdSlliX1ProgramRow,
       sdLdSlliClaim, x1, Transpiler.ind, regidx_to_fin, packFlags, addiX1Bits,
       ZiskFv.AirsClean.boolF]
-    all_goals decide
 
 def sdLdAddiEightProgramDecode :
     ProgramDecode_addi sdLdAcceptedTrace sdLdAddiEightIndex sdLdAddiEightClaim where

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingControl.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingControl.lean
@@ -111,8 +111,6 @@ private theorem store_reg_raw_index_iff_any
     first
     | (rw [Result.ok.injEq] at h; subst h
        simp [hstore, zisk_inst.STORE_REG] ; scalar_tac)
-    | (rw [Result.ok.injEq] at h; subst h
-       simp [zisk_inst.STORE_REG] <;> scalar_tac)
     | (exfalso; scalar_tac)
 
 private theorem src_a_imm_pres_store
@@ -122,7 +120,6 @@ private theorem src_a_imm_pres_store
   simp only [zisk_inst_builder.ZiskInstBuilder.src_a_imm,
     lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
   first
-  | (rw [Result.ok.injEq] at h; subst h; rfl)
   | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
      rw [Result.ok.injEq] at h; subst h; rfl)
 
@@ -133,11 +130,7 @@ private theorem src_b_imm_pres_store
   simp only [zisk_inst_builder.ZiskInstBuilder.src_b_imm,
     lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
   first
-  | (rw [Result.ok.injEq] at h; subst h; rfl)
   | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
-     rw [Result.ok.injEq] at h; subst h; rfl)
-  | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
-     obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
      rw [Result.ok.injEq] at h; subst h; rfl)
 
 private theorem nop_store_pin
@@ -921,7 +914,6 @@ theorem transpile_lui (rd imm : Nat) (hrd : rd < 32) :
     simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
       ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_ofNat,
       ZiskFv.Compliance.Decode.rawUType_opcode imm rd 0x37 (by norm_num)]
-    all_goals rfl
   obtain ⟨decoded, hdecoded, hopd, hrdb, hrdbv⟩ :=
     decode_u_bounds (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x37)) RiscvOpcode.Lui
   have hdec0 : aeneas_extract.rv64im_decode.decode_32_core
@@ -1038,7 +1030,6 @@ theorem transpile_auipc (rd imm : Nat) (hrd : rd < 32) (hrd0 : rd ≠ 0) :
     simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
       ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_ofNat,
       ZiskFv.Compliance.Decode.rawUType_opcode imm rd 0x17 (by norm_num)]
-    all_goals rfl
   obtain ⟨decoded, hdecoded, hopd, hrdb, hrdbv⟩ :=
     decode_u_bounds (toU32 (ZiskFv.Completeness.Rv64imShapes.rawUType imm rd 0x17)) RiscvOpcode.Auipc
   have hdec0 : aeneas_extract.rv64im_decode.decode_32_core
@@ -1176,7 +1167,6 @@ theorem transpile_jal (rd imm : Nat) (hrd : rd < 32) (hrd0 : rd ≠ 0) :
     simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
       ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_ofNat,
       ZiskFv.Compliance.Decode.rawJType_opcode imm rd]
-    all_goals rfl
   obtain ⟨decoded, hdecoded, hopd, hrdb, hrdbv⟩ :=
     decode_j_bounds (toU32 (ZiskFv.Completeness.Rv64imShapes.rawJType imm rd)) RiscvOpcode.Jal
   have hdec0 : aeneas_extract.rv64im_decode.decode_32_core
@@ -1309,7 +1299,6 @@ theorem transpile_jalr (rd rs1 imm : Nat) (hrd : rd < 32) (_hrs1 : rs1 < 32) (hr
     simp only [aeneas_extract.rv64im_decode.decode_32_core, lift, bind_assoc, Bind.bind, bind_ok,
       ZiskFv.Compliance.Decode.toU32_and127, ZiskFv.Compliance.Decode.toU32_ofNat,
       ZiskFv.Compliance.Decode.rawIType_opcode imm rs1 0 rd 0x67 (by norm_num)]
-    all_goals rfl
   obtain ⟨decoded, hdecoded, hopd, hrdb, hrs1b, hrdbv⟩ :=
     decode_i_bounds (toU32 (ZiskFv.Completeness.Rv64imShapes.rawIType imm rs1 0 rd 0x67)) RiscvOpcode.Jalr false
   have hdec0 : aeneas_extract.rv64im_decode.decode_32_core

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingControl.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingControl.lean
@@ -119,9 +119,8 @@ private theorem src_a_imm_pres_store
     z.i.store = self.i.store := by
   simp only [zisk_inst_builder.ZiskInstBuilder.src_a_imm,
     lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
-  first
-  | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
-     rw [Result.ok.injEq] at h; subst h; rfl)
+  obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  rw [Result.ok.injEq] at h; subst h; rfl
 
 private theorem src_b_imm_pres_store
     (self z : zisk_inst_builder.ZiskInstBuilder) (v : Std.U64)
@@ -129,9 +128,8 @@ private theorem src_b_imm_pres_store
     z.i.store = self.i.store := by
   simp only [zisk_inst_builder.ZiskInstBuilder.src_b_imm,
     lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
-  first
-  | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
-     rw [Result.ok.injEq] at h; subst h; rfl)
+  obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  rw [Result.ok.injEq] at h; subst h; rfl
 
 private theorem nop_store_pin
     (self : riscv2zisk_context.Riscv2ZiskContext)
@@ -374,22 +372,20 @@ private theorem decode_u_rawUType_imm
     · interval_cases k <;>
         simp [hlow, BitVec.getLsbD_ushiftRight, BitVec.getLsbD_shiftLeft,
           BitVec.getLsbD_and, BitVec.getLsbD_ofNat, Nat.testBit] <;>
-        first
-        | (have hz := hlow _ (by omega)
-           simpa only [BitVec.getLsbD_eq_getElem (by omega)] using hz)
+        (have hz := hlow _ (by omega)
+         simpa only [BitVec.getLsbD_eq_getElem (by omega)] using hz)
     · interval_cases k <;>
         simp [BitVec.getLsbD_ushiftRight, BitVec.getLsbD_shiftLeft,
           BitVec.getLsbD_and, BitVec.getLsbD_ofNat, BitVec.getLsbD_append,
           Nat.testBit_or, Nat.testBit_shiftLeft, Nat.testBit_and,
           Nat.testBit_mod_two_pow, Nat.testBit, hrdBit, hopBit] <;>
-        first
-        | (rw [show (BitVec.ofNat 32 (rd <<< 7))[_] = false by
-                 rw [← BitVec.getLsbD_eq_getElem (by omega)]
-                 exact hrdHigh _ (by omega),
-               show (BitVec.ofNat 32 opcode)[_] = false by
-                 rw [← BitVec.getLsbD_eq_getElem (by omega)]
-                 exact hopHigh _ (by omega)]
-           simp)
+        (rw [show (BitVec.ofNat 32 (rd <<< 7))[_] = false by
+               rw [← BitVec.getLsbD_eq_getElem (by omega)]
+               exact hrdHigh _ (by omega),
+             show (BitVec.ofNat 32 opcode)[_] = false by
+               rw [← BitVec.getLsbD_eq_getElem (by omega)]
+               exact hopHigh _ (by omega)]
+         simp)
   · simp [BitVec.getLsbD, hk]
 
 private theorem rawJType_rd (imm rd : Nat) (hrd : rd < 32) :

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingCopyb.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingCopyb.lean
@@ -276,11 +276,7 @@ private theorem copyb_src_b_imm_pres_store (self z : zisk_inst_builder.ZiskInstB
   simp only [zisk_inst_builder.ZiskInstBuilder.src_b_imm,
     lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
   first
-  | (rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩)
   | (obtain ⟨_, _, h⟩ := bind_eq_ok_imp h
-     rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩)
-  | (obtain ⟨_, _, h⟩ := bind_eq_ok_imp h
-     obtain ⟨_, _, h⟩ := bind_eq_ok_imp h
      rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩)
 
 /-- The conditional immediate builder preserves the honest destination-register
@@ -1219,7 +1215,6 @@ theorem transpile_addi (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32)
       ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_ofNat,
       ZiskFv.Compliance.Decode.rawIType_opcode imm rs1 0 rd 0x13 (by norm_num),
       ZiskFv.Compliance.Decode.rawIType_funct3 imm rs1 0 rd 0x13 (by norm_num) hrd (by norm_num)]
-    all_goals rfl
   · intro input hP
     obtain ⟨hrd', himm', _⟩ := hP
     simp only [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input, Bind.bind, bind_ok]
@@ -1306,7 +1301,6 @@ theorem transpile_xori (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs
       ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_ofNat,
       ZiskFv.Compliance.Decode.rawIType_opcode imm rs1 4 rd 0x13 (by norm_num),
       ZiskFv.Compliance.Decode.rawIType_funct3 imm rs1 4 rd 0x13 (by norm_num) hrd (by norm_num)]
-    all_goals rfl
   · intro d hd
     obtain ⟨_, hrs1bv⟩ :=
       decode_i_rd_rs1_bv (toU32 (rawIType imm rs1 4 rd 0x13)) RiscvOpcode.Xori false d hd
@@ -1381,7 +1375,6 @@ theorem transpile_ori (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hrs1
       ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_ofNat,
       ZiskFv.Compliance.Decode.rawIType_opcode imm rs1 6 rd 0x13 (by norm_num),
       ZiskFv.Compliance.Decode.rawIType_funct3 imm rs1 6 rd 0x13 (by norm_num) hrd (by norm_num)]
-    all_goals rfl
   · intro d hd
     obtain ⟨_, hrs1bv⟩ :=
       decode_i_rd_rs1_bv (toU32 (rawIType imm rs1 6 rd 0x13)) RiscvOpcode.Ori false d hd

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingCopyb.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingCopyb.lean
@@ -275,9 +275,8 @@ private theorem copyb_src_b_imm_pres_store (self z : zisk_inst_builder.ZiskInstB
     z.i.store_offset = self.i.store_offset ∧ z.i.store = self.i.store := by
   simp only [zisk_inst_builder.ZiskInstBuilder.src_b_imm,
     lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
-  first
-  | (obtain ⟨_, _, h⟩ := bind_eq_ok_imp h
-     rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩)
+  obtain ⟨_, _, h⟩ := bind_eq_ok_imp h
+  rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩
 
 /-- The conditional immediate builder preserves the honest destination-register
     store pins through either `CopyB` or the requested operation arm. -/

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingImmediate.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingImmediate.lean
@@ -278,9 +278,8 @@ private theorem src_b_imm_pres_store (self z : zisk_inst_builder.ZiskInstBuilder
     z.i.store_offset = self.i.store_offset ∧ z.i.store = self.i.store := by
   simp only [zisk_inst_builder.ZiskInstBuilder.src_b_imm,
     lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
-  first
-  | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
-     rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩)
+  obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩
 
 theorem src_b_imm_a_pres (self z : zisk_inst_builder.ZiskInstBuilder)
     (v : Std.U64)
@@ -289,9 +288,8 @@ theorem src_b_imm_a_pres (self z : zisk_inst_builder.ZiskInstBuilder)
       z.i.a_use_sp_imm1 = self.i.a_use_sp_imm1 := by
   simp only [zisk_inst_builder.ZiskInstBuilder.src_b_imm,
     lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
-  first
-  | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
-     rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl, rfl⟩)
+  obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
+  rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl, rfl⟩
 
 theorem src_b_imm_data_pins (self z : zisk_inst_builder.ZiskInstBuilder)
     (v : Std.U64)

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingImmediate.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingImmediate.lean
@@ -279,7 +279,6 @@ private theorem src_b_imm_pres_store (self z : zisk_inst_builder.ZiskInstBuilder
   simp only [zisk_inst_builder.ZiskInstBuilder.src_b_imm,
     lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
   first
-  | (rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩)
   | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
      rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩)
 
@@ -291,15 +290,8 @@ theorem src_b_imm_a_pres (self z : zisk_inst_builder.ZiskInstBuilder)
   simp only [zisk_inst_builder.ZiskInstBuilder.src_b_imm,
     lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
   first
-  | (rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl, rfl⟩)
   | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
      rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl, rfl⟩)
-  | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
-     obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
-     rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl, rfl⟩)
-  | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
-     obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
-     rw [Result.ok.injEq] at h; subst h; exact ⟨rfl, rfl⟩)
 
 theorem src_b_imm_data_pins (self z : zisk_inst_builder.ZiskInstBuilder)
     (v : Std.U64)
@@ -324,7 +316,7 @@ theorem src_b_imm_data_pins (self z : zisk_inst_builder.ZiskInstBuilder)
     rw [BitVec.toNat_ushiftRight, Nat.shiftRight_eq_div_pow]
   · change (v.bv &&& (4294967295 : BitVec 64)).toNat = v.bv.toNat % 4294967296
     have hb := congrArg BitVec.toNat (BitVec.and_two_pow_sub_one_eq_mod v.bv 32)
-    convert hb using 1 <;> norm_num
+    convert hb using 1
 
 theorem op_zisk_pres_b (self z : zisk_inst_builder.ZiskInstBuilder)
     (op : zisk_ops.ZiskOp)
@@ -360,8 +352,6 @@ theorem store_reg_pres_b (self z : zisk_inst_builder.ZiskInstBuilder)
   split_ifs at h <;>
     first
     | (rw [Result.ok.injEq] at h; subst z; exact ⟨rfl, rfl, rfl⟩)
-    | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
-       rw [Result.ok.injEq] at h; subst z; exact ⟨rfl, rfl, rfl⟩)
     | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
        obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
        rw [Result.ok.injEq] at h; subst z; exact ⟨rfl, rfl, rfl⟩)
@@ -976,7 +966,6 @@ theorem transpile_addiw (rd rs1 imm : Nat) (hrd : rd < 32) (hrs1 : rs1 < 32) (hr
       ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_ofNat,
       ZiskFv.Compliance.Decode.rawIType_opcode imm rs1 0 rd 0x1b (by norm_num),
       ZiskFv.Compliance.Decode.rawIType_funct3 imm rs1 0 rd 0x1b (by norm_num) hrd (by norm_num)]
-    all_goals rfl
   · intro self input hrdne
     simp only [riscv2zisk_single_row.Riscv2ZiskContext.lower_rv64im_single_row_input, Bind.bind, bind_ok]
     rw [if_neg hrdne]

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingJalr.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingJalr.lean
@@ -153,7 +153,6 @@ private theorem jalr_raw_rows
       Bind.bind, bind_ok, ZiskFv.Compliance.Decode.toU32_and127,
       ZiskFv.Compliance.Decode.toU32_ofNat,
       ZiskFv.Compliance.Decode.rawIType_opcode imm rs1 0 rd 0x67 (by norm_num)]
-    all_goals rfl
   obtain ⟨decoded, hdecoded, hopd, hrdb, hrs1b, _⟩ :=
     decode_i_bounds (ZiskFv.Compliance.Decode.toU32 raw)
       aeneas_extract.rv64im_decode.RiscvOpcode.Jalr false

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingLoadStore.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingLoadStore.lean
@@ -130,7 +130,6 @@ theorem store_reg_i64_selector_pin (self z : zisk_inst_builder.ZiskInstBuilder)
       first
       | (rw [Result.ok.injEq] at h; subst z; exact hzero)
       | (exfalso; scalar_tac)
-    all_goals exfalso; scalar_tac
   · simp [hz]
     exact store_reg_i64_is_reg self z rd hrd0 hrd hz h
 
@@ -298,11 +297,8 @@ private theorem loadOperandPins_store_reg (self z : zisk_inst_builder.ZiskInstBu
     zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO,
     zisk_registers.REG_FIRST, mem.SYS_ADDR, mem.RAM_ADDR,
     lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
-  split_ifs at h <;> (try simp only [bind_ok] at h) <;>
-    first
+  split_ifs at h <;> first
     | (rw [Result.ok.injEq] at h; subst z; exact ⟨rfl, rfl, rfl⟩)
-    | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
-       rw [Result.ok.injEq] at h; subst z; exact ⟨rfl, rfl, rfl⟩)
     | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
        obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
        rw [Result.ok.injEq] at h; subst z; exact ⟨rfl, rfl, rfl⟩)
@@ -314,11 +310,8 @@ private theorem precompiled_pres_store_reg (self z : zisk_inst_builder.ZiskInstB
     zisk_registers.REGS_IN_MAIN_FROM, zisk_registers.REGS_IN_MAIN_TO,
     zisk_registers.REG_FIRST, mem.SYS_ADDR, mem.RAM_ADDR,
     lift, bind_ok, bind_assoc, Bind.bind, pure, Pure.pure] at h
-  split_ifs at h <;> (try simp only [bind_ok] at h) <;>
-    first
+  split_ifs at h <;> first
     | (rw [Result.ok.injEq] at h; subst z; rfl)
-    | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
-       rw [Result.ok.injEq] at h; subst z; rfl)
     | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
        obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
        rw [Result.ok.injEq] at h; subst z; rfl)
@@ -354,7 +347,6 @@ private theorem src_a_reg_u32_nonzero_pins (self z : zisk_inst_builder.ZiskInstB
     | (rw [Result.ok.injEq] at h; subst z
        simp [zisk_inst.SRC_REG, hc])
     | (exfalso; scalar_tac)
-  all_goals exfalso; scalar_tac
 
 theorem load_op_typed_nonzero_rs1_full_pins
     (self : riscv2zisk_context.Riscv2ZiskContext)
@@ -937,7 +929,6 @@ theorem transpile_sd (rs1 rs2 imm : Nat) (_hrs1 : rs1 < 32) (_hrs2 : rs2 < 32) :
     ZiskFv.Compliance.Decode.toU32_shr12, ZiskFv.Compliance.Decode.toU32_ofNat,
     ZiskFv.Compliance.Decode.rawSType_opcode imm rs2 rs1 3,
     ZiskFv.Compliance.Decode.rawSType_funct3 imm rs2 rs1 3 (by norm_num)]
-  all_goals rfl
 
 theorem sd_decode_fields_of_binding (rs1 rs2 imm : Nat) (hrs1 : rs1 < 32) (hrs2 : rs2 < 32)
     (line : FGL) (msg : ZiskRomMessage FGL)

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingMemoryNonvacuity.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingMemoryNonvacuity.lean
@@ -271,7 +271,7 @@ theorem memorySdRow_eq_romMessageOfRaw :
         ZiskFv.Compliance.Decode.toU32_ofNat,
         ZiskFv.Compliance.Decode.rawSType_opcode 0 2 1 3,
         ZiskFv.Compliance.Decode.rawSType_funct3 0 2 1 3 (by norm_num)]
-      all_goals rfl]
+      ]
     exact hdecoded
   have hraw : raw = 2142243#u32 := by rfl
   rw [hraw] at hdecoded
@@ -486,7 +486,7 @@ theorem memoryLdZeroRow_eq_romMessageOfRaw :
         ZiskFv.Compliance.Decode.rawIType_opcode 0 1 3 3 0x03 (by norm_num),
         ZiskFv.Compliance.Decode.rawIType_funct3 0 1 3 3 0x03 (by norm_num) (by norm_num)
           (by norm_num)]
-      all_goals rfl]
+      ]
     exact hdecoded
   obtain ⟨hrd, hrs1, himm⟩ :=
     decode_i_rawIType_fields 0 1 3 3 0x03 (by norm_num) (by norm_num) (by norm_num)
@@ -594,7 +594,7 @@ theorem memoryLdNegativeRow_eq_romMessageOfRaw :
         ZiskFv.Compliance.Decode.rawIType_opcode 4088 1 3 4 0x03 (by norm_num),
         ZiskFv.Compliance.Decode.rawIType_funct3 4088 1 3 4 0x03 (by norm_num)
           (by norm_num) (by norm_num)]
-      all_goals rfl]
+      ]
     exact hdecoded
   obtain ⟨hrd, hrs1, himm⟩ :=
     decode_i_rawIType_fields 4088 1 3 4 0x03 (by norm_num) (by norm_num)

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingNonvacuity.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingNonvacuity.lean
@@ -214,7 +214,6 @@ theorem singleAddProgramBinding :
     have haeq : ext.row.a_offset_imm0 = 1#u64 := UScalar.eq_of_val_eq hao
     have hbeq : ext.row.b_offset_imm0 = 1#u64 := UScalar.eq_of_val_eq hbo
     rw [romMessageOfRaw, hext]
-    congr 1
     simp [RegisterMemBusBalance.addX1ProgramRow, romRowOf, signedOffset, romFlagBitsOfExtract, ZiskFv.AirsClean.Main.packFlags,
         ha, haeq, hb, hbeq, hiw, hs, hso, hip,
         hop, hie, hm32, hset, hstorepc, hj1, hj2, hcast4,

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingRegister.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingRegister.lean
@@ -223,7 +223,6 @@ theorem store_reg_u32_zero_not_reg
     first
     | (rw [Result.ok.injEq] at h; subst z
        simp [hself, zisk_inst.STORE_REG])
-    | (exfalso; scalar_tac)
 
 theorem src_a_reg_pres_store (self z : zisk_inst_builder.ZiskInstBuilder)
     (reg : Std.U64) (usp : Bool)
@@ -310,12 +309,8 @@ theorem src_a_reg_false_use_sp_zero (self z : zisk_inst_builder.ZiskInstBuilder)
     zisk_registers.REG_FIRST, mem.SYS_ADDR, mem.RAM_ADDR,
     lift, Bind.bind, bind_ok, if_neg hz] at h
   simp only [Bool.false_eq_true, if_false, bind_ok] at h
-  split_ifs at h <;> (try simp only [bind_ok] at h) <;>
-    first
+  split_ifs at h <;> first
     | (rw [Result.ok.injEq] at h; subst h; rfl)
-    | (subst z; rfl)
-    | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
-       rw [Result.ok.injEq] at h; subst h; rfl)
     | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
        obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
        rw [Result.ok.injEq] at h; subst h; rfl)
@@ -333,12 +328,8 @@ theorem src_b_reg_false_use_sp_zero (self z : zisk_inst_builder.ZiskInstBuilder)
     zisk_registers.REG_FIRST, mem.SYS_ADDR, mem.RAM_ADDR,
     lift, Bind.bind, bind_ok, if_neg hz] at h
   simp only [Bool.false_eq_true, if_false, bind_ok] at h
-  split_ifs at h <;> (try simp only [bind_ok] at h) <;>
-    first
+  split_ifs at h <;> first
     | (rw [Result.ok.injEq] at h; subst h; rfl)
-    | (subst z; rfl)
-    | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
-       rw [Result.ok.injEq] at h; subst h; rfl)
     | (obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
        obtain ⟨_, _, h⟩ := ZiskFv.Compliance.Extraction.bind_eq_ok_imp h
        rw [Result.ok.injEq] at h; subst h; rfl)

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingRegister.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBindingRegister.lean
@@ -220,9 +220,8 @@ theorem store_reg_u32_zero_not_reg
   have e1 := ZiskFv.Compliance.Extraction.cast_one_i64
   have e31 := ZiskFv.Compliance.Extraction.cast_31_i64
   split_ifs at h <;>
-    first
-    | (rw [Result.ok.injEq] at h; subst z
-       simp [hself, zisk_inst.STORE_REG])
+    (rw [Result.ok.injEq] at h; subst z
+     simp [hself, zisk_inst.STORE_REG])
 
 theorem src_a_reg_pres_store (self z : zisk_inst_builder.ZiskInstBuilder)
     (reg : Std.U64) (usp : Bool)

--- a/ZiskFv/Compliance/TraceLevelExport/RawProgramBitfields.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RawProgramBitfields.lean
@@ -904,7 +904,7 @@ private theorem rawBType_imm_bits (imm rs2 rs1 funct3 : Nat)
         Nat.mod_eq_of_lt hp12, Nat.mod_eq_of_lt hp11,
         Nat.mod_eq_of_lt h12, Nat.mod_eq_of_lt h11, Nat.mod_eq_of_lt h10,
         Nat.mod_eq_of_lt h4] <;>
-      norm_num [Nat.testBit] at halign ⊢ <;> aesop
+      norm_num [Nat.testBit] at halign ⊢ <;> aesop (config := { warnOnNonterminal := false })
     simp [Nat.shiftRight_eq_div_pow] at *
   · simp [BitVec.getLsbD, hi]
 

--- a/ZiskFv/Compliance/TraceLevelExport/RegisterCoverageBridge.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RegisterCoverageBridge.lean
@@ -770,7 +770,7 @@ theorem stepWritesReg_cslot_on_bootWalk
           (mainTableRowAtOrZero trace.program trace.mainTable m).rom.store_offset := by
         rw [h_e_eq]
         show (ZiskFv.AirsClean.Main.cMemMessage _).ptr = _
-        simp only []
+        dsimp only
         rw [h_addr_spec.2.2.1, h_store_ind, zero_mul, add_zero]
       rw [← h_e_ptr]; exact heq
     -- Step B: Both sides are boot boundary reg values with .val < 32, both
@@ -994,7 +994,7 @@ theorem stepWritesReg_cslot_on_bootWalk_b
           (mainTableRowAtOrZero trace.program trace.mainTable m).rom.store_offset := by
         rw [h_e_eq]
         show (ZiskFv.AirsClean.Main.cMemMessage _).ptr = _
-        simp only []
+        dsimp only
         rw [h_addr_spec.2.2.1, h_store_ind, zero_mul, add_zero]
       rw [← h_e_ptr]; exact heq
     have h_val_lt_b : (last.2.regPreMessage last.1).ptr.val < 32 :=

--- a/ZiskFv/Compliance/TraceLevelExport/RegisterCoverageBridge.lean
+++ b/ZiskFv/Compliance/TraceLevelExport/RegisterCoverageBridge.lean
@@ -551,7 +551,6 @@ private theorem bootAnchoredStep_ptr_val_lt {n : Nat} (trace : AcceptedZiskTrace
     (p.2.regPreMessage p.1).ptr.val < 32 := by
   obtain ⟨btbl, h_btbl, h_bcomp, br, h_br, h_eq⟩ := h
   rw [h_eq]
-  simp only [ZiskFv.AirsClean.RegisterBoundary.bootMessage]
   -- Destructure btbl and subst the component (same pattern as pullCount proof)
   cases btbl with
   | mk component rawRows data raw_uniform_width fixed_domain =>
@@ -771,7 +770,7 @@ theorem stepWritesReg_cslot_on_bootWalk
           (mainTableRowAtOrZero trace.program trace.mainTable m).rom.store_offset := by
         rw [h_e_eq]
         show (ZiskFv.AirsClean.Main.cMemMessage _).ptr = _
-        simp only [ZiskFv.AirsClean.Main.cMemMessage]
+        simp only []
         rw [h_addr_spec.2.2.1, h_store_ind, zero_mul, add_zero]
       rw [← h_e_ptr]; exact heq
     -- Step B: Both sides are boot boundary reg values with .val < 32, both
@@ -995,7 +994,7 @@ theorem stepWritesReg_cslot_on_bootWalk_b
           (mainTableRowAtOrZero trace.program trace.mainTable m).rom.store_offset := by
         rw [h_e_eq]
         show (ZiskFv.AirsClean.Main.cMemMessage _).ptr = _
-        simp only [ZiskFv.AirsClean.Main.cMemMessage]
+        simp only []
         rw [h_addr_spec.2.2.1, h_store_ind, zero_mul, add_zero]
       rw [← h_e_ptr]; exact heq
     have h_val_lt_b : (last.2.regPreMessage last.1).ptr.val < 32 :=

--- a/ZiskFv/Regression/SignedDivOrdinaryCounterexample.lean
+++ b/ZiskFv/Regression/SignedDivOrdinaryCounterexample.lean
@@ -323,14 +323,14 @@ private theorem mainWithArithTableConstraints (offset : ℕ) :
       h_div0, h_overflow, h_mainDiv, h_mainMul, h_signed, h_rangeAB, h_rangeCD,
       h_op, h_cy0, h_cy1, h_cy2, h_cy3, h_cy4, h_cy5, h_cy6]
   next => exact hRom
-  next => norm_num; exact hIdxA1
-  next => norm_num; exact hIdxB1
-  next => norm_num; exact hIdxC1
-  next => norm_num; exact hIdxD1
+  next => exact hIdxA1
+  next => exact hIdxB1
+  next => exact hIdxC1
+  next => exact hIdxD1
   next => exact hIdxA3
-  next => norm_num; exact hIdxB3
+  next => exact hIdxB3
   next => exact hIdxC3
-  next => norm_num; exact hIdxD3
+  next => exact hIdxD3
   all_goals
     norm_num [ZiskFv.AirsClean.RangeTables.rangeTable16,
       ZiskFv.AirsClean.RangeTables.rangeStaticTable,

--- a/ZiskFv/Soundness.lean
+++ b/ZiskFv/Soundness.lean
@@ -522,7 +522,6 @@ private lemma binary_static_w_mode_carry_7_zero
     rcases mul_eq_zero.mp h_mode_bool with h | h
     · exfalso
       have h_ne := ZiskFv.AirsClean.BinaryTable.spec_op_val_ne_W_add_sub h_spec_facts.1
-      simp only [ZiskFv.AirsClean.Binary.lookupMessage0Row] at h_ne
       have h_bop : row.chain.b_op = (op_val : FGL) := by
         have := h_emit; rw [h, mul_zero, add_zero] at this; exact this
       have h_bop_v := congrArg Fin.val h_bop


### PR DESCRIPTION
Stacked on #361. Review that one first; this PR's diff against it is 17 files,
+23/−79.

## What this is

#361 cleared the four script-fixable linter classes, 948 in-tree warnings down to
137. This PR clears the rest by hand.

**After this PR `lake build` emits 1 in-tree warning**, plus the 7 that come from
pinned dependencies (Aeneas `sorry` ×5, LeanRV64D deprecations ×2) and are not ours.

| Class | before #361 | after #361 | after this |
|---|---|---|---|
| `linter.unusedTactic` | 84 | 75 | 0 |
| `linter.unreachableTactic` | 63 | 54 | 0 |
| `linter.unusedSimpArgs` | 696 | 6 | 0 |
| `linter.unnecessarySeqFocus` | 28 | 1 | 1 |
| non-terminal `aesop` | 1 | 1 | 0 |
| **in-tree total** | **948** | **137** | **1** |

## The 129 dead tactic steps

48 deletions, each anchored at the compiler-reported `file:LINE:COL`. Two shapes:

- the flagged step sits in a `first | … | …` rung, so the whole rung goes — 36 of 48;
- otherwise the step goes character-exactly, together with the `<;>` or `;` that
  joined it to its neighbour — 12 of 48.

**There is no macro amplification to exploit.** All 129 warnings sit at 129 distinct
source positions, because these linters skip macro-generated syntax entirely. The 21
`local macro`s in the `RawProgramBinding*` family (`reg_op`, `reg_program_decode`,
`mext_lemmas`, `branch_program_decode`, …) produce zero flagged warnings. Editing a
macro body would fix nothing and could silently break its call sites — in particular
`RawProgramBindingControl.lean:1955-1962` inside `branch_program_decode` holds a
polarity-dependent `first` whose two rungs each serve 3 of its 6 call sites, and no
linter would have warned.

Text matching would have been wrong for the reason #361 gives: the same idiom is
copy-pasted across sibling lemmas and about half the copies are live.
`(try simp only [bind_ok] at h)` appears 9 times in this family — dead at 4 sites,
doing real work at 5.

## The three residual decisions, each settled by experiment

**Non-terminal `aesop`**, `RawProgramBitfields.lean:907`. Deleting it fails:
`RawProgramBitfields.lean:900 unsolved goals`. The call really does work on the
branches where it does not close the goal, and the trailing `simp … at *` finishes
them. Marked with `aesop (config := { warnOnNonterminal := false })` — the spelling
the repo already uses at `BinaryTable.lean:1797` and `:1848`. This is a declaration
of intent, not a fix, and it is the only suppression in either PR.

**Six `simp only [X]` calls whose only argument is dead.** #361 left these because
dropping the argument yields `simp only []`, which still beta/eta/proj reduces. Here
I deleted the whole call first and let the build decide:

| site | verdict |
|---|---|
| `RegisterCoverageBridge.lean:554` | deletable → deleted |
| `Soundness.lean:525` | deletable → deleted |
| `RegisterPushCounting.lean:573` | load-bearing (`rewrite` then fails) |
| `RegisterPushCounting.lean:670` | load-bearing (`omega` then fails) |
| `RegisterCoverageBridge.lean:774` | load-bearing |
| `RegisterCoverageBridge.lean:998` | load-bearing |

The four load-bearing ones are now `dsimp only`. The first pass left them as
`simp only []`, which reads badly and says nothing; review caught that. All four turn
out to do purely definitional work -- structure-projection reduction of a
`MemBusMessage` -- so `dsimp only` names what the call does and keeps the linter quiet.
Verified by build. The same residue sitting on main in `ConstructionDivu.lean:360` and
its three siblings is untouched; it is not this branch's.

**`MemAlign/Circuit.lean:258` stays as it is — a linter false positive.** The linter
says the `<;>` is unnecessary. It is not: `cases isBoot <;> cases phase` leaves
several goals, so sequencing `simp_all` instead of distributing it leaves the
`completeness` proof with unsolved goals. Both the suggested `(tac1; tac2)` form and
plain newline sequencing fail the build. This is the one surviving in-tree warning.

## `Try this: ring_nf` (4 info lines)

A fifth commit clears four `ring` calls that emit `Try this: ring_nf` on every build
— `ArithMul/Bridge.lean:642`, `:669`, `ConstructionDivu.lean:224`,
`ConstructionRemu.lean:111`.

Mathlib's `ring` is a macro that tries `ring1` and, when that fails, runs `ring_nf`
and suggests writing it. At these four sites `ring1` fails and `ring_nf` closes the
goal, so the two are the same tactic here — the source just named the wrong one.

These are `info:` lines, not warnings, so they were outside the 948 this stack
counts. `lake build` now emits none.

## Scope and safety

- Diff is `.lean` files under `ZiskFv/` only. No `set_option`, no
  `axiom`/`opaque`/`sorry`, no `native_decide`, no theorem statement, no validator
  field, no generated artifact, no trust file.
- No file touched is CODEOWNERS-protected, is `ZiskFv/Compliance.lean` or a
  `ZiskFv/Compliance/Dispatch/*` file, or is `ZiskFv/Compliance/RowProvenance.lean`.

## Review follow-up (`22ee6486`)

Deleting the dead `first` rungs left eight `first` blocks holding a single
alternative -- dead syntax no linter reports, and exactly the residue this PR exists
to remove. Six came from this branch (`RawProgramBindingControl.lean:122`, `:132`,
`RawProgramBindingCopyb.lean:278`, `RawProgramBindingImmediate.lean:281`, `:292`,
`RawProgramBindingRegister.lean:223`); two (`Control.lean:375`, `:383`) predate it and
are collapsed with them so the family is consistent. Each is now the bare tactic.

The same commit replaces the four `simp only []` calls with `dsimp only`.

## Verification

```
lake build                                   0 errors, 1 in-tree warning, 0 `Try this`
trust/scripts/check-all.sh                   20/20
trust/scripts/check-all-semantic.sh          20/20
tools/mirror-roundtrip/check_mirrors.py      176/176, 0 unreachable mirror
git diff --check                             clean
```

