### PR TITLE
feat(trust-gate): print the axiom union once instead of 130 closures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,21 @@ nix run .#test
 semantic trust gate does and should be run after `lake build`. Docs-only changes do not require a
 Lean build unless they affect executable examples, generated artifacts, or commands.
 
+The tree carries 138 `#print axioms` commands, so a plain `lake build` prints about 130
+near-identical closures, each dominated by the same Sail floating-point primitives. Silence them
+and read the union once instead:
+
+```bash
+lake build --log-level=warning
+lake exe trust-gate print-axiom-union
+```
+
+The union groups every axiom the `ZiskFv.*` declarations reach into `project` (the ledger in
+`trust/trusted-base.md`), `kernel` (Lean's postulates plus `ofReduceBool` / `trustCompiler`), and
+`spec` (the LeanRV64D Sail primitives and the Aeneas runtime). `project` is the count that
+membership review controls. The command reports; `check-strong-export-closure` and
+`check-extraction-closure` are the checks that fail a build.
+
 Use focused checks while iterating, then run the broader gate after a coherent proof or
 trust-boundary change. Prefer fixing verification failures over working around them.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,10 +156,11 @@ lake build --log-level=warning
 lake exe trust-gate print-axiom-union
 ```
 
-The union groups every axiom the `ZiskFv.*` declarations reach into `project` (the ledger in
-`trust/trusted-base.md`), `kernel` (Lean's postulates plus `ofReduceBool` / `trustCompiler`), and
-`spec` (the LeanRV64D Sail primitives and the Aeneas runtime). `project` is the count that
-membership review controls. The command reports; `check-strong-export-closure` and
+The union groups every axiom the `ZiskFv.*` declarations reach into `sorry` (`sorryAx`, an
+unfinished proof), `project` (the ledger in `trust/trusted-base.md`), `kernel` (Lean's postulates
+plus `ofReduceBool` / `trustCompiler`), and `spec` (the LeanRV64D Sail primitives and the Aeneas
+runtime). `sorry` must stay empty and the command flags it when it is not. `project` is the count
+that membership review controls. The command reports; `check-strong-export-closure` and
 `check-extraction-closure` are the checks that fail a build.
 
 Use focused checks while iterating, then run the broader gate after a coherent proof or

--- a/bin/TrustGate/AxiomClosure.lean
+++ b/bin/TrustGate/AxiomClosure.lean
@@ -51,4 +51,31 @@ def rawAxiomDepsForTheorem (env : Environment) (name : Name) : Array Name :=
   let st := ((Lean.CollectAxioms.collect name).run env).run {} |>.snd
   st.axioms.qsort (fun a b => a.toString < b.toString)
 
+/-- The RAW, UNFILTERED axiom closure of `roots` taken all at once.
+
+`Lean.CollectAxioms.State` carries the `visited` set, so threading one state
+through every root walks the shared constant graph a single time instead of
+once per root. That is what makes a union over thousands of project
+declarations affordable. -/
+def rawAxiomUnion (env : Environment) (roots : Array Name) : Array Name := Id.run do
+  let mut st : Lean.CollectAxioms.State := {}
+  for r in roots do
+    st := ((Lean.CollectAxioms.collect r).run env).run st |>.snd
+  return st.axioms.qsort (fun a b => a.toString < b.toString)
+
+/-- Lean's own postulates, plus the two the compiled-certificate tactics
+(`native_decide`, `bv_decide`) add. Trusted unconditionally, so they are
+reported apart from the axioms membership review actually controls. -/
+def kernelAxioms : Array Name :=
+  #[`propext, `Classical.choice, `Quot.sound, `Lean.ofReduceBool,
+    `Lean.trustCompiler, `sorryAx]
+
+/-- Which trust scope `n` belongs to: `project` (`ZiskFv.*`, the ledger in
+`trust/trusted-base.md`), `kernel` (see `kernelAxioms`), or `spec` (everything
+else, i.e. the LeanRV64D Sail-translation primitives and the Aeneas runtime). -/
+def scopeOf (n : Name) : String :=
+  if isProjectAxiom n then "project"
+  else if kernelAxioms.contains n then "kernel"
+  else "spec"
+
 end TrustGate.AxiomClosure

--- a/bin/TrustGate/AxiomClosure.lean
+++ b/bin/TrustGate/AxiomClosure.lean
@@ -63,18 +63,30 @@ def rawAxiomUnion (env : Environment) (roots : Array Name) : Array Name := Id.ru
     st := ((Lean.CollectAxioms.collect r).run env).run st |>.snd
   return st.axioms.qsort (fun a b => a.toString < b.toString)
 
-/-- Lean's own postulates, plus the two the compiled-certificate tactics
+/-- Lean's three postulates, plus the two the compiled-certificate tactics
 (`native_decide`, `bv_decide`) add. Trusted unconditionally, so they are
-reported apart from the axioms membership review actually controls. -/
+reported apart from the axioms membership review actually controls.
+
+`sorryAx` is deliberately NOT here. It is not a postulate anyone chose to
+trust; it is the marker of a proof that was never finished. It gets its own
+scope so it can never be read as ordinary kernel trust. -/
 def kernelAxioms : Array Name :=
   #[`propext, `Classical.choice, `Quot.sound, `Lean.ofReduceBool,
-    `Lean.trustCompiler, `sorryAx]
+    `Lean.trustCompiler]
 
-/-- Which trust scope `n` belongs to: `project` (`ZiskFv.*`, the ledger in
-`trust/trusted-base.md`), `kernel` (see `kernelAxioms`), or `spec` (everything
-else, i.e. the LeanRV64D Sail-translation primitives and the Aeneas runtime). -/
+/-- Which trust scope `n` belongs to:
+
+  * `sorry`   -- `sorryAx`, an unfinished proof. Never acceptable.
+  * `project` -- `ZiskFv.*`, the ledger in `trust/trusted-base.md`.
+  * `kernel`  -- see `kernelAxioms`.
+  * `spec`    -- everything else, i.e. the LeanRV64D Sail-translation
+    primitives and the Aeneas runtime.
+
+`sorry` is tested first, so a `ZiskFv.*`-namespaced `sorryAx` alias could not
+hide behind the `project` bucket either. -/
 def scopeOf (n : Name) : String :=
-  if isProjectAxiom n then "project"
+  if n == `sorryAx then "sorry"
+  else if isProjectAxiom n then "project"
   else if kernelAxioms.contains n then "kernel"
   else "spec"
 

--- a/bin/TrustGate/Main.lean
+++ b/bin/TrustGate/Main.lean
@@ -6,6 +6,8 @@ Subcommands:
   check-deps PATH              Compare regenerated baseline against PATH.
   check-no-output-eq-v2 PATH   Type-walk; fail on forbidden Names from PATH.
   print-global-binders         Print global theorem binder baseline rows.
+  print-axiom-union            Print the union of every axiom the ZiskFv.*
+                               declarations reach, grouped by trust scope.
   all                          Run check-deps + check-no-output-eq-v2 against
                                trust/generated/baseline-equiv-axiom-deps.txt and
                                trust/forbidden-types.txt.
@@ -453,6 +455,44 @@ def cmdPrintTreeEdges (env : Environment) (rootStr : String) : IO UInt32 := do
     IO.println s!"{p}\t{c}\t{pk.toTag}\t{ck.toTag}"
   return 0
 
+/-- Subcommand: print the union of every axiom the project's own declarations
+reach, once, grouped by trust scope.
+
+The tree carries 138 `#print axioms` commands, so an ordinary `lake build`
+prints ~130 near-identical closures, each dominated by the same Sail
+floating-point primitives. That volume hides the number that matters. This
+walks every auditable `ZiskFv.*` constant in one pass and reports the union
+instead:
+
+  * `project` -- `ZiskFv.*` axioms, the ledger in `trust/trusted-base.md`
+  * `kernel`  -- Lean's postulates plus `ofReduceBool` / `trustCompiler`
+  * `spec`    -- LeanRV64D Sail primitives and the Aeneas runtime
+
+It reports; it does not gate. `check-strong-export-closure` and
+`check-extraction-closure` are the checks that fail a build. -/
+def cmdPrintAxiomUnion (env : Environment) : IO UInt32 := do
+  let roots := ConstantClosure.allAuditableProjectConsts env
+  if roots.isEmpty then
+    IO.eprintln "trust-gate: no auditable `ZiskFv.*` constants -- did ZiskFv fail to import?"
+    return 1
+  let union := AxiomClosure.rawAxiomUnion env roots
+  let bucket (s : String) : Array Name :=
+    union.filter (fun n => AxiomClosure.scopeOf n == s)
+  let project := bucket "project"
+  let kernel := bucket "kernel"
+  let spec := bucket "spec"
+  IO.println s!"# axiom union over {roots.size} auditable `ZiskFv.*` constants"
+  IO.println s!"# project {project.size}   kernel {kernel.size}   spec {spec.size}   total {union.size}"
+  for (label, names) in
+      [("project", project), ("kernel", kernel), ("spec", spec)] do
+    IO.println ""
+    IO.println s!"## {label} ({names.size})"
+    if names.isEmpty then
+      IO.println "  (none)"
+    else
+      for n in names do IO.println s!"  {n}"
+  return 0
+
 def usage : IO Unit := do
   IO.println "Usage: trust-gate <subcommand>"
   IO.println "  regenerate-deps                regen axiom-dep baseline → stdout"
@@ -470,6 +510,7 @@ def usage : IO Unit := do
   IO.println "  check-strong-export-binders BASELINE FORBIDDEN  check strong export binder baseline + forbidden-type walk"
   IO.println "  check-extraction-closure       assert every ZiskFv.Compliance.{Extraction,Decode}.* RAW axiom closure ⊆ {propext, Classical.choice, Quot.sound}"
   IO.println "  print-tree-edges NAME          emit TSV edge list (parent→child) for proof-tree visualizer"
+  IO.println "  print-axiom-union              print the union of every axiom the ZiskFv.* declarations reach, grouped by trust scope"
 
 def dispatch (env : Environment) (args : List String) : IO UInt32 := do
   match args with
@@ -513,6 +554,8 @@ def dispatch (env : Environment) (args : List String) : IO UInt32 := do
     cmdCheckStrongExportBinders env baselinePath forbiddenPath
   | ["check-extraction-closure"] =>
     cmdCheckExtractionClosure env
+  | ["print-axiom-union"] =>
+    cmdPrintAxiomUnion env
   | ["all"] =>
     let baseline ← IO.FS.readFile "trust/generated/baseline-equiv-axiom-deps.txt"
     let r1 ← diffStrings (renderDepsBaseline env) baseline

--- a/bin/TrustGate/Main.lean
+++ b/bin/TrustGate/Main.lean
@@ -464,9 +464,15 @@ floating-point primitives. That volume hides the number that matters. This
 walks every auditable `ZiskFv.*` constant in one pass and reports the union
 instead:
 
+  * `sorry`   -- `sorryAx`, an unfinished proof. Reported first, and flagged.
   * `project` -- `ZiskFv.*` axioms, the ledger in `trust/trusted-base.md`
   * `kernel`  -- Lean's postulates plus `ofReduceBool` / `trustCompiler`
   * `spec`    -- LeanRV64D Sail primitives and the Aeneas runtime
+
+`sorry` is a scope of its own because it is not trust anyone chose. Folding
+`sorryAx` in with `propext` would print an unfinished proof under a heading
+that reads as unconditional kernel trust -- in the one report whose whole job
+is to surface it.
 
 It reports; it does not gate. `check-strong-export-closure` and
 `check-extraction-closure` are the checks that fail a build. -/
@@ -478,13 +484,18 @@ def cmdPrintAxiomUnion (env : Environment) : IO UInt32 := do
   let union := AxiomClosure.rawAxiomUnion env roots
   let bucket (s : String) : Array Name :=
     union.filter (fun n => AxiomClosure.scopeOf n == s)
+  let sorries := bucket "sorry"
   let project := bucket "project"
   let kernel := bucket "kernel"
   let spec := bucket "spec"
   IO.println s!"# axiom union over {roots.size} auditable `ZiskFv.*` constants"
-  IO.println s!"# project {project.size}   kernel {kernel.size}   spec {spec.size}   total {union.size}"
+  IO.println s!"# sorry {sorries.size}   project {project.size}   \
+kernel {kernel.size}   spec {spec.size}   total {union.size}"
+  unless sorries.isEmpty do
+    IO.println "# !! `sorryAx` IS IN THE UNION -- a ZiskFv.* declaration rests on an \
+unfinished proof."
   for (label, names) in
-      [("project", project), ("kernel", kernel), ("spec", spec)] do
+      [("sorry", sorries), ("project", project), ("kernel", kernel), ("spec", spec)] do
     IO.println ""
     IO.println s!"## {label} ({names.size})"
     if names.isEmpty then

--- a/trust/README.md
+++ b/trust/README.md
@@ -170,7 +170,9 @@ provide (that gate filters out `sorryAx` and restricts to `ZiskFv.*`), so a
 leaked external `sorryAx` / `ofReduceBool` / `trustCompiler` from the imported
 Aeneas runtime is caught here.
 `lake exe trust-gate print-axiom-union` reports, once, the union of every axiom
-the `ZiskFv.*` declarations reach, grouped into `project` / `kernel` / `spec`.
+the `ZiskFv.*` declarations reach, grouped into `sorry` / `project` / `kernel` /
+`spec`. `sorryAx` gets a scope of its own so an unfinished proof can never read
+as ordinary kernel trust; that bucket must stay empty.
 It replaces reading the ~130 per-declaration `#print axioms` closures a plain
 `lake build` prints; pair it with `lake build --log-level=warning`, which
 suppresses those info lines. It reports and never fails — the gates above are

--- a/trust/README.md
+++ b/trust/README.md
@@ -169,5 +169,12 @@ Quot.sound}` — the regression gate the per-theorem axiom-dep baseline cannot
 provide (that gate filters out `sorryAx` and restricts to `ZiskFv.*`), so a
 leaked external `sorryAx` / `ofReduceBool` / `trustCompiler` from the imported
 Aeneas runtime is caught here.
+`lake exe trust-gate print-axiom-union` reports, once, the union of every axiom
+the `ZiskFv.*` declarations reach, grouped into `project` / `kernel` / `spec`.
+It replaces reading the ~130 per-declaration `#print axioms` closures a plain
+`lake build` prints; pair it with `lake build --log-level=warning`, which
+suppresses those info lines. It reports and never fails — the gates above are
+what fail a build.
+
 `regenerate.sh` refreshes every generated ledger after an intentional
 trust-boundary change.


### PR DESCRIPTION
Top of the stack: #361 → #362 → this. Its diff against #362 is 4 files, +92/−0,
touching only `bin/TrustGate/` and two docs.

## The problem

The tree carries 138 `#print axioms` commands, so a plain `lake build` prints about
130 near-identical closures. Each looks like this:

```
'…addFaithfulPaddedRawRootSoundness' depends on axioms: [cancel_reservation,
 get_16_random_bits, load_reservation, match_reservation, plat_term_write,
 propext, riscv_f16Add, riscv_f16Div, … riscv_ui64ToF64, Classical.choice,
 Lean.ofReduceBool, Lean.trustCompiler, Quot.sound]
```

72 of those entries are the same Sail floating-point and platform primitives every
time. They appear because every root theorem mentions Sail's `execute_instruction`,
and `collectAxioms` walks the whole RV64D definition rather than the arm an ADD proof
actually takes. No `riscv_f64Add` is ever evaluated.

The volume hides the one number that matters.

## The fix

```
$ lake exe trust-gate print-axiom-union
# axiom union over 16052 auditable `ZiskFv.*` constants
# sorry 0   project 0   kernel 5   spec 72   total 77

## sorry (0)
  (none)

## project (0)
  (none)

## kernel (5)
  Classical.choice
  Lean.ofReduceBool
  Lean.trustCompiler
  Quot.sound
  propext

## spec (72)
  cancel_reservation
  get_16_random_bits
  …
```

Four scopes:

- **`sorry`** — `sorryAx`, a proof nobody finished. It must stay empty, and the
  command prints a flag line above the groups when it is not. See the review
  follow-up below.
- **`project`** — `ZiskFv.*` axioms, the ledger in `trust/trusted-base.md`. This is
  the count membership review controls, and it is 0 across the whole tree.
- **`kernel`** — Lean's own postulates, plus the two `bv_decide` adds.
- **`spec`** — LeanRV64D Sail primitives and the Aeneas runtime, declared in
  `build/sail-lean/LeanRV64D/RiscvExtras.lean` and pinned by `flake.lock`.

No `sorryAx` in the union.

For a quiet build, `lake build --log-level=warning` drops all 132 info lines and
leaves warnings and errors.

## Implementation

`AxiomClosure.rawAxiomUnion` threads one `Lean.CollectAxioms.State` through every
root. That state carries the `visited` set, so 16052 roots walk the shared constant
graph once instead of 16052 times — which is what makes the union affordable rather
than quadratic.

`AxiomClosure.scopeOf` does the three-way classification;
`AxiomClosure.kernelAxioms` names the unconditional set explicitly rather than
leaving it implicit in a filter.

## What this does not do

- **It adds no gate.** The command reports and always returns 0.
  `check-strong-export-closure` and `check-extraction-closure` remain the checks that
  fail a build, and neither is touched. No baseline, no allowlist, no
  forbidden-shape file changes.
- **It does not remove the 138 `#print axioms`.** They are audit evidence at the
  point of definition, and `--log-level=warning` already hides them.
- **It changes no proof and no trust boundary.**

## Review follow-up (`c53a6106`)

The first pass put `sorryAx` in `kernelAxioms`, next to `propext`, under a docstring
calling the whole set "Trusted unconditionally". A leaked `sorryAx` would then have
printed under `## kernel` — a heading that reads as a deliberate, reviewed postulate —
in the one report whose whole job is to surface it. The docstring also said "plus the
two the compiled-certificate tactics add" while the array held six names.

`sorryAx` now has a scope of its own, tested before `project` so a `ZiskFv.*`-namespaced
alias cannot hide there either. The command still always returns 0 and still adds no
gate.

## Verification

Run on the rebased branch, i.e. with #361 and #362 underneath:

```
lake build --log-level=warning     0 errors, 0 axiom info lines, 9 warnings
trust/scripts/check-all.sh                   20/20
trust/scripts/check-all-semantic.sh          20/20
```

Those 9 are 7 from pinned dependencies, 1 nix "tree is dirty" notice, and the one
in-tree linter false positive #362 documents at `MemAlign/Circuit.lean:258`. On this
branch the whole build output is 9 lines of warning instead of 130 axiom closures
plus 948 linter warnings.

